### PR TITLE
Codechange: simplify and move GetArgumentInteger

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -118,30 +118,6 @@ void IConsolePrint(TextColour colour_code, const std::string &string)
 }
 
 /**
- * Change a string into its number representation. Supports
- * decimal and hexadecimal numbers as well as 'on'/'off' 'true'/'false'
- * @param *value the variable a successful conversion will be put in
- * @param *arg the string to be converted
- * @return Return true on success or false on failure
- */
-bool GetArgumentInteger(uint32_t *value, const char *arg)
-{
-	char *endptr;
-
-	if (strcmp(arg, "on") == 0 || strcmp(arg, "true") == 0) {
-		*value = 1;
-		return true;
-	}
-	if (strcmp(arg, "off") == 0 || strcmp(arg, "false") == 0) {
-		*value = 0;
-		return true;
-	}
-
-	*value = std::strtoul(arg, &endptr, 0);
-	return arg != endptr;
-}
-
-/**
  * Creates a copy of a string with underscores removed from it
  * @param name String to remove the underscores from.
  * @return A copy of \a name, without underscores.

--- a/src/console_internal.h
+++ b/src/console_internal.h
@@ -81,9 +81,6 @@ void IConsoleClearBuffer();
 /* console std lib (register ingame commands/aliases) */
 void IConsoleStdLibRegister();
 
-/* Supporting functions */
-bool GetArgumentInteger(uint32_t *value, const char *arg);
-
 void IConsoleGUIInit();
 void IConsoleGUIFree();
 void IConsoleGUIPrint(TextColour colour_code, const std::string &string);


### PR DESCRIPTION
## Motivation / Problem

Console commands use C-style strings which we want to move away from.

On particular function is `GetArgumentInteger`, which returns a `std::optional` the C-way, i.e. with an out parameter. This function also does 'on'/'off' and 'true'/'false' conversion to number, but for the places it is used it makes no sense.
* 'scrollto true' (tile 1)
* 'scrollto on off' (coord 1, 0)
* 'zoomto off' (level 0)
* 'resettile false' (tile 0)
* 'screenshot size true false' (1 by 0)
* 'font Arial false' (size 0).


## Description

Move `GetArgumentInteger` to console_cmds.cpp (the only place using it), rename to `ParseInteger`, make it return `std::optional<uint32_t>`, and trash the 'on/off/true/false' support.

In places where the return validity of what was parsed was not checked, add those checks.

## Limitations

Almost all instances of `atoi` might want to use this as well, but that's a future PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
