### PR TITLE
Codechange: misc std::string_view changes for console commands

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1338,7 +1338,17 @@ static bool ConNewGame([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *arg
 		return true;
 	}
 
-	StartNewGameWithoutGUI((argc == 2) ? std::strtoul(argv[1], nullptr, 10) : GENERATE_NEW_SEED);
+	uint32_t seed = GENERATE_NEW_SEED;
+	if (argc >= 2) {
+		auto param = ParseInteger(argv[1]);
+		if (!param.has_value()) {
+			IConsolePrint(CC_ERROR, "The given seed must be a valid number.");
+			return true;
+		}
+		seed = *param;
+	}
+
+	StartNewGameWithoutGUI(seed);
 	return true;
 }
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1504,17 +1504,15 @@ static bool ConStartAI([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *arg
 		 * try again with the assumption everything right of the dot is
 		 * the version the user wants to load. */
 		if (!config->HasScript()) {
-			const char *e = strrchr(argv[1], '.');
-			if (e != nullptr) {
-				size_t name_length = e - argv[1];
-				e++;
-
-				auto version = ParseInteger(e);
+			StringConsumer consumer{std::string_view{argv[1]}};
+			auto name = consumer.ReadUntilChar('.', StringConsumer::SKIP_ONE_SEPARATOR);
+			if (consumer.AnyBytesLeft()) {
+				auto version = consumer.TryReadIntegerBase<uint32_t>(10);
 				if (!version.has_value()) {
 					IConsolePrint(CC_ERROR, "The version is not a valid number.");
 					return true;
 				}
-				config->Change(std::string(argv[1], name_length), *version, true);
+				config->Change(name, *version, true);
 			}
 		}
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1838,7 +1838,7 @@ static bool ConDebugLevel([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *
 	if (argc == 1) {
 		IConsolePrint(CC_DEFAULT, "Current debug-level: '{}'", GetDebugString());
 	} else {
-		SetDebugString(argv[1], [](const std::string &err) { IConsolePrint(CC_ERROR, err); });
+		SetDebugString(argv[1], [](std::string_view err) { IConsolePrint(CC_ERROR, "{}", err); });
 	}
 
 	return true;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -440,8 +440,7 @@ static bool ConSave([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[]
 	}
 
 	if (argc == 2) {
-		std::string filename = argv[1];
-		filename += ".sav";
+		std::string filename = fmt::format("{}.sav", argv[1]);
 		IConsolePrint(CC_DEFAULT, "Saving map...");
 
 		if (SaveOrLoad(filename, SLO_SAVE, DFT_GAME_FILE, SAVE_DIR) != SL_OK) {
@@ -481,7 +480,7 @@ static bool ConLoad([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[]
 
 	if (argc != 2) return false;
 
-	const char *file = argv[1];
+	std::string_view file = argv[1];
 	_console_file_list_savegame.ValidateFileList();
 	const FiosItem *item = _console_file_list_savegame.FindItem(file);
 	if (item != nullptr) {
@@ -507,7 +506,7 @@ static bool ConLoadScenario([[maybe_unused]] uint8_t argc, [[maybe_unused]] char
 
 	if (argc != 2) return false;
 
-	const char *file = argv[1];
+	std::string_view file = argv[1];
 	_console_file_list_scenario.ValidateFileList();
 	const FiosItem *item = _console_file_list_scenario.FindItem(file);
 	if (item != nullptr) {
@@ -533,7 +532,7 @@ static bool ConLoadHeightmap([[maybe_unused]] uint8_t argc, [[maybe_unused]] cha
 
 	if (argc != 2) return false;
 
-	const char *file = argv[1];
+	std::string_view file = argv[1];
 	_console_file_list_heightmap.ValidateFileList();
 	const FiosItem *item = _console_file_list_heightmap.FindItem(file);
 	if (item != nullptr) {
@@ -559,7 +558,7 @@ static bool ConRemove([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv
 
 	if (argc != 2) return false;
 
-	const char *file = argv[1];
+	std::string_view file = argv[1];
 	_console_file_list_savegame.ValidateFileList();
 	const FiosItem *item = _console_file_list_savegame.FindItem(file);
 	if (item != nullptr) {
@@ -633,7 +632,7 @@ static bool ConChangeDirectory([[maybe_unused]] uint8_t argc, [[maybe_unused]] c
 
 	if (argc != 2) return false;
 
-	const char *file = argv[1];
+	std::string_view file = argv[1];
 	_console_file_list_savegame.ValidateFileList(true);
 	const FiosItem *item = _console_file_list_savegame.FindItem(file);
 	if (item != nullptr) {
@@ -1308,7 +1307,7 @@ static bool ConEcho([[maybe_unused]] uint8_t argc, [[maybe_unused]] char *argv[]
 	}
 
 	if (argc < 2) return false;
-	IConsolePrint(CC_DEFAULT, argv[1]);
+	IConsolePrint(CC_DEFAULT, "{}", argv[1]);
 	return true;
 }
 
@@ -2190,7 +2189,7 @@ static bool ConNetworkAuthorizedKey([[maybe_unused]] uint8_t argc, [[maybe_unuse
 #include "network/network_content.h"
 
 /** Resolve a string to a content type. */
-static ContentType StringToContentType(const char *str)
+static ContentType StringToContentType(std::string_view str)
 {
 	static const std::initializer_list<std::pair<std::string_view, ContentType>> content_types = {
 		{"base",      CONTENT_TYPE_BASE_GRAPHICS},

--- a/src/debug.h
+++ b/src/debug.h
@@ -56,7 +56,8 @@ extern int _debug_random_level;
 #endif
 
 void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_iterator);
-void SetDebugString(const char *s, void (*error_func)(const std::string &));
+using SetDebugStringErrorFunc = void(std::string_view);
+void SetDebugString(std::string_view s, SetDebugStringErrorFunc error_func);
 std::string GetDebugString();
 
 /** TicToc profiling.
@@ -92,7 +93,7 @@ struct TicToc {
 	}
 };
 
-void ShowInfoI(const std::string &str);
+void ShowInfoI(std::string_view str);
 #define ShowInfo(format_string, ...) ShowInfoI(fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__))
 
 std::string GetLogPrefix(bool force = false);

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -184,7 +184,7 @@ std::string FS2OTTD(const std::string &name)
 
 #endif /* WITH_ICONV */
 
-void ShowInfoI(const std::string &str)
+void ShowInfoI(std::string_view str)
 {
 	fmt::print(stderr, "{}\n", str);
 }

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -198,7 +198,7 @@ static INT_PTR CALLBACK HelpDialogFunc(HWND wnd, UINT msg, WPARAM wParam, LPARAM
 	return FALSE;
 }
 
-void ShowInfoI(const std::string &str)
+void ShowInfoI(std::string_view str)
 {
 	if (_has_console) {
 		fmt::print(stderr, "{}\n", str);

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -20,10 +20,10 @@
 
 #include "../safeguards.h"
 
-void ScriptConfig::Change(std::optional<std::string> name, int version, bool force_exact_match)
+void ScriptConfig::Change(std::optional<std::string_view> name, int version, bool force_exact_match)
 {
 	if (name.has_value()) {
-		this->name = std::move(name.value());
+		this->name = name.value();
 		this->info = this->FindInfo(this->name, version, force_exact_match);
 	} else {
 		this->info = nullptr;
@@ -140,7 +140,7 @@ int ScriptConfig::GetVersion() const
 	return this->version;
 }
 
-void ScriptConfig::StringToSettings(const std::string &value)
+void ScriptConfig::StringToSettings(std::string_view value)
 {
 	std::string_view to_process = value;
 	for (;;) {

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -78,7 +78,7 @@ public:
 	 * @param force_exact_match If true try to find the exact same version
 	 *   as specified. If false any compatible version is ok.
 	 */
-	void Change(std::optional<std::string> name, int version = -1, bool force_exact_match = false);
+	void Change(std::optional<std::string_view> name, int version = -1, bool force_exact_match = false);
 
 	/**
 	 * Get the ScriptInfo linked to this ScriptConfig.
@@ -154,7 +154,7 @@ public:
 	 * Convert a string which is stored in the config file or savegames to
 	 *  custom settings of this Script.
 	 */
-	void StringToSettings(const std::string &value);
+	void StringToSettings(std::string_view value);
 
 	/**
 	 * Convert the custom settings to a string that can be stored in the config


### PR DESCRIPTION
## Motivation / Problem

Lots of C-style strings in the console command handling.


## Description

Use `std::string_view` or `std::string` over C-style strings in the commands.
Replace `strtoull` with `StringConsumer` and validate the seed is a valid number.
Make `SetDebugString` work with `std::string_view`.
Make `ScriptConfig::Change` and `ScriptConfig::SetStringSettings` work with `std::string_view`.

## Limitations

There's still more work to do, but small steps.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
