### PR TITLE
Add: [NewGRF] Station/roadstop animation-triggers 'tile loop' (bit 7) and 'path reservation' (bit 8).

### DIFF
--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -906,8 +906,17 @@ void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAni
 {
 	/* List of coverage areas for each animation trigger */
 	static const TriggerArea tas[] = {
-		TA_TILE, TA_WHOLE, TA_WHOLE, TA_PLATFORM, TA_PLATFORM, TA_PLATFORM, TA_WHOLE
+		TA_TILE, // Built
+		TA_WHOLE, // NewCargo
+		TA_WHOLE, // CargoTaken
+		TA_PLATFORM, // VehicleArrives
+		TA_PLATFORM, // VehicleDeparts
+		TA_PLATFORM, // VehicleLoads
+		TA_WHOLE, // AcceptanceTick
+		TA_TILE, // TileLoop
+		TA_PLATFORM, // PathReservation
 	};
+	static_assert(std::size(tas) == static_cast<size_t>(StationAnimationTrigger::End));
 
 	assert(st != nullptr);
 

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -82,6 +82,7 @@ private:
 
 		auto *st = Station::GetByTile(start);
 		TriggerStationRandomisation(st, start, StationRandomTrigger::PathReservation);
+		TriggerStationAnimation(st, start, StationAnimationTrigger::PathReservation);
 
 		return true;
 	}
@@ -114,6 +115,7 @@ private:
 			if (IsRailWaypointTile(tile)) {
 				auto *st = BaseStation::GetByTile(tile);
 				TriggerStationRandomisation(st, tile, StationRandomTrigger::PathReservation);
+				TriggerStationAnimation(st, tile, StationAnimationTrigger::PathReservation);
 			}
 		}
 

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -116,6 +116,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 				if (trigger_stations) {
 					auto *st = BaseStation::GetByTile(tile);
 					TriggerStationRandomisation(st, tile, StationRandomTrigger::PathReservation);
+					TriggerStationAnimation(st, tile, StationAnimationTrigger::PathReservation);
 				}
 				MarkTileDirtyByTile(tile); // some GRFs need redraw after reserving track
 				return true;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3601,9 +3601,15 @@ static TrackStatus GetTileTrackStatus_Station(TileIndex tile, TransportType mode
 
 static void TileLoop_Station(TileIndex tile)
 {
+	auto *st = BaseStation::GetByTile(tile);
 	switch (GetStationType(tile)) {
 		case StationType::Airport:
-			TriggerAirportTileAnimation(Station::GetByTile(tile), tile, AirportAnimationTrigger::TileLoop);
+			TriggerAirportTileAnimation(Station::From(st), tile, AirportAnimationTrigger::TileLoop);
+			break;
+
+		case StationType::Rail:
+		case StationType::RailWaypoint:
+			TriggerStationAnimation(st, tile, StationAnimationTrigger::TileLoop);
 			break;
 
 		case StationType::Dock:
@@ -3613,6 +3619,11 @@ static void TileLoop_Station(TileIndex tile)
 		case StationType::Oilrig: //(station part)
 		case StationType::Buoy:
 			TileLoop_Water(tile);
+			break;
+
+		case StationType::Truck:
+		case StationType::Bus:
+			TriggerRoadStopAnimation(st, tile, StationAnimationTrigger::TileLoop);
 			break;
 
 		case StationType::RoadWaypoint: {
@@ -3648,6 +3659,8 @@ static void TileLoop_Station(TileIndex tile)
 				SetRoadWaypointRoadside(tile, cur_rs == ROADSIDE_BARREN ? new_rs : ROADSIDE_BARREN);
 				MarkTileDirtyByTile(tile);
 			}
+
+			TriggerRoadStopAnimation(st, tile, StationAnimationTrigger::TileLoop);
 			break;
 		}
 

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -96,6 +96,9 @@ enum class StationAnimationTrigger : uint8_t {
 	VehicleDeparts, ///< Trigger platform when train leaves.
 	VehicleLoads, ///< Trigger platform when train loads/unloads.
 	AcceptanceTick, ///< Trigger station every 250 ticks.
+	TileLoop, ///< Trigger in the periodic tile loop.
+	PathReservation, ///< Trigger platform when train reserves path.
+	End
 };
 using StationAnimationTriggers = EnumBitSet<StationAnimationTrigger, uint16_t>;
 


### PR DESCRIPTION
## Motivation / Problem

* Houses, industries, objects and airports have a "tile loop" animation trigger. Stations and roadstops do not.
* Stations have a "path reservation" randomisation trigger, but no animation trigger.

## Description

This includes/depends on #14076.

* Add station/roadstop animation trigger "tile loop" (bit 7).
* Add station animation trigger "path reservation" (bit 8).

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
