### PR TITLE
Codechange: replace more std::string_view in network code

### DIFF
--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -141,4 +141,22 @@ NetworkError GetSocketError(SOCKET d);
 static_assert(sizeof(in_addr)  ==  4); ///< IPv4 addresses should be 4 bytes.
 static_assert(sizeof(in6_addr) == 16); ///< IPv6 addresses should be 16 bytes.
 
+struct SocketSender {
+	SOCKET sock;
+
+	ssize_t operator()(std::span<const uint8_t> buffer)
+	{
+		return send(this->sock, reinterpret_cast<const char *>(buffer.data()), static_cast<int>(buffer.size()), 0);
+	}
+};
+
+struct SocketReceiver {
+	SOCKET sock;
+
+	ssize_t operator()(std::span<uint8_t> buffer)
+	{
+		return recv(this->sock, reinterpret_cast<char *>(buffer.data()), static_cast<int>(buffer.size()), 0);
+	}
+};
+
 #endif /* NETWORK_CORE_OS_ABSTRACTION_H */

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -397,18 +397,18 @@ std::vector<uint8_t> Packet::Recv_buffer()
 
 /**
  * Extract at most the length of the span bytes from the packet into the span.
- * @param span The span to write the bytes to.
+ * @param destination The span to write the bytes to.
  * @return The number of bytes that were actually read.
  */
