### PR TITLE
Codefix: StringConsumer integer parsing failed for the most negative value, which has no positive equivalent.

### DIFF
--- a/src/core/string_consumer.hpp
+++ b/src/core/string_consumer.hpp
@@ -813,10 +813,10 @@ private:
 
 			/* Try negative hex */
 			if (std::is_signed_v<T> && (src.starts_with("-0x") || src.starts_with("-0X"))) {
-				using Unsigned = std::make_signed_t<T>;
+				using Unsigned = std::make_unsigned_t<T>;
 				auto [len, uvalue] = ParseIntegerBase<Unsigned>(src.substr(3), 16, log_errors);
 				if (len == 0) return {};
-				T value = -uvalue;
+				T value = static_cast<T>(0 - uvalue);
 				if (value > 0) {
 					if (log_errors) LogError(fmt::format("Integer out of range: '{}'", src.substr(0, len + 3)));
 					return {};

--- a/src/tests/string_consumer.cpp
+++ b/src/tests/string_consumer.cpp
@@ -485,3 +485,18 @@ TEST_CASE("StringConsumer - invalid int")
 	consumer.SkipIntegerBase(0);
 	CHECK(consumer.ReadUtf8() == 'y');
 }
+
+TEST_CASE("StringConsumer - most negative")
+{
+	StringConsumer consumer("-80000000 -0x80000000 -2147483648"sv);
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(9, 0x80000000));
+	consumer.SkipIntegerBase(16);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(11, 0x80000000));
+	consumer.SkipIntegerBase(0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(11, 0x80000000));
+}


### PR DESCRIPTION
## Motivation / Problem

`StringConsumer` tried to be clever to parse `-0x80000000`.
But because there was no unit test, it was actually broken.

## Description

* Add a unittest, which detects the issue.
* Fix the issue.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
