### PR TITLE
Codechange: Unify random trigger enums and turn them into enum classes.

### DIFF
--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -74,7 +74,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	TimerGameCalendar::Date build_date{}; ///< Date of construction
 
 	uint16_t random_bits = 0; ///< Random bits assigned to this station
-	uint8_t waiting_random_triggers = 0; ///< Waiting triggers (NewGRF) for this station
+	StationRandomTriggers waiting_random_triggers; ///< Waiting triggers (NewGRF), shared by all station parts/tiles, road stops, ... essentially useless and broken by design.
 	uint8_t cached_anim_triggers = 0; ///< NOSAVE: Combined animation trigger bitmask, used to determine if trigger processing should happen.
 	uint8_t cached_roadstop_anim_triggers = 0; ///< NOSAVE: Combined animation trigger bitmask for road stops, used to determine if trigger processing should happen.
 	CargoTypes cached_cargo_triggers{}; ///< NOSAVE: Combined cargo trigger bitmask

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1167,7 +1167,7 @@ static void TriggerIndustryProduction(Industry *i)
 		}
 	}
 
-	TriggerIndustryRandomisation(i, INDUSTRY_TRIGGER_RECEIVED_CARGO);
+	TriggerIndustryRandomisation(i, IndustryRandomTrigger::CargoReceived);
 	TriggerIndustryAnimation(i, IAT_INDUSTRY_RECEIVED_CARGO);
 }
 
@@ -1779,7 +1779,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 			/* If there's goods waiting at the station, and the vehicle
 			 * has capacity for it, load it on the vehicle. */
 			if ((v->cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0 || (ge->HasData() && ge->GetData().cargo.AvailableCount() > 0)) && MayLoadUnderExclusiveRights(st, v)) {
-				if (v->cargo.StoredCount() == 0) TriggerVehicleRandomisation(v, VEHICLE_TRIGGER_NEW_CARGO);
+				if (v->cargo.StoredCount() == 0) TriggerVehicleRandomisation(v, VehicleRandomTrigger::NewCargo);
 				if (_settings_game.order.gradual_loading) cap_left = std::min(cap_left, GetLoadAmount(v));
 
 				uint loaded = ge->GetOrCreateData().cargo.Load(cap_left, &v->cargo, next_station, v->GetCargoTile());
@@ -1811,10 +1811,10 @@ static void LoadUnloadVehicle(Vehicle *front)
 					st->last_vehicle_type = v->type;
 
 					if (ge->GetData().cargo.TotalCount() == 0) {
-						TriggerStationRandomisation(st, st->xy, SRT_CARGO_TAKEN, v->cargo_type);
+						TriggerStationRandomisation(st, st->xy, StationRandomTrigger::CargoTaken, v->cargo_type);
 						TriggerStationAnimation(st, st->xy, SAT_CARGO_TAKEN, v->cargo_type);
 						TriggerAirportAnimation(st, AAT_STATION_CARGO_TAKEN, v->cargo_type);
-						TriggerRoadStopRandomisation(st, st->xy, RSRT_CARGO_TAKEN, v->cargo_type);
+						TriggerRoadStopRandomisation(st, st->xy, StationRandomTrigger::CargoTaken, v->cargo_type);
 						TriggerRoadStopAnimation(st, st->xy, SAT_CARGO_TAKEN, v->cargo_type);
 					}
 
@@ -1834,10 +1834,10 @@ static void LoadUnloadVehicle(Vehicle *front)
 
 	if (anything_loaded || anything_unloaded) {
 		if (front->type == VEH_TRAIN) {
-			TriggerStationRandomisation(st, front->tile, SRT_TRAIN_LOADS);
+			TriggerStationRandomisation(st, front->tile, StationRandomTrigger::VehicleLoads);
 			TriggerStationAnimation(st, front->tile, SAT_TRAIN_LOADS);
 		} else if (front->type == VEH_ROAD) {
-			TriggerRoadStopRandomisation(st, front->tile, RSRT_VEH_LOADS);
+			TriggerRoadStopRandomisation(st, front->tile, StationRandomTrigger::VehicleLoads);
 			TriggerRoadStopAnimation(st, front->tile, SAT_TRAIN_LOADS);
 		}
 	}
@@ -1910,7 +1910,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 		/* Make sure the vehicle is marked dirty, since we need to update the NewGRF
 		 * properties such as weight, power and TE whenever the trigger runs. */
 		dirty_vehicle = true;
-		TriggerVehicleRandomisation(front, VEHICLE_TRIGGER_EMPTY);
+		TriggerVehicleRandomisation(front, VehicleRandomTrigger::Empty);
 	}
 
 	if (dirty_vehicle) {

--- a/src/house_type.h
+++ b/src/house_type.h
@@ -15,4 +15,16 @@ typedef uint16_t HouseClassID; ///< Classes of houses.
 
 struct HouseSpec;
 
+/** Randomisation triggers for houses */
+enum class HouseRandomTrigger : uint8_t {
+	/* The tile of the house has been triggered during the tileloop. */
+	TileLoop,
+	/*
+	 * The top tile of a (multitile) building has been triggered during and all
+	 * the tileloop other tiles of the same building get the same random value.
+	 */
+	TileLoopNorth,
+};
+using HouseRandomTriggers = EnumBitSet<HouseRandomTrigger, uint8_t>;
+
 #endif /* HOUSE_TYPE_H */

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -844,7 +844,7 @@ static void TileLoop_Industry(TileIndex tile)
 	 * returning from TileLoop_Water. */
 	if (!IsTileType(tile, MP_INDUSTRY)) return;
 
-	TriggerIndustryTileRandomisation(tile, INDTILE_TRIGGER_TILE_LOOP);
+	TriggerIndustryTileRandomisation(tile, IndustryRandomTrigger::TileLoop);
 
 	if (!IsIndustryCompleted(tile)) {
 		MakeIndustryTileBigger(tile);
@@ -1222,7 +1222,7 @@ static void ProduceIndustryGoods(Industry *i)
 			if (cut) ChopLumberMillTrees(i);
 		}
 
-		TriggerIndustryRandomisation(i, INDUSTRY_TRIGGER_INDUSTRY_TICK);
+		TriggerIndustryRandomisation(i, IndustryRandomTrigger::IndustryTick);
 		TriggerIndustryAnimation(i, IAT_INDUSTRY_TICK);
 	}
 }

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -247,10 +247,10 @@ inline void SetIndustryRandomBits(Tile tile, uint8_t bits)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return requested triggers
  */
