### PR TITLE
Codechange: Simplify usage of ResolverObject.

### DIFF
--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -258,7 +258,7 @@ AirportResolverObject::AirportResolverObject(TileIndex tile, Station *st, const 
 SpriteID GetCustomAirportSprite(const AirportSpec *as, uint8_t layout)
 {
 	AirportResolverObject object(INVALID_TILE, nullptr, as, layout);
-	const SpriteGroup *group = object.Resolve();
+	const auto *group = object.Resolve<ResultSpriteGroup>();
 	if (group == nullptr || group->GetNumResults() == 0) return as->preview_sprite;
 
 	return group->GetResult();

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -259,9 +259,9 @@ SpriteID GetCustomAirportSprite(const AirportSpec *as, uint8_t layout)
 {
 	AirportResolverObject object(INVALID_TILE, nullptr, as, layout);
 	const auto *group = object.Resolve<ResultSpriteGroup>();
-	if (group == nullptr || group->GetNumResults() == 0) return as->preview_sprite;
+	if (group == nullptr || group->num_sprites == 0) return as->preview_sprite;
 
-	return group->GetResult();
+	return group->sprite;
 }
 
 uint16_t GetAirportCallback(CallbackID callback, uint32_t param1, uint32_t param2, Station *st, TileIndex tile)

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -273,13 +273,12 @@ bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts)
 	}
 
 	AirportTileResolverObject object(airts, ti->tile, st);
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr || group->type != SGT_TILELAYOUT) {
+	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
+	if (group == nullptr) {
 		return false;
 	}
 
-	const TileLayoutSpriteGroup *tlgroup = (const TileLayoutSpriteGroup *)group;
-	AirportDrawTileLayout(ti, tlgroup, Company::Get(st->owner)->colour);
+	AirportDrawTileLayout(ti, group, Company::Get(st->owner)->colour);
 	return true;
 }
 

