### PR TITLE
Add: "Many random towns" button in scenario editor now prompts for the number of towns, with defaults based on the current new game settings

### DIFF
--- a/src/town.h
+++ b/src/town.h
@@ -231,7 +231,8 @@ void ChangeTownRating(Town *t, int add, int max, DoCommandFlags flags);
 HouseZone GetTownRadiusGroup(const Town *t, TileIndex tile);
 void SetTownRatingTestMode(bool mode);
 TownActions GetMaskOfTownActions(CompanyID cid, const Town *t);
-bool GenerateTowns(TownLayout layout);
+uint GetDefaultTownsForMapSize();
+bool GenerateTowns(TownLayout layout, std::optional<uint> number = std::nullopt);
 const CargoSpec *FindFirstCargoWithTownAcceptanceEffect(TownAcceptanceEffect effect);
 CargoArray GetAcceptedCargoOfHouse(const HouseSpec *hs);
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Currently, there is extremely limited options for the "create many random towns" option in the scenario editor. The button will always add the number of towns corresponding to the "Very Low" town setting, which could be significantly more than the player desires on very large map sizes. Without any ability to precisely indicate how many towns are needed, the only possible way of creating an exact number of towns is to repeatedly click the "single random town" button, which is terrible user experience if the player wishes to create more than a handful of towns.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

When clicking the "Many random towns" button, bring up a dialogue box prompting for an exact number of towns.

The default on this box is based on your new game settings: if you have a density preset selected like Very Low or Normal, it will fill in a semi-random number of towns appropriate to your map size, exactly like you would get from world generation outside of the scenario editor. If you have a custom number of towns selected, it will fill in that value instead.  

In either case, the box is freely editable, allowing players an exact level of control over how many towns to spawn at once.

On the technical side, this is done by adding an optional parameter to `GenerateTowns()`, containing the exact number of towns to generate, which is ignored outside of the Scenario Editor. The total number of towns outside the scenario editor is still calculated the same way as it was before, within `GenerateTowns()` itself, according to the map size and the user's new game settings. A portion of this code has been copied to the new pop-up box, allowing it to autofill the number of towns based on the same calculations that `GenerateTowns()` uses. 

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
The defaults could be potentially "magic" in a non-user-friendly way.

Extending `GenerateTowns()` in this way was done to minimize changes to any other parts of the code, and I believe it was the neatest way possible, but it would perhaps be better for the number of towns to be a mandatory parameter and to always separately calculate the number of towns before calling it. This would prevent accidentally calling `GenerateTowns()` from within the scenario editor without specifying how many towns, and would also fix duplicating the code for number of towns based on map size (which is part of both the `GenerateTowns()` function proper, and the popup box code to determine the default number of towns).

The pop-up box could disrupt existing workflows, and other spacebar heating concerns. 

I am inexperienced, and it is possible that this code is significantly messier than intended.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
