### PR TITLE
Fix: Odd drawing and crash if scrollbar is not tall enough.

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -155,19 +155,19 @@ static Point HandleScrollbarHittest(const Scrollbar *sb, int top, int bottom, bo
 	} else {
 		button_size = NWidgetScrollbar::GetVerticalDimension().height;
 	}
-	top += button_size;    // top    points to just below the up-button
-	bottom -= button_size; // bottom points to top of the down-button
+	top += button_size;    // top points to just below the up-button
+	bottom -= button_size; // bottom points to just before the down-button
 
 	int count = sb->GetCount();
 	int cap = sb->GetCapacity();
 
 	if (count > cap) {
-		int height = (bottom - top);
+		int height = bottom + 1 - top;
 		int slider_height = std::max(button_size, cap * height / count);
 		height -= slider_height;
 
 		top += height * sb->GetPosition() / (count - cap);
-		bottom = top + slider_height;
+		bottom = top + slider_height - 1;
 	}
 
 	Point pt;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2315,7 +2315,7 @@ static void HandleScrollbarScrolling(Window *w)
 	int range = sb->GetCount() - sb->GetCapacity();
 	if (range <= 0) return;
 
-	int pos = RoundDivSU((i + _scrollbar_start_pos) * range, _scrollbar_size);
+	int pos = RoundDivSU((i + _scrollbar_start_pos) * range, std::max(1, _scrollbar_size));
 	if (rtl) pos = range - pos;
 	if (sb->SetPosition(pos)) w->SetDirty();
 }


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Under certain conditions the scrollbar "tab" could be too large for the scrollbar, and cause issues.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Caused by an off-by-one in height calculation. `bottom - top` is `height - 1`, rather than `height`.

`std::max(1, ...)` is used to ensure a division-by-zero can't occur, regardless of the scrollbar being it its minimal size limit.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
