### PR TITLE
Codechange: use std::string_view over const char *

### DIFF
--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -176,7 +176,7 @@ protected:
 	 * Get the extension that is used to identify this set.
 	 * @return the extension
 	 */
-	static const char *GetExtension();
+	static std::string_view GetExtension();
 public:
 	/**
 	 * Determine the graphics pack that has to be used.
@@ -219,9 +219,9 @@ public:
  * @param ci The content info to compare it to.
  * @param md5sum Should the MD5 checksum be tested as well?
  * @param s The list with sets.
- * @return The filename of the first file of the base set, or \c nullptr if there is no match.
+ * @return The filename of the first file of the base set, or \c std::nullopt if there is no match.
  */
 template <class Tbase_set>
-const char *TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, const Tbase_set *s);
+std::optional<std::string_view> TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, const Tbase_set *s);
 
 #endif /* BASE_MEDIA_BASE_H */

--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -319,21 +319,21 @@ template <class Tbase_set>
 
 #include "network/core/tcp_content_type.h"
 
-template <class Tbase_set> const char *TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, const Tbase_set *s)
+template <class Tbase_set> std::optional<std::string_view> TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, const Tbase_set *s)
 {
 	for (; s != nullptr; s = s->next) {
 		if (s->GetNumMissing() != 0) continue;
 
 		if (s->shortname != ci.unique_id) continue;
-		if (!md5sum) return s->files[0].filename.c_str();
+		if (!md5sum) return s->files[0].filename;
 
 		MD5Hash md5;
 		for (const auto &file : s->files) {
 			md5 ^= file.hash;
 		}
-		if (md5 == ci.md5sum) return s->files[0].filename.c_str();
+		if (md5 == ci.md5sum) return s->files[0].filename;
 	}
-	return nullptr;
+	return std::nullopt;
 }
 
 template <class Tbase_set>

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -672,20 +672,20 @@ static ScenarioScanner _scanner;
  * Find a given scenario based on its unique ID.
  * @param ci The content info to compare it to.
  * @param md5sum Whether to look at the md5sum or the id.
- * @return The filename of the file, else \c nullptr.
+ * @return The filename of the file, else \c std::nullopt.
  */
-const char *FindScenario(const ContentInfo &ci, bool md5sum)
+std::optional<std::string_view> FindScenario(const ContentInfo &ci, bool md5sum)
 {
 	_scanner.Scan(false);
 
 	for (ScenarioIdentifier &id : _scanner) {
 		if (md5sum ? (id.md5sum == ci.md5sum)
 		           : (id.scenid == ci.unique_id)) {
-			return id.filename.c_str();
+			return id.filename;
 		}
 	}
 
-	return nullptr;
+	return std::nullopt;
 }
 
 /**
@@ -696,7 +696,7 @@ const char *FindScenario(const ContentInfo &ci, bool md5sum)
  */
 bool HasScenario(const ContentInfo &ci, bool md5sum)
 {
-	return (FindScenario(ci, md5sum) != nullptr);
+	return FindScenario(ci, md5sum).has_value();
 }
 
 /**

--- a/src/fios.h
+++ b/src/fios.h
@@ -121,7 +121,7 @@ std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation 
 std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
 
 void ScanScenarios();
-const char *FindScenario(const ContentInfo &ci, bool md5sum);
+std::optional<std::string_view> FindScenario(const ContentInfo &ci, bool md5sum);
 
 /**
  * A savegame name automatically numbered.

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -506,7 +506,7 @@ template <>
 }
 
 template <>
-/* static */ const char *BaseMedia<GraphicsSet>::GetExtension()
+/* static */ std::string_view BaseMedia<GraphicsSet>::GetExtension()
 {
 	return ".obg"; // OpenTTD Base Graphics
 }

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -83,7 +83,7 @@ template <>
 }
 
 template <>
