### PR TITLE
Fix: [NewGRF] The result of Action123 evaluation affected rerandomisation in a weird corner case.

### DIFF
--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1255,8 +1255,7 @@ static void DoTriggerVehicleRandomisation(Vehicle *v, VehicleRandomTrigger trigg
 	v->waiting_random_triggers.Set(trigger); // store now for var 5F
 	object.SetWaitingRandomTriggers(v->waiting_random_triggers);
 
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr) return;
+	object.ResolveRerandomisation();
 
 	/* Store remaining triggers. */
 	v->waiting_random_triggers.Reset(object.GetUsedRandomTriggers());

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -675,8 +675,7 @@ static void DoTriggerHouseRandomisation(TileIndex tile, HouseRandomTrigger trigg
 	SetHouseRandomTriggers(tile, waiting_random_triggers); // store now for var 5F
 	object.SetWaitingRandomTriggers(waiting_random_triggers);
 
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr) return;
+	object.ResolveRerandomisation();
 
 	/* Store remaining triggers. */
 	waiting_random_triggers.Reset(object.GetUsedRandomTriggers());

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -336,8 +336,7 @@ static void DoTriggerIndustryTileRandomisation(TileIndex tile, IndustryRandomTri
 	SetIndustryRandomTriggers(tile, waiting_random_triggers); // store now for var 5F
 	object.SetWaitingRandomTriggers(waiting_random_triggers);
 
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr) return;
+	object.ResolveRerandomisation();
 
 	/* Store remaining triggers. */
 	waiting_random_triggers.Reset(object.GetUsedRandomTriggers());

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -458,8 +458,7 @@ void TriggerRoadStopRandomisation(BaseStation *st, TileIndex tile, StationRandom
 			RoadStopResolverObject object(ss, st, cur_tile, INVALID_ROADTYPE, GetStationType(cur_tile), GetStationGfx(cur_tile));
 			object.SetWaitingRandomTriggers(st->waiting_random_triggers);
 
-			const SpriteGroup *group = object.Resolve();
-			if (group == nullptr) return;
+			object.ResolveRerandomisation();
 
 			used_random_triggers.Set(object.GetUsedRandomTriggers());
 

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -337,12 +337,26 @@ public:
 	}
 
 	/**
+	 * Resolve bits to be rerandomised.
+	 * Access results via:
+	 * - reseed: Bits to rerandomise per scope, for features with proper PARENT rerandomisation. (only industry tiles)
+	 * - GetReseedSum: Bits to rerandomise for SELF scope, for features with broken-by-design PARENT randomisation. (all but industry tiles)
+	 * - GetUsedRandomTriggers: Consumed random triggers to be reset.
+	 */
+	void ResolveRerandomisation()
+	{
+		/* The Resolve result has no meaning.
+		 * It can be a SpriteSet, a callback result, or even an invalid SpriteGroup reference (nullptr). */
+		this->Resolve();
+	}
+
+	/**
 	 * Resolve callback.
 	 * @return Callback result.
 	 */
 	uint16_t ResolveCallback()
 	{
-		const SpriteGroup *result = Resolve();
+		const SpriteGroup *result = this->Resolve();
 		return result != nullptr ? result->GetCallbackResult() : CALLBACK_FAILED;
 	}
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -993,8 +993,7 @@ void TriggerStationRandomisation(BaseStation *st, TileIndex trigger_tile, Statio
 				StationResolverObject object(ss, st, tile, CBID_RANDOM_TRIGGER, 0);
 				object.SetWaitingRandomTriggers(st->waiting_random_triggers);
 
-				const SpriteGroup *group = object.Resolve();
-				if (group == nullptr) continue;
+				object.ResolveRerandomisation();
 
 				used_random_triggers.Set(object.GetUsedRandomTriggers());
 


### PR DESCRIPTION
## Motivation / Problem

* Usually the result of `Resolve` is "dynamic casted" to the expected result type. If the "cast" resulted in `nullptr`, this is treated as failure.
* Rerandomisation triggers have no result type, as such there is no "cast" involved. However, we still checked for `nullptr`, which is a very awkward case. It happens, if VarAction2 reference non-existing Action2 IDs. But there may be other corner cases.
* Rerandomisation should not care about the `Resolve` result. In particular it should not behave differently in weird corner cases, which are hard to track.
* [TTDP](https://github.com/ttdpatch/ttdpatch/blob/a88a0bf794ed0f085f7cd8fba682d060ab4789c9/patches/trigger.asm#L71) does not care either.

## Description

Add `ResolveRerandomisation` with some docs and with no return value.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
