### PR TITLE
Change: Include dragged train in depot tile length display.

### DIFF
--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -303,6 +303,35 @@ struct DepotWindow : Window {
 	}
 
 	/**
+	 * Count the dragged selection length if appropriate for the provided train.
+	 * @note This ignores potential changes in length due to callback returning different results.
+	 * @param t Train being counted.
+	 * @return Additional length of dragged selection to add.
+	 */
+	uint CountDraggedLength(const Train *t) const
+	{
+		/* Nothing is selected to add. */
+		if (this->sel == VehicleID::Invalid()) return 0;
+
+		/* Test if the dragged selection applies to this train. */
+		bool add_dragged = false;
+		for (const Train *u = t; u != nullptr; u = u->Next()) {
+			if (u->index == this->sel) return 0; // Selection is part of this train, so doesn't increase its length.
+			if (u->index == this->vehicle_over) add_dragged = true;
+		}
+
+		if (!add_dragged) return 0;
+
+		/* Sum the length of the dragged selection. */
+		uint length = 0;
+		for (Train *u = Train::Get(this->sel); u != nullptr; u = _cursor.vehchain ? u->Next() : (u->HasArticulatedPart() ? u->GetNextArticulatedPart() : nullptr)) {
+			length += u->gcache.cached_veh_length;
+		}
+
+		return length;
+	}
+
+	/**
 	 * Draw a vehicle in the depot window in the box with the top left corner at x,y.
 	 * @param v     Vehicle to draw.
 	 * @param r     Rect to draw in.
@@ -327,9 +356,10 @@ struct DepotWindow : Window {
 				DrawTrainImage(u, image.Indent(x_space, rtl), this->sel, EIT_IN_DEPOT, free_wagon ? 0 : this->hscroll->GetPosition(), this->vehicle_over);
 
 				/* Length of consist in tiles with 1 fractional digit (rounded up) */
+				uint length = u->gcache.cached_total_length + this->CountDraggedLength(u);
 				Rect count = text.WithWidth(this->count_width - WidgetDimensions::scaled.hsep_normal, !rtl);
 				DrawString(count.left, count.right, count.bottom - GetCharacterHeight(FS_SMALL) + 1,
-						GetString(STR_JUST_DECIMAL, CeilDiv(u->gcache.cached_total_length * 10, TILE_SIZE), 1),
+						GetString(STR_JUST_DECIMAL, CeilDiv(length * 10, TILE_SIZE), 1),
 						TC_BLACK, SA_RIGHT | SA_FORCE, false, FS_SMALL); // Draw the counter
 				break;
 			}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

In the train depot, the tile length displayed for a train shows the train's current length, regardless of any drag and drop selection, but the visual appearance of the train includes highlighted space, increasing its length.

Dragging a 1 tile train onto a 1 tile train still shows 1 tile.

The resultant 2 tiles is only displayed when the drag & drop is completed.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

In the depot, when dragging a train over another train, the tile length displayed now includes the length of the dragged train.

Dragging a 1 tile train onto a 1 tile train now shows 2 tiles.

(Can't easily get a screenshot because drag & drop + modifier keys...)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

As the parts are not moved yet, length changes due to callbacks are not taken into account.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
