### PR TITLE
Codechange: Improve the squirrel-exporter

### DIFF
--- a/cmake/scripts/SquirrelExport.cmake
+++ b/cmake/scripts/SquirrelExport.cmake
@@ -614,8 +614,10 @@ foreach(LINE IN LISTS SOURCE_LINES)
         string(REGEX REPLACE "\\*" "" LINE "${LINE}")
         string(REGEX REPLACE "\\(.*" "" LINE "${LINE}")
 
-        string(REGEX REPLACE ".*\\(" "" PARAM_S "${PARAM_S}")
+        # Parameters start at first "(". Further "(" will appear in ctor lists.
+        string(REGEX MATCH "\\(.*" PARAM_S "${PARAM_S}")
         string(REGEX REPLACE "\\).*" "" PARAM_S "${PARAM_S}")
+        string(REGEX REPLACE "^\\(" "" PARAM_S "${PARAM_S}")
 
         string(REGEX MATCH "([^ 	]+)( ([^ ]+))?" RESULT "${LINE}")
         set(FUNCTYPE "${CMAKE_MATCH_1}")


### PR DESCRIPTION
## Motivation / Problem

When the squirrel-exporter extracts function prototype, the regular expressions fail in the following two cases:
* Function definitions match on any line with parentheses.
    * This means it will also match any function calls inside function bodies.
    * It currently works (by luck), if the whole function is on a single line:
      ```c++
      static ScriptEventCompanyRenamed *Convert(ScriptEvent *instance) { return static_cast<ScriptEventCompanyRenamed *>(instance); }
      ```
    * It fails once the function is wrapped:
      ```c++
      static ScriptEventCompanyRenamed *Convert(ScriptEvent *instance)
      {
          return static_cast<ScriptEventCompanyRenamed *>(instance);  // <= this is matched as function prototype
      }
      ```
* Function parameters match on the last parentheses.
    * This breaks in the presence of ctor lists.
    * It currently works, if the ctor list is on a separate line:
      ```c++
      ScriptEvent(ScriptEvent::ScriptEventType type) :
          type(type)
      {}
      ```
    * It fails, if the ctor list is on the same line:
      ```c++
      ScriptEvent(ScriptEvent::ScriptEventType type) : type(type) {}  // <= "(type)" is matched as parameter list
      ```

## Description

* The first problem is fixed by counting braces, and skipping function bodies.
* The second problem is fixed by matching on the first pair of parentheses.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
