### PR TITLE
Codechange: Move VehicleEnteredDepotThisTick call to a more suitable position.

### DIFF
--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1311,11 +1311,6 @@ static void DoTriggerVehicle(Vehicle *v, VehicleTrigger trigger, uint16_t base_r
 
 void TriggerVehicle(Vehicle *v, VehicleTrigger trigger)
 {
-	if (trigger == VEHICLE_TRIGGER_DEPOT) {
-		/* store that the vehicle entered a depot this tick */
-		VehicleEnteredDepotThisTick(v);
-	}
-
 	v->InvalidateNewGRFCacheOfChain();
 	DoTriggerVehicle(v, trigger, 0, true);
 	v->InvalidateNewGRFCacheOfChain();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -925,7 +925,7 @@ Vehicle::~Vehicle()
  * Adds a vehicle to the list of vehicles that visited a depot this tick
  * @param *v vehicle to add
  */
-void VehicleEnteredDepotThisTick(Vehicle *v)
+static void VehicleEnteredDepotThisTick(Vehicle *v)
 {
 	/* Vehicle should stop in the depot if it was in 'stopping' state */
 	_vehicles_to_autoreplace[v->index] = !v->vehstatus.Test(VehState::Stopped);
@@ -1609,6 +1609,9 @@ void VehicleEnterDepot(Vehicle *v)
 	v->cur_speed = 0;
 
 	VehicleServiceInDepot(v);
+
+	/* Store that the vehicle entered a depot this tick */
+	VehicleEnteredDepotThisTick(v);
 
 	/* After a vehicle trigger, the graphics and properties of the vehicle could change. */
 	TriggerVehicle(v, VEHICLE_TRIGGER_DEPOT);

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -74,7 +74,6 @@ void CheckVehicleBreakdown(Vehicle *v);
 void EconomyAgeVehicle(Vehicle *v);
 void AgeVehicle(Vehicle *v);
 void RunVehicleCalendarDayProc();
-void VehicleEnteredDepotThisTick(Vehicle *v);
 
 UnitID GetFreeUnitNumber(VehicleType type);
 


### PR DESCRIPTION
## Motivation / Problem

* `TriggerVehicle` is about NewGRF stuff.
* `VehicleEnteredDepotThisTick` is about autoreplace.
* `VEHICLE_TRIGGER_DEPOT` is only raised at one location.

## Description

Move `VehicleEnteredDepotThisTick` to the caller.
This even allows to declare it `static`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
