### PR TITLE
Fix: [NewGRF] AI station construction callback did not work for stations with ID >= 0x100.

### DIFF
--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -225,7 +225,7 @@ std::pair<const GRFFile *, uint16_t> GetAiPurchaseCallbackResult(uint8_t feature
 	object.generic_scope.feature           = feature;
 
 	auto callback = GetGenericCallbackResult(feature, object, 0, 0);
-	if (callback.second != CALLBACK_FAILED) callback.second = GB(callback.second, 0, 8);
+	if (callback.second != CALLBACK_FAILED && callback.first->grf_version < 8) callback.second = GB(callback.second, 0, 8);
 	return callback;
 }
 

--- a/src/newgrf_generic.h
+++ b/src/newgrf_generic.h
@@ -47,7 +47,7 @@ static const IndustryType IT_AI_TOWN    = 0xFF; ///< The AI actually wants to tr
 void ResetGenericCallbacks();
 void AddGenericCallback(uint8_t feature, const GRFFile *file, const SpriteGroup *group);
 
-uint16_t GetAiPurchaseCallbackResult(uint8_t feature, CargoType cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size, const GRFFile **file);
+std::pair<const GRFFile *, uint16_t> GetAiPurchaseCallbackResult(uint8_t feature, CargoType cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size);
 void AmbientSoundEffectCallback(TileIndex tile);
 
 /** Play an ambient sound effect for an empty tile. */

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -175,8 +175,7 @@
 	EnforcePrecondition(false, source_industry == ScriptIndustryType::INDUSTRYTYPE_UNKNOWN || source_industry == ScriptIndustryType::INDUSTRYTYPE_TOWN || ScriptIndustryType::IsValidIndustryType(source_industry));
 	EnforcePrecondition(false, goal_industry   == ScriptIndustryType::INDUSTRYTYPE_UNKNOWN || goal_industry   == ScriptIndustryType::INDUSTRYTYPE_TOWN || ScriptIndustryType::IsValidIndustryType(goal_industry));
 
-	const GRFFile *file;
-	uint16_t res = GetAiPurchaseCallbackResult(
+	auto res = GetAiPurchaseCallbackResult(
 		GSF_STATIONS,
 		cargo_type,
 		0,
@@ -185,17 +184,16 @@
 		ClampTo<uint8_t>(distance / 2),
 		AICE_STATION_GET_STATION_ID,
 		source_station ? 0 : 1,
-		std::min<SQInteger>(15u, num_platforms) << 4 | std::min<SQInteger>(15u, platform_length),
-		&file
+		std::min<SQInteger>(15u, num_platforms) << 4 | std::min<SQInteger>(15u, platform_length)
 	);
 
 	Axis axis = direction == RAILTRACK_NW_SE ? AXIS_Y : AXIS_X;
 	bool adjacent = station_id != ScriptStation::STATION_JOIN_ADJACENT;
 	StationID to_join = ScriptStation::IsValidStation(station_id) ? station_id : StationID::Invalid();
-	if (res != CALLBACK_FAILED) {
-		const StationSpec *spec = StationClass::GetByGrf(file->grfid, res);
+	if (res.second != CALLBACK_FAILED) {
+		const StationSpec *spec = StationClass::GetByGrf(res.first->grfid, res.second);
 		if (spec == nullptr) {
-			Debug(grf, 1, "{} returned an invalid station ID for 'AI construction/purchase selection (18)' callback", file->filename);
+			Debug(grf, 1, "{} returned an invalid station ID for 'AI construction/purchase selection (18)' callback", res.first->filename);
 		} else {
 			/* We might have gotten an usable station spec. Try to build it, but if it fails we'll fall back to the original station. */
 			if (ScriptObject::Command<CMD_BUILD_RAIL_STATION>::Do(tile, (::RailType)GetCurrentRailType(), axis, num_platforms, platform_length, spec->class_index, spec->index, to_join, adjacent)) return true;


### PR DESCRIPTION
## Motivation / Problem

* The AI callback still did the old 8-bit callback masking.
* GRF version 8 removed 8-bit callbacks.
* Since OpenTTD 14 there are potentially more than 256 stations per GRF.

## Description

Apply the usual GRF version 8 logic.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
