### PR TITLE
Codechange: Use more fmt::format.

### DIFF
--- a/src/3rdparty/icu/scriptrun.h
+++ b/src/3rdparty/icu/scriptrun.h
@@ -19,6 +19,7 @@
 #include <unicode/utypes.h>
 #include <unicode/uobject.h>
 #include <unicode/uscript.h>
+#include <array>
 
 U_NAMESPACE_BEGIN
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2120,7 +2120,7 @@ static bool ConNetworkAuthorizedKey(std::span<std::string_view> argv)
 		IConsolePrint(CC_HELP, "Instead of a key, use 'client:<id>' to add/remove the key of that given client.");
 
 		std::string buffer;
-		for (auto [name, _] : _console_cmd_authorized_keys) fmt::format_to(std::back_inserter(buffer), ", {}", name);
+		for (auto [name, _] : _console_cmd_authorized_keys) format_append(buffer, ", {}", name);
 		IConsolePrint(CC_HELP, "The supported types are: all{} and company:<id>.", buffer);
 		return true;
 	}
@@ -2623,7 +2623,7 @@ static bool ConNewGRFProfile(std::span<std::string_view> argv)
 				started++;
 
 				if (!grfids.empty()) grfids += ", ";
-				fmt::format_to(std::back_inserter(grfids), "[{:08X}]", std::byteswap(pr.grffile->grfid));
+				format_append(grfids, "[{:08X}]", std::byteswap(pr.grffile->grfid));
 			}
 		}
 		if (started > 0) {

--- a/src/core/format.hpp
+++ b/src/core/format.hpp
@@ -45,4 +45,10 @@ struct fmt::formatter<T, Char> : fmt::formatter<typename T::BaseType> {
 	}
 };
 
+template <class... Args>
+void format_append(std::string &out, fmt::format_string<Args...> &&fmt, Args&&... args)
+{
+	fmt::format_to(std::back_inserter(out), std::forward<decltype(fmt)>(fmt), std::forward<decltype(args)>(args)...);
+}
+
 #endif /* FORMAT_HPP */

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -203,7 +203,7 @@ std::string GetDebugString()
 	std::string result;
 	for (const auto &debug_level : _debug_levels) {
 		if (!result.empty()) result += ", ";
-		fmt::format_to(std::back_inserter(result), "{}={}", debug_level.name, *debug_level.level);
+		format_append(result, "{}={}", debug_level.name, *debug_level.level);
 	}
 	return result;
 }

--- a/src/misc/dbg_helpers.cpp
+++ b/src/misc/dbg_helpers.cpp
@@ -106,31 +106,17 @@ void DumpTarget::WriteIndent()
 	}
 }
 
-/** Write 'name = value' with indent and new-line. */
-void DumpTarget::WriteValue(const std::string &name, int value)
-{
-	WriteIndent();
-	m_out += name + " = " + std::to_string(value) + "\n";
-}
-
-/** Write 'name = value' with indent and new-line. */
-void DumpTarget::WriteValue(const std::string &name, const std::string &value_str)
-{
-	WriteIndent();
-	m_out += name + " = " + value_str + "\n";
-}
-
 /** Write name & TileIndex to the output. */
-void DumpTarget::WriteTile(const std::string &name, TileIndex tile)
+void DumpTarget::WriteTile(std::string_view name, TileIndex tile)
 {
 	WriteIndent();
-	m_out += name + " = " + TileStr(tile) + "\n";
+	format_append(m_out, "{} = {}\n", name, TileStr(tile));
 }
 
 /**
  * Open new structure (one level deeper than the current one) 'name = {\<LF\>'.
  */