-/* static */ const char *BaseMedia<MusicSet>::GetExtension()
+/* static */ std::string_view BaseMedia<MusicSet>::GetExtension()
 {
 	return ".obm"; // OpenTTD Base Music
 }

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -59,7 +59,7 @@ bool ContentInfo::IsValid() const
 std::optional<std::string> ContentInfo::GetTextfile(TextfileType type) const
 {
 	if (this->state == INVALID) return std::nullopt;
-	const char *tmp;
+	std::optional<std::string_view> tmp;
 	switch (this->type) {
 		default: NOT_REACHED();
 		case CONTENT_TYPE_AI:
@@ -93,8 +93,8 @@ std::optional<std::string> ContentInfo::GetTextfile(TextfileType type) const
 			tmp = FindScenario(*this, true);
 			break;
 	}
-	if (tmp == nullptr) return std::nullopt;
-	return ::GetTextfile(type, GetContentInfoSubDir(this->type), tmp);
+	if (!tmp.has_value()) return std::nullopt;
+	return ::GetTextfile(type, GetContentInfoSubDir(this->type), *tmp);
 }
 
 /**

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -240,10 +240,10 @@ bool ScriptScanner::HasScript(const ContentInfo &ci, bool md5sum)
 	return false;
 }
 
-const char *ScriptScanner::FindMainScript(const ContentInfo &ci, bool md5sum)
+std::optional<std::string_view> ScriptScanner::FindMainScript(const ContentInfo &ci, bool md5sum)
 {
 	for (const auto &item : this->info_list) {
-		if (IsSameScript(ci, md5sum, item.second, this->GetDirectory())) return item.second->GetMainScript().c_str();
+		if (IsSameScript(ci, md5sum, item.second, this->GetDirectory())) return item.second->GetMainScript();
 	}
-	return nullptr;
+	return std::nullopt;
 }

--- a/src/script/script_scanner.hpp
+++ b/src/script/script_scanner.hpp
@@ -74,7 +74,7 @@ public:
 	 * @param md5sum Whether to check the MD5 checksum.
 	 * @return A filename of a file of the content, else \c nullptr.
 	 */
-	const char *FindMainScript(const ContentInfo &ci, bool md5sum);
+	std::optional<std::string_view> FindMainScript(const ContentInfo &ci, bool md5sum);
 
 	bool AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename) override;
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -257,7 +257,7 @@ template <>
 }
 
 template <>
-/* static */ const char *BaseMedia<SoundsSet>::GetExtension()
+/* static */ std::string_view BaseMedia<SoundsSet>::GetExtension()
 {
 	return ".obs"; // OpenTTD Base Sounds
 }

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -842,9 +842,9 @@ void TextfileWindow::LoadText(std::string_view buf)
  * @param filename The filename of the content to look for.
  * @return The path to the textfile, \c nullptr otherwise.
  */
-std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, const std::string &filename)
+std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, std::string_view filename)
 {
-	static const char * const prefixes[] = {
+	static const std::string_view prefixes[] = {
 		"readme",
 		"changelog",
 		"license",
@@ -861,7 +861,7 @@ std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, cons
 	auto slash = filename.find_last_of(PATHSEPCHAR);
 	if (slash == std::string::npos) return std::nullopt;
 
-	std::string_view base_path(filename.data(), slash + 1);
+	std::string_view base_path = filename.substr(0, slash + 1);
 
 	static const std::initializer_list<std::string_view> extensions{
 		"txt",

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -15,7 +15,7 @@
 #include "textfile_type.h"
 #include "window_gui.h"
 
-std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, const std::string &filename);
+std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, std::string_view filename);
 
 /** Window for displaying a textfile */
 struct TextfileWindow : public Window, MissingGlyphSearcher {


### PR DESCRIPTION
## Motivation / Problem

C-style strings, in this case related to finding content (locally).


## Description

Replace `const char *` returning functions with `std::string_view` or `std::optional<std::string_view>` when it previously used `nullptr` to say nothing was found.


## Limitations

Still plenty of `char *` left in the code base.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
