### PR TITLE
Codechange: Simplify usage of GRFFileProps by adding some common helper methods.

### DIFF
--- a/src/house.h
+++ b/src/house.h
@@ -106,7 +106,7 @@ struct HouseSpec {
 	bool enabled;                             ///< the house is available to build (true by default, but can be disabled by newgrf)
 
 	/* NewHouses properties */
-	GRFFileProps grf_prop;                    ///< Properties related the the grf file
+	SubstituteGRFFileProps grf_prop; ///< Properties related the the grf file
 	HouseCallbackMasks callback_mask;                     ///< Bitmask of house callbacks that have to be called
 	Colours random_colour[4];                 ///< 4 "random" colours
 	uint8_t probability;                         ///< Relative probability of appearing (16 is the standard value)

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -336,7 +336,7 @@ static void DrawTile_Industry(TileInfo *ti)
 		 * DrawNewIndustry will return false if ever the resolver could not
 		 * find any sprite to display.  So in this case, we will jump on the
 		 * substitute gfx instead. */
-		if (indts->grf_prop.GetSpriteGroup() != nullptr && DrawNewIndustryTile(ti, ind, gfx, indts)) {
+		if (indts->grf_prop.HasSpriteGroups() && DrawNewIndustryTile(ti, ind, gfx, indts)) {
 			return;
 		} else {
 			/* No sprite group (or no valid one) found, meaning no graphics associated.
@@ -405,7 +405,7 @@ static Foundation GetFoundation_Industry(TileIndex tile, Slope tileh)
 	 */
 	if (gfx >= NEW_INDUSTRYTILEOFFSET) {
 		const IndustryTileSpec *indts = GetIndustryTileSpec(gfx);
-		if (indts->grf_prop.GetSpriteGroup() != nullptr && indts->callback_mask.Test(IndustryTileCallbackMask::DrawFoundations)) {
+		if (indts->callback_mask.Test(IndustryTileCallbackMask::DrawFoundations)) {
 			uint32_t callback_res = GetIndustryTileCallback(CBID_INDTILE_DRAW_FOUNDATIONS, 0, 0, gfx, Industry::GetByTile(tile), tile);
 			if (callback_res != CALLBACK_FAILED && !ConvertBooleanCallback(indts->grf_prop.grffile, CBID_INDTILE_DRAW_FOUNDATIONS, callback_res)) return FOUNDATION_NONE;
 		}

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -131,7 +131,7 @@ struct IndustrySpec {
 	/* Newgrf data */
 	IndustryCallbackMasks callback_mask;                       ///< Bitmask of industry callbacks that have to be called
 	bool enabled;                               ///< entity still available (by default true).newgrf can disable it, though
-	GRFFileProps grf_prop;                      ///< properties related to the grf file
+	SubstituteGRFFileProps grf_prop; ///< properties related to the grf file
 	std::vector<uint8_t> random_sounds; ///< Random sounds;
 	std::vector<BadgeID> badges;
 
@@ -165,7 +165,7 @@ struct IndustryTileSpec {
 	AnimationInfo<IndustryAnimationTriggers> animation; ///< Information about the animation (is it looping, how many loops etc)
 	IndustryTileSpecialFlags special_flags; ///< Bitmask of extra flags used by the tile
 	bool enabled;                         ///< entity still available (by default true).newgrf can disable it, though
-	GRFFileProps grf_prop;                ///< properties related to the grf file
+	SubstituteGRFFileProps grf_prop; ///< properties related to the grf file
 	std::vector<BadgeID> badges;
 
 	std::array<std::variant<CargoLabel, MixedCargoType>, INDUSTRY_ORIGINAL_NUM_INPUTS> accepts_cargo_label; ///< Cargo labels of accepted cargo for default industry tiles.

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -119,7 +119,7 @@ struct AirportSpec : NewGRFSpecBase<AirportClassID> {
 	uint16_t maintenance_cost;               ///< maintenance cost multiplier
 	/* Newgrf data */
 	bool enabled;                          ///< Entity still available (by default true). Newgrf can disable it, though.
-	struct GRFFileProps grf_prop;          ///< Properties related to the grf file.
+	SubstituteGRFFileProps grf_prop; ///< Properties related to the grf file.
 	std::vector<BadgeID> badges;
 
 	static const AirportSpec *Get(uint8_t type);

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -150,7 +150,7 @@ static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint
 		}
 	}
 	/* Not an 'old type' tile */
-	if (ats->grf_prop.GetSpriteGroup() != nullptr) { // tile has a spritegroup ?
+	if (ats->grf_prop.HasSpriteGroups()) {
 		if (ats->grf_prop.grfid == cur_grfid) { // same airport, same grf ?
 			return ats->grf_prop.local_id;
 		} else {

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -73,7 +73,7 @@ struct AirportTileSpec {
 	AirportTileCallbackMasks callback_mask;                  ///< Bitmask telling which grf callback is set
 	uint8_t animation_special_flags;        ///< Extra flags to influence the animation
 	bool enabled;                         ///< entity still available (by default true). newgrf can disable it, though
-	GRFFileProps grf_prop;                ///< properties related the the grf file
+	SubstituteGRFFileProps grf_prop; ///< properties related the the grf file
 	std::vector<BadgeID> badges;
 
 	static const AirportTileSpec *Get(StationGfx gfx);

--- a/src/newgrf_badge.cpp
+++ b/src/newgrf_badge.cpp
@@ -203,8 +203,7 @@ BadgeResolverObject::BadgeResolverObject(const Badge &badge, GrfSpecFeature feat
 		: ResolverObject(badge.grf_prop.grffile, callback, callback_param1, callback_param2), self_scope(*this, badge, introduction_date)
 {
 	assert(feature <= GSF_END);
-	this->root_spritegroup = this->self_scope.badge.grf_prop.GetSpriteGroup(feature);
-	if (this->root_spritegroup == nullptr) this->root_spritegroup = this->self_scope.badge.grf_prop.GetSpriteGroup(GSF_DEFAULT);
+	this->root_spritegroup = this->self_scope.badge.grf_prop.GetFirstSpriteGroupOf({feature, GSF_DEFAULT});
 }
 
 /**

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -394,10 +394,12 @@ struct CargoGRFFileProps : VariableGRFFileProps<CargoType> {
 	static constexpr CargoType SG_DEFAULT_NA = NUM_CARGO + 2; ///< Used only by stations and roads when no more-specific cargo matches.
 };
 
-/** Data related to the handling of grf files. */
-struct GRFFileProps : SingleGRFFileProps {
+/**
+ * NewGRF entities which can replace default entities.
+ */
+struct SubstituteGRFFileProps : SingleGRFFileProps {
 	/** Set all default data constructor for the props. */
-	constexpr GRFFileProps(uint16_t subst_id = 0) : subst_id(subst_id), override_id(subst_id) {}
+	constexpr SubstituteGRFFileProps(uint16_t subst_id = 0) : subst_id(subst_id), override_id(subst_id) {}
 
 	uint16_t subst_id;
 	uint16_t override_id; ///< id of the entity been replaced by

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1086,8 +1086,7 @@ VehicleResolverObject::VehicleResolverObject(EngineID engine_type, const Vehicle
 		if (this->root_spritegroup == nullptr) {
 			const Engine *e = Engine::Get(engine_type);
 			CargoType cargo = v != nullptr ? v->cargo_type : CargoGRFFileProps::SG_PURCHASE;
-			this->root_spritegroup = e->grf_prop.GetSpriteGroup(cargo);
-			if (this->root_spritegroup == nullptr) this->root_spritegroup = e->grf_prop.GetSpriteGroup(CargoGRFFileProps::SG_DEFAULT);
+			this->root_spritegroup = e->grf_prop.GetFirstSpriteGroupOf({cargo, CargoGRFFileProps::SG_DEFAULT});
 		}
 	}
 }

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -667,7 +667,7 @@ static void DoTriggerHouseRandomisation(TileIndex tile, HouseRandomTrigger trigg
 	HouseID hid = GetHouseType(tile);
 	HouseSpec *hs = HouseSpec::Get(hid);
 
-	if (hs->grf_prop.GetSpriteGroup() == nullptr) return;
+	if (!hs->grf_prop.HasSpriteGroups()) return;
 
 	HouseResolverObject object(hid, tile, Town::GetByTile(tile), CBID_RANDOM_TRIGGER);
 	auto waiting_random_triggers = GetHouseRandomTriggers(tile);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -79,7 +79,7 @@ uint32_t GetIndustryIDAtOffset(TileIndex tile, const Industry *i, uint32_t cur_g
 		}
 	}
 	/* Not an 'old type' tile */
-	if (indtsp->grf_prop.GetSpriteGroup() != nullptr) { // tile has a spritegroup ?
+	if (indtsp->grf_prop.HasSpriteGroups()) {
 		if (indtsp->grf_prop.grfid == cur_grfid) { // same industry, same grf ?
 			return indtsp->grf_prop.local_id;
 		} else {

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -328,7 +328,7 @@ static void DoTriggerIndustryTileRandomisation(TileIndex tile, IndustryRandomTri
 	IndustryGfx gfx = GetIndustryGfx(tile);
 	const IndustryTileSpec *itspec = GetIndustryTileSpec(gfx);
 
-	if (itspec->grf_prop.GetSpriteGroup() == nullptr) return;
+	if (!itspec->grf_prop.HasSpriteGroups()) return;
 
 	IndustryTileResolverObject object(gfx, tile, ind, CBID_RANDOM_TRIGGER);
 	auto waiting_random_triggers = GetIndustryRandomTriggers(tile);

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -386,8 +386,7 @@ ObjectResolverObject::ObjectResolverObject(const ObjectSpec *spec, Object *obj, 
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), object_scope(*this, obj, spec, tile, view)
 {
-	this->root_spritegroup = (obj == nullptr) ? spec->grf_prop.GetSpriteGroup(StandardSpriteGroup::Purchase) : nullptr;
-	if (this->root_spritegroup == nullptr) this->root_spritegroup = spec->grf_prop.GetSpriteGroup(StandardSpriteGroup::Default);
+	this->root_spritegroup = spec->grf_prop.GetSpriteGroup(obj != nullptr);
 }
 
 /**

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3121,7 +3121,7 @@ static void DrawTile_Station(TileInfo *ti)
 		gfx = GetAirportGfx(ti->tile);
 		if (gfx >= NEW_AIRPORTTILE_OFFSET) {
 			const AirportTileSpec *ats = AirportTileSpec::Get(gfx);
-			if (ats->grf_prop.GetSpriteGroup() != nullptr && DrawNewAirportTile(ti, Station::GetByTile(ti->tile), ats)) {
+			if (ats->grf_prop.HasSpriteGroups() && DrawNewAirportTile(ti, Station::GetByTile(ti->tile), ats)) {
 				return;
 			}
 			/* No sprite group (or no valid one) found, meaning no graphics associated.

--- a/src/table/airport_defaults.h
+++ b/src/table/airport_defaults.h
@@ -378,7 +378,7 @@ static const std::initializer_list<AirportTileLayout> _tile_table_helistation = 
 
 /** General AirportSpec definition. */
 #define AS_GENERIC(fsm, layouts, depots, size_x, size_y, noise, catchment, min_year, max_year, maint_cost, ttdpatch_type, class_id, name, preview, enabled) \
-	{{class_id, 0}, fsm, layouts, depots, size_x, size_y, noise, catchment, TimerGameCalendar::Year{min_year}, TimerGameCalendar::Year{max_year}, name, ttdpatch_type, preview, maint_cost, enabled, GRFFileProps(AT_INVALID), {}}
+	{{class_id, 0}, fsm, layouts, depots, size_x, size_y, noise, catchment, TimerGameCalendar::Year{min_year}, TimerGameCalendar::Year{max_year}, name, ttdpatch_type, preview, maint_cost, enabled, SubstituteGRFFileProps(AT_INVALID), {}}
 
 /** AirportSpec definition for airports without any depot. */
 #define AS_ND(ap_name, size_x, size_y, min_year, max_year, catchment, noise, maint_cost, ttdpatch_type, class_id, name, preview) \

--- a/src/table/airporttiles.h
+++ b/src/table/airporttiles.h
@@ -13,9 +13,9 @@
 #include "table/strings.h"
 
 /** Writes all airport tile properties in the AirportTile struct */
-#define AT(num_frames, anim_speed) {{num_frames, AnimationStatus::Looping, anim_speed, {}}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
+#define AT(num_frames, anim_speed) {{num_frames, AnimationStatus::Looping, anim_speed, {}}, STR_NULL, AirportTileCallbackMasks{}, 0, true, SubstituteGRFFileProps(INVALID_AIRPORTTILE), {}}
 /** Writes an airport tile without animation in the AirportTile struct */
-#define AT_NOANIM {AnimationInfo<AirportAnimationTriggers>{}, STR_NULL, AirportTileCallbackMasks{}, 0, true, GRFFileProps(INVALID_AIRPORTTILE), {}}
+#define AT_NOANIM {AnimationInfo<AirportAnimationTriggers>{}, STR_NULL, AirportTileCallbackMasks{}, 0, true, SubstituteGRFFileProps(INVALID_AIRPORTTILE), {}}
 
 /**
  * All default airport tiles.

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -1135,7 +1135,7 @@ enum IndustryTypes : uint8_t {
 		{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
 		{{im1, 0}, {im2, 0}, {im3, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}, \
 		pr, clim, bev, col, in, intx, s1, s2, s3, STR_UNDEFINED, {ai1, ai2, ai3, ai4}, {ag1, ag2, ag3, ag4}, \
-		IndustryCallbackMasks{}, true, GRFFileProps(IT_INVALID), snd, {}, \
+		IndustryCallbackMasks{}, true, SubstituteGRFFileProps(IT_INVALID), snd, {}, \
 		{{p1, p2}}, {{a1, a2, a3}}}
 	/* Format:
 	   tile table                              count and sounds table
@@ -1535,7 +1535,7 @@ static const IndustrySpec _origin_industry_specs[NEW_INDUSTRYOFFSET] = {
  */
 #define MT(ca1, c1, ca2, c2, ca3, c3, sl, a1, a2, a3) { \
 	{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
-	{ca1, ca2, ca3}, sl, a1, a2, a3, IndustryTileCallbackMasks{}, AnimationInfo<IndustryAnimationTriggers>{}, IndustryTileSpecialFlags{}, true, GRFFileProps(INVALID_INDUSTRYTILE), {}, {c1, c2, c3} \
+	{ca1, ca2, ca3}, sl, a1, a2, a3, IndustryTileCallbackMasks{}, AnimationInfo<IndustryAnimationTriggers>{}, IndustryTileSpecialFlags{}, true, SubstituteGRFFileProps(INVALID_INDUSTRYTILE), {}, {c1, c2, c3} \
 }
 static const IndustryTileSpec _origin_industry_tile_specs[NEW_INDUSTRYTILEOFFSET] = {
 	/* Coal Mine */

--- a/src/table/town_land.h
+++ b/src/table/town_land.h
@@ -1813,7 +1813,7 @@ static_assert(lengthof(_town_draw_tile_data) == (NEW_HOUSE_OFFSET) * 4 * 4);
 	{TimerGameCalendar::Year{mnd}, TimerGameCalendar::Year{mxd}, p, rc, bn, rr, mg, \
 	{ca1, ca2, ca3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, \
 	{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
-	bf, ba, true, GRFFileProps(INVALID_HOUSE_ID), HouseCallbackMasks{}, {COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN}, \
+	bf, ba, true, SubstituteGRFFileProps(INVALID_HOUSE_ID), HouseCallbackMasks{}, {COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN, COLOUR_BEGIN}, \
 	16, HouseExtraFlags{}, HOUSE_NO_CLASS, AnimationInfo<void>{}, 0, 0, 0, {}, {cg1, cg2, cg3}, }
 /** House specifications from original data */
 extern const HouseSpec _original_house_specs[] = {

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -273,7 +273,7 @@ static void DrawTile_Town(TileInfo *ti)
 		/* Houses don't necessarily need new graphics. If they don't have a
 		 * spritegroup associated with them, then the sprite for the substitute
 		 * house id is drawn instead. */
-		if (HouseSpec::Get(house_id)->grf_prop.GetSpriteGroup() != nullptr) {
+		if (HouseSpec::Get(house_id)->grf_prop.HasSpriteGroups()) {
 			DrawNewHouseTile(ti, house_id);
 			return;
 		} else {
@@ -334,7 +334,7 @@ static Foundation GetFoundation_Town(TileIndex tile, Slope tileh)
 	 */
 	if (hid >= NEW_HOUSE_OFFSET) {
 		const HouseSpec *hs = HouseSpec::Get(hid);
-		if (hs->grf_prop.GetSpriteGroup() != nullptr && hs->callback_mask.Test(HouseCallbackMask::DrawFoundations)) {
+		if (hs->callback_mask.Test(HouseCallbackMask::DrawFoundations)) {
 			uint32_t callback_res = GetHouseCallback(CBID_HOUSE_DRAW_FOUNDATIONS, 0, 0, hid, Town::GetByTile(tile), tile);
 			if (callback_res != CALLBACK_FAILED && !ConvertBooleanCallback(hs->grf_prop.grffile, CBID_HOUSE_DRAW_FOUNDATIONS, callback_res)) return FOUNDATION_NONE;
 		}

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1349,7 +1349,7 @@ void DrawHouseInGUI(int x, int y, HouseID house_id, int view)
 			 * spritegroup associated with them, then the sprite for the substitute
 			 * house id is drawn instead. */
 			const HouseSpec *spec = HouseSpec::Get(house_id);
-			if (spec->grf_prop.GetSpriteGroup() != nullptr) {
+			if (spec->grf_prop.HasSpriteGroups()) {
 				DrawNewHouseTileInGUI(x, y, spec, house_id, view);
 				return;
 			} else {


### PR DESCRIPTION
## Motivation / Problem

There are some reoccurring patterns in the usage of GRFFileProps.

## Description

This includes/depends on #14117.

Deduplicate the patterns and move them into helper methods.
* Use `HasSpriteGroups` to test, whether an entity has any Action3. The requirement here is that it must have a valid sprite group for the default CID.
* Remove `HasSpriteGroups` where it is not needed. E.g. `GetXxxCallback` will generally return `CALLBACK_FAILED`, if there are no sprite groups.
* Use `GetFirstSpriteGroupOf` to test for multiple potential sprite groups, and use the first existing one.

While at it, also rename `GRFFileProps`. It is specific to houses, industries and airports. So the old name is a bit too generic.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
