### PR TITLE
Doc: Correct baseset obg file MD5 and url documentation

### DIFF
--- a/docs/obg_format.txt
+++ b/docs/obg_format.txt
@@ -16,8 +16,11 @@
 ; - `openttd -I <name>` starts OpenTTD with the given set (case sensitive)
 ; - adding `graphicsset = <name>` to the misc section of openttd.cfg makes
 ;   OpenTTD start with that graphics set by default
-; - there is a command line tool for all platforms called md5sum that can
-;   create the MD5 checksum you need.
+; - `grfid -m` can give the GRF file MD5 checksums that you need
+; - The `--md5` output option for `nmlc` can also give the MD5 if you are
+;   encoding from an nml source
+; - Simple file MD5 checksums, eg. using `md5sum` are not correct for grf
+;   container versions other than 1
 ; - all files specified in this file are search relatively to the path where
 ;   this file is found, i.e. if the graphics files are in a subdir you have
 ;   to add that subdir to the names in this file to! It will NOT search for
@@ -44,6 +47,8 @@ description.en_US = howdie
 palette      = DOS
 ; preferred blitter, optional; either 8bpp (default) or 32bpp.
 blitter      = 8bpp
+; url, optional
+url          = https://github.com/my/baseset
 
 ; The files section lists the files that replace sprites.
 ; The file names are case sensitive.


### PR DESCRIPTION
## Motivation / Problem

Documentation for baseset `obg` files has some errors and omissions:
* Simple grf file MD5 checksums are not correct for grf container versions other than 1
* There is optional `url` metadata since #11512.

## Description

Add documentation about:
* Generating grf file MD5 checksums using `grfid`
* Generating grf file MD5 checksums while encoding using `nmlc`
* Not using `md5sum` and similar tools for grf file MD5 checksums
* Optional url metadata

## Limitations

There may be other errors or omissions I haven't spotted yet...

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
