### PR TITLE
Add: [NewGRF] House animation-trigger 'built' (callback 0x164).

### DIFF
--- a/src/newgrf_callbacks.h
+++ b/src/newgrf_callbacks.h
@@ -293,6 +293,9 @@ enum CallbackID : uint16_t {
 	 * for each defined cargo after all NewGRFs are loaded.
 	 */
 	CBID_VEHICLE_CUSTOM_REFIT            = 0x0163, // 15 bit callback
+
+	/** Called for starting the animation for newly built houses. */
+	CBID_HOUSE_ANIMATION_TRIGGER_BUILT   = 0x0164, // 15 bit callback
 };
 
 /**
@@ -352,6 +355,7 @@ enum class HouseCallbackMask : uint8_t {
 	DenyDestruction         = 10, ///< conditional protection
 	DrawFoundations         = 11, ///< decides if default foundations need to be drawn
 	Autoslope               = 12, ///< decides allowance of autosloping
+	AnimationTriggerBuilt   = 13, ///< start animation when house is built
 };
 using HouseCallbackMasks = EnumBitSet<HouseCallbackMask, uint16_t>;
 

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -718,3 +718,39 @@ void TriggerHouseAnimation_WatchedCargoAccepted(TileIndex tile, CargoTypes trigg
 	if (hs->building_flags.Any(BUILDING_HAS_4_TILES)) DoTriggerHouseAnimation_WatchedCargoAccepted(TileAddXY(north, 1, 1), tile, trigger_cargoes, r);
 }
 
+/**
+ * Run the house-built callback for a single house tile.
+ * @param tile The house tile.
+ * @param origin The triggering tile.
+ * @param random Shared random bits for all tiles.
+ */
+static void DoTriggerHouseAnimation_Built(TileIndex tile, uint16_t random)
+{
+	HouseID id = GetHouseType(tile);
+	const HouseSpec *hs = HouseSpec::Get(id);
+
+	if (hs->callback_mask.Test(HouseCallbackMask::AnimationTriggerBuilt)) {
+		uint32_t r = random << 16 | GB(Random(), 0, 16);
+		HouseAnimationBase::ChangeAnimationFrame(CBID_HOUSE_ANIMATION_TRIGGER_BUILT, hs, Town::GetByTile(tile), tile, r, 0);
+	}
+}
+
+/**
+ * Run house-built callback for a house.
+ * @param tile_north House northern tile.
+ * @pre IsTileType(t, MP_HOUSE)
+ */
+void TriggerHouseAnimation_Built(TileIndex tile_north)
+{
+	assert(IsTileType(tile_north, MP_HOUSE));
+	HouseID id = GetHouseType(tile_north);
+	const HouseSpec *hs = HouseSpec::Get(id);
+
+	/* Same random value for all tiles of a multi-tile house. */
+	uint16_t r = Random();
+
+	DoTriggerHouseAnimation_Built(tile_north, r);
+	if (hs->building_flags.Any(BUILDING_2_TILES_Y))   DoTriggerHouseAnimation_Built(TileAddXY(tile_north, 0, 1), r);
+	if (hs->building_flags.Any(BUILDING_2_TILES_X))   DoTriggerHouseAnimation_Built(TileAddXY(tile_north, 1, 0), r);
+	if (hs->building_flags.Any(BUILDING_HAS_4_TILES)) DoTriggerHouseAnimation_Built(TileAddXY(tile_north, 1, 1), r);
+}

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -102,6 +102,7 @@ void AnimateNewHouseTile(TileIndex tile);
 /* see also: void TriggerHouseAnimation_TileLoop(TileIndex tile, uint16_t random_bits) */
 void TriggerHouseAnimation_ConstructionStageChanged(TileIndex tile);
 void TriggerHouseAnimation_WatchedCargoAccepted(TileIndex tile, CargoTypes trigger_cargoes);
+void TriggerHouseAnimation_Built(TileIndex tile_north);
 
 uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, HouseID house_id, Town *town, TileIndex tile,
 		bool not_yet_constructed = false, uint8_t initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0, int view = 0);

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2705,6 +2705,8 @@ static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID
 	MakeTownHouse(tile, t, construction_counter, construction_stage, house, random_bits, is_protected);
 	UpdateTownRadius(t);
 	UpdateTownGrowthRate(t);
+
+	TriggerHouseAnimation_Built(tile);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Stations, roadstops, airports and objects have an animation trigger on construction.

Fixes #12986.

## Description

Add an equivalent trigger for houses.
Triggered both during game and during map generation.

Callback 0x164 gets random bits in var10 like all multi-tile triggers:
* First 16 bits are random per tile.
* Second 16 bits are shared for all tiles.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
