### PR TITLE
Codechange: Do not use a mutable global to return calculated VarAction2 results.

### DIFF
--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -998,13 +998,13 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 }
 
 
-/* virtual */ const SpriteGroup *VehicleResolverObject::ResolveReal(const RealSpriteGroup *group) const
+/* virtual */ const SpriteGroup *VehicleResolverObject::ResolveReal(const RealSpriteGroup &group) const
 {
 	const Vehicle *v = this->self_scope.v;
 
 	if (v == nullptr) {
-		if (!group->loading.empty()) return group->loading[0];
-		if (!group->loaded.empty())  return group->loaded[0];
+		if (!group.loading.empty()) return group.loading[0];
+		if (!group.loaded.empty()) return group.loaded[0];
 		return nullptr;
 	}
 
@@ -1012,14 +1012,14 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 	bool not_loading = (order.GetUnloadType() & OUFB_NO_UNLOAD) && (order.GetLoadType() & OLFB_NO_LOAD);
 	bool in_motion = !order.IsType(OT_LOADING) || not_loading;
 
-	uint totalsets = in_motion ? (uint)group->loaded.size() : (uint)group->loading.size();
+	uint totalsets = static_cast<uint>(in_motion ? group.loaded.size() : group.loading.size());
 
 	if (totalsets == 0) return nullptr;
 
 	uint set = (v->cargo.StoredCount() * totalsets) / std::max<uint16_t>(1u, v->cargo_cap);
 	set = std::min(set, totalsets - 1);
 
-	return in_motion ? group->loaded[set] : group->loading[set];
+	return in_motion ? group.loaded[set] : group.loading[set];
 }
 
 GrfSpecFeature VehicleResolverObject::GetFeature() const

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -998,14 +998,14 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 }
 
 
-/* virtual */ const SpriteGroup *VehicleResolverObject::ResolveReal(const RealSpriteGroup &group) const
+/* virtual */ ResolverResult VehicleResolverObject::ResolveReal(const RealSpriteGroup &group) const
 {
 	const Vehicle *v = this->self_scope.v;
 
 	if (v == nullptr) {
 		if (!group.loading.empty()) return group.loading[0];
 		if (!group.loaded.empty()) return group.loaded[0];
-		return nullptr;
+		return std::monostate{};
 	}
 
 	const Order &order = v->First()->current_order;
@@ -1014,7 +1014,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 
 	uint totalsets = static_cast<uint>(in_motion ? group.loaded.size() : group.loading.size());
 
-	if (totalsets == 0) return nullptr;
+	if (totalsets == 0) return std::monostate{};
 
 	uint set = (v->cargo.StoredCount() * totalsets) / std::max<uint16_t>(1u, v->cargo_cap);
 	set = std::min(set, totalsets - 1);

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -64,7 +64,7 @@ struct VehicleResolverObject : public SpecializedResolverObject<VehicleRandomTri
 
 	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override;
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup &group) const override;
+	ResolverResult ResolveReal(const RealSpriteGroup &group) const override;
 
 	GrfSpecFeature GetFeature() const override;
 	uint32_t GetDebugID() const override;

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -64,7 +64,7 @@ struct VehicleResolverObject : public SpecializedResolverObject<VehicleRandomTri
 
 	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override;
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
+	const SpriteGroup *ResolveReal(const RealSpriteGroup &group) const override;
 
 	GrfSpecFeature GetFeature() const override;
 	uint32_t GetDebugID() const override;

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -60,20 +60,28 @@ void NewGRFProfiler::BeginResolve(const ResolverObject &resolver)
 /**
  * Capture the completion of a sprite group resolution.
  */