--- a/src/newgrf_badge.cpp
+++ b/src/newgrf_badge.cpp
@@ -276,11 +276,11 @@ PalSpriteID GetBadgeSprite(const Badge &badge, GrfSpecFeature feature, std::opti
 {
 	BadgeResolverObject object(badge, feature, introduction_date);
 	const auto *group = object.Resolve<ResultSpriteGroup>();
-	if (group == nullptr || group->GetNumResults() == 0) return {0, PAL_NONE};
+	if (group == nullptr || group->num_sprites == 0) return {0, PAL_NONE};
 
 	PaletteID pal = badge.flags.Test(BadgeFlag::UseCompanyColour) ? remap : PAL_NONE;
 
-	return {group->GetResult(), pal};
+	return {group->sprite, pal};
 }
 
 /**

--- a/src/newgrf_badge.cpp
+++ b/src/newgrf_badge.cpp
@@ -275,7 +275,7 @@ void ApplyBadgeFeaturesToClassBadges()
 PalSpriteID GetBadgeSprite(const Badge &badge, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, PaletteID remap)
 {
 	BadgeResolverObject object(badge, feature, introduction_date);
-	const SpriteGroup *group = object.Resolve();
+	const auto *group = object.Resolve<ResultSpriteGroup>();
 	if (group == nullptr || group->GetNumResults() == 0) return {0, PAL_NONE};
 
 	PaletteID pal = badge.flags.Test(BadgeFlag::UseCompanyColour) ? remap : PAL_NONE;

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -140,7 +140,7 @@ CanalResolverObject::CanalResolverObject(CanalFeature feature, TileIndex tile,
 SpriteID GetCanalSprite(CanalFeature feature, TileIndex tile)
 {
 	CanalResolverObject object(feature, tile);
-	const SpriteGroup *group = object.Resolve();
+	const auto *group = object.Resolve<ResultSpriteGroup>();
 	if (group == nullptr || group->GetNumResults() == 0) return 0;
 
 	return group->GetResult();

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -141,9 +141,9 @@ SpriteID GetCanalSprite(CanalFeature feature, TileIndex tile)
 {
 	CanalResolverObject object(feature, tile);
 	const auto *group = object.Resolve<ResultSpriteGroup>();
-	if (group == nullptr || group->GetNumResults() == 0) return 0;
+	if (group == nullptr || group->num_sprites == 0) return 0;
 
-	return group->GetResult();
+	return group->sprite;
 }
 
 /**

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -56,9 +56,9 @@ SpriteID GetCustomCargoSprite(const CargoSpec *cs)
 {
 	CargoResolverObject object(cs);
 	const auto *group = object.Resolve<ResultSpriteGroup>();
-	if (group == nullptr || group->GetNumResults() == 0) return 0;
+	if (group == nullptr || group->num_sprites == 0) return 0;
 
-	return group->GetResult();
+	return group->sprite;
 }
 
 

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -55,7 +55,7 @@ CargoResolverObject::CargoResolverObject(const CargoSpec *cs, CallbackID callbac
 SpriteID GetCustomCargoSprite(const CargoSpec *cs)
 {
 	CargoResolverObject object(cs);
-	const SpriteGroup *group = object.Resolve();
+	const auto *group = object.Resolve<ResultSpriteGroup>();
 	if (group == nullptr || group->GetNumResults() == 0) return 0;
 
 	return group->GetResult();

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1101,7 +1101,7 @@ static void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction d
 	for (uint stack = 0; stack < max_stack; ++stack) {
 		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);
-		const SpriteGroup *group = object.Resolve();
+		const auto *group = object.Resolve<ResultSpriteGroup>();
 		uint32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
 		if (group != nullptr && group->GetNumResults() != 0) {
 			result->seq[result->count].sprite = group->GetResult() + (direction % group->GetNumResults());
@@ -1144,7 +1144,7 @@ static void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, En
 	for (uint stack = 0; stack < max_stack; ++stack) {
 		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);
-		const SpriteGroup *group = object.Resolve();
+		const auto *group = object.Resolve<ResultSpriteGroup>();
 		uint32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
 		if (group != nullptr && group->GetNumResults() != 0) {
 			result->seq[result->count].sprite = group->GetResult() + (rotor_pos % group->GetNumResults());

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1103,8 +1103,8 @@ static void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction d
 		object.callback_param1 = image_type | (stack << 8);
 		const auto *group = object.Resolve<ResultSpriteGroup>();
 		uint32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
-		if (group != nullptr && group->GetNumResults() != 0) {
-			result->seq[result->count].sprite = group->GetResult() + (direction % group->GetNumResults());
+		if (group != nullptr && group->num_sprites != 0) {
+			result->seq[result->count].sprite = group->sprite + (direction % group->num_sprites);
 			result->seq[result->count].pal    = GB(reg100, 0, 16); // zero means default recolouring
 			result->count++;
 		}
@@ -1146,8 +1146,8 @@ static void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, En
 		object.callback_param1 = image_type | (stack << 8);
 		const auto *group = object.Resolve<ResultSpriteGroup>();
 		uint32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
-		if (group != nullptr && group->GetNumResults() != 0) {
-			result->seq[result->count].sprite = group->GetResult() + (rotor_pos % group->GetNumResults());
+		if (group != nullptr && group->num_sprites != 0) {
+			result->seq[result->count].sprite = group->sprite + (rotor_pos % group->num_sprites);
 			result->seq[result->count].pal    = GB(reg100, 0, 16); // zero means default recolouring
 			result->count++;
 		}

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -505,12 +505,11 @@ void DrawNewHouseTile(TileInfo *ti, HouseID house_id)
 
 	HouseResolverObject object(house_id, ti->tile, Town::GetByTile(ti->tile));
 
-	const SpriteGroup *group = object.Resolve();
-	if (group != nullptr && group->type == SGT_TILELAYOUT) {
+	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
+	if (group != nullptr) {
 		/* Limit the building stage to the number of stages supplied. */
-		const TileLayoutSpriteGroup *tlgroup = (const TileLayoutSpriteGroup *)group;
 		uint8_t stage = GetHouseBuildingStage(ti->tile);
-		DrawTileLayout(ti, tlgroup, stage, house_id);
+		DrawTileLayout(ti, group, stage, house_id);
 	}
 }
 
