### PR TITLE
Fix: Focus settings filter box (only) when the tab becomes active.

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -443,7 +443,6 @@ struct GameOptionsWindow : Window {
 
 		this->querystrings[WID_GO_FILTER] = &this->filter_editbox;
 		this->filter_editbox.cancel_button = QueryString::ACTION_CLEAR;
-		this->SetFocusedWidget(WID_GO_FILTER);
 
 		this->OnInvalidateData(0);
 
@@ -773,6 +772,7 @@ struct GameOptionsWindow : Window {
 		}
 
 		this->GetWidget<NWidgetStacked>(WID_GO_TAB_SELECTION)->SetDisplayedPlane(plane);
+		if (widget == WID_GO_TAB_ADVANCED) this->SetFocusedWidget(WID_GO_FILTER);
 		this->SetDirty();
 	}
 


### PR DESCRIPTION
## Motivation / Problem

* The filter box is focused in the constructor, even if some other tab is activated. You can actually type into the hidden filter.
* The filter box is not focused, when switching to the "advanced" tab.

## Description

Focus the filter box, when switching to the "advanced" tab, and only then.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
