### PR TITLE
Codechange: use std::string_view for town name generation

### DIFF
--- a/src/table/townname.h
+++ b/src/table/townname.h
@@ -9,14 +9,14 @@
 
 #include "../core/enum_type.hpp"
 
-static const char * const _name_original_english_1[] = {
+static const std::string_view _name_original_english_1[] = {
 	"Great ",
 	"Little ",
 	"New ",
 	"Fort ",
 };
 
-static const char * const _name_original_english_2[] = {
+static const std::string_view _name_original_english_2[] = {
 	"Wr",
 	"B",
 	"C",
@@ -45,7 +45,7 @@ static const char * const _name_original_english_2[] = {
 	"W",
 };
 
-static const char * const _name_original_english_3[] = {
+static const std::string_view _name_original_english_3[] = {
 	"ar",
 	"a",
 	"e",
@@ -56,7 +56,7 @@ static const char * const _name_original_english_3[] = {
 	"en",
 };
 
-static const char * const _name_original_english_4[] = {
+static const std::string_view _name_original_english_4[] = {
 	"n",
 	"ning",
 	"ding",
@@ -66,7 +66,7 @@ static const char * const _name_original_english_4[] = {
 	"fing",
 };
 
-static const char * const _name_original_english_5[] = {
+static const std::string_view _name_original_english_5[] = {
 	"ville",
 	"ham",
 	"field",
@@ -92,7 +92,7 @@ static const char * const _name_original_english_5[] = {
 	"burg",
 };
 
-static const char * const _name_original_english_6[] = {
+static const std::string_view _name_original_english_6[] = {
 	"-on-sea",
 	" Bay",
 	" Market",
@@ -104,7 +104,7 @@ static const char * const _name_original_english_6[] = {
 	" Springs",
 };
 
-static const char * const _name_additional_english_prefix[] = {
+static const std::string_view _name_additional_english_prefix[] = {
 	"Great ",
 	"Little ",
 	"New ",
@@ -113,7 +113,7 @@ static const char * const _name_additional_english_prefix[] = {
 	"Old ",
 };
 
-static const char * const _name_additional_english_1a[] = {
+static const std::string_view _name_additional_english_1a[] = {
 	"Pen",
 	"Lough",
 	"Stam",
@@ -159,7 +159,7 @@ static const char * const _name_additional_english_1a[] = {
 	"Stan",
 };
 
-static const char * const _name_additional_english_1b1[] = {
+static const std::string_view _name_additional_english_1b1[] = {
 	"Wr",
 	"B",
 	"C",
@@ -188,7 +188,7 @@ static const char * const _name_additional_english_1b1[] = {
 	"W",
 };
 
-static const char * const _name_additional_english_1b2[] = {
+static const std::string_view _name_additional_english_1b2[] = {
 	"ar",
 	"a",
 	"e",
@@ -203,7 +203,7 @@ static const char * const _name_additional_english_1b2[] = {
 	"en",
 };
 
-static const char * const _name_additional_english_1b3a[] = {
+static const std::string_view _name_additional_english_1b3a[] = {
 	"n",
 	"d",
 	"",
@@ -212,13 +212,13 @@ static const char * const _name_additional_english_1b3a[] = {
 	"",
 };
 
-static const char * const _name_additional_english_1b3b[] = {
+static const std::string_view _name_additional_english_1b3b[] = {
 	"ning",
 	"ding",
 	"fing",
 };
 
-static const char * const _name_additional_english_2[] = {
+static const std::string_view _name_additional_english_2[] = {
 	"ville",
 	"ham",
 	"field",
@@ -276,7 +276,7 @@ static const char * const _name_additional_english_2[] = {
 	"thwaite",
 };
 
-static const char * const _name_additional_english_3[] = {
+static const std::string_view _name_additional_english_3[] = {
 	"-on-sea",
 	" Bay",
 	" Market",
@@ -297,7 +297,7 @@ static const char * const _name_additional_english_3[] = {
 	" Springs",
 };
 
-static const char * const _name_austrian_a1[] = {
+static const std::string_view _name_austrian_a1[] = {
 	"Bad ",
 	"Deutsch ",
 	"Gross ",
@@ -306,7 +306,7 @@ static const char * const _name_austrian_a1[] = {
 	"Maria ",
 };
 
-static const char * const _name_austrian_a2[] = {
+static const std::string_view _name_austrian_a2[] = {
 	"Aus",
 	"Alten",
 	"Braun",
@@ -351,7 +351,7 @@ static const char * const _name_austrian_a2[] = {
 	"Weissen",
 };
 
-static const char * const _name_austrian_a3[] = {
+static const std::string_view _name_austrian_a3[] = {
 	"see",
 	"bach",
 	"dorf",
@@ -370,7 +370,7 @@ static const char * const _name_austrian_a3[] = {
 	"haag",
 };
 
-static const char * const _name_austrian_a4[] = {
+static const std::string_view _name_austrian_a4[] = {
 	"Bruck",
 	"Brunn",
 	"Gams",
@@ -385,12 +385,12 @@ static const char * const _name_austrian_a4[] = {
 	"Wald",
 };
 
-static const char * const _name_austrian_a5[] = {
+static const std::string_view _name_austrian_a5[] = {
 	"St. ",
 	"Sankt ",
 };
 
-static const char * const _name_austrian_a6[] = {
+static const std::string_view _name_austrian_a6[] = {
 	"Aegyd",
 	"Andr\u00e4",
 	"Georgen",
@@ -413,12 +413,12 @@ static const char * const _name_austrian_a6[] = {
 	"Wolfgang",
 };
 
-static const char * const _name_austrian_f1[] = {
+static const std::string_view _name_austrian_f1[] = {
 	" an der ",
 	" ob der ",
 };
 
-static const char * const _name_austrian_f2[] = {
+static const std::string_view _name_austrian_f2[] = {
 	"Donau",
 	"Steyr",
 	"Lafnitz",
@@ -434,11 +434,11 @@ static const char * const _name_austrian_f2[] = {
 	"Ill",
 };
 
-static const char * const _name_austrian_b1[] = {
+static const std::string_view _name_austrian_b1[] = {
 	" am ",
 };
 
-static const char * const _name_austrian_b2[] = {
+static const std::string_view _name_austrian_b2[] = {
 	"Brenner",
 	"Dachstein",
 	"Gebirge",
@@ -451,7 +451,7 @@ static const char * const _name_austrian_b2[] = {
 	"Ziller",
 };
 
-static const char * const _name_german_real[] = {
+static const std::string_view _name_german_real[] = {
 	"Berlin",
 	"Bonn",
 	"Bremen",
@@ -475,13 +475,13 @@ static const char * const _name_german_real[] = {
 	"Wiesbaden",
 };
 
-static const char * const _name_german_pre[] = {
+static const std::string_view _name_german_pre[] = {
 	"Bad ",
 	"Klein ",
 	"Neu ",
 };
 
-static const char * const _name_german_1[] = {
+static const std::string_view _name_german_1[] = {
 	"Alb",
 	"Als",
 	"Ander",
@@ -577,7 +577,7 @@ static const char * const _name_german_1[] = {
 	"W\u00fcrz",
 };
 
-static const char * const _name_german_2[] = {
+static const std::string_view _name_german_2[] = {
 	"bach",
 	"berg",
 	"br\u00fcck",
@@ -596,15 +596,15 @@ static const char * const _name_german_2[] = {
 	"wald",
 };
 
-static const char * const _name_german_3_an_der[] = {
+static const std::string_view _name_german_3_an_der[] = {
 	" an der ",
 };
 
-static const char * const _name_german_3_am[] = {
+static const std::string_view _name_german_3_am[] = {
 	" am ",
 };
 
-static const char * const _name_german_4_an_der[] = {
+static const std::string_view _name_german_4_an_der[] = {
 	"Oder",
 	"Spree",
 	"Donau",
@@ -612,11 +612,11 @@ static const char * const _name_german_4_an_der[] = {
 	"Elbe",
 };
 
-static const char * const _name_german_4_am[] = {
+static const std::string_view _name_german_4_am[] = {
 	"Main",
 };
 
-static const char * const _name_spanish_real[] = {
+static const std::string_view _name_spanish_real[] = {
 	"Caracas",
 	"Maracay",
 	"Maracaibo",
@@ -705,7 +705,7 @@ static const char * const _name_spanish_real[] = {
 	"Santa Rosa",
 };
 
-static const char * const _name_french_real[] = {
+static const std::string_view _name_french_real[] = {
 	"Agincourt",
 	"Lille",
 	"Dinan",
@@ -778,7 +778,7 @@ static const char * const _name_french_real[] = {
 	"Alen\u00e7on",
 };
 
-static const char * const _name_silly_1[] = {
+static const std::string_view _name_silly_1[] = {
 	"Binky",
 	"Blubber",
 	"Bumble",
@@ -869,7 +869,7 @@ static const char * const _name_silly_1[] = {
 	"Griddle",
 };
 
-static const char * const _name_silly_2[] = {
+static const std::string_view _name_silly_2[] = {
 	"ton",
 	"bury",
 	"bottom",
@@ -887,14 +887,14 @@ static const char * const _name_silly_2[] = {
 	"bridge",
 };
 
-static const char * const _name_swedish_1[] = {
+static const std::string_view _name_swedish_1[] = {
 	"Gamla ",
 	"Lilla ",
 	"Nya ",
 	"Stora ",
 };
 
-static const char * const _name_swedish_2[] = {
+static const std::string_view _name_swedish_2[] = {
 	"Boll",
 	"Bor",
 	"Ed",
@@ -935,7 +935,7 @@ static const char * const _name_swedish_2[] = {
 	"\u00d6ster",
 };
 
-static const char * const _name_swedish_2a[] = {
+static const std::string_view _name_swedish_2a[] = {
 	"B",
 	"Br",
 	"D",
@@ -980,7 +980,7 @@ static const char * const _name_swedish_2a[] = {
 	"Vr",
 };
 
-static const char * const _name_swedish_2b[] = {
+static const std::string_view _name_swedish_2b[] = {
 	"a",
 	"e",
 	"i",
@@ -992,7 +992,7 @@ static const char * const _name_swedish_2b[] = {
 	"\u00f6",
 };
 
-static const char * const _name_swedish_2c[] = {
+static const std::string_view _name_swedish_2c[] = {
 	"ck",
 	"d",
 	"dd",
@@ -1021,7 +1021,7 @@ static const char * const _name_swedish_2c[] = {
 	"v",
 };
 
-static const char * const _name_swedish_3[] = {
+static const std::string_view _name_swedish_3[] = {
 	"arp",
 	"berg",
 	"boda",
@@ -1056,7 +1056,7 @@ static const char * const _name_swedish_3[] = {
 	"\u00e5s",
 };
 
-static const char * const _name_dutch_1[] = {
+static const std::string_view _name_dutch_1[] = {
 	"Nieuw ",
 	"Oud ",
 	"Groot ",
@@ -1067,7 +1067,7 @@ static const char * const _name_dutch_1[] = {
 	"Klein ",
 };
 
-static const char * const _name_dutch_2[] = {
+static const std::string_view _name_dutch_2[] = {
 	"Hoog",
 	"Laag",
 	"Zuider",
@@ -1123,7 +1123,7 @@ static const char * const _name_dutch_2[] = {
 	"Hil",
 };
 
-static const char * const _name_dutch_3[] = {
+static const std::string_view _name_dutch_3[] = {
 	"Drog",
 	"Nat",
 	"Valk",
@@ -1146,7 +1146,7 @@ static const char * const _name_dutch_3[] = {
 	"Koning",
 };
 
-static const char * const _name_dutch_4[] = {
+static const std::string_view _name_dutch_4[] = {
 	"e",
 	"er",
 	"el",
@@ -1155,7 +1155,7 @@ static const char * const _name_dutch_4[] = {
 	"s",
 };
 
-static const char * const _name_dutch_5[] = {
+static const std::string_view _name_dutch_5[] = {
 	"stad",
 	"vorst",
 	"dorp",
@@ -1214,7 +1214,7 @@ static const char * const _name_dutch_5[] = {
 	"end",
 };
 
-static const char * const _name_finnish_real[] = {
+static const std::string_view _name_finnish_real[] = {
 	"Aijala",
 	"Kisko",
 	"Espoo",
@@ -1248,7 +1248,7 @@ static const char * const _name_finnish_real[] = {
 	"Lieksa",
 };
 
-static const char * const _name_finnish_1[] = {
+static const std::string_view _name_finnish_1[] = {
 	"Hiekka",
 	"Haapa",
 	"Mylly",
@@ -1278,7 +1278,7 @@ static const char * const _name_finnish_1[] = {
 	"Niini",
 };
 
-static const char * const _name_finnish_2[] = {
+static const std::string_view _name_finnish_2[] = {
 	"Lappeen",
 	"Lohjan",
 	"Savon",
@@ -1292,7 +1292,7 @@ static const char * const _name_finnish_2[] = {
 	"Kangas",
 };
 
-static const char * const _name_finnish_3[] = {
+static const std::string_view _name_finnish_3[] = {
 	"harju",
 	"linna",
 	"j\u00e4rvi",
@@ -1314,7 +1314,7 @@ static const char * const _name_finnish_3[] = {
 	"salo",
 };
 
-static const char * const _name_polish_1_m[] = {
+static const std::string_view _name_polish_1_m[] = {
 	"Wielki ",
 	"Ma\u0142y ",
 	"Z\u0142y ",
@@ -1328,7 +1328,7 @@ static const char * const _name_polish_1_m[] = {
 	"D\u0119bowy ",
 };
 
-static const char * const _name_polish_1_f[] = {
+static const std::string_view _name_polish_1_f[] = {
 	"Wielka ",
 	"Ma\u0142a ",
 	"Z\u0142a ",
@@ -1342,7 +1342,7 @@ static const char * const _name_polish_1_f[] = {
 	"D\u0119bowa ",
 };
 
-static const char * const _name_polish_1_n[] = {
+static const std::string_view _name_polish_1_n[] = {
 	"Wielkie ",
 	"Ma\u0142e ",
 	"Z\u0142e ",
@@ -1356,7 +1356,7 @@ static const char * const _name_polish_1_n[] = {
 	"D\u0119bowe ",
 };
 
-static const char * const _name_polish_2_o[] = {
+static const std::string_view _name_polish_2_o[] = {
 	"Frombork",
 	"Gniezno",
 	"Olsztyn",
@@ -1393,7 +1393,7 @@ static const char * const _name_polish_2_o[] = {
 	"Wolsztyn",
 };
 
-static const char * const _name_polish_2_m[] = {
+static const std::string_view _name_polish_2_m[] = {
 	"Jarocin",
 	"Gogolin",
 	"Tomasz\u00f3w",
@@ -1444,7 +1444,7 @@ static const char * const _name_polish_2_m[] = {
 	"Garwolin",
 };
 
-static const char * const _name_polish_2_f[] = {
+static const std::string_view _name_polish_2_f[] = {
 	"Szprotawa",
 	"Pogorzelica",
 	"Mot\u0142awa",
@@ -1475,7 +1475,7 @@ static const char * const _name_polish_2_f[] = {
 	"Pilawa",
 };
 
-static const char * const _name_polish_2_n[] = {
+static const std::string_view _name_polish_2_n[] = {
 	"Lipsko",
 	"Pilzno",
 	"Przodkowo",
@@ -1508,7 +1508,7 @@ static const char * const _name_polish_2_n[] = {
 	"Opoczno",
 };
 
-static const char * const _name_polish_3_m[] = {
+static const std::string_view _name_polish_3_m[] = {
 	" Wybudowanie",
 	" \u015awi\u0119tokrzyski",
 	" G\u00f3rski",
@@ -1540,7 +1540,7 @@ static const char * const _name_polish_3_m[] = {
 	" Lesny",
 };
 
-static const char * const _name_polish_3_f[] = {
+static const std::string_view _name_polish_3_f[] = {
 	" Wybudowanie",
 	" \u015awi\u0119tokrzyska",
 	" G\u00f3rska",
@@ -1572,7 +1572,7 @@ static const char * const _name_polish_3_f[] = {
 	" Le\u015bna",
 };
 
-static const char * const _name_polish_3_n[] = {
+static const std::string_view _name_polish_3_n[] = {
 	" Wybudowanie",
 	" \u015awietokrzyskie",
 	" G\u00f3rskie",
@@ -1604,7 +1604,7 @@ static const char * const _name_polish_3_n[] = {
 	" Le\u015bne",
 };
 
-static const char * const _name_czech_real[] = {
+static const std::string_view _name_czech_real[] = {
 	"A\u0161",
 	"Bene\u0161ov",
 	"Beroun",
@@ -1716,7 +1716,7 @@ enum CzechPattern : uint8_t {
 };
 
 /* [CzechGender][CzechPattern] - suffixes for adjectives */
-static const char * const _name_czech_patmod[][3] = {
+static const std::string_view _name_czech_patmod[][3] = {
 	/* CZG_SMASC */ { "\u00ed", "\u00fd", "uv" },
 	/* CZG_SFEM */  { "\u00ed", "\u00e1", "ova" },
 	/* CZG_SNEUT */ { "\u00ed", "\u00e9", "ovo" },
@@ -1752,13 +1752,13 @@ struct CzechNameSubst {
 	CzechGender gender;
 	CzechAllowFlags allow;
 	CzechChooseFlags choose;
-	const char *name;
+	std::string_view name;
 };
 
 struct CzechNameAdj {
 	CzechPattern pattern;
 	CzechChooseFlags choose;
-	const char *name;
+	std::string_view name;
 };
 
 /* Some of items which should be common are doubled. */
@@ -1880,7 +1880,7 @@ static const CzechNameSubst _name_czech_subst_stem[] = {
 };
 
 /* Optional postfix inserted between stem and ending. */
-static const char * const _name_czech_subst_postfix[] = {
+static const std::string_view _name_czech_subst_postfix[] = {
 	"av", "an", "at",
 	"ov", "on", "ot",
 	"ev", "en", "et",
@@ -1910,7 +1910,7 @@ static const CzechNameSubst _name_czech_subst_ending[] = {
 	{ CZG_SNEUT, {                                               CzechAllowFlag::Long}, CZC_ANY, "i\u0161t\u011b" },
 };
 
-static const char * const _name_czech_suffix[] = {
+static const std::string_view _name_czech_suffix[] = {
 	"nad Cidlinou",
 	"nad Dyj\u00ed",
 	"nad Jihlavou",
@@ -1934,7 +1934,7 @@ static const char * const _name_czech_suffix[] = {
 
 
 
-static const char * const _name_romanian_real[] = {
+static const std::string_view _name_romanian_real[] = {
 	"Adjud",
 	"Alba Iulia",
 	"Alexandria",
@@ -2031,7 +2031,7 @@ static const char * const _name_romanian_real[] = {
 	"Zal\u0103u",
 };
 
-static const char * const _name_slovak_real[] = {
+static const std::string_view _name_slovak_real[] = {
 	"Bratislava",
 	"B\u00e1novce nad Bebravou",
 	"Bansk\u00e1 Bystrica",
@@ -2121,7 +2121,7 @@ static const char * const _name_slovak_real[] = {
 	"Zvolen",
 };
 
-static const char * const _name_norwegian_1[] = {
+static const std::string_view _name_norwegian_1[] = {
 	"Arna",
 	"Aust",
 	"Bj\u00f8rk",
@@ -2208,7 +2208,7 @@ static const char * const _name_norwegian_1[] = {
 	"V\u00e5g",
 };
 
-static const char * const _name_norwegian_2[] = {
+static const std::string_view _name_norwegian_2[] = {
 	"aker",
 	"anger",
 	"bakken",
@@ -2278,7 +2278,7 @@ static const char * const _name_norwegian_2[] = {
 	"\u00e5sen",
 };
 
-static const char * const _name_norwegian_real[] = {
+static const std::string_view _name_norwegian_real[] = {
 	"Alta",
 	"Arendal",
 	"Askim",
@@ -2375,7 +2375,7 @@ static const char * const _name_norwegian_real[] = {
 	"\u00c5ndalsnes",
 };
 
-static const char * const _name_hungarian_1[] = {
+static const std::string_view _name_hungarian_1[] = {
 	"Nagy-",
 	"Kis-",
 	"Fels\u0151-",
@@ -2383,7 +2383,7 @@ static const char * const _name_hungarian_1[] = {
 	"\u00daj-",
 };
 
-static const char * const _name_hungarian_2[] = {
+static const std::string_view _name_hungarian_2[] = {
 	"Bodrog",
 	"Dr\u00e1va",
 	"Duna",
@@ -2440,7 +2440,7 @@ static const char * const _name_hungarian_2[] = {
 	"V\u00e1s\u00e1ros",
 };
 
-static const char * const _name_hungarian_3[] = {
+static const std::string_view _name_hungarian_3[] = {
 	"ap\u00e1ti",
 	"b\u00e1ba",
 	"bikk",
@@ -2459,7 +2459,7 @@ static const char * const _name_hungarian_3[] = {
 	"v\u00f6lgy",
 };
 
-static const char * const _name_hungarian_4[] = {
+static const std::string_view _name_hungarian_4[] = {
 	"alja",
 	"egyh\u00e1za",
 	"h\u00e1za",
@@ -2467,7 +2467,7 @@ static const char * const _name_hungarian_4[] = {
 	"v\u00e1r",
 };
 
-static const char * const _name_hungarian_real[] = {
+static const std::string_view _name_hungarian_real[] = {
 	"Ajka",
 	"Asz\u00f3d",
 	"Badacsony",
@@ -2506,7 +2506,7 @@ static const char * const _name_hungarian_real[] = {
 	"Zirc",
 };
 
-static const char * const _name_swiss_real[] = {
+static const std::string_view _name_swiss_real[] = {
 	"Aarau",
 	"Aesch",
 	"Altdorf",
@@ -2632,7 +2632,7 @@ static const char * const _name_swiss_real[] = {
 	"Zug",
 };
 
-static const char * const _name_danish_1[] = {
+static const std::string_view _name_danish_1[] = {
 	"Gamle ",
 	"Lille ",
 	"Nye ",
@@ -2647,7 +2647,7 @@ static const char * const _name_danish_1[] = {
 	"Kongens ",
 };
 
-static const char * const _name_danish_2[] = {
+static const std::string_view _name_danish_2[] = {
 	"Ager",
 	"Alle",
 	"Aske",
@@ -2731,7 +2731,7 @@ static const char * const _name_danish_2[] = {
 	"\u00c5l",
 };
 
-static const char * const _name_danish_3[] = {
+static const std::string_view _name_danish_3[] = {
 	"basse",
 	"borg",
 	"berg",
@@ -2764,7 +2764,7 @@ static const char * const _name_danish_3[] = {
 	"skov",
 };
 
-static const char * const _name_turkish_prefix[] = {
+static const std::string_view _name_turkish_prefix[] = {
 	"Ak\u00e7a",
 	"Alt\u0131n",
 	"Bah\u00e7e",
@@ -2783,7 +2783,7 @@ static const char * const _name_turkish_prefix[] = {
 	"Yeni",
 };
 
-static const char * const _name_turkish_middle[] = {
+static const std::string_view _name_turkish_middle[] = {
 	"aga\u00e7",
 	"ayva",
 	"\u00e7am",
@@ -2793,7 +2793,7 @@ static const char * const _name_turkish_middle[] = {
 	"yal\u0131",
 };
 
-static const char * const _name_turkish_suffix[] = {
+static const std::string_view _name_turkish_suffix[] = {
 	"dere",
 	"hisar",
 	"kale",
@@ -2810,7 +2810,7 @@ static const char * const _name_turkish_suffix[] = {
 	"yurt",
 };
 
-static const char * const _name_turkish_real[] = {
+static const std::string_view _name_turkish_real[] = {
 	"Adana",
 	"Ad\u0131yaman",
 	"Afyon",
@@ -2878,7 +2878,7 @@ static const char * const _name_turkish_real[] = {
 	"D\u00fczce",
 };
 
-static const char * const _name_italian_real[] = {
+static const std::string_view _name_italian_real[] = {
 	"Roma",
 	"Milano",
 	"Napoli",
@@ -2959,7 +2959,7 @@ static const char * const _name_italian_real[] = {
 	"Grosseto",
 };
 
-static const char * const _name_italian_pref[] = {
+static const std::string_view _name_italian_pref[] = {
 	"Alpe ",
 	"Borgo ",
 	"Cascina ",
@@ -2974,7 +2974,7 @@ static const char * const _name_italian_pref[] = {
 	"Villar ",
 };
 
-static const char * const _name_italian_1m[] = {
+static const std::string_view _name_italian_1m[] = {
 	"Bel",
 	"Borgo",
 	"Bosco",
@@ -3002,7 +3002,7 @@ static const char * const _name_italian_1m[] = {
 	"Vico",
 };
 
-static const char * const _name_italian_1f[] = {
+static const std::string_view _name_italian_1f[] = {
 	"Acqua",
 	"Bra",
 	"Cala",
@@ -3028,7 +3028,7 @@ static const char * const _name_italian_1f[] = {
 	"Villa",
 };
 
-static const char * const _name_italian_2[] = {
+static const std::string_view _name_italian_2[] = {
 	"bell",
 	"bianc",
 	"cald",
@@ -3058,7 +3058,7 @@ static const char * const _name_italian_2[] = {
 	"viv",
 };
 
-static const char * const _name_italian_2i[] = {
+static const std::string_view _name_italian_2i[] = {
 	"",
 	"breve",
 	"brevi",
@@ -3085,7 +3085,7 @@ static const char * const _name_italian_2i[] = {
 };
 
 
-static const char * const _name_italian_3[] = {
+static const std::string_view _name_italian_3[] = {
 	" Marittimo",
 	" Marittima",
 	" del Capo",
@@ -3109,14 +3109,14 @@ static const char * const _name_italian_3[] = {
 	" Ticino",
 };
 
-static const char * const _name_italian_river1[] = {
+static const std::string_view _name_italian_river1[] = {
 	" del",
 	" sul",
 	" al",
 	" nel",
 };
 
-static const char * const _name_italian_river2[] = {
+static const std::string_view _name_italian_river2[] = {
 	"l'Adda",
 	"l'Adige",
 	"le Alpi",
@@ -3144,7 +3144,7 @@ static const char * const _name_italian_river2[] = {
 	" Tevere",
 };
 
-static const char * const _name_catalan_real[] = {
+static const std::string_view _name_catalan_real[] = {
 	"Barcelona",
 	"L'Hospitalet de Llobregat",
 	"Cerdanyola",
@@ -3214,7 +3214,7 @@ static const char * const _name_catalan_real[] = {
 	"Roses",
 };
 
-static const char * const _name_catalan_pref[] = {
+static const std::string_view _name_catalan_pref[] = {
 	"El Pont de ",
 	"Parets de ",
 	"Canet de ",
@@ -3249,7 +3249,7 @@ static const char * const _name_catalan_pref[] = {
 
 };
 
-static const char * const _name_catalan_1m[] = {
+static const std::string_view _name_catalan_1m[] = {
 	"Torrent",
 	"Cami",
 	"Mont",
@@ -3258,7 +3258,7 @@ static const char * const _name_catalan_1m[] = {
 	"Riu",
 };
 
-static const char * const _name_catalan_1f[] = {
+static const std::string_view _name_catalan_1f[] = {
 	"Pala",
 	"Selva",
 	"Vall",
@@ -3269,7 +3269,7 @@ static const char * const _name_catalan_1f[] = {
 	"Terra",
 };
 
-static const char * const _name_catalan_2m[] = {
+static const std::string_view _name_catalan_2m[] = {
 	"alt",
 	"baix",
 	"fosc",
@@ -3280,7 +3280,7 @@ static const char * const _name_catalan_2m[] = {
 	"gr\u00eds",
 };
 
-static const char * const _name_catalan_2f[] = {
+static const std::string_view _name_catalan_2f[] = {
 	"baixa",
 	"alta",
 	"fosca",
@@ -3291,7 +3291,7 @@ static const char * const _name_catalan_2f[] = {
 	"freda",
 };
 
-static const char * const _name_catalan_3[] = {
+static const std::string_view _name_catalan_3[] = {
 	" Desp\u00ed",
 	" Desvern",
 	" del Cam\u00ed",
@@ -3304,7 +3304,7 @@ static const char * const _name_catalan_3[] = {
 	" de la Plana",
 };
 
-static const char * const _name_catalan_river1[] = {
+static const std::string_view _name_catalan_river1[] = {
 	" d'Anoia",
 	" de Ter",
 	" de Llobregat",

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -702,11 +702,11 @@ static void MakeCzechTownName(StringBuilder &builder, uint32_t seed)
 	if (dynamic_subst) {
 		builder += _name_czech_subst_stem[stem].name;
 		if (postfix < std::size(_name_czech_subst_postfix)) {
-			const char *poststr = _name_czech_subst_postfix[postfix];
-			const char *endstr = _name_czech_subst_ending[ending].name;
+			std::string_view poststr = _name_czech_subst_postfix[postfix];
+			std::string_view endstr = _name_czech_subst_ending[ending].name;
 
-			size_t postlen = strlen(poststr);
-			size_t endlen = strlen(endstr);
+			size_t postlen = poststr.size();
+			size_t endlen = endstr.size();
 			assert(postlen > 0 && endlen > 0);
 
 			/* Kill the "avava" and "Jananna"-like cases */
@@ -884,7 +884,7 @@ static void MakeItalianTownName(StringBuilder &builder, uint32_t seed)
 		return;
 	}
 
-	static const char * const mascul_femin_italian[] = {
+	static std::string_view const mascul_femin_italian[] = {
 		"o",
 		"a",
 	};


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

Basically replace 'const char *' in town name generation with `std::string_view`.
And a few `strlen(str)` -> `str.size()`.


## Limitations

More C-style strings exist, but lets keep chipping them away slowly.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
