### PR TITLE
Change: [NewGRF] Animation-trigger 'construction stage changed' of houses and industries now also triggers at construction start.

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -763,7 +763,7 @@ static void MakeIndustryTileBigger(TileIndex tile)
 	uint8_t stage = GetIndustryConstructionStage(tile) + 1;
 	SetIndustryConstructionCounter(tile, 0);
 	SetIndustryConstructionStage(tile, stage);
-	TriggerIndustryTileAnimation(tile, IndustryAnimationTrigger::ConstructionStageChanged);
+	TriggerIndustryTileAnimation_ConstructionStageChanged(tile, false);
 	if (stage == INDUSTRY_COMPLETED) SetIndustryCompleted(tile);
 
 	MarkTileDirtyByTile(tile);
@@ -1943,6 +1943,15 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 			IndustryGfx cur_gfx = GetTranslatedIndustryTileID(it.gfx);
 			const IndustryTileSpec *its = GetIndustryTileSpec(cur_gfx);
 			if (its->animation.status != AnimationStatus::NoAnimation) AddAnimatedTile(cur_tile);
+		}
+	}
+
+	/* Call callbacks after all tiles have been created. */
+	for (TileIndex cur_tile : i->location) {
+		if (i->TileBelongsToIndustry(cur_tile)) {
+			/* There are no shared random bits, consistent with "MakeIndustryTileBigger" in tile loop.
+			 * So, trigger tiles individually */
+			TriggerIndustryTileAnimation_ConstructionStageChanged(cur_tile, true);
 		}
 	}
 

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -537,12 +537,12 @@ void AnimateNewHouseTile(TileIndex tile)
 	HouseAnimationBase::AnimateTile(hs, Town::GetByTile(tile), tile, hs->extra_flags.Test(HouseExtraFlag::Callback1ARandomBits));
 }
 
-void TriggerHouseAnimation_ConstructionStageChanged(TileIndex tile)
+void TriggerHouseAnimation_ConstructionStageChanged(TileIndex tile, bool first_call)
 {
 	const HouseSpec *hs = HouseSpec::Get(GetHouseType(tile));
 
 	if (hs->callback_mask.Test(HouseCallbackMask::AnimationTriggerConstructionStageChanged)) {
-		HouseAnimationBase::ChangeAnimationFrame(CBID_HOUSE_ANIMATION_TRIGGER_CONSTRUCTION_STAGE_CHANGED, hs, Town::GetByTile(tile), tile, 0, 0);
+		HouseAnimationBase::ChangeAnimationFrame(CBID_HOUSE_ANIMATION_TRIGGER_CONSTRUCTION_STAGE_CHANGED, hs, Town::GetByTile(tile), tile, 0, first_call ? 1 : 0);
 	}
 }
 

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -100,7 +100,7 @@ std::span<const uint> GetBuildingHouseIDCounts();
 void DrawNewHouseTile(TileInfo *ti, HouseID house_id);
 void AnimateNewHouseTile(TileIndex tile);
 /* see also: void TriggerHouseAnimation_TileLoop(TileIndex tile, uint16_t random_bits) */
-void TriggerHouseAnimation_ConstructionStageChanged(TileIndex tile);
+void TriggerHouseAnimation_ConstructionStageChanged(TileIndex tile, bool first_call);
 void TriggerHouseAnimation_WatchedCargoAccepted(TileIndex tile, CargoTypes trigger_cargoes);
 
 uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, HouseID house_id, Town *town, TileIndex tile,

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -285,8 +285,15 @@ static bool DoTriggerIndustryTileAnimation(TileIndex tile, IndustryAnimationTrig
 	return true;
 }
 
+bool TriggerIndustryTileAnimation_ConstructionStageChanged(TileIndex tile, bool first_call)
+{
+	auto iat = IndustryAnimationTrigger::ConstructionStageChanged;
+	return DoTriggerIndustryTileAnimation(tile, iat, Random(), first_call ? 0x100 : 0);
+}
+
 bool TriggerIndustryTileAnimation(TileIndex tile, IndustryAnimationTrigger iat)
 {
+	assert(iat != IndustryAnimationTrigger::ConstructionStageChanged);
 	return DoTriggerIndustryTileAnimation(tile, iat, Random());
 }
 

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -63,6 +63,7 @@ CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind
 
 void AnimateNewIndustryTile(TileIndex tile);
 bool TriggerIndustryTileAnimation(TileIndex tile, IndustryAnimationTrigger iat);
+bool TriggerIndustryTileAnimation_ConstructionStageChanged(TileIndex tile, bool first_call);
 bool TriggerIndustryAnimation(const Industry *ind, IndustryAnimationTrigger iat);
 
 void TriggerIndustryTileRandomisation(TileIndex t, IndustryRandomTrigger trigger);

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -503,7 +503,7 @@ static void AdvanceSingleHouseConstruction(TileIndex tile)
 	IncHouseConstructionTick(tile);
 	if (GetHouseConstructionTick(tile) != 0) return;
 
-	TriggerHouseAnimation_ConstructionStageChanged(tile);
+	TriggerHouseAnimation_ConstructionStageChanged(tile, false);
 
 	if (IsHouseCompleted(tile)) {
 		/* Now that construction is complete, we can add the population of the
@@ -2705,6 +2705,13 @@ static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID
 	MakeTownHouse(tile, t, construction_counter, construction_stage, house, random_bits, is_protected);
 	UpdateTownRadius(t);
 	UpdateTownGrowthRate(t);
+
+	BuildingFlags size = hs->building_flags;
+
+	TriggerHouseAnimation_ConstructionStageChanged(tile, true);
+	if (size.Any(BUILDING_2_TILES_Y)) TriggerHouseAnimation_ConstructionStageChanged(tile + TileDiffXY(0, 1), true);
+	if (size.Any(BUILDING_2_TILES_X)) TriggerHouseAnimation_ConstructionStageChanged(tile + TileDiffXY(1, 0), true);
+	if (size.Any(BUILDING_HAS_4_TILES)) TriggerHouseAnimation_ConstructionStageChanged(tile + TileDiffXY(1, 1), true);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Stations, roadstops, airports and objects have an animation-trigger on construction.

Houses and industries have a construction-stage-changed animation-trigger.
* OTTD currently does not call this when placing new houses/industries, only when the tiles grow.
* TTDP does call it when placing new houses/industries (also during mapgen), but only if also the animation-flag is set in house property 09 / industry property 0F. This is different to when the tiles grow and other animation-triggers.

Fixes #12986.
Closes #14078.
Closes #14077.

## Description

* Also raise the animation-trigger, when placing new houses/industries.
* Differ from TTDP by not checking the animation-flag, but stay consistent with all animation-triggers.
* Add flag 0x1 for houses and flag 0x100 for industries in var18, if this is the first call of the callback:
    * A common use case (e.g.#12986) is to initialise the animation-state after placing the tiles. The construction-stage variable is too complicated for this, since it can be 0 or 3.
    * During mapgen and in scenario editor, the construction-stage will be 3 on the first call.
    * During game-play, the construction-stage will be 0 on the first call.
    * Manually placed houses with the house picker can have construction-stage either 0 or 3.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
