### PR TITLE
Add: [NewGRF] Unify animation and randomisation triggers across features

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1946,6 +1946,8 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 		}
 	}
 
+	TriggerIndustryAnimation(i, IndustryAnimationTrigger::Built);
+
 	if (GetIndustrySpec(i->type)->behaviour.Test(IndustryBehaviour::PlantOnBuild)) {
 		for (uint j = 0; j != 50; j++) PlantRandomFarmField(i);
 	}

--- a/src/industry_type.h
+++ b/src/industry_type.h
@@ -36,6 +36,7 @@ enum class IndustryAnimationTrigger : uint8_t {
 	IndustryTick, ///< Trigger every tick.
 	CargoReceived, ///< Trigger when cargo is received .
 	CargoDistributed, ///< Trigger when cargo is distributed.
+	Built, ///< Trigger tile when built.
 };
 using IndustryAnimationTriggers = EnumBitSet<IndustryAnimationTrigger, uint8_t>;
 

--- a/src/newgrf_callbacks.h
+++ b/src/newgrf_callbacks.h
@@ -293,6 +293,9 @@ enum CallbackID : uint16_t {
 	 * for each defined cargo after all NewGRFs are loaded.
 	 */
 	CBID_VEHICLE_CUSTOM_REFIT            = 0x0163, // 15 bit callback
+
+	/** Called for starting the animation for newly built houses. */
+	CBID_HOUSE_ANIMATION_TRIGGER_BUILT   = 0x0164, // 15 bit callback
 };
 
 /**
@@ -352,6 +355,7 @@ enum class HouseCallbackMask : uint8_t {
 	DenyDestruction         = 10, ///< conditional protection
 	DrawFoundations         = 11, ///< decides if default foundations need to be drawn
 	Autoslope               = 12, ///< decides allowance of autosloping
+	AnimationTriggerBuilt   = 13, ///< start animation when house is built
 };
 using HouseCallbackMasks = EnumBitSet<HouseCallbackMask, uint16_t>;
 

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -718,3 +718,39 @@ void TriggerHouseAnimation_WatchedCargoAccepted(TileIndex tile, CargoTypes trigg
 	if (hs->building_flags.Any(BUILDING_HAS_4_TILES)) DoTriggerHouseAnimation_WatchedCargoAccepted(TileAddXY(north, 1, 1), tile, trigger_cargoes, r);
 }
 
+/**
+ * Run the house-built callback for a single house tile.
+ * @param tile The house tile.
+ * @param origin The triggering tile.
+ * @param random Shared random bits for all tiles.
+ */
+static void DoTriggerHouseAnimation_Built(TileIndex tile, uint16_t random)
+{
+	HouseID id = GetHouseType(tile);
+	const HouseSpec *hs = HouseSpec::Get(id);
+
+	if (hs->callback_mask.Test(HouseCallbackMask::AnimationTriggerBuilt)) {
+		uint32_t r = random << 16 | GB(Random(), 0, 16);
+		HouseAnimationBase::ChangeAnimationFrame(CBID_HOUSE_ANIMATION_TRIGGER_BUILT, hs, Town::GetByTile(tile), tile, r, 0);
+	}
+}
+
+/**
+ * Run house-built callback for a house.
+ * @param tile_north House northern tile.
+ * @pre IsTileType(t, MP_HOUSE)
+ */
+void TriggerHouseAnimation_Built(TileIndex tile_north)
+{
+	assert(IsTileType(tile_north, MP_HOUSE));
+	HouseID id = GetHouseType(tile_north);
+	const HouseSpec *hs = HouseSpec::Get(id);
+
+	/* Same random value for all tiles of a multi-tile house. */
+	uint16_t r = Random();
+
+	DoTriggerHouseAnimation_Built(tile_north, r);
+	if (hs->building_flags.Any(BUILDING_2_TILES_Y))   DoTriggerHouseAnimation_Built(TileAddXY(tile_north, 0, 1), r);
+	if (hs->building_flags.Any(BUILDING_2_TILES_X))   DoTriggerHouseAnimation_Built(TileAddXY(tile_north, 1, 0), r);
+	if (hs->building_flags.Any(BUILDING_HAS_4_TILES)) DoTriggerHouseAnimation_Built(TileAddXY(tile_north, 1, 1), r);
+}

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -102,6 +102,7 @@ void AnimateNewHouseTile(TileIndex tile);
 /* see also: void TriggerHouseAnimation_TileLoop(TileIndex tile, uint16_t random_bits) */
 void TriggerHouseAnimation_ConstructionStageChanged(TileIndex tile);
 void TriggerHouseAnimation_WatchedCargoAccepted(TileIndex tile, CargoTypes trigger_cargoes);
