### PR TITLE
Codechange: Use enums as keys to spritegroups in GRFFileProps.

### DIFF
--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -74,13 +74,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	uint16_t list_position = 0;
 
 	/* NewGRF related data */
-	/**
-	 * Properties related the the grf file.
-	 * NUM_CARGO real cargo plus two pseudo cargo sprite groups.
-	 * Used for obtaining the sprite offset of custom sprites, and for
-	 * evaluating callbacks.
-	 */
-	VariableGRFFileProps grf_prop{};
+	CargoGRFFileProps grf_prop{}; ///< Link to NewGRF
 	std::vector<WagonOverride> overrides{};
 	std::vector<BadgeID> badges{};
 

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -92,6 +92,7 @@ enum GrfSpecFeature : uint8_t {
 	GSF_BADGES,
 	GSF_END,
 
+	GSF_DEFAULT = GSF_END, ///< Unspecified feature, default badge
 	GSF_FAKE_TOWNS = GSF_END, ///< Fake town GrfSpecFeature for NewGRF debugging (parent scope)
 	GSF_FAKE_END,             ///< End of the fake features
 

--- a/src/newgrf/newgrf_act3.cpp
+++ b/src/newgrf/newgrf_act3.cpp
@@ -36,8 +36,8 @@
 static CargoType TranslateCargo(uint8_t feature, uint8_t ctype)
 {
 	/* Special cargo types for purchase list and stations */
-	if ((feature == GSF_STATIONS || feature == GSF_ROADSTOPS) && ctype == 0xFE) return SpriteGroupCargo::SG_DEFAULT_NA;
-	if (ctype == 0xFF) return SpriteGroupCargo::SG_PURCHASE;
+	if ((feature == GSF_STATIONS || feature == GSF_ROADSTOPS) && ctype == 0xFE) return CargoGRFFileProps::SG_DEFAULT_NA;
+	if (ctype == 0xFF) return CargoGRFFileProps::SG_PURCHASE;
 
 	auto cargo_list = GetCargoTranslationTable(*_cur_gps.grffile);
 
@@ -145,9 +145,9 @@ static void VehicleMapSpriteGroup(ByteReader &buf, uint8_t feature, uint8_t idco
 		EngineID engine = engines[i];
 
 		if (wagover) {
-			SetWagonOverrideSprites(engine, SpriteGroupCargo::SG_DEFAULT, _cur_gps.spritegroups[groupid], last_engines);
+			SetWagonOverrideSprites(engine, CargoGRFFileProps::SG_DEFAULT, _cur_gps.spritegroups[groupid], last_engines);
 		} else {
-			SetCustomEngineSprites(engine, SpriteGroupCargo::SG_DEFAULT, _cur_gps.spritegroups[groupid]);
+			SetCustomEngineSprites(engine, CargoGRFFileProps::SG_DEFAULT, _cur_gps.spritegroups[groupid]);
 			SetEngineGRF(engine, _cur_gps.grffile);
 		}
 	}
@@ -199,8 +199,8 @@ static void StationMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		uint16_t groupid = buf.ReadWord();
 		if (!IsValidGroupID(groupid, "StationMapSpriteGroup")) continue;
 
-		ctype = TranslateCargo(GSF_STATIONS, ctype);
-		if (!IsValidCargoType(ctype)) continue;
+		CargoType cargo_type = TranslateCargo(GSF_STATIONS, ctype);
+		if (!IsValidCargoType(cargo_type)) continue;
 
 		for (auto &station : stations) {
 			StationSpec *statspec = station >= _cur_gps.grffile->stations.size() ? nullptr : _cur_gps.grffile->stations[station].get();
@@ -210,7 +210,7 @@ static void StationMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 				continue;
 			}
 
-			statspec->grf_prop.SetSpriteGroup(ctype, _cur_gps.spritegroups[groupid]);
+			statspec->grf_prop.SetSpriteGroup(cargo_type, _cur_gps.spritegroups[groupid]);
 		}
 	}
 
