### PR TITLE
Fix f5ffd47: Don't skip separator while reading a record

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1006,7 +1006,8 @@ static void DecodeEncodedString(StringConsumer &consumer, bool game_script, Stri
 	}
 
 	while (consumer.AnyBytesLeft()) {
-		StringConsumer record(consumer.ReadUntilUtf8(SCC_RECORD_SEPARATOR, StringConsumer::SKIP_ONE_SEPARATOR));
+		consumer.SkipUtf8If(SCC_RECORD_SEPARATOR);
+		StringConsumer record(consumer.ReadUntilUtf8(SCC_RECORD_SEPARATOR, StringConsumer::KEEP_SEPARATOR));
 
 		if (!record.AnyBytesLeft()) {
 			/* This is an empty parameter. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
News message for failed autorenew shows `(consumed too many parameters)`
![image](https://github.com/user-attachments/assets/1904078d-e791-4d46-bfc1-0e06594eb711)

This is because it has an empty parameter at the end, causing an early exit of the parsing loop, resulting in the parameter being discarded.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
When reading a record, the next separator was skipped, but if last record was an empty parameter then the `while` loop exited before parsing this empty parameter.

Handle separator skipping outside of record reading.

![image](https://github.com/user-attachments/assets/b25494ab-8ce3-49cd-b1c1-83a1fc23774b)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