@@ -525,11 +524,11 @@ void DrawNewHouseTile(TileInfo *ti, HouseID house_id)
 void DrawNewHouseTileInGUI(int x, int y, const HouseSpec *spec, HouseID house_id, int view)
 {
 	HouseResolverObject object(house_id, INVALID_TILE, nullptr, CBID_NO_CALLBACK, 0, 0, true, view);
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr || group->type != SGT_TILELAYOUT) return;
+	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
+	if (group == nullptr) return;
 
 	uint8_t stage = TOWN_HOUSE_COMPLETED;
-	const DrawTileSprites *dts = reinterpret_cast<const TileLayoutSpriteGroup *>(group)->ProcessRegisters(&stage);
+	const DrawTileSprites *dts = group->ProcessRegisters(&stage);
 
 	PaletteID palette = GetColourPalette(spec->random_colour[0]);
 	if (spec->callback_mask.Test(HouseCallbackMask::Colour)) {

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -629,9 +629,8 @@ void IndustryProductionCallback(Industry *ind, int reason)
 		}
 
 		SB(object.callback_param2, 8, 16, loop);
-		const SpriteGroup *tgroup = object.Resolve();
-		if (tgroup == nullptr || tgroup->type != SGT_INDUSTRY_PRODUCTION) break;
-		const IndustryProductionSpriteGroup *group = (const IndustryProductionSpriteGroup *)tgroup;
+		const auto *group = object.Resolve<IndustryProductionSpriteGroup>();
+		if (group == nullptr) break;
 
 		if (group->version == 0xFF) {
 			/* Result was marked invalid on load, display error message */

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -205,13 +205,12 @@ bool DrawNewIndustryTile(TileInfo *ti, Industry *i, IndustryGfx gfx, const Indus
 
 	IndustryTileResolverObject object(gfx, ti->tile, i);
 
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr || group->type != SGT_TILELAYOUT) return false;
+	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
+	if (group == nullptr) return false;
 
 	/* Limit the building stage to the number of stages supplied. */
-	const TileLayoutSpriteGroup *tlgroup = (const TileLayoutSpriteGroup *)group;
 	uint8_t stage = GetIndustryConstructionStage(ti->tile);
-	IndustryDrawTileLayout(ti, tlgroup, i->random_colour, stage);
+	IndustryDrawTileLayout(ti, group, i->random_colour, stage);
 	return true;
 }
 

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -473,10 +473,10 @@ void DrawNewObjectTile(TileInfo *ti, const ObjectSpec *spec)
 	Object *o = Object::GetByTile(ti->tile);
 	ObjectResolverObject object(spec, o, ti->tile);
 
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr || group->type != SGT_TILELAYOUT) return;
+	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
+	if (group == nullptr) return;
 