+void TriggerHouseAnimation_Built(TileIndex tile_north);
 
 uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, HouseID house_id, Town *town, TileIndex tile,
 		bool not_yet_constructed = false, uint8_t initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0, int view = 0);

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -379,8 +379,7 @@ void AnimateRoadStopTile(TileIndex tile)
 
 void TriggerRoadStopAnimation(BaseStation *st, TileIndex trigger_tile, StationAnimationTrigger trigger, CargoType cargo_type)
 {
-	/* Get Station if it wasn't supplied */
-	if (st == nullptr) st = BaseStation::GetByTile(trigger_tile);
+	assert(st != nullptr);
 
 	/* Check the cached animation trigger bitmask to see if we need
 	 * to bother with any further processing. */
@@ -417,9 +416,9 @@ void TriggerRoadStopAnimation(BaseStation *st, TileIndex trigger_tile, StationAn
  * @param trigger trigger type
  * @param cargo_type cargo type causing the trigger
  */
-void TriggerRoadStopRandomisation(Station *st, TileIndex tile, StationRandomTrigger trigger, CargoType cargo_type)
+void TriggerRoadStopRandomisation(BaseStation *st, TileIndex tile, StationRandomTrigger trigger, CargoType cargo_type)
 {
-	if (st == nullptr) st = Station::GetByTile(tile);
+	assert(st != nullptr);
 
 	/* Check the cached cargo trigger bitmask to see if we need
 	 * to bother with any further processing. */
@@ -431,7 +430,10 @@ void TriggerRoadStopRandomisation(Station *st, TileIndex tile, StationRandomTrig
 	uint32_t whole_reseed = 0;
 
 	/* Bitmask of completely empty cargo types to be matched. */
-	CargoTypes empty_mask = (trigger == StationRandomTrigger::CargoTaken) ? GetEmptyMask(st) : 0;
+	CargoTypes empty_mask{};
+	if (trigger == StationRandomTrigger::CargoTaken) {
+		empty_mask = GetEmptyMask(Station::From(st));
+	}
 
 	StationRandomTriggers used_random_triggers;
 	auto process_tile = [&](TileIndex cur_tile) {

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -470,7 +470,7 @@ void TriggerRoadStopRandomisation(BaseStation *st, TileIndex tile, StationRandom
 			}
 		}
 	};
-	if (trigger == StationRandomTrigger::NewCargo || trigger == StationRandomTrigger::CargoTaken) {
+	if (trigger == StationRandomTrigger::NewCargo || trigger == StationRandomTrigger::CargoTaken || trigger == StationRandomTrigger::AcceptanceTick) {
 		for (const RoadStopTileData &tile_data : st->custom_roadstop_tile_data) {
 			process_tile(tile_data.tile);
 		}

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -421,7 +421,8 @@ void TriggerRoadStopRandomisation(BaseStation *st, TileIndex tile, StationRandom
 	assert(st != nullptr);
 
 	/* Check the cached cargo trigger bitmask to see if we need
-	 * to bother with any further processing. */
+	 * to bother with any further processing.
+	 * Note: cached_roadstop_cargo_triggers must be non-zero even for cargo-independent triggers. */
 	if (st->cached_roadstop_cargo_triggers == 0) return;
 	if (IsValidCargoType(cargo_type) && !HasBit(st->cached_roadstop_cargo_triggers, cargo_type)) return;
 

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -176,7 +176,7 @@ uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t para
 void AnimateRoadStopTile(TileIndex tile);
 uint8_t GetRoadStopTileAnimationSpeed(TileIndex tile);
 void TriggerRoadStopAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
-void TriggerRoadStopRandomisation(Station *st, TileIndex tile, StationRandomTrigger trigger, CargoType cargo_type = INVALID_CARGO);
+void TriggerRoadStopRandomisation(BaseStation *st, TileIndex tile, StationRandomTrigger trigger, CargoType cargo_type = INVALID_CARGO);
 
 bool GetIfNewStopsByType(RoadStopType rs, RoadType roadtype);
 bool GetIfClassHasNewStopsByType(const RoadStopClass *roadstopclass, RoadStopType rs, RoadType roadtype);

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -969,7 +969,8 @@ void TriggerStationRandomisation(BaseStation *st, TileIndex trigger_tile, Statio
 	assert(st != nullptr);
 
 	/* Check the cached cargo trigger bitmask to see if we need
-	 * to bother with any further processing. */
+	 * to bother with any further processing.
+	 * Note: cached_cargo_triggers must be non-zero even for cargo-independent triggers. */
 	if (st->cached_cargo_triggers == 0) return;
 	if (IsValidCargoType(cargo_type) && !HasBit(st->cached_cargo_triggers, cargo_type)) return;
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -909,8 +909,7 @@ void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAni
 		TA_TILE, TA_WHOLE, TA_WHOLE, TA_PLATFORM, TA_PLATFORM, TA_PLATFORM, TA_WHOLE
 	};
 
-	/* Get Station if it wasn't supplied */
-	if (st == nullptr) st = BaseStation::GetByTile(trigger_tile);
+	assert(st != nullptr);
 
 	/* Check the cached animation trigger bitmask to see if we need
 	 * to bother with any further processing. */
@@ -943,15 +942,14 @@ void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAni
  * @param trigger trigger type
  * @param cargo_type cargo type causing trigger
  */
-void TriggerStationRandomisation(Station *st, TileIndex trigger_tile, StationRandomTrigger trigger, CargoType cargo_type)
+void TriggerStationRandomisation(BaseStation *st, TileIndex trigger_tile, StationRandomTrigger trigger, CargoType cargo_type)
 {
 	/* List of coverage areas for each animation trigger */
 	static const TriggerArea tas[] = {
 		TA_WHOLE, TA_WHOLE, TA_PLATFORM, TA_PLATFORM, TA_PLATFORM, TA_PLATFORM
 	};
 
-	/* Get Station if it wasn't supplied */
-	if (st == nullptr) st = Station::GetByTile(trigger_tile);
+	assert(st != nullptr);
 
 	/* Check the cached cargo trigger bitmask to see if we need
 	 * to bother with any further processing. */
@@ -962,7 +960,10 @@ void TriggerStationRandomisation(Station *st, TileIndex trigger_tile, StationRan
 	ETileArea area = ETileArea(st, trigger_tile, tas[static_cast<size_t>(trigger)]);
 
 	/* Bitmask of completely empty cargo types to be matched. */
-	CargoTypes empty_mask = (trigger == StationRandomTrigger::CargoTaken) ? GetEmptyMask(st) : 0;
+	CargoTypes empty_mask{};
+	if (trigger == StationRandomTrigger::CargoTaken) {
+		empty_mask = GetEmptyMask(Station::From(st));
+	}
 
 	/* Store triggers now for var 5F */
 	st->waiting_random_triggers.Set(trigger);

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -906,8 +906,17 @@ void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAni
 {
 	/* List of coverage areas for each animation trigger */
 	static const TriggerArea tas[] = {
-		TA_TILE, TA_WHOLE, TA_WHOLE, TA_PLATFORM, TA_PLATFORM, TA_PLATFORM, TA_WHOLE
+		TA_TILE, // Built
+		TA_WHOLE, // NewCargo
+		TA_WHOLE, // CargoTaken
+		TA_PLATFORM, // VehicleArrives
+		TA_PLATFORM, // VehicleDeparts
+		TA_PLATFORM, // VehicleLoads
+		TA_WHOLE, // AcceptanceTick
+		TA_TILE, // TileLoop
+		TA_PLATFORM, // PathReservation
 	};
+	static_assert(lengthof(tas) == static_cast<size_t>(StationAnimationTrigger::End));
 
 	assert(st != nullptr);
 
@@ -946,8 +955,16 @@ void TriggerStationRandomisation(BaseStation *st, TileIndex trigger_tile, Statio
 {
 	/* List of coverage areas for each animation trigger */
 	static const TriggerArea tas[] = {
-		TA_WHOLE, TA_WHOLE, TA_PLATFORM, TA_PLATFORM, TA_PLATFORM, TA_PLATFORM
+		TA_WHOLE, // NewCargo
+		TA_WHOLE, // CargoTaken
+		TA_PLATFORM, // VehicleArrives
+		TA_PLATFORM, // VehicleDeparts
+		TA_PLATFORM, // VehicleLoads
+		TA_PLATFORM, // PathReservation
+		TA_WHOLE, // AcceptanceTick
+		TA_TILE, // TileLoop
 	};
+	static_assert(lengthof(tas) == static_cast<size_t>(StationRandomTrigger::End));
 
 	assert(st != nullptr);
 

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -213,7 +213,7 @@ bool DrawStationTile(int x, int y, RailType railtype, Axis axis, StationClassID 
 
 void AnimateStationTile(TileIndex tile);
 void TriggerStationAnimation(BaseStation *st, TileIndex tile, StationAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
-void TriggerStationRandomisation(Station *st, TileIndex tile, StationRandomTrigger trigger, CargoType cargo_type = INVALID_CARGO);
+void TriggerStationRandomisation(BaseStation *st, TileIndex tile, StationRandomTrigger trigger, CargoType cargo_type = INVALID_CARGO);
 void StationUpdateCachedTriggers(BaseStation *st);
 
 #endif /* NEWGRF_STATION_H */

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -82,6 +82,7 @@ private:
 
 		auto *st = Station::GetByTile(start);
 		TriggerStationRandomisation(st, start, StationRandomTrigger::PathReservation);
+		TriggerStationAnimation(st, start, StationAnimationTrigger::PathReservation);
 
 		return true;
 	}
@@ -114,6 +115,7 @@ private:
 			if (IsRailWaypointTile(tile)) {
 				auto *st = BaseStation::GetByTile(tile);
 				TriggerStationRandomisation(st, tile, StationRandomTrigger::PathReservation);
+				TriggerStationAnimation(st, tile, StationAnimationTrigger::PathReservation);
 			}
 		}
 

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -110,6 +110,11 @@ private:
 				SetSignalStateByTrackdir(tile, rev_td, SIGNAL_STATE_RED);
 				MarkTileDirtyByTile(tile);
 			}
+
+			if (IsRailWaypointTile(tile)) {
+				auto *st = BaseStation::GetByTile(tile);
+				TriggerStationRandomisation(st, tile, StationRandomTrigger::PathReservation);
+			}
 		}
 
 		return tile != this->res_dest_tile || td != this->res_dest_td;

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -80,7 +80,8 @@ private:
 			tile = TileAdd(tile, diff);
 		} while (IsCompatibleTrainStationTile(tile, start) && tile != this->origin_tile);
 
-		TriggerStationRandomisation(nullptr, start, StationRandomTrigger::PathReservation);
+		auto *st = Station::GetByTile(start);
+		TriggerStationRandomisation(st, start, StationRandomTrigger::PathReservation);
 
 		return true;
 	}

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -113,7 +113,10 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 		case MP_STATION:
 			if (HasStationRail(tile) && !HasStationReservation(tile)) {
 				SetRailStationReservation(tile, true);
-				if (trigger_stations && IsRailStation(tile)) TriggerStationRandomisation(nullptr, tile, StationRandomTrigger::PathReservation);
+				if (trigger_stations && IsRailStation(tile)) {
+					auto *st = Station::GetByTile(tile);
+					TriggerStationRandomisation(st, tile, StationRandomTrigger::PathReservation);
+				}
 				MarkTileDirtyByTile(tile); // some GRFs need redraw after reserving track
 				return true;
 			}

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -113,8 +113,8 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 		case MP_STATION:
 			if (HasStationRail(tile) && !HasStationReservation(tile)) {
 				SetRailStationReservation(tile, true);
-				if (trigger_stations && IsRailStation(tile)) {
-					auto *st = Station::GetByTile(tile);
+				if (trigger_stations) {
+					auto *st = BaseStation::GetByTile(tile);
 					TriggerStationRandomisation(st, tile, StationRandomTrigger::PathReservation);
 				}
 				MarkTileDirtyByTile(tile); // some GRFs need redraw after reserving track

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -116,6 +116,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 				if (trigger_stations) {
 					auto *st = BaseStation::GetByTile(tile);
 					TriggerStationRandomisation(st, tile, StationRandomTrigger::PathReservation);
+					TriggerStationAnimation(st, tile, StationAnimationTrigger::PathReservation);
 				}
 				MarkTileDirtyByTile(tile); // some GRFs need redraw after reserving track
 				return true;

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -84,6 +84,9 @@ enum class StationRandomTrigger : uint8_t {
 	VehicleDeparts, ///< Trigger platform when train leaves.
 	VehicleLoads, ///< Trigger platform when train loads/unloads.
 	PathReservation, ///< Trigger platform when train reserves path.
+	AcceptanceTick, ///< Trigger station every 250 ticks.
+	TileLoop, ///< Trigger in the periodic tile loop.
+	End
 };
 using StationRandomTriggers = EnumBitSet<StationRandomTrigger, uint8_t>;
 
@@ -96,6 +99,9 @@ enum class StationAnimationTrigger : uint8_t {
 	VehicleDeparts, ///< Trigger platform when train leaves.
 	VehicleLoads, ///< Trigger platform when train loads/unloads.
 	AcceptanceTick, ///< Trigger station every 250 ticks.
+	TileLoop, ///< Trigger in the periodic tile loop.
+	PathReservation, ///< Trigger platform when train reserves path.
+	End
 };
 using StationAnimationTriggers = EnumBitSet<StationAnimationTrigger, uint16_t>;
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2705,6 +2705,8 @@ static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID
 	MakeTownHouse(tile, t, construction_counter, construction_stage, house, random_bits, is_protected);
 	UpdateTownRadius(t);
 	UpdateTownGrowthRate(t);
+
+	TriggerHouseAnimation_Built(tile);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Various features have animation and randomisation triggers.
* Some triggers exist only for either animation or randomisation. Most triggers make sense for both.
* Some triggers exist only for a subset of features, but make sense for more.

Fixes #12986.

## Description

* Stations and roadstops:
    * Add randomisation-trigger (bit 6) "250 ticks" matching the existing animation-trigger.
    * Add randomisation (bit 7) and animation-trigger (bit 7) "tile loop", matching other features.
    * Add animation-trigger (bit 8) "path reservation", matching the existing randomisation-trigger.
* Industries and houses:
    * Add animation-trigger for newly built industries (bit 5) and houses (callback 0x164).
        * Also called for all houses/industries during map generation.
        * Randomisation-trigger makes no sense for new stuff; same for other features.
        * Callback 0x164 gets random bits in var10 like all multi-tile triggers:
            * First 16 bits are random per tile.
            * Second 16 bits are shared for all tiles.
* Trigger "PathReservation" also for waypoints. (Not sure whether this is a feature, or a bug fix.)

## Limitations

I left out randomisation triggers for airports:
* Triggers "NewCargo" and "CargoTaken" only make sense with a "cargo_triggers" property, which does not yet exist for airports.
* Triggers "VehicleArrives", "VehicleDeparts" and "VehicleLoads" only make sense for terminal-specific tiles, which does not exist as a concept for airports.
* Triggers "AcceptanceTick" and "TileLoop" would make sense, but for consistency with stationd and road stops this would need a "cargo_triggers" property as well.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
