### PR TITLE
Codechange: Use int instead of uint for widget/dimension code.

### DIFF
--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -48,7 +48,7 @@ enum AirVehicleFlags : uint8_t {
 static const int ROTOR_Z_OFFSET         = 5;    ///< Z Offset between helicopter- and rotorsprite.
 
 void HandleAircraftEnterHangar(Aircraft *v);
-void GetAircraftSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
+void GetAircraftSpriteSize(EngineID engine, int &width, int &height, int &xoffs, int &yoffs, EngineImageType image_type);
 void UpdateAirplanesOnNewStation(const Station *st);
 void UpdateAircraftCache(Aircraft *v, bool update_range = false);
 

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -246,7 +246,7 @@ void DrawAircraftEngine(int left, int right, int preferred_x, int y, EngineID en
  * @param[out] yoffs Number of pixels to shift the sprite downwards.
  * @param image_type Context the sprite is used in.
  */
-void GetAircraftSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type)
+void GetAircraftSpriteSize(EngineID engine, int &width, int &height, int &xoffs, int &yoffs, EngineImageType image_type)
 {
 	VehicleSpriteSeq seq;
 	GetAircraftIcon(engine, image_type, &seq);

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -52,9 +52,9 @@
  * @param type the vehicle type to get the height of
  * @return the height for the entry
  */
-uint GetEngineListHeight(VehicleType type)
+int GetEngineListHeight(VehicleType type)
 {
-	return std::max<uint>(GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.matrix.Vertical(), GetVehicleImageCellSize(type, EIT_PURCHASE).height);
+	return std::max(GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.matrix.Vertical(), GetVehicleImageCellSize(type, EIT_PURCHASE).height);
 }
 
 static constexpr NWidgetPart _nested_build_vehicle_widgets[] = {

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -237,7 +237,7 @@ static constexpr NWidgetPart _nested_cheat_widgets[] = {
 struct CheatWindow : Window {
 	int clicked = 0;
 	int clicked_cheat = 0;
-	uint line_height = 0;
+	int line_height = 0;
 	Dimension icon{}; ///< Dimension of company icon sprite
 
 	std::vector<const SettingDesc *> sandbox_settings{};
@@ -270,9 +270,9 @@ struct CheatWindow : Window {
 		int y = ir.top;
 
 		bool rtl = _current_text_dir == TD_RTL;
-		uint button_left = rtl ? ir.right - SETTING_BUTTON_WIDTH : ir.left;
-		uint text_left   = ir.left + (rtl ? 0 : WidgetDimensions::scaled.hsep_wide + SETTING_BUTTON_WIDTH);
-		uint text_right  = ir.right - (rtl ? WidgetDimensions::scaled.hsep_wide + SETTING_BUTTON_WIDTH : 0);
+		int button_left = rtl ? ir.right - SETTING_BUTTON_WIDTH : ir.left;
+		int text_left   = ir.left + (rtl ? 0 : WidgetDimensions::scaled.hsep_wide + SETTING_BUTTON_WIDTH);
+		int text_right  = ir.right - (rtl ? WidgetDimensions::scaled.hsep_wide + SETTING_BUTTON_WIDTH : 0);
 
 		int text_y_offset = (this->line_height - GetCharacterHeight(FS_NORMAL)) / 2;
 		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
@@ -306,7 +306,7 @@ struct CheatWindow : Window {
 						/* Draw coloured flag for change company cheat */
 						case STR_CHEAT_CHANGE_COMPANY: {
 							str = GetString(ce->str, val + 1);
-							uint offset = WidgetDimensions::scaled.hsep_indent + GetStringBoundingBox(str).width;
+							int offset = WidgetDimensions::scaled.hsep_indent + GetStringBoundingBox(str).width;
 							DrawCompanyIcon(_local_company, rtl ? text_right - offset - WidgetDimensions::scaled.hsep_indent : text_left + offset, y + icon_y_offset);
 							break;
 						}
@@ -377,7 +377,7 @@ struct CheatWindow : Window {
 
 	void UpdateCheatPanelSize(Dimension &size)
 	{
-		uint width = 0;
+		int width = 0;
 		for (const auto &ce : _cheats_ui) {
 			switch (ce.type) {
 				case SLE_BOOL:
@@ -405,8 +405,8 @@ struct CheatWindow : Window {
 			}
 		}
 
-		this->line_height = std::max<uint>(this->icon.height, SETTING_BUTTON_HEIGHT);
-		this->line_height = std::max<uint>(this->line_height, GetCharacterHeight(FS_NORMAL)) + WidgetDimensions::scaled.framerect.Vertical();
+		this->line_height = std::max(this->icon.height, SETTING_BUTTON_HEIGHT);
+		this->line_height = std::max(this->line_height, GetCharacterHeight(FS_NORMAL)) + WidgetDimensions::scaled.framerect.Vertical();
 
 		size.width = width + WidgetDimensions::scaled.hsep_wide * 2 + SETTING_BUTTON_WIDTH;
 		size.height = this->line_height * lengthof(_cheats_ui);
@@ -414,7 +414,7 @@ struct CheatWindow : Window {
 
 	void UpdateSettingsPanelSize(Dimension &size)
 	{
-		uint width = 0;
+		int width = 0;
 		for (const auto &desc : this->sandbox_settings) {
 			const IntSettingDesc *sd = desc->AsIntSetting();
 
@@ -423,7 +423,7 @@ struct CheatWindow : Window {
 		}
 
 		size.width = width + WidgetDimensions::scaled.hsep_wide * 2 + SETTING_BUTTON_WIDTH;
-		size.height = this->line_height * static_cast<uint>(std::size(this->sandbox_settings));
+		size.height = this->line_height * static_cast<int>(std::size(this->sandbox_settings));
 	}
 
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -93,16 +93,16 @@ struct ExpensesList {
 	{
 	}
 
-	uint GetHeight() const
+	int GetHeight() const
 	{
 		/* Add up the height of all the lines.  */
-		return static_cast<uint>(this->items.size()) * GetCharacterHeight(FS_NORMAL);
+		return static_cast<int>(this->items.size()) * GetCharacterHeight(FS_NORMAL);
 	}
 
 	/** Compute width of the expenses categories in pixels. */
-	uint GetListWidth() const
+	int GetListWidth() const
 	{
-		uint width = 0;
+		int width = 0;
 		for (const ExpensesType &et : this->items) {
 			width = std::max(width, GetStringBoundingBox(STR_FINANCES_SECTION_CONSTRUCTION + et).width);
 		}
@@ -121,10 +121,10 @@ static const std::initializer_list<ExpensesList> _expenses_list_types = {
  * Get the total height of the "categories" column.
  * @return The total height in pixels.
  */
-static uint GetTotalCategoriesHeight()
+static int GetTotalCategoriesHeight()
 {
 	/* There's an empty line and blockspace on the year row */
-	uint total_height = GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_wide;
+	int total_height = GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_wide;
 
 	for (const ExpensesList &list : _expenses_list_types) {
 		/* Title + expense list + total line + total + blockspace after category */
@@ -141,9 +141,9 @@ static uint GetTotalCategoriesHeight()
  * Get the required width of the "categories" column, equal to the widest element.
  * @return The required width in pixels.
  */
-static uint GetMaxCategoriesWidth()
+static int GetMaxCategoriesWidth()
 {
-	uint max_width = GetStringBoundingBox(TimerGameEconomy::UsingWallclockUnits() ? STR_FINANCES_PERIOD_CAPTION : STR_FINANCES_YEAR_CAPTION).width;
+	int max_width = GetStringBoundingBox(TimerGameEconomy::UsingWallclockUnits() ? STR_FINANCES_PERIOD_CAPTION : STR_FINANCES_YEAR_CAPTION).width;
 
 	/* Loop through categories to check max widths. */
 	for (const ExpensesList &list : _expenses_list_types) {
@@ -602,7 +602,7 @@ private:
 	LiveryClass livery_class{};
 	Dimension square{};
 	uint rows = 0;
-	uint line_height = 0;
+	int line_height = 0;
 	GUIGroupList groups{};
 	Scrollbar *vscroll = nullptr;
 
@@ -763,7 +763,7 @@ public:
 			case WID_SCL_MATRIX: {
 				/* 11 items in the default rail class */
 				this->square = GetSpriteSize(SPR_SQUARE);
-				this->line_height = std::max(this->square.height, (uint)GetCharacterHeight(FS_NORMAL)) + padding.height;
+				this->line_height = std::max(this->square.height, GetCharacterHeight(FS_NORMAL)) + padding.height;
 
 				size.height = 5 * this->line_height;
 				resize.width = 1;
@@ -1408,7 +1408,7 @@ public:
 		for (int val = 1; val <= 12; val++) {
 			number_dim = maxdim(number_dim, GetStringBoundingBox(GetString(STR_JUST_INT, val)));
 		}
-		uint arrows_width = GetSpriteSize(SPR_ARROW_LEFT).width + GetSpriteSize(SPR_ARROW_RIGHT).width + 2 * (WidgetDimensions::scaled.imgbtn.Horizontal());
+		int arrows_width = GetSpriteSize(SPR_ARROW_LEFT).width + GetSpriteSize(SPR_ARROW_RIGHT).width + 2 * (WidgetDimensions::scaled.imgbtn.Horizontal());
 		number_dim.width += WidgetDimensions::scaled.framerect.Horizontal() + arrows_width;
 		number_dim.height += WidgetDimensions::scaled.framerect.Vertical();
 		/* Compute width of both buttons. */
@@ -1769,7 +1769,7 @@ struct CompanyInfrastructureWindow : Window
 	RailTypes railtypes{}; ///< Valid railtypes.
 	RoadTypes roadtypes{}; ///< Valid roadtypes.
 
-	uint total_width = 0; ///< String width of the total cost line.
+	int total_width = 0; ///< String width of the total cost line.
 
 	CompanyInfrastructureWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
@@ -1849,7 +1849,7 @@ struct CompanyInfrastructureWindow : Window
 
 		switch (widget) {
 			case WID_CI_RAIL_DESC: {
-				uint lines = 1; // Starts at 1 because a line is also required for the section title
+				int lines = 1; // Starts at 1 because a line is also required for the section title
 
 				size.width = std::max(size.width, GetStringBoundingBox(STR_COMPANY_INFRASTRUCTURE_VIEW_RAIL_SECT).width + padding.width);
 
@@ -1870,7 +1870,7 @@ struct CompanyInfrastructureWindow : Window
 
 			case WID_CI_ROAD_DESC:
 			case WID_CI_TRAM_DESC: {
-				uint lines = 1; // Starts at 1 because a line is also required for the section title
+				int lines = 1; // Starts at 1 because a line is also required for the section title
 
 				size.width = std::max(size.width, GetStringBoundingBox(widget == WID_CI_ROAD_DESC ? STR_COMPANY_INFRASTRUCTURE_VIEW_ROAD_SECT : STR_COMPANY_INFRASTRUCTURE_VIEW_TRAM_SECT).width + padding.width);
 
@@ -1926,7 +1926,7 @@ struct CompanyInfrastructureWindow : Window
 				max_val = std::max(max_val, c->infrastructure.airport);
 				max_cost = std::max(max_cost, AirportMaintenanceCost(c->index));
 
-				uint count_width = GetStringBoundingBox(GetString(STR_JUST_COMMA, GetParamMaxValue(max_val))).width + WidgetDimensions::scaled.hsep_indent; // Reserve some wiggle room
+				int count_width = GetStringBoundingBox(GetString(STR_JUST_COMMA, GetParamMaxValue(max_val))).width + WidgetDimensions::scaled.hsep_indent; // Reserve some wiggle room
 
 				if (_settings_game.economy.infrastructure_maintenance) {
 					StringID str_total = TimerGameEconomy::UsingWallclockUnits() ? STR_COMPANY_INFRASTRUCTURE_VIEW_TOTAL_PERIOD : STR_COMPANY_INFRASTRUCTURE_VIEW_TOTAL_YEAR;
@@ -1942,7 +1942,7 @@ struct CompanyInfrastructureWindow : Window
 
 				/* Set height of the total line. */
 				if (widget == WID_CI_TOTAL) {
-					size.height = _settings_game.economy.infrastructure_maintenance ? std::max<uint>(size.height, WidgetDimensions::scaled.vsep_normal + GetCharacterHeight(FS_NORMAL)) : 0;
+					size.height = _settings_game.economy.infrastructure_maintenance ? std::max(size.height, WidgetDimensions::scaled.vsep_normal + GetCharacterHeight(FS_NORMAL)) : 0;
 				}
 				break;
 			}

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -31,9 +31,9 @@
 
 #include "safeguards.h"
 
-static const uint ICON_HISTORY_SIZE       = 20;
-static const uint ICON_RIGHT_BORDERWIDTH  = 10;
-static const uint ICON_BOTTOM_BORDERWIDTH = 12;
+static const int ICON_HISTORY_SIZE       = 20;
+static const int ICON_RIGHT_BORDERWIDTH  = 10;
+static const int ICON_BOTTOM_BORDERWIDTH = 12;
 
 /**
  * Container for a single line of console output

--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -39,31 +39,28 @@ struct Point {
 
 /** Dimensions (a width and height) of a rectangle in 2D */
 struct Dimension {
-	uint width;
-	uint height;
+	int width;
+	int height;
 
 	constexpr Dimension() : width(0), height(0) {}
-	constexpr Dimension(uint w, uint h) : width(w), height(h) {}
+	constexpr Dimension(int w, int h) : width(w), height(h) {}
 
-	bool operator< (const Dimension &other) const
+	bool operator<(const Dimension &other) const
 	{
 		int x = (*this).width - other.width;
 		if (x != 0) return x < 0;
 		return (*this).height < other.height;
 	}
 
-	bool operator== (const Dimension &other) const
-	{
-		return (*this).width == other.width && (*this).height == other.height;
-	}
+	bool operator==(const Dimension &) const = default;
 };
 
 /** Padding dimensions to apply to each side of a Rect. */
 struct RectPadding {
-	uint8_t left = 0;
-	uint8_t top = 0;
-	uint8_t right = 0;
-	uint8_t bottom = 0;
+	int8_t left = 0;
+	int8_t top = 0;
+	int8_t right = 0;
+	int8_t bottom = 0;
 
 	static const RectPadding zero;
 
@@ -71,13 +68,13 @@ struct RectPadding {
 	 * Get total horizontal padding of RectPadding.
 	 * @return total horizontal padding.
 	 */
-	constexpr uint Horizontal() const { return this->left + this->right; }
+	constexpr int Horizontal() const { return this->left + this->right; }
 
 	/**
 	 * Get total vertical padding of RectPadding.
 	 * @return total vertical padding.
 	 */
-	constexpr uint Vertical() const { return this->top + this->bottom; }
+	constexpr int Vertical() const { return this->top + this->bottom; }
 };
 
 inline const RectPadding RectPadding::zero{};
@@ -234,7 +231,8 @@ struct Rect {
 	inline bool Contains(const Point &pt) const
 	{
 		/* This is a local version of IsInsideMM, to avoid including math_func everywhere. */
-		return (uint)(pt.x - this->left) < (uint)(this->right - this->left) && (uint)(pt.y - this->top) < (uint)(this->bottom - this->top);
+		return static_cast<uint>(pt.x - this->left) < static_cast<uint>(this->right - this->left) &&
+				static_cast<uint>(pt.y - this->top) < static_cast<uint>(this->bottom - this->top);
 	}
 };
 

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -152,13 +152,13 @@ struct DropdownWindow : Window {
 	 * @param list Dimensions of the list itself, without padding or cropping.
 	 * @param available_height Available height to fit list within.
 	 */
-	void FitAvailableHeight(Dimension &desired, const Dimension &list, uint available_height)
+	void FitAvailableHeight(Dimension &desired, const Dimension &list, int available_height)
 	{
 		if (desired.height < available_height) return;
 
 		/* If the dropdown doesn't fully fit, we a need a dropdown. */
-		uint avg_height = list.height / (uint)this->list.size();
-		uint rows = std::max((available_height - WidgetDimensions::scaled.dropdownlist.Vertical()) / avg_height, 1U);
+		int avg_height = list.height / static_cast<int>(this->list.size());
+		int rows = std::max((available_height - WidgetDimensions::scaled.dropdownlist.Vertical()) / avg_height, 1);
 
 		desired.width = std::max(list.width, desired.width - NWidgetScrollbar::GetVerticalDimension().width);
 		desired.height = rows * avg_height + WidgetDimensions::scaled.dropdownlist.Vertical();
@@ -180,11 +180,11 @@ struct DropdownWindow : Window {
 		widget_dim.height += WidgetDimensions::scaled.dropdownlist.Vertical();
 
 		/* Width should match at least the width of the parent widget. */
-		widget_dim.width = std::max<uint>(widget_dim.width, button_rect.Width());
+		widget_dim.width = std::max(widget_dim.width, button_rect.Width());
 
 		/* Available height below (or above, if the dropdown is placed above the widget). */
-		uint available_height_below = std::max(GetMainViewBottom() - button_rect.bottom - 1, 0);
-		uint available_height_above = std::max(button_rect.top - 1 - GetMainViewTop(), 0);
+		int available_height_below = std::max(GetMainViewBottom() - button_rect.bottom - 1, 0);
+		int available_height_above = std::max(button_rect.top - 1 - GetMainViewTop(), 0);
 
 		/* Is it better to place the dropdown above the widget? */
 		if (widget_dim.height > available_height_below && available_height_above > available_height_below) {
@@ -404,7 +404,7 @@ void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID b
  *                      list regardless of where the cursor is.
  * @param persist  Set if this dropdown should stay open after an option is selected.
  */
-void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, uint width, bool instant_close, bool persist)
+void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, int width, bool instant_close, bool persist)
 {
 	/* Our parent's button widget is used to determine where to place the drop
 	 * down list window. */
@@ -441,7 +441,7 @@ void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID but
  * @param hidden_mask   Bitmask for hidden items (items with their bit set are not copied to the dropdown list).
  * @param width         Minimum width of the dropdown menu.
  */
-void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width)
+void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, int width)
 {
 	DropDownList list;
 

--- a/src/dropdown_common_type.h
+++ b/src/dropdown_common_type.h
@@ -29,7 +29,7 @@ public:
 	explicit DropDownDivider(Args&&... args) : TBase(std::forward<Args>(args)...) {}
 
 	bool Selectable() const override { return false; }
-	uint Height() const override { return std::max<uint>(GetCharacterHeight(TFs), this->TBase::Height()); }
+	int Height() const override { return std::max(GetCharacterHeight(TFs), this->TBase::Height()); }
 
 	void Draw(const Rect &full, const Rect &, bool, Colours bg_colour) const override
 	{
@@ -65,12 +65,12 @@ public:
 		this->dim = GetStringBoundingBox(this->string, TFs);
 	}
 
-	uint Height() const override
+	int Height() const override
 	{
-		return std::max<uint>(this->dim.height, this->TBase::Height());
+		return std::max(this->dim.height, this->TBase::Height());
 	}
 
-	uint Width() const override { return this->dim.width + this->TBase::Width(); }
+	int Width() const override { return this->dim.width + this->TBase::Width(); }
 
 	void Draw(const Rect &full, const Rect &r, bool sel, Colours bg_colour) const override
 	{
@@ -119,8 +119,8 @@ public:
 		this->dsprite = GetSpriteSize(this->sprite);
 	}
 
-	uint Height() const override { return std::max(this->dbounds.height, this->TBase::Height()); }
-	uint Width() const override { return this->dbounds.width + WidgetDimensions::scaled.hsep_normal + this->TBase::Width(); }
+	int Height() const override { return std::max(this->dbounds.height, this->TBase::Height()); }
+	int Width() const override { return this->dbounds.width + WidgetDimensions::scaled.hsep_normal + this->TBase::Width(); }
 
 	void Draw(const Rect &full, const Rect &r, bool sel, Colours bg_colour) const override
 	{
@@ -148,8 +148,8 @@ public:
 		this->dim = GetStringBoundingBox(STR_JUST_CHECKMARK, TFs);
 	}
 
-	uint Height() const override { return std::max<uint>(this->dim.height, this->TBase::Height()); }
-	uint Width() const override { return this->dim.width + WidgetDimensions::scaled.hsep_wide + this->TBase::Width(); }
+	int Height() const override { return std::max(this->dim.height, this->TBase::Height()); }
+	int Width() const override { return this->dim.width + WidgetDimensions::scaled.hsep_wide + this->TBase::Width(); }
 
 	void Draw(const Rect &full, const Rect &r, bool sel, Colours bg_colour) const override
 	{
@@ -173,7 +173,7 @@ public:
 	template <typename... Args>
 	explicit DropDownIndent(uint indent, Args&&... args) : TBase(std::forward<Args>(args)...), indent(indent) {}
 
-	uint Width() const override { return this->indent * WidgetDimensions::scaled.hsep_indent + this->TBase::Width(); }
+	int Width() const override { return this->indent * WidgetDimensions::scaled.hsep_indent + this->TBase::Width(); }
 
 	void Draw(const Rect &full, const Rect &r, bool sel, Colours bg_colour) const override
 	{

--- a/src/dropdown_func.h
+++ b/src/dropdown_func.h
@@ -13,7 +13,7 @@
 #include "window_gui.h"
 
 /* Show drop down menu containing a fixed list of strings */
-void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width = 0);
+void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, int width = 0);
 
 /* Helper functions for commonly used drop down list items. */
 std::unique_ptr<DropDownListItem> MakeDropDownListDividerItem();

--- a/src/dropdown_type.h
+++ b/src/dropdown_type.h
@@ -29,8 +29,8 @@ public:
 	virtual ~DropDownListItem() = default;
 
 	virtual bool Selectable() const { return true; }
-	virtual uint Height() const { return 0; }
-	virtual uint Width() const { return 0; }
+	virtual int Height() const { return 0; }
+	virtual int Width() const { return 0; }
 
 	virtual void Draw(const Rect &full, const Rect &, bool, Colours bg_colour) const
 	{
@@ -51,7 +51,7 @@ typedef std::vector<std::unique_ptr<const DropDownListItem>> DropDownList;
 
 void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID button, Rect wi_rect, Colours wi_colour, bool instant_close = false, bool persist = false);
 
-void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, uint width = 0, bool instant_close = false, bool persist = false);
+void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, int width = 0, bool instant_close = false, bool persist = false);
 
 Dimension GetDropDownListDimension(const DropDownList &list);
 

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -85,7 +85,7 @@ struct EnginePreviewWindow : Window {
 		/* Get size of engine sprite, on loan from depot_gui.cpp */
 		EngineID engine = static_cast<EngineID>(this->window_number);
 		EngineImageType image_type = EIT_PURCHASE;
-		uint x, y;
+		int x, y;
 		int x_offs, y_offs;
 
 		const Engine *e = Engine::Get(engine);

--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -51,7 +51,7 @@ extern const std::initializer_list<const StringID> _engine_sort_listing[];
 extern EngList_SortTypeFunction * const _engine_sort_functions[][11];
 
 /* Functions in build_vehicle_gui.cpp */
-uint GetEngineListHeight(VehicleType type);
+int GetEngineListHeight(VehicleType type);
 void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selected, WidgetID button);
 void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar &sb, EngineID selected_id, bool show_count, GroupID selected_group, const GUIBadgeClasses &badge_classes);
 void GUIEngineListAddChildren(GUIEngineList &dst, const GUIEngineList &src, EngineID parent = EngineID::Invalid(), uint8_t indent = 0);

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -98,9 +98,9 @@ bool _window_system_initialized = false;
 /** Window class for displaying an error message window. */
 struct ErrmsgWindow : public Window, ErrorMessageData {
 private:
-	uint height_summary = 0; ///< Height of the #summary_msg string in pixels in the #WID_EM_MESSAGE widget.
-	uint height_detailed = 0; ///< Height of the #detailed_msg string in pixels in the #WID_EM_MESSAGE widget.
-	uint height_extra = 0; ///< Height of the #extra_msg string in pixels in the #WID_EM_MESSAGE widget.
+	int height_summary = 0; ///< Height of the #summary_msg string in pixels in the #WID_EM_MESSAGE widget.
+	int height_detailed = 0; ///< Height of the #detailed_msg string in pixels in the #WID_EM_MESSAGE widget.
+	int height_extra = 0; ///< Height of the #extra_msg string in pixels in the #WID_EM_MESSAGE widget.
 	TimeoutTimer<TimerWindow> display_timeout;
 
 public:
@@ -127,7 +127,7 @@ public:
 				this->height_detailed = (this->detailed_msg.empty()) ? 0 : GetStringHeight(this->detailed_msg.GetDecodedString(), size.width);
 				this->height_extra = (this->extra_msg.empty()) ? 0 : GetStringHeight(this->extra_msg.GetDecodedString(), size.width);
 
-				uint panel_height = this->height_summary;
+				int panel_height = this->height_summary;
 				if (!this->detailed_msg.empty()) panel_height += this->height_detailed + WidgetDimensions::scaled.vsep_wide;
 				if (!this->extra_msg.empty()) panel_height += this->height_extra + WidgetDimensions::scaled.vsep_wide;
 

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -739,7 +739,7 @@ struct FrametimeGraphWindow : Window {
 			Dimension size_s_label = GetStringBoundingBox(GetString(STR_FRAMERATE_GRAPH_SECONDS, 100));
 
 			/* Size graph in height to fit at least 10 vertical labels with space between, or at least 100 pixels */
-			graph_size.height = std::max(100u, 10 * (size_ms_label.height + 1));
+			graph_size.height = std::max(100, 10 * (size_ms_label.height + 1));
 			/* Always 2:1 graph area */
 			graph_size.width = 2 * graph_size.height;
 			size = graph_size;
@@ -860,9 +860,9 @@ struct FrametimeGraphWindow : Window {
 			const auto &timestamps = _pf_data[this->element].timestamps;
 			int point = _pf_data[this->element].prev_index;
 
-			const int x_zero = r.right - (int)this->graph_size.width;
+			const int x_zero = r.right - this->graph_size.width;
 			const int x_max = r.right;
-			const int y_zero = r.top + (int)this->graph_size.height;
+			const int y_zero = r.top + this->graph_size.height;
 			const int y_max = r.top;
 			const int c_grid = PC_DARK_GREY;
 			const int c_lines = PC_BLACK;
@@ -872,15 +872,15 @@ struct FrametimeGraphWindow : Window {
 			const TimingMeasurement draw_vert_scale = (TimingMeasurement)this->vertical_scale;
 
 			/* Number of \c horizontal_scale units in each horizontal division */
-			const uint horz_div_scl = (this->horizontal_scale <= 20) ? 1 : 10;
+			const int horz_div_scl = (this->horizontal_scale <= 20) ? 1 : 10;
 			/* Number of divisions of the horizontal axis */
-			const uint horz_divisions = this->horizontal_scale / horz_div_scl;
+			const int horz_divisions = this->horizontal_scale / horz_div_scl;
 			/* Number of divisions of the vertical axis */
-			const uint vert_divisions = 10;
+			const int vert_divisions = 10;
 
 			/* Draw division lines and labels for the vertical axis */
-			for (uint division = 0; division < vert_divisions; division++) {
-				int y = Scinterlate(y_zero, y_max, 0, (int)vert_divisions, (int)division);
+			for (int division = 0; division < vert_divisions; division++) {
+				int y = Scinterlate(y_zero, y_max, 0, vert_divisions, division);
 				GfxDrawLine(x_zero, y, x_max, y, c_grid);
 				if (division % 2 == 0) {
 					if ((TimingMeasurement)this->vertical_scale > TIMESTAMP_PRECISION) {
@@ -895,8 +895,8 @@ struct FrametimeGraphWindow : Window {
 				}
 			}
 			/* Draw division lines and labels for the horizontal axis */
-			for (uint division = horz_divisions; division > 0; division--) {
-				int x = Scinterlate(x_zero, x_max, 0, (int)horz_divisions, (int)horz_divisions - (int)division);
+			for (int division = horz_divisions; division > 0; division--) {
+				int x = Scinterlate(x_zero, x_max, 0, horz_divisions, horz_divisions - division);
 				GfxDrawLine(x, y_max, x, y_zero, c_grid);
 				if (division % 2 == 0) {
 					DrawString(x, x_max, y_zero + 2,
@@ -908,7 +908,7 @@ struct FrametimeGraphWindow : Window {
 			/* Position of last rendered data point */
 			Point lastpoint = {
 				x_max,
-				(int)Scinterlate<int64_t>(y_zero, y_max, 0, this->vertical_scale, durations[point])
+				static_cast<int>(Scinterlate<int64_t>(y_zero, y_max, 0, this->vertical_scale, durations[point]))
 			};
 			/* Timestamp of last rendered data point */
 			TimingMeasurement lastts = timestamps[point];

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -563,7 +563,7 @@ struct GenerateLandscapeWindow : public Window {
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
 	{
-		Dimension d{0, (uint)GetCharacterHeight(FS_NORMAL)};
+		Dimension d{0, GetCharacterHeight(FS_NORMAL)};
 		std::span<const StringID> strs;
 		switch (widget) {
 			case WID_GL_TEMPERATE: case WID_GL_ARCTIC:

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -729,7 +729,7 @@ int GetStringHeight(StringID str, int maxw)
 int GetStringLineCount(std::string_view str, int maxw)
 {
 	Layouter layout(str, maxw);
-	return (uint)layout.size();
+	return static_cast<int>(layout.size());
 }
 
 /**
@@ -740,7 +740,7 @@ int GetStringLineCount(std::string_view str, int maxw)
  */
 Dimension GetStringMultiLineBoundingBox(StringID str, const Dimension &suggestion)
 {
-	Dimension box = {suggestion.width, (uint)GetStringHeight(str, suggestion.width)};
+	Dimension box = {suggestion.width, GetStringHeight(str, suggestion.width)};
 	return box;
 }
 
@@ -752,7 +752,7 @@ Dimension GetStringMultiLineBoundingBox(StringID str, const Dimension &suggestio
  */
 Dimension GetStringMultiLineBoundingBox(std::string_view str, const Dimension &suggestion, FontSize fontsize)
 {
-	Dimension box = {suggestion.width, (uint)GetStringHeight(str, suggestion.width, fontsize)};
+	Dimension box = {suggestion.width, GetStringHeight(str, suggestion.width, fontsize)};
 	return box;
 }
 
@@ -872,9 +872,9 @@ Dimension GetStringBoundingBox(StringID strid, FontSize start_fontsize)
  * @param fontsize Font size to use.
  * @return Width of longest string within the list.
  */
-uint GetStringListWidth(std::span<const StringID> list, FontSize fontsize)
+int GetStringListWidth(std::span<const StringID> list, FontSize fontsize)
 {
-	uint width = 0;
+	int width = 0;
 	for (auto str : list) {
 		width = std::max(width, GetStringBoundingBox(str, fontsize).width);
 	}

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -134,7 +134,7 @@ inline void GfxFillRect(const Rect &r, int colour, FillRectMode mode = FILLRECT_
 
 Dimension GetStringBoundingBox(std::string_view str, FontSize start_fontsize = FS_NORMAL);
 Dimension GetStringBoundingBox(StringID strid, FontSize start_fontsize = FS_NORMAL);
-uint GetStringListWidth(std::span<const StringID> list, FontSize fontsize = FS_NORMAL);
+int GetStringListWidth(std::span<const StringID> list, FontSize fontsize = FS_NORMAL);
 Dimension GetStringListBoundingBox(std::span<const StringID> list, FontSize fontsize = FS_NORMAL);
 int GetStringHeight(std::string_view str, int maxw, FontSize fontsize = FS_NORMAL);
 int GetStringHeight(StringID str, int maxw);

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -187,7 +187,7 @@ struct GoalListWindow : public Window {
 	 * @param progress_col_width Width of the progress column.
 	 * @return max width of drawn text
 	 */
-	void DrawListColumn(GoalColumn column, NWidgetBase *wid, uint progress_col_width) const
+	void DrawListColumn(GoalColumn column, NWidgetBase *wid, int progress_col_width) const
 	{
 		/* Get column draw area. */
 		Rect r = wid->GetCurrentRect().Shrink(WidgetDimensions::scaled.framerect);
@@ -203,7 +203,7 @@ struct GoalListWindow : public Window {
 					switch (column) {
 						case GC_GOAL: {
 							/* Display the goal. */
-							uint width_reduction = progress_col_width > 0 ? progress_col_width + WidgetDimensions::scaled.framerect.Horizontal() : 0;
+							int width_reduction = progress_col_width > 0 ? progress_col_width + WidgetDimensions::scaled.framerect.Horizontal() : 0;
 							DrawString(r.Indent(width_reduction, !rtl), GetString(STR_GOALS_TEXT, s->text.GetDecodedString()));
 							break;
 						}
@@ -236,17 +236,17 @@ struct GoalListWindow : public Window {
 		if (this->IsShaded()) return; // Don't draw anything when the window is shaded.
 
 		/* Calculate progress column width. */
-		uint max_width = 0;
+		int max_width = 0;
 		for (const Goal *s : Goal::Iterate()) {
 			if (!s->progress.empty()) {
 				StringID str = s->completed ? STR_GOALS_PROGRESS_COMPLETE : STR_GOALS_PROGRESS;
-				uint str_width = GetStringBoundingBox(GetString(str, s->progress.GetDecodedString())).width;
+				int str_width = GetStringBoundingBox(GetString(str, s->progress.GetDecodedString())).width;
 				if (str_width > max_width) max_width = str_width;
 			}
 		}
 
 		NWidgetBase *wid = this->GetWidget<NWidgetBase>(WID_GOAL_LIST);
-		uint progress_col_width = std::min(max_width, wid->current_x);
+		int progress_col_width = std::min(max_width, wid->current_x);
 
 		/* Draw goal list. */
 		this->DrawListColumn(GC_PROGRESS, wid, progress_col_width);

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -40,7 +40,7 @@ static CargoTypes _legend_excluded_cargo_production_history;
 
 /* Apparently these don't play well with enums. */
 static const OverflowSafeInt64 INVALID_DATAPOINT(INT64_MAX); // Value used for a datapoint that shouldn't be drawn.
-static const uint INVALID_DATAPOINT_POS = UINT_MAX;  // Used to determine if the previous point was drawn.
+static constexpr int INVALID_DATAPOINT_POS = INT_MAX;  // Used to determine if the previous point was drawn.
 
 constexpr double INT64_MAX_IN_DOUBLE = static_cast<double>(INT64_MAX - 512); ///< The biggest double that when cast to int64_t still fits in a int64_t.
 static_assert(static_cast<int64_t>(INT64_MAX_IN_DOUBLE) < INT64_MAX);
@@ -116,7 +116,7 @@ static std::unique_ptr<NWidgetBase> MakeNWidgetCompanyLines()
 {
 	auto vert = std::make_unique<NWidgetVertical>(NWidContainerFlag::EqualSize);
 	vert->SetPadding(2, 2, 2, 2);
-	uint sprite_height = GetSpriteSize(SPR_COMPANY_ICON, nullptr, ZOOM_LVL_NORMAL).height;
+	int sprite_height = GetSpriteSize(SPR_COMPANY_ICON, nullptr, ZOOM_LVL_NORMAL).height;
 
 	for (WidgetID widnum = WID_GL_FIRST_COMPANY; widnum <= WID_GL_LAST_COMPANY; widnum++) {
 		auto panel = std::make_unique<NWidgetBackground>(WWT_PANEL, COLOUR_BROWN, widnum);
@@ -299,13 +299,13 @@ protected:
 	 * @param current_interval Interval that contains all of the graph data.
 	 * @param num_hori_lines Number of horizontal lines to be drawn.
 	 */
-	uint GetYLabelWidth(ValuesInterval current_interval, int num_hori_lines) const
+	int GetYLabelWidth(ValuesInterval current_interval, int num_hori_lines) const
 	{
 		/* draw text strings on the y axis */
 		int64_t y_label = current_interval.highest;
 		int64_t y_label_separation = (current_interval.highest - current_interval.lowest) / num_hori_lines;
 
-		uint max_width = 0;
+		int max_width = 0;
 
 		for (int i = 0; i < (num_hori_lines + 1); i++) {
 			Dimension d = GetStringBoundingBox(GetString(STR_GRAPH_Y_LABEL, this->format_str_y_axis, y_label));
@@ -323,7 +323,7 @@ protected:
 	 */
 	void DrawGraph(Rect r) const
 	{
-		uint x, y;               ///< Reused whenever x and y coordinates are needed.
+		int x, y;               ///< Reused whenever x and y coordinates are needed.
 		ValuesInterval interval; ///< Interval that contains all of the graph data.
 		int x_axis_offset;       ///< Distance from the top of the graph to the x axis.
 
@@ -498,9 +498,9 @@ protected:
 		}
 
 		/* draw lines and dots */
-		uint linewidth = _settings_client.gui.graph_line_thickness;
-		uint pointoffs1 = (linewidth + 1) / 2;
-		uint pointoffs2 = linewidth + 1 - pointoffs1;
+		int linewidth = _settings_client.gui.graph_line_thickness;
+		int pointoffs1 = (linewidth + 1) / 2;
+		int pointoffs2 = linewidth + 1 - pointoffs1;
 
 		for (const DataSet &dataset : this->data) {
 			if (HasBit(this->excluded_data, dataset.exclude_bit)) continue;
@@ -516,8 +516,8 @@ protected:
 			/* if there are not enough datapoints to fill the graph, align to the right */
 			x += (this->num_vert_lines - this->num_on_x_axis) * x_sep;
 
-			uint prev_x = INVALID_DATAPOINT_POS;
-			uint prev_y = INVALID_DATAPOINT_POS;
+			int prev_x = INVALID_DATAPOINT_POS;
+			int prev_y = INVALID_DATAPOINT_POS;
 
 			const uint dash = ScaleGUITrad(dataset.dash);
 			for (OverflowSafeInt64 datapoint : this->GetDataSetRange(dataset)) {
@@ -597,7 +597,7 @@ public:
 				size.height += WidgetDimensions::scaled.framerect.Vertical();
 
 				/* Set fixed height for number of ranges. */
-				size.height *= static_cast<uint>(std::size(this->ranges));
+				size.height *= static_cast<int>(std::size(this->ranges));
 
 				resize.width = 0;
 				resize.height = 0;
@@ -605,7 +605,7 @@ public:
 				break;
 
 			case WID_GRAPH_GRAPH: {
-				uint x_label_width = 0;
+				int x_label_width = 0;
 
 				/* Draw x-axis labels and markings for graphs based on financial quarters and years.  */
 				if (this->draw_dates) {
@@ -626,11 +626,11 @@ public:
 					x_label_width = GetStringBoundingBox(GetString(STR_GRAPH_Y_LABEL_NUMBER, max_value)).width;
 				}
 
-				uint y_label_width = GetStringBoundingBox(GetString(STR_GRAPH_Y_LABEL, this->format_str_y_axis, INT64_MAX)).width;
+				int y_label_width = GetStringBoundingBox(GetString(STR_GRAPH_Y_LABEL, this->format_str_y_axis, INT64_MAX)).width;
 
-				size.width  = std::max<uint>(size.width,  ScaleGUITrad(5) + y_label_width + this->num_vert_lines * (x_label_width + ScaleGUITrad(5)) + ScaleGUITrad(9));
-				size.height = std::max<uint>(size.height, ScaleGUITrad(5) + (1 + MIN_GRAPH_NUM_LINES_Y * 2 + (this->draw_dates ? 3 : 1)) * GetCharacterHeight(FS_SMALL) + ScaleGUITrad(4));
-				size.height = std::max<uint>(size.height, size.width / 3);
+				size.width  = std::max(size.width,  ScaleGUITrad(5) + y_label_width + this->num_vert_lines * (x_label_width + ScaleGUITrad(5)) + ScaleGUITrad(9));
+				size.height = std::max(size.height, ScaleGUITrad(5) + (1 + MIN_GRAPH_NUM_LINES_Y * 2 + (this->draw_dates ? 3 : 1)) * GetCharacterHeight(FS_SMALL) + ScaleGUITrad(4));
+				size.height = std::max(size.height, size.width / 3);
 				break;
 			}
 
@@ -646,7 +646,7 @@ public:
 				break;
 
 			case WID_GRAPH_RANGE_MATRIX: {
-				uint line_height = GetCharacterHeight(FS_SMALL) + WidgetDimensions::scaled.framerect.Vertical();
+				int line_height = GetCharacterHeight(FS_SMALL) + WidgetDimensions::scaled.framerect.Vertical();
 				uint index = 0;
 				Rect line = r.WithHeight(line_height);
 				for (const auto &str : this->ranges) {
@@ -1058,9 +1058,9 @@ void ShowCompanyValueGraph()
 /*****************/
 
 struct PaymentRatesGraphWindow : BaseGraphWindow {
-	uint line_height = 0; ///< Pixel height of each cargo type row.
+	int line_height = 0; ///< Pixel height of each cargo type row.
 	Scrollbar *vscroll = nullptr; ///< Cargo list scrollbar.
-	uint legend_width = 0; ///< Width of legend 'blob'.
+	int legend_width = 0; ///< Width of legend 'blob'.
 
 	PaymentRatesGraphWindow(WindowDesc &desc, WindowNumber window_number) :
 			BaseGraphWindow(desc, STR_JUST_CURRENCY_SHORT)
@@ -1294,14 +1294,14 @@ void ShowCargoPaymentRates()
 struct PerformanceRatingDetailWindow : Window {
 	static CompanyID company;
 	int timeout = 0;
-	uint score_info_left = 0;
-	uint score_info_right = 0;
-	uint bar_left = 0;
-	uint bar_right = 0;
-	uint bar_width = 0;
-	uint bar_height = 0;
-	uint score_detail_left = 0;
-	uint score_detail_right = 0;
+	int score_info_left = 0;
+	int score_info_right = 0;
+	int bar_left = 0;
+	int bar_right = 0;
+	int bar_width = 0;
+	int bar_height = 0;
+	int score_detail_left = 0;
+	int score_detail_right = 0;
 
 	PerformanceRatingDetailWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
@@ -1329,7 +1329,7 @@ struct PerformanceRatingDetailWindow : Window {
 				this->bar_height = GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.fullbevel.Vertical();
 				size.height = this->bar_height + WidgetDimensions::scaled.matrix.Vertical();
 
-				uint score_info_width = 0;
+				int score_info_width = 0;
 				for (uint i = SCORE_BEGIN; i < SCORE_END; i++) {
 					score_info_width = std::max(score_info_width, GetStringBoundingBox(STR_PERFORMANCE_DETAIL_VEHICLES + i).width);
 				}
@@ -1357,11 +1357,11 @@ struct PerformanceRatingDetailWindow : Window {
 				 * exchange rate is that high, 999 999 k is usually not enough anymore
 				 * to show the different currency numbers. */
 				if (GetCurrency().rate < 1000) max /= GetCurrency().rate;
-				uint score_detail_width = GetStringBoundingBox(GetString(STR_PERFORMANCE_DETAIL_AMOUNT_CURRENCY, max, max)).width;
+				int score_detail_width = GetStringBoundingBox(GetString(STR_PERFORMANCE_DETAIL_AMOUNT_CURRENCY, max, max)).width;
 
 				size.width = WidgetDimensions::scaled.frametext.Horizontal() + score_info_width + WidgetDimensions::scaled.hsep_wide + this->bar_width + WidgetDimensions::scaled.hsep_wide + score_detail_width;
-				uint left  = WidgetDimensions::scaled.frametext.left;
-				uint right = size.width - WidgetDimensions::scaled.frametext.right;
+				int left  = WidgetDimensions::scaled.frametext.left;
+				int right = size.width - WidgetDimensions::scaled.frametext.right;
 
 				bool rtl = _current_text_dir == TD_RTL;
 				this->score_info_left  = rtl ? right - score_info_width : left;
@@ -1408,8 +1408,8 @@ struct PerformanceRatingDetailWindow : Window {
 			needed = SCORE_MAX;
 		}
 
-		uint bar_top  = CentreBounds(r.top, r.bottom, this->bar_height);
-		uint text_top = CentreBounds(r.top, r.bottom, GetCharacterHeight(FS_NORMAL));
+		int bar_top  = CentreBounds(r.top, r.bottom, this->bar_height);
+		int text_top = CentreBounds(r.top, r.bottom, GetCharacterHeight(FS_NORMAL));
 
 		DrawString(this->score_info_left, this->score_info_right, text_top, STR_PERFORMANCE_DETAIL_VEHICLES + score_type);
 
@@ -1417,7 +1417,7 @@ struct PerformanceRatingDetailWindow : Window {
 		DrawString(this->score_info_left, this->score_info_right, text_top, GetString(STR_JUST_COMMA, score), TC_BLACK, SA_RIGHT);
 
 		/* Calculate the %-bar */
-		uint x = Clamp<int64_t>(val, 0, needed) * this->bar_width / needed;
+		int x = Clamp<int64_t>(val, 0, needed) * this->bar_width / needed;
 		bool rtl = _current_text_dir == TD_RTL;
 		if (rtl) {
 			x = this->bar_right - x;
@@ -1515,9 +1515,9 @@ CompanyID PerformanceRatingDetailWindow::company = CompanyID::Invalid();
 /*******************************/
 
 struct IndustryProductionGraphWindow : BaseGraphWindow {
-	uint line_height = 0; ///< Pixel height of each cargo type row.
+	int line_height = 0; ///< Pixel height of each cargo type row.
 	Scrollbar *vscroll = nullptr; ///< Cargo list scrollbar.
-	uint legend_width = 0;  ///< Width of legend 'blob'.
+	int legend_width = 0;  ///< Width of legend 'blob'.
 
 	static inline constexpr StringID RANGE_LABELS[] = {
 		STR_GRAPH_INDUSTRY_RANGE_PRODUCED,

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -205,7 +205,7 @@ private:
 	GroupID group_over = GroupID::Invalid(); ///< Group over which a vehicle is dragged, GroupID::Invalid() if none
 	GroupID group_confirm = GroupID::Invalid(); ///< Group awaiting delete confirmation
 	GUIGroupList groups{}; ///< List of groups
-	uint tiny_step_height = 0; ///< Step height for the group list
+	int tiny_step_height = 0; ///< Step height for the group list
 	Scrollbar *group_sb = nullptr;
 
 	std::array<Dimension, VGC_END> column_size{}; ///< Size of the columns in the group list.
@@ -237,7 +237,7 @@ private:
 		this->tiny_step_height = this->column_size[VGC_FOLD].height;
 
 		this->column_size[VGC_NAME] = maxdim(GetStringBoundingBox(STR_GROUP_DEFAULT_TRAINS + this->vli.vtype), GetStringBoundingBox(STR_GROUP_ALL_TRAINS + this->vli.vtype));
-		this->column_size[VGC_NAME].width = std::max(170u, this->column_size[VGC_NAME].width) + WidgetDimensions::scaled.hsep_indent;
+		this->column_size[VGC_NAME].width = std::max(170, this->column_size[VGC_NAME].width) + WidgetDimensions::scaled.hsep_indent;
 		this->tiny_step_height = std::max(this->tiny_step_height, this->column_size[VGC_NAME].height);
 
 		this->column_size[VGC_PROTECT] = GetSpriteSize(SPR_GROUP_REPLACE_PROTECT);
@@ -296,7 +296,7 @@ private:
 		const GroupStatistics &stats = GroupStatistics::Get(this->vli.company, g_id, this->vli.vtype);
 		bool rtl = _current_text_dir == TD_RTL;
 
-		const int offset = (rtl ? -(int)this->column_size[VGC_FOLD].width : (int)this->column_size[VGC_FOLD].width) / 2;
+		const int offset = (rtl ? -this->column_size[VGC_FOLD].width : this->column_size[VGC_FOLD].width) / 2;
 		const int level_width = rtl ? -WidgetDimensions::scaled.hsep_indent : WidgetDimensions::scaled.hsep_indent;
 		const int linecolour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
 
@@ -639,7 +639,7 @@ public:
 
 					y1 += this->tiny_step_height;
 				}
-				if ((uint)this->group_sb->GetPosition() + this->group_sb->GetCapacity() > this->groups.size()) {
+				if (static_cast<size_t>(this->group_sb->GetPosition() + this->group_sb->GetCapacity()) > this->groups.size()) {
 					DrawGroupInfo(y1, r.left, r.right, NEW_GROUP);
 				}
 				break;
@@ -731,7 +731,7 @@ public:
 					int x = _current_text_dir == TD_RTL ?
 							group_display->pos_x + group_display->current_x - WidgetDimensions::scaled.framerect.right - it->indent * WidgetDimensions::scaled.hsep_indent - this->column_size[VGC_FOLD].width :
 							group_display->pos_x + WidgetDimensions::scaled.framerect.left + it->indent * WidgetDimensions::scaled.hsep_indent;
-					if (click_count > 1 || (pt.x >= x && pt.x < (int)(x + this->column_size[VGC_FOLD].width))) {
+					if (click_count > 1 || (pt.x >= x && pt.x < x + this->column_size[VGC_FOLD].width)) {
 
 						GroupID g = this->vli.ToGroupID();
 						if (!IsAllGroupID(g) && !IsDefaultGroupID(g)) {

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -430,7 +430,7 @@ public:
 				for (const auto &indtype : this->list) {
 					d = maxdim(d, GetStringBoundingBox(GetIndustrySpec(indtype)->name));
 				}
-				resize.height = std::max<uint>({this->legend.height, d.height, count.height}) + padding.height;
+				resize.height = std::max({this->legend.height, d.height, count.height}) + padding.height;
 				d.width += this->badge_classes.GetTotalColumnsWidth() + this->legend.width + WidgetDimensions::scaled.hsep_wide + WidgetDimensions::scaled.hsep_normal + count.width + padding.width;
 				d.height = 5 * resize.height;
 				size = maxdim(size, d);
@@ -440,10 +440,10 @@ public:
 			case WID_DPI_INFOPANEL: {
 				/* Extra line for cost outside of editor. */
 				int height = 2 + (_game_mode == GM_EDITOR ? 0 : 1);
-				uint extra_lines_req = 0;
-				uint extra_lines_prd = 0;
-				uint extra_lines_newgrf = 0;
-				uint max_minwidth = GetCharacterHeight(FS_NORMAL) * MAX_MINWIDTH_LINEHEIGHTS;
+				int extra_lines_req = 0;
+				int extra_lines_prd = 0;
+				int extra_lines_newgrf = 0;
+				int max_minwidth = GetCharacterHeight(FS_NORMAL) * MAX_MINWIDTH_LINEHEIGHTS;
 				Dimension d = {0, 0};
 				for (const auto &indtype : this->list) {
 					const IndustrySpec *indsp = GetIndustrySpec(indtype);
@@ -1421,9 +1421,9 @@ protected:
 	 * Get the width needed to draw the longest industry line.
 	 * @return Returns width of the longest industry line, including padding.
 	 */
-	uint GetIndustryListWidth() const
+	int GetIndustryListWidth() const
 	{
-		uint width = this->hscroll->GetCount();
+		int width = this->hscroll->GetCount();
 		auto [first, last] = this->vscroll->GetVisibleRangeIterators(this->industries);
 		for (auto it = first; it != last; ++it) {
 			width = std::max(width, GetStringBoundingBox(this->GetIndustryString(*it)).width);
@@ -2309,7 +2309,7 @@ struct CargoesField {
 		uint col;
 		for (col = 0; col < this->u.cargo.num_cargoes; col++) {
 			if (pt.x < cpos) break;
-			if (pt.x < cpos + (int)CargoesField::cargo_line.width) return this->u.cargo.vertical_cargoes[col];
+			if (pt.x < cpos + CargoesField::cargo_line.width) return this->u.cargo.vertical_cargoes[col];
 			cpos += CargoesField::cargo_line.width + CargoesField::cargo_space.width;
 		}
 		/* col = 0 -> left of first col, 1 -> left of 2nd col, ... this->u.cargo.num_cargoes right of last-col. */
@@ -2623,7 +2623,7 @@ struct IndustryCargoesWindow : public Window {
 
 		d.width += WidgetDimensions::scaled.frametext.Horizontal();
 		/* Ensure the height is enough for the industry type text, for the horizontal connections, and for the cargo labels. */
-		uint min_ind_height = CargoesField::cargo_border.height * 2 + CargoesField::max_cargoes * GetCharacterHeight(FS_NORMAL) + (CargoesField::max_cargoes - 1) * CargoesField::cargo_space.height;
+		int min_ind_height = CargoesField::cargo_border.height * 2 + CargoesField::max_cargoes * GetCharacterHeight(FS_NORMAL) + (CargoesField::max_cargoes - 1) * CargoesField::cargo_space.height;
 		d.height = std::max(d.height + WidgetDimensions::scaled.frametext.Vertical(), min_ind_height);
 
 		CargoesField::industry_width = d.width;

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -57,8 +57,8 @@ static inline StringID GetPerformanceTitleFromValue(uint value)
 class PerformanceLeagueWindow : public Window {
 private:
 	GUIList<const Company *> companies{};
-	uint ordinal_width = 0; ///< The width of the ordinal number
-	uint text_width = 0; ///< The width of the actual text
+	int ordinal_width = 0; ///< The width of the ordinal number
+	int text_width = 0; ///< The width of the actual text
 	int line_height = 0; ///< Height of the text lines
 	Dimension icon{}; ///< Dimension of the company icon.
 
@@ -111,7 +111,7 @@ public:
 
 		bool rtl = _current_text_dir == TD_RTL;
 		Rect ordinal = ir.WithWidth(this->ordinal_width, rtl);
-		uint icon_left = ir.Indent(rtl ? this->text_width : this->ordinal_width, rtl).left;
+		int icon_left = ir.Indent(rtl ? this->text_width : this->ordinal_width, rtl).left;
 		Rect text    = ir.WithWidth(this->text_width, !rtl);
 
 		for (uint i = 0; i != this->companies.size(); i++) {
@@ -135,10 +135,10 @@ public:
 		}
 		this->ordinal_width += WidgetDimensions::scaled.hsep_wide; // Keep some extra spacing
 
-		uint widest_width = 0;
+		int widest_width = 0;
 		StringID widest_title = STR_NULL;
 		for (auto title : _performance_titles) {
-			uint width = GetStringBoundingBox(title).width;
+			int width = GetStringBoundingBox(title).width;
 			if (width > widest_width) {
 				widest_title = title;
 				widest_width = width;
@@ -146,7 +146,7 @@ public:
 		}
 
 		this->icon = GetSpriteSize(SPR_COMPANY_ICON);
-		this->line_height = std::max<int>(this->icon.height + WidgetDimensions::scaled.vsep_normal, GetCharacterHeight(FS_NORMAL));
+		this->line_height = std::max(this->icon.height + WidgetDimensions::scaled.vsep_normal, GetCharacterHeight(FS_NORMAL));
 
 		for (const Company *c : Company::Iterate()) {
 			widest_width = std::max(widest_width, GetStringBoundingBox(GetString(STR_COMPANY_LEAGUE_COMPANY_NAME, c->index, c->index, widest_title)).width);
@@ -251,10 +251,10 @@ class ScriptLeagueWindow : public Window {
 private:
 	LeagueTableID table{};
 	std::vector<std::pair<uint, const LeagueTableElement *>> rows{};
-	uint rank_width = 0; ///< The width of the rank ordinal
-	uint text_width = 0; ///< The width of the actual text
-	uint score_width = 0; ///< The width of the score text
-	uint header_height = 0; ///< Height of the table header
+	int rank_width = 0; ///< The width of the rank ordinal
+	int text_width = 0; ///< The width of the actual text
+	int score_width = 0; ///< The width of the score text
+	int header_height = 0; ///< Height of the table header
 	int line_height = 0; ///< Height of the text lines
 	Dimension icon_size{}; ///< Dimension of the company icon.
 	EncodedString title{};
@@ -372,9 +372,9 @@ public:
 			this->icon_size.width += WidgetDimensions::scaled.hsep_wide;
 		}
 
-		uint non_text_width = this->rank_width + this->icon_size.width + this->score_width + WidgetDimensions::scaled.framerect.Horizontal() + WidgetDimensions::scaled.hsep_wide * 2;
+		int non_text_width = this->rank_width + this->icon_size.width + this->score_width + WidgetDimensions::scaled.framerect.Horizontal() + WidgetDimensions::scaled.hsep_wide * 2;
 		size.width = std::max(size.width, non_text_width + this->text_width);
-		uint used_height = this->line_height * std::max<uint>(3u, static_cast<uint>(this->rows.size())) + WidgetDimensions::scaled.framerect.Vertical();
+		int used_height = this->line_height * std::max(3, static_cast<int>(this->rows.size())) + WidgetDimensions::scaled.framerect.Vertical();
 
 		/* Adjust text_width to fill any space left over if the preset minimal width is larger than our calculated width. */
 		this->text_width = size.width - non_text_width;

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -92,15 +92,15 @@ public:
 
 		size.height = WidgetDimensions::scaled.frametext.Vertical();
 		for (size_t i = 0; i < this->landinfo_data.size(); i++) {
-			uint width = GetStringBoundingBox(this->landinfo_data[i]).width + WidgetDimensions::scaled.frametext.Horizontal();
+			int width = GetStringBoundingBox(this->landinfo_data[i]).width + WidgetDimensions::scaled.frametext.Horizontal();
 			size.width = std::max(size.width, width);
 
 			size.height += GetCharacterHeight(FS_NORMAL) + (i == 0 ? WidgetDimensions::scaled.vsep_wide : WidgetDimensions::scaled.vsep_normal);
 		}
 
 		if (!this->cargo_acceptance.empty()) {
-			uint width = GetStringBoundingBox(this->cargo_acceptance).width + WidgetDimensions::scaled.frametext.Horizontal();
-			size.width = std::max(size.width, std::min(static_cast<uint>(ScaleGUITrad(300)), width));
+			int width = GetStringBoundingBox(this->cargo_acceptance).width + WidgetDimensions::scaled.frametext.Horizontal();
+			size.width = std::max(size.width, std::min(ScaleGUITrad(300), width));
 			size.height += GetStringHeight(GetString(STR_JUST_RAW_STRING, this->cargo_acceptance), size.width - WidgetDimensions::scaled.frametext.Horizontal());
 		}
 	}
@@ -638,7 +638,7 @@ struct TooltipsWindow : public Window
 		if (widget != WID_TT_BACKGROUND) return;
 
 		auto str = this->text.GetDecodedString();
-		size.width  = std::min<uint>(GetStringBoundingBox(str).width, ScaleGUITrad(194));
+		size.width  = std::min(GetStringBoundingBox(str).width, ScaleGUITrad(194));
 		size.height = GetStringHeight(str, size.width);
 
 		/* Increase slightly to have some space around the box. */

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -32,7 +32,7 @@
 #include "../safeguards.h"
 
 /** Spacing between chat lines. */
-static const uint NETWORK_CHAT_LINE_SPACING = 3;
+static const int NETWORK_CHAT_LINE_SPACING = 3;
 
 /** Container for a message. */
 struct ChatMessage {
@@ -45,7 +45,7 @@ struct ChatMessage {
 static std::deque<ChatMessage> _chatmsg_list; ///< The actual chat message list.
 static bool _chatmessage_dirty = false;   ///< Does the chat message need repainting?
 static bool _chatmessage_visible = false; ///< Is a chat message visible.
-static uint MAX_CHAT_MESSAGES = 0;        ///< The limit of chat messages to show.
+static int MAX_CHAT_MESSAGES = 0;        ///< The limit of chat messages to show.
 
 /**
  * Time the chat history was marked dirty. This is used to determine if expired
@@ -85,7 +85,7 @@ static inline bool HaveChatMessages(bool show_all)
  */
 void CDECL NetworkAddChatMessage(TextColour colour, uint duration, const std::string &message)
 {
-	if (_chatmsg_list.size() == MAX_CHAT_MESSAGES) {
+	if (_chatmsg_list.size() == static_cast<size_t>(MAX_CHAT_MESSAGES)) {
 		_chatmsg_list.pop_back();
 	}
 
@@ -220,7 +220,7 @@ void NetworkDrawChatMessage()
 		string_height += GetStringLineCount(GetString(STR_JUST_RAW_STRING, cmsg.message), width - 1) * GetCharacterHeight(FS_NORMAL) + NETWORK_CHAT_LINE_SPACING;
 	}
 
-	string_height = std::min<uint>(string_height, MAX_CHAT_MESSAGES * (GetCharacterHeight(FS_NORMAL) + NETWORK_CHAT_LINE_SPACING));
+	string_height = std::min(string_height, MAX_CHAT_MESSAGES * (GetCharacterHeight(FS_NORMAL) + NETWORK_CHAT_LINE_SPACING));
 
 	int top = _screen.height - _chatmsg_box.y - string_height - 2;
 	int bottom = _screen.height - _chatmsg_box.y - 2;

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -596,7 +596,7 @@ public:
 			}
 
 			case WID_NCL_MATRIX:
-				resize.height = std::max(this->checkbox_size.height, (uint)GetCharacterHeight(FS_NORMAL)) + padding.height;
+				resize.height = std::max(this->checkbox_size.height, GetCharacterHeight(FS_NORMAL)) + padding.height;
 				size.height = 10 * resize.height;
 				break;
 		}
@@ -644,7 +644,7 @@ public:
 		const Rect type = this->GetWidget<NWidgetBase>(WID_NCL_TYPE)->GetCurrentRect().Shrink(WidgetDimensions::scaled.framerect);
 
 		/* Fill the matrix with the information */
-		const uint step_height = this->GetWidget<NWidgetBase>(WID_NCL_MATRIX)->resize_y;
+		const int step_height = this->GetWidget<NWidgetBase>(WID_NCL_MATRIX)->resize_y;
 		const int text_y_offset = WidgetDimensions::scaled.matrix.top + (step_height - WidgetDimensions::scaled.matrix.Vertical() - GetCharacterHeight(FS_NORMAL)) / 2;
 
 		Rect mr = r.WithHeight(step_height);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -84,7 +84,7 @@ static const ServerListPosition SLP_INVALID = -1;
 
 /** Full blown container to make it behave exactly as we want :) */
 class NWidgetServerListHeader : public NWidgetContainer {
-	static const uint MINIMUM_NAME_WIDTH_BEFORE_NEW_HEADER = 150; ///< Minimum width before adding a new header
+	static constexpr int MINIMUM_NAME_WIDTH_BEFORE_NEW_HEADER = 150; ///< Minimum width before adding a new header
 public:
 	NWidgetServerListHeader() : NWidgetContainer(NWID_HORIZONTAL)
 	{
@@ -127,7 +127,7 @@ public:
 		this->ApplyAspectRatio();
 	}
 
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override
 	{
 		assert(given_width >= this->smallest_x && given_height >= this->smallest_y);
 
@@ -156,7 +156,7 @@ public:
 		this->children.front()->current_x = given_width;
 
 		/* Now assign the widgets to their rightful place */
-		uint position = 0; // Place to put next child relative to origin of the container.
+		int position = 0; // Place to put next child relative to origin of the container.
 		auto assign_position = [&](const std::unique_ptr<NWidgetBase> &child_wid) {
 			if (child_wid->current_x != 0) {
 				child_wid->AssignSizePosition(sizing, x + position, y, child_wid->current_x, this->current_y, rtl);
@@ -355,7 +355,7 @@ protected:
 
 		/* show highlighted item with a different colour */
 		if (highlight) {
-			Rect r = {std::min(name.left, info.left), y, std::max(name.right, info.right), y + (int)this->resize.step_height - 1};
+			Rect r = {std::min(name.left, info.left), y, std::max(name.right, info.right), y + this->resize.step_height - 1};
 			GfxFillRect(r.Shrink(WidgetDimensions::scaled.bevel), PC_GREY);
 		}
 
@@ -475,13 +475,13 @@ public:
 	{
 		switch (widget) {
 			case WID_NG_MATRIX:
-				resize.height = std::max(GetSpriteSize(SPR_BLOT).height, (uint)GetCharacterHeight(FS_NORMAL)) + padding.height;
+				resize.height = std::max(GetSpriteSize(SPR_BLOT).height, GetCharacterHeight(FS_NORMAL)) + padding.height;
 				fill.height = resize.height;
 				size.height = 12 * resize.height;
 				break;
 
 			case WID_NG_LASTJOINED:
-				size.height = std::max(GetSpriteSize(SPR_BLOT).height, (uint)GetCharacterHeight(FS_NORMAL)) + WidgetDimensions::scaled.matrix.Vertical();
+				size.height = std::max(GetSpriteSize(SPR_BLOT).height, GetCharacterHeight(FS_NORMAL)) + WidgetDimensions::scaled.matrix.Vertical();
 				break;
 
 			case WID_NG_LASTJOINED_SPACER:
@@ -1334,8 +1334,8 @@ public:
 	StringID tooltip;  ///< The tooltip of the button.
 	Colours colour;    ///< The colour of the button.
 	bool disabled;     ///< Is the button disabled?
-	uint height;       ///< Calculated height of the button.
-	uint width;        ///< Calculated width of the button.
+	int height;       ///< Calculated height of the button.
+	int width;        ///< Calculated width of the button.
 
 	ButtonCommon(SpriteID sprite, StringID tooltip, Colours colour, bool disabled = false) :
 		sprite(sprite),
@@ -1396,13 +1396,13 @@ private:
 	CompanyID dd_company_id = CompanyID::Invalid(); ///< During admin dropdown, track which company this was for.
 
 	Scrollbar *vscroll = nullptr; ///< Vertical scrollbar of this window.
-	uint line_height = 0; ///< Current lineheight of each entry in the matrix.
-	uint line_count = 0; ///< Amount of lines in the matrix.
+	int line_height = 0; ///< Current lineheight of each entry in the matrix.
+	int line_count = 0; ///< Amount of lines in the matrix.
 	int hover_index = -1; ///< Index of the current line we are hovering over, or -1 if none.
 	int player_self_index = -1; ///< The line the current player is on.
 	int player_host_index = -1; ///< The line the host is on.
 
-	std::map<uint, std::vector<std::unique_ptr<ButtonCommon>>> buttons{}; ///< Per line which buttons are available.
+	std::map<int, std::vector<std::unique_ptr<ButtonCommon>>> buttons{}; ///< Per line which buttons are available.
 
 	/**
 	 * Chat button on a Company is clicked.
@@ -1581,11 +1581,11 @@ private:
 	 */
 	ButtonCommon *GetButtonAtPoint(Point pt)
 	{
-		uint index = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_CL_MATRIX);
+		int index = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_CL_MATRIX);
 		Rect matrix = this->GetWidget<NWidgetBase>(WID_CL_MATRIX)->GetCurrentRect().Shrink(WidgetDimensions::scaled.framerect);
 
 		bool rtl = _current_text_dir == TD_RTL;
-		uint x = rtl ? matrix.left : matrix.right;
+		int x = rtl ? matrix.left : matrix.right;
 
 		/* Find the buttons for this row. */
 		auto button_find = this->buttons.find(index);
@@ -1593,8 +1593,8 @@ private:
 
 		/* Check if we want to display a tooltip for any of the buttons. */
 		for (auto &button : button_find->second) {
-			uint left = rtl ? x : x - button->width;
-			uint right = rtl ? x + button->width : x;
+			int left = rtl ? x : x - button->width;
+			int right = rtl ? x + button->width : x;
 
 			if (IsInsideMM(pt.x, left, right)) {
 				return button.get();
@@ -1643,7 +1643,7 @@ public:
 					str = GetString(STR_JUST_RAW_STRING, own_ci != nullptr ? own_ci->client_name : _settings_client.network.client_name);
 				}
 				size = GetStringBoundingBox(str);
-				size.width = std::min(size.width, static_cast<uint>(ScaleGUITrad(200))); // By default, don't open the window too wide.
+				size.width = std::min(size.width, ScaleGUITrad(200)); // By default, don't open the window too wide.
 				break;
 			}
 
@@ -1654,9 +1654,9 @@ public:
 				break;
 
 			case WID_CL_MATRIX: {
-				uint height = std::max({GetSpriteSize(SPR_COMPANY_ICON).height, GetSpriteSize(SPR_JOIN).height, GetSpriteSize(SPR_ADMIN).height, GetSpriteSize(SPR_CHAT).height});
+				int height = std::max({GetSpriteSize(SPR_COMPANY_ICON).height, GetSpriteSize(SPR_JOIN).height, GetSpriteSize(SPR_ADMIN).height, GetSpriteSize(SPR_CHAT).height});
 				height += WidgetDimensions::scaled.framerect.Vertical();
-				this->line_height = std::max(height, (uint)GetCharacterHeight(FS_NORMAL)) + padding.height;
+				this->line_height = std::max(height, GetCharacterHeight(FS_NORMAL)) + padding.height;
 
 				resize.width = 1;
 				resize.height = this->line_height;
@@ -1742,13 +1742,13 @@ public:
 				Rect matrix = this->GetWidget<NWidgetBase>(WID_CL_MATRIX)->GetCurrentRect().Shrink(WidgetDimensions::scaled.framerect);
 
 				Dimension d = GetSpriteSize(SPR_COMPANY_ICON);
-				uint text_left  = matrix.left  + (rtl ? 0 : d.width + WidgetDimensions::scaled.hsep_wide);
-				uint text_right = matrix.right - (rtl ? d.width + WidgetDimensions::scaled.hsep_wide : 0);
+				int text_left  = matrix.left  + (rtl ? 0 : d.width + WidgetDimensions::scaled.hsep_wide);
+				int text_right = matrix.right - (rtl ? d.width + WidgetDimensions::scaled.hsep_wide : 0);
 
 				Dimension d2 = GetSpriteSize(SPR_PLAYER_SELF);
-				uint offset_x = WidgetDimensions::scaled.hsep_indent - d2.width - ScaleGUITrad(3);
+				int offset_x = WidgetDimensions::scaled.hsep_indent - d2.width - ScaleGUITrad(3);
 
-				uint player_icon_x = rtl ? text_right - offset_x - d2.width : text_left + offset_x;
+				int player_icon_x = rtl ? text_right - offset_x - d2.width : text_left + offset_x;
 
 				if (IsInsideMM(pt.x, player_icon_x, player_icon_x + d2.width)) {
 					if (index == this->player_self_index) {
@@ -1867,7 +1867,7 @@ public:
 	 * @param y The y-position to start with the buttons.
 	 * @param buttons The buttons to draw.
 	 */
-	void DrawButtons(int &x, uint y, const std::vector<std::unique_ptr<ButtonCommon>> &buttons) const
+	void DrawButtons(int &x, int y, const std::vector<std::unique_ptr<ButtonCommon>> &buttons) const
 	{
 		Rect r;
 
@@ -1897,7 +1897,7 @@ public:
 	 * @param r The rect to draw within.
 	 * @param line The Nth line we are drawing. Updated during this function.
 	 */
-	void DrawCompany(CompanyID company_id, const Rect &r, uint &line) const
+	void DrawCompany(CompanyID company_id, const Rect &r, int &line) const
 	{
 		bool rtl = _current_text_dir == TD_RTL;
 		int text_y_offset = CentreBounds(0, this->line_height, GetCharacterHeight(FS_NORMAL));
@@ -1905,10 +1905,10 @@ public:
 		Dimension d = GetSpriteSize(SPR_COMPANY_ICON);
 		int offset = CentreBounds(0, this->line_height, d.height);
 
-		uint line_start = this->vscroll->GetPosition();
-		uint line_end = line_start + this->vscroll->GetCapacity();
+		int line_start = this->vscroll->GetPosition();
+		int line_end = line_start + this->vscroll->GetCapacity();
 
-		uint y = r.top + (this->line_height * (line - line_start));
+		int y = r.top + (this->line_height * (line - line_start));
 
 		/* Draw the company line (if in range of scrollbar). */
 		if (IsInsideMM(line, line_start, line_end)) {
@@ -1979,7 +1979,7 @@ public:
 		switch (widget) {
 			case WID_CL_MATRIX: {
 				Rect ir = r.Shrink(WidgetDimensions::scaled.framerect, RectPadding::zero);
-				uint line = 0;
+				int line = 0;
 
 				if (this->hover_index >= 0) {
 					Rect br = r.WithHeight(this->line_height).Translate(0, this->hover_index * this->line_height);

--- a/src/newgrf_badge_gui.cpp
+++ b/src/newgrf_badge_gui.cpp
@@ -25,8 +25,8 @@
 
 #include "safeguards.h"
 
-static constexpr uint MAX_BADGE_HEIGHT = 12; ///< Maximal height of a badge sprite.
-static constexpr uint MAX_BADGE_WIDTH = MAX_BADGE_HEIGHT * 2; ///< Maximal width.
+static constexpr int MAX_BADGE_HEIGHT = 12; ///< Maximal height of a badge sprite.
+static constexpr int MAX_BADGE_WIDTH = MAX_BADGE_HEIGHT * 2; ///< Maximal width.
 
 /**
  * Get the largest badge size (within limits) for a badge class.
@@ -94,7 +94,7 @@ GUIBadgeClasses::GUIBadgeClasses(GrfSpecFeature feature)
 	}
 
 	/* Replace trailing `hsep_normal` spacer with wider `hsep_wide` spacer. */
-	for (uint &badge_width : this->column_widths) {
+	for (int &badge_width : this->column_widths) {
 		if (badge_width == 0) continue;
 		badge_width = badge_width - WidgetDimensions::scaled.hsep_normal + WidgetDimensions::scaled.hsep_wide;
 	}
@@ -104,9 +104,9 @@ GUIBadgeClasses::GUIBadgeClasses(GrfSpecFeature feature)
  * Get total width of all columns.
  * @returns sum of all column widths.
  */
-uint GUIBadgeClasses::GetTotalColumnsWidth() const
+int GUIBadgeClasses::GetTotalColumnsWidth() const
 {
-	return std::accumulate(std::begin(this->column_widths), std::end(this->column_widths), 0U);
+	return std::accumulate(std::begin(this->column_widths), std::end(this->column_widths), 0);
 }
 
 /**
@@ -198,12 +198,12 @@ public:
 		}
 	}
 
-	uint Height() const override
+	int Height() const override
 	{
-		return std::max<uint>(this->dim.height, this->TBase::Height());
+		return std::max(this->dim.height, this->TBase::Height());
 	}
 
-	uint Width() const override
+	int Width() const override
 	{
 		return this->dim.width + WidgetDimensions::scaled.hsep_wide + this->TBase::Width();
 	}

--- a/src/newgrf_badge_gui.h
+++ b/src/newgrf_badge_gui.h
@@ -34,16 +34,16 @@ public:
 		return this->gui_classes;
 	}
 
-	inline std::span<const uint> GetColumnWidths() const
+	inline std::span<const int> GetColumnWidths() const
 	{
 		return this->column_widths;
 	}
 
-	uint GetTotalColumnsWidth() const;
+	int GetTotalColumnsWidth() const;
 
 private:
 	std::vector<Element> gui_classes{};
-	std::vector<uint> column_widths{};
+	std::vector<int> column_widths{};
 };
 
 int DrawBadgeNameList(Rect r, std::span<const BadgeID> badges, GrfSpecFeature feature);

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -70,9 +70,9 @@ struct VehicleResolverObject : public ResolverObject {
 	uint32_t GetDebugID() const override;
 };
 
-static const uint TRAININFO_DEFAULT_VEHICLE_WIDTH   = 29;
-static const uint ROADVEHINFO_DEFAULT_VEHICLE_WIDTH = 32;
-static const uint VEHICLEINFO_FULL_VEHICLE_WIDTH    = 32;
+static constexpr int TRAININFO_DEFAULT_VEHICLE_WIDTH   = 29;
+static constexpr int ROADVEHINFO_DEFAULT_VEHICLE_WIDTH = 32;
+static constexpr int VEHICLEINFO_FULL_VEHICLE_WIDTH    = 32;
 
 struct VehicleSpriteSeq;
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -229,7 +229,7 @@ struct NewGRFParametersWindow : public Window {
 
 			case WID_NP_DESCRIPTION:
 				/* Minimum size of 4 lines. The 500 is the default size of the window. */
-				Dimension suggestion = {500U - WidgetDimensions::scaled.frametext.Horizontal(), (uint)GetCharacterHeight(FS_NORMAL) * 4 + WidgetDimensions::scaled.frametext.Vertical()};
+				Dimension suggestion = {500 - WidgetDimensions::scaled.frametext.Horizontal(), GetCharacterHeight(FS_NORMAL) * 4 + WidgetDimensions::scaled.frametext.Vertical()};
 				for (const auto &par_info : this->grf_config.param_info) {
 					if (!par_info.has_value()) continue;
 					auto desc = GetGRFStringFromGRFText(par_info->desc);
@@ -290,7 +290,7 @@ struct NewGRFParametersWindow : public Window {
 
 		Rect ir = r.Shrink(WidgetDimensions::scaled.frametext, RectPadding::zero);
 		bool rtl = _current_text_dir == TD_RTL;
-		uint buttons_left = rtl ? ir.right - SETTING_BUTTON_WIDTH : ir.left;
+		int buttons_left = rtl ? ir.right - SETTING_BUTTON_WIDTH : ir.left;
 		Rect tr = ir.Indent(SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide, rtl);
 
 		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
@@ -733,7 +733,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 			case WID_NS_FILE_LIST:
 			{
 				Dimension d = maxdim(GetScaledSpriteSize(SPR_SQUARE), GetScaledSpriteSize(SPR_WARNING_SIGN));
-				resize.height = std::max<uint>(d.height + 2U, GetCharacterHeight(FS_NORMAL));
+				resize.height = std::max(d.height + 2, GetCharacterHeight(FS_NORMAL));
 				size.height = std::max(size.height, padding.height + 6 * resize.height);
 				break;
 			}
@@ -741,7 +741,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 			case WID_NS_AVAIL_LIST:
 			{
 				Dimension d = maxdim(GetScaledSpriteSize(SPR_SQUARE), GetScaledSpriteSize(SPR_WARNING_SIGN));
-				resize.height = std::max<uint>(d.height + 2U, GetCharacterHeight(FS_NORMAL));
+				resize.height = std::max(d.height + 2, GetCharacterHeight(FS_NORMAL));
 				size.height = std::max(size.height, padding.height + 8 * resize.height);
 				break;
 			}
@@ -754,7 +754,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 			}
 
 			case WID_NS_NEWGRF_INFO:
-				size.height = std::max<uint>(size.height, WidgetDimensions::scaled.framerect.Vertical() + 10 * GetCharacterHeight(FS_NORMAL));
+				size.height = std::max(size.height, WidgetDimensions::scaled.framerect.Vertical() + 10 * GetCharacterHeight(FS_NORMAL));
 				break;
 
 			case WID_NS_PRESET_LIST: {
@@ -840,7 +840,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				GfxFillRect(br, PC_BLACK);
 
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
-				uint step_height = this->GetWidget<NWidgetBase>(WID_NS_FILE_LIST)->resize_y;
+				int step_height = this->GetWidget<NWidgetBase>(WID_NS_FILE_LIST)->resize_y;
 				Dimension square = GetSpriteSize(SPR_SQUARE);
 				Dimension warning = GetSpriteSize(SPR_WARNING_SIGN);
 				int square_offset_y = (step_height - square.height) / 2;
@@ -848,10 +848,10 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				int offset_y = (step_height - GetCharacterHeight(FS_NORMAL)) / 2;
 
 				bool rtl = _current_text_dir == TD_RTL;
-				uint text_left    = rtl ? tr.left : tr.left + square.width + 13;
-				uint text_right   = rtl ? tr.right - square.width - 13 : tr.right;
-				uint square_left  = rtl ? tr.right - square.width - 3 : tr.left + 3;
-				uint warning_left = rtl ? tr.right - square.width - warning.width - 8 : tr.left + square.width + 8;
+				int text_left    = rtl ? tr.left : tr.left + square.width + 13;
+				int text_right   = rtl ? tr.right - square.width - 13 : tr.right;
+				int square_left  = rtl ? tr.right - square.width - 3 : tr.left + 3;
+				int warning_left = rtl ? tr.right - square.width - warning.width - 8 : tr.left + square.width + 8;
 
 				int i = 0;
 				for (const auto &c : this->actives) {
@@ -866,13 +866,13 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 							/* Get index of current selection. */
 							int active_sel_pos = this->GetCurrentActivePosition();
 							if (active_sel_pos != this->active_over) {
-								uint top = this->active_over < active_sel_pos ? tr.top + 1 : tr.top + step_height - 2;
+								int top = this->active_over < active_sel_pos ? tr.top + 1 : tr.top + step_height - 2;
 								GfxFillRect(tr.left, top - 1, tr.right, top + 1, PC_GREY);
 							}
 						}
 						DrawSprite(SPR_SQUARE, pal, square_left, tr.top + square_offset_y);
 						if (c->error.has_value()) DrawSprite(SPR_WARNING_SIGN, 0, warning_left, tr.top + warning_offset_y);
-						uint txtoffset = !c->error.has_value() ? 0 : warning.width;
+						int txtoffset = !c->error.has_value() ? 0 : warning.width;
 						DrawString(text_left + (rtl ? 0 : txtoffset), text_right - (rtl ? txtoffset : 0), tr.top + offset_y, std::move(text), h ? TC_WHITE : TC_ORANGE);
 						tr.top += step_height;
 					}
@@ -889,7 +889,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				GfxFillRect(br, this->active_over == -2 ? PC_DARK_GREY : PC_BLACK);
 
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
-				uint step_height = this->GetWidget<NWidgetBase>(WID_NS_AVAIL_LIST)->resize_y;
+				int step_height = this->GetWidget<NWidgetBase>(WID_NS_AVAIL_LIST)->resize_y;
 				int offset_y = (step_height - GetCharacterHeight(FS_NORMAL)) / 2;
 
 				auto [first, last] = this->vscroll2->GetVisibleRangeIterators(this->avails);
@@ -1547,8 +1547,8 @@ const std::initializer_list<NewGRFWindow::GUIGRFConfigList::FilterFunction * con
  */
 class NWidgetNewGRFDisplay : public NWidgetBase {
 public:
-	static const uint MAX_EXTRA_INFO_WIDTH;    ///< Maximal additional width given to the panel.
-	static const uint MIN_EXTRA_FOR_3_COLUMNS; ///< Minimal additional width needed before switching to 3 columns.
+	static inline constexpr int MAX_EXTRA_INFO_WIDTH = 150; ///< Maximal additional width given to the panel.
+	static inline constexpr int MIN_EXTRA_FOR_3_COLUMNS = 50; ///< Minimal additional width needed before switching to 3 columns.
 
 	std::unique_ptr<NWidgetBase> avs{}; ///< Widget with the available grfs list and buttons.
 	std::unique_ptr<NWidgetBase> acs{}; ///< Widget with the active grfs list and buttons.
@@ -1573,13 +1573,13 @@ public:
 		this->acs->SetupSmallestSize(w);
 		this->inf->SetupSmallestSize(w);
 
-		uint min_avs_width = this->avs->smallest_x + this->avs->padding.Horizontal();
-		uint min_acs_width = this->acs->smallest_x + this->acs->padding.Horizontal();
-		uint min_inf_width = this->inf->smallest_x + this->inf->padding.Horizontal();
+		int min_avs_width = this->avs->smallest_x + this->avs->padding.Horizontal();
+		int min_acs_width = this->acs->smallest_x + this->acs->padding.Horizontal();
+		int min_inf_width = this->inf->smallest_x + this->inf->padding.Horizontal();
 
-		uint min_avs_height = this->avs->smallest_y + this->avs->padding.Vertical();
-		uint min_acs_height = this->acs->smallest_y + this->acs->padding.Vertical();
-		uint min_inf_height = this->inf->smallest_y + this->inf->padding.Vertical();
+		int min_avs_height = this->avs->smallest_y + this->avs->padding.Vertical();
+		int min_acs_height = this->acs->smallest_y + this->acs->padding.Vertical();
+		int min_inf_height = this->inf->smallest_y + this->inf->padding.Vertical();
 
 		/* Smallest window is in two column mode. */
 		this->smallest_x = std::max(min_avs_width, min_acs_width) + WidgetDimensions::scaled.hsep_wide + min_inf_width;
@@ -1605,56 +1605,56 @@ public:
 		this->smallest_y = ComputeMaxSize(min_acs_height, this->smallest_y + this->resize_y - 1, this->resize_y);
 	}
 
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override
 	{
 		this->StoreSizePosition(sizing, x, y, given_width, given_height);
 
-		uint min_avs_width = this->avs->smallest_x + this->avs->padding.Horizontal();
-		uint min_acs_width = this->acs->smallest_x + this->acs->padding.Horizontal();
-		uint min_inf_width = this->inf->smallest_x + this->inf->padding.Horizontal();
+		int min_avs_width = this->avs->smallest_x + this->avs->padding.Horizontal();
+		int min_acs_width = this->acs->smallest_x + this->acs->padding.Horizontal();
+		int min_inf_width = this->inf->smallest_x + this->inf->padding.Horizontal();
 
-		uint min_list_width = std::max(min_avs_width, min_acs_width); // Smallest width of the lists such that they have equal width (incl padding).
-		uint avs_extra_width = min_list_width - min_avs_width;   // Additional width needed for avs to reach min_list_width.
-		uint acs_extra_width = min_list_width - min_acs_width;   // Additional width needed for acs to reach min_list_width.
+		int min_list_width = std::max(min_avs_width, min_acs_width); // Smallest width of the lists such that they have equal width (incl padding).
+		int avs_extra_width = min_list_width - min_avs_width;   // Additional width needed for avs to reach min_list_width.
+		int acs_extra_width = min_list_width - min_acs_width;   // Additional width needed for acs to reach min_list_width.
 
 		/* Use 2 or 3 columns? */
-		uint min_three_columns = min_avs_width + min_acs_width + min_inf_width + 2 * WidgetDimensions::scaled.hsep_wide;
-		uint min_two_columns   = min_list_width + min_inf_width + WidgetDimensions::scaled.hsep_wide;
+		int min_three_columns = min_avs_width + min_acs_width + min_inf_width + 2 * WidgetDimensions::scaled.hsep_wide;
+		int min_two_columns   = min_list_width + min_inf_width + WidgetDimensions::scaled.hsep_wide;
 		bool use_three_columns = this->editable && (min_three_columns + ScaleGUITrad(MIN_EXTRA_FOR_3_COLUMNS) <= given_width);
 
 		/* Info panel is a separate column in both modes. Compute its width first. */
-		uint extra_width, inf_width;
+		int extra_width, inf_width;
 		if (use_three_columns) {
 			extra_width = given_width - min_three_columns;
-			inf_width = std::min<uint>(ScaleGUITrad(MAX_EXTRA_INFO_WIDTH), extra_width / 2);
+			inf_width = std::min(ScaleGUITrad(MAX_EXTRA_INFO_WIDTH), extra_width / 2);
 		} else {
 			extra_width = given_width - min_two_columns;
-			inf_width = std::min<uint>(ScaleGUITrad(MAX_EXTRA_INFO_WIDTH), extra_width / 2);
+			inf_width = std::min(ScaleGUITrad(MAX_EXTRA_INFO_WIDTH), extra_width / 2);
 		}
 		inf_width = ComputeMaxSize(this->inf->smallest_x, this->inf->smallest_x + inf_width, this->inf->GetHorizontalStepSize(sizing));
 		extra_width -= inf_width - this->inf->smallest_x;
 
-		uint inf_height = ComputeMaxSize(this->inf->smallest_y, given_height, this->inf->GetVerticalStepSize(sizing));
+		int inf_height = ComputeMaxSize(this->inf->smallest_y, given_height, this->inf->GetVerticalStepSize(sizing));
 
 		if (use_three_columns) {
 			/* Three column display, first make both lists equally wide, then divide whatever is left between both lists.
 			 * Only keep track of what avs gets, all other space goes to acs. */
-			uint avs_width = std::min(avs_extra_width, extra_width);
+			int avs_width = std::min(avs_extra_width, extra_width);
 			extra_width -= avs_width;
 			extra_width -= std::min(acs_extra_width, extra_width);
 			avs_width += extra_width / 2;
 
 			avs_width = ComputeMaxSize(this->avs->smallest_x, this->avs->smallest_x + avs_width, this->avs->GetHorizontalStepSize(sizing));
 
-			uint acs_width = given_width - // Remaining space, including horizontal padding.
+			int acs_width = given_width - // Remaining space, including horizontal padding.
 					inf_width - this->inf->padding.Horizontal() -
 					avs_width - this->avs->padding.Horizontal() - 2 * WidgetDimensions::scaled.hsep_wide;
 			acs_width = ComputeMaxSize(min_acs_width, acs_width, this->acs->GetHorizontalStepSize(sizing)) -
 					this->acs->padding.Horizontal();
 
 			/* Never use fill_y on these; the minimal size is chosen, so that the 3 column view looks nice */
-			uint avs_height = ComputeMaxSize(this->avs->smallest_y, given_height, this->avs->resize_y);
-			uint acs_height = ComputeMaxSize(this->acs->smallest_y, given_height, this->acs->resize_y);
+			int avs_height = ComputeMaxSize(this->avs->smallest_y, given_height, this->avs->resize_y);
+			int acs_height = ComputeMaxSize(this->acs->smallest_y, given_height, this->acs->resize_y);
 
 			/* Assign size and position to the children. */
 			if (rtl) {
@@ -1681,19 +1681,19 @@ public:
 		} else {
 			/* Two columns, all space in extra_width goes to both lists. Since the lists are underneath each other,
 			 * the column is min_list_width wide at least. */
-			uint avs_width = ComputeMaxSize(this->avs->smallest_x, this->avs->smallest_x + avs_extra_width + extra_width,
+			int avs_width = ComputeMaxSize(this->avs->smallest_x, this->avs->smallest_x + avs_extra_width + extra_width,
 					this->avs->GetHorizontalStepSize(sizing));
-			uint acs_width = ComputeMaxSize(this->acs->smallest_x, this->acs->smallest_x + acs_extra_width + extra_width,
+			int acs_width = ComputeMaxSize(this->acs->smallest_x, this->acs->smallest_x + acs_extra_width + extra_width,
 					this->acs->GetHorizontalStepSize(sizing));
 
-			uint min_avs_height = (!this->editable) ? 0 : this->avs->smallest_y + this->avs->padding.Vertical() + WidgetDimensions::scaled.vsep_wide;
-			uint min_acs_height = this->acs->smallest_y + this->acs->padding.Vertical();
-			uint extra_height = given_height - min_acs_height - min_avs_height;
+			int min_avs_height = (!this->editable) ? 0 : this->avs->smallest_y + this->avs->padding.Vertical() + WidgetDimensions::scaled.vsep_wide;
+			int min_acs_height = this->acs->smallest_y + this->acs->padding.Vertical();
+			int extra_height = given_height - min_acs_height - min_avs_height;
 
 			/* Never use fill_y on these; instead use WidgetDimensions::scaled.vsep_wide as filler */
-			uint avs_height = ComputeMaxSize(this->avs->smallest_y, this->avs->smallest_y + extra_height / 2, this->avs->resize_y);
+			int avs_height = ComputeMaxSize(this->avs->smallest_y, this->avs->smallest_y + extra_height / 2, this->avs->resize_y);
 			if (this->editable) extra_height -= avs_height - this->avs->smallest_y;
-			uint acs_height = ComputeMaxSize(this->acs->smallest_y, this->acs->smallest_y + extra_height, this->acs->resize_y);
+			int acs_height = ComputeMaxSize(this->acs->smallest_y, this->acs->smallest_y + extra_height, this->acs->resize_y);
 
 			/* Assign size and position to the children. */
 			if (rtl) {
@@ -1714,7 +1714,7 @@ public:
 				} else {
 					this->avs->AssignSizePosition(sizing, 0, 0, this->avs->smallest_x, this->avs->smallest_y, rtl);
 				}
-				uint dx = this->acs->current_x + this->acs->padding.Horizontal();
+				int dx = this->acs->current_x + this->acs->padding.Horizontal();
 				if (this->editable) {
 					dx = std::max(dx, this->avs->current_x + this->avs->padding.Horizontal());
 				}
@@ -1748,9 +1748,6 @@ public:
 		this->inf->Draw(w);
 	}
 };
-
-const uint NWidgetNewGRFDisplay::MAX_EXTRA_INFO_WIDTH    = 150;
-const uint NWidgetNewGRFDisplay::MIN_EXTRA_FOR_3_COLUMNS = 50;
 
 static constexpr NWidgetPart _nested_newgrf_actives_widgets[] = {
 	NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0),
@@ -2073,7 +2070,7 @@ struct SavePresetWindow : public Window {
 				const Rect br = r.Shrink(WidgetDimensions::scaled.bevel);
 				GfxFillRect(br, PC_BLACK);
 
-				uint step_height = this->GetWidget<NWidgetBase>(WID_SVP_PRESET_LIST)->resize_y;
+				int step_height = this->GetWidget<NWidgetBase>(WID_SVP_PRESET_LIST)->resize_y;
 				int offset_y = (step_height - GetCharacterHeight(FS_NORMAL)) / 2;
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
 
@@ -2178,7 +2175,7 @@ struct ScanProgressWindow : public Window {
 				uint64_t max_digits = GetParamMaxDigits(4);
 				/* We really don't know the width. We could determine it by scanning the NewGRFs,
 				 * but this is the status window for scanning them... */
-				size.width = std::max<uint>(size.width, GetStringBoundingBox(GetString(STR_NEWGRF_SCAN_STATUS, max_digits, max_digits)).width + padding.width);
+				size.width = std::max(size.width, GetStringBoundingBox(GetString(STR_NEWGRF_SCAN_STATUS, max_digits, max_digits)).width + padding.width);
 				size.height = GetCharacterHeight(FS_NORMAL) * 2 + WidgetDimensions::scaled.vsep_normal;
 				break;
 			}

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -352,8 +352,8 @@ NewsDisplay NewsTypeData::GetDisplay() const
 
 /** Window class displaying a news item. */
 struct NewsWindow : Window {
-	uint16_t chat_height = 0; ///< Height of the chat window.
-	uint16_t status_height = 0; ///< Height of the status bar window
+	int16_t chat_height = 0; ///< Height of the chat window.
+	int16_t status_height = 0; ///< Height of the status bar window
 	const NewsItem *ni = nullptr; ///< News item to display.
 	static int duration; ///< Remaining time for showing the current news message (may only be access while a news item is displayed).
 
@@ -1187,7 +1187,7 @@ void ShowLastNewsMessage()
  * @param colour the colour the string will be shown in
  * @param *ni NewsItem being printed
  */
-static void DrawNewsString(uint left, uint right, int y, TextColour colour, const NewsItem &ni)
+static void DrawNewsString(int left, int right, int y, TextColour colour, const NewsItem &ni)
 {
 	/* Get the string, replaces newlines with spaces and remove control codes from the string. */
 	std::string message = StrMakeValid(ni.GetStatusText(), StringValidationSetting::ReplaceTabCrNlWithSpace);
@@ -1221,7 +1221,7 @@ struct MessageHistoryWindow : Window {
 			this->date_width = GetStringBoundingBox(GetString(STR_JUST_DATE_TINY, TimerGameCalendar::ConvertYMDToDate(CalendarTime::ORIGINAL_MAX_YEAR, 7, 30))).width + WidgetDimensions::scaled.hsep_wide;
 
 			size.height = 4 * resize.height + WidgetDimensions::scaled.framerect.Vertical(); // At least 4 lines are visible.
-			size.width = std::max(200u, size.width); // At least 200 pixels wide.
+			size.width = std::max(200, size.width); // At least 200 pixels wide.
 		}
 	}
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -670,8 +670,8 @@ int openttd_main(std::span<char * const> arguments)
 	 * integer, This way all internal drawing routines work correctly.
 	 * A resolution that has one component as 0 is treated as a marker to
 	 * auto-detect a good window size. */
-	_cur_resolution.width  = std::min(_cur_resolution.width, UINT16_MAX / 2u);
-	_cur_resolution.height = std::min(_cur_resolution.height, UINT16_MAX / 2u);
+	_cur_resolution.width  = std::min<int>(_cur_resolution.width, UINT16_MAX / 2);
+	_cur_resolution.height = std::min<int>(_cur_resolution.height, UINT16_MAX / 2);
 
 	/* Assume the cursor starts within the game as not all video drivers
 	 * get an event that the cursor is within the window when it is opened.

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -232,11 +232,11 @@ void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int 
 	Dimension sprite_size = GetSpriteSize(sprite);
 	if (v->cur_real_order_index == order_index) {
 		/* Draw two arrows before the next real order. */
-		DrawSprite(sprite, PAL_NONE, rtl ? right -     sprite_size.width : left,                     y + ((int)GetCharacterHeight(FS_NORMAL) - (int)sprite_size.height) / 2);
-		DrawSprite(sprite, PAL_NONE, rtl ? right - 2 * sprite_size.width : left + sprite_size.width, y + ((int)GetCharacterHeight(FS_NORMAL) - (int)sprite_size.height) / 2);
+		DrawSprite(sprite, PAL_NONE, rtl ? right -     sprite_size.width : left,                     y + (GetCharacterHeight(FS_NORMAL) - sprite_size.height) / 2);
+		DrawSprite(sprite, PAL_NONE, rtl ? right - 2 * sprite_size.width : left + sprite_size.width, y + (GetCharacterHeight(FS_NORMAL) - sprite_size.height) / 2);
 	} else if (v->cur_implicit_order_index == order_index) {
 		/* Draw one arrow before the next implicit order; the next real order will still get two arrows. */
-		DrawSprite(sprite, PAL_NONE, rtl ? right -     sprite_size.width : left,                     y + ((int)GetCharacterHeight(FS_NORMAL) - (int)sprite_size.height) / 2);
+		DrawSprite(sprite, PAL_NONE, rtl ? right -     sprite_size.width : left,                     y + (GetCharacterHeight(FS_NORMAL) - sprite_size.height) / 2);
 	}
 
 	TextColour colour = TC_BLACK;

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1051,7 +1051,7 @@ public:
 
 struct BuildRailStationWindow : public PickerWindow {
 private:
-	uint coverage_height = 0; ///< Height of the coverage texts.
+	int coverage_height = 0; ///< Height of the coverage texts.
 
 	/**
 	 * Verify whether the currently selected station size is allowed after selecting a new station class/type.

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1291,7 +1291,7 @@ static PickerCallbacks &GetRoadStopPickerCallbacks(RoadStopType rs)
 
 struct BuildRoadStationWindow : public PickerWindow {
 private:
-	uint coverage_height = 0; ///< Height of the coverage texts.
+	int coverage_height = 0; ///< Height of the coverage texts.
 
 	void CheckOrientationValid()
 	{

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -79,7 +79,7 @@ static const uint RVC_DEPOT_STOP_FRAME                   = 11;
 static const uint8_t RV_OVERTAKE_TIMEOUT = 35;
 
 void RoadVehUpdateCache(RoadVehicle *v, bool same_length = false);
-void GetRoadVehSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
+void GetRoadVehSpriteSize(EngineID engine, int &width, int &height, int &xoffs, int &yoffs, EngineImageType image_type);
 
 /** Element of the RoadVehPathCache. */
 struct RoadVehPathElement {

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -170,7 +170,7 @@ void DrawRoadVehEngine(int left, int right, int preferred_x, int y, EngineID eng
  * @param[out] yoffs Number of pixels to shift the sprite downwards.
  * @param image_type Context the sprite is used in.
  */
-void GetRoadVehSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type)
+void GetRoadVehSpriteSize(EngineID engine, int &width, int &height, int &xoffs, int &yoffs, EngineImageType image_type)
 {
 	VehicleSpriteSeq seq;
 	GetRoadVehIcon(engine, image_type, &seq);

--- a/src/script/api/script_log_types.hpp
+++ b/src/script/api/script_log_types.hpp
@@ -32,7 +32,7 @@ namespace ScriptLogTypes {
 	struct LogLine {
 		std::string text; ///< The text
 		ScriptLogType type; ///< Text type
-		uint width; ///< The text width
+		int width; ///< The text width
 	};
 
 	/**

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -1131,7 +1131,7 @@ struct ScriptDebugWindow : public Window {
 
 		this->SelectValidDebugCompany();
 
-		uint max_width = 0;
+		int max_width = 0;
 		if (this->filter.script_debug_company != CompanyID::Invalid()) {
 			for (auto &line : this->GetLogData()) {
 				if (line.width == 0 || data == -1) line.width = GetStringBoundingBox(line.text).width;

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -94,7 +94,7 @@ uint BaseSettingEntry::Draw(GameSettings *settings_ptr, int left, int right, int
 	if (cur_row >= max_row) return cur_row;
 
 	bool rtl = _current_text_dir == TD_RTL;
-	int offset = (rtl ? -(int)_setting_circle_size.width : (int)_setting_circle_size.width) / 2;
+	int offset = (rtl ? -_setting_circle_size.width : _setting_circle_size.width) / 2;
 	int level_width = rtl ? -WidgetDimensions::scaled.hsep_indent : WidgetDimensions::scaled.hsep_indent;
 
 	int x = rtl ? right : left;
@@ -173,7 +173,7 @@ uint SettingEntry::Length() const
  * @param maxw Maximal width of a line help text.
  * @return Biggest height needed to display any help text of this node (and its descendants).
  */
-uint SettingEntry::GetMaxHelpHeight(int maxw)
+int SettingEntry::GetMaxHelpHeight(int maxw)
 {
 	return GetStringHeight(this->setting->GetHelp(), maxw);
 }
@@ -281,10 +281,10 @@ void SettingEntry::DrawSetting(GameSettings *settings_ptr, int left, int right, 
 	int state = (this->flags & SEF_BUTTONS_MASK).base();
 
 	bool rtl = _current_text_dir == TD_RTL;
-	uint buttons_left = rtl ? right + 1 - SETTING_BUTTON_WIDTH : left;
-	uint text_left  = left + (rtl ? 0 : SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide);
-	uint text_right = right - (rtl ? SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide : 0);
-	uint button_y = y + (SETTING_HEIGHT - SETTING_BUTTON_HEIGHT) / 2;
+	int buttons_left = rtl ? right + 1 - SETTING_BUTTON_WIDTH : left;
+	int text_left  = left + (rtl ? 0 : SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide);
+	int text_right = right - (rtl ? SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide : 0);
+	int button_y = y + (SETTING_HEIGHT - SETTING_BUTTON_HEIGHT) / 2;
 
 	/* We do not allow changes of some items when we are a client in a networkgame */
 	bool editable = sd->IsEditable();
@@ -421,9 +421,9 @@ BaseSettingEntry *SettingsContainer::FindEntry(uint row_num, uint *cur_row)
  * @param maxw Maximal width of a line help text.
  * @return Biggest height needed to display any help text of this (sub-)tree.
  */
-uint SettingsContainer::GetMaxHelpHeight(int maxw)
+int SettingsContainer::GetMaxHelpHeight(int maxw)
 {
-	uint biggest = 0;
+	int biggest = 0;
 	for (const auto &it : this->entries) {
 		biggest = std::max(biggest, it->GetMaxHelpHeight(maxw));
 	}

--- a/src/settingentry_gui.h
+++ b/src/settingentry_gui.h
@@ -74,7 +74,7 @@ struct BaseSettingEntry {
 	virtual void GetFoldingState([[maybe_unused]] bool &all_folded, [[maybe_unused]] bool &all_unfolded) const {}
 	virtual bool IsVisible(const BaseSettingEntry *item) const;
 	virtual BaseSettingEntry *FindEntry(uint row, uint *cur_row);
-	virtual uint GetMaxHelpHeight([[maybe_unused]] int maxw) { return 0; }
+	virtual int GetMaxHelpHeight([[maybe_unused]] int maxw) { return 0; }
 
 	/**
 	 * Check whether an entry is hidden due to filters
@@ -100,7 +100,7 @@ struct SettingEntry : BaseSettingEntry {
 	void Init(uint8_t level = 0) override;
 	void ResetAll() override;
 	uint Length() const override;
-	uint GetMaxHelpHeight(int maxw) override;
+	int GetMaxHelpHeight(int maxw) override;
 	bool UpdateFilterState(SettingFilter &filter, bool force_visible) override;
 
 	void SetButtons(SettingEntryFlags new_val);
@@ -133,7 +133,7 @@ struct SettingsContainer {
 	void GetFoldingState(bool &all_folded, bool &all_unfolded) const;
 	bool IsVisible(const BaseSettingEntry *item) const;
 	BaseSettingEntry *FindEntry(uint row, uint *cur_row);
-	uint GetMaxHelpHeight(int maxw);
+	int GetMaxHelpHeight(int maxw);
 
 	bool UpdateFilterState(SettingFilter &filter, bool force_visible);
 
@@ -156,7 +156,7 @@ struct SettingsPage : BaseSettingEntry, SettingsContainer {
 	void GetFoldingState(bool &all_folded, bool &all_unfolded) const override;
 	bool IsVisible(const BaseSettingEntry *item) const override;
 	BaseSettingEntry *FindEntry(uint row, uint *cur_row) override;
-	uint GetMaxHelpHeight(int maxw) override { return SettingsContainer::GetMaxHelpHeight(maxw); }
+	int GetMaxHelpHeight(int maxw) override { return SettingsContainer::GetMaxHelpHeight(maxw); }
 
 	bool UpdateFilterState(SettingFilter &filter, bool force_visible) override;
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1274,7 +1274,7 @@ struct GameSettingsWindow : Window {
 	{
 		switch (widget) {
 			case WID_GS_OPTIONSPANEL:
-				resize.height = SETTING_HEIGHT = std::max({(int)_setting_circle_size.height, SETTING_BUTTON_HEIGHT, GetCharacterHeight(FS_NORMAL)}) + WidgetDimensions::scaled.vsep_normal;
+				resize.height = SETTING_HEIGHT = std::max({_setting_circle_size.height, SETTING_BUTTON_HEIGHT, GetCharacterHeight(FS_NORMAL)}) + WidgetDimensions::scaled.vsep_normal;
 				resize.width = 1;
 
 				size.height = 5 * resize.height + WidgetDimensions::scaled.framerect.Vertical();
@@ -1387,7 +1387,7 @@ struct GameSettingsWindow : Window {
 				Rect tr = r.Shrink(WidgetDimensions::scaled.frametext, WidgetDimensions::scaled.framerect);
 				tr.top += this->warn_lines * SETTING_HEIGHT;
 				uint last_row = this->vscroll->GetPosition() + this->vscroll->GetCapacity() - this->warn_lines;
-				int next_row = GetSettingsTree().Draw(settings_ptr, tr.left, tr.right, tr.top,
+				uint next_row = GetSettingsTree().Draw(settings_ptr, tr.left, tr.right, tr.top,
 						this->vscroll->GetPosition(), last_row, this->last_clicked);
 				if (next_row == 0) DrawString(tr, STR_CONFIG_SETTINGS_NONE);
 				break;
@@ -1826,8 +1826,8 @@ void DrawArrowButtons(int x, int y, Colours button_colour, uint8_t state, bool c
 	int colour = GetColourGradient(button_colour, SHADE_DARKER);
 	Dimension dim = NWidgetScrollbar::GetHorizontalDimension();
 
-	Rect lr = {x,                  y, x + (int)dim.width     - 1, y + (int)dim.height - 1};
-	Rect rr = {x + (int)dim.width, y, x + (int)dim.width * 2 - 1, y + (int)dim.height - 1};
+	Rect lr = {x,             y, x + dim.width     - 1, y + dim.height - 1};
+	Rect rr = {x + dim.width, y, x + dim.width * 2 - 1, y + dim.height - 1};
 
 	DrawFrameRect(lr, button_colour, (state == 1) ? FrameFlag::Lowered : FrameFlags{});
 	DrawFrameRect(rr, button_colour, (state == 2) ? FrameFlag::Lowered : FrameFlags{});
@@ -1925,14 +1925,14 @@ struct CustomCurrencyWindow : Window {
 			case WID_CC_RATE_UP:
 			case WID_CC_YEAR_DOWN:
 			case WID_CC_YEAR_UP:
-				size = maxdim(size, {(uint)SETTING_BUTTON_WIDTH / 2, (uint)SETTING_BUTTON_HEIGHT});
+				size = maxdim(size, {SETTING_BUTTON_WIDTH / 2, SETTING_BUTTON_HEIGHT});
 				break;
 
 			/* Set the appropriate width for the edit buttons. */
 			case WID_CC_SEPARATOR_EDIT:
 			case WID_CC_PREFIX_EDIT:
 			case WID_CC_SUFFIX_EDIT:
-				size = maxdim(size, {(uint)SETTING_BUTTON_WIDTH, (uint)SETTING_BUTTON_HEIGHT});
+				size = maxdim(size, {SETTING_BUTTON_WIDTH, SETTING_BUTTON_HEIGHT});
 				break;
 
 			/* Make sure the window is wide enough for the widest exchange rate */

--- a/src/settings_gui.h
+++ b/src/settings_gui.h
@@ -14,9 +14,9 @@
 #include "dropdown_type.h"
 
 /** Width of setting buttons */
-#define SETTING_BUTTON_WIDTH  ((int)NWidgetScrollbar::GetHorizontalDimension().width * 2)
+#define SETTING_BUTTON_WIDTH  (NWidgetScrollbar::GetHorizontalDimension().width * 2)
 /** Height of setting buttons */
-#define SETTING_BUTTON_HEIGHT ((int)NWidgetScrollbar::GetHorizontalDimension().height)
+#define SETTING_BUTTON_HEIGHT (NWidgetScrollbar::GetHorizontalDimension().height)
 
 void DrawArrowButtons(int x, int y, Colours button_colour, uint8_t state, bool clickable_left, bool clickable_right);
 void DrawDropDownButton(int x, int y, Colours button_colour, bool state, bool clickable);

--- a/src/ship.h
+++ b/src/ship.h
@@ -13,7 +13,7 @@
 #include "vehicle_base.h"
 #include "water_map.h"
 
-void GetShipSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
+void GetShipSpriteSize(EngineID engine, int &width, int &height, int &xoffs, int &yoffs, EngineImageType image_type);
 WaterClass GetEffectiveWaterClass(TileIndex tile);
 
 /** Element of the ShipPathCache. */

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -117,7 +117,7 @@ void DrawShipEngine(int left, int right, int preferred_x, int y, EngineID engine
  * @param[out] yoffs Number of pixels to shift the sprite downwards.
  * @param image_type Context the sprite is used in.
  */
-void GetShipSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type)
+void GetShipSpriteSize(EngineID engine, int &width, int &height, int &xoffs, int &yoffs, EngineImageType image_type)
 {
 	VehicleSpriteSeq seq;
 	GetShipIcon(engine, image_type, &seq);

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -197,7 +197,7 @@ struct SignListWindow : Window, SignList {
 		switch (widget) {
 			case WID_SIL_LIST: {
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
-				uint text_offset_y = (this->resize.step_height - GetCharacterHeight(FS_NORMAL) + 1) / 2;
+				int text_offset_y = (this->resize.step_height - GetCharacterHeight(FS_NORMAL) + 1) / 2;
 				/* No signs? */
 				if (this->vscroll->GetCount() == 0) {
 					DrawString(tr.left, tr.right, tr.top + text_offset_y, STR_STATION_LIST_NONE);
@@ -207,7 +207,7 @@ struct SignListWindow : Window, SignList {
 				Dimension d = GetSpriteSize(SPR_COMPANY_ICON);
 				bool rtl = _current_text_dir == TD_RTL;
 				int sprite_offset_y = (this->resize.step_height - d.height + 1) / 2;
-				uint icon_left = rtl ? tr.right - this->text_offset : tr.left;
+				int icon_left = rtl ? tr.right - this->text_offset : tr.left;
 				tr = tr.Indent(this->text_offset, rtl);
 
 				/* At least one sign available. */
@@ -263,8 +263,8 @@ struct SignListWindow : Window, SignList {
 			case WID_SIL_LIST: {
 				Dimension spr_dim = GetSpriteSize(SPR_COMPANY_ICON);
 				this->text_offset = WidgetDimensions::scaled.frametext.left + spr_dim.width + 2; // 2 pixels space between icon and the sign text.
-				resize.height = std::max<uint>(GetCharacterHeight(FS_NORMAL), spr_dim.height + 2);
-				Dimension d = {(uint)(this->text_offset + WidgetDimensions::scaled.frametext.right), padding.height + 5 * resize.height};
+				resize.height = std::max(GetCharacterHeight(FS_NORMAL), spr_dim.height + 2);
+				Dimension d = {this->text_offset + WidgetDimensions::scaled.frametext.right, padding.height + 5 * resize.height};
 				size = maxdim(size, d);
 				break;
 			}

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -289,7 +289,7 @@ protected:
 	FilterState filter{};
 	GUIStationList stations{filter.cargoes};
 	Scrollbar *vscroll = nullptr;
-	uint rating_width = 0;
+	int rating_width = 0;
 	bool filter_expanded = false;
 	std::array<uint16_t, NUM_CARGO> stations_per_cargo_type{}; ///< Number of stations with a rating for each cargo type.
 	uint16_t stations_per_cargo_type_no_rating = 0; ///< Number of stations without a rating.
@@ -502,7 +502,7 @@ public:
 			case WID_STL_LIST: {
 				bool rtl = _current_text_dir == TD_RTL;
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
-				uint line_height = this->GetWidget<NWidgetBase>(widget)->resize_y;
+				int line_height = this->GetWidget<NWidgetBase>(widget)->resize_y;
 				/* Spacing between station name and first rating graph. */
 				int text_spacing = WidgetDimensions::scaled.hsep_wide;
 				/* Spacing between additional rating graphs. */
@@ -1293,7 +1293,7 @@ struct StationViewWindow : public Window {
 		MODE_PLANNED  ///< Show cargo planned to pass through the station.
 	};
 
-	uint expand_shrink_width = 0; ///< The width allocated to the expand/shrink 'button'
+	int expand_shrink_width = 0; ///< The width allocated to the expand/shrink 'button'
 	int rating_lines = RATING_LINES; ///< Number of lines in the cargo ratings view.
 	int accepts_lines = ACCEPTS_LINES; ///< Number of lines in the accepted cargo view.
 	Scrollbar *vscroll = nullptr;

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -264,7 +264,7 @@ protected:
 	/**
 	 * Get the width available for displaying content on the page panel.
 	 */
-	uint GetAvailablePageContentWidth() const
+	int GetAvailablePageContentWidth() const
 	{
 		return this->GetWidget<NWidgetCore>(WID_SB_PAGE_PANEL)->current_x - WidgetDimensions::scaled.frametext.Horizontal() - 1;
 	}
@@ -276,7 +276,7 @@ protected:
 	 * @param max_width Available width to display content.
 	 * @return the height in pixels.
 	 */
-	uint GetHeadHeight(int max_width) const
+	int GetHeadHeight(int max_width) const
 	{
 		StoryPage *page = this->GetSelPage();
 		if (page == nullptr) return 0;
@@ -316,7 +316,7 @@ protected:
 	 * @param max_width Available width to display content.
 	 * @return the height in pixels.
 	 */
-	uint GetPageElementHeight(const StoryPageElement &pe, int max_width) const
+	int GetPageElementHeight(const StoryPageElement &pe, int max_width) const
 	{
 		switch (pe.type) {
 			case SPET_TEXT:
@@ -513,10 +513,10 @@ protected:
 	void DrawActionElement(int &y_offset, int width, int line_height, SpriteID action_sprite, const std::string &text) const
 	{
 		Dimension sprite_dim = GetSpriteSize(action_sprite);
-		uint element_height = std::max(sprite_dim.height, (uint)line_height);
+		int element_height = std::max(sprite_dim.height, line_height);
 
-		uint sprite_top = y_offset + (element_height - sprite_dim.height) / 2;
-		uint text_top = y_offset + (element_height - line_height) / 2;
+		int sprite_top = y_offset + (element_height - sprite_dim.height) / 2;
+		int text_top = y_offset + (element_height - line_height) / 2;
 
 		DrawSprite(action_sprite, PAL_NONE, 0, sprite_top);
 		DrawString(sprite_dim.width + WidgetDimensions::scaled.frametext.left, width, text_top, text, TC_BLACK);

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -552,8 +552,8 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 	{
 		if (widget != WID_ETT_DOTS) return;
 
-		size.width  = std::max<uint>(size.width,  ScaleGUITrad(59));
-		size.height = std::max<uint>(size.height, ScaleGUITrad(31));
+		size.width  = std::max(size.width,  ScaleGUITrad(59));
+		size.height = std::max(size.height, ScaleGUITrad(31));
 	}
 
 	void DrawWidget(const Rect &r, WidgetID widget) const override

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -107,9 +107,9 @@ void TextfileWindow::ConstructWindow()
  * Get the total height of the content displayed in this window, if wrapping is disabled.
  * @return the height in pixels
  */
-uint TextfileWindow::ReflowContent()
+int TextfileWindow::ReflowContent()
 {
-	uint height = 0;
+	int height = 0;
 	if (!IsWidgetLowered(WID_TF_WRAPTEXT)) {
 		for (auto &line : this->lines) {
 			line.top = height;
@@ -128,7 +128,7 @@ uint TextfileWindow::ReflowContent()
 	return height;
 }
 
-uint TextfileWindow::GetContentHeight()
+int TextfileWindow::GetContentHeight()
 {
 	if (this->lines.empty()) return 0;
 	return this->lines.back().bottom;
@@ -141,7 +141,7 @@ uint TextfileWindow::GetContentHeight()
 			resize.height = GetCharacterHeight(FS_MONO);
 
 			size.height = 4 * resize.height + WidgetDimensions::scaled.frametext.Vertical(); // At least 4 lines are visible.
-			size.width = std::max(200u, size.width); // At least 200 pixels wide.
+			size.width = std::max(200, size.width); // At least 200 pixels wide.
 			break;
 	}
 }
@@ -151,12 +151,12 @@ void TextfileWindow::SetupScrollbars(bool force_reflow)
 {
 	if (IsWidgetLowered(WID_TF_WRAPTEXT)) {
 		/* Reflow is mandatory if text wrapping is on */
-		uint height = this->ReflowContent();
-		this->vscroll->SetCount(ClampTo<uint16_t>(height));
+		int height = this->ReflowContent();
+		this->vscroll->SetCount(height);
 		this->hscroll->SetCount(0);
 	} else {
-		uint height = force_reflow ? this->ReflowContent() : this->GetContentHeight();
-		this->vscroll->SetCount(ClampTo<uint16_t>(height));
+		int height = force_reflow ? this->ReflowContent() : this->GetContentHeight();
+		this->vscroll->SetCount(height);
 		this->hscroll->SetCount(this->max_length);
 	}
 
@@ -821,7 +821,7 @@ void TextfileWindow::LoadText(std::string_view buf)
 	this->lines.emplace_back(row, p);
 
 	/* Calculate maximum text line length. */
-	uint max_length = 0;
+	int max_length = 0;
 	for (auto &line : this->lines) {
 		max_length = std::max(max_length, GetStringBoundingBox(line.text, FS_MONO).width);
 	}

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -99,10 +99,10 @@ protected:
 
 private:
 	uint search_iterator = 0; ///< Iterator for the font check search.
-	uint max_length = 0; ///< Maximum length of unwrapped text line.
+	int max_length = 0; ///< Maximum length of unwrapped text line.
 
-	uint ReflowContent();
-	uint GetContentHeight();
+	int ReflowContent();
+	int GetContentHeight();
 	void SetupScrollbars(bool force_reflow);
 	const Hyperlink *GetHyperlink(Point pt) const;
 

--- a/src/toolbar_gui.h
+++ b/src/toolbar_gui.h
@@ -58,6 +58,6 @@ void ToggleBoundingBoxes();
 void ToggleDirtyBlocks();
 void ToggleWidgetOutlines();
 
-extern uint _toolbar_width;
+extern int _toolbar_width;
 
 #endif /* TOOLBAR_GUI_H */

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -289,7 +289,7 @@ public:
 				break;
 
 			case WID_TA_RATING_INFO:
-				resize.height = std::max({this->icon_size.height + WidgetDimensions::scaled.vsep_normal, this->exclusive_size.height + WidgetDimensions::scaled.vsep_normal, (uint)GetCharacterHeight(FS_NORMAL)});
+				resize.height = std::max({this->icon_size.height + WidgetDimensions::scaled.vsep_normal, this->exclusive_size.height + WidgetDimensions::scaled.vsep_normal, GetCharacterHeight(FS_NORMAL)});
 				size.height = 9 * resize.height + padding.height;
 				break;
 		}
@@ -531,9 +531,9 @@ public:
 	 * Gets the desired height for the information panel.
 	 * @return the desired height in pixels.
 	 */
-	uint GetDesiredInfoHeight(int width) const
+	int GetDesiredInfoHeight(int width) const
 	{
-		uint aimed_height = static_cast<uint>(1 + CargoSpec::town_production_cargoes[TPE_PASSENGERS].size() + CargoSpec::town_production_cargoes[TPE_MAIL].size()) * GetCharacterHeight(FS_NORMAL);
+		int aimed_height = static_cast<int>(1 + CargoSpec::town_production_cargoes[TPE_PASSENGERS].size() + CargoSpec::town_production_cargoes[TPE_MAIL].size()) * GetCharacterHeight(FS_NORMAL);
 
 		bool first = true;
 		for (int i = TAE_BEGIN; i < TAE_END; i++) {
@@ -561,7 +561,7 @@ public:
 	void ResizeWindowAsNeeded()
 	{
 		const NWidgetBase *nwid_info = this->GetWidget<NWidgetBase>(WID_TV_INFO);
-		uint aimed_height = GetDesiredInfoHeight(nwid_info->current_x);
+		int aimed_height = GetDesiredInfoHeight(nwid_info->current_x);
 		if (aimed_height > nwid_info->current_y || (aimed_height < nwid_info->current_y && nwid_info->current_y > nwid_info->smallest_y)) {
 			this->ReInit();
 		}

--- a/src/train.h
+++ b/src/train.h
@@ -64,7 +64,7 @@ bool TryPathReserve(Train *v, bool mark_as_stuck = false, bool first_tile_okay =
 
 int GetTrainStopLocation(StationID station_id, TileIndex tile, const Train *v, int *station_ahead, int *station_length);
 
-void GetTrainSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
+void GetTrainSpriteSize(EngineID engine, int &width, int &height, int &xoffs, int &yoffs, EngineImageType image_type);
 
 bool TrainOnCrossing(TileIndex tile);
 void NormalizeTrainVehInDepot(const Train *u);

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -577,7 +577,7 @@ void DrawTrainEngine(int left, int right, int preferred_x, int y, EngineID engin
  * @param[out] yoffs Number of pixels to shift the sprite downwards.
  * @param image_type Context the sprite is used in.
  */
-void GetTrainSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type)
+void GetTrainSpriteSize(EngineID engine, int &width, int &height, int &xoffs, int &yoffs, EngineImageType image_type)
 {
 	int y = 0;
 
@@ -598,7 +598,7 @@ void GetTrainSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, 
 
 		/* Calculate values relative to an imaginary center between the two sprites. */
 		width = ScaleSpriteTrad(TRAININFO_DEFAULT_VEHICLE_WIDTH) + UnScaleGUI(rect.right) - xoffs;
-		height = std::max<uint>(height, UnScaleGUI(rect.Height()));
+		height = std::max(height, UnScaleGUI(rect.Height()));
 		xoffs  = xoffs - ScaleSpriteTrad(TRAININFO_DEFAULT_VEHICLE_WIDTH) / 2;
 		yoffs  = std::min(yoffs, UnScaleGUI(rect.top));
 	}

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -295,9 +295,9 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary &su
  * @param v the vehicle to get the length of.
  * @return the length in pixels.
  */
-static uint GetLengthOfArticulatedVehicle(const Train *v)
+static int GetLengthOfArticulatedVehicle(const Train *v)
 {
-	uint length = 0;
+	int length = 0;
 
 	do {
 		length += v->GetDisplayImageWidth();
@@ -327,10 +327,10 @@ int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab)
 	} else {
 		for (const Train *v = Train::Get(veh_id); v != nullptr; v = v->GetNextVehicle()) {
 			GetCargoSummaryOfArticulatedVehicle(v, _cargo_summary);
-			num += std::max(1u, (unsigned)_cargo_summary.size());
+			num += std::max(1, static_cast<int>(_cargo_summary.size()));
 
-			uint length = GetLengthOfArticulatedVehicle(v);
-			if (length > (uint)ScaleSpriteTrad(TRAIN_DETAILS_MAX_INDENT)) num++;
+			int length = GetLengthOfArticulatedVehicle(v);
+			if (length > ScaleSpriteTrad(TRAIN_DETAILS_MAX_INDENT)) num++;
 		}
 	}
 
@@ -361,7 +361,7 @@ void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uint16_t v
 			GetCargoSummaryOfArticulatedVehicle(v, _cargo_summary);
 
 			/* Draw sprites */
-			uint dx = 0;
+			int dx = 0;
 			int px = x;
 			const Train *u = v;
 			do {
@@ -383,7 +383,7 @@ void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uint16_t v
 				u = u->Next();
 			} while (u != nullptr && u->IsArticulatedPart());
 
-			bool separate_sprite_row = (dx > (uint)ScaleSpriteTrad(TRAIN_DETAILS_MAX_INDENT));
+			bool separate_sprite_row = (dx > ScaleSpriteTrad(TRAIN_DETAILS_MAX_INDENT));
 			if (separate_sprite_row) {
 				vscroll_pos--;
 				dx = 0;
@@ -391,8 +391,8 @@ void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uint16_t v
 
 			int sprite_width = std::max<int>(dx, ScaleSpriteTrad(TRAIN_DETAILS_MIN_INDENT)) + WidgetDimensions::scaled.hsep_normal;
 			Rect dr = r.Indent(sprite_width, rtl);
-			uint num_lines = std::max(1u, (unsigned)_cargo_summary.size());
-			for (uint i = 0; i < num_lines; i++) {
+			int num_lines = std::max(1, static_cast<int>(_cargo_summary.size()));
+			for (int i = 0; i < num_lines; i++) {
 				if (vscroll_pos <= 0 && vscroll_pos > -vscroll_cap) {
 					int py = r.top - line_height * vscroll_pos + text_y_offset;
 					if (i > 0 || separate_sprite_row) {
@@ -400,7 +400,7 @@ void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uint16_t v
 					}
 					switch (det_tab) {
 						case TDW_TAB_CARGO:
-							if (i < _cargo_summary.size()) {
+							if (i < static_cast<int>(_cargo_summary.size())) {
 								TrainDetailsCargoTab(&_cargo_summary[i], dr.left, dr.right, py);
 							} else {
 								DrawString(dr.left, dr.right, py, STR_QUANTITY_N_A, TC_LIGHT_BLUE);
@@ -412,7 +412,7 @@ void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uint16_t v
 							break;
 
 						case TDW_TAB_CAPACITY:
-							if (i < _cargo_summary.size()) {
+							if (i < static_cast<int>(_cargo_summary.size())) {
 								TrainDetailsCapacityTab(&_cargo_summary[i], dr.left, dr.right, py);
 							} else {
 								DrawString(dr.left, dr.right, py, GetString(STR_VEHICLE_INFO_NO_CAPACITY, STR_EMPTY));

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -695,8 +695,8 @@ static void DrawVehicleRefitWindow(const RefitOptions &refits, const RefitOption
 	uint current = 0;
 
 	bool rtl = _current_text_dir == TD_RTL;
-	uint iconwidth = std::max(GetSpriteSize(SPR_CIRCLE_FOLDED).width, GetSpriteSize(SPR_CIRCLE_UNFOLDED).width);
-	uint iconheight = GetSpriteSize(SPR_CIRCLE_FOLDED).height;
+	int iconwidth = std::max(GetSpriteSize(SPR_CIRCLE_FOLDED).width, GetSpriteSize(SPR_CIRCLE_UNFOLDED).width);
+	int iconheight = GetSpriteSize(SPR_CIRCLE_FOLDED).height;
 	int linecolour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
 
 	int iconleft   = rtl ? ir.right - iconwidth     : ir.left;
@@ -747,7 +747,7 @@ struct RefitWindow : public Window {
 	const RefitOption *selected_refit = nullptr; ///< Selected refit option.
 	RefitOptions refit_list{}; ///< List of refit subtypes available for each sorted cargo.
 	VehicleOrderID order = INVALID_VEH_ORDER_ID; ///< If not #INVALID_VEH_ORDER_ID, selection is part of a refit order (rather than execute directly).
-	uint information_width = 0; ///< Width required for correctly displaying all cargoes in the information panel.
+	int information_width = 0; ///< Width required for correctly displaying all cargoes in the information panel.
 	Scrollbar *vscroll = nullptr; ///< The main scrollbar.
 	Scrollbar *hscroll = nullptr; ///< Only used for long vehicles.
 	int vehicle_width = 0; ///< Width of the vehicle being drawn.
@@ -1143,7 +1143,7 @@ struct RefitWindow : public Window {
 
 				/* The vehicle width has changed too. */
 				this->vehicle_width = GetVehicleWidth(Vehicle::Get(this->window_number), EIT_IN_DETAILS);
-				uint max_width = 0;
+				int max_width = 0;
 
 				/* Check the width of all cargo information strings. */
 				for (const auto &list : this->refit_list) {
@@ -1654,7 +1654,7 @@ static constexpr NWidgetPart _nested_vehicle_list[] = {
 	EndContainer(),
 };
 
-static void DrawSmallOrderList(const Vehicle *v, int left, int right, int y, uint order_arrow_width, VehicleOrderID start)
+static void DrawSmallOrderList(const Vehicle *v, int left, int right, int y, int order_arrow_width, VehicleOrderID start)
 {
 	const Order *order = v->GetOrder(start);
 	if (order == nullptr) return;
@@ -1685,7 +1685,7 @@ static void DrawSmallOrderList(const Vehicle *v, int left, int right, int y, uin
 }
 
 /** Draw small order list in the vehicle GUI, but without the little black arrow.  This is used for shared order groups. */
-static void DrawSmallOrderList(const Order *order, int left, int right, int y, uint order_arrow_width)
+static void DrawSmallOrderList(const Order *order, int left, int right, int y, int order_arrow_width)
 {
 	bool rtl = _current_text_dir == TD_RTL;
 	int l_offset = rtl ? 0 : order_arrow_width;
@@ -1726,17 +1726,17 @@ void DrawVehicleImage(const Vehicle *v, const Rect &r, VehicleID selection, Engi
  * @param divisor the resulting height must be dividable by this
  * @return the height
  */
-uint GetVehicleListHeight(VehicleType type, uint divisor)
+int GetVehicleListHeight(VehicleType type, int divisor)
 {
 	/* Name + vehicle + profit */
-	uint base = ScaleGUITrad(GetVehicleHeight(type)) + 2 * GetCharacterHeight(FS_SMALL) + WidgetDimensions::scaled.matrix.Vertical();
+	int base = ScaleGUITrad(GetVehicleHeight(type)) + 2 * GetCharacterHeight(FS_SMALL) + WidgetDimensions::scaled.matrix.Vertical();
 	/* Drawing of the 4 small orders + profit*/
-	if (type >= VEH_SHIP) base = std::max(base, 6U * GetCharacterHeight(FS_SMALL) + WidgetDimensions::scaled.matrix.Vertical());
+	if (type >= VEH_SHIP) base = std::max(base, 6 * GetCharacterHeight(FS_SMALL) + WidgetDimensions::scaled.matrix.Vertical());
 
 	if (divisor == 1) return base;
 
 	/* Make sure the height is dividable by divisor */
-	uint rem = base % divisor;
+	int rem = base % divisor;
 	return base + (rem == 0 ? 0 : divisor - rem);
 }
 
@@ -2436,7 +2436,7 @@ struct VehicleDetailsWindow : Window {
 		const Vehicle *v = Vehicle::Get(this->window_number);
 		if (v->type == VEH_ROAD) {
 			const NWidgetBase *nwid_info = this->GetWidget<NWidgetBase>(WID_VD_MIDDLE_DETAILS);
-			uint aimed_height = this->GetRoadVehDetailsHeight(v);
+			int aimed_height = this->GetRoadVehDetailsHeight(v);
 			/* If the number of articulated parts changes, the size of the window must change too. */
 			if (aimed_height != nwid_info->current_y) {
 				this->ReInit();
@@ -2449,9 +2449,9 @@ struct VehicleDetailsWindow : Window {
 	 * @param v Road vehicle being shown.
 	 * @return Desired height in pixels.
 	 */
-	uint GetRoadVehDetailsHeight(const Vehicle *v)
+	int GetRoadVehDetailsHeight(const Vehicle *v)
 	{
-		uint desired_height;
+		int desired_height;
 		if (v->HasArticulatedPart()) {
 			/* An articulated RV has its text drawn under the sprite instead of after it, hence 15 pixels extra. */
 			desired_height = ScaleGUITrad(15) + 3 * GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal * 2;
@@ -2506,7 +2506,7 @@ struct VehicleDetailsWindow : Window {
 			}
 
 			case WID_VD_MATRIX:
-				resize.height = std::max<uint>(ScaleGUITrad(14), GetCharacterHeight(FS_NORMAL) + padding.height);
+				resize.height = std::max(ScaleGUITrad(14), GetCharacterHeight(FS_NORMAL) + padding.height);
 				size.height = 4 * resize.height;
 				break;
 
@@ -2645,7 +2645,7 @@ struct VehicleDetailsWindow : Window {
 			case WID_VD_MIDDLE_DETAILS: {
 				/* For other vehicles, at the place of the matrix. */
 				bool rtl = _current_text_dir == TD_RTL;
-				uint sprite_width = GetSingleVehicleWidth(v, EIT_IN_DETAILS) + WidgetDimensions::scaled.framerect.Horizontal();
+				int sprite_width = GetSingleVehicleWidth(v, EIT_IN_DETAILS) + WidgetDimensions::scaled.framerect.Horizontal();
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
 
 				/* Articulated road vehicles use a complete line. */
@@ -3061,7 +3061,7 @@ public:
 		const Vehicle *v = Vehicle::Get(this->window_number);
 		switch (widget) {
 			case WID_VV_START_STOP:
-				size.height = std::max<uint>({size.height, (uint)GetCharacterHeight(FS_NORMAL), GetScaledSpriteSize(SPR_WARNING_SIGN).height, GetScaledSpriteSize(SPR_FLAG_VEH_STOPPED).height, GetScaledSpriteSize(SPR_FLAG_VEH_RUNNING).height}) + padding.height;
+				size.height = std::max({size.height, GetCharacterHeight(FS_NORMAL), GetScaledSpriteSize(SPR_WARNING_SIGN).height, GetScaledSpriteSize(SPR_FLAG_VEH_STOPPED).height, GetScaledSpriteSize(SPR_FLAG_VEH_RUNNING).height}) + padding.height;
 				break;
 
 			case WID_VV_FORCE_PROCEED:
@@ -3201,7 +3201,7 @@ public:
 
 		/* Draw the flag plus orders. */
 		bool rtl = (_current_text_dir == TD_RTL);
-		uint icon_width = std::max({GetScaledSpriteSize(SPR_WARNING_SIGN).width, GetScaledSpriteSize(SPR_FLAG_VEH_STOPPED).width, GetScaledSpriteSize(SPR_FLAG_VEH_RUNNING).width});
+		int icon_width = std::max({GetScaledSpriteSize(SPR_WARNING_SIGN).width, GetScaledSpriteSize(SPR_FLAG_VEH_STOPPED).width, GetScaledSpriteSize(SPR_FLAG_VEH_RUNNING).width});
 		Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
 
 		const Vehicle *v = Vehicle::Get(this->window_number);

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -71,7 +71,7 @@ void ShowVehicleListWindow(CompanyID company, VehicleType vehicle_type, TileInde
  * @param type the vehicle type to look at
  * @return the height
  */
-inline uint GetVehicleHeight(VehicleType type)
+inline int GetVehicleHeight(VehicleType type)
 {
 	return (type == VEH_TRAIN || type == VEH_ROAD) ? 14 : 24;
 }
@@ -81,9 +81,9 @@ int GetVehicleWidth(const Vehicle *v, EngineImageType image_type);
 
 /** Dimensions of a cell in the purchase/depot windows. */
 struct VehicleCellSize {
-	uint height;       ///< Vehicle cell height.
-	uint extend_left;  ///< Extend of the cell to the left.
-	uint extend_right; ///< Extend of the cell to the right.
+	int height;       ///< Vehicle cell height.
+	int extend_left;  ///< Extend of the cell to the left.
+	int extend_right; ///< Extend of the cell to the right.
 };
 
 VehicleCellSize GetVehicleImageCellSize(VehicleType type, EngineImageType image_type);

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -82,7 +82,7 @@ struct BaseVehicleListWindow : public Window {
 	VehicleListIdentifier vli{}; ///< Identifier of the vehicle list we want to currently show.
 	VehicleID vehicle_sel{}; ///< Selected vehicle
 	CargoType cargo_filter_criteria{}; ///< Selected cargo filter index
-	uint order_arrow_width = 0; ///< Width of the arrow in the small order list.
+	int order_arrow_width = 0; ///< Width of the arrow in the small order list.
 	CargoTypes used_cargoes{};
 
 	typedef GUIVehicleGroupList::SortFunction VehicleGroupSortFunction;
@@ -155,7 +155,7 @@ void AddCargoIconOverlay(std::vector<CargoIconOverlay> &overlays, int x, int wid
 void DrawCargoIconOverlay(int x, int y, CargoType cargo_type);
 void DrawCargoIconOverlays(std::span<const CargoIconOverlay> overlays, int y);
 
-uint GetVehicleListHeight(VehicleType type, uint divisor = 1);
+int GetVehicleListHeight(VehicleType type, int divisor = 1);
 
 struct Sorting {
 	Listing aircraft;

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -148,8 +148,8 @@ static void GetVideoModes()
 	GFX_MODE *modes = mode_list->mode;
 
 	for (int i = 0; modes[i].bpp != 0; i++) {
-		uint w = modes[i].width;
-		uint h = modes[i].height;
+		int w = modes[i].width;
+		int h = modes[i].height;
 		if (w < 640 || h < 480) continue;
 		if (std::ranges::find(_resolutions, Dimension(w, h)) != _resolutions.end()) continue;
 		_resolutions.emplace_back(w, h);
@@ -160,7 +160,7 @@ static void GetVideoModes()
 	destroy_gfx_mode_list(mode_list);
 }
 
-static void GetAvailableVideoMode(uint *w, uint *h)
+static void GetAvailableVideoMode(int *w, int *h)
 {
 	/* No video modes, so just try it and see where it ends */
 	if (_resolutions.empty()) return;
@@ -170,9 +170,9 @@ static void GetAvailableVideoMode(uint *w, uint *h)
 
 	/* use the closest possible resolution */
 	uint best = 0;
-	uint delta = Delta(_resolutions[0].width, *w) * Delta(_resolutions[0].height, *h);
+	int delta = Delta(_resolutions[0].width, *w) * Delta(_resolutions[0].height, *h);
 	for (uint i = 1; i != _resolutions.size(); ++i) {
-		uint newdelta = Delta(_resolutions[i].width, *w) * Delta(_resolutions[i].height, *h);
+		int newdelta = Delta(_resolutions[i].width, *w) * Delta(_resolutions[i].height, *h);
 		if (newdelta < delta) {
 			best = i;
 			delta = newdelta;
@@ -182,7 +182,7 @@ static void GetAvailableVideoMode(uint *w, uint *h)
 	*h = _resolutions[best].height;
 }
 
-static bool CreateMainSurface(uint w, uint h)
+static bool CreateMainSurface(int w, int h)
 {
 	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
 	if (bpp == 0) UserError("Can't use a blitter that blits 0 bpp for normal visuals");

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -280,7 +280,7 @@ std::vector<int> VideoDriver_Cocoa::GetListOfMonitorRefreshRates()
 Dimension VideoDriver_Cocoa::GetScreenSize() const
 {
 	NSRect frame = [ [ NSScreen mainScreen ] frame ];
-	return { static_cast<uint>(NSWidth(frame)), static_cast<uint>(NSHeight(frame)) };
+	return {static_cast<int>(NSWidth(frame)), static_cast<int>(NSHeight(frame))};
 }
 
 /** Get DPI scale of our window. */

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -587,7 +587,7 @@ std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 	/* Check maximum texture size against screen resolution. */
 	GLint max_tex_size = 0;
 	_glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_tex_size);
-	if (std::max(screen_res.width, screen_res.height) > (uint)max_tex_size) return "Max supported texture size is too small";
+	if (std::max(screen_res.width, screen_res.height) > max_tex_size) return "Max supported texture size is too small";
 
 	/* Check available texture units. */
 	GLint max_tex_units = 0;
@@ -1502,7 +1502,7 @@ void OpenGLSprite::Update(uint width, uint height, uint level, const SpriteLoade
  */
 inline Dimension OpenGLSprite::GetSize(ZoomLevel level) const
 {
-	Dimension sd = { (uint)UnScaleByZoomLower(this->dim.width, level), (uint)UnScaleByZoomLower(this->dim.height, level) };
+	Dimension sd = { UnScaleByZoomLower(this->dim.width, level), UnScaleByZoomLower(this->dim.height, level) };
 	return sd;
 }
 

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -47,7 +47,7 @@ static OGLProc GetOGLProcAddressCallback(const char *proc)
 	return reinterpret_cast<OGLProc>(SDL_GL_GetProcAddress(proc));
 }
 
-bool VideoDriver_SDL_OpenGL::CreateMainWindow(uint w, uint h, uint flags)
+bool VideoDriver_SDL_OpenGL::CreateMainWindow(int w, int h, uint flags)
 {
 	return this->VideoDriver_SDL_Base::CreateMainWindow(w, h, flags | SDL_WINDOW_OPENGL);
 }

--- a/src/video/sdl2_opengl_v.h
+++ b/src/video/sdl2_opengl_v.h
@@ -38,7 +38,7 @@ protected:
 	void *GetVideoPointer() override;
 	void ReleaseVideoPointer() override;
 	void Paint() override;
-	bool CreateMainWindow(uint w, uint h, uint flags) override;
+	bool CreateMainWindow(int w, int h, uint flags) override;
 
 private:
 	void  *gl_context;  ///< OpenGL context.

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -79,7 +79,7 @@ static void FindResolutions()
 	SortResolutions();
 }
 
-static void GetAvailableVideoMode(uint *w, uint *h)
+static void GetAvailableVideoMode(int *w, int *h)
 {
 	/* All modes available? */
 	if (!_fullscreen || _resolutions.empty()) return;
@@ -134,7 +134,7 @@ void VideoDriver_SDL_Base::ClientSizeChanged(int w, int h, bool force)
 	}
 }
 
-bool VideoDriver_SDL_Base::CreateMainWindow(uint w, uint h, uint flags)
+bool VideoDriver_SDL_Base::CreateMainWindow(int w, int h, uint flags)
 {
 	if (this->sdl_window != nullptr) return true;
 
@@ -147,8 +147,8 @@ bool VideoDriver_SDL_Base::CreateMainWindow(uint w, uint h, uint flags)
 	int x = SDL_WINDOWPOS_UNDEFINED, y = SDL_WINDOWPOS_UNDEFINED;
 	SDL_Rect r;
 	if (SDL_GetDisplayBounds(this->startup_display, &r) == 0) {
-		x = r.x + std::max(0, r.w - static_cast<int>(w)) / 2;
-		y = r.y + std::max(0, r.h - static_cast<int>(h)) / 4; // decent desktops have taskbars at the bottom
+		x = r.x + std::max(0, r.w - w) / 2;
+		y = r.y + std::max(0, r.h - h) / 4; // decent desktops have taskbars at the bottom
 	}
 
 	std::string caption = VideoDriver::GetCaption();
@@ -180,7 +180,7 @@ bool VideoDriver_SDL_Base::CreateMainWindow(uint w, uint h, uint flags)
 	return true;
 }
 
-bool VideoDriver_SDL_Base::CreateMainSurface(uint w, uint h, bool resize)
+bool VideoDriver_SDL_Base::CreateMainSurface(int w, int h, bool resize)
 {
 	GetAvailableVideoMode(&w, &h);
 	Debug(driver, 1, "SDL2: using mode {}x{}", w, h);
@@ -732,7 +732,7 @@ Dimension VideoDriver_SDL_Base::GetScreenSize() const
 	SDL_DisplayMode mode;
 	if (SDL_GetCurrentDisplayMode(this->startup_display, &mode) != 0) return VideoDriver::GetScreenSize();
 
-	return { static_cast<uint>(mode.w), static_cast<uint>(mode.h) };
+	return {mode.w, mode.h};
 }
 
 bool VideoDriver_SDL_Base::LockVideoBuffer()

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -67,12 +67,12 @@ protected:
 	/** Hand video buffer back to the painting backend. */
 	virtual void ReleaseVideoPointer() = 0;
 	/** Create the main window. */
-	virtual bool CreateMainWindow(uint w, uint h, uint flags = 0);
+	virtual bool CreateMainWindow(int w, int h, uint flags = 0);
 
 private:
 	void LoopOnce();
 	void MainLoopCleanup();
-	bool CreateMainSurface(uint w, uint h, bool resize);
+	bool CreateMainSurface(int w, int h, bool resize);
 	std::optional<std::string_view> Initialize();
 
 #ifdef __EMSCRIPTEN__

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -32,8 +32,8 @@ extern bool _video_vsync;
 
 /** The base of all video drivers. */
 class VideoDriver : public Driver {
-	const uint DEFAULT_WINDOW_WIDTH = 640u;  ///< Default window width.
-	const uint DEFAULT_WINDOW_HEIGHT = 480u; ///< Default window height.
+	const int DEFAULT_WINDOW_WIDTH = 640; ///< Default window width.
+	const int DEFAULT_WINDOW_HEIGHT = 480; ///< Default window height.
 
 public:
 	VideoDriver(bool uses_hardware_acceleration = false) : fast_forward_key_pressed(false), fast_forward_via_key(false), is_game_threaded(true), uses_hardware_acceleration(uses_hardware_acceleration) {}

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1044,7 +1044,7 @@ std::vector<int> VideoDriver_Win32Base::GetListOfMonitorRefreshRates()
 
 Dimension VideoDriver_Win32Base::GetScreenSize() const
 {
-	return { static_cast<uint>(GetSystemMetrics(SM_CXSCREEN)), static_cast<uint>(GetSystemMetrics(SM_CYSCREEN)) };
+	return {GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN)};
 }
 
 float VideoDriver_Win32Base::GetDPIScale()

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -47,7 +47,7 @@ static std::string GetStringForWidget(const Window *w, const NWidgetCore *nwid, 
  */
 static inline RectPadding ScaleGUITrad(const RectPadding &r)
 {
-	return {(uint8_t)ScaleGUITrad(r.left), (uint8_t)ScaleGUITrad(r.top), (uint8_t)ScaleGUITrad(r.right), (uint8_t)ScaleGUITrad(r.bottom)};
+	return {(int8_t)ScaleGUITrad(r.left), (int8_t)ScaleGUITrad(r.top), (int8_t)ScaleGUITrad(r.right), (int8_t)ScaleGUITrad(r.bottom)};
 }
 
 /**
@@ -57,7 +57,7 @@ static inline RectPadding ScaleGUITrad(const RectPadding &r)
  */
 static inline Dimension ScaleGUITrad(const Dimension &dim)
 {
-	return {(uint)ScaleGUITrad(dim.width), (uint)ScaleGUITrad(dim.height)};
+	return {ScaleGUITrad(dim.width), ScaleGUITrad(dim.height)};
 }
 
 /**
@@ -300,11 +300,11 @@ void DrawFrameRect(int left, int top, int right, int bottom, Colours colour, Fra
 	} else {
 		assert(colour < COLOUR_END);
 
-		const uint dark         = GetColourGradient(colour, SHADE_DARK);
-		const uint medium_dark  = GetColourGradient(colour, SHADE_LIGHT);
-		const uint medium_light = GetColourGradient(colour, SHADE_LIGHTER);
-		const uint light        = GetColourGradient(colour, SHADE_LIGHTEST);
-		uint interior;
+		const uint8_t dark         = GetColourGradient(colour, SHADE_DARK);
+		const uint8_t medium_dark  = GetColourGradient(colour, SHADE_LIGHT);
+		const uint8_t medium_light = GetColourGradient(colour, SHADE_LIGHTER);
+		const uint8_t light        = GetColourGradient(colour, SHADE_LIGHTEST);
+		uint8_t interior;
 
 		Rect outer = {left, top, right, bottom};                   // Outside rectangle
 		Rect inner = outer.Shrink(WidgetDimensions::scaled.bevel); // Inside rectangle
@@ -416,7 +416,7 @@ static inline void DrawInset(const Rect &r, Colours colour, TextColour text_colo
  * @param resize_x Matrix resize unit size.
  * @param resize_y Matrix resize unit size.
  */
-static inline void DrawMatrix(const Rect &r, Colours colour, bool clicked, uint32_t num_columns, uint32_t num_rows, uint resize_x, uint resize_y)
+static inline void DrawMatrix(const Rect &r, Colours colour, bool clicked, int num_columns, int num_rows, int resize_x, int resize_y)
 {
 	DrawFrameRect(r.left, r.top, r.right, r.bottom, colour, (clicked) ? FrameFlag::Lowered : FrameFlags{});
 
@@ -492,8 +492,8 @@ static inline void DrawVerticalScrollbar(const Rect &r, Colours colour, bool up_
 	/* track positions. These fractions are based on original 1x dimensions, but scale better. */
 	int left  = r.left + r.Width() * 3 / 11; /*  left track is positioned 3/11ths from the left */
 	int right = r.left + r.Width() * 8 / 11; /* right track is positioned 8/11ths from the left */
-	const uint8_t bl = WidgetDimensions::scaled.bevel.left;
-	const uint8_t br = WidgetDimensions::scaled.bevel.right;
+	const int8_t bl = WidgetDimensions::scaled.bevel.left;
+	const int8_t br = WidgetDimensions::scaled.bevel.right;
 
 	/* draw shaded lines */
 	GfxFillRect(left - bl,  r.top + height, left       - 1, r.bottom - height, c1);
@@ -531,8 +531,8 @@ static inline void DrawHorizontalScrollbar(const Rect &r, Colours colour, bool l
 	/* track positions. These fractions are based on original 1x dimensions, but scale better. */
 	int top    = r.top + r.Height() * 3 / 11; /*    top track is positioned 3/11ths from the top */
 	int bottom = r.top + r.Height() * 8 / 11; /* bottom track is positioned 8/11ths from the top */
-	const uint8_t bt = WidgetDimensions::scaled.bevel.top;
-	const uint8_t bb = WidgetDimensions::scaled.bevel.bottom;
+	const int8_t bt = WidgetDimensions::scaled.bevel.top;
+	const int8_t bb = WidgetDimensions::scaled.bevel.bottom;
 
 	/* draw shaded lines */
 	GfxFillRect(r.left + width, top - bt,    r.right - width, top         - 1, c1);
@@ -872,7 +872,7 @@ static void DrawOutline(const Window *, const NWidgetBase *wid)
  */
 
 /**
- * @fn void NWidgetBase::AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl)
+ * @fn void NWidgetBase::AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl)
  * Assign size and position to the widget.
  * @param sizing       Type of resizing to perform.
  * @param x            Horizontal offset of the widget relative to the left edge of the window.
@@ -932,10 +932,10 @@ void NWidgetBase::ApplyAspectRatio()
 	if (this->aspect_ratio == 0) return;
 	if (this->smallest_x == 0 || this->smallest_y == 0) return;
 
-	uint x = this->smallest_x;
-	uint y = this->smallest_y;
-	if (this->aspect_flags.Test(AspectFlag::ResizeX)) x = std::max(this->smallest_x, static_cast<uint>(this->smallest_y * std::abs(this->aspect_ratio)));
-	if (this->aspect_flags.Test(AspectFlag::ResizeY)) y = std::max(this->smallest_y, static_cast<uint>(this->smallest_x / std::abs(this->aspect_ratio)));
+	int x = this->smallest_x;
+	int y = this->smallest_y;
+	if (this->aspect_flags.Test(AspectFlag::ResizeX)) x = std::max(this->smallest_x, static_cast<int>(this->smallest_y * std::abs(this->aspect_ratio)));
+	if (this->aspect_flags.Test(AspectFlag::ResizeY)) y = std::max(this->smallest_y, static_cast<int>(this->smallest_x / std::abs(this->aspect_ratio)));
 
 	this->smallest_x = x;
 	this->smallest_y = y;
@@ -952,7 +952,7 @@ void NWidgetBase::AdjustPaddingForZoom()
  * @param fill_x Horizontal fill step size, \c 0 means no filling is allowed.
  * @param fill_y Vertical fill step size, \c 0 means no filling is allowed.
  */
-NWidgetResizeBase::NWidgetResizeBase(WidgetType tp, uint fill_x, uint fill_y) : NWidgetBase(tp)
+NWidgetResizeBase::NWidgetResizeBase(WidgetType tp, int fill_x, int fill_y) : NWidgetBase(tp)
 {
 	this->fill_x = fill_x;
 	this->fill_y = fill_y;
@@ -994,7 +994,7 @@ void NWidgetResizeBase::AdjustPaddingForZoom()
  * @param min_x Horizontal minimal size of the widget.
  * @param min_y Vertical minimal size of the widget.
  */
-void NWidgetResizeBase::SetMinimalSize(uint min_x, uint min_y)
+void NWidgetResizeBase::SetMinimalSize(int min_x, int min_y)
 {
 	this->uz_min_x = std::max(this->uz_min_x, min_x);
 	this->uz_min_y = std::max(this->uz_min_y, min_y);
@@ -1007,7 +1007,7 @@ void NWidgetResizeBase::SetMinimalSize(uint min_x, uint min_y)
  * @param min_x Horizontal minimal size of the widget.
  * @param min_y Vertical minimal size of the widget.
  */
-void NWidgetResizeBase::SetMinimalSizeAbsolute(uint min_x, uint min_y)
+void NWidgetResizeBase::SetMinimalSizeAbsolute(int min_x, int min_y)
 {
 	this->absolute = true;
 	this->min_x = std::max(this->min_x, min_x);
@@ -1020,7 +1020,7 @@ void NWidgetResizeBase::SetMinimalSizeAbsolute(uint min_x, uint min_y)
  * @param spacing   Extra unscaled spacing (eg WidgetDimensions::unscaled.framerect.Vertical()) of the widget.
  * @param size      Font size of text.
  */
-void NWidgetResizeBase::SetMinimalTextLines(uint8_t min_lines, uint8_t spacing, FontSize size)
+void NWidgetResizeBase::SetMinimalTextLines(int8_t min_lines, int8_t spacing, FontSize size)
 {
 	this->uz_text_lines = min_lines;
 	this->uz_text_spacing = spacing;
@@ -1033,7 +1033,7 @@ void NWidgetResizeBase::SetMinimalTextLines(uint8_t min_lines, uint8_t spacing, 
  * @param fill_x Horizontal fill step size, \c 0 means no filling is allowed.
  * @param fill_y Vertical fill step size, \c 0 means no filling is allowed.
  */
-void NWidgetResizeBase::SetFill(uint fill_x, uint fill_y)
+void NWidgetResizeBase::SetFill(int fill_x, int fill_y)
 {
 	this->fill_x = fill_x;
 	this->fill_y = fill_y;
@@ -1044,7 +1044,7 @@ void NWidgetResizeBase::SetFill(uint fill_x, uint fill_y)
  * @param resize_x Resize step in horizontal direction, value \c 0 means no resize, otherwise the step size in pixels.
  * @param resize_y Resize step in vertical direction, value \c 0 means no resize, otherwise the step size in pixels.
  */
-void NWidgetResizeBase::SetResize(uint resize_x, uint resize_y)
+void NWidgetResizeBase::SetResize(int resize_x, int resize_y)
 {
 	this->resize_x = resize_x;
 	this->resize_y = resize_y;
@@ -1077,7 +1077,7 @@ bool NWidgetResizeBase::UpdateMultilineWidgetSize(const std::string &str, int ma
  * @param min_y Vertical minimal size of the widget.
  * @return true iff the widget minimum size has changed.
  */
-bool NWidgetResizeBase::UpdateSize(uint min_x, uint min_y)
+bool NWidgetResizeBase::UpdateSize(int min_x, int min_y)
 {
 	if (min_x == this->min_x && min_y == this->min_y) return false;
 	this->min_x = min_x;
@@ -1091,14 +1091,14 @@ bool NWidgetResizeBase::UpdateSize(uint min_x, uint min_y)
  * @param min_y Vertical minimal size of the widget.
  * @return true iff the widget minimum size has changed.
  */
-bool NWidgetResizeBase::UpdateVerticalSize(uint min_y)
+bool NWidgetResizeBase::UpdateVerticalSize(int min_y)
 {
 	if (min_y == this->min_y) return false;
 	this->min_y = min_y;
 	return true;
 }
 
-void NWidgetResizeBase::AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool)
+void NWidgetResizeBase::AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool)
 {
 	this->StoreSizePosition(sizing, x, y, given_width, given_height);
 }
@@ -1113,7 +1113,7 @@ void NWidgetResizeBase::AssignSizePosition(SizingType sizing, int x, int y, uint
  * @param widget_data Data component of the widget. @see Widget::data
  * @param tool_tip    Tool tip of the widget. @see Widget::tooltips
  */
-NWidgetCore::NWidgetCore(WidgetType tp, Colours colour, WidgetID index, uint fill_x, uint fill_y, const WidgetData &widget_data, StringID tool_tip) : NWidgetResizeBase(tp, fill_x, fill_y), index(index)
+NWidgetCore::NWidgetCore(WidgetType tp, Colours colour, WidgetID index, int fill_x, int fill_y, const WidgetData &widget_data, StringID tool_tip) : NWidgetResizeBase(tp, fill_x, fill_y), index(index)
 {
 	this->colour = colour;
 	this->widget_data = widget_data;
@@ -1166,9 +1166,9 @@ void NWidgetCore::SetSpriteTip(SpriteID sprite, StringID tool_tip)
  * @param columns The number of columns in the matrix (0 for autoscaling).
  * @param rows The number of rows in the matrix (0 for autoscaling).
  */
-void NWidgetCore::SetMatrixDimension(uint32_t columns, uint32_t rows)
+void NWidgetCore::SetMatrixDimension(int columns, int rows)
 {
-	this->widget_data.matrix = { columns, rows };
+	this->widget_data.matrix = {columns, rows};
 }
 
 /**
@@ -1352,7 +1352,7 @@ void NWidgetStacked::SetupSmallestSize(Window *w)
 	}
 }
 
-void NWidgetStacked::AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl)
+void NWidgetStacked::AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl)
 {
 	assert(given_width >= this->smallest_x && given_height >= this->smallest_y);
 	this->StoreSizePosition(sizing, x, y, given_width, given_height);
@@ -1360,13 +1360,13 @@ void NWidgetStacked::AssignSizePosition(SizingType sizing, int x, int y, uint gi
 	if (this->shown_plane >= SZSP_BEGIN) return;
 
 	for (const auto &child_wid : this->children) {
-		uint hor_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetHorizontalStepSize(sizing);
-		uint child_width = ComputeMaxSize(child_wid->smallest_x, given_width - child_wid->padding.Horizontal(), hor_step);
-		uint child_pos_x = (rtl ? child_wid->padding.right : child_wid->padding.left);
+		int hor_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetHorizontalStepSize(sizing);
+		int child_width = ComputeMaxSize(child_wid->smallest_x, given_width - child_wid->padding.Horizontal(), hor_step);
+		int child_pos_x = (rtl ? child_wid->padding.right : child_wid->padding.left);
 
-		uint vert_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetVerticalStepSize(sizing);
-		uint child_height = ComputeMaxSize(child_wid->smallest_y, given_height - child_wid->padding.Vertical(), vert_step);
-		uint child_pos_y = child_wid->padding.top;
+		int vert_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetVerticalStepSize(sizing);
+		int child_height = ComputeMaxSize(child_wid->smallest_y, given_height - child_wid->padding.Vertical(), vert_step);
+		int child_pos_y = child_wid->padding.top;
 
 		child_wid->AssignSizePosition(sizing, x + child_pos_x, y + child_pos_y, child_width, child_height, rtl);
 	}
@@ -1421,7 +1421,7 @@ public:
 	NWidgetLayer(WidgetID index) : NWidgetContainer(NWID_LAYER), index(index) {}
 
 	void SetupSmallestSize(Window *w) override;
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override;
 
 	void Draw(const Window *w) override;
 
@@ -1450,19 +1450,19 @@ void NWidgetLayer::SetupSmallestSize(Window *w)
 	}
 }
 
-void NWidgetLayer::AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl)
+void NWidgetLayer::AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl)
 {
 	assert(given_width >= this->smallest_x && given_height >= this->smallest_y);
 	this->StoreSizePosition(sizing, x, y, given_width, given_height);
 
 	for (const auto &child_wid : this->children) {
-		uint hor_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetHorizontalStepSize(sizing);
-		uint child_width = ComputeMaxSize(child_wid->smallest_x, given_width - child_wid->padding.Horizontal(), hor_step);
-		uint child_pos_x = (rtl ? child_wid->padding.right : child_wid->padding.left);
+		int hor_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetHorizontalStepSize(sizing);
+		int child_width = ComputeMaxSize(child_wid->smallest_x, given_width - child_wid->padding.Horizontal(), hor_step);
+		int child_pos_x = (rtl ? child_wid->padding.right : child_wid->padding.left);
 
-		uint vert_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetVerticalStepSize(sizing);
-		uint child_height = ComputeMaxSize(child_wid->smallest_y, given_height - child_wid->padding.Vertical(), vert_step);
-		uint child_pos_y = child_wid->padding.top;
+		int vert_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetVerticalStepSize(sizing);
+		int child_height = ComputeMaxSize(child_wid->smallest_y, given_height - child_wid->padding.Vertical(), vert_step);
+		int child_pos_y = child_wid->padding.top;
 
 		child_wid->AssignSizePosition(sizing, x + child_pos_x, y + child_pos_y, child_width, child_height, rtl);
 	}
@@ -1500,7 +1500,7 @@ void NWidgetPIPContainer::AdjustPaddingForZoom()
  * @param pip_post  Additional space after the last child widget (below for the
  *                  vertical container, at the right for the horizontal container).
  */
-void NWidgetPIPContainer::SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip_post)
+void NWidgetPIPContainer::SetPIP(int8_t pip_pre, int8_t pip_inter, int8_t pip_post)
 {
 	this->uz_pip_pre = pip_pre;
 	this->uz_pip_inter = pip_inter;
@@ -1520,7 +1520,7 @@ void NWidgetPIPContainer::SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip
  * @param pip_ratio_post  Ratio of additional space after the last child widget (below for the
  *                        vertical container, at the right for the horizontal container).
  */
-void NWidgetPIPContainer::SetPIPRatio(uint8_t pip_ratio_pre, uint8_t pip_ratio_inter, uint8_t pip_ratio_post)
+void NWidgetPIPContainer::SetPIPRatio(int8_t pip_ratio_pre, int8_t pip_ratio_inter, int8_t pip_ratio_post)
 {
 	this->pip_ratio_pre = pip_ratio_pre;
 	this->pip_ratio_inter = pip_ratio_inter;
@@ -1543,8 +1543,8 @@ void NWidgetHorizontal::SetupSmallestSize(Window *w)
 	this->gaps = 0;
 
 	/* 1a. Forward call, collect longest/widest child length. */
-	uint longest = 0; // Longest child found.
-	uint max_vert_fill = 0; // Biggest vertical fill step.
+	int longest = 0; // Longest child found.
+	int max_vert_fill = 0; // Biggest vertical fill step.
 	for (const auto &child_wid : this->children) {
 		child_wid->SetupSmallestSize(w);
 		longest = std::max(longest, child_wid->smallest_x);
@@ -1554,14 +1554,14 @@ void NWidgetHorizontal::SetupSmallestSize(Window *w)
 	}
 	if (this->gaps > 0) this->gaps--; // Number of gaps is number of widgets less one.
 	/* 1b. Make the container higher if needed to accommodate all children nicely. */
-	[[maybe_unused]] uint max_smallest = this->smallest_y + 3 * max_vert_fill; // Upper limit to computing smallest height.
-	uint cur_height = this->smallest_y;
+	[[maybe_unused]] int max_smallest = this->smallest_y + 3 * max_vert_fill; // Upper limit to computing smallest height.
+	int cur_height = this->smallest_y;
 	for (;;) {
 		for (const auto &child_wid : this->children) {
-			uint step_size = child_wid->GetVerticalStepSize(ST_SMALLEST);
-			uint child_height = child_wid->smallest_y + child_wid->padding.Vertical();
+			int step_size = child_wid->GetVerticalStepSize(ST_SMALLEST);
+			int child_height = child_wid->smallest_y + child_wid->padding.Vertical();
 			if (step_size > 1 && child_height < cur_height) { // Small step sizes or already fitting children are not interesting.
-				uint remainder = (cur_height - child_height) % step_size;
+				int remainder = (cur_height - child_height) % step_size;
 				if (remainder > 0) { // Child did not fit entirely, widen the container.
 					cur_height += step_size - remainder;
 					assert(cur_height < max_smallest); // Safeguard against infinite height expansion.
@@ -1601,12 +1601,12 @@ void NWidgetHorizontal::SetupSmallestSize(Window *w)
 	this->smallest_x += this->pip_pre + this->gaps * this->pip_inter + this->pip_post;
 }
 
-void NWidgetHorizontal::AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl)
+void NWidgetHorizontal::AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl)
 {
 	assert(given_width >= this->smallest_x && given_height >= this->smallest_y);
 
 	/* Compute additional width given to us. */
-	uint additional_length = given_width - (this->pip_pre + this->gaps * this->pip_inter + this->pip_post);
+	int additional_length = given_width - (this->pip_pre + this->gaps * this->pip_inter + this->pip_post);
 	for (const auto &child_wid : this->children) {
 		if (child_wid->smallest_x != 0 || child_wid->fill_x != 0) additional_length -= child_wid->smallest_x + child_wid->padding.Horizontal();
 	}
@@ -1628,9 +1628,9 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, int x, int y, uint
 	 * handle horizontal size for non-resizing children.
 	 */
 	int num_changing_childs = 0; // Number of children that can change size.
-	uint biggest_stepsize = 0;
+	int biggest_stepsize = 0;
 	for (const auto &child_wid : this->children) {
-		uint hor_step = child_wid->GetHorizontalStepSize(sizing);
+		int hor_step = child_wid->GetHorizontalStepSize(sizing);
 		if (hor_step > 0) {
 			if (!flags.Test(NWidContainerFlag::BigFirst)) num_changing_childs++;
 			biggest_stepsize = std::max(biggest_stepsize, hor_step);
@@ -1638,14 +1638,14 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, int x, int y, uint
 			child_wid->current_x = child_wid->smallest_x;
 		}
 
-		uint vert_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetVerticalStepSize(sizing);
+		int vert_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetVerticalStepSize(sizing);
 		child_wid->current_y = ComputeMaxSize(child_wid->smallest_y, given_height - child_wid->padding.Vertical(), vert_step);
 	}
 
 	/* First.5 loop: count how many children are of the biggest step size. */
 	if (flags.Test(NWidContainerFlag::BigFirst) && biggest_stepsize > 0) {
 		for (const auto &child_wid : this->children) {
-			uint hor_step = child_wid->GetHorizontalStepSize(sizing);
+			int hor_step = child_wid->GetHorizontalStepSize(sizing);
 			if (hor_step == biggest_stepsize) {
 				num_changing_childs++;
 			}
@@ -1654,12 +1654,12 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, int x, int y, uint
 
 	/* Second loop: Allocate the additional horizontal space over the resizing children, starting with the biggest resize steps. */
 	while (biggest_stepsize > 0) {
-		uint next_biggest_stepsize = 0;
+		int next_biggest_stepsize = 0;
 		for (const auto &child_wid : this->children) {
-			uint hor_step = child_wid->GetHorizontalStepSize(sizing);
+			int hor_step = child_wid->GetHorizontalStepSize(sizing);
 			if (hor_step > biggest_stepsize) continue; // Already done
 			if (hor_step == biggest_stepsize) {
-				uint increment = additional_length / num_changing_childs;
+				int increment = additional_length / num_changing_childs;
 				num_changing_childs--;
 				if (hor_step > 1) increment -= increment % hor_step;
 				child_wid->current_x = child_wid->smallest_x + increment;
@@ -1673,7 +1673,7 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, int x, int y, uint
 		if (num_changing_childs == 0 && flags.Test(NWidContainerFlag::BigFirst) && biggest_stepsize > 0) {
 			/* Second.5 loop: count how many children are of the updated biggest step size. */
 			for (const auto &child_wid : this->children) {
-				uint hor_step = child_wid->GetHorizontalStepSize(sizing);
+				int hor_step = child_wid->GetHorizontalStepSize(sizing);
 				if (hor_step == biggest_stepsize) {
 					num_changing_childs++;
 				}
@@ -1682,8 +1682,8 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, int x, int y, uint
 	}
 	assert(num_changing_childs == 0);
 
-	uint pre = this->pip_pre;
-	uint inter = this->pip_inter;
+	int pre = this->pip_pre;
+	int inter = this->pip_inter;
 
 	if (additional_length > 0) {
 		/* Allocate remaining space by pip ratios. If this doesn't round exactly, the unused space will fall into pip_post
@@ -1696,15 +1696,15 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, int x, int y, uint
 	}
 
 	/* Third loop: Compute position and call the child. */
-	uint position = rtl ? this->current_x - pre : pre; // Place to put next child relative to origin of the container.
+	int position = rtl ? this->current_x - pre : pre; // Place to put next child relative to origin of the container.
 	for (const auto &child_wid : this->children) {
-		uint child_width = child_wid->current_x;
-		uint child_x = x + (rtl ? position - child_width - child_wid->padding.left : position + child_wid->padding.left);
-		uint child_y = y + child_wid->padding.top;
+		int child_width = child_wid->current_x;
+		int child_x = x + (rtl ? position - child_width - child_wid->padding.left : position + child_wid->padding.left);
+		int child_y = y + child_wid->padding.top;
 
 		child_wid->AssignSizePosition(sizing, child_x, child_y, child_width, child_wid->current_y, rtl);
 		if (child_wid->current_x != 0) {
-			uint padded_child_width = child_width + child_wid->padding.Horizontal() + inter;
+			int padded_child_width = child_width + child_wid->padding.Horizontal() + inter;
 			position = rtl ? position - padded_child_width : position + padded_child_width;
 		}
 	}
@@ -1716,7 +1716,7 @@ NWidgetHorizontalLTR::NWidgetHorizontalLTR(NWidContainerFlags flags) : NWidgetHo
 	this->type = NWID_HORIZONTAL_LTR;
 }
 
-void NWidgetHorizontalLTR::AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool)
+void NWidgetHorizontalLTR::AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool)
 {
 	NWidgetHorizontal::AssignSizePosition(sizing, x, y, given_width, given_height, false);
 }
@@ -1737,8 +1737,8 @@ void NWidgetVertical::SetupSmallestSize(Window *w)
 	this->gaps = 0;
 
 	/* 1a. Forward call, collect longest/widest child length. */
-	uint highest = 0; // Highest child found.
-	uint max_hor_fill = 0; // Biggest horizontal fill step.
+	int highest = 0; // Highest child found.
+	int max_hor_fill = 0; // Biggest horizontal fill step.
 	for (const auto &child_wid : this->children) {
 		child_wid->SetupSmallestSize(w);
 		highest = std::max(highest, child_wid->smallest_y);
@@ -1748,14 +1748,14 @@ void NWidgetVertical::SetupSmallestSize(Window *w)
 	}
 	if (this->gaps > 0) this->gaps--; // Number of gaps is number of widgets less one.
 	/* 1b. Make the container wider if needed to accommodate all children nicely. */
-	[[maybe_unused]] uint max_smallest = this->smallest_x + 3 * max_hor_fill; // Upper limit to computing smallest height.
-	uint cur_width = this->smallest_x;
+	[[maybe_unused]] int max_smallest = this->smallest_x + 3 * max_hor_fill; // Upper limit to computing smallest height.
+	int cur_width = this->smallest_x;
 	for (;;) {
 		for (const auto &child_wid : this->children) {
-			uint step_size = child_wid->GetHorizontalStepSize(ST_SMALLEST);
-			uint child_width = child_wid->smallest_x + child_wid->padding.Horizontal();
+			int step_size = child_wid->GetHorizontalStepSize(ST_SMALLEST);
+			int child_width = child_wid->smallest_x + child_wid->padding.Horizontal();
 			if (step_size > 1 && child_width < cur_width) { // Small step sizes or already fitting children are not interesting.
-				uint remainder = (cur_width - child_width) % step_size;
+				int remainder = (cur_width - child_width) % step_size;
 				if (remainder > 0) { // Child did not fit entirely, widen the container.
 					cur_width += step_size - remainder;
 					assert(cur_width < max_smallest); // Safeguard against infinite width expansion.
@@ -1795,12 +1795,12 @@ void NWidgetVertical::SetupSmallestSize(Window *w)
 	this->smallest_y += this->pip_pre + this->gaps * this->pip_inter + this->pip_post;
 }
 
-void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl)
+void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl)
 {
 	assert(given_width >= this->smallest_x && given_height >= this->smallest_y);
 
 	/* Compute additional height given to us. */
-	uint additional_length = given_height - (this->pip_pre + this->gaps * this->pip_inter + this->pip_post);
+	int additional_length = given_height - (this->pip_pre + this->gaps * this->pip_inter + this->pip_post);
 	for (const auto &child_wid : this->children) {
 		if (child_wid->smallest_y != 0 || child_wid->fill_y != 0) additional_length -= child_wid->smallest_y + child_wid->padding.Vertical();
 	}
@@ -1813,9 +1813,9 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint g
 
 	/* First loop: Find biggest stepsize, find number of children that want a piece of the pie, handle horizontal size for all children, handle vertical size for non-resizing child. */
 	int num_changing_childs = 0; // Number of children that can change size.
-	uint biggest_stepsize = 0;
+	int biggest_stepsize = 0;
 	for (const auto &child_wid : this->children) {
-		uint vert_step = child_wid->GetVerticalStepSize(sizing);
+		int vert_step = child_wid->GetVerticalStepSize(sizing);
 		if (vert_step > 0) {
 			if (!flags.Test(NWidContainerFlag::BigFirst)) num_changing_childs++;
 			biggest_stepsize = std::max(biggest_stepsize, vert_step);
@@ -1823,14 +1823,14 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint g
 			child_wid->current_y = child_wid->smallest_y;
 		}
 
-		uint hor_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetHorizontalStepSize(sizing);
+		int hor_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetHorizontalStepSize(sizing);
 		child_wid->current_x = ComputeMaxSize(child_wid->smallest_x, given_width - child_wid->padding.Horizontal(), hor_step);
 	}
 
 	/* First.5 loop: count how many children are of the biggest step size. */
 	if (this->flags.Test(NWidContainerFlag::BigFirst) && biggest_stepsize > 0) {
 		for (const auto &child_wid : this->children) {
-			uint vert_step = child_wid->GetVerticalStepSize(sizing);
+			int vert_step = child_wid->GetVerticalStepSize(sizing);
 			if (vert_step == biggest_stepsize) {
 				num_changing_childs++;
 			}
@@ -1839,12 +1839,12 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint g
 
 	/* Second loop: Allocate the additional vertical space over the resizing children, starting with the biggest resize steps. */
 	while (biggest_stepsize > 0) {
-		uint next_biggest_stepsize = 0;
+		int next_biggest_stepsize = 0;
 		for (const auto &child_wid : this->children) {
-			uint vert_step = child_wid->GetVerticalStepSize(sizing);
+			int vert_step = child_wid->GetVerticalStepSize(sizing);
 			if (vert_step > biggest_stepsize) continue; // Already done
 			if (vert_step == biggest_stepsize) {
-				uint increment = additional_length / num_changing_childs;
+				int increment = additional_length / num_changing_childs;
 				num_changing_childs--;
 				if (vert_step > 1) increment -= increment % vert_step;
 				child_wid->current_y = child_wid->smallest_y + increment;
@@ -1858,7 +1858,7 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint g
 		if (num_changing_childs == 0 && flags.Test(NWidContainerFlag::BigFirst) && biggest_stepsize > 0) {
 			/* Second.5 loop: count how many children are of the updated biggest step size. */
 			for (const auto &child_wid : this->children) {
-				uint vert_step = child_wid->GetVerticalStepSize(sizing);
+				int vert_step = child_wid->GetVerticalStepSize(sizing);
 				if (vert_step == biggest_stepsize) {
 					num_changing_childs++;
 				}
@@ -1867,8 +1867,8 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint g
 	}
 	assert(num_changing_childs == 0);
 
-	uint pre = this->pip_pre;
-	uint inter = this->pip_inter;
+	int pre = this->pip_pre;
+	int inter = this->pip_inter;
 
 	if (additional_length > 0) {
 		/* Allocate remaining space by pip ratios. If this doesn't round exactly, the unused space will fall into pip_post
@@ -1881,10 +1881,10 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint g
 	}
 
 	/* Third loop: Compute position and call the child. */
-	uint position = pre; // Place to put next child relative to origin of the container.
+	int position = pre; // Place to put next child relative to origin of the container.
 	for (const auto &child_wid : this->children) {
-		uint child_x = x + (rtl ? child_wid->padding.right : child_wid->padding.left);
-		uint child_height = child_wid->current_y;
+		int child_x = x + (rtl ? child_wid->padding.right : child_wid->padding.left);
+		int child_height = child_wid->current_y;
 
 		child_wid->AssignSizePosition(sizing, child_x, y + position + child_wid->padding.top, child_wid->current_x, child_height, rtl);
 		if (child_wid->current_y != 0) {
@@ -2007,7 +2007,7 @@ void NWidgetMatrix::SetupSmallestSize(Window *w)
 
 	this->children.front()->SetupSmallestSize(w);
 
-	Dimension padding = { (uint)this->pip_pre + this->pip_post, (uint)this->pip_pre + this->pip_post};
+	Dimension padding = {this->pip_pre + this->pip_post, this->pip_pre + this->pip_post};
 	Dimension size    = {this->children.front()->smallest_x + padding.width, this->children.front()->smallest_y + padding.height};
 	Dimension fill    = {0, 0};
 	Dimension resize  = {this->pip_inter + this->children.front()->smallest_x, this->pip_inter + this->children.front()->smallest_y};
@@ -2023,7 +2023,7 @@ void NWidgetMatrix::SetupSmallestSize(Window *w)
 	this->ApplyAspectRatio();
 }
 
-void NWidgetMatrix::AssignSizePosition(SizingType, int x, int y, uint given_width, uint given_height, bool)
+void NWidgetMatrix::AssignSizePosition(SizingType, int x, int y, int given_width, int given_height, bool)
 {
 	assert(given_width >= this->smallest_x && given_height >= this->smallest_y);
 
@@ -2064,11 +2064,11 @@ NWidgetCore *NWidgetMatrix::GetWidgetFromPos(int x, int y)
 	bool rtl = _current_text_dir == TD_RTL;
 
 	int widget_col = (rtl ?
-				-x + (int)this->pip_post + this->pos_x + base_offs_x + this->widget_w - 1 - (int)this->pip_inter :
-				 x - (int)this->pip_pre  - this->pos_x - base_offs_x
+				-x + this->pip_post + this->pos_x + base_offs_x + this->widget_w - 1 - this->pip_inter :
+				 x - this->pip_pre  - this->pos_x - base_offs_x
 			) / this->widget_w;
 
-	int widget_row = (y - base_offs_y - (int)this->pip_pre - this->pos_y) / this->widget_h;
+	int widget_row = (y - base_offs_y - this->pip_pre - this->pos_y) / this->widget_h;
 
 	this->current_element = (widget_row + start_y) * this->widgets_x + start_x + widget_col;
 	if (this->current_element >= this->count) return nullptr;
@@ -2115,7 +2115,7 @@ NWidgetCore *NWidgetMatrix::GetWidgetFromPos(int x, int y)
 			for (int x = start_x; x < start_x + this->widgets_x + 1; x++, offs_x += rtl ? -this->widget_w : this->widget_w) {
 				/* Are we within bounds? */
 				if (offs_x + child->smallest_x <= 0) continue;
-				if (offs_x >= (int)this->current_x) continue;
+				if (offs_x >= this->current_x) continue;
 
 				/* Do we have this many widgets? */
 				this->current_element = y * this->widgets_x + x;
@@ -2203,7 +2203,7 @@ void NWidgetBackground::Add(std::unique_ptr<NWidgetBase> &&nwid)
  *                  vertical container, at the right for the horizontal container).
  * @note Using this function implies that the widget has (or will have) child widgets.
  */
-void NWidgetBackground::SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip_post)
+void NWidgetBackground::SetPIP(int8_t pip_pre, int8_t pip_inter, int8_t pip_post)
 {
 	if (this->child == nullptr) {
 		this->child = std::make_unique<NWidgetVertical>();
@@ -2222,7 +2222,7 @@ void NWidgetBackground::SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip_p
  *                        vertical container, at the right for the horizontal container).
  * @note Using this function implies that the widget has (or will have) child widgets.
  */
-void NWidgetBackground::SetPIPRatio(uint8_t pip_ratio_pre, uint8_t pip_ratio_inter, uint8_t pip_ratio_post)
+void NWidgetBackground::SetPIPRatio(int8_t pip_ratio_pre, int8_t pip_ratio_inter, int8_t pip_ratio_post)
 {
 	if (this->child == nullptr) {
 		this->child = std::make_unique<NWidgetVertical>();
@@ -2258,7 +2258,7 @@ void NWidgetBackground::SetupSmallestSize(Window *w)
 
 			/* Account for the size of the frame's text if that exists */
 			this->child->padding     = WidgetDimensions::scaled.frametext;
-			this->child->padding.top = std::max<uint8_t>(WidgetDimensions::scaled.frametext.top, text_size.height != 0 ? text_size.height + WidgetDimensions::scaled.frametext.top / 2 : 0);
+			this->child->padding.top = std::max<int8_t>(WidgetDimensions::scaled.frametext.top, text_size.height != 0 ? text_size.height + WidgetDimensions::scaled.frametext.top / 2 : 0);
 
 			this->smallest_x += this->child->padding.Horizontal();
 			this->smallest_y += this->child->padding.Vertical();
@@ -2304,14 +2304,14 @@ void NWidgetBackground::SetupSmallestSize(Window *w)
 	}
 }
 
-void NWidgetBackground::AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl)
+void NWidgetBackground::AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl)
 {
 	this->StoreSizePosition(sizing, x, y, given_width, given_height);
 
 	if (this->child != nullptr) {
-		uint x_offset = (rtl ? this->child->padding.right : this->child->padding.left);
-		uint width = given_width - this->child->padding.Horizontal();
-		uint height = given_height - this->child->padding.Vertical();
+		int x_offset = (rtl ? this->child->padding.right : this->child->padding.left);
+		int width = given_width - this->child->padding.Horizontal();
+		int height = given_height - this->child->padding.Vertical();
 		this->child->AssignSizePosition(sizing, x + x_offset, y + this->child->padding.top, width, height, rtl);
 	}
 }
@@ -2524,9 +2524,9 @@ void Scrollbar::SetCapacityFromWidget(Window *w, WidgetID widget, int padding)
 {
 	NWidgetBase *nwid = w->GetWidget<NWidgetBase>(widget);
 	if (this->IsVertical()) {
-		this->SetCapacity(((int)nwid->current_y - padding) / (int)nwid->resize_y);
+		this->SetCapacity((nwid->current_y - padding) / nwid->resize_y);
 	} else {
-		this->SetCapacity(((int)nwid->current_x - padding) / (int)nwid->resize_x);
+		this->SetCapacity((nwid->current_x - padding) / nwid->resize_x);
 	}
 }
 

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -139,7 +139,7 @@ public:
 	void ApplyAspectRatio();
 	virtual void AdjustPaddingForZoom();
 	virtual void SetupSmallestSize(Window *w) = 0;
-	virtual void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) = 0;
+	virtual void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) = 0;
 
 	virtual void FillWidgetLookup(WidgetLookup &widget_lookup) = 0;
 
@@ -185,7 +185,7 @@ public:
 	 * @param bottom Amount of additional space below the widget.
 	 * @param left   Amount of additional space left of the widget.
 	 */
-	inline void SetPadding(uint8_t top, uint8_t right, uint8_t bottom, uint8_t left)
+	inline void SetPadding(int8_t top, int8_t right, int8_t bottom, int8_t left)
 	{
 		this->uz_padding.top = top;
 		this->uz_padding.right = right;
@@ -204,8 +204,8 @@ public:
 		this->AdjustPaddingForZoom();
 	}
 
-	inline uint GetHorizontalStepSize(SizingType sizing) const;
-	inline uint GetVerticalStepSize(SizingType sizing) const;
+	inline int GetHorizontalStepSize(SizingType sizing) const;
+	inline int GetVerticalStepSize(SizingType sizing) const;
 
 	virtual void Draw(const Window *w) = 0;
 	virtual void SetDirty(const Window *w) const;
@@ -221,18 +221,18 @@ public:
 	}
 
 	WidgetType type{}; ///< Type of the widget / nested widget.
-	uint fill_x = 0; ///< Horizontal fill stepsize (from initial size, \c 0 means not resizable).
-	uint fill_y = 0; ///< Vertical fill stepsize (from initial size, \c 0 means not resizable).
-	uint resize_x = 0; ///< Horizontal resize step (\c 0 means not resizable).
-	uint resize_y = 0; ///< Vertical resize step (\c 0 means not resizable).
+	int fill_x = 0; ///< Horizontal fill stepsize (from initial size, \c 0 means not resizable).
+	int fill_y = 0; ///< Vertical fill stepsize (from initial size, \c 0 means not resizable).
+	int resize_x = 0; ///< Horizontal resize step (\c 0 means not resizable).
+	int resize_y = 0; ///< Vertical resize step (\c 0 means not resizable).
 	/* Size of the widget in the smallest window possible.
 	 * Computed by #SetupSmallestSize() followed by #AssignSizePosition().
 	 */
-	uint smallest_x = 0; ///< Smallest horizontal size of the widget in a filled window.
-	uint smallest_y = 0; ///< Smallest vertical size of the widget in a filled window.
+	int smallest_x = 0; ///< Smallest horizontal size of the widget in a filled window.
+	int smallest_y = 0; ///< Smallest vertical size of the widget in a filled window.
 	/* Current widget size (that is, after resizing). */
-	uint current_x = 0; ///< Current horizontal size (after resizing).
-	uint current_y = 0; ///< Current vertical size (after resizing).
+	int current_x = 0; ///< Current horizontal size (after resizing).
+	int current_y = 0; ///< Current vertical size (after resizing).
 	float aspect_ratio = 0; ///< Desired aspect ratio of widget.
 	AspectFlags aspect_flags = AspectFlag::ResizeX; ///< Which dimensions can be resized.
 
@@ -245,14 +245,14 @@ public:
 	NWidgetBase *parent = nullptr; ///< Parent widget of this widget, automatically filled in when added to container.
 
 protected:
-	inline void StoreSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height);
+	inline void StoreSizePosition(SizingType sizing, int x, int y, int given_width, int given_height);
 };
 
 /**
  * Get the horizontal sizing step.
  * @param sizing Type of resize being performed.
  */
-inline uint NWidgetBase::GetHorizontalStepSize(SizingType sizing) const
+inline int NWidgetBase::GetHorizontalStepSize(SizingType sizing) const
 {
 	return (sizing == ST_RESIZE) ? this->resize_x : this->fill_x;
 }
@@ -261,7 +261,7 @@ inline uint NWidgetBase::GetHorizontalStepSize(SizingType sizing) const
  * Get the vertical sizing step.
  * @param sizing Type of resize being performed.
  */
-inline uint NWidgetBase::GetVerticalStepSize(SizingType sizing) const
+inline int NWidgetBase::GetVerticalStepSize(SizingType sizing) const
 {
 	return (sizing == ST_RESIZE) ? this->resize_y : this->fill_y;
 }
@@ -274,8 +274,9 @@ inline uint NWidgetBase::GetVerticalStepSize(SizingType sizing) const
  * @param given_width  Width allocated to the widget.
  * @param given_height Height allocated to the widget.
  */
-inline void NWidgetBase::StoreSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height)
+inline void NWidgetBase::StoreSizePosition(SizingType sizing, int x, int y, int given_width, int given_height)
 {
+	assert(given_width >= 0 && given_height >= 0);
 	this->pos_x = x;
 	this->pos_y = y;
 	if (sizing == ST_SMALLEST) {
@@ -293,32 +294,32 @@ inline void NWidgetBase::StoreSizePosition(SizingType sizing, int x, int y, uint
  */
 class NWidgetResizeBase : public NWidgetBase {
 public:
-	NWidgetResizeBase(WidgetType tp, uint fill_x, uint fill_y);
+	NWidgetResizeBase(WidgetType tp, int fill_x, int fill_y);
 
 	void AdjustPaddingForZoom() override;
-	void SetMinimalSize(uint min_x, uint min_y);
-	void SetMinimalSizeAbsolute(uint min_x, uint min_y);
-	void SetMinimalTextLines(uint8_t min_lines, uint8_t spacing, FontSize size);
-	void SetFill(uint fill_x, uint fill_y);
-	void SetResize(uint resize_x, uint resize_y);
+	void SetMinimalSize(int min_x, int min_y);
+	void SetMinimalSizeAbsolute(int min_x, int min_y);
+	void SetMinimalTextLines(int8_t min_lines, int8_t spacing, FontSize size);
+	void SetFill(int fill_x, int fill_y);
+	void SetResize(int resize_x, int resize_y);
 	void SetAspect(float ratio, AspectFlags flags = AspectFlag::ResizeX);
 	void SetAspect(int x_ratio, int y_ratio, AspectFlags flags = AspectFlag::ResizeX);
 
 	bool UpdateMultilineWidgetSize(const std::string &str, int max_lines);
-	bool UpdateSize(uint min_x, uint min_y);
-	bool UpdateVerticalSize(uint min_y);
+	bool UpdateSize(int min_x, int min_y);
+	bool UpdateVerticalSize(int min_y);
 
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override;
 
-	uint min_x = 0; ///< Minimal horizontal size of only this widget.
-	uint min_y = 0; ///< Minimal vertical size of only this widget.
+	int min_x = 0; ///< Minimal horizontal size of only this widget.
+	int min_y = 0; ///< Minimal vertical size of only this widget.
 
 	bool absolute = false; ///< Set if minimum size is fixed and should not be resized.
-	uint uz_min_x = 0; ///< Unscaled Minimal horizontal size of only this widget.
-	uint uz_min_y = 0; ///< Unscaled Minimal vertical size of only this widget.
+	int uz_min_x = 0; ///< Unscaled Minimal horizontal size of only this widget.
+	int uz_min_y = 0; ///< Unscaled Minimal vertical size of only this widget.
 
-	uint8_t uz_text_lines = 0; ///< 'Unscaled' text lines, stored for resize calculation.
-	uint8_t uz_text_spacing = 0; ///< 'Unscaled' text padding, stored for resize calculation.
+	int8_t uz_text_lines = 0; ///< 'Unscaled' text lines, stored for resize calculation.
+	int8_t uz_text_spacing = 0; ///< 'Unscaled' text padding, stored for resize calculation.
 	FontSize uz_text_size{}; ///< 'Unscaled' font size, stored for resize calculation.
 };
 
@@ -361,13 +362,13 @@ struct WidgetData {
  */
 class NWidgetCore : public NWidgetResizeBase {
 public:
-	NWidgetCore(WidgetType tp, Colours colour, WidgetID index, uint fill_x, uint fill_y, const WidgetData &widget_data, StringID tool_tip);
+	NWidgetCore(WidgetType tp, Colours colour, WidgetID index, int fill_x, int fill_y, const WidgetData &widget_data, StringID tool_tip);
 
 	void SetString(StringID string);
 	void SetStringTip(StringID string, StringID tool_tip);
 	void SetSprite(SpriteID sprite);
 	void SetSpriteTip(SpriteID sprite, StringID tool_tip);
-	void SetMatrixDimension(uint32_t columns, uint32_t rows);
+	void SetMatrixDimension(int columns, int rows);
 	void SetResizeWidgetType(ResizeWidgetValues type);
 	void SetToolTip(StringID tool_tip);
 	StringID GetToolTip() const;
@@ -509,7 +510,7 @@ public:
 	NWidgetStacked(WidgetID index) : NWidgetContainer(NWID_SELECTION), index(index) {}
 
 	void SetupSmallestSize(Window *w) override;
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override;
 	void FillWidgetLookup(WidgetLookup &widget_lookup) override;
 
 	void Draw(const Window *w) override;
@@ -536,23 +537,23 @@ public:
 	NWidgetPIPContainer(WidgetType tp, NWidContainerFlags flags = {});
 
 	void AdjustPaddingForZoom() override;
-	void SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip_post);
-	void SetPIPRatio(uint8_t pip_ratio_pre, uint8_t pip_ratio_inter, uint8_t pip_rato_post);
+	void SetPIP(int8_t pip_pre, int8_t pip_inter, int8_t pip_post);
+	void SetPIPRatio(int8_t pip_ratio_pre, int8_t pip_ratio_inter, int8_t pip_rato_post);
 
 protected:
 	NWidContainerFlags flags{}; ///< Flags of the container.
-	uint8_t pip_pre = 0; ///< Amount of space before first widget.
-	uint8_t pip_inter = 0; ///< Amount of space between widgets.
-	uint8_t pip_post = 0; ///< Amount of space after last widget.
-	uint8_t pip_ratio_pre = 0; ///< Ratio of remaining space before first widget.
-	uint8_t pip_ratio_inter = 0; ///< Ratio of remaining space between widgets.
-	uint8_t pip_ratio_post = 0; ///< Ratio of remaining space after last widget.
+	int8_t pip_pre = 0; ///< Amount of space before first widget.
+	int8_t pip_inter = 0; ///< Amount of space between widgets.
+	int8_t pip_post = 0; ///< Amount of space after last widget.
+	int8_t pip_ratio_pre = 0; ///< Ratio of remaining space before first widget.
+	int8_t pip_ratio_inter = 0; ///< Ratio of remaining space between widgets.
+	int8_t pip_ratio_post = 0; ///< Ratio of remaining space after last widget.
 
-	uint8_t uz_pip_pre = 0; ///< Unscaled space before first widget.
-	uint8_t uz_pip_inter = 0; ///< Unscaled space between widgets.
-	uint8_t uz_pip_post = 0; ///< Unscaled space after last widget.
+	int8_t uz_pip_pre = 0; ///< Unscaled space before first widget.
+	int8_t uz_pip_inter = 0; ///< Unscaled space between widgets.
+	int8_t uz_pip_post = 0; ///< Unscaled space after last widget.
 
-	uint8_t gaps = 0; ///< Number of gaps between widgets.
+	int8_t gaps = 0; ///< Number of gaps between widgets.
 };
 
 /**
@@ -564,7 +565,7 @@ public:
 	NWidgetHorizontal(NWidContainerFlags flags = {});
 
 	void SetupSmallestSize(Window *w) override;
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override;
 };
 
 /**
@@ -575,7 +576,7 @@ class NWidgetHorizontalLTR : public NWidgetHorizontal {
 public:
 	NWidgetHorizontalLTR(NWidContainerFlags flags = {});
 
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override;
 };
 
 /**
@@ -587,7 +588,7 @@ public:
 	NWidgetVertical(NWidContainerFlags flags = {});
 
 	void SetupSmallestSize(Window *w) override;
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override;
 };
 
 /**
@@ -608,7 +609,7 @@ public:
 	int GetCurrentElement() const;
 
 	void SetupSmallestSize(Window *w) override;
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override;
 	void FillWidgetLookup(WidgetLookup &widget_lookup) override;
 
 	NWidgetCore *GetWidgetFromPos(int x, int y) override;
@@ -655,12 +656,12 @@ public:
 	NWidgetBackground(WidgetType tp, Colours colour, WidgetID index, std::unique_ptr<NWidgetPIPContainer> &&child = nullptr);
 
 	void Add(std::unique_ptr<NWidgetBase> &&nwid);
-	void SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip_post);
-	void SetPIPRatio(uint8_t pip_ratio_pre, uint8_t pip_ratio_inter, uint8_t pip_ratio_post);
+	void SetPIP(int8_t pip_pre, int8_t pip_inter, int8_t pip_post);
+	void SetPIPRatio(int8_t pip_ratio_pre, int8_t pip_ratio_inter, int8_t pip_ratio_post);
 
 	void AdjustPaddingForZoom() override;
 	void SetupSmallestSize(Window *w) override;
-	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
+	void AssignSizePosition(SizingType sizing, int x, int y, int given_width, int given_height, bool rtl) override;
 
 	void FillWidgetLookup(WidgetLookup &widget_lookup) override;
 
@@ -943,11 +944,11 @@ private:
  * @param step      Stepsize of the widget.
  * @return Biggest possible size of the widget, assuming that \a base may only be incremented by \a step size steps.
  */
-inline uint ComputeMaxSize(uint base, uint max_space, uint step)
+inline int ComputeMaxSize(int base, int max_space, int step)
 {
 	if (base >= max_space || step == 0) return base;
 	if (step == 1) return max_space;
-	uint increment = max_space - base;
+	int increment = max_space - base;
 	increment -= increment % step;
 	return base + increment;
 }
@@ -1031,7 +1032,7 @@ struct NWidgetPartPaddings : RectPadding {
  * @ingroup NestedWidgetParts
  */
 struct NWidgetPartPIP {
-	uint8_t pre, inter, post; ///< Amount of space before/between/after child widgets.
+	int8_t pre, inter, post; ///< Amount of space before/between/after child widgets.
 };
 
 /**
@@ -1039,8 +1040,8 @@ struct NWidgetPartPIP {
  * @ingroup NestedWidgetParts
  */
 struct NWidgetPartTextLines {
-	uint8_t lines;   ///< Number of text lines.
-	uint8_t spacing; ///< Extra spacing around lines.
+	int8_t lines;   ///< Number of text lines.
+	int8_t spacing; ///< Extra spacing around lines.
 	FontSize size; ///< Font size of text lines.
 };
 
@@ -1150,7 +1151,7 @@ constexpr NWidgetPart SetMinimalSize(int16_t x, int16_t y)
  * @param size    Font size of text.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart SetMinimalTextLines(uint8_t lines, uint8_t spacing, FontSize size = FS_NORMAL)
+constexpr NWidgetPart SetMinimalTextLines(int8_t lines, int8_t spacing, FontSize size = FS_NORMAL)
 {
 	return NWidgetPart{WPT_MINTEXTLINES, NWidgetPartTextLines{lines, spacing, size}};
 }
@@ -1182,7 +1183,7 @@ constexpr NWidgetPart SetAlignment(StringAlignment align)
  * @param fill_y Vertical filling step from minimal size.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart SetFill(uint16_t fill_x, uint16_t fill_y)
+constexpr NWidgetPart SetFill(int16_t fill_x, int16_t fill_y)
 {
 	return NWidgetPart{WPT_FILL, Point{fill_x, fill_y}};
 }
@@ -1248,9 +1249,9 @@ constexpr NWidgetPart SetResizeWidgetTypeTip(ResizeWidgetValues widget_type, Str
  * @param tip  Tooltip of the widget.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart SetMatrixDataTip(uint32_t cols, uint32_t rows, StringID tip = {})
+constexpr NWidgetPart SetMatrixDataTip(int cols, int rows, StringID tip = {})
 {
-	return NWidgetPart{WPT_DATATIP, NWidgetPartDataTip{{.matrix{ cols, rows }}, tip}};
+	return NWidgetPart{WPT_DATATIP, NWidgetPartDataTip{{.matrix{cols, rows}}, tip}};
 }
 
 /**
@@ -1272,7 +1273,7 @@ constexpr NWidgetPart SetToolTip(StringID tip)
  * @param left The padding left of the widget.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart SetPadding(uint8_t top, uint8_t right, uint8_t bottom, uint8_t left)
+constexpr NWidgetPart SetPadding(int8_t top, int8_t right, int8_t bottom, int8_t left)
 {
 	return NWidgetPart{WPT_PADDING, NWidgetPartPaddings{left, top, right, bottom}};
 }
@@ -1283,7 +1284,7 @@ constexpr NWidgetPart SetPadding(uint8_t top, uint8_t right, uint8_t bottom, uin
  * @param vertical The padding above and below the widget.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart SetPadding(uint8_t horizontal, uint8_t vertical)
+constexpr NWidgetPart SetPadding(int8_t horizontal, int8_t vertical)
 {
 	return NWidgetPart{WPT_PADDING, NWidgetPartPaddings{horizontal, vertical, horizontal, vertical}};
 }
@@ -1303,7 +1304,7 @@ constexpr NWidgetPart SetPadding(const RectPadding &padding)
  * @param padding The padding to use for all directions.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart SetPadding(uint8_t padding)
+constexpr NWidgetPart SetPadding(int8_t padding)
 {
 	return SetPadding(padding, padding, padding, padding);
 }
@@ -1315,7 +1316,7 @@ constexpr NWidgetPart SetPadding(uint8_t padding)
  * @param post The amount of space after the last widget.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart SetPIP(uint8_t pre, uint8_t inter, uint8_t post)
+constexpr NWidgetPart SetPIP(int8_t pre, int8_t inter, int8_t post)
 {
 	return NWidgetPart{WPT_PIPSPACE, NWidgetPartPIP{pre, inter, post}};
 }
@@ -1327,7 +1328,7 @@ constexpr NWidgetPart SetPIP(uint8_t pre, uint8_t inter, uint8_t post)
  * @param post The ratio of space after the last widget.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart SetPIPRatio(uint8_t ratio_pre, uint8_t ratio_inter, uint8_t ratio_post)
+constexpr NWidgetPart SetPIPRatio(int8_t ratio_pre, int8_t ratio_inter, int8_t ratio_post)
 {
 	return NWidgetPart{WPT_PIPRATIO, NWidgetPartPIP{ratio_pre, ratio_inter, ratio_post}};
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2030,14 +2030,14 @@ void ResizeWindow(Window *w, int delta_x, int delta_y, bool clamp_to_screen, boo
 			 * the resolution clamp it in such a manner that it stays within the bounds. */
 			int new_right  = w->left + w->width  + delta_x;
 			int new_bottom = w->top  + w->height + delta_y;
-			if (new_right  >= (int)_screen.width)  delta_x -= Ceil(new_right  - _screen.width,  std::max(1U, w->nested_root->resize_x));
-			if (new_bottom >= (int)_screen.height) delta_y -= Ceil(new_bottom - _screen.height, std::max(1U, w->nested_root->resize_y));
+			if (new_right  >= _screen.width)  delta_x -= Ceil(new_right  - _screen.width,  std::max(1, w->nested_root->resize_x));
+			if (new_bottom >= _screen.height) delta_y -= Ceil(new_bottom - _screen.height, std::max(1, w->nested_root->resize_y));
 		}
 
 		w->SetDirty();
 
-		uint new_xinc = std::max(0, (w->nested_root->resize_x == 0) ? 0 : (int)(w->nested_root->current_x - w->nested_root->smallest_x) + delta_x);
-		uint new_yinc = std::max(0, (w->nested_root->resize_y == 0) ? 0 : (int)(w->nested_root->current_y - w->nested_root->smallest_y) + delta_y);
+		int new_xinc = std::max(0, (w->nested_root->resize_x == 0) ? 0 : (w->nested_root->current_x - w->nested_root->smallest_x) + delta_x);
+		int new_yinc = std::max(0, (w->nested_root->resize_y == 0) ? 0 : (w->nested_root->current_y - w->nested_root->smallest_y) + delta_y);
 		assert(w->nested_root->resize_x == 0 || new_xinc % w->nested_root->resize_x == 0);
 		assert(w->nested_root->resize_y == 0 || new_yinc % w->nested_root->resize_y == 0);
 
@@ -3459,12 +3459,12 @@ void RelocateAllWindows(int neww, int newh)
 
 	/* Reposition toolbar then status bar before other all windows. */
 	if (Window *wt = FindWindowById(WC_MAIN_TOOLBAR, 0); wt != nullptr) {
-		ResizeWindow(wt, std::min<uint>(neww, _toolbar_width) - wt->width, 0, false);
+		ResizeWindow(wt, std::min(neww, _toolbar_width) - wt->width, 0, false);
 		wt->left = PositionMainToolbar(wt);
 	}
 
 	if (Window *ws = FindWindowById(WC_STATUS_BAR, 0); ws != nullptr) {
-		ResizeWindow(ws, std::min<uint>(neww, _toolbar_width) - ws->width, 0, false);
+		ResizeWindow(ws, std::min(neww, _toolbar_width) - ws->width, 0, false);
 		ws->top = newh - ws->height;
 		ws->left = PositionStatusbar(ws);
 	}
@@ -3491,7 +3491,7 @@ void RelocateAllWindows(int neww, int newh)
 				break;
 
 			case WC_SEND_NETWORK_MSG:
-				ResizeWindow(w, std::min<uint>(neww, _toolbar_width) - w->width, 0, false);
+				ResizeWindow(w, std::min(neww, _toolbar_width) - w->width, 0, false);
 
 				top = newh - w->height - FindWindowById(WC_STATUS_BAR, 0)->height;
 				left = PositionNetworkChatWindow(w);

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -79,14 +79,14 @@ private:
 	 * Distances used in drawing widgets.
 	 * These constants should not be used elsewhere, use scaled/unscaled WidgetDimensions instead.
 	 */
-	static constexpr uint WD_SHADEBOX_WIDTH = 12; ///< Minimum width of a standard shade box widget.
-	static constexpr uint WD_STICKYBOX_WIDTH = 12; ///< Minimum width of a standard sticky box widget.
-	static constexpr uint WD_DEBUGBOX_WIDTH = 12; ///< Minimum width of a standard debug box widget.
-	static constexpr uint WD_DEFSIZEBOX_WIDTH = 12; ///< Minimum width of a standard defsize box widget.
-	static constexpr uint WD_RESIZEBOX_WIDTH = 12; ///< Minimum width of a resize box widget.
-	static constexpr uint WD_CLOSEBOX_WIDTH = 11; ///< Minimum width of a close box widget.
-	static constexpr uint WD_CAPTION_HEIGHT = 14; ///< Minimum height of a title bar.
-	static constexpr uint WD_DROPDOWN_HEIGHT = 12; ///< Minimum height of a drop down widget.
+	static constexpr int WD_SHADEBOX_WIDTH = 12; ///< Minimum width of a standard shade box widget.
+	static constexpr int WD_STICKYBOX_WIDTH = 12; ///< Minimum width of a standard sticky box widget.
+	static constexpr int WD_DEBUGBOX_WIDTH = 12; ///< Minimum width of a standard debug box widget.
+	static constexpr int WD_DEFSIZEBOX_WIDTH = 12; ///< Minimum width of a standard defsize box widget.
+	static constexpr int WD_RESIZEBOX_WIDTH = 12; ///< Minimum width of a resize box widget.
+	static constexpr int WD_CLOSEBOX_WIDTH = 11; ///< Minimum width of a close box widget.
+	static constexpr int WD_CAPTION_HEIGHT = 14; ///< Minimum height of a title bar.
+	static constexpr int WD_DROPDOWN_HEIGHT = 12; ///< Minimum height of a drop down widget.
 
 	friend NWidgetLeaf;
 };
@@ -209,8 +209,8 @@ private:
  * Data structure for resizing a window
  */
 struct ResizeInfo {
-	uint step_width;  ///< Step-size of width resize changes
-	uint step_height; ///< Step-size of height resize changes
+	int step_width;  ///< Step-size of width resize changes
+	int step_height; ///< Step-size of height resize changes
 };
 
 /** State of a sort direction button. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

In widget code we have a mix of signed and unsigned integers. This is based on the principle that, some values can't ever be negative, so can be stored in an unsigned type which ensures this.

Sometimes we perform calculations where the signedness is important, and so we have to explicitly cast to get the correct result. If those casts are missed, it could give a compilation warning, or it could just be completely missed. Instead of the calculation ending up with a negative value, it could end up with a very large positive value.

And in general, casting is bad.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Switch most widget and dimension related code to use signed `int` instead of unsigned `uint`.

This makes a lot of casts and template types redundant, so they are also removed.

Going further, we could add asserts for values that should always be positive.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

In some places we store values in `uint8_t`, which is not `int8_t`. There is a possibility that these could overflow. Switching to `int16_t` would be enough.

Some non-UI code also uses `Dimension`, so this is affected too.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
