### PR TITLE
Codechange: replace C-style strings with std::string_view related to strings functions

### DIFF
--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -47,7 +47,7 @@ template <class T> struct BaseSetTraits;
  */
 template <class T>
 struct BaseSet {
-	typedef std::unordered_map<std::string, std::string> TranslatedStrings;
+	typedef std::unordered_map<std::string, std::string, StringHash, std::equal_to<>> TranslatedStrings;
 
 	/** Number of files in this set */
 	static constexpr size_t NUM_FILES = BaseSetTraits<T>::num_files;
@@ -107,7 +107,7 @@ struct BaseSet {
 	 * @param isocode the isocode to search for
 	 * @return the description
 	 */
-	const std::string &GetDescription(const std::string &isocode) const
+	const std::string &GetDescription(std::string_view isocode) const
 	{
 		if (!isocode.empty()) {
 			/* First the full ISO code */

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -302,22 +302,22 @@ void MacOSResetScriptCache(FontSize size)
 }
 
 /** Register an external font file with the CoreText system. */
-void MacOSRegisterExternalFont(const char *file_path)
+void MacOSRegisterExternalFont(std::string_view file_path)
 {
 	if (!MacOSVersionIsAtLeast(10, 6, 0)) return;
 
-	CFAutoRelease<CFStringRef> path(CFStringCreateWithCString(kCFAllocatorDefault, file_path, kCFStringEncodingUTF8));
+	CFAutoRelease<CFStringRef> path(CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(file_path.data()), file_path.size(), kCFStringEncodingUTF8, false));
 	CFAutoRelease<CFURLRef> url(CFURLCreateWithFileSystemPath(kCFAllocatorDefault, path.get(), kCFURLPOSIXPathStyle, false));
 
 	CTFontManagerRegisterFontsForURL(url.get(), kCTFontManagerScopeProcess, nullptr);
 }
 
 /** Store current language locale as a CoreFoundation locale. */
-void MacOSSetCurrentLocaleName(const char *iso_code)
+void MacOSSetCurrentLocaleName(std::string_view iso_code)
 {
 	if (!MacOSVersionIsAtLeast(10, 5, 0)) return;
 
-	CFAutoRelease<CFStringRef> iso(CFStringCreateWithCString(kCFAllocatorDefault, iso_code, kCFStringEncodingUTF8));
+	CFAutoRelease<CFStringRef> iso(CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(iso_code.data()), iso_code.size(), kCFStringEncodingUTF8, false));
 	_osx_locale.reset(CFLocaleCreate(kCFAllocatorDefault, iso.get()));
 }
 

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -82,10 +82,10 @@ public:
 };
 
 void MacOSResetScriptCache(FontSize size);
-void MacOSSetCurrentLocaleName(const char *iso_code);
+void MacOSSetCurrentLocaleName(std::string_view iso_code);
 int MacOSStringCompare(std::string_view s1, std::string_view s2);
 int MacOSStringContains(const std::string_view str, const std::string_view value, bool case_insensitive);
 
-void MacOSRegisterExternalFont(const char *file_path);
+void MacOSRegisterExternalFont(std::string_view file_path);
 
 #endif /* STRING_OSX_H */

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -12,6 +12,7 @@
 
 #include "../core/string_consumer.hpp"
 #include "../language.h"
+#include "../string_type.h"
 #include "../3rdparty/fmt/format.h"
 
 #include <unordered_map>
