### PR TITLE
Codechange: Replace (Has|Find)VehicleOnPos and callbacks with for-loops or lambdas.

### DIFF
--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -355,15 +355,6 @@ public:
 		return 0;
 	}
 
-	static Vehicle *CountShipProc(Vehicle *v, void *data)
-	{
-		uint *count = (uint*)data;
-		/* Ignore other vehicles (aircraft) and ships inside depot. */
-		if (v->type == VEH_SHIP && !v->vehstatus.Test(VehState::Hidden)) (*count)++;
-
-		return nullptr;
-	}
-
 	/**
 	 * Called by YAPF to calculate the cost from the origin to the given node.
 	 * Calculates only the cost of given node, adds it to the parent node cost
@@ -378,8 +369,10 @@ public:
 
 		if (IsDockingTile(n.GetTile())) {
 			/* Check docking tile for occupancy. */
-			uint count = 0;
-			FindVehicleOnPos(n.GetTile(), &count, &CountShipProc);
+			uint count = std::ranges::count_if(VehiclesOnTile(n.GetTile()), [](const Vehicle *v) {
+				/* Ignore other vehicles (aircraft) and ships inside depot. */
+				return v->type == VEH_SHIP && !v->vehstatus.Test(VehState::Hidden);
+			});
 			c += count * 3 * YAPF_TILE_LENGTH;
 		}
 

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -379,7 +379,7 @@ public:
 		if (IsDockingTile(n.GetTile())) {
 			/* Check docking tile for occupancy. */
 			uint count = 0;
-			HasVehicleOnPos(n.GetTile(), &count, &CountShipProc);
+			FindVehicleOnPos(n.GetTile(), &count, &CountShipProc);
 			c += count * 3 * YAPF_TILE_LENGTH;
 		}
 

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -3032,14 +3032,6 @@ static CommandCost TestAutoslopeOnRailTile(TileIndex tile, DoCommandFlags flags,
 	return  cost;
 }
 
-/**
- * Test-procedure for HasVehicleOnPos to check for a ship.
- */
-static Vehicle *EnsureNoShipProc(Vehicle *v, void *)
-{
-	return v->type == VEH_SHIP ? v : nullptr;
-}
-
 static CommandCost TerraformTile_Track(TileIndex tile, DoCommandFlags flags, int z_new, Slope tileh_new)
 {
 	auto [tileh_old, z_old] = GetTileSlopeZ(tile);
@@ -3049,7 +3041,9 @@ static CommandCost TerraformTile_Track(TileIndex tile, DoCommandFlags flags, int
 		bool was_water = (GetRailGroundType(tile) == RAIL_GROUND_WATER && IsSlopeWithOneCornerRaised(tileh_old));
 
 		/* Allow clearing the water only if there is no ship */
-		if (was_water && HasVehicleOnPos(tile, nullptr, &EnsureNoShipProc)) return CommandCost(STR_ERROR_SHIP_IN_THE_WAY);
+		if (was_water && HasVehicleOnTile(tile, [](const Vehicle *v) {
+				return v->type == VEH_SHIP;
+			})) return CommandCost(STR_ERROR_SHIP_IN_THE_WAY);
 
 		/* First test autoslope. However if it succeeds we still have to test the rest, because non-autoslope terraforming is cheaper. */
 		CommandCost autoslope_result = TestAutoslopeOnRailTile(tile, flags, z_old, tileh_old, z_new, tileh_new, rail_bits);

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -659,8 +659,12 @@ static RoadVehicle *RoadVehFindCloseTo(RoadVehicle *v, int x, int y, Direction d
 	rvf.best_diff = UINT_MAX;
 
 	if (front->state == RVSB_WORMHOLE) {
-		FindVehicleOnPos(v->tile, &rvf, EnumCheckRoadVehClose);
-		FindVehicleOnPos(GetOtherTunnelBridgeEnd(v->tile), &rvf, EnumCheckRoadVehClose);
+		for (Vehicle *u : VehiclesOnTile(v->tile)) {
+			EnumCheckRoadVehClose(u, &rvf);
+		}
+		for (Vehicle *u : VehiclesOnTile(GetOtherTunnelBridgeEnd(v->tile))) {
+			EnumCheckRoadVehClose(u, &rvf);
+		}
 	} else {
 		FindVehicleOnPosXY(x, y, &rvf, EnumCheckRoadVehClose);
 	}

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -767,13 +767,6 @@ struct OvertakeData {
 	Trackdir trackdir;
 };
 
-static Vehicle *EnumFindVehBlockingOvertake(Vehicle *v, void *data)
-{
-	const OvertakeData *od = (OvertakeData*)data;
-
-	return (v->type == VEH_ROAD && v->First() == v && v != od->u && v != od->v) ? v : nullptr;
-}
-
 /**
  * Check if overtaking is possible on a piece of track
  *
@@ -792,7 +785,9 @@ static bool CheckRoadBlockedForOvertaking(OvertakeData *od)
 	if (!HasBit(trackdirbits, od->trackdir) || (trackbits & ~TRACK_BIT_CROSS) || (red_signals != TRACKDIR_BIT_NONE)) return true;
 
 	/* Are there more vehicles on the tile except the two vehicles involved in overtaking */
-	return HasVehicleOnPos(od->tile, od, EnumFindVehBlockingOvertake);
+	return HasVehicleOnTile(od->tile, [&](const Vehicle *v) {
+		return v->type == VEH_ROAD && v->First() == v && v != od->u && v != od->v;
+	});
 }
 
 static void RoadVehCheckOvertake(RoadVehicle *v, RoadVehicle *u)

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -359,14 +359,6 @@ void Ship::UpdateDeltaXY()
 	}
 }
 
