### PR TITLE
Change: [NewGRF] If Action123 does not resolve in a valid SpriteSet, prefer drawing the default sprite instead of an invalid sprite.

### DIFF
--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -259,7 +259,7 @@ SpriteID GetCustomAirportSprite(const AirportSpec *as, uint8_t layout)
 {
 	AirportResolverObject object(INVALID_TILE, nullptr, as, layout);
 	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr) return as->preview_sprite;
+	if (group == nullptr || group->GetNumResults() == 0) return as->preview_sprite;
 
 	return group->GetResult();
 }

--- a/src/newgrf_badge.cpp
+++ b/src/newgrf_badge.cpp
@@ -276,7 +276,7 @@ PalSpriteID GetBadgeSprite(const Badge &badge, GrfSpecFeature feature, std::opti
 {
 	BadgeResolverObject object(badge, feature, introduction_date);
 	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr) return {0, PAL_NONE};
+	if (group == nullptr || group->GetNumResults() == 0) return {0, PAL_NONE};
 
 	PaletteID pal = badge.flags.Test(BadgeFlag::UseCompanyColour) ? remap : PAL_NONE;
 

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -141,7 +141,7 @@ SpriteID GetCanalSprite(CanalFeature feature, TileIndex tile)
 {
 	CanalResolverObject object(feature, tile);
 	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr) return 0;
+	if (group == nullptr || group->GetNumResults() == 0) return 0;
 
 	return group->GetResult();
 }

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -56,7 +56,7 @@ SpriteID GetCustomCargoSprite(const CargoSpec *cs)
 {
 	CargoResolverObject object(cs);
 	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr) return 0;
+	if (group == nullptr || group->GetNumResults() == 0) return 0;
 
 	return group->GetResult();
 }

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -633,14 +633,14 @@ StationResolverObject::StationResolverObject(const StationSpec *statspec, BaseSt
  * @param st Station (nullptr in GUI)
  * @param tile Station tile being drawn (INVALID_TILE in GUI)
  * @param var10 Value to put in variable 10; normally 0; 1 when resolving the groundsprite and StationSpecFlag::SeparateGround is set.
- * @return First sprite of the Action 1 spriteset to use, minus an offset of 0x42D to accommodate for weird NewGRF specs.
+ * @return First sprite of the Action 1 spriteset to use, minus an offset of SPR_RAIL_PLATFORM_Y_FRONT (0x42D) to accommodate for weird NewGRF specs.
  */
 SpriteID GetCustomStationRelocation(const StationSpec *statspec, BaseStation *st, TileIndex tile, uint32_t var10)
 {
 	StationResolverObject object(statspec, st, tile, CBID_NO_CALLBACK, var10);
 	const SpriteGroup *group = object.Resolve();
 	if (group == nullptr || group->type != SGT_RESULT) return 0;
-	return group->GetResult() - 0x42D;
+	return group->GetResult() - SPR_RAIL_PLATFORM_Y_FRONT;
 }
 
 /**

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -639,7 +639,7 @@ SpriteID GetCustomStationRelocation(const StationSpec *statspec, BaseStation *st
 {
 	StationResolverObject object(statspec, st, tile, CBID_NO_CALLBACK, var10);
 	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr || group->type != SGT_RESULT) return 0;
+	if (group == nullptr || group->GetNumResults() == 0) return 0;
 	return group->GetResult() - SPR_RAIL_PLATFORM_Y_FRONT;
 }
 
@@ -658,10 +658,11 @@ SpriteID GetCustomStationFoundationRelocation(const StationSpec *statspec, BaseS
 	StationResolverObject object(statspec, st, tile, CBID_NO_CALLBACK, 2, layout | (edge_info << 16));
 
 	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr || group->type != SGT_RESULT) return 0;
-
 	/* Note: SpriteGroup::Resolve zeroes all registers, so register 0x100 is initialised to 0. (compatibility) */
-	return group->GetResult() + GetRegister(0x100);
+	auto offset = GetRegister(0x100);
+	if (group == nullptr || group->GetNumResults() <= offset) return 0;
+
+	return group->GetResult() + offset;
 }
 
 


### PR DESCRIPTION
## Motivation / Problem

* NewGRF can define sprite sets with zero sprites.
* When resolving sprites, some features checked for this case, some didn't.

## Description

* Always check results for a non-zero number of sprites.
* `GetNumResults() != 0` implies `type == SGT_RESULT`, so the latter can be removed.
* For station foundations also check whether the offset from register 0x100 is in range.

## Limitations

This only checks the existence of the first sprite in the sprite set.
Most callers of features with more than one sprite per sprite set do not validate the range when adding offset.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
