### PR TITLE
Codefix: checking unsigned int >= 0 is pointless, check before subtraction

### DIFF
--- a/src/roadstop.cpp
+++ b/src/roadstop.cpp
@@ -268,8 +268,8 @@ bool RoadStop::Enter(RoadVehicle *rv)
  */
 void RoadStop::Entry::Leave(const RoadVehicle *rv)
 {
+	assert(this->occupied >= rv->gcache.cached_total_length);
 	this->occupied -= rv->gcache.cached_total_length;
-	assert(this->occupied >= 0);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

CodeQL: 'Pointless comparison of unsigned value to zero.'


## Description

Instead of checking the result of subtraction for >= 0, check that what will be subtracted to the value that is subtracted from.


## Limitations

None I know of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
