### PR TITLE
Codechange: replace atoi in console_cmds

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1133,7 +1133,8 @@ static bool ConNetworkConnect([[maybe_unused]] uint8_t argc, [[maybe_unused]] ch
 static bool ConExec([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[])
 {
 	if (argc == 0) {
-		IConsolePrint(CC_HELP, "Execute a local script file. Usage: 'exec <script> <?>'.");
+		IConsolePrint(CC_HELP, "Execute a local script file. Usage: 'exec <script> [0]'.");
+		IConsolePrint(CC_HELP, "By passing '0' after the script name, no warning about a missing script file will be shown.");
 		return true;
 	}
 
@@ -1142,7 +1143,7 @@ static bool ConExec([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[]
 	auto script_file = FioFOpenFile(argv[1], "r", BASE_DIR);
 
 	if (!script_file.has_value()) {
-		if (argc == 2 || atoi(argv[2]) != 0) IConsolePrint(CC_ERROR, "Script file '{}' not found.", argv[1]);
+		if (argc == 2 || strcmp(argv[2], "0") != 0) IConsolePrint(CC_ERROR, "Script file '{}' not found.", argv[1]);
 		return true;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

To bring console commands into C++, their internal parsing of numbers need to work with C-style strings. `atoi` doesn't support that, so use something else.

Next to that, `atoi` did not even validate a number was read, just passing in garbage did do something bug possibly not what was expected. It would be better to reject such parameters.

Finally, there's a second parameter to `exec` which by existing and not being a non-zero number disabled the message that a file could not be found. This behaviour is not mentioned in the documentation and implemented weirdly.


## Description

Replace the weird `atoi` in `exec` with a simple string comparison.

Use `ParseInteger` instead of `atoi` and show errors when there was no valid number.

Some textual changes in help messages to unify the writing of e.g. `client-id`.


## Limitations

Someone might be using the weird `exec` behaviour. I have no idea how to figure out who, besides just removing it and waiting for someone to complain.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
