### PR TITLE
Fix #14044: Negative string parameters from GS were rendered as zero.

### DIFF
--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -400,7 +400,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_ENCODED_STRING_FORMAT,              ///< 350  PR#13499 Encoded String format changed.
 	SLV_PROTECT_PLACED_HOUSES,              ///< 351  PR#13270 Houses individually placed by players can be protected from town/AI removal.
 	SLV_SCRIPT_SAVE_INSTANCES,              ///< 352  PR#13556 Scripts are allowed to save instances.
-	SLV_FIX_SCC_ENCODED_NEGATIVE,           ///< 352  PR# Fix encoding of negative parameters.
+	SLV_FIX_SCC_ENCODED_NEGATIVE,           ///< 353  PR#14049 Fix encoding of negative parameters.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -400,6 +400,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_ENCODED_STRING_FORMAT,              ///< 350  PR#13499 Encoded String format changed.
 	SLV_PROTECT_PLACED_HOUSES,              ///< 351  PR#13270 Houses individually placed by players can be protected from town/AI removal.
 	SLV_SCRIPT_SAVE_INSTANCES,              ///< 352  PR#13556 Scripts are allowed to save instances.
+	SLV_FIX_SCC_ENCODED_NEGATIVE,           ///< 352  PR# Fix encoding of negative parameters.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -211,7 +211,8 @@ void ScriptText::ParamCheck::Encode(StringBuilder &builder, std::string_view cmd
 		void operator()(const SQInteger &value)
 		{
 			this->builder.PutUtf8(SCC_ENCODED_NUMERIC);
-			this->builder.PutIntegerBase(value, 16);
+			/* Sign-extend the value, then store as unsigned */
+			this->builder.PutIntegerBase<uint64_t>(static_cast<uint64_t>(static_cast<int64_t>(value)), 16);
 		}
 
 		void operator()(const ScriptTextRef &value)

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -462,6 +462,9 @@ TEST_CASE("FixSCCEncoded")
 	/* Test conversion with one numeric parameter. */
 	CHECK(FixSCCEncodedWrapper("\uE00022:1", false) == Compose(SCC_ENCODED, "22", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "1"));
 
+	/* Test conversion with signed numeric parameter. */
+	CHECK(FixSCCEncodedWrapper("\uE00022:-1", false) == Compose(SCC_ENCODED, "22", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "-1"));
+
 	/* Test conversion with two numeric parameters. */
 	CHECK(FixSCCEncodedWrapper("\uE0003:12:2", false) == Compose(SCC_ENCODED, "3", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "12", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "2"));
 
@@ -478,7 +481,27 @@ TEST_CASE("FixSCCEncoded")
 	CHECK(FixSCCEncodedWrapper("\uE000777:\uE0008888:\"Foo\":\"BarBaz\"", false) == Compose(SCC_ENCODED, "777", SCC_RECORD_SEPARATOR, SCC_ENCODED, "8888", SCC_RECORD_SEPARATOR, SCC_ENCODED_STRING, "Foo", SCC_RECORD_SEPARATOR, SCC_ENCODED_STRING, "BarBaz"));
 }
 
-TEST_CASE("EncodedString::ReplaceParam")
+extern void FixSCCEncodedNegative(std::string &str);
+
+/* Helper to call FixSCCEncodedNegative and return the result in a new string. */
+static std::string FixSCCEncodedNegativeWrapper(const std::string &str)
+{
+	std::string result = str;
+	FixSCCEncodedNegative(result);
+	return result;
+}
+
+TEST_CASE("FixSCCEncodedNegative")
+{
+	auto positive = Compose(SCC_ENCODED, "777", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "ffffffffffffffff");
+	auto negative = Compose(SCC_ENCODED, "777", SCC_RECORD_SEPARATOR, SCC_ENCODED_NUMERIC, "-1");
+
+	CHECK(FixSCCEncodedNegativeWrapper("") == "");
+	CHECK(FixSCCEncodedNegativeWrapper(positive) == positive);
+	CHECK(FixSCCEncodedNegativeWrapper(negative) == positive);
+}
+
+TEST_CASE("EncodedString::ReplaceParam - positive")
 {
 	/* Test that two encoded strings with different parameters are not the same. */
 	EncodedString string1 = GetEncodedString(STR_NULL, "Foo", 10, "Bar");
@@ -488,4 +511,19 @@ TEST_CASE("EncodedString::ReplaceParam")
 	/* Test that replacing parameter results in the same string. */
 	EncodedString string3 = string1.ReplaceParam(1, 15);
 	CHECK(string2 == string3);
+}
+
+TEST_CASE("EncodedString::ReplaceParam - negative")
+{
+	EncodedString string1 = GetEncodedString(STR_NULL, "Foo", -1, "Bar");
+	EncodedString string2 = GetEncodedString(STR_NULL, "Foo", -2, "Bar");
+	EncodedString string3 = GetEncodedString(STR_NULL, "Foo", 0xFFFF'FFFF'FFFF'FFFF, "Bar");
+	/* Test that two encoded strings with different parameters are not the same. */
+	CHECK(string1 != string2);
+	/* Test that signed values are stored as unsigned. */
+	CHECK(string1 == string3);
+
+	/* Test that replacing parameter results in the same string. */
+	EncodedString string4 = string1.ReplaceParam(1, -2);
+	CHECK(string2 == string4);
 }


### PR DESCRIPTION
## Motivation / Problem

* String parameters are always stored as `uint64_t`.
* Negative values are sign-extended to `int64_t` and then casted to `uint64_t`.
* The same applies to encoded strings.
* But `ScriptText` did it different, and encoded them as `int64_t`.

Funnilly the old `strtoull` did not care, parsed signed integers and returned them as unsigned.

## Description

* Fix the encoding in `ScriptText`.
* Add savegame conversion for existing texts.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