@@ -230,7 +230,7 @@ static void StationMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		statspec->grf_prop.SetSpriteGroup(SpriteGroupCargo::SG_DEFAULT, _cur_gps.spritegroups[groupid]);
+		statspec->grf_prop.SetSpriteGroup(CargoGRFFileProps::SG_DEFAULT, _cur_gps.spritegroups[groupid]);
 		statspec->grf_prop.SetGRFFile(_cur_gps.grffile);
 		statspec->grf_prop.local_id = station;
 		StationClass::Assign(statspec);
@@ -569,8 +569,8 @@ static void RoadStopMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		uint16_t groupid = buf.ReadWord();
 		if (!IsValidGroupID(groupid, "RoadStopMapSpriteGroup")) continue;
 
-		ctype = TranslateCargo(GSF_ROADSTOPS, ctype);
-		if (!IsValidCargoType(ctype)) continue;
+		CargoType cargo_type = TranslateCargo(GSF_ROADSTOPS, ctype);
+		if (!IsValidCargoType(cargo_type)) continue;
 
 		for (auto &roadstop : roadstops) {
 			RoadStopSpec *roadstopspec = roadstop >= _cur_gps.grffile->roadstops.size() ? nullptr : _cur_gps.grffile->roadstops[roadstop].get();
@@ -580,7 +580,7 @@ static void RoadStopMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 				continue;
 			}
 
-			roadstopspec->grf_prop.SetSpriteGroup(ctype, _cur_gps.spritegroups[groupid]);
+			roadstopspec->grf_prop.SetSpriteGroup(cargo_type, _cur_gps.spritegroups[groupid]);
 		}
 	}
 
@@ -600,7 +600,7 @@ static void RoadStopMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		roadstopspec->grf_prop.SetSpriteGroup(SpriteGroupCargo::SG_DEFAULT, _cur_gps.spritegroups[groupid]);
+		roadstopspec->grf_prop.SetSpriteGroup(CargoGRFFileProps::SG_DEFAULT, _cur_gps.spritegroups[groupid]);
 		roadstopspec->grf_prop.SetGRFFile(_cur_gps.grffile);
 		roadstopspec->grf_prop.local_id = roadstop;
 		RoadStopClass::Assign(roadstopspec);
@@ -636,7 +636,7 @@ static void BadgeMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			}
 
 			auto &badge = *GetBadge(found->second);
-			badge.grf_prop.SetSpriteGroup(ctype, _cur_gps.spritegroups[groupid]);
+			badge.grf_prop.SetSpriteGroup(static_cast<GrfSpecFeature>(ctype), _cur_gps.spritegroups[groupid]);
 		}
 	}
 

--- a/src/newgrf/newgrf_act3.cpp
+++ b/src/newgrf/newgrf_act3.cpp
@@ -266,7 +266,7 @@ static void TownHouseMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		hs->grf_prop.SetSpriteGroup(0, _cur_gps.spritegroups[groupid]);
+		hs->grf_prop.SetSpriteGroup(_cur_gps.spritegroups[groupid]);
 	}
 }
 
@@ -298,7 +298,7 @@ static void IndustryMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		indsp->grf_prop.SetSpriteGroup(0, _cur_gps.spritegroups[groupid]);
+		indsp->grf_prop.SetSpriteGroup(_cur_gps.spritegroups[groupid]);
 	}
 }
 
@@ -330,7 +330,7 @@ static void IndustrytileMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		indtsp->grf_prop.SetSpriteGroup(0, _cur_gps.spritegroups[groupid]);
+		indtsp->grf_prop.SetSpriteGroup(_cur_gps.spritegroups[groupid]);
 	}
 }
 
@@ -514,7 +514,7 @@ static void AirportMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		as->grf_prop.SetSpriteGroup(0, _cur_gps.spritegroups[groupid]);
+		as->grf_prop.SetSpriteGroup(_cur_gps.spritegroups[groupid]);
 	}
 }
 
