### PR TITLE
Add: Limit height of settings description, and add scrollbar.

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -417,6 +417,8 @@ struct GameOptionsWindow : Window {
 	int warn_lines = 0; ///< Number of lines used for warning about missing search results.
 
 	Scrollbar *vscroll;
+	Scrollbar *vscroll_description;
+	static constexpr uint NUM_DESCRIPTION_LINES = 5;
 
 	GameSettings *opt = nullptr;
 	bool reload = false;
@@ -439,6 +441,8 @@ struct GameOptionsWindow : Window {
 
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_GO_SCROLLBAR);
+		this->vscroll_description = this->GetScrollbar(WID_GO_HELP_TEXT_SCROLL);
+		this->vscroll_description->SetCapacity(NUM_DESCRIPTION_LINES);
 		this->FinishInitNested(WN_GAME_OPTIONS_GAME_OPTIONS);
 
 		this->querystrings[WID_GO_FILTER] = &this->filter_editbox;
@@ -737,7 +741,12 @@ struct GameOptionsWindow : Window {
 					DrawString(tr, GetString(STR_CONFIG_SETTING_DEFAULT_VALUE, param1, param2));
 					tr.top += GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
 
-					DrawStringMultiLine(tr, sd->GetHelp(), TC_WHITE);
+					DrawPixelInfo tmp_dpi;
+					if (FillDrawPixelInfo(&tmp_dpi, tr)) {
+						AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
+						int scrolls_pos = this->vscroll_description->GetPosition() * GetCharacterHeight(FS_NORMAL);
+						DrawStringMultiLine(0, tr.Width() - 1, -scrolls_pos, tr.Height() - 1, sd->GetHelp(), TC_WHITE);
+					}
 				}
 				break;
 
@@ -754,6 +763,13 @@ struct GameOptionsWindow : Window {
 	{
 		if (this->last_clicked != pe) this->SetDirty();
 		this->last_clicked = pe;
+		UpdateHelpTextSize();
+	}
+
+	void UpdateHelpTextSize()
+	{
+		NWidgetResizeBase *wid = this->GetWidget<NWidgetResizeBase>(WID_GO_HELP_TEXT);
+		this->vscroll_description->SetCount(this->last_clicked ? CeilDiv(this->last_clicked->GetMaxHelpHeight(wid->current_x), GetCharacterHeight(FS_NORMAL)) : 0);
 	}
 
 	void SetTab(WidgetID widget)
@@ -779,6 +795,7 @@ struct GameOptionsWindow : Window {
 	void OnResize() override
 	{
 		this->vscroll->SetCapacityFromWidget(this, WID_GO_OPTIONSPANEL, WidgetDimensions::scaled.framerect.Vertical());
+		UpdateHelpTextSize();
 
 		bool changed = false;
 
@@ -809,10 +826,6 @@ struct GameOptionsWindow : Window {
 		wid = this->GetWidget<NWidgetResizeBase>(WID_GO_VIDEO_DRIVER_INFO);
 		std::string str = GetString(STR_GAME_OPTIONS_VIDEO_DRIVER_INFO, std::string{VideoDriver::GetInstance()->GetInfoString()});
 		y = GetStringHeight(str, wid->current_x);
-		changed |= wid->UpdateVerticalSize(y);
-
-		wid = this->GetWidget<NWidgetResizeBase>(WID_GO_HELP_TEXT);
-		y = 2 * GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal + GetSettingsTree().GetMaxHelpHeight(wid->current_x);
 		changed |= wid->UpdateVerticalSize(y);
 
 		if (changed) this->ReInit(0, 0, this->flags.Test(WindowFlag::Centred));
@@ -859,6 +872,7 @@ struct GameOptionsWindow : Window {
 				for (const auto &setting_type : setting_types) {
 					size.width = std::max(size.width, GetStringBoundingBox(GetString(STR_CONFIG_SETTING_TYPE, setting_type)).width + padding.width);
 				}
+				size.height = (2 + NUM_DESCRIPTION_LINES) * GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
 				break;
 			}
 
@@ -1792,7 +1806,10 @@ static constexpr NWidgetPart _nested_game_options_widgets[] = {
 					NWidget(WWT_PUSHTXTBTN, GAME_OPTIONS_BUTTON, WID_GO_RESET_ALL), SetStringTip(STR_CONFIG_SETTING_RESET_ALL), SetFill(1, 0), SetResize(1, 0),
 				EndContainer(),
 
-				NWidget(WWT_EMPTY, INVALID_COLOUR, WID_GO_HELP_TEXT), SetFill(1, 0), SetResize(1, 0),
+				NWidget(NWID_HORIZONTAL),
+					NWidget(WWT_EMPTY, INVALID_COLOUR, WID_GO_HELP_TEXT), SetFill(1, 0), SetResize(1, 0), SetScrollbar(WID_GO_HELP_TEXT_SCROLL),
+					NWidget(NWID_VSCROLLBAR, GAME_OPTIONS_BACKGROUND, WID_GO_HELP_TEXT_SCROLL),
+				EndContainer(),
 			EndContainer(),
 		EndContainer(),
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -722,7 +722,7 @@ struct GameOptionsWindow : Window {
 				break;
 			}
 
-			case WID_GO_HELP_TEXT:
+			case WID_GO_SETTING_PROPERTIES:
 				if (this->last_clicked != nullptr) {
 					const IntSettingDesc *sd = this->last_clicked->setting;
 
@@ -739,13 +739,18 @@ struct GameOptionsWindow : Window {
 
 					auto [param1, param2] = sd->GetValueParams(sd->GetDefaultValue());
 					DrawString(tr, GetString(STR_CONFIG_SETTING_DEFAULT_VALUE, param1, param2));
-					tr.top += GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
+				}
+				break;
+
+			case WID_GO_HELP_TEXT:
+				if (this->last_clicked != nullptr) {
+					const IntSettingDesc *sd = this->last_clicked->setting;
 
 					DrawPixelInfo tmp_dpi;
-					if (FillDrawPixelInfo(&tmp_dpi, tr)) {
+					if (FillDrawPixelInfo(&tmp_dpi, r)) {
 						AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 						int scrolls_pos = this->vscroll_description->GetPosition() * GetCharacterHeight(FS_NORMAL);
-						DrawStringMultiLine(0, tr.Width() - 1, -scrolls_pos, tr.Height() - 1, sd->GetHelp(), TC_WHITE);
+						DrawStringMultiLine(0, r.Width() - 1, -scrolls_pos, r.Height() - 1, sd->GetHelp(), TC_WHITE);
 					}
 				}
 				break;
@@ -863,7 +868,7 @@ struct GameOptionsWindow : Window {
 				size.height = 8 * resize.height + WidgetDimensions::scaled.framerect.Vertical();
 				break;
 
-			case WID_GO_HELP_TEXT: {
+			case WID_GO_SETTING_PROPERTIES: {
 				static const StringID setting_types[] = {
 					STR_CONFIG_SETTING_TYPE_CLIENT,
 					STR_CONFIG_SETTING_TYPE_COMPANY_MENU, STR_CONFIG_SETTING_TYPE_COMPANY_INGAME,
@@ -872,9 +877,13 @@ struct GameOptionsWindow : Window {
 				for (const auto &setting_type : setting_types) {
 					size.width = std::max(size.width, GetStringBoundingBox(GetString(STR_CONFIG_SETTING_TYPE, setting_type)).width + padding.width);
 				}
-				size.height = (2 + NUM_DESCRIPTION_LINES) * GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
+				size.height = 2 * GetCharacterHeight(FS_NORMAL);
 				break;
 			}
+
+			case WID_GO_HELP_TEXT:
+				size.height = NUM_DESCRIPTION_LINES * GetCharacterHeight(FS_NORMAL);
+				break;
 
 			case WID_GO_RESTRICT_CATEGORY:
 			case WID_GO_RESTRICT_TYPE:
@@ -1806,6 +1815,7 @@ static constexpr NWidgetPart _nested_game_options_widgets[] = {
 					NWidget(WWT_PUSHTXTBTN, GAME_OPTIONS_BUTTON, WID_GO_RESET_ALL), SetStringTip(STR_CONFIG_SETTING_RESET_ALL), SetFill(1, 0), SetResize(1, 0),
 				EndContainer(),
 
+				NWidget(WWT_EMPTY, INVALID_COLOUR, WID_GO_SETTING_PROPERTIES), SetFill(1, 0), SetResize(1, 0),
 				NWidget(NWID_HORIZONTAL),
 					NWidget(WWT_EMPTY, INVALID_COLOUR, WID_GO_HELP_TEXT), SetFill(1, 0), SetResize(1, 0), SetScrollbar(WID_GO_HELP_TEXT_SCROLL),
 					NWidget(NWID_VSCROLLBAR, GAME_OPTIONS_BACKGROUND, WID_GO_HELP_TEXT_SCROLL),

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -75,6 +75,7 @@ enum GameOptionsWidgets : WidgetID {
 	WID_GO_OPTIONSPANEL,       ///< Panel widget containing the option lists.
 	WID_GO_SCROLLBAR,          ///< Scrollbar.
 	WID_GO_HELP_TEXT,          ///< Information area to display help text of the selected option.
+	WID_GO_HELP_TEXT_SCROLL,   ///< Scrollbar for setting description.
 	WID_GO_EXPAND_ALL,         ///< Expand all button.
 	WID_GO_COLLAPSE_ALL,       ///< Collapse all button.
 	WID_GO_RESET_ALL,          ///< Reset all button.

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -74,6 +74,7 @@ enum GameOptionsWidgets : WidgetID {
 	WID_GO_FILTER,             ///< Text filter.
 	WID_GO_OPTIONSPANEL,       ///< Panel widget containing the option lists.
 	WID_GO_SCROLLBAR,          ///< Scrollbar.
+	WID_GO_SETTING_PROPERTIES, ///< Information area to display setting type and default value.
 	WID_GO_HELP_TEXT,          ///< Information area to display help text of the selected option.
 	WID_GO_HELP_TEXT_SCROLL,   ///< Scrollbar for setting description.
 	WID_GO_EXPAND_ALL,         ///< Expand all button.


### PR DESCRIPTION
## Motivation / Problem

Many complained about the height of the settings description, noone suggested the obvious.

## Description

Use a fixed height of 5 lines for the settings description, and add a scrollbar.

Result for minimum window size:
![image](https://github.com/user-attachments/assets/66828467-d90f-49dc-83d3-567948a061b6)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
