### PR TITLE
Codechange: store revision information in C++ style strings

### DIFF
--- a/src/rev.cpp.in
+++ b/src/rev.cpp.in
@@ -35,7 +35,7 @@ bool IsReleasedVersion()
  *
  * <modified> shows a "M", if the binary is made from modified source code.
  */
-const char _openttd_revision[] = "${REV_VERSION}";
+const std::string _openttd_revision = "${REV_VERSION}";
 
 /**
  * The text version of OpenTTD's build date.
@@ -43,17 +43,17 @@ const char _openttd_revision[] = "${REV_VERSION}";
  * updated for each revision in contrary to most other files that only see
  * updates when they are actually changed themselves.
  */
-const char _openttd_build_date[] = __DATE__ " " __TIME__;
+const std::string_view _openttd_build_date = __DATE__ " " __TIME__;
 
 /**
  * The git revision hash of this version.
  */
-const char _openttd_revision_hash[] = "${REV_HASH}";
+const std::string_view _openttd_revision_hash = "${REV_HASH}";
 
 /**
  * The year of this version.
  */
-const char _openttd_revision_year[] = "${REV_YEAR}";
+const std::string_view _openttd_revision_year = "${REV_YEAR}";
 
 /**
  * Let us know if current build was modified. This detection
@@ -77,7 +77,7 @@ const uint8_t _openttd_revision_tagged = ${REV_ISTAG};
  * It should never contain things like "beta", but only the release version
  * we are compatible with.
  */
-const char _openttd_content_version[] = "${REV_MAJOR}.${REV_MINOR}";
+const std::string_view _openttd_content_version = "${REV_MAJOR}.${REV_MINOR}";
 
 /**
  * The NewGRF revision of OTTD:

--- a/src/rev.h
+++ b/src/rev.h
@@ -10,13 +10,13 @@
 #ifndef REV_H
 #define REV_H
 
-extern const char _openttd_revision[];
-extern const char _openttd_build_date[];
-extern const char _openttd_revision_hash[];
-extern const char _openttd_revision_year[];
+extern const std::string _openttd_revision;
+extern const std::string_view _openttd_build_date;
+extern const std::string_view _openttd_revision_hash;
+extern const std::string_view _openttd_revision_year;
 extern const uint8_t _openttd_revision_modified;
 extern const uint8_t _openttd_revision_tagged;
-extern const char _openttd_content_version[];
+extern const std::string_view _openttd_content_version;
 extern const uint32_t _openttd_newgrf_version;
 
 bool IsReleasedVersion();

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -77,8 +77,8 @@ public:
 		png_text_struct text[2];
 		memset(text, 0, sizeof(text));
 		text[0].key = const_cast<char *>("Software");
-		text[0].text = const_cast<char *>(_openttd_revision);
-		text[0].text_length = strlen(_openttd_revision);
+		text[0].text = const_cast<char *>(_openttd_revision.c_str());
+		text[0].text_length = _openttd_revision.size();
 		text[0].compression = PNG_TEXT_COMPRESSION_NONE;
 
 		std::string message;

--- a/src/social_integration.cpp
+++ b/src/social_integration.cpp
@@ -28,7 +28,7 @@ class InternalSocialIntegrationPlugin {
 public:
 	InternalSocialIntegrationPlugin(const std::string &filename, const std::string &basepath) : library(nullptr), external(basepath)
 	{
-		openttd_info.openttd_version = _openttd_revision;
+		openttd_info.openttd_version = _openttd_revision.c_str();
 
 		if (!ValidateSignatureFile(fmt::format("{}.sig", filename))) {
 			external.state = SocialIntegrationPlugin::INVALID_SIGNATURE;


### PR DESCRIPTION
## Motivation / Problem

Revision information is stored in C-style strings.


## Description

Change most to `std::string_view`, except the revision as this is passed as C-style string to the social plugins and to the PNG library. Make revision a `std::string` to ensure `'\0'` termination.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