-	DrawTileLayout(ti, (const TileLayoutSpriteGroup *)group, spec);
+	DrawTileLayout(ti, group, spec);
 }
 
 /**
@@ -489,10 +489,10 @@ void DrawNewObjectTile(TileInfo *ti, const ObjectSpec *spec)
 void DrawNewObjectTileInGUI(int x, int y, const ObjectSpec *spec, uint8_t view)
 {
 	ObjectResolverObject object(spec, nullptr, INVALID_TILE, view);
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr || group->type != SGT_TILELAYOUT) return;
+	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
+	if (group == nullptr) return;
 
-	const DrawTileSprites *dts = ((const TileLayoutSpriteGroup *)group)->ProcessRegisters(nullptr);
+	const DrawTileSprites *dts = group->ProcessRegisters(nullptr);
 
 	PaletteID palette;
 	if (Company::IsValidID(_local_company)) {

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -110,7 +110,7 @@ SpriteID GetCustomRailSprite(const RailTypeInfo *rti, TileIndex tile, RailTypeSp
 	if (rti->group[rtsg] == nullptr) return 0;
 
 	RailTypeResolverObject object(rti, tile, context, rtsg);
-	const SpriteGroup *group = object.Resolve();
+	const auto *group = object.Resolve<ResultSpriteGroup>();
 	if (group == nullptr || group->GetNumResults() == 0) return 0;
 
 	if (num_results) *num_results = group->GetNumResults();
@@ -136,7 +136,7 @@ SpriteID GetCustomSignalSprite(const RailTypeInfo *rti, TileIndex tile, SignalTy
 	uint32_t param2 = (type << 16) | (var << 8) | state;
 	RailTypeResolverObject object(rti, tile, TCX_NORMAL, RTSG_SIGNALS, param1, param2);
 
-	const SpriteGroup *group = object.Resolve();
+	const auto *group = object.Resolve<ResultSpriteGroup>();
 	if (group == nullptr || group->GetNumResults() == 0) return 0;
 
 	return group->GetResult();

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -111,11 +111,11 @@ SpriteID GetCustomRailSprite(const RailTypeInfo *rti, TileIndex tile, RailTypeSp
 
 	RailTypeResolverObject object(rti, tile, context, rtsg);
 	const auto *group = object.Resolve<ResultSpriteGroup>();
-	if (group == nullptr || group->GetNumResults() == 0) return 0;
+	if (group == nullptr || group->num_sprites == 0) return 0;
 
-	if (num_results) *num_results = group->GetNumResults();
+	if (num_results) *num_results = group->num_sprites;
 
-	return group->GetResult();
+	return group->sprite;
 }
 
 /**
@@ -137,9 +137,9 @@ SpriteID GetCustomSignalSprite(const RailTypeInfo *rti, TileIndex tile, SignalTy
 	RailTypeResolverObject object(rti, tile, TCX_NORMAL, RTSG_SIGNALS, param1, param2);
 
 	const auto *group = object.Resolve<ResultSpriteGroup>();
-	if (group == nullptr || group->GetNumResults() == 0) return 0;
+	if (group == nullptr || group->num_sprites == 0) return 0;
 
-	return group->GetResult();
+	return group->sprite;
 }
 
 /**

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -291,9 +291,9 @@ void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec,
 
 	const RoadTypeInfo *rti = GetRoadTypeInfo(roadtype);
 	RoadStopResolverObject object(spec, nullptr, INVALID_TILE, roadtype, type, view);
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr || group->type != SGT_TILELAYOUT) return;
-	const DrawTileSprites *dts = ((const TileLayoutSpriteGroup *)group)->ProcessRegisters(nullptr);
+	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
+	if (group == nullptr) return;
+	const DrawTileSprites *dts = group->ProcessRegisters(nullptr);
 
 	PaletteID palette = GetCompanyPalette(_local_company);
 
@@ -346,9 +346,7 @@ void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec,
 const TileLayoutSpriteGroup *GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view)
 {
 	RoadStopResolverObject object(spec, st, ti->tile, INVALID_ROADTYPE, type, view);
-	const SpriteGroup *group = object.Resolve();
-	if (group == nullptr || group->type != SGT_TILELAYOUT) return nullptr;
-	return static_cast<const TileLayoutSpriteGroup *>(group);
+	return object.Resolve<TileLayoutSpriteGroup>();
 }
 
 /** Wrapper for animation control, see GetRoadStopCallback. */

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -154,11 +154,11 @@ SpriteID GetCustomRoadSprite(const RoadTypeInfo *rti, TileIndex tile, RoadTypeSp
 
 	RoadTypeResolverObject object(rti, tile, context, rtsg);
 	const auto *group = object.Resolve<ResultSpriteGroup>();
-	if (group == nullptr || group->GetNumResults() == 0) return 0;
+	if (group == nullptr || group->num_sprites == 0) return 0;
 
-	if (num_results) *num_results = group->GetNumResults();
+	if (num_results) *num_results = group->num_sprites;
 
-	return group->GetResult();
+	return group->sprite;
 }
 
 /**

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -153,7 +153,7 @@ SpriteID GetCustomRoadSprite(const RoadTypeInfo *rti, TileIndex tile, RoadTypeSp
 	if (rti->group[rtsg] == nullptr) return 0;
 
 	RoadTypeResolverObject object(rti, tile, context, rtsg);
-	const SpriteGroup *group = object.Resolve();
+	const auto *group = object.Resolve<ResultSpriteGroup>();
 	if (group == nullptr || group->GetNumResults() == 0) return 0;
 
 	if (num_results) *num_results = group->GetNumResults();

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -67,8 +67,6 @@ public:
 	uint32_t nfo_line = 0;
 	SpriteGroupType type{};
 
-	virtual SpriteID GetResult() const { return 0; }
-	virtual uint8_t GetNumResults() const { return 0; }
 	virtual uint16_t GetCallbackResult() const { return CALLBACK_FAILED; }
 
 	static const SpriteGroup *Resolve(const SpriteGroup *group, ResolverObject &object, bool top_level = true);
@@ -240,9 +238,6 @@ struct ResultSpriteGroup : SpriteGroup {
 
 	uint8_t num_sprites = 0;
 	SpriteID sprite = 0;
-
-	SpriteID GetResult() const override { return this->sprite; }
-	uint8_t GetNumResults() const override { return this->num_sprites; }
 };
 
 /**

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -641,8 +641,8 @@ SpriteID GetCustomStationRelocation(const StationSpec *statspec, BaseStation *st
 {
 	StationResolverObject object(statspec, st, tile, CBID_NO_CALLBACK, var10);
 	const auto *group = object.Resolve<ResultSpriteGroup>();
-	if (group == nullptr || group->GetNumResults() == 0) return 0;
-	return group->GetResult() - SPR_RAIL_PLATFORM_Y_FRONT;
+	if (group == nullptr || group->num_sprites == 0) return 0;
+	return group->sprite - SPR_RAIL_PLATFORM_Y_FRONT;
 }
 
 /**
@@ -662,9 +662,9 @@ SpriteID GetCustomStationFoundationRelocation(const StationSpec *statspec, BaseS
 	const auto *group = object.Resolve<ResultSpriteGroup>();
 	/* Note: SpriteGroup::Resolve zeroes all registers, so register 0x100 is initialised to 0. (compatibility) */
 	auto offset = GetRegister(0x100);
