### PR TITLE
Codechange: more conversions to std::string_view (or move semantics) in network

### DIFF
--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -442,7 +442,7 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
  * @param company Pointer to the company variable to set iff indicated.
  * @return A valid ServerAddress of the parsed information.
  */
-/* static */ ServerAddress ServerAddress::Parse(const std::string &connection_string, uint16_t default_port, CompanyID *company_id)
+/* static */ ServerAddress ServerAddress::Parse(std::string_view connection_string, uint16_t default_port, CompanyID *company_id)
 {
 	if (connection_string.starts_with("+")) {
 		std::string_view invite_code = ParseCompanyFromConnectionString(connection_string, company_id);
@@ -451,5 +451,5 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
 
 	uint16_t port = default_port;
 	std::string_view ip = ParseFullConnectionString(connection_string, port, company_id);
-	return ServerAddress(SERVER_ADDRESS_DIRECT, std::string(ip) + ":" + std::to_string(port));
+	return ServerAddress(SERVER_ADDRESS_DIRECT, fmt::format("{}:{}", ip, port));
 }

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -194,13 +194,13 @@ private:
 	 * @param type The type of the ServerAdress.
 	 * @param connection_string The connection_string that belongs to this ServerAddress type.
 	 */
-	ServerAddress(ServerAddressType type, const std::string &connection_string) : type(type), connection_string(connection_string) {}
+	ServerAddress(ServerAddressType type, std::string &&connection_string) : type(type), connection_string(std::move(connection_string)) {}
 
 public:
 	ServerAddressType type;        ///< The type of this ServerAddress.
 	std::string connection_string; ///< The connection string for this ServerAddress.
 
-	static ServerAddress Parse(const std::string &connection_string, uint16_t default_port, CompanyID *company_id = nullptr);
+	static ServerAddress Parse(std::string_view connection_string, uint16_t default_port, CompanyID *company_id = nullptr);
 };
 
 #endif /* NETWORK_CORE_ADDRESS_H */

--- a/src/network/core/os_abstraction.cpp
+++ b/src/network/core/os_abstraction.cpp
@@ -29,7 +29,7 @@
  * @param error The error code.
  * @param message The error message. Leave empty to determine this automatically based on the error number.
  */
-NetworkError::NetworkError(int error, const std::string &message) : error(error), message(message)
+NetworkError::NetworkError(int error, std::string_view message) : error(error), message(message)
 {
 }
 
@@ -78,7 +78,7 @@ bool NetworkError::IsConnectInProgress() const
  * Get the string representation of the error message.
  * @return The string representation that will get overwritten by next calls.
  */