-void NewGRFProfiler::EndResolve(const SpriteGroup *result)
+void NewGRFProfiler::EndResolve(const ResolverResult &result)
 {
 	using namespace std::chrono;
 	this->cur_call.time = (uint32_t)time_point_cast<microseconds>(high_resolution_clock::now()).time_since_epoch().count() - this->cur_call.time;
 
-	if (result == nullptr) {
-		this->cur_call.result = 0;
-	} else if (result->type == SGT_CALLBACK) {
-		this->cur_call.result = static_cast<const CallbackResultSpriteGroup *>(result)->result;
-	} else if (result->type == SGT_RESULT) {
-		this->cur_call.result = GetSpriteLocalID(static_cast<const ResultSpriteGroup *>(result)->sprite);
-	} else {
-		this->cur_call.result = result->nfo_line;
-	}
+	struct visitor {
+		uint32_t operator()(std::monostate)
+		{
+			return 0;
+		}
+		uint32_t operator()(CallbackResult cb_result)
+		{
+			return cb_result;
+		}
+		uint32_t operator()(const SpriteGroup *group)
+		{
+			if (group == nullptr) return 0;
+			if (group->type != SGT_RESULT) return group->nfo_line;
+			return GetSpriteLocalID(static_cast<const ResultSpriteGroup *>(group)->sprite);
+		}
+	};
+	this->cur_call.result = std::visit(visitor{}, result);
 
 	this->calls.push_back(this->cur_call);
 }

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -24,7 +24,7 @@ struct NewGRFProfiler {
 	~NewGRFProfiler();
 
 	void BeginResolve(const ResolverObject &resolver);
-	void EndResolve(const SpriteGroup *result);
+	void EndResolve(const ResolverResult &result);
 	void RecursiveResolve();
 
 	void Start();

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -120,10 +120,10 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
  * @param group Group to get.
  * @return The available sprite group.
  */
-/* virtual */ const SpriteGroup *ResolverObject::ResolveReal(const RealSpriteGroup *group) const
+/* virtual */ const SpriteGroup *ResolverObject::ResolveReal(const RealSpriteGroup &group) const
 {
-	if (!group->loaded.empty())  return group->loaded[0];
-	if (!group->loading.empty()) return group->loading[0];
+	if (!group.loaded.empty()) return group.loaded[0];
+	if (!group.loading.empty()) return group.loading[0];
 
 	return nullptr;
 }
@@ -276,7 +276,7 @@ const SpriteGroup *RandomizedSpriteGroup::Resolve(ResolverObject &object) const
 
 const SpriteGroup *RealSpriteGroup::Resolve(ResolverObject &object) const
 {
-	return object.ResolveReal(this);
+	return object.ResolveReal(*this);
 }
 
 /**

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -370,7 +370,7 @@ public:
 		return result != nullptr ? result->GetCallbackResult() : CALLBACK_FAILED;
 	}
 
-	virtual const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const;
+	virtual const SpriteGroup *ResolveReal(const RealSpriteGroup &group) const;
 
 	virtual ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0);
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -519,10 +519,10 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 	return UINT_MAX;
 }
 
-/* virtual */ const SpriteGroup *StationResolverObject::ResolveReal(const RealSpriteGroup *group) const
+/* virtual */ const SpriteGroup *StationResolverObject::ResolveReal(const RealSpriteGroup &group) const
 {
 	if (this->station_scope.st == nullptr || !Station::IsExpected(this->station_scope.st)) {
-		if (!group->loading.empty()) return group->loading[0];
+		if (!group.loading.empty()) return group.loading[0];
 		return nullptr;
 	}
 
@@ -554,18 +554,18 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 	cargo = std::min(0xfffu, cargo);
 
 	if (cargo > this->station_scope.statspec->cargo_threshold) {
-		if (!group->loading.empty()) {
-			uint set = ((cargo - this->station_scope.statspec->cargo_threshold) * (uint)group->loading.size()) / (4096 - this->station_scope.statspec->cargo_threshold);
-			return group->loading[set];
+		if (!group.loading.empty()) {
+			uint set = ((cargo - this->station_scope.statspec->cargo_threshold) * static_cast<uint>(group.loading.size())) / (4096 - this->station_scope.statspec->cargo_threshold);
+			return group.loading[set];
 		}
 	} else {
-		if (!group->loaded.empty()) {
-			uint set = (cargo * (uint)group->loaded.size()) / (this->station_scope.statspec->cargo_threshold + 1);
-			return group->loaded[set];
+		if (!group.loaded.empty()) {
+			uint set = (cargo * static_cast<uint>(group.loaded.size())) / (this->station_scope.statspec->cargo_threshold + 1);
+			return group.loaded[set];
 		}
 	}
 
-	if (!group->loading.empty()) return group->loading[0];
+	if (!group.loading.empty()) return group.loading[0];
 	return nullptr;
 }
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -519,11 +519,11 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 	return UINT_MAX;
 }
 
-/* virtual */ const SpriteGroup *StationResolverObject::ResolveReal(const RealSpriteGroup &group) const
+/* virtual */ ResolverResult StationResolverObject::ResolveReal(const RealSpriteGroup &group) const
 {
 	if (this->station_scope.st == nullptr || !Station::IsExpected(this->station_scope.st)) {
 		if (!group.loading.empty()) return group.loading[0];
-		return nullptr;
+		return std::monostate{};
 	}
 
 	uint cargo = 0;
@@ -566,7 +566,7 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 	}
 
 	if (!group.loading.empty()) return group.loading[0];
-	return nullptr;
+	return std::monostate{};
 }
 
 GrfSpecFeature StationResolverObject::GetFeature() const

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -75,7 +75,7 @@ struct StationResolverObject : public SpecializedResolverObject<StationRandomTri
 		}
 	}
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup &group) const override;
+	ResolverResult ResolveReal(const RealSpriteGroup &group) const override;
 
 	GrfSpecFeature GetFeature() const override;
 	uint32_t GetDebugID() const override;

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -75,7 +75,7 @@ struct StationResolverObject : public SpecializedResolverObject<StationRandomTri
 		}
 	}
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
+	const SpriteGroup *ResolveReal(const RealSpriteGroup &group) const override;
 
 	GrfSpecFeature GetFeature() const override;
 	uint32_t GetDebugID() const override;


### PR DESCRIPTION
## Motivation / Problem

Small step on the long road to multi-threaded sprite resolving.

## Description

* Add a `ResolverResult` variant, which can hold "failure", "callback result" and "spritegroup result".

## Limitations

* I tried adding `ResultSpriteGroup`, `TileLayoutSpriteGroup`, `IndustryProductionSpriteGroup` instead of `SpriteGroup`  to the `variant`.
* This fails for cases like returning `RealSpriteGroup::loaded`, and would need type detection there.
* It's better to keep a single "dynamic" cast in `Resolve` then.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
