### PR TITLE
Codechange: provide 'sv' (string_view) literals globally

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -73,6 +73,8 @@
 #include <variant>
 #include <vector>
 
+using namespace std::literals::string_view_literals;
+
 #if defined(UNIX) || defined(__MINGW32__)
 #	include <sys/types.h>
 #endif

--- a/src/tests/string_builder.cpp
+++ b/src/tests/string_builder.cpp
@@ -12,8 +12,6 @@
 #include "../core/string_builder.hpp"
 #include "../safeguards.h"
 
-using namespace std::literals;
-
 TEST_CASE("StringBuilder - basic")
 {
 	std::string buffer;

--- a/src/tests/string_consumer.cpp
+++ b/src/tests/string_consumer.cpp
@@ -17,8 +17,6 @@
 
 #include "../safeguards.h"
 
-using namespace std::literals;
-
 TEST_CASE("StringConsumer - basic")
 {
 	StringConsumer consumer("ab"sv);

--- a/src/tests/string_inplace.cpp
+++ b/src/tests/string_inplace.cpp
@@ -12,8 +12,6 @@
 #include "../core/string_inplace.hpp"
 #include "../safeguards.h"
 
-using namespace std::literals;
-
 TEST_CASE("InPlaceReplacement")
 {
 	std::array<char, 4> buffer{1, 2, 3, 4};

--- a/src/tests/utf8.cpp
+++ b/src/tests/utf8.cpp
@@ -15,8 +15,6 @@
 
 #include "../safeguards.h"
 
-using namespace std::literals;
-
 TEST_CASE("Utf8View - empty")
 {
 	Utf8View view;


### PR DESCRIPTION
## Motivation / Problem

When removing `const char*` functions, e.g. `StringParameter(const char *)` there will be cases where string literals are used. If the function has an overload for both `std::string&` and `std::string_view`, then the converting `const char *` becomes ambiguous.

The solution is to either `std::string_view{"..."}` everything, or use the string_view literal, i.e. `"..."sv`.


## Description

Introduce including the `sv` literal in `stdafx.h`, and remove the includes of all literals in the cases that used it.


## Limitations

Maybe `stdafx.h` is a level too high. Might it belong in `string_type.h`?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
