### PR TITLE
Change: Remove minimum width from advanced settings panel of Game Options window.

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1747,7 +1747,7 @@ static constexpr NWidgetPart _nested_game_options_widgets[] = {
 				EndContainer(),
 
 				NWidget(NWID_HORIZONTAL),
-					NWidget(WWT_PANEL, GAME_OPTIONS_BACKGROUND, WID_GO_OPTIONSPANEL), SetMinimalSize(400, 0), SetFill(1, 1), SetResize(1, 1), SetScrollbar(WID_GO_SCROLLBAR),
+					NWidget(WWT_PANEL, GAME_OPTIONS_BACKGROUND, WID_GO_OPTIONSPANEL), SetFill(1, 1), SetResize(1, 1), SetScrollbar(WID_GO_SCROLLBAR),
 					EndContainer(),
 					NWidget(NWID_VSCROLLBAR, GAME_OPTIONS_BACKGROUND, WID_GO_SCROLLBAR),
 				EndContainer(),


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Game Options window is wider than necessary with CJK languages due to the pixel-based minimum width of the settings panel.

This was 'necessary' previously as the standalone Advanced Settings window would have been too narrow, but the Game Options has plenty of other widgets which force the window to a suitable minimum size, with the key difference that these are sized by the content, not an arbitrary pixel size.

Previously the Game Options window was very narrow with CJK (and those users kinda got used to that I guess?):

![image](https://github.com/user-attachments/assets/c481ceb9-6e2a-4834-904a-5f164ead59ec)
![image](https://github.com/user-attachments/assets/6e5867d4-f811-490d-98d8-1c22156d5a87)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove minimum width from advanced settings panel of Game Options window.

Previous minimum width of 400 was fairly arbitrary and isn't necessary when the minimum size is suitably constrained by other widgets in the window.

This allows the window to be narrower for CJK languages. Not much changes for latin/cyrillc/greek languages which were already wider to begin with.

![image](https://github.com/user-attachments/assets/6c265357-e97d-437e-b4ad-e339d70dbb2c)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The aspect ratio of this window was intended to be on the squarer-landscape side rather than tall and narrow, but that's subjective. Adapting for CJK makes sense.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
