### PR TITLE
Fix: [NewGRF] Cargo-types for airport-tile animation-triggers were not properly translated.

### DIFF
--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -325,7 +325,8 @@ bool TriggerAirportAnimation(Station *st, AirportAnimationTrigger trigger, Cargo
 
 		uint8_t var18_extra = 0;
 		if (IsValidCargoType(cargo_type)) {
-			var18_extra |= cargo_type << 8;
+			const AirportTileSpec *ats = AirportTileSpec::GetByTile(tile);
+			var18_extra |= ats->grf_prop.grffile->cargo_map[cargo_type] << 8;
 		}
 
 		if (DoTriggerAirportTileAnimation(st, tile, trigger, random, var18_extra)) {


### PR DESCRIPTION
## Motivation / Problem

* Some animation-triggers of airport tiles provide a cargo-type in var18.
* The cargo-type was passed untranslated.

## Description

* Pass the translated cargo index.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