@@ -546,7 +546,7 @@ static void AirportTileMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		airtsp->grf_prop.SetSpriteGroup(0, _cur_gps.spritegroups[groupid]);
+		airtsp->grf_prop.SetSpriteGroup(_cur_gps.spritegroups[groupid]);
 	}
 }
 

--- a/src/newgrf/newgrf_act3.cpp
+++ b/src/newgrf/newgrf_act3.cpp
@@ -651,7 +651,7 @@ static void BadgeMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		}
 
 		auto &badge = *GetBadge(found->second);
-		badge.grf_prop.SetSpriteGroup(GSF_END, _cur_gps.spritegroups[groupid]);
+		badge.grf_prop.SetSpriteGroup(GSF_DEFAULT, _cur_gps.spritegroups[groupid]);
 		badge.grf_prop.SetGRFFile(_cur_gps.grffile);
 		badge.grf_prop.local_id = local_id;
 	}

--- a/src/newgrf/newgrf_act3.cpp
+++ b/src/newgrf/newgrf_act3.cpp
@@ -394,7 +394,7 @@ static void ObjectMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 				continue;
 			}
 
-			spec->grf_prop.SetSpriteGroup(OBJECT_SPRITE_GROUP_PURCHASE, _cur_gps.spritegroups[groupid]);
+			spec->grf_prop.SetSpriteGroup(StandardSpriteGroup::Purchase, _cur_gps.spritegroups[groupid]);
 		}
 	}
 
@@ -414,7 +414,7 @@ static void ObjectMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 			continue;
 		}
 
-		spec->grf_prop.SetSpriteGroup(OBJECT_SPRITE_GROUP_DEFAULT, _cur_gps.spritegroups[groupid]);
+		spec->grf_prop.SetSpriteGroup(StandardSpriteGroup::Default, _cur_gps.spritegroups[groupid]);
 		spec->grf_prop.SetGRFFile(_cur_gps.grffile);
 		spec->grf_prop.local_id = object;
 	}

--- a/src/newgrf_badge.cpp
+++ b/src/newgrf_badge.cpp
@@ -204,7 +204,7 @@ BadgeResolverObject::BadgeResolverObject(const Badge &badge, GrfSpecFeature feat
 {
 	assert(feature <= GSF_END);
 	this->root_spritegroup = this->self_scope.badge.grf_prop.GetSpriteGroup(feature);
-	if (this->root_spritegroup == nullptr) this->root_spritegroup = this->self_scope.badge.grf_prop.GetSpriteGroup(GSF_END);
+	if (this->root_spritegroup == nullptr) this->root_spritegroup = this->self_scope.badge.grf_prop.GetSpriteGroup(GSF_DEFAULT);
 }
 
 /**

--- a/src/newgrf_badge.h
+++ b/src/newgrf_badge.h
@@ -24,7 +24,7 @@ public:
 	BadgeFlags flags = {}; ///< Display flags
 	StringID name = 0; ///< Short name.
 	GrfSpecFeatures features{}; ///< Bitmask of which features use this badge.
-	VariableGRFFileProps grf_prop; ///< Sprite information.
+	VariableGRFFileProps<GrfSpecFeature> grf_prop; ///< Sprite information.
 
 	Badge(std::string_view label, BadgeID index, BadgeClassID class_index) : label(label), index(index), class_index(class_index) {}
 };

--- a/src/newgrf_cargo.h
+++ b/src/newgrf_cargo.h
@@ -14,17 +14,6 @@
 #include "cargo_type.h"
 #include "gfx_type.h"
 
-/**
- * Sprite Group Cargo types.
- * These special cargo types are used when resolving sprite groups when non-cargo-specific sprites or callbacks are needed,
- * e.g. in purchase lists, or if no specific cargo type sprite group is supplied.
- */
-namespace SpriteGroupCargo {
-	static constexpr CargoType SG_DEFAULT    = NUM_CARGO;     ///< Default type used when no more-specific cargo matches.
-	static constexpr CargoType SG_PURCHASE   = NUM_CARGO + 1; ///< Used in purchase lists before an item exists.
-	static constexpr CargoType SG_DEFAULT_NA = NUM_CARGO + 2; ///< Used only by stations and roads when no more-specific cargo matches.
-};
-
 /* Forward declarations of structs used */
 struct CargoSpec;
 struct GRFFile;

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -740,30 +740,3 @@ void GRFFilePropsBase::SetGRFFile(const struct GRFFile *grffile)
 	this->grffile = grffile;
 	this->grfid = grffile == nullptr ? 0 : grffile->grfid;
 }
