### PR TITLE
Fix: [NewGRF] For animation-triggers which do not supply a cargo-type in var18, the var18 bits should remain empty.

### DIFF
--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -309,9 +309,9 @@ static bool DoTriggerAirportTileAnimation(Station *st, TileIndex tile, AirportAn
 	return true;
 }
 
-bool TriggerAirportTileAnimation(Station *st, TileIndex tile, AirportAnimationTrigger trigger, CargoType cargo_type)
+bool TriggerAirportTileAnimation(Station *st, TileIndex tile, AirportAnimationTrigger trigger)
 {
-	return DoTriggerAirportTileAnimation(st, tile, trigger, Random(), cargo_type << 8);
+	return DoTriggerAirportTileAnimation(st, tile, trigger, Random());
 }
 
 bool TriggerAirportAnimation(Station *st, AirportAnimationTrigger trigger, CargoType cargo_type)
@@ -323,7 +323,12 @@ bool TriggerAirportAnimation(Station *st, AirportAnimationTrigger trigger, Cargo
 	for (TileIndex tile : st->airport) {
 		if (!st->TileBelongsToAirport(tile)) continue;
 
-		if (DoTriggerAirportTileAnimation(st, tile, trigger, random, cargo_type << 8)) {
+		uint8_t var18_extra = 0;
+		if (IsValidCargoType(cargo_type)) {
+			var18_extra |= cargo_type << 8;
+		}
+
+		if (DoTriggerAirportTileAnimation(st, tile, trigger, random, var18_extra)) {
 			SB(random, 0, 16, Random());
 		} else {
 			ret = false;

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -88,7 +88,7 @@ private:
 };
 
 void AnimateAirportTile(TileIndex tile);
-bool TriggerAirportTileAnimation(Station *st, TileIndex tile, AirportAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
+bool TriggerAirportTileAnimation(Station *st, TileIndex tile, AirportAnimationTrigger trigger);
 bool TriggerAirportAnimation(Station *st, AirportAnimationTrigger trigger, CargoType cargo_type = INVALID_CARGO);
 bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts);
 

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -389,13 +389,11 @@ void TriggerRoadStopAnimation(BaseStation *st, TileIndex trigger_tile, StationAn
 	auto process_tile = [&](TileIndex cur_tile) {
 		const RoadStopSpec *ss = GetRoadStopSpec(cur_tile);
 		if (ss != nullptr && ss->animation.triggers.Test(trigger)) {
-			uint8_t local_cargo;
-			if (!IsValidCargoType(cargo_type)) {
-				local_cargo = UINT8_MAX;
-			} else {
-				local_cargo = ss->grf_prop.grffile->cargo_map[cargo_type];
+			uint8_t var18_extra = 0;
+			if (IsValidCargoType(cargo_type)) {
+				var18_extra |= ss->grf_prop.grffile->cargo_map[cargo_type] << 8;
 			}
-			RoadStopAnimationBase::ChangeAnimationFrame(CBID_STATION_ANIMATION_TRIGGER, ss, st, cur_tile, (random_bits << 16) | GB(Random(), 0, 16), to_underlying(trigger) | (local_cargo << 8));
+			RoadStopAnimationBase::ChangeAnimationFrame(CBID_STATION_ANIMATION_TRIGGER, ss, st, cur_tile, (random_bits << 16) | GB(Random(), 0, 16), to_underlying(trigger) | var18_extra);
 		}
 	};
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -923,13 +923,11 @@ void TriggerStationAnimation(BaseStation *st, TileIndex trigger_tile, StationAni
 		if (st->TileBelongsToRailStation(tile)) {
 			const StationSpec *ss = GetStationSpec(tile);
 			if (ss != nullptr && ss->animation.triggers.Test(trigger)) {
-				uint8_t local_cargo;
-				if (!IsValidCargoType(cargo_type)) {
-					local_cargo = UINT8_MAX;
-				} else {
-					local_cargo = ss->grf_prop.grffile->cargo_map[cargo_type];
+				uint8_t var18_extra = 0;
+				if (IsValidCargoType(cargo_type)) {
+					var18_extra |= ss->grf_prop.grffile->cargo_map[cargo_type] << 8;
 				}
-				StationAnimationBase::ChangeAnimationFrame(CBID_STATION_ANIMATION_TRIGGER, ss, st, tile, (random_bits << 16) | GB(Random(), 0, 16), to_underlying(trigger) | (local_cargo << 8));
+				StationAnimationBase::ChangeAnimationFrame(CBID_STATION_ANIMATION_TRIGGER, ss, st, tile, (random_bits << 16) | GB(Random(), 0, 16), to_underlying(trigger) | var18_extra);
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

* Some animation-triggers provide extra information in var18.
* Some animation-triggers of airport tiles, roadstops and stations provide a cargo-type.
* For other animation-triggers, which do not provide any cargo-type, OpenTTD still fills the bits in var18.
* This differs from both the spec and [TTDP](https://github.com/ttdpatch/ttdpatch/blob/a88a0bf794ed0f085f7cd8fba682d060ab4789c9/patches/statspri.asm#L3299).

## Description

Leave the unused bits empty, for animation-triggers without cargo-type.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