@@ -41,7 +42,7 @@ struct LangString {
 /** Information about the currently known strings. */
 struct StringData {
 	std::vector<std::shared_ptr<LangString>> strings; ///< List of all known strings.
-	std::unordered_map<std::string, std::shared_ptr<LangString>> name_to_string; ///< Lookup table for the strings.
+	std::unordered_map<std::string, std::shared_ptr<LangString>, StringHash, std::equal_to<>> name_to_string; ///< Lookup table for the strings.
 	size_t tabs;          ///< The number of 'tabs' of strings.
 	size_t max_strings;   ///< The maximum number of strings.
 	size_t next_string_id;///< The next string ID to allocate.
@@ -49,7 +50,7 @@ struct StringData {
 	StringData(size_t tabs);
 	void FreeTranslation();
 	void Add(std::shared_ptr<LangString> ls);
-	LangString *Find(const std::string &s);
+	LangString *Find(std::string_view s);
 	uint32_t Version() const;
 	size_t CountInUse(size_t tab) const;
 };

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -100,7 +100,7 @@ void StringData::Add(std::shared_ptr<LangString> ls)
  * @param s The string name to search on.
  * @return The LangString or nullptr if it is not known.
  */
-LangString *StringData::Find(const std::string &s)
+LangString *StringData::Find(std::string_view s)
 {
 	auto it = this->name_to_string.find(s);
 	if (it == this->name_to_string.end()) return nullptr;
@@ -527,7 +527,7 @@ void StringReader::HandleString(std::string_view src)
 	}
 
 	/* Check if this string already exists.. */
-	LangString *ent = this->data.Find(std::string(str_name));
+	LangString *ent = this->data.Find(str_name);
 
 	if (this->master) {
 		if (casep.has_value()) {

--- a/src/string_type.h
+++ b/src/string_type.h
@@ -59,4 +59,14 @@ using StringValidationSettings = EnumBitSet<StringValidationSetting, uint8_t>;
 /** Type for a list of strings. */
 typedef std::vector<std::string> StringList;
 
+/** Helper to provide transparent hashing for string types in e.g. std::unordered_map. */
+struct StringHash {
+	using hash_type = std::hash<std::string_view>;
+	using is_transparent = void;
+
+	std::size_t operator()(const char *str) const { return hash_type{}(str); }
+	std::size_t operator()(std::string_view str) const { return hash_type{}(str); }
+	std::size_t operator()(const std::string &str) const { return hash_type{}(str); }
+};
+
 #endif /* STRING_TYPE_H */

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -457,10 +457,10 @@ std::string GetStringWithArgs(StringID string, std::span<StringParameter> args)
 	return result;
 }
 
-static const char *GetDecimalSeparator()
+static std::string_view GetDecimalSeparator()
 {
-	const char *decimal_separator = _settings_game.locale.digit_decimal_separator.c_str();
-	if (StrEmpty(decimal_separator)) decimal_separator = _langpack.langpack->digit_decimal_separator;
+	std::string_view decimal_separator = _settings_game.locale.digit_decimal_separator;
+	if (decimal_separator.empty()) decimal_separator = _langpack.langpack->digit_decimal_separator;
 	return decimal_separator;
 }
 
@@ -470,7 +470,7 @@ static const char *GetDecimalSeparator()
  * @param number    the number to write down
  * @param separator the thousands-separator to use
  */
-static void FormatNumber(StringBuilder &builder, int64_t number, const char *separator)
+static void FormatNumber(StringBuilder &builder, int64_t number, std::string_view separator)
 {
 	static const int max_digits = 20;
 	uint64_t divisor = 10000000000000000000ULL;
@@ -500,8 +500,8 @@ static void FormatNumber(StringBuilder &builder, int64_t number, const char *sep
 
 static void FormatCommaNumber(StringBuilder &builder, int64_t number)
 {
-	const char *separator = _settings_game.locale.digit_group_separator.c_str();
-	if (StrEmpty(separator)) separator = _langpack.langpack->digit_group_separator;
+	std::string_view separator = _settings_game.locale.digit_group_separator;
+	if (separator.empty()) separator = _langpack.langpack->digit_group_separator;
 	FormatNumber(builder, number, separator);
 }
 
@@ -529,8 +529,8 @@ static void FormatBytes(StringBuilder &builder, int64_t number)
 {
 	assert(number >= 0);
 
-	/*                                   1   2^10  2^20  2^30  2^40  2^50  2^60 */
-	const char * const iec_prefixes[] = {"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"};
+	/*                                       1   2^10  2^20  2^30  2^40  2^50  2^60 */
+	const std::string_view iec_prefixes[] = {"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"};
 	uint id = 1;
 	while (number >= 1024 * 1024) {
 		number /= 1024;
@@ -620,9 +620,9 @@ static void FormatGenericCurrency(StringBuilder &builder, const CurrencySpec *sp
 		}
 	}
 
-	const char *separator = _settings_game.locale.digit_group_separator_currency.c_str();
-	if (StrEmpty(separator)) separator = GetCurrency().separator.c_str();
-	if (StrEmpty(separator)) separator = _langpack.langpack->digit_group_separator_currency;
+	std::string_view separator = _settings_game.locale.digit_group_separator_currency;
+	if (separator.empty()) separator = GetCurrency().separator;
+	if (separator.empty()) separator = _langpack.langpack->digit_group_separator_currency;
 	FormatNumber(builder, number, separator);
 	if (number_str != STR_NULL) {
 		FormatString(builder, GetStringPtr(number_str), {});
@@ -1808,7 +1808,7 @@ static void StationGetSpecialString(StringBuilder &builder, StationFacilities x)
 	if (x.Test(StationFacility::Airport)) builder.PutUtf8(SCC_PLANE);
 }
 
-static const char * const _silly_company_names[] = {
+static const std::string_view _silly_company_names[] = {
 	"Bloggs Brothers",
 	"Tiny Transport Ltd.",
 	"Express Travel",
@@ -1824,7 +1824,7 @@ static const char * const _silly_company_names[] = {
 	"Getout & Pushit Ltd."
 };
 
-static const char * const _surname_list[] = {
+static const std::string_view _surname_list[] = {
 	"Adams",
 	"Allan",
 	"Baker",
@@ -1856,7 +1856,7 @@ static const char * const _surname_list[] = {
 	"Watkins"
 };
 
-static const char * const _silly_surname_list[] = {
+static const std::string_view _silly_surname_list[] = {
 	"Grumpy",
 	"Dozy",
 	"Speedy",
@@ -1876,7 +1876,7 @@ static const char _initial_name_letters[] = {
 	'K', 'L', 'M', 'N', 'P', 'R', 'S', 'T', 'W',
 };
 
-static std::span<const char * const> GetSurnameOptions()
+static std::span<const std::string_view> GetSurnameOptions()
 {
 	if (_settings_game.game_creation.landscape == LandscapeType::Toyland) return _silly_surname_list;
 	return _surname_list;
@@ -1887,7 +1887,7 @@ static std::span<const char * const> GetSurnameOptions()
  * @param seed The seed the surname was generated from.
  * @return The surname.
  */
-static const char *GetSurname(uint32_t seed)
+static std::string_view GetSurname(uint32_t seed)
 {
 	auto surname_options = GetSurnameOptions();
 	return surname_options[surname_options.size() * GB(seed, 16, 8) >> 8];
@@ -2037,7 +2037,7 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 #endif
 
 #ifdef WITH_COCOA
-	extern void MacOSSetCurrentLocaleName(const char *iso_code);
+	extern void MacOSSetCurrentLocaleName(std::string_view iso_code);
 	MacOSSetCurrentLocaleName(_current_language->isocode);
 #endif
 
@@ -2220,7 +2220,7 @@ void InitializeLanguagePacks()
  * Get the ISO language code of the currently loaded language.
  * @return the ISO code.
  */
-const char *GetCurrentLanguageIsoCode()
+std::string_view GetCurrentLanguageIsoCode()
 {
 	return _langpack.langpack->isocode;
 }
@@ -2297,7 +2297,7 @@ class LanguagePackGlyphSearcher : public MissingGlyphSearcher {
 		return false;
 	}
 
-	void SetFontNames([[maybe_unused]] FontCacheSettings *settings, [[maybe_unused]] const char *font_name, [[maybe_unused]] const void *os_data) override
+	void SetFontNames([[maybe_unused]] FontCacheSettings *settings, [[maybe_unused]] std::string_view font_name, [[maybe_unused]] const void *os_data) override
 	{
 #if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
 		settings->small.font = font_name;

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -96,7 +96,7 @@ uint64_t GetParamMaxDigits(uint count, FontSize size = FS_NORMAL);
 extern TextDirection _current_text_dir; ///< Text direction of the currently selected language
 
 void InitializeLanguagePacks();
-const char *GetCurrentLanguageIsoCode();
+std::string_view GetCurrentLanguageIsoCode();
 std::string_view GetListSeparator();
 
 /**
@@ -189,7 +189,7 @@ public:
 	 * @param font_name The new font name.
 	 * @param os_data Opaque pointer to OS-specific data.
 	 */
-	virtual void SetFontNames(struct FontCacheSettings *settings, const char *font_name, const void *os_data = nullptr) = 0;
+	virtual void SetFontNames(struct FontCacheSettings *settings, std::string_view font_name, const void *os_data = nullptr) = 0;
 
 	bool FindMissingGlyphs();
 };

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -656,7 +656,7 @@ void TextfileWindow::ScrollToLine(size_t line)
 	return true;
 }
 
-/* virtual */ void TextfileWindow::SetFontNames([[maybe_unused]] FontCacheSettings *settings, [[maybe_unused]] const char *font_name, [[maybe_unused]] const void *os_data)
+/* virtual */ void TextfileWindow::SetFontNames([[maybe_unused]] FontCacheSettings *settings, [[maybe_unused]] std::string_view font_name, [[maybe_unused]] const void *os_data)
 {
 #if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
 	settings->mono.font = font_name;

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -35,7 +35,7 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 	FontSize DefaultSize() override;
 	std::optional<std::string_view> NextString() override;
 	bool Monospace() override;
-	void SetFontNames(FontCacheSettings *settings, const char *font_name, const void *os_data) override;
+	void SetFontNames(FontCacheSettings *settings, std::string_view font_name, const void *os_data) override;
 	void ScrollToLine(size_t line);
 
 	virtual void LoadTextfile(const std::string &textfile, Subdirectory dir);


### PR DESCRIPTION
## Motivation / Problem

Old style C-strings.


## Description

Mostly just changing `const char *` to `std::string_view`, but also replacing `StrEmpty(str)` with `str.empty()` and some other similar changes.


## Limitations

There are still many C-style strings left. Even in this file, but those require way more work to get rid of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