-inline uint8_t GetIndustryRandomTriggers(Tile tile)
+inline IndustryRandomTriggers GetIndustryRandomTriggers(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	return GB(tile.m6(), 3, 3);
+	return static_cast<IndustryRandomTriggers>(GB(tile.m6(), 3, 3));
 }
 
 
@@ -261,10 +261,10 @@ inline uint8_t GetIndustryRandomTriggers(Tile tile)
  * @param triggers the triggers to set
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-inline void SetIndustryRandomTriggers(Tile tile, uint8_t triggers)
+inline void SetIndustryRandomTriggers(Tile tile, IndustryRandomTriggers triggers)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	SB(tile.m6(), 3, 3, triggers);
+	SB(tile.m6(), 3, 3, triggers.base());
 }
 
 /**
@@ -283,7 +283,7 @@ inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8_t rand
 	SetIndustryRandomBits(t, random); // m3
 	t.m4() = 0;
 	SetIndustryGfx(t, gfx); // m5, part of m6
-	SetIndustryRandomTriggers(t, 0); // rest of m6
+	SetIndustryRandomTriggers(t, {}); // rest of m6
 	SetWaterClass(t, wc);
 	t.m7() = 0;
 }

--- a/src/industry_type.h
+++ b/src/industry_type.h
@@ -21,6 +21,14 @@ struct Industry;
 struct IndustrySpec;
 struct IndustryTileSpec;
 
+/** Available industry random triggers. */
+enum class IndustryRandomTrigger : uint8_t {
+	TileLoop, ///< The tile of the industry has been triggered during the tileloop.
+	IndustryTick, ///< The industry has been triggered via its tick.
+	CargoReceived, ///< Cargo has been delivered.
+};
+using IndustryRandomTriggers = EnumBitSet<IndustryRandomTrigger, uint8_t>;
+
 static const IndustryType NUM_INDUSTRYTYPES_PER_GRF = 128;            ///< maximum number of industry types per NewGRF; limited to 128 because bit 7 has a special meaning in some variables/callbacks (see MapNewGRFIndustryType).
 
 static const IndustryType NEW_INDUSTRYOFFSET     = 37;                ///< original number of industry types

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -44,7 +44,7 @@ struct VehicleScopeResolver : public ScopeResolver {
 };
 
 /** Resolver for a vehicle (chain) */