-/**
- * Test-procedure for HasVehicleOnPos to check for any ships which are moving.
- */
-static Vehicle *EnsureNoMovingShipProc(Vehicle *v, void *)
-{
-	return v->type == VEH_SHIP && v->cur_speed != 0 ? v : nullptr;
-}
-
 static bool CheckReverseShip(const Ship *v, Trackdir *trackdir = nullptr)
 {
 	/* Ask pathfinder for best direction */
@@ -392,7 +384,9 @@ static bool CheckShipLeaveDepot(Ship *v)
 
 	/* Don't leave depot if another vehicle is already entering/leaving */
 	/* This helps avoid CPU load if many ships are set to start at the same time */
-	if (HasVehicleOnPos(v->tile, nullptr, &EnsureNoMovingShipProc)) return true;
+	if (HasVehicleOnTile(v->tile, [](const Vehicle *u) {
+			return u->type == VEH_SHIP && u->cur_speed != 0;
+		})) return true;
 
 	TileIndex tile = v->tile;
 	Axis axis = GetShipDepotAxis(tile);

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -189,11 +189,9 @@ static SmallSet<DiagDirection, SIG_GLOB_SIZE> _globset("_globset"); ///< set of 
 
 
 /** Check whether there is a train on rail, not in a depot */
-static Vehicle *TrainOnTileEnum(Vehicle *v, void *)
+static bool IsTrainAndNotInDepot(const Vehicle *v)
 {
-	if (v->type != VEH_TRAIN || Train::From(v)->track == TRACK_BIT_DEPOT) return nullptr;
-
-	return v;
+	return v->type == VEH_TRAIN && Train::From(v)->track != TRACK_BIT_DEPOT;
 }
 
 
@@ -280,13 +278,13 @@ static SigFlags ExploreSegment(Owner owner)
 
 				if (IsRailDepot(tile)) {
 					if (enterdir == INVALID_DIAGDIR) { // from 'inside' - train just entered or left the depot
-						if (!flags.Test(SigFlag::Train) && HasVehicleOnPos(tile, nullptr, &TrainOnTileEnum)) flags.Set(SigFlag::Train);
+						if (!flags.Test(SigFlag::Train) && HasVehicleOnTile(tile, IsTrainAndNotInDepot)) flags.Set(SigFlag::Train);
 						exitdir = GetRailDepotDirection(tile);
 						tile += TileOffsByDiagDir(exitdir);
 						enterdir = ReverseDiagDir(exitdir);
 						break;
 					} else if (enterdir == GetRailDepotDirection(tile)) { // entered a depot
-						if (!flags.Test(SigFlag::Train) && HasVehicleOnPos(tile, nullptr, &TrainOnTileEnum)) flags.Set(SigFlag::Train);
+						if (!flags.Test(SigFlag::Train) && HasVehicleOnTile(tile, IsTrainAndNotInDepot)) flags.Set(SigFlag::Train);
 						continue;
 					} else {
 						continue;
@@ -303,7 +301,7 @@ static SigFlags ExploreSegment(Owner owner)
 					if (!flags.Test(SigFlag::Train) && EnsureNoTrainOnTrackBits(tile, tracks).Failed()) flags. Set(SigFlag::Train);
 				} else {
 					if (tracks_masked == TRACK_BIT_NONE) continue; // no incidating track
-					if (!flags.Test(SigFlag::Train) && HasVehicleOnPos(tile, nullptr, &TrainOnTileEnum)) flags.Set(SigFlag::Train);
+					if (!flags.Test(SigFlag::Train) && HasVehicleOnTile(tile, IsTrainAndNotInDepot)) flags.Set(SigFlag::Train);
 				}
 
 				/* Is this a track merge or split? */
@@ -358,7 +356,7 @@ static SigFlags ExploreSegment(Owner owner)
 				if (DiagDirToAxis(enterdir) != GetRailStationAxis(tile)) continue; // different axis
 				if (IsStationTileBlocked(tile)) continue; // 'eye-candy' station tile
 
-				if (!flags.Test(SigFlag::Train) && HasVehicleOnPos(tile, nullptr, &TrainOnTileEnum)) flags.Set(SigFlag::Train);
+				if (!flags.Test(SigFlag::Train) && HasVehicleOnTile(tile, IsTrainAndNotInDepot)) flags.Set(SigFlag::Train);
 				tile += TileOffsByDiagDir(exitdir);
 				break;
 
@@ -367,7 +365,7 @@ static SigFlags ExploreSegment(Owner owner)
 				if (GetTileOwner(tile) != owner) continue;
 				if (DiagDirToAxis(enterdir) == GetCrossingRoadAxis(tile)) continue; // different axis
 
-				if (!flags.Test(SigFlag::Train) && HasVehicleOnPos(tile, nullptr, &TrainOnTileEnum)) flags.Set(SigFlag::Train);
+				if (!flags.Test(SigFlag::Train) && HasVehicleOnTile(tile, IsTrainAndNotInDepot)) flags.Set(SigFlag::Train);
 				tile += TileOffsByDiagDir(exitdir);
 				break;
 
@@ -377,13 +375,13 @@ static SigFlags ExploreSegment(Owner owner)
 				DiagDirection dir = GetTunnelBridgeDirection(tile);
 
 				if (enterdir == INVALID_DIAGDIR) { // incoming from the wormhole
-					if (!flags.Test(SigFlag::Train) && HasVehicleOnPos(tile, nullptr, &TrainOnTileEnum)) flags.Set(SigFlag::Train);
+					if (!flags.Test(SigFlag::Train) && HasVehicleOnTile(tile, IsTrainAndNotInDepot)) flags.Set(SigFlag::Train);
 					enterdir = dir;
 					exitdir = ReverseDiagDir(dir);
 					tile += TileOffsByDiagDir(exitdir); // just skip to next tile
 				} else { // NOT incoming from the wormhole!
 					if (ReverseDiagDir(enterdir) != dir) continue;
-					if (!flags.Test(SigFlag::Train) && HasVehicleOnPos(tile, nullptr, &TrainOnTileEnum)) flags.Set(SigFlag::Train);
+					if (!flags.Test(SigFlag::Train) && HasVehicleOnTile(tile, IsTrainAndNotInDepot)) flags.Set(SigFlag::Train);
 					tile = GetOtherTunnelBridgeEnd(tile); // just skip to exit tile
 					enterdir = INVALID_DIAGDIR;
 					exitdir = INVALID_DIAGDIR;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -472,6 +472,35 @@ bool HasVehicleOnPosXY(int x, int y, void *data, VehicleFromPosProc *proc)
 }
 
 /**
+ * Iterator constructor.
+ * Find first vehicle on tile.
+ */
+VehiclesOnTile::Iterator::Iterator(TileIndex tile) : tile(tile)
+{
+	int x = GB(TileX(tile), HASH_RES, HASH_BITS);
+	int y = GB(TileY(tile), HASH_RES, HASH_BITS) << HASH_BITS;
+	this->current = _vehicle_tile_hash[(x + y) & TOTAL_HASH_MASK];
+	this->SkipFalseMatches();
+}
+
+/**
+ * Advance the internal state to the next potential vehicle.
+ * The vehicle may not be on the correct tile though.
+ */
+void VehiclesOnTile::Iterator::Increment()
+{
+	this->current = this->current->hash_tile_next;
+}
+
+/**
+ * Advance the internal state until it reaches a vehicle on the correct tile or the end.
+ */
+void VehiclesOnTile::Iterator::SkipFalseMatches()
+{
+	while (this->current != nullptr && this->current->tile != this->tile) this->Increment();
+}
+
+/**
  * Helper function for FindVehicleOnPos/HasVehicleOnPos.
  * @note Do not call this function directly!
  * @param tile The location on the map

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -545,21 +545,6 @@ void FindVehicleOnPos(TileIndex tile, void *data, VehicleFromPosProc *proc)
 }
 
 /**
- * Checks whether a vehicle is on a specific location. It will call \a proc for
- * vehicles until it returns non-nullptr.
- * @note Use #FindVehicleOnPos when you have the intention that all vehicles
- *       should be iterated over.
- * @param tile The location on the map
- * @param data Arbitrary data passed to \a proc.
- * @param proc The \a proc that determines whether a vehicle will be "found".
- * @return True if proc returned non-nullptr.
- */
-bool HasVehicleOnPos(TileIndex tile, void *data, VehicleFromPosProc *proc)
-{
-	return VehicleFromPos(tile, data, proc, true) != nullptr;
-}
-
-/**
  * Callback that returns 'real' vehicles lower or at height \c *(int*)data .
  * @param v Vehicle to examine.
  * @param data Pointer to height data.

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -115,7 +115,6 @@ typedef Vehicle *VehicleFromPosProc(Vehicle *v, void *data);
 
 void VehicleServiceInDepot(Vehicle *v);
 uint CountVehiclesInChain(const Vehicle *v);
-void FindVehicleOnPos(TileIndex tile, void *data, VehicleFromPosProc *proc);
 void FindVehicleOnPosXY(int x, int y, void *data, VehicleFromPosProc *proc);
 bool HasVehicleOnPosXY(int x, int y, void *data, VehicleFromPosProc *proc);
 void CallVehicleTicks();

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -98,13 +98,25 @@ private:
 	Iterator start;
 };
 
+/**
+ * Loop over vehicles on a tile, and check whether a predicate is true for any of them.
+ * The predicate must have the signature: bool Predicate(const Vehicle *);
+ */
+template <class UnaryPred>
+bool HasVehicleOnTile(TileIndex tile, UnaryPred &&predicate)
+{
+	for (const auto *v : VehiclesOnTile(tile)) {
+		if (predicate(v)) return true;
+	}
+	return false;
+}
+
 typedef Vehicle *VehicleFromPosProc(Vehicle *v, void *data);
 
 void VehicleServiceInDepot(Vehicle *v);
 uint CountVehiclesInChain(const Vehicle *v);
 void FindVehicleOnPos(TileIndex tile, void *data, VehicleFromPosProc *proc);
 void FindVehicleOnPosXY(int x, int y, void *data, VehicleFromPosProc *proc);
-bool HasVehicleOnPos(TileIndex tile, void *data, VehicleFromPosProc *proc);
 bool HasVehicleOnPosXY(int x, int y, void *data, VehicleFromPosProc *proc);
 void CallVehicleTicks();
 uint8_t CalcPercentVehicleFilled(const Vehicle *v, StringID *colour);

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -46,6 +46,58 @@ static const Money VEHICLE_PROFIT_THRESHOLD = 10000;        ///< Threshold for a
 template <VehicleType T>
 bool IsValidImageIndex(uint8_t image_index);
 
+/**
+ * Iterate over all vehicles on a tile.
+ * @warning The order is non-deterministic. You have to make sure, that your processing is not order dependant.
+ */
+class VehiclesOnTile {
+public:
+	/**
+	 * Forward iterator
+	 */
+	class Iterator {
+	public:
+		using value_type = Vehicle *;
+		using difference_type = std::ptrdiff_t;
+		using iterator_category = std::forward_iterator_tag;
+		using pointer = void;
+		using reference = void;
+
+		explicit Iterator(TileIndex tile);
+
+		bool operator==(const Iterator &rhs) const { return this->current == rhs.current; }
+		bool operator==(const std::default_sentinel_t &) const { return this->current == nullptr; }
+
+		Vehicle *operator*() const { return this->current; }
+
+		Iterator &operator++()
+		{
+			this->Increment();
+			this->SkipFalseMatches();
+			return *this;
+		}
+
+		Iterator operator++(int)
+		{
+			Iterator result = *this;
+			++*this;
+			return result;
+		}
+	private:
+		TileIndex tile;
+		Vehicle *current;
+
+		void Increment();
+		void SkipFalseMatches();
+	};
+
+	explicit VehiclesOnTile(TileIndex tile) : start(tile) {}
+	Iterator begin() const { return this->start; }
+	std::default_sentinel_t end() const { return std::default_sentinel_t(); }
+private:
+	Iterator start;
+};
+
 typedef Vehicle *VehicleFromPosProc(Vehicle *v, void *data);
 
 void VehicleServiceInDepot(Vehicle *v);

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -32,39 +32,6 @@ WindowNumber VehicleListIdentifier::ToWindowNumber() const
 	return c << 28 | this->type << 23 | this->vtype << 26 | this->index;
 }
 
-/** Data for building a depot vehicle list. */
-struct BuildDepotVehicleListData
-{
-	VehicleList *engines; ///< Pointer to list to add vehicles to.
-	VehicleList *wagons; ///< Pointer to list to add wagons to (can be nullptr).
-	VehicleType type; ///< Type of vehicle.
-	bool individual_wagons; ///< If true add every wagon to \a wagons which is not attached to an engine. If false only add the first wagon of every row.
-};
-
-/**
- * Add vehicles to a depot vehicle list.
- * @param v The found vehicle.
- * @param data The depot vehicle list data.
- * @return Always nullptr.
- */
-static Vehicle *BuildDepotVehicleListProc(Vehicle *v, void *data)
-{
-	auto bdvld = static_cast<BuildDepotVehicleListData *>(data);
-	if (v->type != bdvld->type || !v->IsInDepot()) return nullptr;
-
-	if (bdvld->type == VEH_TRAIN) {
-		const Train *t = Train::From(v);
-		if (t->IsArticulatedPart() || t->IsRearDualheaded()) return nullptr;
-		if (bdvld->wagons != nullptr && t->First()->IsFreeWagon()) {
-			if (bdvld->individual_wagons || t->IsFreeWagon()) bdvld->wagons->push_back(t);
-			return nullptr;
-		}
-	}
-
-	if (v->IsPrimaryVehicle()) bdvld->engines->push_back(v);
-	return nullptr;
-};
-
 /**
  * Generate a list of vehicles inside a depot.
  * @param type    Type of vehicle
@@ -78,8 +45,20 @@ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine
 	engines->clear();
 	if (wagons != nullptr && wagons != engines) wagons->clear();
 
-	BuildDepotVehicleListData bdvld{engines, wagons, type, individual_wagons};
-	FindVehicleOnPos(tile, &bdvld, BuildDepotVehicleListProc);
+	for (Vehicle *v : VehiclesOnTile(tile)) {
+		if (v->type != type || !v->IsInDepot()) continue;
+
+		if (type == VEH_TRAIN) {
+			const Train *t = Train::From(v);
+			if (t->IsArticulatedPart() || t->IsRearDualheaded()) continue;
+			if (wagons != nullptr && t->First()->IsFreeWagon()) {
+				if (individual_wagons || t->IsFreeWagon()) wagons->push_back(t);
+				continue;
+			}
+		}
+
+		if (v->IsPrimaryVehicle()) engines->push_back(v);
+	}
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

* `Has|FindVehicleOnPos` iterates over all vehicles on a tile, and call a callback for each.
    * `HasVehicleOnPos` checks the return value of the callback, and aborts the iteration early on match.
    * `FindVehicleOnPos` does not care about the callback result, and always iterates all vehicles.
* Both functions use `void*` user-data.
* `HasVehicleOnPos` should use a `const Vehicle`, because vehicle order is non-deterministic, and modifying things based on a partial iteration will probably desync.

## Description

* Replace `FindVehicleOnPos` with an iterator and for-loops over `VehiclesOnTile`.
* Replace `HasVehicleOnPos` with `HasVehicleOnTile` taking a lamba-predicate to test `const Vehicle`.

## Limitations

There are still `Has|FindVehicleOnPosXY`. They are more complicated and will follow later.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