-void DumpTarget::BeginStruct(size_t type_id, const std::string &name, const void *ptr)
+void DumpTarget::BeginStruct(size_t type_id, std::string_view name, const void *ptr)
 {
 	/* make composite name */
 	std::string cur_name = GetCurrentStructName();
@@ -147,7 +133,7 @@ void DumpTarget::BeginStruct(size_t type_id, const std::string &name, const void
 	m_known_names.insert(KNOWN_NAMES::value_type(KnownStructKey(type_id, ptr), cur_name));
 
 	WriteIndent();
-	m_out += name + " = {\n";
+	format_append(m_out, "{} = {{\n", name);
 	m_indent++;
 }
 

--- a/src/misc/dbg_helpers.h
+++ b/src/misc/dbg_helpers.h
@@ -16,6 +16,7 @@
 #include "../signal_type.h"
 #include "../tile_type.h"
 #include "../track_type.h"
+#include "../core/format.hpp"
 
 /** Helper template class that provides C array length and item type */
 template <typename T> struct ArrayT;
@@ -156,21 +157,26 @@ struct DumpTarget {
 
 	void WriteIndent();
 
-	void WriteValue(const std::string &name, int value);
-	void WriteValue(const std::string &name, const std::string &value_str);
-	void WriteTile(const std::string &name, TileIndex t);
+	/** Write 'name = value' with indent and new-line. */
+	void WriteValue(std::string_view name, const auto &value)
+	{
+		WriteIndent();
+		format_append(m_out, "{} = {}\n", name, value);
+	}
+
+	void WriteTile(std::string_view name, TileIndex t);
 
 	/** Dump given enum value (as a number and as named value) */
-	template <typename E> void WriteEnumT(const std::string &name, E e)
+	template <typename E> void WriteEnumT(std::string_view name, E e)
 	{
 		WriteValue(name, ValueStr(e));
 	}
 
-	void BeginStruct(size_t type_id, const std::string &name, const void *ptr);
+	void BeginStruct(size_t type_id, std::string_view name, const void *ptr);
 	void EndStruct();
 
 	/** Dump nested object (or only its name if this instance is already known). */
-	template <typename S> void WriteStructT(const std::string &name, const S *s)
+	template <typename S> void WriteStructT(std::string_view name, const S *s)
 	{
 		static size_t type_id = ++LastTypeId();
 
@@ -193,7 +199,7 @@ struct DumpTarget {
 	}
 
 	/** Dump nested object (or only its name if this instance is already known). */
-	template <typename S> void WriteStructT(const std::string &name, const std::deque<S> *s)
+	template <typename S> void WriteStructT(std::string_view name, const std::deque<S> *s)
 	{
 		static size_t type_id = ++LastTypeId();
 
@@ -211,7 +217,7 @@ struct DumpTarget {
 			/* Still unknown, dump it */
 			BeginStruct(type_id, name, s);
 			size_t num_items = s->size();
-			this->WriteValue("num_items", std::to_string(num_items));
+			this->WriteValue("num_items", num_items);
 			for (size_t i = 0; i < num_items; i++) {
 				const auto &item = (*s)[i];
 				this->WriteStructT(fmt::format("item[{}]", i), &item);

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -1065,7 +1065,7 @@ std::string MidiFile::GetSMFFile(const MusicSongInfo &song)
 	AppendPathSeparator(tempdirname);
 	FioCreateDirectory(tempdirname);
 
-	std::string output_filename = tempdirname + std::to_string(song.cat_index) + ".mid";
+	std::string output_filename = fmt::format("{}{}.mid", tempdirname, song.cat_index);
 
 	if (FileExists(output_filename)) {
 		/* If the file already exists, assume it's the correct decoded data */

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -209,7 +209,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 	hints.ai_socktype = socktype;
 
 	/* The port needs to be a string. Six is enough to contain all characters + '\0'. */
-	std::string port_name = std::to_string(this->GetPort());
+	std::string port_name = fmt::format("{}", this->GetPort());
 
 	bool reset_hostname = false;
 	/* Setting both hostname to nullptr and port to 0 is not allowed.

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -228,7 +228,7 @@ void TCPConnecter::Resolve()
 	hints.ai_flags = AI_ADDRCONFIG;
 	hints.ai_socktype = SOCK_STREAM;
 
-	std::string port_name = std::to_string(address.GetPort());
+	std::string port_name = fmt::format("{}", address.GetPort());
 
 	static bool getaddrinfo_timeout_error_shown = false;
 	auto start = std::chrono::steady_clock::now();

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -322,7 +322,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContentHTTP(const Conten
 {
 	std::string content_request;
 	for (const ContentID &id : content) {
-		content_request += std::to_string(id) + "\n";
+		format_append(content_request, "{}\n", id);
 	}
 
 	this->http_response_index = -1;

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -364,7 +364,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 				if (!first) url.push_back(',');
 				first = false;
 
-				fmt::format_to(std::back_inserter(url), "{:08X}:{}", ci->unique_id, FormatArrayAsHex(ci->md5sum));
+				format_append(url, "{:08X}:{}", ci->unique_id, FormatArrayAsHex(ci->md5sum));
 			}
 		} else {
 			url += "do=searchtext&q=";
@@ -376,7 +376,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 
 				/* Escape special chars, such as &%,= */
 				if (*search < 0x30) {
-					fmt::format_to(std::back_inserter(url), "%{:02X}", *search);
+					format_append(url, "%{:02X}", *search);
 				} else {
 					url.push_back(*search);
 				}

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1627,7 +1627,7 @@ bool NetworkMakeClientNameUnique(std::string &name)
 
 		if (!is_name_unique) {
 			/* Try a new name (<name> #1, <name> #2, and so on) */
-			name = original_name + " #" + std::to_string(number);
+			name = fmt::format("{} #{}", original_name, number);
 
 			/* The constructed client name is larger than the limit,
 			 * so... bail out as no valid name can be created. */

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -643,7 +643,7 @@ std::string GRFBuildParamList(const GRFConfig &c)
 	std::string result;
 	for (const uint32_t &value : c.param) {
 		if (!result.empty()) result += ' ';
-		result += std::to_string(value);
+		format_append(result, "{}", value);
 	}
 	return result;
 }

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -237,19 +237,19 @@ static void WriteSavegameInfo(const std::string &name)
 
 	std::string message;
 	message.reserve(1024);
-	fmt::format_to(std::back_inserter(message), "Name:         {}\n", name);
-	fmt::format_to(std::back_inserter(message), "Savegame ver: {}\n", _sl_version);
-	fmt::format_to(std::back_inserter(message), "NewGRF ver:   0x{:08X}\n", last_ottd_rev);
-	fmt::format_to(std::back_inserter(message), "Modified:     {}\n", ever_modified);
+	format_append(message, "Name:         {}\n", name);
+	format_append(message, "Savegame ver: {}\n", _sl_version);
+	format_append(message, "NewGRF ver:   0x{:08X}\n", last_ottd_rev);
+	format_append(message, "Modified:     {}\n", ever_modified);
 
 	if (removed_newgrfs) {
-		fmt::format_to(std::back_inserter(message), "NewGRFs have been removed\n");
+		format_append(message, "NewGRFs have been removed\n");
 	}
 
 	message += "NewGRFs:\n";
 	if (_load_check_data.HasNewGrfs()) {
 		for (const auto &c : _load_check_data.grfconfig) {
-			fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", std::byteswap(c->ident.grfid),
+			format_append(message, "{:08X} {} {}\n", std::byteswap(c->ident.grfid),
 				FormatArrayAsHex(c->flags.Test(GRFConfigFlag::Compatible) ? c->original_md5sum : c->ident.md5sum), c->filename);
 		}
 	}

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -274,13 +274,13 @@ static const uint MAX_FRAMES     = 64;
 			/* Get symbol name and line info if possible. */
 			DWORD64 offset;
 			if (proc.pSymGetSymFromAddr64(hCur, frame.AddrPC.Offset, &offset, sym_info)) {
-				message += fmt::format(" {} + {}", sym_info->Name, offset);
+				format_append(message, " {} + {}", sym_info->Name, offset);
 
 				DWORD line_offs;
 				IMAGEHLP_LINE64 line;
 				line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
 				if (proc.pSymGetLineFromAddr64(hCur, frame.AddrPC.Offset, &line_offs, &line)) {
-					message += fmt::format(" ({}:{})", line.FileName, line.LineNumber);
+					format_append(message, " ({}:{})", line.FileName, line.LineNumber);
 				}
 			}
 

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -196,7 +196,7 @@ public:
 	{
 		Debug(map, 9, "Water region {},{} labels and edge traversability = ...", GetWaterRegionX(this->tile_area.tile), GetWaterRegionY(this->tile_area.tile));
 
-		const size_t max_element_width = std::to_string(this->NumberOfPatches()).size();
+		const size_t max_element_width = fmt::format("{}", this->NumberOfPatches()).size();
 
 		std::string traversability = fmt::format("{:0{}b}", this->GetEdgeTraversabilityBits(DIAGDIR_NW), WATER_REGION_EDGE_LENGTH);
 		Debug(map, 9, "    {:{}}", fmt::join(traversability, " "), max_element_width);
@@ -206,8 +206,11 @@ public:
 			std::string line{};
 			for (int x = 0; x < WATER_REGION_EDGE_LENGTH; ++x) {
 				const auto label = this->GetLabel(TileAddXY(this->tile_area.tile, x, y));
-				const std::string label_str = label == INVALID_WATER_REGION_PATCH ? "." : std::to_string(label);
-				line = fmt::format("{:{}}", label_str, max_element_width) + " " + line;
+				if (label == INVALID_WATER_REGION_PATCH) {
+					line = fmt::format("{:{}} {}", ".", max_element_width, line);
+				} else {
+					line = fmt::format("{:{}} {}", label, max_element_width, line);
+				}
 			}
 			Debug(map, 9, "{} | {}| {}", GB(this->GetEdgeTraversabilityBits(DIAGDIR_SW), y, 1), line, GB(this->GetEdgeTraversabilityBits(DIAGDIR_NE), y, 1));
 		}

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -54,6 +54,9 @@
 #define fputs     SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define putchar   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
+/* Use fmt::format instead */
+#define to_string SAFEGUARD_DO_NOT_USE_THIS_METHOD
+
 /* Use our own templated implementation instead of a macro or function with only one type. */
 #ifdef min
 #undef min

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -383,11 +383,11 @@ static void CDECL HandleSavegameLoadCrash(int signum)
 		for (const auto &c : _grfconfig) {
 			if (c->flags.Test(GRFConfigFlag::Compatible)) {
 				const GRFIdentifier &replaced = _gamelog.GetOverriddenIdentifier(*c);
-				fmt::format_to(std::back_inserter(message), "NewGRF {:08X} (checksum {}) not found.\n  Loaded NewGRF \"{}\" (checksum {}) with same GRF ID instead.\n",
+				format_append(message, "NewGRF {:08X} (checksum {}) not found.\n  Loaded NewGRF \"{}\" (checksum {}) with same GRF ID instead.\n",
 						std::byteswap(c->ident.grfid), FormatArrayAsHex(c->original_md5sum), c->filename, FormatArrayAsHex(replaced.md5sum));
 			}
 			if (c->status == GCS_NOT_FOUND) {
-				fmt::format_to(std::back_inserter(message), "NewGRF {:08X} ({}) not found; checksum {}.\n",
+				format_append(message, "NewGRF {:08X} ({}) not found; checksum {}.\n",
 						std::byteswap(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
 			}
 		}

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -152,7 +152,7 @@ static std::string_view MakeScreenshotName(std::string_view default_fn, std::str
 
 	size_t len = _screenshot_name.size();
 	/* Add extension to screenshot file */
-	_screenshot_name += fmt::format(".{}", ext);
+	format_append(_screenshot_name, ".{}", ext);
 
 	std::string_view screenshot_dir = crashlog ? _personal_dir : FiosGetScreenshotDir();
 
@@ -163,7 +163,7 @@ static std::string_view MakeScreenshotName(std::string_view default_fn, std::str
 		if (!FileExists(_full_screenshot_path)) break;
 		/* If file exists try another one with same name, but just with a higher index */
 		_screenshot_name.erase(len);
-		_screenshot_name += fmt::format("#{}.{}", serial, ext);
+		format_append(_screenshot_name, "#{}.{}", serial, ext);
 	}
 
 	return _full_screenshot_path;

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -83,19 +83,19 @@ public:
 
 		std::string message;
 		message.reserve(1024);
-		fmt::format_to(std::back_inserter(message), "Graphics set: {} ({})\n", BaseGraphics::GetUsedSet()->name, BaseGraphics::GetUsedSet()->version);
+		format_append(message, "Graphics set: {} ({})\n", BaseGraphics::GetUsedSet()->name, BaseGraphics::GetUsedSet()->version);
 		message += "NewGRFs:\n";
 		if (_game_mode != GM_MENU) {
 			for (const auto &c : _grfconfig) {
-				fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", std::byteswap(c->ident.grfid), FormatArrayAsHex(c->ident.md5sum), c->filename);
+				format_append(message, "{:08X} {} {}\n", std::byteswap(c->ident.grfid), FormatArrayAsHex(c->ident.md5sum), c->filename);
 			}
 		}
 		message += "\nCompanies:\n";
 		for (const Company *c : Company::Iterate()) {
 			if (c->ai_info == nullptr) {
-				fmt::format_to(std::back_inserter(message), "{:2d}: Human\n", c->index);
+				format_append(message, "{:2d}: Human\n", c->index);
 			} else {
-				fmt::format_to(std::back_inserter(message), "{:2d}: {} (v{})\n", c->index, c->ai_info->GetName(), c->ai_info->GetVersion());
+				format_append(message, "{:2d}: {} (v{})\n", c->index, c->ai_info->GetName(), c->ai_info->GetVersion());
 			}
 		}
 		text[1].key = const_cast<char *>("Description");

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -168,7 +168,7 @@ std::string ScriptConfig::SettingsToString() const
 
 	std::string result;
 	for (const auto &item : this->settings) {
-		fmt::format_to(std::back_inserter(result), "{}={},", item.first, item.second);
+		format_append(result, "{}={},", item.first, item.second);
 	}
 
 	/* Remove the last ','. */

--- a/src/script/script_info_dummy.cpp
+++ b/src/script/script_info_dummy.cpp
@@ -12,7 +12,7 @@
 
 #include "../string_func.h"
 #include "../strings_func.h"
-#include "../3rdparty/fmt/format.h"
+#include "../core/format.hpp"
 
 #include "../safeguards.h"
 
@@ -90,13 +90,12 @@ void Script_CreateDummy(HSQUIRRELVM vm, StringID string, std::string_view type)
 
 	/* 2) We construct the AI's code. This is done by merging a header, body and footer */
 	std::string dummy_script;
-	auto back_inserter = std::back_inserter(dummy_script);
 	/* Just a rough ballpark estimate. */
 	dummy_script.reserve(error_message.size() + 128 + 64 * messages.size());
 
-	fmt::format_to(back_inserter, "class Dummy{0} extends {0}Controller {{\n  function Start()\n  {{\n", type);
+	format_append(dummy_script, "class Dummy{0} extends {0}Controller {{\n  function Start()\n  {{\n", type);
 	for (std::string &message : messages) {
-		fmt::format_to(back_inserter, "    {}Log.Error(\"{}\");\n", type, message);
+		format_append(dummy_script, "    {}Log.Error(\"{}\");\n", type, message);
 	}
 	dummy_script += "  }\n}\n";
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -334,7 +334,7 @@ std::string ListSettingDesc::FormatValue(const void *object) const
 			default: NOT_REACHED();
 		}
 		if (i != 0) result += ',';
-		result += std::to_string(v);
+		format_append(result, "{}", v);
 	}
 	return result;
 }
@@ -342,7 +342,7 @@ std::string ListSettingDesc::FormatValue(const void *object) const
 std::string OneOfManySettingDesc::FormatSingleValue(uint id) const
 {
 	if (id >= this->many.size()) {
-		return std::to_string(id);
+		return fmt::format("{}", id);
 	}
 	return this->many[id];
 }
@@ -745,7 +745,7 @@ std::string IntSettingDesc::FormatValue(const void *object) const
 	} else {
 		i = (uint32_t)this->Read(object);
 	}
-	return std::to_string(i);
+	return fmt::format("{}", i);
 }
 
 std::string BoolSettingDesc::FormatValue(const void *object) const
@@ -1212,7 +1212,7 @@ static void SaveVersionInConfig(IniFile &ini)
 	IniGroup &group = ini.GetOrCreateGroup("version");
 	group.GetOrCreateItem("version_string").SetValue(_openttd_revision);
 	group.GetOrCreateItem("version_number").SetValue(fmt::format("{:08X}", _openttd_newgrf_version));
-	group.GetOrCreateItem("ini_version").SetValue(std::to_string(INIFILE_VERSION));
+	group.GetOrCreateItem("ini_version").SetValue(fmt::format("{}", INIFILE_VERSION));
 }
 
 /**

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -78,7 +78,7 @@ std::string FormatArrayAsHex(std::span<const uint8_t> data)
 	str.reserve(data.size() * 2 + 1);
 
 	for (auto b : data) {
-		fmt::format_to(std::back_inserter(str), "{:02X}", b);
+		format_append(str, "{:02X}", b);
 	}
 
 	return str;

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -311,7 +311,7 @@ void SurveyFont(nlohmann::json &survey)
 void SurveyCompanies(nlohmann::json &survey)
 {
 	for (const Company *c : Company::Iterate()) {
-		auto &company = survey[std::to_string(c->index.base())];
+		auto &company = survey[fmt::format("{}", c->index.base())];
 		if (c->ai_info == nullptr) {
 			company["type"] = "human";
 		} else {


### PR DESCRIPTION
## Motivation / Problem

`std::to_string` is potentially locale specific (depending on overload). We never want that.

## Description

* Add `format_append` as short-cut for `fmt::format_to(std::back_inserter`.
* Replace all occurrences of `std::to_string` with `fmt::format`.
* Add `to_string` to the banned functions.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
