### PR TITLE
Fix: [NewGRF] Computed VarAction2 callback results were not always properly masked to 15 bit results.

### DIFF
--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -230,9 +230,8 @@ const SpriteGroup *DeterministicSpriteGroup::Resolve(ResolverObject &object) con
 
 	if (this->calculated_result) {
 		/* nvar == 0 is a special case -- we turn our value into a callback result */
-		if (value != CALLBACK_FAILED) value = GB(value, 0, 15);
 		static CallbackResultSpriteGroup nvarzero(0);
-		nvarzero.result = value;
+		nvarzero.result = GB(value, 0, 15);
 		return &nvarzero;
 	}
 

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -198,9 +198,10 @@ const SpriteGroup *DeterministicSpriteGroup::Resolve(ResolverObject &object) con
 		if (adjust.variable == 0x7E) {
 			const SpriteGroup *subgroup = SpriteGroup::Resolve(adjust.subroutine, object, false);
 			if (subgroup == nullptr) {
-				value = CALLBACK_FAILED;
+				value = UINT16_MAX;
 			} else {
 				value = subgroup->GetCallbackResult();
+				if (value == CALLBACK_FAILED) value = UINT16_MAX;
 			}
 
 			/* Note: 'last_value' and 'reseed' are shared between the main chain and the procedure */


### PR DESCRIPTION
## Motivation / Problem

VarAction2 can return computed results. Computed values can be either `uint8`, `uint16` or `uint32`.
* The full 8/16/32 bit value is stored in `last_value`.
* The return value is masked to 15 bits.

There is some confusion in `DeterministicSpriteGroup::Resolve` on how to handle callback failure values.
Turns out: if the computed result ends up as 0xFFFF, the 15 bit masking is skipped.

## Description

* Procedure calls via var 7E can return `CALLBACK_FAILED`.
    * Further computations treat this value as 0xFFFF.
    * This matches [TTDP](https://github.com/ttdpatch/ttdpatch/blob/a88a0bf794ed0f085f7cd8fba682d060ab4789c9/patches/newsprit.asm#L2061).
    * `CALLBACK_FAILED` is an internal constant, which also happens to have the value 0xFFFF.
    * That is, the behaviour is technically correct, but would break if we change `CALLBACK_FAILED` to something else. (e.g. `std::nullopt`, see later PR)
* Possibly related... when returning the computed result, the 15 bit masking was skipped, if the computation resulted in a numeric value equaling `CALLBACK_FAILED`.
    * This comparison is essentially a type mismatch. Comparing the computed value with `CALLBACK_FAILED` makes no sense.
    * There is also no special case in [TTDP](https://github.com/ttdpatch/ttdpatch/blob/master/patches/newsprit.asm#L1402).

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
