### PR TITLE
Fix 5575379: Crash with default airports.

### DIFF
--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -323,9 +323,11 @@ bool TriggerAirportAnimation(Station *st, AirportAnimationTrigger trigger, Cargo
 	for (TileIndex tile : st->airport) {
 		if (!st->TileBelongsToAirport(tile)) continue;
 
+		const AirportTileSpec *ats = AirportTileSpec::GetByTile(tile);
+		if (ats->grf_prop.grffile == nullptr) continue;
+
 		uint8_t var18_extra = 0;
 		if (IsValidCargoType(cargo_type)) {
-			const AirportTileSpec *ats = AirportTileSpec::GetByTile(tile);
 			var18_extra |= ats->grf_prop.grffile->cargo_map[cargo_type] << 8;
 		}
 


### PR DESCRIPTION
## Motivation / Problem

The title game segfaults after a few seconds.

## Description

Test for `nullptr` first.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
