### PR TITLE
Codefix: Add missing header includes

### DIFF
--- a/.github/unused-strings.py
+++ b/.github/unused-strings.py
@@ -158,7 +158,7 @@ def scan_source_files(path, strings_found):
         # Most files we can just open, but some use magic, that requires the
         # G++ preprocessor before we can make sense out of it.
         if new_path == "src/table/cargo_const.h":
-            p = subprocess.run(["g++", "-E", new_path], stdout=subprocess.PIPE)
+            p = subprocess.run(["g++", "-E", "-DCHECK_UNUSED_STRINGS", new_path], stdout=subprocess.PIPE)
             output = p.stdout.decode()
         else:
             with open(new_path) as fp:

--- a/src/core/kdtree.hpp
+++ b/src/core/kdtree.hpp
@@ -10,8 +10,6 @@
 #ifndef KDTREE_HPP
 #define KDTREE_HPP
 
-#include "../stdafx.h"
-
 /**
  * K-dimensional tree, specialised for 2-dimensional space.
  * This is not intended as a primary storage of data, but as an index into existing data.

--- a/src/date_gui.h
+++ b/src/date_gui.h
@@ -10,7 +10,7 @@
 #ifndef DATE_GUI_H
 #define DATE_GUI_H
 
-#include "timer/timer_game_calendar.h"
+#include "timer/timer_game_economy.h"
 #include "window_type.h"
 
 /**

--- a/src/depot_cmd.h
+++ b/src/depot_cmd.h
@@ -12,6 +12,7 @@
 
 #include "command_type.h"
 #include "depot_type.h"
+#include "vehicle_type.h"
 
 CommandCost CmdRenameDepot(DoCommandFlags flags, DepotID depot_id, const std::string &text);
 

--- a/src/dropdown_common_type.h
+++ b/src/dropdown_common_type.h
@@ -10,12 +10,15 @@
 #ifndef DROPDOWN_COMMON_TYPE_H
 #define DROPDOWN_COMMON_TYPE_H
 
+#include "dropdown_type.h"
 #include "gfx_func.h"
 #include "gfx_type.h"
 #include "palette_func.h"
 #include "string_func.h"
 #include "strings_func.h"
 #include "window_gui.h"
+
+#include "table/strings.h"
 
 /**
  * Drop down divider component.

--- a/src/dropdown_func.h
+++ b/src/dropdown_func.h
@@ -10,6 +10,7 @@
 #ifndef DROPDOWN_FUNC_H
 #define DROPDOWN_FUNC_H
 
+#include "dropdown_type.h"
 #include "window_gui.h"
 
 /* Show drop down menu containing a fixed list of strings */

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -10,6 +10,7 @@
 #ifndef ENGINE_TYPE_H
 #define ENGINE_TYPE_H
 