-
-/**
- * Get the SpriteGroup at the specified index.
- * @param index Index to get.
- * @returns SpriteGroup at index, or nullptr if not present.
- */
-const SpriteGroup *VariableGRFFileProps::GetSpriteGroup(size_t index) const
-{
-	auto it = std::ranges::lower_bound(this->spritegroups, index, std::less{}, &CargoSpriteGroup::first);
-	if (it == std::end(this->spritegroups) || it->first != index) return nullptr;
-	return it->second;
-}
-
-/**
- * Set the SpriteGroup at the specified index.
- * @param index Index to set.
- * @param spritegroup SpriteGroup to set.
- */
-void VariableGRFFileProps::SetSpriteGroup(size_t index, const SpriteGroup *spritegroup)
-{
-	auto it = std::ranges::lower_bound(this->spritegroups, index, std::less{}, &CargoSpriteGroup::first);
-	if (it == std::end(this->spritegroups) || it->first != index) {
-		this->spritegroups.emplace(it, index, spritegroup);
-	} else {
-		it->second = spritegroup;
-	}
-}

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -306,9 +306,10 @@ struct GRFFilePropsBase {
 
 /**
  * Fixed-length list of sprite groups for an entity.
+ * @tparam Tkey Key for indexing spritegroups
  * @tparam Tcount Number of spritegroups
  */
-template <size_t Tcount>
+template <class Tkey, size_t Tcount>
 struct FixedGRFFileProps : GRFFilePropsBase {
 	std::array<const struct SpriteGroup *, Tcount> spritegroups{}; ///< pointers to the different sprite groups of the entity
 
@@ -317,14 +318,14 @@ struct FixedGRFFileProps : GRFFilePropsBase {
 	 * @param index Index to get.
 	 * @returns SpriteGroup at index, or nullptr if not present.
 	 */
-	const struct SpriteGroup *GetSpriteGroup(size_t index = 0) const { return this->spritegroups[index]; }
+	const struct SpriteGroup *GetSpriteGroup(Tkey index) const { return this->spritegroups[static_cast<size_t>(index)]; }
 
 	/**
 	 * Set the SpriteGroup at the specified index.
 	 * @param index Index to set.
 	 * @param spritegroup SpriteGroup to set.
 	 */
-	void SetSpriteGroup(size_t index, const struct SpriteGroup *spritegroup) { this->spritegroups[index] = spritegroup; }
+	void SetSpriteGroup(Tkey index, const struct SpriteGroup *spritegroup) { this->spritegroups[static_cast<size_t>(index)] = spritegroup; }
 };
 
 /**
@@ -336,6 +337,16 @@ struct SingleGRFFileProps : GRFFilePropsBase {
 	const struct SpriteGroup *GetSpriteGroup() const { return this->spritegroup; }
 	void SetSpriteGroup(const struct SpriteGroup *spritegroup) { this->spritegroup = spritegroup; }
 };
+
+/**
+ * Standard sprite groups.
+ */
+enum class StandardSpriteGroup {
+	Default, ///< Default type used when no more-specific group matches.
+	Purchase, ///< Used before an entity exists.
+	End
+};
+using StandardGRFFileProps = FixedGRFFileProps<StandardSpriteGroup, static_cast<size_t>(StandardSpriteGroup::End)>;
 
 /**
  * Variable-length list of sprite groups for an entity.

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -328,6 +328,16 @@ struct FixedGRFFileProps : GRFFilePropsBase {
 };
 
 /**
+ * Entities with single sprite group.
+ */
+struct SingleGRFFileProps : GRFFilePropsBase {
+	const struct SpriteGroup *spritegroup;
+
+	const struct SpriteGroup *GetSpriteGroup() const { return this->spritegroup; }
+	void SetSpriteGroup(const struct SpriteGroup *spritegroup) { this->spritegroup = spritegroup; }
+};
+
+/**
  * Variable-length list of sprite groups for an entity.
  * @tparam Tkey Key for indexing spritegroups
  */
@@ -374,7 +384,7 @@ struct CargoGRFFileProps : VariableGRFFileProps<CargoType> {
 };
 
 /** Data related to the handling of grf files. */
-struct GRFFileProps : FixedGRFFileProps<1> {
+struct GRFFileProps : SingleGRFFileProps {
 	/** Set all default data constructor for the props. */
 	constexpr GRFFileProps(uint16_t subst_id = 0) : subst_id(subst_id), override_id(subst_id) {}
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -45,7 +45,7 @@ const SpriteGroup *GetWagonOverrideSpriteSet(EngineID engine, CargoType cargo, E
 	const Engine *e = Engine::Get(engine);
 
 	for (const WagonOverride &wo : e->overrides) {
-		if (wo.cargo != cargo && wo.cargo != SpriteGroupCargo::SG_DEFAULT) continue;
+		if (wo.cargo != cargo && wo.cargo != CargoGRFFileProps::SG_DEFAULT) continue;
 		if (std::ranges::find(wo.engines, overriding_engine) != wo.engines.end()) return wo.group;
 	}
 	return nullptr;
@@ -1068,7 +1068,7 @@ VehicleResolverObject::VehicleResolverObject(EngineID engine_type, const Vehicle
 	cached_relative_count(0)
 {
 	if (wagon_override == WO_SELF) {
-		this->root_spritegroup = GetWagonOverrideSpriteSet(engine_type, SpriteGroupCargo::SG_DEFAULT, engine_type);
+		this->root_spritegroup = GetWagonOverrideSpriteSet(engine_type, CargoGRFFileProps::SG_DEFAULT, engine_type);
 	} else {
 		if (wagon_override != WO_NONE && v != nullptr && v->IsGroundVehicle()) {
 			assert(v->engine_type == engine_type); // overrides make little sense with fake scopes
@@ -1085,9 +1085,9 @@ VehicleResolverObject::VehicleResolverObject(EngineID engine_type, const Vehicle
 
 		if (this->root_spritegroup == nullptr) {
 			const Engine *e = Engine::Get(engine_type);
-			CargoType cargo = v != nullptr ? v->cargo_type : SpriteGroupCargo::SG_PURCHASE;
+			CargoType cargo = v != nullptr ? v->cargo_type : CargoGRFFileProps::SG_PURCHASE;
 			this->root_spritegroup = e->grf_prop.GetSpriteGroup(cargo);
-			if (this->root_spritegroup == nullptr) this->root_spritegroup = e->grf_prop.GetSpriteGroup(SpriteGroupCargo::SG_DEFAULT);
+			if (this->root_spritegroup == nullptr) this->root_spritegroup = e->grf_prop.GetSpriteGroup(CargoGRFFileProps::SG_DEFAULT);
 		}
 	}
 }

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -386,8 +386,8 @@ ObjectResolverObject::ObjectResolverObject(const ObjectSpec *spec, Object *obj, 
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), object_scope(*this, obj, spec, tile, view)
 {
-	this->root_spritegroup = (obj == nullptr) ? spec->grf_prop.GetSpriteGroup(OBJECT_SPRITE_GROUP_PURCHASE) : nullptr;
-	if (this->root_spritegroup == nullptr) this->root_spritegroup = spec->grf_prop.GetSpriteGroup(OBJECT_SPRITE_GROUP_DEFAULT);
+	this->root_spritegroup = (obj == nullptr) ? spec->grf_prop.GetSpriteGroup(StandardSpriteGroup::Purchase) : nullptr;
+	if (this->root_spritegroup == nullptr) this->root_spritegroup = spec->grf_prop.GetSpriteGroup(StandardSpriteGroup::Default);
 }
 
 /**

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -58,8 +58,7 @@ DECLARE_INCREMENT_DECREMENT_OPERATORS(ObjectClassID)
  * default objects in table/object_land.h
  */
 struct ObjectSpec : NewGRFSpecBase<ObjectClassID> {
-	/* 2 because of the "normal" and "buy" sprite stacks. */
-	FixedGRFFileProps<2> grf_prop; ///< Properties related the the grf file
+	StandardGRFFileProps grf_prop; ///< Properties related the the grf file
 	/* Animation speed default differs from other features */
 	AnimationInfo<ObjectAnimationTriggers> animation{0, AnimationStatus::NoAnimation, 0, {}};  ///< Information about the animation.
 	StringID name;                ///< The name for this object.
@@ -165,9 +164,6 @@ private:
 
 /** Class containing information relating to object classes. */
 using ObjectClass = NewGRFClass<ObjectSpec, ObjectClassID, OBJECT_CLASS_MAX>;
-
-static const size_t OBJECT_SPRITE_GROUP_DEFAULT = 0;
-static const size_t OBJECT_SPRITE_GROUP_PURCHASE = 1;
 
 uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2, const ObjectSpec *spec, Object *o, TileIndex tile, uint8_t view = 0);
 

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -228,11 +228,11 @@ RoadStopResolverObject::RoadStopResolverObject(const RoadStopSpec *roadstopspec,
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: SpecializedResolverObject<StationRandomTriggers>(roadstopspec->grf_prop.grffile, callback, param1, param2), roadstop_scope(*this, st, roadstopspec, tile, roadtype, type, view)
 {
-	CargoType ctype = SpriteGroupCargo::SG_DEFAULT_NA;
+	CargoType ctype = CargoGRFFileProps::SG_DEFAULT_NA;
 
 	if (st == nullptr) {
 		/* No station, so we are in a purchase list */
-		ctype = SpriteGroupCargo::SG_PURCHASE;
+		ctype = CargoGRFFileProps::SG_PURCHASE;
 		this->root_spritegroup = roadstopspec->grf_prop.GetSpriteGroup(ctype);
 	} else if (Station::IsExpected(st)) {
 		const Station *station = Station::From(st);
@@ -246,13 +246,13 @@ RoadStopResolverObject::RoadStopResolverObject(const RoadStopSpec *roadstopspec,
 		}
 
 		if (this->root_spritegroup == nullptr) {
-			ctype = SpriteGroupCargo::SG_DEFAULT_NA;
+			ctype = CargoGRFFileProps::SG_DEFAULT_NA;
 			this->root_spritegroup = roadstopspec->grf_prop.GetSpriteGroup(ctype);
 		}
 	}
 
 	if (this->root_spritegroup == nullptr) {
-		ctype = SpriteGroupCargo::SG_DEFAULT;
+		ctype = CargoGRFFileProps::SG_DEFAULT;
 		this->root_spritegroup = roadstopspec->grf_prop.GetSpriteGroup(ctype);
 	}
 

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -126,13 +126,7 @@ struct RoadStopResolverObject : public SpecializedResolverObject<StationRandomTr
 
 /** Road stop specification. */
 struct RoadStopSpec : NewGRFSpecBase<RoadStopClassID> {
-	/**
-	 * Properties related the the grf file.
-	 * NUM_CARGO real cargo plus three pseudo cargo sprite groups.
-	 * Used for obtaining the sprite offset of custom sprites, and for
-	 * evaluating callbacks.
-	 */
-	VariableGRFFileProps grf_prop;
+	CargoGRFFileProps grf_prop; ///< Link to NewGRF
 	StringID name;              ///< Name of this stop
 
 	RoadStopAvailabilityType stop_type = ROADSTOPTYPE_ALL;

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -530,12 +530,12 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 
 	switch (this->station_scope.cargo_type) {
 		case INVALID_CARGO:
-		case SpriteGroupCargo::SG_DEFAULT_NA:
-		case SpriteGroupCargo::SG_PURCHASE:
+		case CargoGRFFileProps::SG_DEFAULT_NA:
+		case CargoGRFFileProps::SG_PURCHASE:
 			cargo = 0;
 			break;
 
-		case SpriteGroupCargo::SG_DEFAULT:
+		case CargoGRFFileProps::SG_DEFAULT:
 			for (const GoodsEntry &ge : st->goods) {
 				if (!ge.HasData()) continue;
 				cargo += ge.GetData().cargo.TotalCount();
@@ -594,11 +594,11 @@ StationResolverObject::StationResolverObject(const StationSpec *statspec, BaseSt
 	/* Invalidate all cached vars */
 	_svc.valid = 0;
 
-	CargoType ctype = SpriteGroupCargo::SG_DEFAULT_NA;
+	CargoType ctype = CargoGRFFileProps::SG_DEFAULT_NA;
 
 	if (this->station_scope.st == nullptr) {
 		/* No station, so we are in a purchase list */
-		ctype = SpriteGroupCargo::SG_PURCHASE;
+		ctype = CargoGRFFileProps::SG_PURCHASE;
 		this->root_spritegroup = statspec->grf_prop.GetSpriteGroup(ctype);
 	} else if (Station::IsExpected(this->station_scope.st)) {
 		const Station *st = Station::From(this->station_scope.st);
@@ -612,14 +612,14 @@ StationResolverObject::StationResolverObject(const StationSpec *statspec, BaseSt
 		}
 
 		if (this->root_spritegroup == nullptr) {
-			ctype = SpriteGroupCargo::SG_DEFAULT_NA;
+			ctype = CargoGRFFileProps::SG_DEFAULT_NA;
 			this->root_spritegroup = statspec->grf_prop.GetSpriteGroup(ctype);
 		}
 	}
 
 
 	if (this->root_spritegroup == nullptr) {
-		ctype = SpriteGroupCargo::SG_DEFAULT;
+		ctype = CargoGRFFileProps::SG_DEFAULT;
 		this->root_spritegroup = statspec->grf_prop.GetSpriteGroup(ctype);
 	}
 

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -110,13 +110,8 @@ struct StationSpec : NewGRFSpecBase<StationClassID> {
 		cargo_threshold(0), cargo_triggers(0),
 		callback_mask(0), flags(0)
 	{}
-	/**
-	 * Properties related the the grf file.
-	 * NUM_CARGO real cargo plus three pseudo cargo sprite groups.
-	 * Used for obtaining the sprite offset of custom sprites, and for
-	 * evaluating callbacks.
-	 */
-	VariableGRFFileProps grf_prop;
+
+	CargoGRFFileProps grf_prop; ///< Link to NewGRF
 	StringID name;             ///< Name of this station.
 
 	/**

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -106,7 +106,7 @@ static const DrawTileSpriteSpan _object_hq[] = {
 #undef TILE_SPRITE_LINE
 #undef TILE_SPRITE_LINE_NOTHING
 
-#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, FixedGRFFileProps<2>{}, AnimationInfo<ObjectAnimationTriggers>{}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, TimerGameCalendar::Date{}, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount, {}}
+#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, StandardGRFFileProps{}, AnimationInfo<ObjectAnimationTriggers>{}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, TimerGameCalendar::Date{}, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount, {}}
 
 /* Climates
  * T = Temperate


### PR DESCRIPTION
## Motivation / Problem

* There are a number of GRFFileProp classes to hold the root sprite groups of some NewGRF entity.
* The sprite groups are currently indexed with plain integers.

## Description

Use enum (classes) to index the sprite groups.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
