### PR TITLE
Add: [NewGRF] Provide random bits in var10 of house callback 1C 'construction stage changed'.

### DIFF
--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -542,7 +542,7 @@ void TriggerHouseAnimation_ConstructionStageChanged(TileIndex tile, bool first_c
 	const HouseSpec *hs = HouseSpec::Get(GetHouseType(tile));
 
 	if (hs->callback_mask.Test(HouseCallbackMask::AnimationTriggerConstructionStageChanged)) {
-		HouseAnimationBase::ChangeAnimationFrame(CBID_HOUSE_ANIMATION_TRIGGER_CONSTRUCTION_STAGE_CHANGED, hs, Town::GetByTile(tile), tile, 0, first_call ? 1 : 0);
+		HouseAnimationBase::ChangeAnimationFrame(CBID_HOUSE_ANIMATION_TRIGGER_CONSTRUCTION_STAGE_CHANGED, hs, Town::GetByTile(tile), tile, Random(), first_call ? 1 : 0);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

* All animation triggers provide random bits in var10.
* Exceptions are:
    * House trigger 'watches cargo accepts' put them into var18.
    * House trigger 'construction stage changed' provides non, var10 is empty.

## Description

* Provide random bits in var10 for trigger 'construction stage changed', like for most animation triggers.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
