### PR TITLE
Fix: Out-of-bounds read, if NewGRF stations provided no spritesets.

### DIFF
--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -218,13 +218,6 @@ uint32_t RoadStopScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] u
 	return UINT_MAX;
 }
 
-const SpriteGroup *RoadStopResolverObject::ResolveReal(const RealSpriteGroup *group) const
-{
-	if (group == nullptr) return nullptr;
-
-	return group->loading[0];
-}
-
 RoadStopResolverObject::RoadStopResolverObject(const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view,
 		CallbackID callback, uint32_t param1, uint32_t param2)
 	: SpecializedResolverObject<StationRandomTriggers>(roadstopspec->grf_prop.grffile, callback, param1, param2), roadstop_scope(*this, st, roadstopspec, tile, roadtype, type, view)

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -122,8 +122,6 @@ struct RoadStopResolverObject : public SpecializedResolverObject<StationRandomTr
 	}
 
 	TownScopeResolver *GetTown();
-
-	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
 };
 
 /** Road stop specification. */

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -522,7 +522,8 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 /* virtual */ const SpriteGroup *StationResolverObject::ResolveReal(const RealSpriteGroup *group) const
 {
 	if (this->station_scope.st == nullptr || !Station::IsExpected(this->station_scope.st)) {
-		return group->loading[0];
+		if (!group->loading.empty()) return group->loading[0];
+		return nullptr;
 	}
 
 	uint cargo = 0;
@@ -564,7 +565,8 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 		}
 	}
 
-	return group->loading[0];
+	if (!group->loading.empty()) return group->loading[0];
+	return nullptr;
 }
 
 GrfSpecFeature StationResolverObject::GetFeature() const


### PR DESCRIPTION
## Motivation / Problem

* NewGRF stations in purchase list access `RealSpriteGroup::loading[0]` unchecked.
* The same code exists for road stops, but since they have no `RealSpriteGroup`, it is dead code.

## Description

* Check bounds for stations.
* Remove unused function for road stops.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
