### PR TITLE
Codechange: use std::string_view over const char *

### DIFF
--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -78,7 +78,7 @@ void NetworkAddress::SetPort(uint16_t port)
  * @param with_family Whether to add the familty to the address (e.g. IPv4).
  * @return The format string for the address.
  */
-static const char *GetAddressFormatString(uint16_t family, bool with_family)
+static std::string_view GetAddressFormatString(uint16_t family, bool with_family)
 {
 	switch (family) {
 		case AF_INET: return with_family ? "{}:{} (IPv4)" : "{}:{}";
@@ -296,8 +296,8 @@ static SOCKET ListenLoopProc(addrinfo *runp)
 
 	SOCKET sock = socket(runp->ai_family, runp->ai_socktype, runp->ai_protocol);
 	if (sock == INVALID_SOCKET) {
-		const char *type = NetworkAddress::SocketTypeAsString(runp->ai_socktype);
-		const char *family = NetworkAddress::AddressFamilyAsString(runp->ai_family);
+		std::string_view type = NetworkAddress::SocketTypeAsString(runp->ai_socktype);
+		std::string_view family = NetworkAddress::AddressFamilyAsString(runp->ai_family);
 		Debug(net, 0, "Could not create {} {} socket: {}", type, family, NetworkError::GetLast().AsString());
 		return INVALID_SOCKET;
 	}
@@ -365,7 +365,7 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
  * @return the string representation
  * @note only works for SOCK_STREAM and SOCK_DGRAM
  */
-/* static */ const char *NetworkAddress::SocketTypeAsString(int socktype)
+/* static */ std::string_view NetworkAddress::SocketTypeAsString(int socktype)
 {
 	switch (socktype) {
 		case SOCK_STREAM: return "tcp";
@@ -380,7 +380,7 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
  * @return the string representation
  * @note only works for AF_INET, AF_INET6 and AF_UNSPEC
  */
-/* static */ const char *NetworkAddress::AddressFamilyAsString(int family)
+/* static */ std::string_view NetworkAddress::AddressFamilyAsString(int family)
 {
 	switch (family) {
 		case AF_UNSPEC: return "either IPv4 or IPv6";

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -162,8 +162,8 @@ public:
 
 	void Listen(int socktype, SocketList *sockets);
 
-	static const char *SocketTypeAsString(int socktype);
-	static const char *AddressFamilyAsString(int family);
+	static std::string_view SocketTypeAsString(int socktype);
+	static std::string_view AddressFamilyAsString(int family);
 	static NetworkAddress GetPeerAddress(SOCKET sock);
 	static NetworkAddress GetSockAddress(SOCKET sock);
 	static const std::string GetPeerName(SOCKET sock);

--- a/src/network/core/config.cpp
+++ b/src/network/core/config.cpp
@@ -21,7 +21,7 @@
  * @param fallback The fallback in case the environment variable is not set.
  * @return The environment value, or when that does not exist the given fallback value.
  */
-static const char *GetEnv(const char *variable, const char *fallback)
+static std::string_view GetEnv(const char *variable, std::string_view fallback)
 {
 	const char *value = std::getenv(variable);
 	return StrEmpty(value) ? fallback : value;
@@ -32,7 +32,7 @@ static const char *GetEnv(const char *variable, const char *fallback)
  * or when it has not been set a hard coded default DNS hostname of the production server.
  * @return The game coordinator's connection string.
  */
-const char *NetworkCoordinatorConnectionString()
+std::string_view NetworkCoordinatorConnectionString()
 {
 	return GetEnv("OTTD_COORDINATOR_CS", "coordinator.openttd.org");
 }
@@ -42,7 +42,7 @@ const char *NetworkCoordinatorConnectionString()
  * or when it has not been set a hard coded default DNS hostname of the production server.
  * @return The STUN server's connection string.
  */
-const char *NetworkStunConnectionString()
+std::string_view NetworkStunConnectionString()
 {
 	return GetEnv("OTTD_STUN_CS", "stun.openttd.org");
 }
@@ -52,7 +52,7 @@ const char *NetworkStunConnectionString()
  * or when it has not been set a hard coded default DNS hostname of the production server.
  * @return The content server's connection string.
  */
-const char *NetworkContentServerConnectionString()
+std::string_view NetworkContentServerConnectionString()
 {
 	return GetEnv("OTTD_CONTENT_SERVER_CS", "content.openttd.org");
 }
@@ -62,7 +62,7 @@ const char *NetworkContentServerConnectionString()
  * or when it has not been set a hard coded URI of the production server.
  * @return The content mirror's URI string.
  */
-const char *NetworkContentMirrorUriString()
+std::string_view NetworkContentMirrorUriString()
 {
 	return GetEnv("OTTD_CONTENT_MIRROR_URI", "https://binaries.openttd.org/bananas");
 }
@@ -72,7 +72,7 @@ const char *NetworkContentMirrorUriString()
  * or when it has not been set a hard coded URI of the production server.
  * @return The survey's URI string.
  */
-const char *NetworkSurveyUriString()
+std::string_view NetworkSurveyUriString()
 {
 	return GetEnv("OTTD_SURVEY_URI", "https://survey-participate.openttd.org/");
 }

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -12,11 +12,11 @@
 #ifndef NETWORK_CORE_CONFIG_H
 #define NETWORK_CORE_CONFIG_H
 
-const char *NetworkCoordinatorConnectionString();
-const char *NetworkStunConnectionString();
-const char *NetworkContentServerConnectionString();
-const char *NetworkContentMirrorUriString();
-const char *NetworkSurveyUriString();
+std::string_view NetworkCoordinatorConnectionString();
+std::string_view NetworkStunConnectionString();
+std::string_view NetworkContentServerConnectionString();
+std::string_view NetworkContentMirrorUriString();
+std::string_view NetworkSurveyUriString();
 
 static const uint16_t NETWORK_COORDINATOR_SERVER_PORT = 3976;           ///< The default port of the Game Coordinator server (TCP)
 static const uint16_t NETWORK_STUN_SERVER_PORT        = 3975;           ///< The default port of the STUN server (TCP)

--- a/src/network/core/http.h
+++ b/src/network/core/http.h
@@ -55,7 +55,7 @@ public:
 	 * @param callback the callback to send data back on.
 	 * @param data     the data we want to send. When non-empty, this will be a POST request, otherwise a GET request.
 	 */
-	static void Connect(const std::string &uri, HTTPCallback *callback, const std::string data = "");
+	static void Connect(std::string_view uri, HTTPCallback *callback, std::string &&data = "");
 
 	/**
 	 * Do the receiving for all HTTP connections.

--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -60,10 +60,10 @@ public:
 	 * @param callback the callback to send data back on.
 	 * @param data     the data we want to send. When non-empty, this will be a POST request, otherwise a GET request.
 	 */
-	NetworkHTTPRequest(const std::string &uri, HTTPCallback *callback, const std::string &data) :
+	NetworkHTTPRequest(std::string_view uri, HTTPCallback *callback, std::string &&data) :
 		uri(uri),
 		callback(callback),
-		data(data)
+		data(std::move(data))
 	{
 		std::lock_guard<std::mutex> lock(_new_http_callback_mutex);
 		_new_http_callbacks.push_back(&this->callback);
@@ -90,7 +90,7 @@ static std::string _http_ca_file = "";
 static std::string _http_ca_path = "";
 #endif /* UNIX */
 
-/* static */ void NetworkHTTPSocketHandler::Connect(const std::string &uri, HTTPCallback *callback, const std::string data)
+/* static */ void NetworkHTTPSocketHandler::Connect(std::string_view uri, HTTPCallback *callback, std::string &&data)
 {
 #if defined(UNIX)
 	if (_http_ca_file.empty() && _http_ca_path.empty()) {
@@ -100,7 +100,7 @@ static std::string _http_ca_path = "";
 #endif /* UNIX */
 
 	std::lock_guard<std::mutex> lock(_http_mutex);
-	_http_requests.push(std::make_unique<NetworkHTTPRequest>(uri, callback, data));
+	_http_requests.push(std::make_unique<NetworkHTTPRequest>(uri, callback, std::move(data)));
 	_http_cv.notify_one();
 }
 

--- a/src/network/core/http_none.cpp
+++ b/src/network/core/http_none.cpp
@@ -18,7 +18,7 @@
 
 #include "../../safeguards.h"
 
-/* static */ void NetworkHTTPSocketHandler::Connect(const std::string &, HTTPCallback *callback, const std::string)
+/* static */ void NetworkHTTPSocketHandler::Connect(std::string_view, HTTPCallback *callback, std::string&&)
 {
 	/* No valid HTTP backend was compiled in, so we fail all HTTP requests. */
 	callback->OnFailure();

--- a/src/network/core/http_winhttp.cpp
+++ b/src/network/core/http_winhttp.cpp
@@ -37,7 +37,7 @@ private:
 	int depth = 0;                       ///< Current redirect depth we are in.
 
 public:
-	NetworkHTTPRequest(const std::wstring &uri, HTTPCallback *callback, const std::string &data);
+	NetworkHTTPRequest(std::wstring &&uri, HTTPCallback *callback, std::string &&data);
 
 	~NetworkHTTPRequest();
 
@@ -62,10 +62,10 @@ static std::mutex _new_http_callback_mutex;
  * @param callback the callback to send data back on.
  * @param data     the data we want to send. When non-empty, this will be a POST request, otherwise a GET request.
  */
-NetworkHTTPRequest::NetworkHTTPRequest(const std::wstring &uri, HTTPCallback *callback, const std::string &data) :
-	uri(uri),
+NetworkHTTPRequest::NetworkHTTPRequest(std::wstring &&uri, HTTPCallback *callback, std::string &&data) :
+	uri(std::move(uri)),
 	callback(callback),
-	data(data)
+	data(std::move(data))
 {
 	std::lock_guard<std::mutex> lock(_new_http_callback_mutex);
 	_new_http_callbacks.push_back(&this->callback);
@@ -291,9 +291,9 @@ NetworkHTTPRequest::~NetworkHTTPRequest()
 	_http_callbacks.erase(std::remove(_http_callbacks.begin(), _http_callbacks.end(), &this->callback), _http_callbacks.end());
 }
 
-/* static */ void NetworkHTTPSocketHandler::Connect(const std::string &uri, HTTPCallback *callback, const std::string data)
+/* static */ void NetworkHTTPSocketHandler::Connect(std::string_view uri, HTTPCallback *callback, std::string &&data)
 {
-	auto request = new NetworkHTTPRequest(std::wstring(uri.begin(), uri.end()), callback, data);
+	auto request = new NetworkHTTPRequest(std::wstring(uri.begin(), uri.end()), callback, std::move(data));
 	request->Connect();
 
 	std::lock_guard<std::mutex> lock(_new_http_requests_mutex);

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -106,7 +106,7 @@ enum class NewsDisplay : uint8_t {
  * Per-NewsType data
  */
 struct NewsTypeData {
-	const char * const name;    ///< Name
+	const std::string_view name; ///< Name
 	const uint8_t age;             ///< Maximum age of news items (in days)
 	const SoundFx sound;        ///< Sound
 
@@ -116,7 +116,7 @@ struct NewsTypeData {
 	 * @param age The maximum age for these messages.
 	 * @param sound The sound to play.
 	 */
-	NewsTypeData(const char *name, uint8_t age, SoundFx sound) :
+	NewsTypeData(std::string_view name, uint8_t age, SoundFx sound) :
 		name(name),
 		age(age),
 		sound(sound)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -118,8 +118,8 @@ static auto &SecretSettingTables()
 	return _secrets_setting_tables;
 }
 
-typedef void SettingDescProc(IniFile &ini, const SettingTable &desc, const char *grpname, void *object, bool only_startup);
-typedef void SettingDescProcList(IniFile &ini, const char *grpname, StringList &list);
+using SettingDescProc = void(IniFile &ini, const SettingTable &desc, std::string_view grpname, void *object, bool only_startup);
+using SettingDescProcList = void(IniFile &ini, std::string_view grpname, StringList &list);
 
 static bool IsSignedVarMemType(VarType vt)
 {
@@ -626,7 +626,7 @@ const std::string &StringSettingDesc::Read(const void *object) const
  * @param object pointer to the object been loaded
  * @param only_startup load only the startup settings set
  */
-static void IniLoadSettings(IniFile &ini, const SettingTable &settings_table, const char *grpname, void *object, bool only_startup)
+static void IniLoadSettings(IniFile &ini, const SettingTable &settings_table, std::string_view grpname, void *object, bool only_startup)
 {
 	const IniGroup *group;
 	const IniGroup *group_def = ini.GetGroup(grpname);
@@ -706,7 +706,7 @@ void ListSettingDesc::ParseValue(const IniItem *item, void *object) const
  * values are reloaded when saving). If settings indeed have changed, we get
  * these and save them.
  */
-static void IniSaveSettings(IniFile &ini, const SettingTable &settings_table, const char *grpname, void *object, bool)
+static void IniSaveSettings(IniFile &ini, const SettingTable &settings_table, std::string_view grpname, void *object, bool)
 {
 	IniGroup *group_def = nullptr, *group;
 
@@ -836,7 +836,7 @@ void ListSettingDesc::ResetToDefault(void *) const
  * @param grpname character string identifying the section-header of the ini file that will be parsed
  * @param list new list with entries of the given section
  */
-static void IniLoadSettingList(IniFile &ini, const char *grpname, StringList &list)
+static void IniLoadSettingList(IniFile &ini, std::string_view grpname, StringList &list)
 {
 	const IniGroup *group = ini.GetGroup(grpname);
 
@@ -858,7 +858,7 @@ static void IniLoadSettingList(IniFile &ini, const char *grpname, StringList &li
  * @param list pointer to an string(pointer) array that will be used as the
  *             source to be saved into the relevant ini section
  */
-static void IniSaveSettingList(IniFile &ini, const char *grpname, StringList &list)
+static void IniSaveSettingList(IniFile &ini, std::string_view grpname, StringList &list)
 {
 	IniGroup &group = ini.GetOrCreateGroup(grpname);
 	group.Clear();
@@ -874,7 +874,7 @@ static void IniSaveSettingList(IniFile &ini, const char *grpname, StringList &li
  * @param grpname character string identifying the section-header of the ini file that will be parsed
  * @param desc Destination WindowDesc
  */
-void IniLoadWindowSettings(IniFile &ini, const char *grpname, WindowDesc *desc)
+void IniLoadWindowSettings(IniFile &ini, std::string_view grpname, WindowDesc *desc)
 {
 	IniLoadSettings(ini, _window_settings, grpname, desc, false);
 }
@@ -885,7 +885,7 @@ void IniLoadWindowSettings(IniFile &ini, const char *grpname, WindowDesc *desc)
  * @param grpname character string identifying the section-header of the ini file
  * @param desc Source WindowDesc
  */
-void IniSaveWindowSettings(IniFile &ini, const char *grpname, WindowDesc *desc)
+void IniSaveWindowSettings(IniFile &ini, std::string_view grpname, WindowDesc *desc)
 {
 	IniSaveSettings(ini, _window_settings, grpname, desc, false);
 }
@@ -952,7 +952,7 @@ static void ValidateSettings()
 	}
 }
 
-static void AILoadConfig(const IniFile &ini, const char *grpname)
+static void AILoadConfig(const IniFile &ini, std::string_view grpname)
 {
 	const IniGroup *group = ini.GetGroup(grpname);
 
@@ -981,7 +981,7 @@ static void AILoadConfig(const IniFile &ini, const char *grpname)
 	}
 }
 
-static void GameLoadConfig(const IniFile &ini, const char *grpname)
+static void GameLoadConfig(const IniFile &ini, std::string_view grpname)
 {
 	const IniGroup *group = ini.GetGroup(grpname);
 
@@ -1044,7 +1044,7 @@ static void GraphicsSetLoadConfig(IniFile &ini)
  * @param grpname   Group name containing the configuration of the GRF.
  * @param is_static GRF is static.
  */
-static GRFConfigList GRFLoadConfig(const IniFile &ini, const char *grpname, bool is_static)
+static GRFConfigList GRFLoadConfig(const IniFile &ini, std::string_view grpname, bool is_static)
 {
 	const IniGroup *group = ini.GetGroup(grpname);
 	GRFConfigList list;
@@ -1165,7 +1165,7 @@ static IniFileVersion LoadVersionFromConfig(const IniFile &ini)
 	return static_cast<IniFileVersion>(version);
 }
 
-static void AISaveConfig(IniFile &ini, const char *grpname)
+static void AISaveConfig(IniFile &ini, std::string_view grpname)
 {
 	IniGroup &group = ini.GetOrCreateGroup(grpname);
 	group.Clear();
@@ -1185,7 +1185,7 @@ static void AISaveConfig(IniFile &ini, const char *grpname)
 	}
 }
 
-static void GameSaveConfig(IniFile &ini, const char *grpname)
+static void GameSaveConfig(IniFile &ini, std::string_view grpname)
 {
 	IniGroup &group = ini.GetOrCreateGroup(grpname);
 	group.Clear();
@@ -1237,7 +1237,7 @@ static void GraphicsSetSaveConfig(IniFile &ini)
 }
 
 /* Save a GRF configuration to the given group name */
-static void GRFSaveConfig(IniFile &ini, const char *grpname, const GRFConfigList &list)
+static void GRFSaveConfig(IniFile &ini, std::string_view grpname, const GRFConfigList &list)
 {
 	IniGroup &group = ini.GetOrCreateGroup(grpname);
 	group.Clear();
@@ -1547,7 +1547,7 @@ StringList GetGRFPresetList()
  * @return NewGRF configuration.
  * @see GetGRFPresetList
  */
-GRFConfigList LoadGRFPresetFromConfig(const char *config_name)
+GRFConfigList LoadGRFPresetFromConfig(std::string_view config_name)
 {
 	std::string section("preset-");
 	section += config_name;
@@ -1564,7 +1564,7 @@ GRFConfigList LoadGRFPresetFromConfig(const char *config_name)
  * @param config      NewGRF configuration to save.
  * @see GetGRFPresetList
  */
-void SaveGRFPresetToConfig(const char *config_name, GRFConfigList &config)
+void SaveGRFPresetToConfig(std::string_view config_name, GRFConfigList &config)
 {
 	std::string section("preset-");
 	section += config_name;
@@ -1578,7 +1578,7 @@ void SaveGRFPresetToConfig(const char *config_name, GRFConfigList &config)
  * Delete a NewGRF configuration by preset name.
  * @param config_name Name of the preset.
  */
-void DeleteGRFPresetFromConfig(const char *config_name)
+void DeleteGRFPresetFromConfig(std::string_view config_name)
 {
 	std::string section("preset-");
 	section += config_name;

--- a/src/settings_func.h
+++ b/src/settings_func.h
@@ -25,13 +25,13 @@ void IConsoleListSettings(std::string_view prefilter);
 void LoadFromConfig(bool minimal = false);
 void SaveToConfig();
 
-void IniLoadWindowSettings(IniFile &ini, const char *grpname, WindowDesc *desc);
-void IniSaveWindowSettings(IniFile &ini, const char *grpname, WindowDesc *desc);
+void IniLoadWindowSettings(IniFile &ini, std::string_view grpname, WindowDesc *desc);
+void IniSaveWindowSettings(IniFile &ini, std::string_view grpname, WindowDesc *desc);
 
 StringList GetGRFPresetList();
-GRFConfigList LoadGRFPresetFromConfig(const char *config_name);
-void SaveGRFPresetToConfig(const char *config_name, GRFConfigList &config);
-void DeleteGRFPresetFromConfig(const char *config_name);
+GRFConfigList LoadGRFPresetFromConfig(std::string_view config_name);
+void SaveGRFPresetToConfig(std::string_view config_name, GRFConfigList &config);
+void DeleteGRFPresetFromConfig(std::string_view config_name);
 
 void SetDefaultCompanySettings(CompanyID cid);
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1238,16 +1238,9 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 					builder += _openttd_revision;
 					break;
 
-				case SCC_RAW_STRING_POINTER: { // {RAW_STRING}
-					const char *raw_string = args.GetNextParameterString();
-					/* raw_string can be nullptr. */
-					if (raw_string == nullptr) {
-						builder += "(invalid RAW_STRING parameter)";
-						break;
-					}
-					FormatString(builder, raw_string, args);
+				case SCC_RAW_STRING_POINTER: // {RAW_STRING}
+					FormatString(builder, args.GetNextParameterString(), args);
 					break;
-				}
 
 				case SCC_STRING: {// {STRING}
 					StringID string_id = args.GetNextParameter<StringID>();

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -112,12 +112,12 @@ public:
 	 * will be read.
 	 * @return The next parameter's value.
 	 */
-	const char *GetNextParameterString()
+	std::string_view GetNextParameterString()
 	{
 		struct visitor {
-			const char *operator()(const std::monostate &) { throw std::out_of_range("Attempt to read uninitialised parameter as string"); }
-			const char *operator()(const uint64_t &) { throw std::out_of_range("Attempt to read integer parameter as string"); }
-			const char *operator()(const std::string &arg) { return arg.c_str(); }
+			std::string_view operator()(const std::monostate &) { throw std::out_of_range("Attempt to read uninitialised parameter as string"); }
+			std::string_view operator()(const uint64_t &) { throw std::out_of_range("Attempt to read integer parameter as string"); }
+			std::string_view operator()(const std::string &arg) { return arg; }
 		};
 
 		const auto &param = this->GetNextParameterReference();


### PR DESCRIPTION
## Motivation / Problem

There is still a lot of C-style string passing/handling.


## Description

Replace some cases of `const char *` with `std::string_view`.

With `GetNextStringParameter` there was code that assumes the return could be `nullptr`, but now it throws an exception in that case so it can't be `nullptr` anymore.

With the HTTP requests the `data` was passed as `std::string` meaning some copies were made. Given the data can be relatively large, prefer using `std::move`.


## Limitations

There's way more `const char *` left. I left them out to keep the PRs manageable.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
