### PR TITLE
Codechange: Remove unnecessary string constructions.

### DIFF
--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -260,7 +260,7 @@ struct NewGRFParametersWindow : public Window {
 
 		auto it = std::ranges::lower_bound(par_info.value_names, value, std::less{}, &GRFParameterInfo::ValueName::first);
 		if (it != std::end(par_info.value_names) && it->first == value) {
-			if (auto label = GetGRFStringFromGRFText(it->second); label.has_value()) return {STR_JUST_RAW_STRING, std::string(*label)};
+			if (auto label = GetGRFStringFromGRFText(it->second); label.has_value()) return {STR_JUST_RAW_STRING, *label};
 		}
 
 		return {STR_JUST_INT, value};

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -185,7 +185,7 @@ EncodedString EncodedString::ReplaceParam(size_t param, StringParameter &&data) 
 			}
 
 			case SCC_ENCODED_STRING: {
-				params.emplace_back(std::string(record.Read(StringConsumer::npos)));
+				params.emplace_back(record.Read(StringConsumer::npos));
 				break;
 			}
 
@@ -1037,7 +1037,7 @@ static void DecodeEncodedString(StringConsumer &consumer, bool game_script, Stri
 			}
 
 			case SCC_ENCODED_STRING: {
-				sub_args.emplace_back(std::string(record.Read(StringConsumer::npos)));
+				sub_args.emplace_back(record.Read(StringConsumer::npos));
 				break;
 			}
 


### PR DESCRIPTION
## Motivation / Problem

`StringParameter` now have a constructor from `std::string_view`.
There are some older usages, which manually construct a `std::string` from `std::string_view`.

## Description

Remove the `string` construction, pass `std::string_view` directly to `StringParameter` constructor.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