-const std::string &NetworkError::AsString() const
+std::string_view NetworkError::AsString() const
 {
 	if (this->message.empty()) {
 #if defined(_WIN32)

--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -23,13 +23,13 @@ private:
 	int error;                   ///< The underlying error number from errno or WSAGetLastError.
 	mutable std::string message; ///< The string representation of the error (set on first call to #AsString).
 public:
-	NetworkError(int error, const std::string &message = {});
+	NetworkError(int error, std::string_view message = {});
 
 	bool HasError() const;
 	bool WouldBlock() const;
 	bool IsConnectionReset() const;
 	bool IsConnectInProgress() const;
-	const std::string &AsString() const;
+	std::string_view AsString() const;
 
 	static NetworkError GetLast();
 };

--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -120,7 +120,7 @@ private:
 
 public:
 	TCPConnecter() {};
-	TCPConnecter(const std::string &connection_string, uint16_t default_port, const NetworkAddress &bind_address = {}, int family = AF_UNSPEC);
+	TCPConnecter(std::string_view connection_string, uint16_t default_port, const NetworkAddress &bind_address = {}, int family = AF_UNSPEC);
 	virtual ~TCPConnecter();
 
 	/**
@@ -161,7 +161,7 @@ private:
 public:
 	ServerAddress server_address; ///< Address we are connecting to.
 
-	TCPServerConnecter(const std::string &connection_string, uint16_t default_port);
+	TCPServerConnecter(std::string_view connection_string, uint16_t default_port);
 
 	void SetConnected(SOCKET sock);
 	void SetFailure();

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -26,7 +26,7 @@
  * @param default_port If not indicated in connection_string, what port to use.
  * @param bind_address The local bind address to use. Defaults to letting the OS find one.
  */
-TCPConnecter::TCPConnecter(const std::string &connection_string, uint16_t default_port, const NetworkAddress &bind_address, int family) :
+TCPConnecter::TCPConnecter(std::string_view connection_string, uint16_t default_port, const NetworkAddress &bind_address, int family) :
 	bind_address(bind_address),
 	family(family)
 {
@@ -38,7 +38,7 @@ TCPConnecter::TCPConnecter(const std::string &connection_string, uint16_t defaul
  * @param connection_string The address to connect to.
  * @param default_port If not indicated in connection_string, what port to use.
  */
-TCPServerConnecter::TCPServerConnecter(const std::string &connection_string, uint16_t default_port) :
+TCPServerConnecter::TCPServerConnecter(std::string_view connection_string, uint16_t default_port) :
 	server_address(ServerAddress::Parse(connection_string, default_port))
 {
 	switch (this->server_address.type) {

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -472,7 +472,7 @@ static void CheckPauseOnJoin()
  * @param company_id        The company ID to set, if available.
  * @return A std::string_view into the connection string without the company part.
  */
-std::string_view ParseCompanyFromConnectionString(const std::string &connection_string, CompanyID *company_id)
+std::string_view ParseCompanyFromConnectionString(std::string_view connection_string, CompanyID *company_id)
 {
 	std::string_view ip = connection_string;
 	if (company_id == nullptr) return ip;
@@ -516,7 +516,7 @@ std::string_view ParseCompanyFromConnectionString(const std::string &connection_
  * @param company_id        The company ID to set, if available.
  * @return A std::string_view into the connection string with the (IP) address part.
  */
-std::string_view ParseFullConnectionString(const std::string &connection_string, uint16_t &port, CompanyID *company_id)
+std::string_view ParseFullConnectionString(std::string_view connection_string, uint16_t &port, CompanyID *company_id)
 {
 	std::string_view ip = ParseCompanyFromConnectionString(connection_string, company_id);
 
@@ -536,11 +536,11 @@ std::string_view ParseFullConnectionString(const std::string &connection_string,
  * @param default_port The port to use if none is given.
  * @return The normalized connection string.
  */
-std::string NormalizeConnectionString(const std::string &connection_string, uint16_t default_port)
+std::string NormalizeConnectionString(std::string_view connection_string, uint16_t default_port)
 {
 	uint16_t port = default_port;
 	std::string_view ip = ParseFullConnectionString(connection_string, port);
-	return std::string(ip) + ":" + std::to_string(port);
+	return fmt::format("{}:{}", ip, port);
 }
 
 /**
@@ -551,7 +551,7 @@ std::string NormalizeConnectionString(const std::string &connection_string, uint
  * @param default_port The default port to set port to if not in connection_string.
  * @return A valid NetworkAddress of the parsed information.
  */
-NetworkAddress ParseConnectionString(const std::string &connection_string, uint16_t default_port)
+NetworkAddress ParseConnectionString(std::string_view connection_string, uint16_t default_port)
 {
 	uint16_t port = default_port;
 	std::string_view ip = ParseFullConnectionString(connection_string, port);
@@ -642,7 +642,7 @@ private:
 	std::string connection_string;
 
 public:
-	TCPQueryConnecter(const std::string &connection_string) : TCPServerConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
+	TCPQueryConnecter(std::string_view connection_string) : TCPServerConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
 
 	void OnFailure() override
 	{
@@ -667,7 +667,7 @@ public:
  * Query a server to fetch the game-info.
  * @param connection_string the address to query.
  */
-void NetworkQueryServer(const std::string &connection_string)
+void NetworkQueryServer(std::string_view connection_string)
 {
 	if (!_network_available) return;
 
@@ -689,7 +689,7 @@ void NetworkQueryServer(const std::string &connection_string)
  * @param never_expire Whether the entry can expire (removed when no longer found in the public listing).
  * @return The entry on the game list.
  */
-NetworkGame *NetworkAddServer(const std::string &connection_string, bool manually, bool never_expire)
+NetworkGame *NetworkAddServer(std::string_view connection_string, bool manually, bool never_expire)
 {
 	if (connection_string.empty()) return nullptr;
 
@@ -745,7 +745,7 @@ private:
 	std::string connection_string;
 
 public:
-	TCPClientConnecter(const std::string &connection_string) : TCPServerConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
+	TCPClientConnecter(std::string_view connection_string) : TCPServerConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
 
 	void OnFailure() override
 	{
@@ -782,7 +782,7 @@ public:
  * @param join_server_password  The password for the server.
  * @return Whether the join has started.
  */
-bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const std::string &join_server_password)
+bool NetworkClientConnectGame(std::string_view connection_string, CompanyID default_company, const std::string &join_server_password)
 {
 	Debug(net, 9, "NetworkClientConnectGame(): connection_string={}", connection_string);
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -109,7 +109,7 @@ void ClientNetworkEmergencySave()
  * Create a new socket for the client side of the game connection.
  * @param s The socket to connect with.
  */
-ClientNetworkGameSocketHandler::ClientNetworkGameSocketHandler(SOCKET s, const std::string &connection_string) : NetworkGameSocketHandler(s), connection_string(connection_string)
+ClientNetworkGameSocketHandler::ClientNetworkGameSocketHandler(SOCKET s, std::string_view connection_string) : NetworkGameSocketHandler(s), connection_string(connection_string)
 {
 	assert(ClientNetworkGameSocketHandler::my_client == nullptr);
 	ClientNetworkGameSocketHandler::my_client = this;

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -74,7 +74,7 @@ protected:
 	static NetworkRecvStatus SendIdentify();
 	void CheckConnection();
 public:
-	ClientNetworkGameSocketHandler(SOCKET s, const std::string &connection_string);
+	ClientNetworkGameSocketHandler(SOCKET s, std::string_view connection_string);
 	~ClientNetworkGameSocketHandler();
 
 	NetworkRecvStatus CloseConnection(NetworkRecvStatus status) override;

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -718,7 +718,7 @@ public:
 	 * Initiate the connecting.
 	 * @param address The address of the server.
 	 */
-	NetworkContentConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_CONTENT_SERVER_PORT) {}
+	NetworkContentConnecter(std::string_view connection_string) : TCPConnecter(connection_string, NETWORK_CONTENT_SERVER_PORT) {}
 
 	void OnFailure() override
 	{

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -106,7 +106,7 @@ public:
 	 * Initiate the connecting.
 	 * @param connection_string The address of the Game Coordinator server.
 	 */
-	NetworkCoordinatorConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_COORDINATOR_SERVER_PORT) {}
+	NetworkCoordinatorConnecter(std::string_view connection_string) : TCPConnecter(connection_string, NETWORK_COORDINATOR_SERVER_PORT) {}
 
 	void OnFailure() override
 	{

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -45,7 +45,7 @@ public:
 	 * @param token The token as given by the Game Coordinator to track this connection attempt.
 	 * @param tracking_number The tracking number as given by the Game Coordinator to track this connection attempt.
 	 */
-	NetworkDirectConnecter(const std::string &hostname, uint16_t port, const std::string &token, uint8_t tracking_number) : TCPConnecter(hostname, port), token(token), tracking_number(tracking_number) {}
+	NetworkDirectConnecter(std::string_view hostname, uint16_t port, std::string &&token, uint8_t tracking_number) : TCPConnecter(hostname, port), token(std::move(token)), tracking_number(tracking_number) {}
 
 	void OnFailure() override
 	{
@@ -76,7 +76,7 @@ public:
 	 * @param tracking_number The tracking number of the connection.
 	 * @param family The family this connection is using.
 	 */
-	NetworkReuseStunConnecter(const std::string &hostname, uint16_t port, const NetworkAddress &bind_address, std::string token, uint8_t tracking_number, uint8_t family) :
+	NetworkReuseStunConnecter(std::string_view hostname, uint16_t port, const NetworkAddress &bind_address, std::string &&token, uint8_t tracking_number, uint8_t family) :
 		TCPConnecter(hostname, port, bind_address),
 		token(std::move(token)),
 		tracking_number(tracking_number),
@@ -305,7 +305,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_DIRECT_CONNECT(Packet &p)
 		this->game_connecter = nullptr;
 	}
 
-	this->game_connecter = TCPConnecter::Create<NetworkDirectConnecter>(hostname, port, token, tracking_number);
+	this->game_connecter = TCPConnecter::Create<NetworkDirectConnecter>(hostname, port, std::move(token), tracking_number);
 	return true;
 }
 
@@ -348,7 +348,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_STUN_CONNECT(Packet &p)
 	 * STUN server. This means that if there is any NAT in the local network,
 	 * the public ip:port is still pointing to the local address, and as such
 	 * a connection can be established. */
-	this->game_connecter = TCPConnecter::Create<NetworkReuseStunConnecter>(host, port, family_it->second->local_addr, token, tracking_number, family);
+	this->game_connecter = TCPConnecter::Create<NetworkReuseStunConnecter>(host, port, family_it->second->local_addr, std::move(token), tracking_number, family);
 	return true;
 }
 
@@ -393,7 +393,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_TURN_CONNECT(Packet &p)
 				break;
 
 			case URS_ASK:
-				ShowNetworkAskRelay(connecter_it->second.first, connection_string, token);
+				ShowNetworkAskRelay(connecter_it->second.first, std::move(connection_string), std::move(token));
 				break;
 
 			case URS_ALLOW:
@@ -407,7 +407,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_TURN_CONNECT(Packet &p)
 	return true;
 }
 
-void ClientNetworkCoordinatorSocketHandler::StartTurnConnection(std::string &token)
+void ClientNetworkCoordinatorSocketHandler::StartTurnConnection(std::string_view token)
 {
 	auto turn_it = this->turn_handlers.find(token);
 	if (turn_it == this->turn_handlers.end()) return;
@@ -511,7 +511,7 @@ void ClientNetworkCoordinatorSocketHandler::GetListing()
  * @param invite_code The invite code of the server to connect to.
  * @param connecter The connecter of the request.
  */
-void ClientNetworkCoordinatorSocketHandler::ConnectToServer(const std::string &invite_code, TCPServerConnecter *connecter)
+void ClientNetworkCoordinatorSocketHandler::ConnectToServer(std::string_view invite_code, TCPServerConnecter *connecter)
 {
 	assert(invite_code.starts_with("+"));
 
@@ -525,7 +525,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectToServer(const std::string &i
 
 	/* Initially we store based on invite code; on first reply we know the
 	 * token, and will start using that key instead. */
-	this->connecter_pre[invite_code] = connecter;
+	this->connecter_pre[std::string(invite_code)] = connecter;
 
 	this->Connect();
 
@@ -541,7 +541,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectToServer(const std::string &i
  * @param token Token of the connecter that failed.
  * @param tracking_number Tracking number of the connecter that failed.
  */
-void ClientNetworkCoordinatorSocketHandler::ConnectFailure(const std::string &token, uint8_t tracking_number)
+void ClientNetworkCoordinatorSocketHandler::ConnectFailure(std::string_view token, uint8_t tracking_number)
 {
 	/* Connecter will destroy itself. */
 	this->game_connecter = nullptr;
@@ -563,7 +563,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectFailure(const std::string &to
  * @param token Token of the connecter that succeeded.
  * @param sock The socket that the connecter can now use.
  */
-void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(const std::string &token, SOCKET sock, NetworkAddress &address)
+void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(std::string_view token, SOCKET sock, NetworkAddress &address)
 {
 	assert(sock != INVALID_SOCKET);
 
@@ -603,7 +603,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(const std::string &to
  * This helps the Game Coordinator not to wait for a timeout on its end, but
  * rather react as soon as the client/server knows the result.
  */
-void ClientNetworkCoordinatorSocketHandler::StunResult(const std::string &token, uint8_t family, bool result)
+void ClientNetworkCoordinatorSocketHandler::StunResult(std::string_view token, uint8_t family, bool result)
 {
 	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_SERCLI_STUN_RESULT);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
@@ -618,7 +618,7 @@ void ClientNetworkCoordinatorSocketHandler::StunResult(const std::string &token,
  * @param token The token used for the STUN handlers.
  * @param family The family of STUN handlers to close. AF_UNSPEC to close all STUN handlers for this token.
  */
-void ClientNetworkCoordinatorSocketHandler::CloseStunHandler(const std::string &token, uint8_t family)
+void ClientNetworkCoordinatorSocketHandler::CloseStunHandler(std::string_view token, uint8_t family)
 {
 	auto stun_it = this->stun_handlers.find(token);
 	if (stun_it == this->stun_handlers.end()) return;
@@ -645,7 +645,7 @@ void ClientNetworkCoordinatorSocketHandler::CloseStunHandler(const std::string &
  * Close the TURN handler.
  * @param token The token used for the TURN handler.
  */
-void ClientNetworkCoordinatorSocketHandler::CloseTurnHandler(const std::string &token)
+void ClientNetworkCoordinatorSocketHandler::CloseTurnHandler(std::string_view token)
 {
 	CloseWindowByClass(WC_NETWORK_ASK_RELAY, NRWCD_HANDLED);
 
@@ -664,7 +664,7 @@ void ClientNetworkCoordinatorSocketHandler::CloseTurnHandler(const std::string &
  * Close everything related to this connection token.
  * @param token The connection token to close.
  */
-void ClientNetworkCoordinatorSocketHandler::CloseToken(const std::string &token)
+void ClientNetworkCoordinatorSocketHandler::CloseToken(std::string_view token)
 {
 	/* Close all remaining STUN / TURN connections. */
 	this->CloseStunHandler(token);

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -53,10 +53,10 @@
 class ClientNetworkCoordinatorSocketHandler : public NetworkCoordinatorSocketHandler {
 private:
 	std::chrono::steady_clock::time_point next_update; ///< When to send the next update (if server and public).
-	std::map<std::string, std::pair<std::string, TCPServerConnecter *>> connecter; ///< Based on tokens, the current (invite-code, connecter) that are pending.
-	std::map<std::string, TCPServerConnecter *> connecter_pre; ///< Based on invite codes, the current connecters that are pending.
-	std::map<std::string, std::map<int, std::unique_ptr<ClientNetworkStunSocketHandler>>> stun_handlers; ///< All pending STUN handlers, stored by token:family.
-	std::map<std::string, std::unique_ptr<ClientNetworkTurnSocketHandler>> turn_handlers; ///< Pending TURN handler (if any), stored by token.
+	std::map<std::string, std::pair<std::string, TCPServerConnecter *>, std::less<>> connecter; ///< Based on tokens, the current (invite-code, connecter) that are pending.
+	std::map<std::string, TCPServerConnecter *, std::less<>> connecter_pre; ///< Based on invite codes, the current connecters that are pending.
+	std::map<std::string, std::map<int, std::unique_ptr<ClientNetworkStunSocketHandler>>, std::less<>> stun_handlers; ///< All pending STUN handlers, stored by token:family.
+	std::map<std::string, std::unique_ptr<ClientNetworkTurnSocketHandler>, std::less<>> turn_handlers; ///< Pending TURN handler (if any), stored by token.
 	std::shared_ptr<TCPConnecter> game_connecter{}; ///< Pending connecter to the game server.
 
 	uint32_t newgrf_lookup_table_cursor = 0; ///< Last received cursor for the #GameInfoNewGRFLookupTable updates.
@@ -86,22 +86,22 @@ public:
 	NetworkRecvStatus CloseConnection(bool error = true) override;
 	void SendReceive();
 
-	void ConnectFailure(const std::string &token, uint8_t tracking_number);
-	void ConnectSuccess(const std::string &token, SOCKET sock, NetworkAddress &address);
-	void StunResult(const std::string &token, uint8_t family, bool result);
+	void ConnectFailure(std::string_view token, uint8_t tracking_number);
+	void ConnectSuccess(std::string_view token, SOCKET sock, NetworkAddress &address);
+	void StunResult(std::string_view token, uint8_t family, bool result);
 
 	void Connect();
-	void CloseToken(const std::string &token);
+	void CloseToken(std::string_view token);
 	void CloseAllConnections();
-	void CloseStunHandler(const std::string &token, uint8_t family = AF_UNSPEC);
-	void CloseTurnHandler(const std::string &token);
+	void CloseStunHandler(std::string_view token, uint8_t family = AF_UNSPEC);
+	void CloseTurnHandler(std::string_view token);
 
 	void Register();
 	void SendServerUpdate();
 	void GetListing();
 
-	void ConnectToServer(const std::string &invite_code, TCPServerConnecter *connecter);
-	void StartTurnConnection(std::string &token);
+	void ConnectToServer(std::string_view invite_code, TCPServerConnecter *connecter);
+	void StartTurnConnection(std::string_view token);
 };
 
 extern ClientNetworkCoordinatorSocketHandler _network_coordinator_client;

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -44,13 +44,13 @@ void NetworkReboot();
 void NetworkDisconnect(bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
-std::string_view ParseFullConnectionString(const std::string &connection_string, uint16_t &port, CompanyID *company_id = nullptr);
+std::string_view ParseFullConnectionString(std::string_view connection_string, uint16_t &port, CompanyID *company_id = nullptr);
 using NetworkCompanyStatsArray = ReferenceThroughBaseContainer<std::array<NetworkCompanyStats, MAX_COMPANIES>>;
 NetworkCompanyStatsArray NetworkGetCompanyStats();
 
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
-bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const std::string &join_server_password = "");
+bool NetworkClientConnectGame(std::string_view connection_string, CompanyID default_company, const std::string &join_server_password = "");
 void NetworkClientJoinGame();
 void NetworkClientRequestMove(CompanyID company);
 void NetworkClientSendRcon(std::string_view password, std::string_view command);

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -29,7 +29,7 @@ int _network_game_list_version = 0; ///< Current version of all items in the lis
  * @param connection_string the address of the to-be added item
  * @return a point to the newly added or already existing item
  */
-NetworkGame *NetworkGameListAddItem(const std::string &connection_string)
+NetworkGame *NetworkGameListAddItem(std::string_view connection_string)
 {
 	/* Parse the connection string to ensure the default port is there. */
 	const std::string resolved_connection_string = ServerAddress::Parse(connection_string, NETWORK_DEFAULT_PORT).connection_string;

--- a/src/network/network_gamelist.h
+++ b/src/network/network_gamelist.h
@@ -25,7 +25,7 @@ enum NetworkGameStatus : uint8_t {
 
 /** Structure with information shown in the game list (GUI) */
 struct NetworkGame {
-	NetworkGame(const std::string &connection_string) : connection_string(connection_string) {}
+	NetworkGame(std::string_view connection_string) : connection_string(connection_string) {}
 
 	NetworkGameInfo info{};                  ///< The game information of this server.
 	std::string connection_string;           ///< Address of the server.
@@ -38,7 +38,7 @@ struct NetworkGame {
 extern std::vector<std::unique_ptr<NetworkGame>> _network_game_list;
 extern int _network_game_list_version;
 
-NetworkGame *NetworkGameListAddItem(const std::string &connection_string);
+NetworkGame *NetworkGameListAddItem(std::string_view connection_string);
 void NetworkGameListRemoveItem(NetworkGame *remove);
 void NetworkGameListRemoveExpired();
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2186,11 +2186,11 @@ struct NetworkAskRelayWindow : public Window {
 	std::string relay_connection_string{}; ///< The relay server we want to connect to.
 	std::string token{}; ///< The token for this connection.
 
-	NetworkAskRelayWindow(WindowDesc &desc, Window *parent, const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token) :
+	NetworkAskRelayWindow(WindowDesc &desc, Window *parent, std::string_view server_connection_string, std::string &&relay_connection_string, std::string &&token) :
 		Window(desc),
 		server_connection_string(server_connection_string),
-		relay_connection_string(relay_connection_string),
-		token(token)
+		relay_connection_string(std::move(relay_connection_string)),
+		token(std::move(token))
 	{
 		this->parent = parent;
 		this->InitNested(0);
@@ -2276,12 +2276,12 @@ static WindowDesc _network_ask_relay_desc(
  * @param relay_connection_string The relay server we want to connect to.
  * @param token The token for this connection.
  */
-void ShowNetworkAskRelay(const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token)
+void ShowNetworkAskRelay(std::string_view server_connection_string, std::string &&relay_connection_string, std::string &&token)
 {
 	CloseWindowByClass(WC_NETWORK_ASK_RELAY, NRWCD_HANDLED);
 
 	Window *parent = GetMainWindow();
-	new NetworkAskRelayWindow(_network_ask_relay_desc, parent, server_connection_string, relay_connection_string, token);
+	new NetworkAskRelayWindow(_network_ask_relay_desc, parent, server_connection_string, std::move(relay_connection_string), std::move(token));
 }
 
 /**

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -22,7 +22,7 @@ void ShowNetworkChatQueryWindow(DestType type, int dest);
 void ShowJoinStatusWindow();
 void ShowNetworkGameWindow();
 void ShowClientList();
-void ShowNetworkAskRelay(const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token);
+void ShowNetworkAskRelay(std::string_view server_connection_string, std::string &&relay_connection_string, std::string &&token);
 void ShowNetworkAskSurvey();
 void ShowSurveyResultTextfileWindow();
 

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -81,10 +81,10 @@ extern std::string _network_server_name;
 
 extern uint8_t _network_reconnect;
 
-void NetworkQueryServer(const std::string &connection_string);
+void NetworkQueryServer(std::string_view connection_string);
 
 void GetBindAddresses(NetworkAddressList *addresses, uint16_t port);
-struct NetworkGame *NetworkAddServer(const std::string &connection_string, bool manually = true, bool never_expire = false);
+struct NetworkGame *NetworkAddServer(std::string_view connection_string, bool manually = true, bool never_expire = false);
 void NetworkRebuildHostList();
 void UpdateNetworkGameWindow();
 
@@ -115,9 +115,9 @@ uint NetworkCalculateLag(const NetworkClientSocket *cs);
 StringID GetNetworkErrorMsg(NetworkErrorCode err);
 bool NetworkMakeClientNameUnique(std::string &new_name);
 
-std::string_view ParseCompanyFromConnectionString(const std::string &connection_string, CompanyID *company_id);
-NetworkAddress ParseConnectionString(const std::string &connection_string, uint16_t default_port);
-std::string NormalizeConnectionString(const std::string &connection_string, uint16_t default_port);
+std::string_view ParseCompanyFromConnectionString(std::string_view connection_string, CompanyID *company_id);
+NetworkAddress ParseConnectionString(std::string_view connection_string, uint16_t default_port);
+std::string NormalizeConnectionString(std::string_view connection_string, uint16_t default_port);
 
 void ClientNetworkEmergencySave();
 

--- a/src/network/network_query.h
+++ b/src/network/network_query.h
@@ -36,14 +36,14 @@ public:
 	 * @param s The socket to connect with.
 	 * @param connection_string The connection string of the server.
 	 */
-	QueryNetworkGameSocketHandler(SOCKET s, const std::string &connection_string) : NetworkGameSocketHandler(s), connection_string(connection_string) {}
+	QueryNetworkGameSocketHandler(SOCKET s, std::string_view connection_string) : NetworkGameSocketHandler(s), connection_string(connection_string) {}
 
 	/**
 	 * Start to query a server based on an open socket.
 	 * @param s The socket to connect with.
 	 * @param connection_string The connection string of the server.
 	 */
-	static void QueryServer(SOCKET s, const std::string &connection_string)
+	static void QueryServer(SOCKET s, std::string_view connection_string)
 	{
 		auto query = std::make_unique<QueryNetworkGameSocketHandler>(s, connection_string);
 		query->SendGameInfo();

--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -28,7 +28,7 @@ public:
 	 * @param stun_handler The handler for this request.
 	 * @param connection_string The address of the server.
 	 */
-	NetworkStunConnecter(ClientNetworkStunSocketHandler *stun_handler, std::string_view connection_string, const std::string &token, uint8_t family) :
+	NetworkStunConnecter(ClientNetworkStunSocketHandler *stun_handler, std::string_view connection_string, std::string_view token, uint8_t family) :
 		TCPConnecter(connection_string, NETWORK_STUN_SERVER_PORT, NetworkAddress(), family),
 		stun_handler(stun_handler),
 		token(token),
@@ -70,7 +70,7 @@ public:
  * @param token The token as received from the Game Coordinator.
  * @param family What IP family to use.
  */
-void ClientNetworkStunSocketHandler::Connect(const std::string &token, uint8_t family)
+void ClientNetworkStunSocketHandler::Connect(std::string_view token, uint8_t family)
 {
 	this->token = token;
 	this->family = family;
@@ -86,7 +86,7 @@ void ClientNetworkStunSocketHandler::Connect(const std::string &token, uint8_t f
  * @param family What IP family this STUN request is for.
  * @return The handler for this STUN request.
  */
-std::unique_ptr<ClientNetworkStunSocketHandler> ClientNetworkStunSocketHandler::Stun(const std::string &token, uint8_t family)
+std::unique_ptr<ClientNetworkStunSocketHandler> ClientNetworkStunSocketHandler::Stun(std::string_view token, uint8_t family)
 {
 	auto stun_handler = std::make_unique<ClientNetworkStunSocketHandler>();
 

--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -28,7 +28,7 @@ public:
 	 * @param stun_handler The handler for this request.
 	 * @param connection_string The address of the server.
 	 */
-	NetworkStunConnecter(ClientNetworkStunSocketHandler *stun_handler, const std::string &connection_string, const std::string &token, uint8_t family) :
+	NetworkStunConnecter(ClientNetworkStunSocketHandler *stun_handler, std::string_view connection_string, const std::string &token, uint8_t family) :
 		TCPConnecter(connection_string, NETWORK_STUN_SERVER_PORT, NetworkAddress(), family),
 		stun_handler(stun_handler),
 		token(token),

--- a/src/network/network_stun.h
+++ b/src/network/network_stun.h
@@ -27,9 +27,9 @@ public:
 	~ClientNetworkStunSocketHandler() override;
 	void SendReceive();
 
-	void Connect(const std::string &token, uint8_t family);
+	void Connect(std::string_view token, uint8_t family);
 
-	static std::unique_ptr<ClientNetworkStunSocketHandler> Stun(const std::string &token, uint8_t family);
+	static std::unique_ptr<ClientNetworkStunSocketHandler> Stun(std::string_view token, uint8_t family);
 };
 
 #endif /* NETWORK_STUN_H */

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -28,7 +28,7 @@ public:
 	 * Initiate the connecting.
 	 * @param connection_string The address of the TURN server.
 	 */
-	NetworkTurnConnecter(ClientNetworkTurnSocketHandler *handler, const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_TURN_SERVER_PORT), handler(handler) {}
+	NetworkTurnConnecter(ClientNetworkTurnSocketHandler *handler, std::string_view connection_string) : TCPConnecter(connection_string, NETWORK_TURN_SERVER_PORT), handler(handler) {}
 
 	void OnFailure() override
 	{
@@ -96,7 +96,7 @@ void ClientNetworkTurnSocketHandler::Connect()
  * @param connection_string Connection string of the TURN server.
  * @return The handler for this TURN connection.
  */
-/* static */ std::unique_ptr<ClientNetworkTurnSocketHandler> ClientNetworkTurnSocketHandler::Turn(const std::string &token, uint8_t tracking_number, const std::string &ticket, const std::string &connection_string)
+/* static */ std::unique_ptr<ClientNetworkTurnSocketHandler> ClientNetworkTurnSocketHandler::Turn(const std::string &token, uint8_t tracking_number, const std::string &ticket, std::string_view connection_string)
 {
 	auto turn_handler = std::make_unique<ClientNetworkTurnSocketHandler>(token, tracking_number, connection_string);
 

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -96,7 +96,7 @@ void ClientNetworkTurnSocketHandler::Connect()
  * @param connection_string Connection string of the TURN server.
  * @return The handler for this TURN connection.
  */
-/* static */ std::unique_ptr<ClientNetworkTurnSocketHandler> ClientNetworkTurnSocketHandler::Turn(const std::string &token, uint8_t tracking_number, const std::string &ticket, std::string_view connection_string)
+/* static */ std::unique_ptr<ClientNetworkTurnSocketHandler> ClientNetworkTurnSocketHandler::Turn(std::string_view token, uint8_t tracking_number, std::string_view ticket, std::string_view connection_string)
 {
 	auto turn_handler = std::make_unique<ClientNetworkTurnSocketHandler>(token, tracking_number, connection_string);
 

--- a/src/network/network_turn.h
+++ b/src/network/network_turn.h
@@ -27,7 +27,7 @@ public:
 	std::shared_ptr<TCPConnecter> connecter{}; ///< Connecter instance.
 	bool connect_started = false;      ///< Whether we started the connection.
 
-	ClientNetworkTurnSocketHandler(const std::string &token, uint8_t tracking_number, std::string_view connection_string) : token(token), tracking_number(tracking_number), connection_string(connection_string) {}
+	ClientNetworkTurnSocketHandler(std::string_view token, uint8_t tracking_number, std::string_view connection_string) : token(token), tracking_number(tracking_number), connection_string(connection_string) {}
 
 	NetworkRecvStatus CloseConnection(bool error = true) override;
 	~ClientNetworkTurnSocketHandler() override;
@@ -36,7 +36,7 @@ public:
 	void Connect();
 	void ConnectFailure();
 
-	static std::unique_ptr<ClientNetworkTurnSocketHandler> Turn(const std::string &token, uint8_t tracking_number, const std::string &ticket, std::string_view connection_string);
+	static std::unique_ptr<ClientNetworkTurnSocketHandler> Turn(std::string_view token, uint8_t tracking_number, std::string_view ticket, std::string_view connection_string);
 };
 
 #endif /* NETWORK_TURN_H */

--- a/src/network/network_turn.h
+++ b/src/network/network_turn.h
@@ -27,7 +27,7 @@ public:
 	std::shared_ptr<TCPConnecter> connecter{}; ///< Connecter instance.
 	bool connect_started = false;      ///< Whether we started the connection.
 
-	ClientNetworkTurnSocketHandler(const std::string &token, uint8_t tracking_number, const std::string &connection_string) : token(token), tracking_number(tracking_number), connection_string(connection_string) {}
+	ClientNetworkTurnSocketHandler(const std::string &token, uint8_t tracking_number, std::string_view connection_string) : token(token), tracking_number(tracking_number), connection_string(connection_string) {}
 
 	NetworkRecvStatus CloseConnection(bool error = true) override;
 	~ClientNetworkTurnSocketHandler() override;
@@ -36,7 +36,7 @@ public:
 	void Connect();
 	void ConnectFailure();
 
-	static std::unique_ptr<ClientNetworkTurnSocketHandler> Turn(const std::string &token, uint8_t tracking_number, const std::string &ticket, const std::string &connection_string);
+	static std::unique_ptr<ClientNetworkTurnSocketHandler> Turn(const std::string &token, uint8_t tracking_number, const std::string &ticket, std::string_view connection_string);
 };
 
 #endif /* NETWORK_TURN_H */


### PR DESCRIPTION
## Motivation / Problem

Partly a continuation of #14040, as I missed one case.
Partly getting rid of `const std::string&`, as `std::string_view` is a more versatile paradigm to use.


## Description

Replace `const std::string &` with `std::string_view` or `std::move`-semantics, when that's more appropriate.


## Limitations

There are more cases in the network code, but I'd like to keep the PRs relatively small.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