-size_t Packet::Recv_bytes(std::span<uint8_t> span)
+size_t Packet::Recv_bytes(std::span<uint8_t> destination)
 {
-	auto tranfer_to_span = [](std::span<uint8_t> destination, const char *source, size_t amount) {
-		size_t to_copy = std::min(amount, destination.size());
-		std::copy(source, source + to_copy, destination.data());
-		return to_copy;
+	auto transfer_to_span = [&destination](std::span<const uint8_t> source) {
+		auto to_copy = source.subspan(0, destination.size());
+		std::ranges::copy(to_copy, destination.begin());
+		return to_copy.size();
 	};
 
-	return this->TransferOut(tranfer_to_span, span);
+	return this->TransferOut(transfer_to_span);
 }
 
 /**

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -95,29 +95,22 @@ public:
 	 * Transfer data from the packet to the given function. It starts reading at the
 	 * position the last transfer stopped.
 	 * See Packet::TransferIn for more information about transferring data to functions.
-	 * @param transfer_function The function to pass the buffer as second parameter and the
-	 *                          amount to write as third parameter. It returns the amount that
-	 *                          was written or -1 upon errors.
+	 * @param transfer_function The function to pass span of bytes to write to.
+	 *                          It returns the amount that was written or -1 upon errors.
 	 * @param limit             The maximum amount of bytes to transfer.
-	 * @param destination       The first parameter of the transfer function.
-	 * @param args              The fourth and further parameters to the transfer function, if any.
+	 * @tparam F The type of the transfer_function.
 	 * @return The return value of the transfer_function.
 	 */
-	template <
-		typename A = size_t, ///< The type for the amount to be passed, so it can be cast to the right type.
-		typename F,          ///< The type of the function.
-		typename D,          ///< The type of the destination.
-		typename ... Args>   ///< The types of the remaining arguments to the function.
-	ssize_t TransferOutWithLimit(F transfer_function, size_t limit, D destination, Args&& ... args)
+	template <typename F>
+	ssize_t TransferOutWithLimit(F transfer_function, size_t limit)
 	{
 		size_t amount = std::min(this->RemainingBytesToTransfer(), limit);
 		if (amount == 0) return 0;
 
 		assert(this->pos < this->buffer.size());
 		assert(this->pos + amount <= this->buffer.size());
-		/* Making buffer a char means casting a lot in the Recv/Send functions. */
-		const char *output_buffer = reinterpret_cast<const char*>(this->buffer.data() + this->pos);
-		ssize_t bytes = transfer_function(destination, output_buffer, static_cast<A>(amount), std::forward<Args>(args)...);
+		auto output_buffer = std::span<const uint8_t>(this->buffer.data() + this->pos, amount);
+		ssize_t bytes = transfer_function(output_buffer);
 		if (bytes > 0) this->pos += bytes;
 		return bytes;
 	}
@@ -126,21 +119,15 @@ public:
 	 * Transfer data from the packet to the given function. It starts reading at the
 	 * position the last transfer stopped.
 	 * See Packet::TransferIn for more information about transferring data to functions.
-	 * @param transfer_function The function to pass the buffer as second parameter and the
-	 *                          amount to write as third parameter. It returns the amount that
-	 *                          was written or -1 upon errors.
-	 * @param destination       The first parameter of the transfer function.
-	 * @param args              The fourth and further parameters to the transfer function, if any.
-	 * @tparam A    The type for the amount to be passed, so it can be cast to the right type.
-	 * @tparam F    The type of the transfer_function.
-	 * @tparam D    The type of the destination.
-	 * @tparam Args The types of the remaining arguments to the function.
+	 * @param transfer_function The function to pass span of bytes to write to.
+	 *                          It returns the amount that was written or -1 upon errors.
+	 * @tparam F The type of the transfer_function.
 	 * @return The return value of the transfer_function.
 	 */
-	template <typename A = size_t, typename F, typename D, typename ... Args>
-	ssize_t TransferOut(F transfer_function, D destination, Args&& ... args)
+	template <typename F>
+	ssize_t TransferOut(F transfer_function)
 	{
-		return TransferOutWithLimit<A>(transfer_function, std::numeric_limits<size_t>::max(), destination, std::forward<Args>(args)...);
+		return TransferOutWithLimit(transfer_function, std::numeric_limits<size_t>::max());
 	}
 
 	/**
@@ -161,28 +148,21 @@ public:
 	 *
 	 * This will attempt to write all the remaining bytes into the packet. It updates the
 	 * position based on how many bytes were actually written by the called transfer_function.
-	 * @param transfer_function The function to pass the buffer as second parameter and the
-	 *                          amount to read as third parameter. It returns the amount that
-	 *                          was read or -1 upon errors.
-	 * @param source            The first parameter of the transfer function.
-	 * @param args              The fourth and further parameters to the transfer function, if any.
-	 * @tparam A    The type for the amount to be passed, so it can be cast to the right type.
-	 * @tparam F    The type of the transfer_function.
-	 * @tparam S    The type of the source.
-	 * @tparam Args The types of the remaining arguments to the function.
+	 * @param transfer_function The function to pass a span of bytes to read to.
+	 *                          It returns the amount that was read or -1 upon errors.
+	 * @tparam F The type of the transfer_function.
 	 * @return The return value of the transfer_function.
 	 */
-	template <typename A = size_t, typename F, typename S, typename ... Args>
-	ssize_t TransferIn(F transfer_function, S source, Args&& ... args)
+	template <typename F>
+	ssize_t TransferIn(F transfer_function)
 	{
 		size_t amount = this->RemainingBytesToTransfer();
 		if (amount == 0) return 0;
 
 		assert(this->pos < this->buffer.size());
 		assert(this->pos + amount <= this->buffer.size());
-		/* Making buffer a char means casting a lot in the Recv/Send functions. */
-		char *input_buffer = reinterpret_cast<char*>(this->buffer.data() + this->pos);
-		ssize_t bytes = transfer_function(source, input_buffer, static_cast<A>(amount), std::forward<Args>(args)...);
+		auto input_buffer = std::span<uint8_t>(this->buffer.data() + this->pos, amount);
+		ssize_t bytes = transfer_function(input_buffer);
 		if (bytes > 0) this->pos += bytes;
 		return bytes;
 	}

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -81,7 +81,7 @@ SendPacketsState NetworkTCPSocketHandler::SendPackets(bool closing_down)
 
 	while (!this->packet_queue.empty()) {
 		Packet &p = *this->packet_queue.front();
-		ssize_t res = p.TransferOut<int>(send, this->sock, 0);
+		ssize_t res = p.TransferOut(SocketSender{this->sock});
 		if (res == -1) {
 			NetworkError err = NetworkError::GetLast();
 			if (!err.WouldBlock()) {
@@ -131,7 +131,7 @@ std::unique_ptr<Packet> NetworkTCPSocketHandler::ReceivePacket()
 	/* Read packet size */
 	if (!p.HasPacketSizeData()) {
 		while (p.RemainingBytesToTransfer() != 0) {
-			res = p.TransferIn<int>(recv, this->sock, 0);
+			res = p.TransferIn(SocketReceiver{this->sock});
 			if (res == -1) {
 				NetworkError err = NetworkError::GetLast();
 				if (!err.WouldBlock()) {
@@ -159,7 +159,7 @@ std::unique_ptr<Packet> NetworkTCPSocketHandler::ReceivePacket()
 
 	/* Read rest of packet */
 	while (p.RemainingBytesToTransfer() != 0) {
-		res = p.TransferIn<int>(recv, this->sock, 0);
+		res = p.TransferIn(SocketReceiver{this->sock});
 		if (res == -1) {
 			NetworkError err = NetworkError::GetLast();
 			if (!err.WouldBlock()) {

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -519,7 +519,7 @@ public:
 
 	NetworkRecvStatus ReceivePackets();
 
-	const char *ReceiveCommand(Packet &p, CommandPacket &cp);
+	std::optional<std::string_view> ReceiveCommand(Packet &p, CommandPacket &cp);
 	void SendCommand(Packet &p, const CommandPacket &cp);
 
 	bool IsPendingDeletion() const { return this->is_pending_deletion; }

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -43,7 +43,7 @@ public:
 
 				Debug(net, 2, "[{}] Banned ip tried to join ({}), refused", Tsocket::GetName(), entry);
 
-				if (p.TransferOut<int>(send, s, 0) < 0) {
+				if (p.TransferOut(SocketSender{s}) < 0) {
 					Debug(net, 0, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
 				}
 				closesocket(s);
@@ -58,7 +58,7 @@ public:
 			Packet p(nullptr, Tfull_packet);
 			p.PrepareToSend();
 
-			if (p.TransferOut<int>(send, s, 0) < 0) {
+			if (p.TransferOut(SocketSender{s}) < 0) {
 				Debug(net, 0, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
 			}
 			closesocket(s);

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -94,7 +94,9 @@ void NetworkUDPSocketHandler::SendPacket(Packet &p, NetworkAddress &recv, bool a
 		}
 
 		/* Send the buffer */
-		ssize_t res = p.TransferOut<int>(sendto, s.first, 0, (const struct sockaddr *)send.GetAddress(), send.GetAddressLength());
+		ssize_t res = p.TransferOut([&](std::span<const uint8_t> buffer) {
+			return sendto(s.first, reinterpret_cast<const char *>(buffer.data()), static_cast<int>(buffer.size()), 0, reinterpret_cast<const struct sockaddr *>(send.GetAddress()), send.GetAddressLength());
+		});
 		Debug(net, 7, "sendto({})", send.GetAddressAsString());
 
 		/* Check for any errors, but ignore it otherwise */
@@ -120,7 +122,9 @@ void NetworkUDPSocketHandler::ReceivePackets()
 
 			/* Try to receive anything */
 			SetNonBlocking(s.first); // Some OSes seem to lose the non-blocking status of the socket
-			ssize_t nbytes = p.TransferIn<int>(recvfrom, s.first, 0, (struct sockaddr *)&client_addr, &client_len);
+			ssize_t nbytes = p.TransferIn([&](std::span<uint8_t> buffer) {
+				return recvfrom(s.first, reinterpret_cast<char *>(buffer.data()), static_cast<int>(buffer.size()), 0, reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);
+			});
 
 			/* Did we get the bytes for the base header of the packet? */
 			if (nbytes <= 0) break;    // No data, i.e. no packet

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -85,7 +85,7 @@ public:
 	 * Get the name used by the listener.
 	 * @return the name to show in debug logs and the like.
 	 */
-	static const char *GetName()
+	static std::string_view GetName()
 	{
 		return "admin";
 	}

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -915,14 +915,14 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMMAND(Packet 
 	if (this->status != STATUS_ACTIVE) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 
 	CommandPacket cp;
-	const char *err = this->ReceiveCommand(p, cp);
+	auto err = this->ReceiveCommand(p, cp);
 	cp.frame    = p.Recv_uint32();
 	cp.my_cmd   = p.Recv_bool();
 
 	Debug(net, 9, "Client::Receive_SERVER_COMMAND(): cmd={}, frame={}", cp.cmd, cp.frame);
 
-	if (err != nullptr) {
-		IConsolePrint(CC_WARNING, "Dropping server connection due to {}.", err);
+	if (err.has_value()) {
+		IConsolePrint(CC_WARNING, "Dropping server connection due to {}.", *err);
 		return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 	}
 

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -358,22 +358,22 @@ void NetworkDistributeCommands()
  * Receives a command from the network.
  * @param p the packet to read from.
  * @param cp the struct to write the data to.
- * @return an error message. When nullptr there has been no error.
+ * @return An error message, or std::nullopt there has been no error.
  */
-const char *NetworkGameSocketHandler::ReceiveCommand(Packet &p, CommandPacket &cp)
+std::optional<std::string_view> NetworkGameSocketHandler::ReceiveCommand(Packet &p, CommandPacket &cp)
 {
 	cp.company = (CompanyID)p.Recv_uint8();
 	cp.cmd     = static_cast<Commands>(p.Recv_uint16());
-	if (!IsValidCommand(cp.cmd))               return "invalid command";
+	if (!IsValidCommand(cp.cmd)) return "invalid command";
 	if (GetCommandFlags(cp.cmd).Test(CommandFlag::Offline)) return "single-player only command";
 	cp.err_msg = p.Recv_uint16();
 	cp.data    = _cmd_dispatch[cp.cmd].Sanitize(p.Recv_buffer());
 
 	uint8_t callback = p.Recv_uint8();
-	if (callback >= _callback_table.size() || _cmd_dispatch[cp.cmd].Unpack[callback] == nullptr)  return "invalid callback";
+	if (callback >= _callback_table.size() || _cmd_dispatch[cp.cmd].Unpack[callback] == nullptr) return "invalid callback";
 
 	cp.callback = _callback_table[callback];
-	return nullptr;
+	return std::nullopt;
 }
 
 /**

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -110,7 +110,7 @@ public:
 	 * Get the name used by the listener.
 	 * @return the name to show in debug logs and the like.
 	 */
-	static const char *GetName()
+	static std::string_view GetName()
 	{
 		return "server";
 	}

--- a/src/tests/test_network_crypto.cpp
+++ b/src/tests/test_network_crypto.cpp
@@ -39,14 +39,14 @@ static std::tuple<Packet, bool> CreatePacketForReading(Packet &source, MockNetwo
 
 	Packet dest(socket_handler, COMPAT_MTU, source.Size());
 
-	auto transfer_in = [](Packet &source, char *dest_data, size_t length) {
-		auto transfer_out = [](char *dest_data, const char *source_data, size_t length) {
-			std::copy(source_data, source_data + length, dest_data);
-			return length;
+	auto transfer_in = [&source](std::span<uint8_t> dest_data) {
+		auto transfer_out = [&dest_data](std::span<const uint8_t> source_data) {
+			std::ranges::copy(source_data, dest_data.begin());
+			return source_data.size();
 		};
-		return source.TransferOutWithLimit(transfer_out, length, dest_data);
+		return source.TransferOutWithLimit(transfer_out, dest_data.size());
 	};
-	dest.TransferIn(transfer_in, source);
+	dest.TransferIn(transfer_in);
 
 	bool valid = dest.PrepareToRead();
 	dest.Recv_uint8(); // Ignore the type


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

Rewrite packet data transfer functions to just use `std::span` to pass buffers around. This means a significant rewrite, but it simplifies the code and requires fewer `const char*`s.

Also replace a number of single `const char *`s with `std::string_view` or `std::optional<std::string_view>`.


## Limitations

The casts in os_abstraction.h and udp.cpp are needed for Windows to build, as that requires `char*` instead of `void*`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