-struct VehicleResolverObject : public ResolverObject {
+struct VehicleResolverObject : public SpecializedResolverObject<VehicleRandomTriggers> {
 	/** Application of 'wagon overrides'. */
 	enum WagonOverride : uint8_t {
 		WO_NONE,     //!< Resolve no wagon overrides.
@@ -107,18 +107,7 @@ enum class BuildProbabilityType : uint8_t {
 
 bool TestVehicleBuildProbability(Vehicle *v, EngineID engine, BuildProbabilityType type);
 
-enum VehicleTrigger : uint8_t {
-	VEHICLE_TRIGGER_NEW_CARGO     = 0x01,
-	/* Externally triggered only for the first vehicle in chain */
-	VEHICLE_TRIGGER_DEPOT         = 0x02,
-	/* Externally triggered only for the first vehicle in chain, only if whole chain is empty */
-	VEHICLE_TRIGGER_EMPTY         = 0x04,
-	/* Not triggered externally (called for the whole chain if we got NEW_CARGO) */
-	VEHICLE_TRIGGER_ANY_NEW_CARGO = 0x08,
-	/* Externally triggered for each vehicle in chain */
-	VEHICLE_TRIGGER_CALLBACK_32   = 0x10,
-};
-void TriggerVehicleRandomisation(Vehicle *veh, VehicleTrigger trigger);
+void TriggerVehicleRandomisation(Vehicle *veh, VehicleRandomTrigger trigger);
 
 void AlterVehicleListOrder(EngineID engine, uint16_t target);
 void CommitVehicleListOrderChanges();

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -49,7 +49,7 @@ struct HouseScopeResolver : public ScopeResolver {
 };
 
 /** Resolver object to be used for houses (feature 07 spritegroups). */
-struct HouseResolverObject : public ResolverObject {
+struct HouseResolverObject : public SpecializedResolverObject<HouseRandomTriggers> {
 	HouseScopeResolver house_scope;
 	TownScopeResolver  town_scope;
 
@@ -110,15 +110,6 @@ bool CanDeleteHouse(TileIndex tile);
 
 bool NewHouseTileLoop(TileIndex tile);
 
-enum HouseTrigger : uint8_t {
-	/* The tile of the house has been triggered during the tileloop. */
-	HOUSE_TRIGGER_TILE_LOOP     = 0x01,
-	/*
-	 * The top tile of a (multitile) building has been triggered during and all
-	 * the tileloop other tiles of the same building get the same random value.
-	 */
-	HOUSE_TRIGGER_TILE_LOOP_TOP = 0x02,
-};
-void TriggerHouseRandomisation(TileIndex t, HouseTrigger trigger);
+void TriggerHouseRandomisation(TileIndex t, HouseRandomTrigger trigger);
 
 #endif /* NEWGRF_HOUSE_H */

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -36,7 +36,7 @@ struct IndustryTileScopeResolver : public ScopeResolver {
 };
 
 /** Resolver for industry tiles. */
-struct IndustryTileResolverObject : public ResolverObject {
+struct IndustryTileResolverObject : public SpecializedResolverObject<IndustryRandomTriggers> {
 	IndustryTileScopeResolver indtile_scope; ///< Scope resolver for the industry tile.
 	IndustriesScopeResolver ind_scope;       ///< Scope resolver for the industry owning the tile.
 	IndustryGfx gfx;
@@ -65,14 +65,7 @@ void AnimateNewIndustryTile(TileIndex tile);
 bool TriggerIndustryTileAnimation(TileIndex tile, IndustryAnimationTrigger iat, uint32_t random = Random());
 bool TriggerIndustryAnimation(const Industry *ind, IndustryAnimationTrigger iat);
 
-
-/** Available industry tile triggers. */
-enum IndustryTileTrigger : uint8_t {
-	INDTILE_TRIGGER_TILE_LOOP       = 0x01, ///< The tile of the industry has been triggered during the tileloop.
-	INDUSTRY_TRIGGER_INDUSTRY_TICK  = 0x02, ///< The industry has been triggered via its tick.
-	INDUSTRY_TRIGGER_RECEIVED_CARGO = 0x04, ///< Cargo has been delivered.
-};
-void TriggerIndustryTileRandomisation(TileIndex t, IndustryTileTrigger trigger);
-void TriggerIndustryRandomisation(Industry *ind, IndustryTileTrigger trigger);
+void TriggerIndustryTileRandomisation(TileIndex t, IndustryRandomTrigger trigger);
+void TriggerIndustryRandomisation(Industry *ind, IndustryRandomTrigger trigger);
 
 #endif /* NEWGRF_INDUSTRYTILES_H */

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -35,15 +35,6 @@ enum RoadStopClassID : uint16_t {
 };
 DECLARE_INCREMENT_DECREMENT_OPERATORS(RoadStopClassID)
 
-/* Some Triggers etc. */
-enum RoadStopRandomTrigger : uint8_t {
-	RSRT_NEW_CARGO,       ///< Trigger roadstop on arrival of new cargo.
-	RSRT_CARGO_TAKEN,     ///< Trigger roadstop when cargo is completely taken.
-	RSRT_VEH_ARRIVES,     ///< Trigger roadstop when road vehicle arrives.
-	RSRT_VEH_DEPARTS,     ///< Trigger roadstop when road vehicle leaves.
-	RSRT_VEH_LOADS,       ///< Trigger roadstop when road vehicle loads.
-};
-
 /**
  * Various different options for availability, restricting
  * the roadstop to be only for busses or for trucks.
@@ -109,7 +100,7 @@ struct RoadStopScopeResolver : public ScopeResolver {
 };
 
 /** Road stop resolver. */
-struct RoadStopResolverObject : public ResolverObject {
+struct RoadStopResolverObject : public SpecializedResolverObject<StationRandomTriggers> {
 	RoadStopScopeResolver roadstop_scope; ///< The stop scope resolver.
 	std::optional<TownScopeResolver> town_scope = std::nullopt; ///< The town scope resolver (created on the first call).
 
@@ -185,7 +176,7 @@ uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t para
 void AnimateRoadStopTile(TileIndex tile);
 uint8_t GetRoadStopTileAnimationSpeed(TileIndex tile);
 void TriggerRoadStopAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
-void TriggerRoadStopRandomisation(Station *st, TileIndex tile, RoadStopRandomTrigger trigger, CargoType cargo_type = INVALID_CARGO);
+void TriggerRoadStopRandomisation(Station *st, TileIndex tile, StationRandomTrigger trigger, CargoType cargo_type = INVALID_CARGO);
 
 bool GetIfNewStopsByType(RoadStopType rs, RoadType roadtype);
 bool GetIfClassHasNewStopsByType(const RoadStopClass *roadstopclass, RoadStopType rs, RoadType roadtype);

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -258,11 +258,11 @@ const SpriteGroup *RandomizedSpriteGroup::Resolve(ResolverObject &object) const
 	ScopeResolver *scope = object.GetScope(this->var_scope, this->count);
 	if (object.callback == CBID_RANDOM_TRIGGER) {
 		/* Handle triggers */
-		uint8_t match = this->triggers & object.waiting_random_triggers;
+		uint8_t match = this->triggers & object.GetWaitingRandomTriggers();
 		bool res = (this->cmp_mode == RSG_CMP_ANY) ? (match != 0) : (match == this->triggers);
 
 		if (res) {
-			object.used_random_triggers |= match;
+			object.AddUsedRandomTriggers(match);
 			object.reseed[this->var_scope] |= (this->groups.size() - 1) << this->lowest_randbit;
 		}
 	}

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -49,7 +49,7 @@ struct StationScopeResolver : public ScopeResolver {
 };
 
 /** Station resolver. */
-struct StationResolverObject : public ResolverObject {
+struct StationResolverObject : public SpecializedResolverObject<StationRandomTriggers> {
 	StationScopeResolver station_scope; ///< The station scope resolver.
 	std::optional<TownScopeResolver> town_scope = std::nullopt; ///< The town scope resolver (created on the first call).
 
@@ -102,16 +102,6 @@ enum class StationSpecFlag : uint8_t {
 	ExtendedFoundations = 4, ///< Extended foundation block instead of simple.
 };
 using StationSpecFlags = EnumBitSet<StationSpecFlag, uint8_t>;
-
-/** Randomisation triggers for stations */
-enum StationRandomTrigger : uint8_t {
-	SRT_NEW_CARGO,        ///< Trigger station on new cargo arrival.
-	SRT_CARGO_TAKEN,      ///< Trigger station when cargo is completely taken.
-	SRT_TRAIN_ARRIVES,    ///< Trigger platform when train arrives.
-	SRT_TRAIN_DEPARTS,    ///< Trigger platform when train leaves.
-	SRT_TRAIN_LOADS,      ///< Trigger platform when train loads/unloads.
-	SRT_PATH_RESERVATION, ///< Trigger platform when train reserves path.
-};
 
 /** Station specification. */
 struct StationSpec : NewGRFSpecBase<StationClassID> {

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -80,7 +80,7 @@ private:
 			tile = TileAdd(tile, diff);
 		} while (IsCompatibleTrainStationTile(tile, start) && tile != this->origin_tile);
 
-		TriggerStationRandomisation(nullptr, start, SRT_PATH_RESERVATION);
+		TriggerStationRandomisation(nullptr, start, StationRandomTrigger::PathReservation);
 
 		return true;
 	}

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -113,7 +113,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 		case MP_STATION:
 			if (HasStationRail(tile) && !HasStationReservation(tile)) {
 				SetRailStationReservation(tile, true);
-				if (trigger_stations && IsRailStation(tile)) TriggerStationRandomisation(nullptr, tile, SRT_PATH_RESERVATION);
+				if (trigger_stations && IsRailStation(tile)) TriggerStationRandomisation(nullptr, tile, StationRandomTrigger::PathReservation);
 				MarkTileDirtyByTile(tile); // some GRFs need redraw after reserving track
 				return true;
 			}

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1455,7 +1455,7 @@ again:
 				v->last_station_visited = st->index;
 				RoadVehArrivesAt(v, st);
 				v->BeginLoading();
-				TriggerRoadStopRandomisation(st, v->tile, RSRT_VEH_ARRIVES);
+				TriggerRoadStopRandomisation(st, v->tile, StationRandomTrigger::VehicleArrives);
 				TriggerRoadStopAnimation(st, v->tile, SAT_TRAIN_ARRIVES);
 			}
 			return false;
@@ -1519,7 +1519,7 @@ again:
 			if (IsDriveThroughStopTile(v->tile) || (v->current_order.IsType(OT_GOTO_STATION) && v->current_order.GetDestination() == st->index)) {
 				RoadVehArrivesAt(v, st);
 				v->BeginLoading();
-				TriggerRoadStopRandomisation(st, v->tile, RSRT_VEH_ARRIVES);
+				TriggerRoadStopRandomisation(st, v->tile, StationRandomTrigger::VehicleArrives);
 				TriggerRoadStopAnimation(st, v->tile, SAT_TRAIN_ARRIVES);
 				return false;
 			}

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4278,10 +4278,10 @@ static uint UpdateStationWaiting(Station *st, CargoType cargo, uint amount, Sour
 		ge.status.Set(GoodsEntry::State::Rating);
 	}
 
-	TriggerStationRandomisation(st, st->xy, SRT_NEW_CARGO, cargo);
+	TriggerStationRandomisation(st, st->xy, StationRandomTrigger::NewCargo, cargo);
 	TriggerStationAnimation(st, st->xy, SAT_NEW_CARGO, cargo);
 	TriggerAirportAnimation(st, AAT_STATION_NEW_CARGO, cargo);
-	TriggerRoadStopRandomisation(st, st->xy, RSRT_NEW_CARGO, cargo);
+	TriggerRoadStopRandomisation(st, st->xy, StationRandomTrigger::NewCargo, cargo);
 	TriggerRoadStopAnimation(st, st->xy, SAT_NEW_CARGO, cargo);
 
 

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -76,6 +76,17 @@ enum StationHadVehicleOfType : uint8_t {
 };
 DECLARE_ENUM_AS_BIT_SET(StationHadVehicleOfType)
 
+/** Randomisation triggers for stations and roadstops */
+enum class StationRandomTrigger : uint8_t {
+	NewCargo, ///< Trigger station on new cargo arrival.
+	CargoTaken, ///< Trigger station when cargo is completely taken.
+	VehicleArrives, ///< Trigger platform when train arrives.
+	VehicleDeparts, ///< Trigger platform when train leaves.
+	VehicleLoads, ///< Trigger platform when train loads/unloads.
+	PathReservation, ///< Trigger platform when train reserves path.
+};
+using StationRandomTriggers = EnumBitSet<StationRandomTrigger, uint8_t>;
+
 /* The different catchment area sizes. */
 static constexpr uint CA_NONE = 0; ///< Catchment when the station has no facilities
 static constexpr uint CA_BUS = 3; ///< Catchment for bus stops with "modified catchment" enabled

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -307,10 +307,10 @@ inline uint8_t GetHouseRandomBits(Tile t)
  * @param triggers the activated triggers
  * @pre IsTileType(t, MP_HOUSE)
  */
-inline void SetHouseRandomTriggers(Tile t, uint8_t triggers)
+inline void SetHouseRandomTriggers(Tile t, HouseRandomTriggers triggers)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	SB(t.m3(), 0, 5, triggers);
+	SB(t.m3(), 0, 5, triggers.base());
 }
 
 /**
@@ -320,10 +320,10 @@ inline void SetHouseRandomTriggers(Tile t, uint8_t triggers)
  * @pre IsTileType(t, MP_HOUSE)
  * @return triggers
  */
-inline uint8_t GetHouseRandomTriggers(Tile t)
+inline HouseRandomTriggers GetHouseRandomTriggers(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return GB(t.m3(), 0, 5);
+	return static_cast<HouseRandomTriggers>(GB(t.m3(), 0, 5));
 }
 
 /**

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3024,7 +3024,7 @@ static void TrainEnterStation(Train *v, StationID station)
 
 	v->BeginLoading();
 
-	TriggerStationRandomisation(st, v->tile, SRT_TRAIN_ARRIVES);
+	TriggerStationRandomisation(st, v->tile, StationRandomTrigger::VehicleArrives);
 	TriggerStationAnimation(st, v->tile, SAT_TRAIN_ARRIVES);
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -972,7 +972,7 @@ static void RunEconomyVehicleDayProc()
 			uint16_t callback = GetVehicleCallback(CBID_VEHICLE_32DAY_CALLBACK, 0, 0, v->engine_type, v);
 			if (callback != CALLBACK_FAILED) {
 				if (HasBit(callback, 0)) {
-					TriggerVehicleRandomisation(v, VEHICLE_TRIGGER_CALLBACK_32); // Trigger vehicle trigger 10
+					TriggerVehicleRandomisation(v, VehicleRandomTrigger::Callback32); // Trigger vehicle trigger 10
 				}
 
 				/* After a vehicle trigger, the graphics and properties of the vehicle could change.
@@ -1614,7 +1614,7 @@ void VehicleEnterDepot(Vehicle *v)
 	VehicleEnteredDepotThisTick(v);
 
 	/* After a vehicle trigger, the graphics and properties of the vehicle could change. */
-	TriggerVehicleRandomisation(v, VEHICLE_TRIGGER_DEPOT);
+	TriggerVehicleRandomisation(v, VehicleRandomTrigger::Depot);
 	v->MarkDirty();
 
 	InvalidateWindowData(WC_VEHICLE_VIEW, v->index);
@@ -2394,7 +2394,7 @@ void Vehicle::LeaveStation()
 	if (this->type == VEH_TRAIN && !this->vehstatus.Test(VehState::Crashed)) {
 		/* Trigger station animation (trains only) */
 		if (IsTileType(this->tile, MP_STATION)) {
-			TriggerStationRandomisation(st, this->tile, SRT_TRAIN_DEPARTS);
+			TriggerStationRandomisation(st, this->tile, StationRandomTrigger::VehicleDeparts);
 			TriggerStationAnimation(st, this->tile, SAT_TRAIN_DEPARTS);
 		}
 
@@ -2403,7 +2403,7 @@ void Vehicle::LeaveStation()
 	if (this->type == VEH_ROAD && !this->vehstatus.Test(VehState::Crashed)) {
 		/* Trigger road stop animation */
 		if (IsStationRoadStopTile(this->tile)) {
-			TriggerRoadStopRandomisation(st, this->tile, RSRT_VEH_DEPARTS);
+			TriggerRoadStopRandomisation(st, this->tile, StationRandomTrigger::VehicleDeparts);
 			TriggerRoadStopAnimation(st, this->tile, SAT_TRAIN_DEPARTS);
 		}
 	}

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -311,7 +311,7 @@ public:
 	uint32_t motion_counter = 0; ///< counter to occasionally play a vehicle sound.
 	uint8_t progress = 0; ///< The percentage (if divided by 256) this vehicle already crossed the tile unit.
 
-	uint8_t waiting_random_triggers = 0; ///< Triggers to be yet matched before rerandomizing the random bits.
+	VehicleRandomTriggers waiting_random_triggers; ///< Triggers to be yet matched before rerandomizing the random bits.
 	uint16_t random_bits = 0; ///< Bits used for randomized variational spritegroups.
 
 	StationID last_station_visited = StationID::Invalid(); ///< The last station we stopped at.

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -80,4 +80,14 @@ enum EngineImageType : uint8_t {
 	EIT_PREVIEW    = 0x21,  ///< Vehicle drawn in preview window, news, ...
 };
 
+/** Randomisation triggers for vehicles */
+enum class VehicleRandomTrigger : uint8_t {
+	NewCargo, ///< Affected vehicle only: Vehicle is loaded with cargo, after it was empty.
+	Depot, ///< Front vehicle only: Consist arrived in depot.
+	Empty, ///< Front vehicle only: Entire consist is empty.
+	AnyNewCargo, ///< All vehicles in consist: Any vehicle in the consist received new cargo.
+	Callback32, ///< All vehicles in consist: 32 day callback requested rerandomisation
+};
+using VehicleRandomTriggers = EnumBitSet<VehicleRandomTrigger, uint8_t>;
+
 #endif /* VEHICLE_TYPE_H */


### PR DESCRIPTION
## Motivation / Problem

Random triggers are currently stored in different ways:
* Some features use an enum for the trigger bits.
* Some features use an enum for the trigger masks.
* Often either of them are stored in `uint8_t`, instead of using the enums.

## Description

This includes/depends on #14004.

* Use an enum class for the trigger bits for all features.
* Use `EnumBitSet` for the trigger masks for all features.
* Stations and roadstops used to have separate enums for random triggers:
    * They share the same `waiting_random_triggers` in the `BaseStation` struct.
    * Even though `waiting_random_triggers` is useless and broken-by-spec for stations, this forces both features to use the same enum.
* Unify the naming to use enum class `<Feature>RandomTrigger` with bitmask `<Feature>RandomTriggers`
    * `HouseRandomTrigger`, `HouseRandomTriggers`
    * `IndustryRandomTrigger`, `IndustryRandomTriggers`
    * `StationRandomTrigger`, `StationRandomTriggers` (used for both stations and roadstops)
    * `VehicleRandomTrigger`, `VehicleRandomTriggers`


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