+#include "core/pool_type.hpp"
 #include "economy_type.h"
 #include "landscape_type.h"
 #include "newgrf_callbacks.h"

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 #include "error_func.h"
+#include "safeguards.h"
 
 [[noreturn]] void NOT_REACHED(const std::source_location location)
 {

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -7,6 +7,8 @@
 
 /** @file framerate_gui.cpp GUI for displaying framerate/game speed information. */
 
+#include "stdafx.h"
+
 #include "framerate_type.h"
 #include <chrono>
 #include "gfx_func.h"

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -35,7 +35,6 @@
 #ifndef FRAMERATE_TYPE_H
 #define FRAMERATE_TYPE_H
 
-#include "stdafx.h"
 #include "core/enum_type.hpp"
 
 /**

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -10,6 +10,7 @@
 #ifndef GAME_TEXT_HPP
 #define GAME_TEXT_HPP
 
+#include "../string_type.h"
 #include "../strings_type.h"
 
 struct StringParam {

--- a/src/group_gui.h
+++ b/src/group_gui.h
@@ -11,6 +11,8 @@
 #define GROUP_GUI_H
 
 #include "company_type.h"
+#include "group_type.h"
+#include "sortlist_type.h"
 #include "vehicle_type.h"
 
 void ShowCompanyGroup(CompanyID company, VehicleType veh, GroupID group = GroupID::Invalid());

--- a/src/industry_type.h
+++ b/src/industry_type.h
@@ -10,6 +10,8 @@
 #ifndef INDUSTRY_TYPE_H
 #define INDUSTRY_TYPE_H
 
+#include "core/pool_type.hpp"
+
 using IndustryID = PoolID<uint16_t, struct IndustryIDTag, 64000, 0xFFFF>;
 
 typedef uint16_t IndustryGfx;

--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -16,6 +16,7 @@
 #include <fluidsynth.h>
 #include "../mixer.h"
 #include <mutex>
+#include "../safeguards.h"
 
 static struct {
 	fluid_settings_t *settings;    ///< FluidSynth settings handle

--- a/src/music/midi.h
+++ b/src/music/midi.h
@@ -10,8 +10,6 @@
 #ifndef MUSIC_MIDI_H
 #define MUSIC_MIDI_H
 
-#include "../stdafx.h"
-
 /** Header of a Stanard MIDI File */
 struct SMFHeader {
 	uint16_t format;

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -7,6 +7,8 @@
 
 /* @file midifile.cpp Parser for standard MIDI files */
 
+#include "../stdafx.h"
+
 #include "midifile.hpp"
 #include "../fileio_func.h"
 #include "../fileio_type.h"
@@ -20,6 +22,8 @@
 #include "../console_internal.h"
 
 #include "table/strings.h"
+
+#include "../safeguards.h"
 
 /* SMF reader based on description at: http://www.somascape.org/midi/tech/mfile.html */
 

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -10,7 +10,6 @@
 #ifndef MUSIC_MIDIFILE_HPP
 #define MUSIC_MIDIFILE_HPP
 
-#include "../stdafx.h"
 #include "../fileio_type.h"
 #include "midi.h"
 

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -14,6 +14,9 @@
 
 #include "../../3rdparty/md5/md5.h"
 
+#include "../../string_type.h"
+#include "../../textfile_type.h"
+
 /** The values in the enum are important; they are used as database 'keys' */
 enum ContentType : uint8_t {
 	CONTENT_TYPE_BEGIN         = 1, ///< Helper to mark the begin of the types

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -14,6 +14,8 @@
 
 #include "tcp.h"
 #include "../network.h"
+#include "../network_func.h"
+#include "../network_internal.h"
 #include "../../core/pool_type.hpp"
 #include "../../debug.h"
 

--- a/src/newgrf/newgrf_act0.cpp
+++ b/src/newgrf/newgrf_act0.cpp
@@ -19,7 +19,7 @@
 #include "newgrf_bytereader.h"
 #include "newgrf_internal.h"
 
-#include "../table/strings.h"
+#include "table/strings.h"
 
 #include "../safeguards.h"
 

--- a/src/newgrf/newgrf_act2.cpp
+++ b/src/newgrf/newgrf_act2.cpp
@@ -18,7 +18,7 @@
 #include "newgrf_bytereader.h"
 #include "newgrf_internal.h"
 
-#include "../table/strings.h"
+#include "table/strings.h"
 
 #include "../safeguards.h"
 

--- a/src/newgrf/newgrf_act8.cpp
+++ b/src/newgrf/newgrf_act8.cpp
@@ -13,7 +13,7 @@
 #include "newgrf_bytereader.h"
 #include "newgrf_internal.h"
 
-#include "../table/strings.h"
+#include "table/strings.h"
 
 #include "../safeguards.h"
 

--- a/src/newgrf/newgrf_stringmapping.cpp
+++ b/src/newgrf/newgrf_stringmapping.cpp
@@ -16,9 +16,9 @@
 #include "newgrf_internal.h"
 #include "newgrf_stringmapping.h"
 
-#include "../safeguards.h"
+#include "table/strings.h"
 
-#include "../table/strings.h"
+#include "../safeguards.h"
 
 /**
  * Information for mapping static StringIDs.

--- a/src/newgrf_act5.h
+++ b/src/newgrf_act5.h
@@ -10,6 +10,8 @@
 #ifndef NEWGRF_ACT5_H
 #define NEWGRF_ACT5_H
 
+#include "gfx_type.h"
+
 /** The type of action 5 type. */
 enum Action5BlockType : uint8_t {
 	A5BLOCK_FIXED,                ///< Only allow replacing a whole block of sprites. (TTDP compatible)

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -9,6 +9,8 @@
 
 #include "newgrf_class.h"
 
+#include "table/strings.h"
+
 /** Reset the classes, i.e. clear everything. */
 template <typename Tspec, typename Tindex, Tindex Tmax>
 void NewGRFClass<Tspec, Tindex, Tmax>::Reset()

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -7,6 +7,8 @@
 
  /** @file newgrf_profiling.cpp Profiling of NewGRF action 2 handling. */
 
+#include "stdafx.h"
+
 #include "newgrf_profiling.h"
 #include "fileio_func.h"
 #include "string_func.h"
@@ -18,6 +20,7 @@
 
 #include <chrono>
 
+#include "safeguards.h"
 
 std::vector<NewGRFProfiler> _newgrf_profilers;
 

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -10,7 +10,6 @@
 #ifndef NEWGRF_PROFILING_H
 #define NEWGRF_PROFILING_H
 
-#include "stdafx.h"
 #include "timer/timer_game_calendar.h"
 #include "newgrf.h"
 #include "newgrf_callbacks.h"

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -10,6 +10,7 @@
 #ifndef NEWGRF_SPRITEGROUP_H
 #define NEWGRF_SPRITEGROUP_H
 
+#include "core/pool_type.hpp"
 #include "town_type.h"
 #include "engine_type.h"
 #include "house_type.h"

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -18,6 +18,7 @@
 #include "macos.h"
 
 #include <CoreFoundation/CoreFoundation.h>
+#include "../../safeguards.h"
 
 
 /* CTRunDelegateCreate is supported since MacOS X 10.5, but was only included in the SDKs starting with the 10.9 SDK. */

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -19,6 +19,7 @@
 #include "../ship.h"
 #include "../debug.h"
 #include "../3rdparty/fmt/ranges.h"
+#include "../safeguards.h"
 
 using TWaterRegionTraversabilityBits = uint16_t;
 constexpr TWaterRegionPatchLabel FIRST_REGION_LABEL = 1;

--- a/src/pathfinder/yapf/yapf_ship_regions.h
+++ b/src/pathfinder/yapf/yapf_ship_regions.h
@@ -10,7 +10,6 @@
 #ifndef YAPF_SHIP_REGIONS_H
 #define YAPF_SHIP_REGIONS_H
 
-#include "../../stdafx.h"
 #include "../../tile_type.h"
 #include "../water_regions.h"
 

--- a/src/rail_cmd.h
+++ b/src/rail_cmd.h
@@ -12,6 +12,7 @@
 
 #include "command_type.h"
 #include "track_type.h"
+#include "direction_type.h"
 #include "rail_type.h"
 #include "signal_type.h"
 

--- a/src/road_cmd.h
+++ b/src/road_cmd.h
@@ -13,6 +13,8 @@
 #include "direction_type.h"
 #include "road_type.h"
 #include "command_type.h"
+#include "station_type.h"
+#include "town_type.h"
 
 enum RoadStopClassID : uint16_t;
 

--- a/src/road_gui.h
+++ b/src/road_gui.h
@@ -10,6 +10,7 @@
 #ifndef ROAD_GUI_H
 #define ROAD_GUI_H
 
+#include "road.h"
 #include "road_type.h"
 #include "tile_type.h"
 #include "direction_type.h"

--- a/src/saveload/newgrf_sl.h
+++ b/src/saveload/newgrf_sl.h
@@ -11,6 +11,7 @@
 #define SAVELOAD_NEWGRF_SL_H
 
 #include "../newgrf_commons.h"
+#include "saveload.h"
 
 struct NewGRFMappingChunkHandler : ChunkHandler {
 	OverrideManagerBase &mapping;

--- a/src/script/api/script_controller.hpp
+++ b/src/script/api/script_controller.hpp
@@ -11,6 +11,7 @@
 #define SCRIPT_CONTROLLER_HPP
 
 #include "script_types.hpp"
+#include "../../string_func.h"
 #include "../../company_type.h"
 
 /**

--- a/src/script/script_gui.h
+++ b/src/script/script_gui.h
@@ -13,6 +13,8 @@
 #include "../company_type.h"
 #include "../textfile_type.h"
 
+struct Window;
+
 void ShowScriptListWindow(CompanyID slot, bool show_all);
 Window *ShowScriptDebugWindow(CompanyID show_company = CompanyID::Invalid(), bool new_window = false);
 void ShowScriptSettingsWindow(CompanyID slot);

--- a/src/signs_type.h
+++ b/src/signs_type.h
@@ -10,6 +10,8 @@
 #ifndef SIGNS_TYPE_H
 #define SIGNS_TYPE_H
 
+#include "core/pool_type.hpp"
+
 /** The type of the IDs of signs. */
 using SignID = PoolID<uint16_t, struct SignIDTag, 64000, 0xFFFF>;
 

--- a/src/spritecache_internal.h
+++ b/src/spritecache_internal.h
@@ -10,8 +10,6 @@
 #ifndef SPRITECACHE_INTERNAL_H
 #define SPRITECACHE_INTERNAL_H
 
-#include "stdafx.h"
-
 #include "core/math_func.hpp"
 #include "gfx_type.h"
 #include "spriteloader/spriteloader.hpp"

--- a/src/spriteloader/sprite_file.cpp
+++ b/src/spriteloader/sprite_file.cpp
@@ -9,6 +9,7 @@
 
 #include "../stdafx.h"
 #include "sprite_file_type.hpp"
+#include "../safeguards.h"
 
 /** Signature of a container version 2 GRF. */
 extern const std::array<uint8_t, 8> _grf_cont_v2_sig = {'G', 'R', 'F', 0x82, 0x0D, 0x0A, 0x1A, 0x0A};

--- a/src/station_cmd.h
+++ b/src/station_cmd.h
@@ -11,7 +11,11 @@
 #define STATION_CMD_H
 
 #include "command_type.h"
+#include "rail_type.h"
+#include "road_type.h"
 #include "station_type.h"
+
+struct Town;
 
 enum StationClassID : uint16_t;
 enum RoadStopClassID : uint16_t;

--- a/src/subsidy_func.h
+++ b/src/subsidy_func.h
@@ -10,6 +10,7 @@
 #ifndef SUBSIDY_FUNC_H
 #define SUBSIDY_FUNC_H
 
+#include "source_type.h"
 #include "station_type.h"
 #include "company_type.h"
 #include "cargo_type.h"

--- a/src/subsidy_type.h
+++ b/src/subsidy_type.h
@@ -11,6 +11,7 @@
 #define SUBSIDY_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "core/pool_type.hpp"
 
 /** What part of a subsidy is something? */
 enum class PartOfSubsidy : uint8_t {

--- a/src/table/airporttiles.h
+++ b/src/table/airporttiles.h
@@ -10,6 +10,8 @@
 #ifndef AIRPORTTILES_H
 #define AIRPORTTILES_H
 
+#include "table/strings.h"
+
 /** Writes all airport tile properties in the AirportTile struct */
 #define AT(num_frames, anim_speed) {{num_frames, AnimationStatus::Looping, anim_speed, 0}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
 /** Writes an airport tile without animation in the AirportTile struct */

--- a/src/table/bridge_land.h
+++ b/src/table/bridge_land.h
@@ -5,6 +5,8 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "table/strings.h"
+
 /**
  * @file bridge_land.h This file contains all the sprites for bridges
  * It consists of a number of arrays.

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -10,6 +10,8 @@
 #ifndef BUILD_INDUSTRY_H
 #define BUILD_INDUSTRY_H
 
+#include "table/strings.h"
+
 /**
  * Definition of an industry tiles layout.
  * @param x offset x of this tile

--- a/src/table/cargo_const.h
+++ b/src/table/cargo_const.h
@@ -7,6 +7,11 @@
 
 /** @file cargo_const.h Table of all default cargo types */
 
+#include "../table/sprites.h"
+#ifndef CHECK_UNUSED_STRINGS
+#include "table/strings.h"
+#endif
+
 /** Construction macros for the #CargoSpec StringID entries. */
 #define MK_STR_CARGO_PLURAL(label_plural) STR_CARGO_PLURAL_ ## label_plural
 #define MK_STR_CARGO_SINGULAR(label_singular) STR_CARGO_SINGULAR_ ## label_singular

--- a/src/table/clear_land.h
+++ b/src/table/clear_land.h
@@ -7,6 +7,8 @@
 
 /** @file clear_land.h Tables with sprites for clear land and fences. */
 
+#include "sprites.h"
+
 static const SpriteID _landscape_clear_sprites_rough[8] = {
 	SPR_FLAT_ROUGH_LAND,
 	SPR_FLAT_ROUGH_LAND_1,

--- a/src/table/engines.h
+++ b/src/table/engines.h
@@ -13,6 +13,8 @@
 #ifndef ENGINES_H
 #define ENGINES_H
 
+#include "table/strings.h"
+
 /**
  * Writes the properties of a train into the EngineInfo struct.
  * @see EngineInfo

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -7,6 +7,8 @@
 
 /** @file object_land.h Sprites to use and how to display them for object tiles. */
 
+#include "table/strings.h"
+
 #define TILE_SEQ_LINE(sz, img) { 0, 0, 0, 16, 16, sz, {img, PAL_NONE} },
 
 static const DrawTileSeqStruct _object_transmitter_seq[] = {

--- a/src/table/railtypes.h
+++ b/src/table/railtypes.h
@@ -13,6 +13,8 @@
 #ifndef RAILTYPES_H
 #define RAILTYPES_H
 
+#include "table/strings.h"
+
 /**
  * Global Railtype definition
  */

--- a/src/table/roadtypes.h
+++ b/src/table/roadtypes.h
@@ -13,6 +13,8 @@
 #ifndef ROADTYPES_H
 #define ROADTYPES_H
 
+#include "table/strings.h"
+
 /**
  * Global Roadtype definition
  */

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -7,6 +7,8 @@
 
 /** @file table/settings.h Settings to save in the savegame and config file. */
 
+#include "table/strings.h"
+
 /* Callback function used in _settings[] as well as _company_settings[] */
 static size_t ConvertLandscape(const char *value);
 

--- a/src/tests/bitmath_func.cpp
+++ b/src/tests/bitmath_func.cpp
@@ -13,6 +13,8 @@
 
 #include "../core/bitmath_func.hpp"
 
+#include "../safeguards.h"
+
 TEST_CASE("SetBitIterator tests")
 {
 	auto test_case = [&](auto input, std::initializer_list<uint> expected) {

--- a/src/tests/enum_over_optimisation.cpp
+++ b/src/tests/enum_over_optimisation.cpp
@@ -17,6 +17,8 @@
 
 #include "../3rdparty/catch2/catch.hpp"
 
+#include "../safeguards.h"
+
 enum TestEnum : int8_t {
 	ZERO,
 	ONE,

--- a/src/tests/landscape_partial_pixel_z.cpp
+++ b/src/tests/landscape_partial_pixel_z.cpp
@@ -14,6 +14,8 @@
 #include "../landscape.h"
 #include "../slope_func.h"
 
+#include "../safeguards.h"
+
 /**
  * Check whether the addition of two slope's GetPartialPixelZ values results in
  * the GetPartialPixelZ values of the expected slope.

--- a/src/tests/math_func.cpp
+++ b/src/tests/math_func.cpp
@@ -13,6 +13,8 @@
 
 #include "../core/math_func.hpp"
 
+#include "../safeguards.h"
+
 TEST_CASE("DivideApproxTest - Negative")
 {
 	CHECK(-2 == DivideApprox(-5, 2));

--- a/src/tests/mock_fontcache.h
+++ b/src/tests/mock_fontcache.h
@@ -10,8 +10,6 @@
 #ifndef MOCK_FONTCACHE_H
 #define MOCK_FONTCACHE_H
 
-#include "../stdafx.h"
-
 #include "../fontcache.h"
 #include "../string_func.h"
 

--- a/src/tests/mock_spritecache.cpp
+++ b/src/tests/mock_spritecache.cpp
@@ -15,6 +15,8 @@
 #include "../spritecache_internal.h"
 #include "../table/sprites.h"
 
+#include "../safeguards.h"
+
 static bool MockLoadNextSprite(SpriteID load_index)
 {
 	static UniquePtrSpriteAllocator allocator;

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -18,6 +18,8 @@
 
 #include "table/strings.h"
 
+#include "../safeguards.h"
+
 /**** String compare/equals *****/
 
 TEST_CASE("StrCompareIgnoreCase - std::string")

--- a/src/tests/test_network_crypto.cpp
+++ b/src/tests/test_network_crypto.cpp
@@ -16,6 +16,8 @@
 #include "../network/core/packet.h"
 #include "../string_func.h"
 
+#include "../safeguards.h"
+
 /* The length of the hexadecimal representation of a X25519 key must fit in the key length. */
 static_assert(NETWORK_SECRET_KEY_LENGTH >= X25519_KEY_SIZE * 2 + 1);
 static_assert(NETWORK_PUBLIC_KEY_LENGTH >= X25519_KEY_SIZE * 2 + 1);

--- a/src/tests/test_script_admin.cpp
+++ b/src/tests/test_script_admin.cpp
@@ -22,6 +22,8 @@
 
 #include <squirrel.h>
 
+#include "../safeguards.h"
+
 /**
  * A controller to start enough so we can use Squirrel for testing.
  *

--- a/src/tests/test_window_desc.cpp
+++ b/src/tests/test_window_desc.cpp
@@ -15,6 +15,8 @@
 
 #include "../window_gui.h"
 
+#include "../safeguards.h"
+
 /**
  * List of WindowDescs. Defined in window.cpp but not exposed as this unit-test is the only other place that needs it.
  * WindowDesc is a self-registering class so all WindowDescs will be included in the list.

--- a/src/timer/timer_game_calendar.h
+++ b/src/timer/timer_game_calendar.h
@@ -10,7 +10,6 @@
 #ifndef TIMER_GAME_CALENDAR_H
 #define TIMER_GAME_CALENDAR_H
 
-#include "../stdafx.h"
 #include "../core/strong_typedef_type.hpp"
 #include "timer_game_common.h"
 

--- a/src/timer/timer_manager.h
+++ b/src/timer/timer_manager.h
@@ -11,8 +11,6 @@
 #ifndef TIMER_MANAGER_H
 #define TIMER_MANAGER_H
 
-#include "../stdafx.h"
-
 template <typename TTimerType>
 class BaseTimer;
 

--- a/src/timetable_cmd.h
+++ b/src/timetable_cmd.h
@@ -11,7 +11,9 @@
 #define TIMETABLE_CMD_H
 
 #include "command_type.h"
+#include "order_type.h"
 #include "timer/timer_game_tick.h"
+#include "vehicle_type.h"
 
 CommandCost CmdChangeTimetable(DoCommandFlags flags, VehicleID veh, VehicleOrderID order_number, ModifyTimetableFlags mtf, uint16_t data);
 CommandCost CmdBulkChangeTimetable(DoCommandFlags flags, VehicleID veh, ModifyTimetableFlags mtf, uint16_t data);

--- a/src/train_cmd.h
+++ b/src/train_cmd.h
@@ -12,6 +12,7 @@
 
 #include "command_type.h"
 #include "engine_type.h"
+#include "network/network_type.h"
 #include "vehicle_type.h"
 
 CommandCost CmdBuildRailVehicle(DoCommandFlags flags, TileIndex tile, const Engine *e, Vehicle **ret);

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -22,6 +22,8 @@
 #include "../window_func.h"
 #include "video_driver.hpp"
 
+#include "../safeguards.h"
+
 bool _video_hw_accel; ///< Whether to consider hardware accelerated video drivers on startup.
 bool _video_vsync; ///< Whether we should use vsync (only if active video driver supports HW acceleration).
 

--- a/src/viewport_sprite_sorter.h
+++ b/src/viewport_sprite_sorter.h
@@ -7,7 +7,6 @@
 
 /** @file viewport_sprite_sorter.h Types related to sprite sorting. */
 
-#include "stdafx.h"
 #include "gfx_type.h"
 
 #ifndef VIEWPORT_SPRITE_SORTER_H


### PR DESCRIPTION
## Motivation / Problem

Many header files rely on the source file including other headers first.
The problems here were detected, when sorting includes.

## Description

* Fix usage of "stdafx.h" and "safeguards.h":
    * All source files should include "stdafx.h" first.
    * All source files should include "safeguards.h" last.
    * No header file should include "stdafx.h" or "safeguards.h".
* Add missing include files and/or add forward declarations.
    * This probably does not address all cases, but those found so far.
* Fix usage of "strings.h":
    * This is a generated header, including via relative path "../strings.h" makes no sense. Actually no idea why this compiled before.
    * There is a special case in the "unused-string" script, which runs the preprocessor for "cargo_const.h".
    * "strings.h" is not generated in this case.
    * Add a define via command line to skip the inclusion of "strings.h".

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
