### PR TITLE
Codechange: remove const char* overloads when there are C++ string overloads

### DIFF
--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -132,7 +132,6 @@ class FileHandle {
 public:
 	static std::optional<FileHandle> Open(const std::string &filename, std::string_view mode);
 	static std::optional<FileHandle> Open(std::string_view filename, std::string_view mode) { return FileHandle::Open(std::string{filename}, mode); }
-	static std::optional<FileHandle> Open(const char *filename, std::string_view mode) { return FileHandle::Open(std::string{filename}, mode); }
 
 	inline void Close() { this->f.reset(); }
 

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -329,7 +329,7 @@ static void FiosGetFileList(SaveLoadOperation fop, bool show_dirs, FiosGetTypeAn
 			fios.type = FIOS_TYPE_PARENT;
 			fios.mtime = 0;
 			fios.name = "..";
-			fios.title = GetString(STR_SAVELOAD_PARENT_DIRECTORY, "..");
+			fios.title = GetString(STR_SAVELOAD_PARENT_DIRECTORY, ".."sv);
 			sort_start = file_list.size();
 		}
 

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -370,10 +370,10 @@ static const PerformanceElement DISPLAY_ORDER_PFE[PFE_MAX] = {
 	PFE_SOUND,
 };
 
-static const char * GetAIName(int ai_index)
+static std::string_view GetAIName(int ai_index)
 {
-	if (!Company::IsValidAiID(ai_index)) return "";
-	return Company::Get(ai_index)->ai_info->GetName().c_str();
+	if (!Company::IsValidAiID(ai_index)) return {};
+	return Company::Get(ai_index)->ai_info->GetName();
 }
 
 /** @hideinitializer */

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -390,7 +390,7 @@ class BuildIndustryWindow : public Window {
 		if (numcargo > 0) {
 			cargostring = GetString(prefixstr, CargoSpec::Get(cargolist[firstcargo])->name, cargo_suffix[firstcargo].text) + cargostring;
 		} else {
-			cargostring = GetString(prefixstr, STR_JUST_NOTHING, "");
+			cargostring = GetString(prefixstr, STR_JUST_NOTHING, ""sv);
 		}
 
 		return cargostring;

--- a/src/misc/dbg_helpers.h
+++ b/src/misc/dbg_helpers.h
@@ -64,7 +64,7 @@ inline typename ArrayT<T>::Item ItemAtT(E idx, const T &t, typename ArrayT<T>::I
  * or t_unk when index is out of bounds.
  */
 template <typename E, typename T>
-inline std::string ComposeNameT(E value, T &t, const char *t_unk, E val_inv, const char *name_inv)
+inline std::string ComposeNameT(E value, T &t, std::string_view t_unk, E val_inv, std::string_view name_inv)
 {
 	std::string out;
 	if (value == val_inv) {

--- a/src/misc/endian_buffer.hpp
+++ b/src/misc/endian_buffer.hpp
@@ -31,7 +31,6 @@ public:
 
 	EndianBufferWriter &operator <<(const std::string &data) { return *this << std::string_view{ data }; }
 	EndianBufferWriter &operator <<(const EncodedString &data) { return *this << data.string; }
-	EndianBufferWriter &operator <<(const char *data) { return *this << std::string_view{ data }; }
 	EndianBufferWriter &operator <<(std::string_view data) { this->Write(data); return *this; }
 	EndianBufferWriter &operator <<(bool data) { return *this << static_cast<uint8_t>(data ? 1 : 0); }
 

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -24,8 +24,8 @@ template <typename Tpf> void DumpState(Tpf &pf1, Tpf &pf2)
 	DumpTarget dmp1, dmp2;
 	pf1.DumpBase(dmp1);
 	pf2.DumpBase(dmp2);
-	auto f1 = FileHandle::Open("yapf1.txt", "wt");
-	auto f2 = FileHandle::Open("yapf2.txt", "wt");
+	auto f1 = FileHandle::Open("yapf1.txt"sv, "wt");
+	auto f2 = FileHandle::Open("yapf2.txt"sv, "wt");
 	assert(f1.has_value());
 	assert(f2.has_value());
 	fwrite(dmp1.m_out.c_str(), 1, dmp1.m_out.size(), *f1);

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2791,7 +2791,7 @@ struct LZMASaveFilter : SaveFilter {
 
 /** The format for a reader/writer type of a savegame */
 struct SaveLoadFormat {
-	const char *name;                     ///< name of the compressor/decompressor (debug-only)
+	std::string_view name; ///< name of the compressor/decompressor (debug-only)
 	uint32_t tag;                           ///< the 4-letter tag by which it is identified in the savegame
 
 	std::shared_ptr<LoadFilter> (*init_load)(std::shared_ptr<LoadFilter> chain); ///< Constructor for the load filter.

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -520,7 +520,7 @@ struct GameOptionsWindow : Window {
 					bool hide_language = IsReleasedVersion() && !_languages[i].IsReasonablyFinished();
 					if (hide_language) continue;
 					bool hide_percentage = IsReleasedVersion() || _languages[i].missing < _settings_client.gui.missing_strings_threshold;
-					char *name;
+					std::string name;
 					if (&_languages[i] == _current_language) {
 						*selected_index = i;
 						name = _languages[i].own_name;
@@ -533,10 +533,10 @@ struct GameOptionsWindow : Window {
 						name = _languages[i].name;
 					}
 					if (hide_percentage) {
-						list.push_back(MakeDropDownListStringItem(name, i));
+						list.push_back(MakeDropDownListStringItem(std::move(name), i));
 					} else {
 						int percentage = (LANGUAGE_TOTAL_STRINGS - _languages[i].missing) * 100 / LANGUAGE_TOTAL_STRINGS;
-						list.push_back(MakeDropDownListStringItem(GetString(STR_GAME_OPTIONS_LANGUAGE_PERCENTAGE, name, percentage), i));
+						list.push_back(MakeDropDownListStringItem(GetString(STR_GAME_OPTIONS_LANGUAGE_PERCENTAGE, std::move(name), percentage), i));
 					}
 				}
 				std::sort(list.begin(), list.end(), DropDownListStringItem::NatSortFunc);

--- a/src/string_type.h
+++ b/src/string_type.h
@@ -64,7 +64,6 @@ struct StringHash {
 	using hash_type = std::hash<std::string_view>;
 	using is_transparent = void;
 
-	std::size_t operator()(const char *str) const { return hash_type{}(str); }
 	std::size_t operator()(std::string_view str) const { return hash_type{}(str); }
 	std::size_t operator()(const std::string &str) const { return hash_type{}(str); }
 };

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -185,13 +185,11 @@ public:
 		SetParam(n, v.base());
 	}
 
-	void SetParam(size_t n, const char *str)
+	void SetParam(size_t n, const std::string &str)
 	{
 		assert(n < this->parameters.size());
 		this->parameters[n].data = str;
 	}
-
-	void SetParam(size_t n, const std::string &str) { this->SetParam(n, str.c_str()); }
 
 	void SetParam(size_t n, std::string &&str)
 	{

--- a/src/strings_type.h
+++ b/src/strings_type.h
@@ -85,7 +85,6 @@ struct StringParameter {
 	inline StringParameter(const std::monostate &data) : data(data), type(0) {}
 	inline StringParameter(uint64_t data) : data(data), type(0) {}
 
-	inline StringParameter(const char *data) : data(std::string{data}), type(0) {}
 	inline StringParameter(std::string_view data) : data(std::string{data}), type(0) {}
 	inline StringParameter(std::string &&data) : data(std::move(data)), type(0) {}
 	inline StringParameter(const std::string &data) : data(data), type(0) {}

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -506,8 +506,8 @@ TEST_CASE("FixSCCEncodedNegative")
 TEST_CASE("EncodedString::ReplaceParam - positive")
 {
 	/* Test that two encoded strings with different parameters are not the same. */
-	EncodedString string1 = GetEncodedString(STR_NULL, "Foo", 10, "Bar");
-	EncodedString string2 = GetEncodedString(STR_NULL, "Foo", 15, "Bar");
+	EncodedString string1 = GetEncodedString(STR_NULL, "Foo"sv, 10, "Bar"sv);
+	EncodedString string2 = GetEncodedString(STR_NULL, "Foo"sv, 15, "Bar"sv);
 	CHECK(string1 != string2);
 
 	/* Test that replacing parameter results in the same string. */
@@ -517,9 +517,9 @@ TEST_CASE("EncodedString::ReplaceParam - positive")
 
 TEST_CASE("EncodedString::ReplaceParam - negative")
 {
-	EncodedString string1 = GetEncodedString(STR_NULL, "Foo", -1, "Bar");
-	EncodedString string2 = GetEncodedString(STR_NULL, "Foo", -2, "Bar");
-	EncodedString string3 = GetEncodedString(STR_NULL, "Foo", 0xFFFF'FFFF'FFFF'FFFF, "Bar");
+	EncodedString string1 = GetEncodedString(STR_NULL, "Foo"sv, -1, "Bar"sv);
+	EncodedString string2 = GetEncodedString(STR_NULL, "Foo"sv, -2, "Bar"sv);
+	EncodedString string3 = GetEncodedString(STR_NULL, "Foo"sv, 0xFFFF'FFFF'FFFF'FFFF, "Bar"sv);
 	/* Test that two encoded strings with different parameters are not the same. */
 	CHECK(string1 != string2);
 	/* Test that signed values are stored as unsigned. */


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

Remove some of the `const char *` overloads when there is an overload for both `const std::string&` and `std::string_view`.
Also change some `const char *`s to `std::string_view` to accommodate that, and in rare cases add a `sv` literal to strings.


## Limitations

There are still quite a few C-style strings left.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
