### PR TITLE
Add: [NewGRF] Add explicit (Var)Action2 results for "callback failed" and "calculated result".

### DIFF
--- a/src/newgrf/newgrf_act2.cpp
+++ b/src/newgrf/newgrf_act2.cpp
@@ -22,6 +22,8 @@
 
 #include "../safeguards.h"
 
+constexpr uint16_t GROUPID_CALLBACK_FAILED = 0x7FFF; ///< Explicit "failure" result.
+
 /**
  * Map the colour modifiers of TTDPatch to those that Open is using.
  * @param grf_sprite Pointer to the structure been modified.
@@ -293,6 +295,7 @@ static const SpriteGroup *GetCallbackResultGroup(uint16_t value)
 static const SpriteGroup *GetGroupFromGroupID(uint8_t setid, uint8_t type, uint16_t groupid)
 {
 	if (HasBit(groupid, 15)) return GetCallbackResultGroup(groupid);
+	if (groupid == GROUPID_CALLBACK_FAILED) return nullptr;
 
 	if (groupid > MAX_SPRITEGROUP || _cur_gps.spritegroups[groupid] == nullptr) {
 		GrfMsg(1, "GetGroupFromGroupID(0x{:02X}:0x{:02X}): Groupid 0x{:04X} does not exist, leaving empty", setid, type, groupid);

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -224,26 +224,27 @@ static bool RangeHighComparator(const DeterministicSpriteGroupRange &range, uint
 
 	object.last_value = last_value;
 
-	if (this->calculated_result) {
-		/* nvar == 0 is a special case -- we turn our value into a callback result */
-		return static_cast<CallbackResult>(GB(value, 0, 15));
-	}
+	auto result = this->default_result;
 
 	if (this->ranges.size() > 4) {
 		const auto &lower = std::lower_bound(this->ranges.begin(), this->ranges.end(), value, RangeHighComparator);
 		if (lower != this->ranges.end() && lower->low <= value) {
 			assert(lower->low <= value && value <= lower->high);
-			return SpriteGroup::Resolve(lower->group, object, false);
+			result = lower->result;
 		}
 	} else {
 		for (const auto &range : this->ranges) {
 			if (range.low <= value && value <= range.high) {
-				return SpriteGroup::Resolve(range.group, object, false);
+				result = range.result;
+				break;
 			}
 		}
 	}
 
-	return SpriteGroup::Resolve(this->default_group, object, false);
+	if (result.calculated_result) {
+		return static_cast<CallbackResult>(GB(value, 0, 15));
+	}
+	return SpriteGroup::Resolve(result.group, object, false);
 }
 
 

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -163,8 +163,15 @@ struct DeterministicSpriteGroupAdjust {
 };
 
 
-struct DeterministicSpriteGroupRange {
+struct DeterministicSpriteGroupResult {
+	bool calculated_result = false;
 	const SpriteGroup *group = nullptr;
+
+	bool operator==(const DeterministicSpriteGroupResult &) const = default;
+};
+
+struct DeterministicSpriteGroupRange {
+	DeterministicSpriteGroupResult result;
 	uint32_t low = 0;
 	uint32_t high = 0;
 };
@@ -175,12 +182,11 @@ struct DeterministicSpriteGroup : SpriteGroup {
 
 	VarSpriteGroupScope var_scope{};
 	DeterministicSpriteGroupSize size{};
-	bool calculated_result = false;
 	std::vector<DeterministicSpriteGroupAdjust> adjusts{};
 	std::vector<DeterministicSpriteGroupRange> ranges{}; // Dynamically allocated
 
 	/* Dynamically allocated, this is the sole owner */
-	const SpriteGroup *default_group = nullptr;
+	DeterministicSpriteGroupResult default_result;
 
 	const SpriteGroup *error_group = nullptr; // was first range, before sorting ranges
 


### PR DESCRIPTION
## Motivation / Problem

* NML has a hard time to return "failure" from switches.
    * To fail callbacks, you have to return a fake/empty sprite set.
    * To fail sprite resolving, you have to return a dummy callback result.
* There is an infamous trap: Defining only a "default" result in VarAction2 makes it not branch to the references group, but instead returns a calculated result.
* Action2 results 0x100 to 0x7FFF are unused.

## Description

* Add an explicit "failure" value 0x7FFF to all Action2 (basic, variational, random).
* Add an explicit "calculated result" value 0x7FFE to VarAction2.
    * If a GRF always wants to return a calculated result, it can use the default case, or a range 0 - MAX.
    * It's now possible to return the calculated result only for some result, while replacing other values with the range results.
* In GRFv9 we can deprecate the infamous "zero ranges" special case.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
