### PR TITLE
Codechange: use std::string_view for parts of settings

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2329,7 +2329,7 @@ static bool ConListSettings([[maybe_unused]] uint8_t argc, [[maybe_unused]] char
 
 	if (argc > 2) return false;
 
-	IConsoleListSettings((argc == 2) ? argv[1] : nullptr);
+	IConsoleListSettings((argc == 2) ? argv[1] : std::string_view{});
 	return true;
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1877,16 +1877,16 @@ void SyncCompanySettings()
  * @param force_newgame force the newgame settings
  * @note Strings WILL NOT be synced over the network
  */
-bool SetSettingValue(const StringSettingDesc *sd, std::string value, bool force_newgame)
+bool SetSettingValue(const StringSettingDesc *sd, std::string_view value, bool force_newgame)
 {
 	assert(sd->flags.Test(SettingFlag::NoNetworkSync));
 
-	if (GetVarMemType(sd->save.conv) == SLE_VAR_STRQ && value.compare("(null)") == 0) {
-		value.clear();
+	if (GetVarMemType(sd->save.conv) == SLE_VAR_STRQ && value == "(null)") {
+		value = {};
 	}
 
 	const void *object = (_game_mode == GM_MENU || force_newgame) ? &_settings_newgame : &_settings_game;
-	sd->AsStringSetting()->ChangeValue(object, value);
+	sd->AsStringSetting()->ChangeValue(object, std::string{value});
 	return true;
 }
 
@@ -1896,7 +1896,7 @@ bool SetSettingValue(const StringSettingDesc *sd, std::string value, bool force_
  * @param object The object the setting is in.
  * @param newval The new value for the setting.
  */
-void StringSettingDesc::ChangeValue(const void *object, std::string &newval) const
+void StringSettingDesc::ChangeValue(const void *object, std::string &&newval) const
 {
 	this->MakeValueValid(newval);
 	if (this->pre_check != nullptr && !this->pre_check(newval)) return;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1909,7 +1909,7 @@ void StringSettingDesc::ChangeValue(const void *object, std::string &&newval) co
 
 /* Those 2 functions need to be here, else we have to make some stuff non-static
  * and besides, it is also better to keep stuff like this at the same place */
-void IConsoleSetSetting(const char *name, const char *value, bool force_newgame)
+void IConsoleSetSetting(std::string_view name, std::string_view value, bool force_newgame)
 {
 	const SettingDesc *sd = GetSettingFromName(name);
 	/* Company settings are not in "list_settings", so don't try to modify them. */
@@ -1941,7 +1941,7 @@ void IConsoleSetSetting(const char *name, const char *value, bool force_newgame)
 	}
 }
 
-void IConsoleSetSetting(const char *name, int value)
+void IConsoleSetSetting(std::string_view name, int value)
 {
 	const SettingDesc *sd = GetSettingFromName(name);
 	assert(sd != nullptr);
@@ -1953,7 +1953,7 @@ void IConsoleSetSetting(const char *name, int value)
  * @param name  Name of the setting to output its value
  * @param force_newgame force the newgame settings
  */
-void IConsoleGetSetting(const char *name, bool force_newgame)
+void IConsoleGetSetting(std::string_view name, bool force_newgame)
 {
 	const SettingDesc *sd = GetSettingFromName(name);
 	/* Company settings are not in "list_settings", so don't try to read them. */
@@ -1976,12 +1976,12 @@ void IConsoleGetSetting(const char *name, bool force_newgame)
 	}
 }
 
-static void IConsoleListSettingsTable(const SettingTable &table, const char *prefilter)
+static void IConsoleListSettingsTable(const SettingTable &table, std::string_view prefilter)
 {
 	for (auto &desc : table) {
 		const SettingDesc *sd = GetSettingDesc(desc);
 		if (!SlIsObjectCurrentlyValid(sd->save.version_from, sd->save.version_to)) continue;
-		if (prefilter != nullptr && sd->GetName().find(prefilter) == std::string::npos) continue;
+		if (!prefilter.empty() && sd->GetName().find(prefilter) == std::string::npos) continue;
 		IConsolePrint(CC_DEFAULT, "{} = {}", sd->GetName(), sd->FormatValue(&GetGameSettings()));
 	}
 }
@@ -1991,7 +1991,7 @@ static void IConsoleListSettingsTable(const SettingTable &table, const char *pre
  *
  * @param prefilter  If not \c nullptr, only list settings with names that begin with \a prefilter prefix
  */
-void IConsoleListSettings(const char *prefilter)
+void IConsoleListSettings(std::string_view prefilter)
 {
 	IConsolePrint(CC_HELP, "All settings with their current value:");
 

--- a/src/settings_func.h
+++ b/src/settings_func.h
@@ -17,10 +17,10 @@
 struct IniFile;
 struct WindowDesc;
 
-void IConsoleSetSetting(const char *name, const char *value, bool force_newgame = false);
-void IConsoleSetSetting(const char *name, int32_t value);
-void IConsoleGetSetting(const char *name, bool force_newgame = false);
-void IConsoleListSettings(const char *prefilter);
+void IConsoleSetSetting(std::string_view name, std::string_view value, bool force_newgame = false);
+void IConsoleSetSetting(std::string_view name, int32_t value);
+void IConsoleGetSetting(std::string_view name, bool force_newgame = false);
+void IConsoleListSettings(std::string_view prefilter);
 
 void LoadFromConfig(bool minimal = false);
 void SaveToConfig();

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -235,7 +235,7 @@ struct IntSettingDesc : SettingDesc {
 	void ChangeValue(const void *object, int32_t newvalue) const;
 	void MakeValueValidAndWrite(const void *object, int32_t value) const;
 
-	virtual size_t ParseValue(const char *str) const;
+	virtual int32_t ParseValue(std::string_view str) const;
 	std::string FormatValue(const void *object) const override;
 	void ParseValue(const IniItem *item, void *object) const override;
 	bool IsSameValue(const IniItem *item, void *object) const override;
@@ -258,16 +258,16 @@ struct BoolSettingDesc : IntSettingDesc {
 		IntSettingDesc(save, flags, startup, def ? 1 : 0, 0, 1, 0, str, str_help, str_val, cat,
 			pre_check, post_callback, get_title_cb, get_help_cb, get_value_params_cb, get_def_cb, nullptr) {}
 
-	static std::optional<bool> ParseSingleValue(const char *str);
+	static std::optional<bool> ParseSingleValue(std::string_view str);
 
 	bool IsBoolSetting() const override { return true; }
-	size_t ParseValue(const char *str) const override;
+	int32_t ParseValue(std::string_view str) const override;
 	std::string FormatValue(const void *object) const override;
 };
 
 /** One of many setting. */
 struct OneOfManySettingDesc : IntSettingDesc {
-	typedef size_t OnConvert(const char *value); ///< callback prototype for conversion error
+	typedef std::optional<uint32_t> OnConvert(std::string_view value); ///< callback prototype for conversion error
 
 	template <ConvertibleThroughBaseOrTo<int32_t> Tdef, ConvertibleThroughBaseOrTo<uint32_t> Tmax>
 	OneOfManySettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, Tdef def,
@@ -284,10 +284,10 @@ struct OneOfManySettingDesc : IntSettingDesc {
 	std::vector<std::string> many; ///< possible values for this type
 	OnConvert *many_cnvt;          ///< callback procedure when loading value mechanism fails
 
-	static size_t ParseSingleValue(const char *str, size_t len, const std::vector<std::string> &many);
+	static std::optional<uint32_t> ParseSingleValue(std::string_view str, const std::vector<std::string> &many);
 	std::string FormatSingleValue(uint id) const;
 
-	size_t ParseValue(const char *str) const override;
+	int32_t ParseValue(std::string_view str) const override;
 	std::string FormatValue(const void *object) const override;
 };
 
@@ -302,7 +302,7 @@ struct ManyOfManySettingDesc : OneOfManySettingDesc {
 		OneOfManySettingDesc(save, flags, startup, def, (1 << many.size()) - 1, str, str_help,
 			str_val, cat, pre_check, post_callback, get_title_cb, get_help_cb, get_value_params_cb, get_def_cb, many, many_cnvt) {}
 
-	size_t ParseValue(const char *str) const override;
+	int32_t ParseValue(std::string_view str) const override;
 	std::string FormatValue(const void *object) const override;
 };
 

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -334,7 +334,7 @@ struct StringSettingDesc : SettingDesc {
 	PostChangeCallback *post_callback; ///< Callback when the setting has been changed.
 
 	bool IsStringSetting() const override { return true; }
-	void ChangeValue(const void *object, std::string &newval) const;
+	void ChangeValue(const void *object, std::string &&newval) const;
 
 	std::string FormatValue(const void *object) const override;
 	void ParseValue(const IniItem *item, void *object) const override;
@@ -392,7 +392,7 @@ const SettingDesc *GetSettingFromName(const std::string_view name);
 void GetSaveLoadFromSettingTable(SettingTable settings, std::vector<SaveLoad> &saveloads);
 SettingTable GetSaveLoadSettingTable();
 bool SetSettingValue(const IntSettingDesc *sd, int32_t value, bool force_newgame = false);
-bool SetSettingValue(const StringSettingDesc *sd, const std::string value, bool force_newgame = false);
+bool SetSettingValue(const StringSettingDesc *sd, std::string_view value, bool force_newgame = false);
 
 std::vector<const SettingDesc *> GetFilteredSettingCollection(std::function<bool(const SettingDesc &desc)> func);
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -445,11 +445,11 @@ static bool CheckRoadSide(int32_t &)
  * @param value that was read from config file
  * @return the "hopefully" converted value
  */
-static size_t ConvertLandscape(const char *value)
+static std::optional<uint32_t> ConvertLandscape(std::string_view value)
 {
 	/* try with the old values */
 	static std::vector<std::string> _old_landscape_values{"normal", "hilly", "desert", "candy"};
-	return OneOfManySettingDesc::ParseSingleValue(value, strlen(value), _old_landscape_values);
+	return OneOfManySettingDesc::ParseSingleValue(value, _old_landscape_values);
 }
 
 static bool CheckFreeformEdges(int32_t &new_value)

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -10,7 +10,7 @@
 #include "table/strings.h"
 
 /* Callback function used in _settings[] as well as _company_settings[] */
-static size_t ConvertLandscape(const char *value);
+static std::optional<uint32_t> ConvertLandscape(std::string_view value);
 
 static StringID SettingTitleWallclock(const IntSettingDesc &sd);
 static StringID SettingHelpWallclock(const IntSettingDesc &sd);


### PR DESCRIPTION
## Motivation / Problem

C-style string handling when changing settings from the console. So essentially a prerequisite for the console settings commands getting converted away from C-style strings.


## Description

Use `std::string_view` over `const char *` for parsing and setting settings.


## Limitations

There's way more in settings that could go to `std::string_view`, but that'd be future work.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
