### PR TITLE
Codechange: use std::string_view for scripts

### DIFF
--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -238,7 +238,7 @@ void sq_newclosure(HSQUIRRELVM v,SQFUNCTION func,SQUnsignedInteger nfreevars);
 SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheck,const SQChar *typemask);
 SQRESULT sq_bindenv(HSQUIRRELVM v,SQInteger idx);
 void sq_pushstring(HSQUIRRELVM v,const SQChar *s,SQInteger len);
-inline void sq_pushstring(HSQUIRRELVM v, const std::string &str, SQInteger len = -1) { sq_pushstring(v, str.data(), len == -1 ? str.size() : len); }
+inline void sq_pushstring(HSQUIRRELVM v, std::string_view str, SQInteger len = -1) { sq_pushstring(v, str.data(), len == -1 ? str.size() : len); }
 void sq_pushfloat(HSQUIRRELVM v,SQFloat f);
 void sq_pushinteger(HSQUIRRELVM v,SQInteger n);
 void sq_pushbool(HSQUIRRELVM v,SQBool b);
@@ -263,7 +263,7 @@ void sq_setreleasehook(HSQUIRRELVM v,SQInteger idx,SQRELEASEHOOK hook);
 SQChar *sq_getscratchpad(HSQUIRRELVM v,SQInteger minsize);
 SQRESULT sq_getfunctioninfo(HSQUIRRELVM v,SQInteger idx,SQFunctionInfo *fi);
 SQRESULT sq_getclosureinfo(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger *nparams,SQUnsignedInteger *nfreevars);
-SQRESULT sq_setnativeclosurename(HSQUIRRELVM v,SQInteger idx,const SQChar *name);
+SQRESULT sq_setnativeclosurename(HSQUIRRELVM v,SQInteger idx,std::string_view name);
 SQRESULT sq_setinstanceup(HSQUIRRELVM v, SQInteger idx, SQUserPointer p);
 SQRESULT sq_getinstanceup(HSQUIRRELVM v, SQInteger idx, SQUserPointer *p,SQUserPointer typetag);
 SQRESULT sq_setclassudsize(HSQUIRRELVM v, SQInteger idx, SQInteger udsize);

--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -376,7 +376,7 @@ SQRESULT sq_getclosureinfo(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger *nparam
 	return sq_throwerror(v,"the object is not a closure");
 }
 
-SQRESULT sq_setnativeclosurename(HSQUIRRELVM v,SQInteger idx,const SQChar *name)
+SQRESULT sq_setnativeclosurename(HSQUIRRELVM v,SQInteger idx,std::string_view name)
 {
 	SQObject o = stack_get(v, idx);
 	if(sq_isnativeclosure(o)) {

--- a/src/3rdparty/squirrel/squirrel/sqstring.h
+++ b/src/3rdparty/squirrel/squirrel/sqstring.h
@@ -17,7 +17,7 @@ struct SQString : public SQRefCounted
 	~SQString(){}
 public:
 	static SQString *Create(SQSharedState *ss, const SQChar *, SQInteger len = -1 );
-	static SQString *Create(SQSharedState *ss, const std::string &str) { return Create(ss, str.data(), str.size()); }
+	static SQString *Create(SQSharedState *ss, std::string_view str) { return Create(ss, str.data(), str.size()); }
 	SQInteger Next(const SQObjectPtr &refpos, SQObjectPtr &outkey, SQObjectPtr &outval);
 	void Release() override;
 	SQSharedState *_sharedstate;

--- a/src/ai/ai_scanner.hpp
+++ b/src/ai/ai_scanner.hpp
@@ -41,9 +41,9 @@ public:
 
 protected:
 	std::string GetScriptName(ScriptInfo *info) override;
-	const char *GetFileName() const override { return PATHSEP "info.nut"; }
+	std::string_view GetFileName() const override { return PATHSEP "info.nut"; }
 	Subdirectory GetDirectory() const override { return AI_DIR; }
-	const char *GetScannerName() const override { return "AIs"; }
+	std::string_view GetScannerName() const override { return "AIs"; }
 	void RegisterAPI(class Squirrel *engine) override;
 
 private:
@@ -64,9 +64,9 @@ public:
 
 protected:
 	std::string GetScriptName(ScriptInfo *info) override;
-	const char *GetFileName() const override { return PATHSEP "library.nut"; }
+	std::string_view GetFileName() const override { return PATHSEP "library.nut"; }
 	Subdirectory GetDirectory() const override { return AI_LIBRARY_DIR; }
-	const char *GetScannerName() const override { return "AI Libraries"; }
+	std::string_view GetScannerName() const override { return "AI Libraries"; }
 	void RegisterAPI(class Squirrel *engine) override;
 };
 

--- a/src/game/game_scanner.hpp
+++ b/src/game/game_scanner.hpp
@@ -27,9 +27,9 @@ public:
 
 protected:
 	std::string GetScriptName(ScriptInfo *info) override;
-	const char *GetFileName() const override { return PATHSEP "info.nut"; }
+	std::string_view GetFileName() const override { return PATHSEP "info.nut"; }
 	Subdirectory GetDirectory() const override { return GAME_DIR; }
-	const char *GetScannerName() const override { return "Game Scripts"; }
+	std::string_view GetScannerName() const override { return "Game Scripts"; }
 	void RegisterAPI(class Squirrel *engine) override;
 };
 