-	if (group == nullptr || group->GetNumResults() <= offset) return 0;
+	if (group == nullptr || group->num_sprites <= offset) return 0;
 
-	return group->GetResult() + offset;
+	return group->sprite + offset;
 }
 
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -640,7 +640,7 @@ StationResolverObject::StationResolverObject(const StationSpec *statspec, BaseSt
 SpriteID GetCustomStationRelocation(const StationSpec *statspec, BaseStation *st, TileIndex tile, uint32_t var10)
 {
 	StationResolverObject object(statspec, st, tile, CBID_NO_CALLBACK, var10);
-	const SpriteGroup *group = object.Resolve();
+	const auto *group = object.Resolve<ResultSpriteGroup>();
 	if (group == nullptr || group->GetNumResults() == 0) return 0;
 	return group->GetResult() - SPR_RAIL_PLATFORM_Y_FRONT;
 }
@@ -659,7 +659,7 @@ SpriteID GetCustomStationFoundationRelocation(const StationSpec *statspec, BaseS
 	/* callback_param1 == 2 means  we are resolving the foundation sprites. */
 	StationResolverObject object(statspec, st, tile, CBID_NO_CALLBACK, 2, layout | (edge_info << 16));
 
-	const SpriteGroup *group = object.Resolve();
+	const auto *group = object.Resolve<ResultSpriteGroup>();
 	/* Note: SpriteGroup::Resolve zeroes all registers, so register 0x100 is initialised to 0. (compatibility) */
 	auto offset = GetRegister(0x100);
 	if (group == nullptr || group->GetNumResults() <= offset) return 0;


### PR DESCRIPTION
## Motivation / Problem

All users of `ResolverObject::Resolve` perform a "dynamic cast" of the result sprite group.

## Description

* Deduplicate the code by moving the "dynamic cast" into `Resolve`.
* This also allows removing two virtual functions.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
