### PR TITLE
Codechange: use const for std::string_view where appropriate

### DIFF
--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -308,7 +308,7 @@ SQRESULT sq_resume(HSQUIRRELVM v,SQBool retval,SQBool raiseerror);
 const SQChar *sq_getlocal(HSQUIRRELVM v,SQUnsignedInteger level,SQUnsignedInteger idx);
 const SQChar *sq_getfreevariable(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger nval);
 SQRESULT sq_throwerror(HSQUIRRELVM v,const SQChar *err, SQInteger len = -1);
-inline SQRESULT sq_throwerror(HSQUIRRELVM v, const std::string_view err) { return sq_throwerror(v, err.data(), err.size()); }
+inline SQRESULT sq_throwerror(HSQUIRRELVM v, std::string_view err) { return sq_throwerror(v, err.data(), err.size()); }
 void sq_reseterror(HSQUIRRELVM v);
 void sq_getlasterror(HSQUIRRELVM v);
 

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -93,7 +93,7 @@ public:
 	 * @param name the blitter to select.
 	 * @post Sets the blitter so GetCurrentBlitter() returns it too.
 	 */
-	static Blitter *SelectBlitter(const std::string_view name)
+	static Blitter *SelectBlitter(std::string_view name)
 	{
 		BlitterFactory *b = GetBlitterFactory(name);
 		if (b == nullptr) return nullptr;
@@ -109,17 +109,17 @@ public:
 	 * @param name the blitter factory to select.
 	 * @return The blitter factory, or nullptr when there isn't one with the wanted name.
 	 */
-	static BlitterFactory *GetBlitterFactory(const std::string_view name)
+	static BlitterFactory *GetBlitterFactory(std::string_view name)
 	{
 #if defined(DEDICATED)
-		const std::string_view default_blitter = "null";
+		static const std::string_view default_blitter = "null";
 #elif defined(WITH_COCOA)
-		const std::string_view default_blitter = "32bpp-anim";
+		static const std::string_view default_blitter = "32bpp-anim";
 #else
-		const std::string_view default_blitter = "8bpp-optimized";
+		static const std::string_view default_blitter = "8bpp-optimized";
 #endif
 		if (GetBlitters().empty()) return nullptr;
-		const std::string_view bname = name.empty() ? default_blitter : name;
+		std::string_view bname = name.empty() ? default_blitter : name;
 
 		for (auto &it : GetBlitters()) {
 			BlitterFactory *b = it.second;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -684,7 +684,7 @@ static bool ConClearBuffer(std::span<std::string_view> argv)
  * Network Core Console Commands
  **********************************/
 
-static bool ConKickOrBan(std::string_view arg, bool ban, const std::string_view reason)
+static bool ConKickOrBan(std::string_view arg, bool ban, std::string_view reason)
 {
 	uint n;
 
@@ -1241,7 +1241,7 @@ static bool ConSchedule(std::span<std::string_view> argv)
 	}
 
 	/* We only support a single script scheduled, so we tell the user what's happening if there was already one. */
-	const std::string_view filename = std::string_view(argv[2]);
+	std::string_view filename = std::string_view(argv[2]);
 	if (!_scheduled_monthly_script.empty() && filename == _scheduled_monthly_script) {
 		IConsolePrint(CC_INFO, "Script file '{}' was already scheduled to execute at the start of next calendar month.", filename);
 	} else if (!_scheduled_monthly_script.empty() && filename != _scheduled_monthly_script) {

--- a/src/core/string_consumer.cpp
+++ b/src/core/string_consumer.cpp
@@ -24,8 +24,8 @@
 
 #include "../safeguards.h"
 
-const std::string_view StringConsumer::WHITESPACE_NO_NEWLINE = "\t\v\f\r ";
-const std::string_view StringConsumer::WHITESPACE_OR_NEWLINE = "\t\n\v\f\r ";
+/* static */ const std::string_view StringConsumer::WHITESPACE_NO_NEWLINE = "\t\v\f\r ";
+/* static */ const std::string_view StringConsumer::WHITESPACE_OR_NEWLINE = "\t\n\v\f\r ";
 
 /* static */ void StringConsumer::LogError(std::string &&msg)
 {

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1152,7 +1152,7 @@ uint FileScanner::Scan(std::string_view extension, Subdirectory sd, bool tars, b
  * @return the number of found files, i.e. the number of times that
  *         AddFile returned true.
  */
-uint FileScanner::Scan(const std::string_view extension, const std::string &directory, bool recursive)
+uint FileScanner::Scan(std::string_view extension, const std::string &directory, bool recursive)
 {
 	std::string path(directory);
 	AppendPathSeparator(path);

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -100,7 +100,7 @@ void FileList::BuildFileList(AbstractFileType abstract_filetype, SaveLoadOperati
  *             or a numbered entry into the filename list.
  * @return The information on the file, or \c nullptr if the file is not available.
  */
-const FiosItem *FileList::FindItem(const std::string_view file)
+const FiosItem *FileList::FindItem(std::string_view file)
 {
 	for (const auto &it : *this) {
 		const FiosItem *item = &it;
@@ -240,7 +240,7 @@ bool FiosDelete(std::string_view name)
 	return FioRemove(FiosMakeSavegameName(name));
 }
 
-typedef std::tuple<FiosType, std::string> FiosGetTypeAndNameProc(SaveLoadOperation fop, const std::string &filename, const std::string_view ext);
+typedef std::tuple<FiosType, std::string> FiosGetTypeAndNameProc(SaveLoadOperation fop, const std::string &filename, std::string_view ext);
 
 /**
  * Scanner to scan for a particular type of FIOS file.
@@ -398,7 +398,7 @@ static std::string GetFileTitle(const std::string &file, Subdirectory subdir)
  * @see FiosGetFileList
  * @see FiosGetSavegameList
  */
-std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext)
 {
 	/* Show savegame files
 	 * .SAV OpenTTD saved game
@@ -447,7 +447,7 @@ void FiosGetSavegameList(SaveLoadOperation fop, bool show_dirs, FileList &file_l
  * @see FiosGetFileList
  * @see FiosGetScenarioList
  */
-std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext)
 {
 	/* Show scenario files
 	 * .SCN OpenTTD style scenario file
@@ -488,7 +488,7 @@ void FiosGetScenarioList(SaveLoadOperation fop, bool show_dirs, FileList &file_l
 	FiosGetFileList(fop, show_dirs, &FiosGetScenarioListCallback, subdir, file_list);
 }
 
-std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation, const std::string &file, const std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation, const std::string &file, std::string_view ext)
 {
 	/* Show heightmap files
 	 * .PNG PNG Based heightmap files
@@ -553,7 +553,7 @@ void FiosGetHeightmapList(SaveLoadOperation fop, bool show_dirs, FileList &file_
  * @param file Name of the file to check.
  * @return a FIOS_TYPE_JSON type of the found file, FIOS_TYPE_INVALID if not a valid JSON file, and the title of the file (if any).
  */
-static std::tuple<FiosType, std::string> FiosGetTownDataListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext)
+static std::tuple<FiosType, std::string> FiosGetTownDataListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext)
 {
 	if (fop == SLO_LOAD) {
 		if (StrEqualsIgnoreCase(ext, ".json")) {
@@ -715,7 +715,7 @@ FiosNumberedSaveName::FiosNumberedSaveName(const std::string &prefix) : prefix(p
 	static std::string _prefix; ///< Static as the lambda needs access to it.
 
 	/* Callback for FiosFileScanner. */
-	static FiosGetTypeAndNameProc *proc = [](SaveLoadOperation, const std::string &file, const std::string_view ext) {
+	static FiosGetTypeAndNameProc *proc = [](SaveLoadOperation, const std::string &file, std::string_view ext) {
 		if (StrEqualsIgnoreCase(ext, ".sav") && file.starts_with(_prefix)) return std::tuple(FIOS_TYPE_FILE, std::string{});
 		return std::tuple(FIOS_TYPE_INVALID, std::string{});
 	};

--- a/src/fios.h
+++ b/src/fios.h
@@ -87,7 +87,7 @@ struct FiosItem {
 class FileList : public std::vector<FiosItem> {
 public:
 	void BuildFileList(AbstractFileType abstract_filetype, SaveLoadOperation fop, bool show_dirs);
-	const FiosItem *FindItem(const std::string_view file);
+	const FiosItem *FindItem(std::string_view file);
 };
 
 enum SortingBits : uint8_t {
@@ -116,9 +116,9 @@ bool FiosDelete(std::string_view name);
 std::string FiosMakeHeightmapName(std::string_view name);
 std::string FiosMakeSavegameName(std::string_view name);
 
-std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
-std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
-std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext);
 
 void ScanScenarios();
 std::optional<std::string_view> FindScenario(const ContentInfo &ci, bool md5sum);

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -228,9 +228,9 @@ static void LoadSpriteTables()
 }
 
 
-static void RealChangeBlitter(const std::string_view repl_blitter)
+static void RealChangeBlitter(std::string_view repl_blitter)
 {
-	const std::string_view cur_blitter = BlitterFactory::GetCurrentBlitter()->GetName();
+	std::string_view cur_blitter = BlitterFactory::GetCurrentBlitter()->GetName();
 	if (cur_blitter == repl_blitter) return;
 
 	Debug(driver, 1, "Switching blitter from '{}' to '{}'... ", cur_blitter, repl_blitter);
@@ -299,7 +299,7 @@ static bool SwitchNewGRFBlitter()
 	};
 
 	const bool animation_wanted = HasBit(_display_opt, DO_FULL_ANIMATION);
-	const std::string_view cur_blitter = BlitterFactory::GetCurrentBlitter()->GetName();
+	std::string_view cur_blitter = BlitterFactory::GetCurrentBlitter()->GetName();
 
 	for (const auto &replacement_blitter : replacement_blitters) {
 		if (animation_wanted && (replacement_blitter.animation == 0)) continue;

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -169,7 +169,7 @@ void Packet::Send_uint64(uint64_t data)
  * the string + '\0'. No size-byte or something.
  * @param data The string to send
  */
-void Packet::Send_string(const std::string_view data)
+void Packet::Send_string(std::string_view data)
 {
 	assert(this->CanWriteToPacket(data.size() + 1));
 	this->buffer.insert(this->buffer.end(), data.begin(), data.end());

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -68,7 +68,7 @@ public:
 	void   Send_uint16(uint16_t data);
 	void   Send_uint32(uint32_t data);
 	void   Send_uint64(uint64_t data);
-	void   Send_string(const std::string_view data);
+	void   Send_string(std::string_view data);
 	void   Send_buffer(const std::vector<uint8_t> &data);
 	std::span<const uint8_t> Send_bytes(const std::span<const uint8_t> span);
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -458,7 +458,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendChat(NetworkAction action
  * Send a notification indicating the rcon command has completed.
  * @param command The original command sent.
  */
-NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRconEnd(const std::string_view command)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRconEnd(std::string_view command)
 {
 	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_RCON_END);
 
@@ -473,7 +473,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRconEnd(const std::string
  * @param colour The colour of the text.
  * @param result The result of the command.
  */
-NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRcon(uint16_t colour, const std::string_view result)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRcon(uint16_t colour, std::string_view result)
 {
 	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_RCON);
 
@@ -526,7 +526,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_PING(Packet &p)
  * @param origin The origin of the string.
  * @param string The string that's put on the console.
  */
-NetworkRecvStatus ServerNetworkAdminSocketHandler::SendConsole(const std::string_view origin, const std::string_view string)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::SendConsole(std::string_view origin, std::string_view string)
 {
 	/* If the length of both strings, plus the 2 '\0' terminations and 3 bytes of the packet
 	 * are bigger than the MTU, just ignore the message. Better safe than sorry. It should
@@ -547,7 +547,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendConsole(const std::string
  * Send GameScript JSON output.
  * @param json The JSON string.
  */
-NetworkRecvStatus ServerNetworkAdminSocketHandler::SendGameScript(const std::string_view json)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::SendGameScript(std::string_view json)
 {
 	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_GAMESCRIPT);
 
@@ -997,7 +997,7 @@ void NetworkAdminChat(NetworkAction action, DestType desttype, ClientID client_i
  * @param colour_code The colour of the string.
  * @param string      The string to show.
  */
-void NetworkServerSendAdminRcon(AdminID admin_index, TextColour colour_code, const std::string_view string)
+void NetworkServerSendAdminRcon(AdminID admin_index, TextColour colour_code, std::string_view string)
 {
 	ServerNetworkAdminSocketHandler::Get(admin_index)->SendRcon(colour_code, string);
 }
@@ -1007,7 +1007,7 @@ void NetworkServerSendAdminRcon(AdminID admin_index, TextColour colour_code, con
  * @param origin the origin of the message.
  * @param string the message as printed on the console.
  */
-void NetworkAdminConsole(const std::string_view origin, const std::string_view string)
+void NetworkAdminConsole(std::string_view origin, std::string_view string)
 {
 	for (ServerNetworkAdminSocketHandler *as : ServerNetworkAdminSocketHandler::IterateActive()) {
 		if (as->update_frequency[ADMIN_UPDATE_CONSOLE].Test(AdminUpdateFrequency::Automatic)) {
@@ -1020,7 +1020,7 @@ void NetworkAdminConsole(const std::string_view origin, const std::string_view s
  * Send GameScript JSON to the admin network (if they did opt in for the respective update).
  * @param json The JSON data as received from the GameScript.
  */
-void NetworkAdminGameScript(const std::string_view json)
+void NetworkAdminGameScript(std::string_view json)
 {
 	for (ServerNetworkAdminSocketHandler *as : ServerNetworkAdminSocketHandler::IterateActive()) {
 		if (as->update_frequency[ADMIN_UPDATE_GAMESCRIPT].Test(AdminUpdateFrequency::Automatic)) {

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -69,12 +69,12 @@ public:
 	NetworkRecvStatus SendCompanyStats();
 
 	NetworkRecvStatus SendChat(NetworkAction action, DestType desttype, ClientID client_id, std::string_view msg, int64_t data);
-	NetworkRecvStatus SendRcon(uint16_t colour, const std::string_view command);
-	NetworkRecvStatus SendConsole(const std::string_view origin, const std::string_view command);
-	NetworkRecvStatus SendGameScript(const std::string_view json);
+	NetworkRecvStatus SendRcon(uint16_t colour, std::string_view command);
+	NetworkRecvStatus SendConsole(std::string_view origin, std::string_view command);
+	NetworkRecvStatus SendGameScript(std::string_view json);
 	NetworkRecvStatus SendCmdNames();
 	NetworkRecvStatus SendCmdLogging(ClientID client_id, const CommandPacket &cp);
-	NetworkRecvStatus SendRconEnd(const std::string_view command);
+	NetworkRecvStatus SendRconEnd(std::string_view command);
 
 	static void Send();
 	static void AcceptConnection(SOCKET s, const NetworkAddress &address);
@@ -115,9 +115,9 @@ void NetworkAdminCompanyRemove(CompanyID company_id, AdminCompanyRemoveReason bc
 
 void NetworkAdminChat(NetworkAction action, DestType desttype, ClientID client_id, std::string_view msg, int64_t data = 0, bool from_admin = false);
 void NetworkAdminUpdate(AdminUpdateFrequency freq);
-void NetworkServerSendAdminRcon(AdminID admin_index, TextColour colour_code, const std::string_view string);
-void NetworkAdminConsole(const std::string_view origin, const std::string_view string);
-void NetworkAdminGameScript(const std::string_view json);
+void NetworkServerSendAdminRcon(AdminID admin_index, TextColour colour_code, std::string_view string);
+void NetworkAdminConsole(std::string_view origin, std::string_view string);
+void NetworkAdminGameScript(std::string_view json);
 void NetworkAdminCmdLogging(const NetworkClientSocket *owner, const CommandPacket &cp);
 
 #endif /* NETWORK_ADMIN_H */

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1242,7 +1242,7 @@ void NetworkClientsToSpectators(CompanyID cid)
  * @param client_name The client name to check for validity.
  * @return True iff the name is valid.
  */
-bool NetworkIsValidClientName(const std::string_view client_name)
+bool NetworkIsValidClientName(std::string_view client_name)
 {
 	if (client_name.empty()) return false;
 	if (client_name[0] == ' ') return false;

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -33,7 +33,7 @@ extern StringList _network_host_list;
 extern StringList _network_ban_list;
 
 uint8_t NetworkSpectatorCount();
-bool NetworkIsValidClientName(const std::string_view client_name);
+bool NetworkIsValidClientName(std::string_view client_name);
 bool NetworkValidateOurClientName();
 bool NetworkValidateClientName(std::string &client_name);
 bool NetworkValidateServerName(std::string &server_name);

--- a/src/newgrf/newgrf_act4.cpp
+++ b/src/newgrf/newgrf_act4.cpp
@@ -77,7 +77,7 @@ static void FeatureNewName(ByteReader &buf)
 	uint32_t feature_overlay = generic ? 0 : ((feature + 1) << 16);
 
 	for (; id < endid && buf.HasData(); id++) {
-		const std::string_view name = buf.ReadString();
+		std::string_view name = buf.ReadString();
 		GrfMsg(8, "FeatureNewName: 0x{:04X} <- {}", id, StrMakeValid(name));
 
 		switch (feature) {

--- a/src/newgrf/newgrf_act5.cpp
+++ b/src/newgrf/newgrf_act5.cpp
@@ -27,7 +27,7 @@
  * @param name        Used for error warnings.
  * @return The number of sprites that is going to be skipped.
  */
-static uint16_t SanitizeSpriteOffset(uint16_t &num, uint16_t offset, int max_sprites, const std::string_view name)
+static uint16_t SanitizeSpriteOffset(uint16_t &num, uint16_t offset, int max_sprites, std::string_view name)
 {
 
 	if (offset >= max_sprites) {

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -352,7 +352,7 @@ int MacOSStringCompare(std::string_view s1, std::string_view s2)
  * @param case_insensitive Search case-insensitive.
  * @return 1 if value was found, 0 if it was not found, or -1 if not supported by the OS.
  */
-int MacOSStringContains(const std::string_view str, const std::string_view value, bool case_insensitive)
+int MacOSStringContains(std::string_view str, std::string_view value, bool case_insensitive)
 {
 	static bool supported = MacOSVersionIsAtLeast(10, 5, 0);
 	if (!supported) return -1;

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -84,7 +84,7 @@ public:
 void MacOSResetScriptCache(FontSize size);
 void MacOSSetCurrentLocaleName(std::string_view iso_code);
 int MacOSStringCompare(std::string_view s1, std::string_view s2);
-int MacOSStringContains(const std::string_view str, const std::string_view value, bool case_insensitive);
+int MacOSStringContains(std::string_view str, std::string_view value, bool case_insensitive);
 
 void MacOSRegisterExternalFont(std::string_view file_path);
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -386,7 +386,7 @@ char *convert_from_fs(const std::wstring_view src, std::span<char> dst_buf)
  * @param dst_buf span of valid wide-char buffer that will receive the converted string
  * @return pointer to dst_buf. If conversion fails the string is of zero-length
  */
-wchar_t *convert_to_fs(const std::string_view src, std::span<wchar_t> dst_buf)
+wchar_t *convert_to_fs(std::string_view src, std::span<wchar_t> dst_buf)
 {
 	int len = MultiByteToWideChar(CP_UTF8, 0, src.data(), static_cast<int>(src.size()), dst_buf.data(), static_cast<int>(dst_buf.size() - 1U));
 	dst_buf[len] = '\0';
@@ -476,7 +476,7 @@ int OTTDStringCompare(std::string_view s1, std::string_view s2)
  * @param case_insensitive Search case-insensitive.
  * @return 1 if value was found, 0 if it was not found, or -1 if not supported by the OS.
  */
-int Win32StringContains(const std::string_view str, const std::string_view value, bool case_insensitive)
+int Win32StringContains(std::string_view str, std::string_view value, bool case_insensitive)
 {
 	typedef int (WINAPI *PFNFINDNLSSTRINGEX)(LPCWSTR, DWORD, LPCWSTR, int, LPCWSTR, int, LPINT, LPNLSVERSIONINFO, LPVOID, LPARAM);
 	static PFNFINDNLSSTRINGEX _FindNLSStringEx = nullptr;

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -13,10 +13,10 @@
 bool MyShowCursor(bool show, bool toggle = false);
 
 char *convert_from_fs(const std::wstring_view src, std::span<char> dst_buf);
-wchar_t *convert_to_fs(const std::string_view src, std::span<wchar_t> dst_buf);
+wchar_t *convert_to_fs(std::string_view src, std::span<wchar_t> dst_buf);
 
 void Win32SetCurrentLocaleName(const char *iso_code);
 int OTTDStringCompare(std::string_view s1, std::string_view s2);
-int Win32StringContains(const std::string_view str, const std::string_view value, bool case_insensitive);
+int Win32StringContains(std::string_view str, std::string_view value, bool case_insensitive);
 
 #endif /* WIN32_H */

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -88,7 +88,7 @@ int ScriptConfig::GetSetting(const std::string &name) const
 	return (*it).second;
 }
 
-void ScriptConfig::SetSetting(const std::string_view name, int value)
+void ScriptConfig::SetSetting(std::string_view name, int value)
 {
 	/* You can only set Script specific settings if an Script is selected. */
 	if (this->info == nullptr) return;

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -122,7 +122,7 @@ public:
 	/**
 	 * Set the value of a setting for this config.
 	 */
-	void SetSetting(const std::string_view name, int value);
+	void SetSetting(std::string_view name, int value);
 
 	/**
 	 * Reset all settings to their default value.

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -38,7 +38,7 @@ bool ScriptInfo::CheckMethod(std::string_view name) const
 	info.engine = info.scanner->GetEngine();
 
 	/* Ensure the mandatory functions exist */
-	static std::string_view const required_functions[] = {
+	static const std::string_view required_functions[] = {
 		"GetAuthor",
 		"GetName",
 		"GetShortName",
@@ -253,7 +253,7 @@ const ScriptConfigItemList *ScriptInfo::GetConfigList() const
 	return &this->config_list;
 }
 
-const ScriptConfigItem *ScriptInfo::GetConfigItem(const std::string_view name) const
+const ScriptConfigItem *ScriptInfo::GetConfigItem(std::string_view name) const
 {
 	for (const auto &item : this->config_list) {
 		if (item.name == name) return &item;

--- a/src/script/script_info.hpp
+++ b/src/script/script_info.hpp
@@ -107,7 +107,7 @@ public:
 	/**
 	 * Get the description of a certain Script config option.
 	 */
-	const ScriptConfigItem *GetConfigItem(const std::string_view name) const;
+	const ScriptConfigItem *GetConfigItem(std::string_view name) const;
 
 	/**
 	 * Set a setting.

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -238,7 +238,7 @@ public:
 	/**
 	 * Throw a Squirrel error that will be nicely displayed to the user.
 	 */
-	void ThrowError(const std::string_view error) { sq_throwerror(this->vm, error); }
+	void ThrowError(std::string_view error) { sq_throwerror(this->vm, error); }
 
 	/**
 	 * Release a SQ object.

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1623,7 +1623,7 @@ void IntSettingDesc::ChangeValue(const void *object, int32_t newval) const
  * @return Pointer to the setting description of setting \a name if it can be found,
  *         \c nullptr indicates failure to obtain the description.
  */
-static const SettingDesc *GetSettingFromName(const std::string_view name, const SettingTable &settings)
+static const SettingDesc *GetSettingFromName(std::string_view name, const SettingTable &settings)
 {
 	/* First check all full names */
 	for (auto &desc : settings) {
@@ -1705,7 +1705,7 @@ static const SettingDesc *GetCompanySettingFromName(std::string_view name)
  * @return Pointer to the setting description of setting \a name if it can be found,
  *         \c nullptr indicates failure to obtain the description.
  */
-const SettingDesc *GetSettingFromName(const std::string_view name)
+const SettingDesc *GetSettingFromName(std::string_view name)
 {
 	for (auto &table : GenericSettingTables()) {
 		auto sd = GetSettingFromName(name, table);

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -388,7 +388,7 @@ static constexpr const SettingDesc *GetSettingDesc(const SettingVariant &desc)
 
 typedef std::span<const SettingVariant> SettingTable;
 
-const SettingDesc *GetSettingFromName(const std::string_view name);
+const SettingDesc *GetSettingFromName(std::string_view name);
 void GetSaveLoadFromSettingTable(SettingTable settings, std::vector<SaveLoad> &saveloads);
 SettingTable GetSaveLoadSettingTable();
 bool SetSettingValue(const IntSettingDesc *sd, int32_t value, bool force_newgame = false);

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -173,11 +173,11 @@ struct SettingsIniFile : IniLoadFile {
 OutputStore _stored_output; ///< Temporary storage of the output, until all processing is done.
 OutputStore _post_amble_output; ///< Similar to _stored_output, but for the post amble.
 
-static std::string_view PREAMBLE_GROUP_NAME  = "pre-amble"; ///< Name of the group containing the pre amble.
-static std::string_view POSTAMBLE_GROUP_NAME = "post-amble"; ///< Name of the group containing the post amble.
-static std::string_view TEMPLATES_GROUP_NAME = "templates"; ///< Name of the group containing the templates.
-static std::string_view VALIDATION_GROUP_NAME = "validation"; ///< Name of the group containing the validation statements.
-static std::string_view DEFAULTS_GROUP_NAME  = "defaults"; ///< Name of the group containing default values for the template variables.
+static const std::string_view PREAMBLE_GROUP_NAME  = "pre-amble"; ///< Name of the group containing the pre amble.
+static const std::string_view POSTAMBLE_GROUP_NAME = "post-amble"; ///< Name of the group containing the post amble.
+static const std::string_view TEMPLATES_GROUP_NAME = "templates"; ///< Name of the group containing the templates.
+static const std::string_view VALIDATION_GROUP_NAME = "validation"; ///< Name of the group containing the validation statements.
+static const std::string_view DEFAULTS_GROUP_NAME  = "defaults"; ///< Name of the group containing default values for the template variables.
 
 /**
  * Dump a #IGT_SEQUENCE group into #_stored_output.

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -244,7 +244,7 @@ std::string_view StrTrimView(std::string_view str)
  * @param prefix The prefix to look for.
  * @return True iff the begin of the string is the same as the prefix, ignoring case.
  */
-bool StrStartsWithIgnoreCase(std::string_view str, const std::string_view prefix)
+bool StrStartsWithIgnoreCase(std::string_view str, std::string_view prefix)
 {
 	if (str.size() < prefix.size()) return false;
 	return StrEqualsIgnoreCase(str.substr(0, prefix.size()), prefix);
@@ -284,7 +284,7 @@ typedef std::basic_string_view<char, CaseInsensitiveCharTraits> CaseInsensitiveS
  * @param suffix The suffix to look for.
  * @return True iff the end of the string is the same as the suffix, ignoring case.
  */
-bool StrEndsWithIgnoreCase(std::string_view str, const std::string_view suffix)
+bool StrEndsWithIgnoreCase(std::string_view str, std::string_view suffix)
 {
 	if (str.size() < suffix.size()) return false;
 	return StrEqualsIgnoreCase(str.substr(str.size() - suffix.size()), suffix);
@@ -297,7 +297,7 @@ bool StrEndsWithIgnoreCase(std::string_view str, const std::string_view suffix)
  * @return Less than zero if str1 < str2, zero if str1 == str2, greater than
  *         zero if str1 > str2. All ignoring the case of the characters.
  */
-int StrCompareIgnoreCase(const std::string_view str1, const std::string_view str2)
+int StrCompareIgnoreCase(std::string_view str1, std::string_view str2)
 {
 	CaseInsensitiveStringView ci_str1{ str1.data(), str1.size() };
 	CaseInsensitiveStringView ci_str2{ str2.data(), str2.size() };
@@ -310,7 +310,7 @@ int StrCompareIgnoreCase(const std::string_view str1, const std::string_view str
  * @param str2 The second string.
  * @return True iff both strings are equal, barring the case of the characters.
  */
-bool StrEqualsIgnoreCase(const std::string_view str1, const std::string_view str2)
+bool StrEqualsIgnoreCase(std::string_view str1, std::string_view str2)
 {
 	if (str1.size() != str2.size()) return false;
 	return StrCompareIgnoreCase(str1, str2) == 0;
@@ -323,7 +323,7 @@ bool StrEqualsIgnoreCase(const std::string_view str1, const std::string_view str
  * @param value The string to search for.
  * @return True if a match was found.
  */
-bool StrContainsIgnoreCase(const std::string_view str, const std::string_view value)
+bool StrContainsIgnoreCase(std::string_view str, std::string_view value)
 {
 	CaseInsensitiveStringView ci_str{ str.data(), str.size() };
 	CaseInsensitiveStringView ci_value{ value.data(), value.size() };
@@ -455,7 +455,7 @@ int StrNaturalCompare(std::string_view s1, std::string_view s2, bool ignore_garb
  * @param case_insensitive Search case-insensitive.
  * @return 1 if value was found, 0 if it was not found, or -1 if not supported by the OS.
  */
-static int ICUStringContains(const std::string_view str, const std::string_view value, bool case_insensitive)
+static int ICUStringContains(std::string_view str, std::string_view value, bool case_insensitive)
 {
 	if (_current_collator) {
 		std::unique_ptr<icu::RuleBasedCollator> coll(dynamic_cast<icu::RuleBasedCollator *>(_current_collator->clone()));
@@ -485,7 +485,7 @@ static int ICUStringContains(const std::string_view str, const std::string_view 
  * @param value The string to search for.
  * @return True if a match was found.
  */
-[[nodiscard]] bool StrNaturalContains(const std::string_view str, const std::string_view value)
+[[nodiscard]] bool StrNaturalContains(std::string_view str, std::string_view value)
 {
 #ifdef WITH_ICU_I18N
 	int res_u = ICUStringContains(str, value, false);
@@ -512,7 +512,7 @@ static int ICUStringContains(const std::string_view str, const std::string_view 
  * @param value The string to search for.
  * @return True if a match was found.
  */
-[[nodiscard]] bool StrNaturalContainsIgnoreCase(const std::string_view str, const std::string_view value)
+[[nodiscard]] bool StrNaturalContainsIgnoreCase(std::string_view str, std::string_view value)
 {
 #ifdef WITH_ICU_I18N
 	int res_u = ICUStringContains(str, value, true);

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -41,21 +41,21 @@ bool strtolower(std::string &str, std::string::size_type offs = 0);
 void StrTrimInPlace(std::string &str);
 [[nodiscard]] std::string_view StrTrimView(std::string_view str);
 
-[[nodiscard]] bool StrStartsWithIgnoreCase(std::string_view str, const std::string_view prefix);
-[[nodiscard]] bool StrEndsWithIgnoreCase(std::string_view str, const std::string_view suffix);
+[[nodiscard]] bool StrStartsWithIgnoreCase(std::string_view str, std::string_view prefix);
+[[nodiscard]] bool StrEndsWithIgnoreCase(std::string_view str, std::string_view suffix);
 
-[[nodiscard]] int StrCompareIgnoreCase(const std::string_view str1, const std::string_view str2);
-[[nodiscard]] bool StrEqualsIgnoreCase(const std::string_view str1, const std::string_view str2);
-[[nodiscard]] bool StrContainsIgnoreCase(const std::string_view str, const std::string_view value);
+[[nodiscard]] int StrCompareIgnoreCase(std::string_view str1, std::string_view str2);
+[[nodiscard]] bool StrEqualsIgnoreCase(std::string_view str1, std::string_view str2);
+[[nodiscard]] bool StrContainsIgnoreCase(std::string_view str, std::string_view value);
 [[nodiscard]] int StrNaturalCompare(std::string_view s1, std::string_view s2, bool ignore_garbage_at_front = false);
-[[nodiscard]] bool StrNaturalContains(const std::string_view str, const std::string_view value);
-[[nodiscard]] bool StrNaturalContainsIgnoreCase(const std::string_view str, const std::string_view value);
+[[nodiscard]] bool StrNaturalContains(std::string_view str, std::string_view value);
+[[nodiscard]] bool StrNaturalContainsIgnoreCase(std::string_view str, std::string_view value);
 
 bool ConvertHexToBytes(std::string_view hex, std::span<uint8_t> bytes);
 
 /** Case insensitive comparator for strings, for example for use in std::map. */
 struct CaseInsensitiveComparator {
-	bool operator()(const std::string_view s1, const std::string_view s2) const { return StrCompareIgnoreCase(s1, s2) < 0; }
+	bool operator()(std::string_view s1, std::string_view s2) const { return StrCompareIgnoreCase(s1, s2) < 0; }
 };
 
 /**

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -529,8 +529,8 @@ static void FormatBytes(StringBuilder &builder, int64_t number)
 {
 	assert(number >= 0);
 
-	/*                                       1   2^10  2^20  2^30  2^40  2^50  2^60 */
-	const std::string_view iec_prefixes[] = {"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"};
+	/*                                              1   2^10  2^20  2^30  2^40  2^50  2^60 */
+	static const std::string_view iec_prefixes[] = {"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"};
 	uint id = 1;
 	while (number >= 1024 * 1024) {
 		number /= 1024;

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -417,7 +417,7 @@ Textbuf::Textbuf(uint16_t max_bytes, uint16_t max_chars)
  * Copy a string into the textbuffer.
  * @param text Source.
  */
-void Textbuf::Assign(const std::string_view text)
+void Textbuf::Assign(std::string_view text)
 {
 	size_t bytes = std::min<size_t>(this->max_bytes - 1, text.size());
 	this->buf = StrMakeValid(text.substr(0, bytes));

--- a/src/textbuf_type.h
+++ b/src/textbuf_type.h
@@ -43,7 +43,7 @@ struct Textbuf {
 
 	explicit Textbuf(uint16_t max_bytes, uint16_t max_chars = UINT16_MAX);
 
-	void Assign(const std::string_view text);
+	void Assign(std::string_view text);
 
 	void DeleteAll();
 	bool InsertClipboard();

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -884,7 +884,7 @@ static void MakeItalianTownName(StringBuilder &builder, uint32_t seed)
 		return;
 	}
 
-	static std::string_view const mascul_femin_italian[] = {
+	static const std::string_view mascul_femin_italian[] = {
 		"o",
 		"a",
 	};


### PR DESCRIPTION
## Motivation / Problem

`const std::string_view` as parameter to a function.
`static std::string_view` as variable when it's never going to be changed.


## Description

Remove the `const` from `std::string_view` from parameters and local variables.
Add `const` to `static std::string_view` when the variable is not supposed to be changed at all.
Also some east vs west `const`s.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
