### PR TITLE
Codechange: replace char*s in file related functions

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1288,7 +1288,7 @@ static bool ConScript(std::span<std::string_view> argv)
 	if (!CloseConsoleLogIfActive()) {
 		if (argv.size() < 2) return false;
 
-		_iconsole_output_file = FileHandle::Open(std::string(argv[1]), "ab");
+		_iconsole_output_file = FileHandle::Open(argv[1], "ab");
 		if (!_iconsole_output_file.has_value()) {
 			IConsolePrint(CC_ERROR, "Could not open console log file '{}'.", argv[1]);
 		} else {

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1166,13 +1166,13 @@ uint FileScanner::Scan(const std::string_view extension, const std::string &dire
  * @param mode Mode to open file.
  * @return FileHandle, or std::nullopt on failure.
  */
-std::optional<FileHandle> FileHandle::Open(const std::string &filename, const std::string &mode)
+std::optional<FileHandle> FileHandle::Open(const std::string &filename, std::string_view mode)
 {
 #if defined(_WIN32)
 	/* Windows also requires mode to be wchar_t. */
 	auto f = _wfopen(OTTD2FS(filename).c_str(), OTTD2FS(mode).c_str());
 #else
-	auto f = fopen(filename.c_str(), mode.c_str());
+	auto f = fopen(filename.c_str(), std::string{mode}.c_str());
 #endif /* _WIN32 */
 
 	if (f == nullptr) return std::nullopt;

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -13,7 +13,7 @@
 #include "core/enum_type.hpp"
 #include "fileio_type.h"
 
-std::optional<FileHandle> FioFOpenFile(std::string_view filename, const char *mode, Subdirectory subdir, size_t *filesize = nullptr);
+std::optional<FileHandle> FioFOpenFile(std::string_view filename, std::string_view mode, Subdirectory subdir, size_t *filesize = nullptr);
 bool FioCheckFileExists(std::string_view filename, Subdirectory subdir);
 std::string FioFindFullPath(Subdirectory subdir, std::string_view filename);
 std::string FioGetDirectory(Searchpath sp, Subdirectory subdir);
@@ -21,11 +21,11 @@ std::string FioFindDirectory(Subdirectory subdir);
 void FioCreateDirectory(const std::string &name);
 bool FioRemove(const std::string &filename);
 
-const char *FiosGetScreenshotDir();
+std::string_view FiosGetScreenshotDir();
 
 void SanitizeFilename(std::string &filename);
 void AppendPathSeparator(std::string &buf);
-void DeterminePaths(const char *exe, bool only_local_path);
+void DeterminePaths(std::string_view exe, bool only_local_path);
 std::unique_ptr<char[]> ReadFileToMem(const std::string &filename, size_t &lenp, size_t maxsize);
 bool FileExists(const std::string &filename);
 bool ExtractTar(const std::string &tar_filename, Subdirectory subdir);

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -130,7 +130,9 @@ DECLARE_INCREMENT_DECREMENT_OPERATORS(Searchpath)
 
 class FileHandle {
 public:
-	static std::optional<FileHandle> Open(const std::string &filename, const std::string &mode);
+	static std::optional<FileHandle> Open(const std::string &filename, std::string_view mode);
+	static std::optional<FileHandle> Open(std::string_view filename, std::string_view mode) { return FileHandle::Open(std::string{filename}, mode); }
+	static std::optional<FileHandle> Open(const char *filename, std::string_view mode) { return FileHandle::Open(std::string{filename}, mode); }
 
 	inline void Close() { this->f.reset(); }
 

--- a/src/fios.h
+++ b/src/fios.h
@@ -112,9 +112,9 @@ bool FiosBrowseTo(const FiosItem *item);
 
 std::string FiosGetCurrentPath();
 std::optional<uint64_t> FiosGetDiskFreeSpace(const std::string &path);
-bool FiosDelete(const char *name);
-std::string FiosMakeHeightmapName(const char *name);
-std::string FiosMakeSavegameName(const char *name);
+bool FiosDelete(std::string_view name);
+std::string FiosMakeHeightmapName(std::string_view name);
+std::string FiosMakeSavegameName(std::string_view name);
 
 std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
 std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -231,7 +231,7 @@ char *getcwd(char *buf, size_t size)
 
 extern std::string _config_file;
 
-void DetermineBasePaths(const char *exe)
+void DetermineBasePaths(std::string_view exe)
 {
 	extern std::array<std::string, NUM_SEARCHPATHS> _searchpaths;
 

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -132,7 +132,7 @@ static void LargeWorldCallback(Viewport &vp, void *buf, uint y, uint pitch, uint
  * @param crashlog   Create path for crash.png
  * @return Pathname for a screenshot file.
  */
-static const char *MakeScreenshotName(std::string_view default_fn, std::string_view ext, bool crashlog = false)
+static std::string_view MakeScreenshotName(std::string_view default_fn, std::string_view ext, bool crashlog = false)
 {
 	bool generate = _screenshot_name.empty();
 
@@ -154,7 +154,7 @@ static const char *MakeScreenshotName(std::string_view default_fn, std::string_v
 	/* Add extension to screenshot file */
 	_screenshot_name += fmt::format(".{}", ext);
 
-	const char *screenshot_dir = crashlog ? _personal_dir.c_str() : FiosGetScreenshotDir();
+	std::string_view screenshot_dir = crashlog ? _personal_dir : FiosGetScreenshotDir();
 
 	for (uint serial = 1;; serial++) {
 		_full_screenshot_path = fmt::format("{}{}", screenshot_dir, _screenshot_name);
@@ -166,7 +166,7 @@ static const char *MakeScreenshotName(std::string_view default_fn, std::string_v
 		_screenshot_name += fmt::format("#{}.{}", serial, ext);
 	}
 
-	return _full_screenshot_path.c_str();
+	return _full_screenshot_path;
 }
 
 /** Make a screenshot of the current screen. */
@@ -311,7 +311,7 @@ static void HeightmapCallback(void *buffer, uint y, uint, uint n)
  * Make a heightmap of the current map.
  * @param filename Filename to use for saving.
  */
-bool MakeHeightmapScreenshot(const char *filename)
+bool MakeHeightmapScreenshot(std::string_view filename)
 {
 	auto provider = GetScreenshotProvider();
 	if (provider == nullptr) return false;

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -23,7 +23,7 @@ enum ScreenshotType : uint8_t {
 	SC_MINIMAP,     ///< Minimap screenshot.
 };
 
-bool MakeHeightmapScreenshot(const char *filename);
+bool MakeHeightmapScreenshot(std::string_view filename);
 void MakeScreenshotWithConfirm(ScreenshotType t);
 bool MakeScreenshot(ScreenshotType t, const std::string &name, uint32_t width = 0, uint32_t height = 0);
 bool MakeMinimapWorldScreenshot();

--- a/src/screenshot_bmp.cpp
+++ b/src/screenshot_bmp.cpp
@@ -43,7 +43,7 @@ class ScreenshotProvider_Bmp : public ScreenshotProvider {
 public:
 	ScreenshotProvider_Bmp() : ScreenshotProvider("bmp", "BMP", 10) {}
 
-	bool MakeImage(const char *name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
+	bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
 	{
 		uint bpp; // bytes per pixel
 		switch (pixelformat) {

--- a/src/screenshot_pcx.cpp
+++ b/src/screenshot_pcx.cpp
@@ -41,7 +41,7 @@ class ScreenshotProvider_Pcx : public ScreenshotProvider {
 public:
 	ScreenshotProvider_Pcx() : ScreenshotProvider("pcx", "PCX", 20) {}
 
-	bool MakeImage(const char *name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
+	bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
 	{
 		uint maxlines;
 		uint y;

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -30,7 +30,7 @@ class ScreenshotProvider_Png : public ScreenshotProvider {
 public:
 	ScreenshotProvider_Png() : ScreenshotProvider("png", "PNG", 0) {}
 
-	bool MakeImage(const char *name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
+	bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
 	{
 		png_color rq[256];
 		uint i, y, n;
@@ -46,7 +46,7 @@ public:
 		if (!of.has_value()) return false;
 		auto &f = *of;
 
-		png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, const_cast<char *>(name), png_my_error, png_my_warning);
+		png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, &name, png_my_error, png_my_warning);
 
 		if (png_ptr == nullptr) {
 			return false;
@@ -169,13 +169,13 @@ public:
 private:
 	static void PNGAPI png_my_error(png_structp png_ptr, png_const_charp message)
 	{
-		Debug(misc, 0, "[libpng] error: {} - {}", message, (const char *)png_get_error_ptr(png_ptr));
+		Debug(misc, 0, "[libpng] error: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
 		longjmp(png_jmpbuf(png_ptr), 1);
 	}
 
 	static void PNGAPI png_my_warning(png_structp png_ptr, png_const_charp message)
 	{
-		Debug(misc, 1, "[libpng] warning: {} - {}", message, (const char *)png_get_error_ptr(png_ptr));
+		Debug(misc, 1, "[libpng] warning: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
 	}
 };
 

--- a/src/screenshot_type.h
+++ b/src/screenshot_type.h
@@ -36,7 +36,7 @@ public:
 		ProviderManager<ScreenshotProvider>::Unregister(*this);
 	}
 
-	virtual bool MakeImage(const char *name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) = 0;
+	virtual bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) = 0;
 };
 
 #endif /* SCREENSHOT_TYPE_H */

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -502,9 +502,9 @@ int CDECL main(int argc, char *argv[])
  * @param mode Mode to open file.
  * @return FileHandle, or std::nullopt on failure.
  */
-std::optional<FileHandle> FileHandle::Open(const std::string &filename, const std::string &mode)
+std::optional<FileHandle> FileHandle::Open(const std::string &filename, std::string_view mode)
 {
-	auto f = fopen(filename.c_str(), mode.c_str());
+	auto f = fopen(filename.c_str(), std::string{mode}.c_str());
 	if (f == nullptr) return std::nullopt;
 	return FileHandle(f);
 }


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

First add `std::string_view` support to `FileHandle::Open`, and such to the ambiguity that creates for `const char *` introduce a `const char *` variant as well.

Replace some `const char *`s with `std::string_view`, and some other miscellaneous changes requires to make `std::string_view` work nicely.


## Limitations

Adding `const char *` to remove `const char *`... Do we need to start adding string/string_view literals to constant strings to prevent these?
Also, how would we know we're done? There'll still be `char *`s in some places where we simply cannot get rid of them due to accessing C-style APIs.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