@@ -48,9 +48,9 @@ public:
 
 protected:
 	std::string GetScriptName(ScriptInfo *info) override;
-	const char *GetFileName() const override { return PATHSEP "library.nut"; }
+	std::string_view GetFileName() const override { return PATHSEP "library.nut"; }
 	Subdirectory GetDirectory() const override { return GAME_LIBRARY_DIR; }
-	const char *GetScannerName() const override { return "GS Libraries"; }
+	std::string_view GetScannerName() const override { return "GS Libraries"; }
 	void RegisterAPI(class Squirrel *engine) override;
 };
 

--- a/src/script/api/script_error.cpp
+++ b/src/script/api/script_error.cpp
@@ -27,7 +27,7 @@ ScriptError::ScriptErrorMapString ScriptError::error_map_string = ScriptError::S
 {
 	auto it = ScriptError::error_map_string.find(ScriptError::GetLastError());
 	assert(it != ScriptError::error_map_string.end());
-	return it->second;
+	return std::string{it->second};
 }
 
 /* static */ ScriptErrorType ScriptError::StringToError(StringID internal_string_id)
@@ -62,7 +62,7 @@ ScriptError::ScriptErrorMapString ScriptError::error_map_string = ScriptError::S
 	error_map[internal_string_id] = ai_error_msg;
 }
 
-/* static */ void ScriptError::RegisterErrorMapString(ScriptErrorType ai_error_msg, const char *message)
+/* static */ void ScriptError::RegisterErrorMapString(ScriptErrorType ai_error_msg, std::string_view message)
 {
 	error_map_string[ai_error_msg] = message;
 }

--- a/src/script/api/script_error.hpp
+++ b/src/script/api/script_error.hpp
@@ -218,11 +218,11 @@ public:
 	 * @param ai_error_msg The script error message representation.
 	 * @param message The string representation of this error message, used for debug purposes.
 	 */
-	static void RegisterErrorMapString(ScriptErrorType ai_error_msg, const char *message);
+	static void RegisterErrorMapString(ScriptErrorType ai_error_msg, std::string_view message);
 
 private:
-	typedef std::map<StringID, ScriptErrorType> ScriptErrorMap;           ///< The type for mapping between error (internal OpenTTD) StringID to the script error type.
-	typedef std::map<ScriptErrorType, const char *> ScriptErrorMapString; ///< The type for mapping between error type and textual representation.
+	using ScriptErrorMap = std::map<StringID, ScriptErrorType>; ///< The type for mapping between error (internal OpenTTD) StringID to the script error type.
+	using ScriptErrorMapString = std::map<ScriptErrorType, std::string_view>; ///< The type for mapping between error type and textual representation.
 
 	static ScriptErrorMap error_map;              ///< The mapping between error (internal OpenTTD) StringID to the script error type.
 	static ScriptErrorMapString error_map_string; ///< The mapping between error type and textual representation.

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -18,7 +18,7 @@
 
 #include "../safeguards.h"
 
-bool ScriptInfo::CheckMethod(const char *name) const
+bool ScriptInfo::CheckMethod(std::string_view name) const
 {
 	if (!this->engine->MethodExists(this->SQ_instance, name)) {
 		this->engine->ThrowError(fmt::format("your info.nut/library.nut doesn't have the method '{}'", name));
@@ -38,7 +38,7 @@ bool ScriptInfo::CheckMethod(const char *name) const
 	info->engine = info->scanner->GetEngine();
 
 	/* Ensure the mandatory functions exist */
-	static const char * const required_functions[] = {
+	static std::string_view const required_functions[] = {
 		"GetAuthor",
 		"GetName",
 		"GetShortName",

--- a/src/script/script_info.hpp
+++ b/src/script/script_info.hpp
@@ -82,7 +82,7 @@ public:
 	/**
 	 * Check if a given method exists.
 	 */
-	bool CheckMethod(const char *name) const;
+	bool CheckMethod(std::string_view name) const;
 
 	/**
 	 * Process the creation of a FileInfo object.
@@ -149,7 +149,7 @@ private:
 	class ScriptScanner *scanner = nullptr; ///< ScriptScanner object that was used to scan this script info.
 };
 
-void Script_CreateDummyInfo(HSQUIRRELVM vm, const char *type, const char *dir);
-void Script_CreateDummy(HSQUIRRELVM vm, StringID string, const char *type);
+void Script_CreateDummyInfo(HSQUIRRELVM vm, std::string_view type, std::string_view dir);
+void Script_CreateDummy(HSQUIRRELVM vm, StringID string, std::string_view type);
 
 #endif /* SCRIPT_INFO_HPP */

--- a/src/script/script_info_dummy.cpp
+++ b/src/script/script_info_dummy.cpp
@@ -26,7 +26,7 @@
  */
 
 /** Run the dummy info.nut. */
-void Script_CreateDummyInfo(HSQUIRRELVM vm, const char *type, const char *dir)
+void Script_CreateDummyInfo(HSQUIRRELVM vm, std::string_view type, std::string_view dir)
 {
 	std::string dummy_script = fmt::format(
 			"class Dummy{0} extends {0}Info {{\n"
@@ -78,7 +78,7 @@ static std::vector<std::string> EscapeQuotesAndSlashesAndSplitOnNewLines(const s
 }
 
 /** Run the dummy AI and let it generate an error message. */
-void Script_CreateDummy(HSQUIRRELVM vm, StringID string, const char *type)
+void Script_CreateDummy(HSQUIRRELVM vm, StringID string, std::string_view type)
 {
 	/* We want to translate the error message.
 	 * We do this in three steps:

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -46,10 +46,10 @@ static void PrintFunc(bool error_msg, const std::string &message)
 	ScriptController::Print(error_msg, message);
 }
 
-ScriptInstance::ScriptInstance(const char *APIName)
+ScriptInstance::ScriptInstance(std::string_view api_name)
 {
 	this->storage = new ScriptStorage();
-	this->engine  = new Squirrel(APIName);
+	this->engine  = new Squirrel(api_name);
 	this->engine->SetPrintFunction(&PrintFunc);
 }
 

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -46,7 +46,7 @@ public:
 	/**
 	 * Create a new script.
 	 */
-	ScriptInstance(const char *APIName);
+	ScriptInstance(std::string_view api_name);
 	virtual ~ScriptInstance();
 
 	/**

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -56,7 +56,7 @@ void ScriptScanner::ResetEngine()
 	this->RegisterAPI(this->engine);
 }
 
-void ScriptScanner::Initialize(const char *name)
+void ScriptScanner::Initialize(std::string_view name)
 {
 	this->engine = new Squirrel(name);
 
@@ -198,8 +198,8 @@ struct ScriptFileChecksumCreator : FileScanner {
 static bool IsSameScript(const ContentInfo &ci, bool md5sum, ScriptInfo *info, Subdirectory dir)
 {
 	uint32_t id = 0;
-	const char *str = info->GetShortName().c_str();
-	for (int j = 0; j < 4 && *str != '\0'; j++, str++) id |= *str << (8 * j);
+	auto str = std::string_view{info->GetShortName()}.substr(0, 4);
+	for (size_t j = 0; j < str.size(); j++) id |= static_cast<uint8_t>(str[j]) << (8 * j);
 
 	if (id != ci.unique_id) return false;
 	if (!md5sum) return true;

--- a/src/script/script_scanner.hpp
+++ b/src/script/script_scanner.hpp
@@ -95,7 +95,7 @@ protected:
 	 * Initialize the scanner.
 	 * @param name The name of the scanner ("AIScanner", "GSScanner", ..).
 	 */
-	void Initialize(const char *name);
+	void Initialize(std::string_view name);
 
 	/**
 	 * Get the script name how to store the script in memory.
@@ -105,7 +105,7 @@ protected:
 	/**
 	 * Get the filename to scan for this type of script.
 	 */
-	virtual const char *GetFileName() const = 0;
+	virtual std::string_view GetFileName() const = 0;
 
 	/**
 	 * Get the directory to scan in.
@@ -120,7 +120,7 @@ protected:
 	/**
 	 * Get the type of the script, in plural.
 	 */
-	virtual const char *GetScannerName() const = 0;
+	virtual std::string_view GetScannerName() const = 0;
 
 	/**
 	 * Reset all allocated lists.

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -253,7 +253,7 @@ void Squirrel::PrintFunc(HSQUIRRELVM vm, const std::string &s)
 	}
 }
 
-void Squirrel::AddMethod(const char *method_name, SQFUNCTION proc, uint nparam, const char *params, void *userdata, int size)
+void Squirrel::AddMethod(std::string_view method_name, SQFUNCTION proc, uint nparam, const char *params, void *userdata, int size)
 {
 	ScriptAllocatorScope alloc_scope(this);
 
@@ -270,7 +270,7 @@ void Squirrel::AddMethod(const char *method_name, SQFUNCTION proc, uint nparam, 
 	sq_newslot(this->vm, -3, SQFalse);
 }
 
-void Squirrel::AddConst(const char *var_name, int value)
+void Squirrel::AddConst(std::string_view var_name, int value)
 {
 	ScriptAllocatorScope alloc_scope(this);
 
@@ -279,7 +279,7 @@ void Squirrel::AddConst(const char *var_name, int value)
 	sq_newslot(this->vm, -3, SQTrue);
 }
 
-void Squirrel::AddConst(const char *var_name, bool value)
+void Squirrel::AddConst(std::string_view var_name, bool value)
 {
 	ScriptAllocatorScope alloc_scope(this);
 
@@ -288,7 +288,7 @@ void Squirrel::AddConst(const char *var_name, bool value)
 	sq_newslot(this->vm, -3, SQTrue);
 }
 
-void Squirrel::AddClassBegin(const char *class_name)
+void Squirrel::AddClassBegin(std::string_view class_name)
 {
 	ScriptAllocatorScope alloc_scope(this);
 
@@ -297,7 +297,7 @@ void Squirrel::AddClassBegin(const char *class_name)
 	sq_newclass(this->vm, SQFalse);
 }
 
-void Squirrel::AddClassBegin(const char *class_name, const char *parent_class)
+void Squirrel::AddClassBegin(std::string_view class_name, std::string_view parent_class)
 {
 	ScriptAllocatorScope alloc_scope(this);
 
@@ -320,7 +320,7 @@ void Squirrel::AddClassEnd()
 	sq_pop(vm, 1);
 }
 
-bool Squirrel::MethodExists(HSQOBJECT instance, const char *method_name)
+bool Squirrel::MethodExists(HSQOBJECT instance, std::string_view method_name)
 {
 	assert(!this->crashed);
 	ScriptAllocatorScope alloc_scope(this);
@@ -373,7 +373,7 @@ void Squirrel::CollectGarbage()
 	sq_collectgarbage(this->vm);
 }
 
-bool Squirrel::CallMethod(HSQOBJECT instance, const char *method_name, HSQOBJECT *ret, int suspend)
+bool Squirrel::CallMethod(HSQOBJECT instance, std::string_view method_name, HSQOBJECT *ret, int suspend)
 {
 	assert(!this->crashed);
 	ScriptAllocatorScope alloc_scope(this);
@@ -407,7 +407,7 @@ bool Squirrel::CallMethod(HSQOBJECT instance, const char *method_name, HSQOBJECT
 	return true;
 }
 
-bool Squirrel::CallStringMethod(HSQOBJECT instance, const char *method_name, std::string *res, int suspend)
+bool Squirrel::CallStringMethod(HSQOBJECT instance, std::string_view method_name, std::string *res, int suspend)
 {
 	HSQOBJECT ret;
 	if (!this->CallMethod(instance, method_name, &ret, suspend)) return false;
@@ -416,7 +416,7 @@ bool Squirrel::CallStringMethod(HSQOBJECT instance, const char *method_name, std
 	return true;
 }
 
-bool Squirrel::CallIntegerMethod(HSQOBJECT instance, const char *method_name, int *res, int suspend)
+bool Squirrel::CallIntegerMethod(HSQOBJECT instance, std::string_view method_name, int *res, int suspend)
 {
 	HSQOBJECT ret;
 	if (!this->CallMethod(instance, method_name, &ret, suspend)) return false;
@@ -425,7 +425,7 @@ bool Squirrel::CallIntegerMethod(HSQOBJECT instance, const char *method_name, in
 	return true;
 }
 
-bool Squirrel::CallBoolMethod(HSQOBJECT instance, const char *method_name, bool *res, int suspend)
+bool Squirrel::CallBoolMethod(HSQOBJECT instance, std::string_view method_name, bool *res, int suspend)
 {
 	HSQOBJECT ret;
 	if (!this->CallMethod(instance, method_name, &ret, suspend)) return false;
@@ -444,8 +444,7 @@ bool Squirrel::CallBoolMethod(HSQOBJECT instance, const char *method_name, bool 
 	sq_pushroottable(vm);
 
 	if (prepend_API_name) {
-		std::string prepended_class_name = engine->GetAPIName();
-		prepended_class_name += class_name;
+		std::string prepended_class_name = fmt::format("{}{}", engine->GetAPIName(), class_name);
 		sq_pushstring(vm, prepended_class_name, -1);
 	} else {
 		sq_pushstring(vm, class_name, -1);
@@ -488,7 +487,7 @@ bool Squirrel::CreateClassInstance(const std::string &class_name, void *real_ins
 	return Squirrel::CreateClassInstanceVM(this->vm, class_name, real_instance, instance, nullptr);
 }
 
-/* static */ SQUserPointer Squirrel::GetRealInstance(HSQUIRRELVM vm, int index, const char *tag)
+/* static */ SQUserPointer Squirrel::GetRealInstance(HSQUIRRELVM vm, int index, std::string_view tag)
 {
 	if (index < 0) index += sq_gettop(vm) + 1;
 	Squirrel *engine = static_cast<Squirrel *>(sq_getforeignptr(vm));
@@ -505,8 +504,8 @@ bool Squirrel::CreateClassInstance(const std::string &class_name, void *real_ins
 	throw sq_throwerror(vm, fmt::format("parameter {} has an invalid type ; expected: '{}'", index - 1, class_name));
 }
 
-Squirrel::Squirrel(const char *APIName) :
-	APIName(APIName), allocator(new ScriptAllocator())
+Squirrel::Squirrel(std::string_view api_name) :
+	api_name(api_name), allocator(new ScriptAllocator())
 {
 	this->Initialize();
 }
@@ -623,10 +622,10 @@ SQRESULT Squirrel::LoadFile(HSQUIRRELVM vm, const std::string &filename, SQBool 
 
 	std::optional<FileHandle> file = std::nullopt;
 	size_t size;
-	if (strncmp(this->GetAPIName(), "AI", 2) == 0) {
+	if (this->GetAPIName().starts_with("AI")) {
 		file = FioFOpenFile(filename, "rb", AI_DIR, &size);
 		if (!file.has_value()) file = FioFOpenFile(filename, "rb", AI_LIBRARY_DIR, &size);
-	} else if (strncmp(this->GetAPIName(), "GS", 2) == 0) {
+	} else if (this->GetAPIName().starts_with("GS")) {
 		file = FioFOpenFile(filename, "rb", GAME_DIR, &size);
 		if (!file.has_value()) file = FioFOpenFile(filename, "rb", GAME_LIBRARY_DIR, &size);
 	} else {

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -33,7 +33,7 @@ private:
 	SQPrintFunc *print_func; ///< Points to either nullptr, or a custom print handler
 	bool crashed;            ///< True if the squirrel script made an error.
 	int overdrawn_ops;       ///< The amount of operations we have overdrawn.
-	const char *APIName;     ///< Name of the API used for this squirrel.
+	std::string_view api_name; ///< Name of the API used for this squirrel.
 	std::unique_ptr<ScriptAllocator> allocator; ///< Allocator object used by this script.
 
 	/**
@@ -44,7 +44,7 @@ private:
 	/**
 	 * Get the API name.
 	 */
-	const char *GetAPIName() { return this->APIName; }
+	std::string_view GetAPIName() { return this->api_name; }
 
 	/** Perform all initialization steps to create the engine. */
 	void Initialize();
@@ -73,7 +73,7 @@ protected:
 	static void ErrorPrintFunc(HSQUIRRELVM vm, const std::string &s);
 
 public:
-	Squirrel(const char *APIName);
+	Squirrel(std::string_view api_name);
 	~Squirrel();
 
 	/**
@@ -98,39 +98,39 @@ public:
 	 * Adds a function to the stack. Depending on the current state this means
 	 *  either a method or a global function.
 	 */
-	void AddMethod(const char *method_name, SQFUNCTION proc, uint nparam = 0, const char *params = nullptr, void *userdata = nullptr, int size = 0);
+	void AddMethod(std::string_view method_name, SQFUNCTION proc, uint nparam = 0, const char *params = nullptr, void *userdata = nullptr, int size = 0);
 
 	/**
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
 	 */
-	void AddConst(const char *var_name, int value);
+	void AddConst(std::string_view var_name, int value);
 
 	/**
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
 	 */
-	void AddConst(const char *var_name, uint value) { this->AddConst(var_name, (int)value); }
+	void AddConst(std::string_view var_name, uint value) { this->AddConst(var_name, (int)value); }
 
-	void AddConst(const char *var_name, const ConvertibleThroughBase auto &value) { this->AddConst(var_name, static_cast<int>(value.base())); }
+	void AddConst(std::string_view var_name, const ConvertibleThroughBase auto &value) { this->AddConst(var_name, static_cast<int>(value.base())); }
 
 	/**
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
 	 */
-	void AddConst(const char *var_name, bool value);
+	void AddConst(std::string_view var_name, bool value);
 
 	/**
 	 * Adds a class to the global scope. Make sure to call AddClassEnd when you
 	 *  are done adding methods.
 	 */
-	void AddClassBegin(const char *class_name);
+	void AddClassBegin(std::string_view class_name);
 
 	/**
 	 * Adds a class to the global scope, extending 'parent_class'.
 	 * Make sure to call AddClassEnd when you are done adding methods.
 	 */
-	void AddClassBegin(const char *class_name, const char *parent_class);
+	void AddClassBegin(std::string_view class_name, std::string_view parent_class);
 
 	/**
 	 * Finishes adding a class to the global scope. If this isn't called, no
@@ -162,16 +162,16 @@ public:
 	 * Call a method of an instance, in various flavors.
 	 * @return False if the script crashed or returned a wrong type.
 	 */
-	bool CallMethod(HSQOBJECT instance, const char *method_name, HSQOBJECT *ret, int suspend);
-	bool CallMethod(HSQOBJECT instance, const char *method_name, int suspend) { return this->CallMethod(instance, method_name, nullptr, suspend); }
-	bool CallStringMethod(HSQOBJECT instance, const char *method_name, std::string *res, int suspend);
-	bool CallIntegerMethod(HSQOBJECT instance, const char *method_name, int *res, int suspend);
-	bool CallBoolMethod(HSQOBJECT instance, const char *method_name, bool *res, int suspend);
+	bool CallMethod(HSQOBJECT instance, std::string_view method_name, HSQOBJECT *ret, int suspend);
+	bool CallMethod(HSQOBJECT instance, std::string_view method_name, int suspend) { return this->CallMethod(instance, method_name, nullptr, suspend); }
+	bool CallStringMethod(HSQOBJECT instance, std::string_view method_name, std::string *res, int suspend);
+	bool CallIntegerMethod(HSQOBJECT instance, std::string_view method_name, int *res, int suspend);
+	bool CallBoolMethod(HSQOBJECT instance, std::string_view method_name, bool *res, int suspend);
 
 	/**
 	 * Check if a method exists in an instance.
 	 */
-	bool MethodExists(HSQOBJECT instance, const char *method_name);
+	bool MethodExists(HSQOBJECT instance, std::string_view method_name);
 
 	/**
 	 * Creates a class instance.
@@ -195,7 +195,7 @@ public:
 	 * @note This will only work just after a function-call from within Squirrel
 	 *  to your C++ function.
 	 */
-	static SQUserPointer GetRealInstance(HSQUIRRELVM vm, int index, const char *tag);
+	static SQUserPointer GetRealInstance(HSQUIRRELVM vm, int index, std::string_view tag);
 
 	/**
 	 * Get the Squirrel-instance pointer.
@@ -207,7 +207,7 @@ public:
 	/**
 	 * Convert a Squirrel-object to a string.
 	 */
-	static const char *ObjectToString(HSQOBJECT *ptr) { return sq_objtostring(ptr); }
+	static std::string_view ObjectToString(HSQOBJECT *ptr) { return sq_objtostring(ptr); }
 
 	/**
 	 * Convert a Squirrel-object to an integer.

--- a/src/script/squirrel_class.hpp
+++ b/src/script/squirrel_class.hpp
@@ -19,10 +19,10 @@
 template <class CL, ScriptType ST>
 class DefSQClass {
 private:
-	const char *classname;
+	std::string_view classname;
 
 public:
-	DefSQClass(const char *_classname) :
+	DefSQClass(std::string_view _classname) :
 		classname(_classname)
 	{}
 
@@ -30,7 +30,7 @@ public:
 	 * This defines a method inside a class for Squirrel.
 	 */
 	template <typename Func>
-	void DefSQMethod(Squirrel *engine, Func function_proc, const char *function_name)
+	void DefSQMethod(Squirrel *engine, Func function_proc, std::string_view function_name)
 	{
 		using namespace SQConvert;
 		engine->AddMethod(function_name, DefSQNonStaticCallback<CL, Func, ST>, 0, nullptr, &function_proc, sizeof(function_proc));
@@ -40,7 +40,7 @@ public:
 	 * This defines a method inside a class for Squirrel, which has access to the 'engine' (experts only!).
 	 */
 	template <typename Func>
-	void DefSQAdvancedMethod(Squirrel *engine, Func function_proc, const char *function_name)
+	void DefSQAdvancedMethod(Squirrel *engine, Func function_proc, std::string_view function_name)
 	{
 		using namespace SQConvert;
 		engine->AddMethod(function_name, DefSQAdvancedNonStaticCallback<CL, Func, ST>, 0, nullptr, &function_proc, sizeof(function_proc));
@@ -53,7 +53,7 @@ public:
 	 *  of the code, but without it calling your function will fail!
 	 */
 	template <typename Func>
-	void DefSQMethod(Squirrel *engine, Func function_proc, const char *function_name, int nparam, const char *params)
+	void DefSQMethod(Squirrel *engine, Func function_proc, std::string_view function_name, int nparam, const char *params)
 	{
 		using namespace SQConvert;
 		engine->AddMethod(function_name, DefSQNonStaticCallback<CL, Func, ST>, nparam, params, &function_proc, sizeof(function_proc));
@@ -63,7 +63,7 @@ public:
 	 * This defines a static method inside a class for Squirrel.
 	 */
 	template <typename Func>
-	void DefSQStaticMethod(Squirrel *engine, Func function_proc, const char *function_name)
+	void DefSQStaticMethod(Squirrel *engine, Func function_proc, std::string_view function_name)
 	{
 		using namespace SQConvert;
 		engine->AddMethod(function_name, DefSQStaticCallback<CL, Func>, 0, nullptr, &function_proc, sizeof(function_proc));
@@ -73,7 +73,7 @@ public:
 	 * This defines a static method inside a class for Squirrel, which has access to the 'engine' (experts only!).
 	 */
 	template <typename Func>
-	void DefSQAdvancedStaticMethod(Squirrel *engine, Func function_proc, const char *function_name)
+	void DefSQAdvancedStaticMethod(Squirrel *engine, Func function_proc, std::string_view function_name)
 	{
 		using namespace SQConvert;
 		engine->AddMethod(function_name, DefSQAdvancedStaticCallback<CL, Func>, 0, nullptr, &function_proc, sizeof(function_proc));
@@ -86,14 +86,14 @@ public:
 	 *  of the code, but without it calling your function will fail!
 	 */
 	template <typename Func>
-	void DefSQStaticMethod(Squirrel *engine, Func function_proc, const char *function_name, int nparam, const char *params)
+	void DefSQStaticMethod(Squirrel *engine, Func function_proc, std::string_view function_name, int nparam, const char *params)
 	{
 		using namespace SQConvert;
 		engine->AddMethod(function_name, DefSQStaticCallback<CL, Func>, nparam, params, &function_proc, sizeof(function_proc));
 	}
 
 	template <typename Var>
-	void DefSQConst(Squirrel *engine, Var value, const char *var_name)
+	void DefSQConst(Squirrel *engine, Var value, std::string_view var_name)
 	{
 		engine->AddConst(var_name, value);
 	}
@@ -103,7 +103,7 @@ public:
 		engine->AddClassBegin(this->classname);
 	}
 
-	void PreRegister(Squirrel *engine, const char *parent_class)
+	void PreRegister(Squirrel *engine, std::string_view parent_class)
 	{
 		engine->AddClassBegin(this->classname, parent_class);
 	}


### PR DESCRIPTION
## Motivation / Problem

Lots of C-style strings.


## Description

Mostly `const char *` to `std::string_view`, but also:
* a few `const std::string &` to `std::string_view`.
* `APIName` -> `api_name`.
* passing method/parameter type as `std::string_view` means we can remove number of parameters as that's always the same as the string length.
* a few `strncmp` to `.starts_with`.


## Limitations

There are still a few stragglers, but those require more complicated work so those are better left as a separate PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
