### PR TITLE
Add: [NewGRF] Industry animation-trigger 'built' (bit 5).

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1946,6 +1946,8 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 		}
 	}
 
+	TriggerIndustryAnimation(i, IndustryAnimationTrigger::Built);
+
 	if (GetIndustrySpec(i->type)->behaviour.Test(IndustryBehaviour::PlantOnBuild)) {
 		for (uint j = 0; j != 50; j++) PlantRandomFarmField(i);
 	}

--- a/src/industry_type.h
+++ b/src/industry_type.h
@@ -36,6 +36,7 @@ enum class IndustryAnimationTrigger : uint8_t {
 	IndustryTick, ///< Trigger every tick.
 	CargoReceived, ///< Trigger when cargo is received .
 	CargoDistributed, ///< Trigger when cargo is distributed.
+	Built, ///< Trigger tile when built.
 };
 using IndustryAnimationTriggers = EnumBitSet<IndustryAnimationTrigger, uint8_t>;
 


### PR DESCRIPTION
## Motivation / Problem

Stations, roadstops, airports and objects have an animation trigger on construction.

## Description

Add an equivalent trigger for industries.
Triggered both during game and during map generation.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
