### PR TITLE
Fix: Road vehicle blocking and train collissions used slightly inconsistent distance thresholds.

### DIFF
--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -234,7 +234,7 @@ struct Rect {
 	inline bool Contains(const Point &pt) const
 	{
 		/* This is a local version of IsInsideMM, to avoid including math_func everywhere. */
-		return (uint)(pt.x - this->left) < (uint)(this->right - this->left) && (uint)(pt.y - this->top) < (uint)(this->bottom - this->top);
+		return (uint)(pt.x - this->left) <= (uint)(this->right - this->left) && (uint)(pt.y - this->top) <= (uint)(this->bottom - this->top);
 	}
 };
 

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -553,9 +553,8 @@ static bool RoadVehCheckTrainCrash(RoadVehicle *v)
 
 		if (!IsLevelCrossingTile(tile)) continue;
 
-		if (HasVehicleNearTileXY(v->x_pos, v->y_pos, 6, [&u](const Vehicle *t) {
-				return t->type == VEH_TRAIN && abs(t->z_pos - u->z_pos) <= 6 &&
-					abs(t->x_pos - u->x_pos) <= 4 && abs(t->y_pos - u->y_pos) <= 4;
+		if (HasVehicleNearTileXY(v->x_pos, v->y_pos, 4, [&u](const Vehicle *t) {
+				return t->type == VEH_TRAIN && abs(t->z_pos - u->z_pos) <= 6;
 			})) {
 			RoadVehCrash(v);
 			return true;
@@ -649,7 +648,7 @@ static RoadVehicle *RoadVehFindCloseTo(RoadVehicle *v, int x, int y, Direction d
 			FindClosestBlockingRoadVeh(u, &rvf);
 		}
 	} else {
-		for (Vehicle *u : VehiclesNearTileXY(x, y, 6)) {
+		for (Vehicle *u : VehiclesNearTileXY(x, y, 8)) {
 			FindClosestBlockingRoadVeh(u, &rvf);
 		}
 	}

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -553,7 +553,7 @@ static bool RoadVehCheckTrainCrash(RoadVehicle *v)
 
 		if (!IsLevelCrossingTile(tile)) continue;
 
-		if (HasVehicleNearTileXY(v->x_pos, v->y_pos, [&u](const Vehicle *t) {
+		if (HasVehicleNearTileXY(v->x_pos, v->y_pos, 6, [&u](const Vehicle *t) {
 				return t->type == VEH_TRAIN && abs(t->z_pos - u->z_pos) <= 6 &&
 					abs(t->x_pos - u->x_pos) <= 4 && abs(t->y_pos - u->y_pos) <= 4;
 			})) {
@@ -649,7 +649,7 @@ static RoadVehicle *RoadVehFindCloseTo(RoadVehicle *v, int x, int y, Direction d
 			FindClosestBlockingRoadVeh(u, &rvf);
 		}
 	} else {
-		for (Vehicle *u : VehiclesNearTileXY(x, y)) {
+		for (Vehicle *u : VehiclesNearTileXY(x, y, 6)) {
 			FindClosestBlockingRoadVeh(u, &rvf);
 		}
 	}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3228,7 +3228,7 @@ static bool CheckTrainCollision(Train *v)
 			num_victims += CheckTrainCollision(u, v);
 		}
 	} else {
-		for (Vehicle *u : VehiclesNearTileXY(v->x_pos, v->y_pos, 6)) {
+		for (Vehicle *u : VehiclesNearTileXY(v->x_pos, v->y_pos, 7)) {
 			num_victims += CheckTrainCollision(u, v);
 		}
 	}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3228,7 +3228,7 @@ static bool CheckTrainCollision(Train *v)
 			num_victims += CheckTrainCollision(u, v);
 		}
 	} else {
-		for (Vehicle *u : VehiclesNearTileXY(v->x_pos, v->y_pos)) {
+		for (Vehicle *u : VehiclesNearTileXY(v->x_pos, v->y_pos, 6)) {
 			num_victims += CheckTrainCollision(u, v);
 		}
 	}

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -432,10 +432,11 @@ static std::array<Vehicle *, TOTAL_TILE_HASH_SIZE> _vehicle_tile_hash{};
 VehiclesNearTileXY::Iterator::Iterator(int32_t x, int32_t y)
 {
 	const int COLL_DIST = 6;
-	pos_rect.left = x - COLL_DIST;
-	pos_rect.right = x + COLL_DIST;
-	pos_rect.top = y - COLL_DIST;
-	pos_rect.bottom = y + COLL_DIST;
+	/* There are no negative tile coordinates */
+	pos_rect.left = std::max<int>(0, x - COLL_DIST);
+	pos_rect.right = std::max<int>(0, x + COLL_DIST);
+	pos_rect.top = std::max<int>(0, y - COLL_DIST);
+	pos_rect.bottom = std::max<int>(0, y + COLL_DIST);
 
 	/* Hash area to scan */
 	this->hxmin = this->hx = GetTileHash1D(pos_rect.left / TILE_SIZE);

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -129,7 +129,7 @@ public:
 		using pointer = void;
 		using reference = void;
 
-		explicit Iterator(int32_t x, int32_t y);
+		explicit Iterator(int32_t x, int32_t y, uint max_dist);
 
 		bool operator==(const Iterator &rhs) const { return this->current_veh == rhs.current_veh; }
 		bool operator==(const std::default_sentinel_t &) const { return this->current_veh == nullptr; }
@@ -160,7 +160,7 @@ public:
 		void SkipFalseMatches();
 	};
 
-	explicit VehiclesNearTileXY(int32_t x, int32_t y) : start(x, y) {}
+	explicit VehiclesNearTileXY(int32_t x, int32_t y, uint max_dist) : start(x, y, max_dist) {}
 	Iterator begin() const { return this->start; }
 	std::default_sentinel_t end() const { return std::default_sentinel_t(); }
 private:
@@ -173,9 +173,9 @@ private:
  * @warning This only works for vehicles with proper Vehicle::Tile, so only ground vehicles outside wormholes.
  */
 template <class UnaryPred>
-bool HasVehicleNearTileXY(int32_t x, int32_t y, UnaryPred &&predicate)
+bool HasVehicleNearTileXY(int32_t x, int32_t y, uint max_dist, UnaryPred &&predicate)
 {
-	for (const auto *v : VehiclesNearTileXY(x, y)) {
+	for (const auto *v : VehiclesNearTileXY(x, y, max_dist)) {
 		if (predicate(v)) return true;
 	}
 	return false;

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -139,6 +139,7 @@ public:
 		Iterator &operator++()
 		{
 			this->Increment();
+			this->SkipFalseMatches();
 			return *this;
 		}
 
@@ -149,12 +150,14 @@ public:
 			return result;
 		}
 	private:
+		Rect pos_rect;
 		uint hxmin, hxmax, hymin, hymax;
 		uint hx, hy;
 		Vehicle *current_veh;
 
 		void Increment();
 		void SkipEmptyBuckets();
+		void SkipFalseMatches();
 	};
 
 	explicit VehiclesNearTileXY(int32_t x, int32_t y) : start(x, y) {}


### PR DESCRIPTION
## Motivation / Problem

* `VehiclesNearTileXY` used a fixed world-coordinate-distance of 6 to select tiles, which may have blocking road vehicles or colliding trains.
* `VehiclesNearTileXY` would then yield all vehicles on those tiles, and other tiles with the same hash. So it would also yield vehicles with far greater distance than 6.
* The usages of `VehiclesNearTileXY` however need vehicles with other distances than 6.
    * Roadvehicle-train crash: The threshold is distance 4. It was checked separately, so no behavior change here.
    * Roadvehicle-roadvehicle blocking: The threshold distance in `FindClosestBlockingRoadVeh` is up to 8. Depending on the exact position of the road vehicles on tiles, they would block each other at different distance between 6 an 8.
    * Train-train collision: The threshold distance in `CheckTrainCollision` is up to 7. Depending on the exact position of the trains on the tiles, they would collide at different distances between 6 and 7.

## Description

* Fix an OBIWAN in `Rect::Contains`. It was only used to check button-clicks of the two cheat buttons in the industry GUI, so noone relied on the buggy behavior.
* Check vehicle distance before yielding them from `VehiclesNearTileXY`.
* Clamp the search area to positive world coordinates. There are no negative tile coordinates, and the hash bucket selection would not handle them anyway.
* Make the search distance a parameter to `VehiclesNearTileXY`.
* Adjust the search distances to the callers' requirements.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
