### PR TITLE
Codechange: Remove usages of sscanf, atoi, strtol, strtoul, ...

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -5,6 +5,7 @@
 #include "../../../stdafx.h"
 #include "../../fmt/format.h"
 
+#include "../../../core/string_consumer.hpp"
 #include "sqpcheader.h"
 #include "sqvm.h"
 #include "sqstring.h"
@@ -27,9 +28,9 @@ bool str2num(const SQChar *s,SQObjectPtr &res)
 		return true;
 	}
 	else{
-		SQInteger r = SQInteger(strtol(s,&end,10));
-		if(s == end) return false;
-		res = r;
+		auto val = ParseInteger<int64_t>(s);
+		if (!val.has_value()) return false;
+		res = *val;
 		return true;
 	}
 }

--- a/src/3rdparty/squirrel/squirrel/sqlexer.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqlexer.cpp
@@ -12,6 +12,7 @@
 #include "sqlexer.h"
 
 #include "../../../core/utf8.hpp"
+#include "../../../core/string_consumer.hpp"
 
 #include "../../../safeguards.h"
 
@@ -310,16 +311,16 @@ SQInteger SQLexer::ReadString(char32_t ndelim,bool verbatim)
 					case 'x': NEXT(); {
 						if(!isxdigit(CUR_CHAR)) Error("hexadecimal number expected");
 						const SQInteger maxdigits = 4;
-						SQChar temp[maxdigits+1];
-						SQInteger n = 0;
+						SQChar temp[maxdigits];
+						size_t n = 0;
 						while(isxdigit(CUR_CHAR) && n < maxdigits) {
 							temp[n] = CUR_CHAR;
 							n++;
 							NEXT();
 						}
-						temp[n] = 0;
-						SQChar *sTemp;
-						APPEND_CHAR((SQChar)strtoul(temp,&sTemp,16));
+						auto val = ParseInteger(std::string_view{temp, n}, 16);
+						if (!val.has_value()) Error("hexadecimal number expected");
+						APPEND_CHAR(static_cast<SQChar>(*val));
 					}
 				    break;
 					case 't': APPEND_CHAR('\t'); NEXT(); break;

--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -14,6 +14,7 @@
 #include "ini_type.h"
 #include "string_func.h"
 #include "error_func.h"
+#include "core/string_consumer.hpp"
 
 extern void CheckExternalFiles();
 
@@ -70,7 +71,12 @@ bool BaseSet<T>::FillSetDetails(const IniFile &ini, const std::string &path, con
 	}
 
 	fetch_metadata("version");
-	this->version = atoi(item->value->c_str());
+	auto value = ParseInteger(*item->value);
+	if (!value.has_value()) {
+		Debug(grf, 0, "Base {}set detail loading: {} field is invalid: {}", BaseSet<T>::SET_TYPE, item->name, *item->value);
+		return false;
+	}
+	this->version = *value;
 
 	item = metadata->GetItem("fallback");
 	this->fallback = (item != nullptr && item->value && *item->value != "0" && *item->value != "false");

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -35,6 +35,7 @@
 #include "timer/timer.h"
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_game_economy.h"
+#include "core/string_consumer.hpp"
 
 #include "widgets/cheat_widget.h"
 
@@ -607,12 +608,13 @@ struct CheatWindow : Window {
 
 			int32_t value;
 			if (!str->empty()) {
-				long long llvalue = atoll(str->c_str());
+				auto llvalue = ParseInteger<int64_t>(*str);
+				if (!llvalue.has_value()) return;
 
 				/* Save the correct currency-translated value */
-				if (sd->flags.Test(SettingFlag::GuiCurrency)) llvalue /= GetCurrency().rate;
+				if (sd->flags.Test(SettingFlag::GuiCurrency)) llvalue = *llvalue / GetCurrency().rate;
 
-				value = ClampTo<int32_t>(llvalue);
+				value = ClampTo<int32_t>(*llvalue);
 			} else {
 				value = sd->GetDefaultValue();
 			}
@@ -621,11 +623,12 @@ struct CheatWindow : Window {
 		} else {
 			const CheatEntry *ce = &_cheats_ui[clicked_cheat];
 			int oldvalue = static_cast<int32_t>(ReadValue(ce->variable, ce->type));
-			int value = atoi(str->c_str());
+			auto value = ParseInteger<int32_t>(*str);
+			if (!value.has_value()) return;
 			*ce->been_used = true;
-			value = ce->proc(value, value - oldvalue);
+			value = ce->proc(*value, *value - oldvalue);
 
-			if (value != oldvalue) WriteValue(ce->variable, ce->type, static_cast<int64_t>(value));
+			if (*value != oldvalue) WriteValue(ce->variable, ce->type, static_cast<int64_t>(*value));
 		}
 
 		this->valuewindow_entry = nullptr;

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -45,6 +45,7 @@
 #include "object_cmd.h"
 #include "timer/timer.h"
 #include "timer/timer_window.h"
+#include "core/string_consumer.hpp"
 
 #include "widgets/company_widget.h"
 
@@ -1692,7 +1693,9 @@ public:
 		if (!str.has_value()) return;
 		/* Set a new company manager face number */
 		if (!str->empty()) {
-			this->face = std::strtoul(str->c_str(), nullptr, 10);
+			auto val = ParseInteger(*str);
+			if (!val.has_value()) return;
+			this->face = *val;
 			ScaleAllCompanyManagerFaceBits(this->face);
 			ShowErrorMessage(GetEncodedString(STR_FACE_FACECODE_SET), {}, WL_INFO);
 			this->UpdateData();
@@ -2455,7 +2458,9 @@ struct CompanyWindow : Window
 			default: NOT_REACHED();
 
 			case WID_C_GIVE_MONEY: {
-				Money money = std::strtoull(str->c_str(), nullptr, 10) / GetCurrency().rate;
+				auto value = ParseInteger<uint64_t>(*str);
+				if (!value.has_value()) return;
+				Money money = *value / GetCurrency().rate;
 				Command<CMD_GIVE_MONEY>::Post(STR_ERROR_CAN_T_GIVE_MONEY, money, this->window_number);
 				break;
 			}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -71,18 +71,6 @@ static IntervalTimer<TimerGameCalendar> _scheduled_monthly_timer = {{TimerGameCa
 	IConsoleCmdExec(fmt::format("exec {}", filename));
 }};
 
-
-/**
- * Change a string into its number representation. Supports decimal and hexadecimal numbers.
- * @param arg The string to be converted.
- * @param base The base for parsing the number, defaults to only decimal numbers. Use 0 to also allow hexadecimal.
- * @return The number, or std::nullopt when it could not be parsed.
- */
-static std::optional<uint32_t> ParseInteger(std::string_view arg, int base = 10)
-{
-	return StringConsumer{arg}.TryReadIntegerBase<uint32_t>(base);
-}
-
 /**
  * Parse an integer using #ParseInteger and convert it to the requested type.
  * @param arg The string to be converted.

--- a/src/core/string_consumer.hpp
+++ b/src/core/string_consumer.hpp
@@ -892,4 +892,23 @@ public:
 	void SkipIntegerBase(int base);
 };
 
+/**
+ * Change a string into its number representation.
+ * Supports decimal and hexadecimal numbers.
+ * Accepts leading and trailing whitespace. Trailing junk is an error.
+ * @param arg The string to be converted.
+ * @param base The base for parsing the number, defaults to only decimal numbers. Use 0 to also allow hexadecimal.
+ * @return The number, or std::nullopt if it could not be parsed.
+ */
+template <class T = uint32_t>
+static inline std::optional<T> ParseInteger(std::string_view arg, int base = 10)
+{
+	StringConsumer consumer{arg};
+	consumer.SkipUntilCharNotIn(StringConsumer::WHITESPACE_NO_NEWLINE);
+	auto result = consumer.TryReadIntegerBase<T>(base);
+	consumer.SkipUntilCharNotIn(StringConsumer::WHITESPACE_NO_NEWLINE);
+	if (consumer.AnyBytesLeft()) return std::nullopt;
+	return result;
+}
+
 #endif /* STRING_CONSUMER_HPP */

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -17,6 +17,7 @@
 #include "video/video_driver.hpp"
 #include "string_func.h"
 #include "fileio_func.h"
+#include "core/string_consumer.hpp"
 
 #include "table/strings.h"
 
@@ -77,7 +78,10 @@ bool GetDriverParamBool(const StringList &parm, const char *name)
 int GetDriverParamInt(const StringList &parm, const char *name, int def)
 {
 	const char *p = GetDriverParam(parm, name);
-	return p != nullptr ? atoi(p) : def;
+	if (p == nullptr) return def;
+	auto value = ParseInteger<int>(p);
+	if (value.has_value()) return *value;
+	UserError("Invalid value for driver parameter {}: {}", name, p);
 }
 
 /**

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -18,6 +18,7 @@
 #include "../dropdown_func.h"
 #include "../timer/timer.h"
 #include "../timer/timer_window.h"
+#include "../core/string_consumer.hpp"
 
 #include "game.hpp"
 #include "game_gui.hpp"
@@ -346,9 +347,10 @@ struct GSConfigWindow : public Window {
 
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (!str.has_value() || str->empty()) return;
-		int32_t value = atoi(str->c_str());
-		SetValue(value);
+		if (!str.has_value()) return;
+		auto value = ParseInteger<int32_t>(*str);
+		if (!value.has_value()) return;
+		SetValue(*value);
 	}
 
 	void OnDropdownSelect(WidgetID widget, int index) override

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -33,6 +33,7 @@
 #include "ai/ai_gui.hpp"
 #include "game/game_gui.hpp"
 #include "industry.h"
+#include "core/string_consumer.hpp"
 
 #include "widgets/genworld_widget.h"
 
@@ -913,7 +914,9 @@ struct GenerateLandscapeWindow : public Window {
 
 		int32_t value;
 		if (!str->empty()) {
-			value = atoi(str->c_str());
+			auto val = ParseInteger<int32_t>(*str);
+			if (!val.has_value()) return;
+			value = *val;
 		} else {
 			/* An empty string means revert to the default */
 			switch (this->widget_id) {
@@ -1198,19 +1201,20 @@ struct CreateScenarioWindow : public Window
 
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (!str.has_value() || str->empty()) return;
+		if (!str.has_value()) return;
 
-		int32_t value = atoi(str->c_str());
+		auto value = ParseInteger<int32_t>(*str);
+		if (!value.has_value()) return;
 
 		switch (this->widget_id) {
 			case WID_CS_START_DATE_TEXT:
 				this->SetWidgetDirty(WID_CS_START_DATE_TEXT);
-				_settings_newgame.game_creation.starting_year = Clamp(TimerGameCalendar::Year(value), CalendarTime::MIN_YEAR, CalendarTime::MAX_YEAR);
+				_settings_newgame.game_creation.starting_year = Clamp(TimerGameCalendar::Year(*value), CalendarTime::MIN_YEAR, CalendarTime::MAX_YEAR);
 				break;
 
 			case WID_CS_FLAT_LAND_HEIGHT_TEXT:
 				this->SetWidgetDirty(WID_CS_FLAT_LAND_HEIGHT_TEXT);
-				_settings_newgame.game_creation.se_flat_world_height = Clamp(value, 0, GetMapHeightLimit());
+				_settings_newgame.game_creation.se_flat_world_height = Clamp(*value, 0, GetMapHeightLimit());
 				break;
 		}
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -48,6 +48,7 @@
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 #include "hotkeys.h"
+#include "core/string_consumer.hpp"
 
 #include "widgets/industry_widget.h"
 
@@ -1142,16 +1143,17 @@ public:
 		if (!str.has_value() || str->empty()) return;
 
 		Industry *i = Industry::Get(this->window_number);
-		uint value = atoi(str->c_str());
+		auto value = ParseInteger(*str);
+		if (!value.has_value()) return;
 		switch (this->editbox_line) {
 			case IL_NONE: NOT_REACHED();
 
 			case IL_MULTIPLIER:
-				i->prod_level = ClampU(RoundDivSU(value * PRODLEVEL_DEFAULT, 100), PRODLEVEL_MINIMUM, PRODLEVEL_MAXIMUM);
+				i->prod_level = ClampU(RoundDivSU(*value * PRODLEVEL_DEFAULT, 100), PRODLEVEL_MINIMUM, PRODLEVEL_MAXIMUM);
 				break;
 
 			default:
-				i->produced[this->editbox_line - IL_RATE1].rate = ClampU(RoundDivSU(value, 8), 0, 255);
+				i->produced[this->editbox_line - IL_RATE1].rate = ClampU(RoundDivSU(*value, 8), 0, 255);
 				break;
 		}
 		UpdateIndustryProduction(i);

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -134,7 +134,12 @@ bool MusicSet::FillSetDetails(const IniFile &ini, const std::string &path, const
 			if (item != nullptr && item->value.has_value() && !item->value->empty()) {
 				/* Song has a CAT file index, assume it's MPS MIDI format */
 				this->songinfo[i].filetype = MTT_MPSMIDI;
-				this->songinfo[i].cat_index = atoi(item->value->c_str());
+				auto value = ParseInteger(*item->value);
+				if (!value.has_value()) {
+					Debug(grf, 0, "Invalid base music set song index: {}/{}", filename, *item->value);
+					continue;
+				}
+				this->songinfo[i].cat_index = *value;
 				auto songname = GetMusicCatEntryName(filename, this->songinfo[i].cat_index);
 				if (!songname.has_value()) {
 					Debug(grf, 0, "Base music set song missing from CAT file: {}/{}", filename, this->songinfo[i].cat_index);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -41,6 +41,7 @@
 #include "../timer/timer_game_calendar.h"
 #include "../textfile_gui.h"
 #include "../stringfilter_type.h"
+#include "../core/string_consumer.hpp"
 
 #include "../widgets/network_widget.h"
 
@@ -1120,12 +1121,13 @@ struct NetworkStartServerWindow : public Window {
 		if (this->widget_id == WID_NSS_SETPWD) {
 			_settings_client.network.server_password = std::move(*str);
 		} else {
-			int32_t value = atoi(str->c_str());
+			auto value = ParseInteger<int32_t>(*str);
+			if (!value.has_value()) return;
 			this->SetWidgetDirty(this->widget_id);
 			switch (this->widget_id) {
 				default: NOT_REACHED();
-				case WID_NSS_CLIENTS_TXT:    _settings_client.network.max_clients    = Clamp(value, 2, MAX_CLIENTS); break;
-				case WID_NSS_COMPANIES_TXT:  _settings_client.network.max_companies  = Clamp(value, 1, MAX_COMPANIES); break;
+				case WID_NSS_CLIENTS_TXT:    _settings_client.network.max_clients    = Clamp(*value, 2, MAX_CLIENTS); break;
+				case WID_NSS_COMPANIES_TXT:  _settings_client.network.max_companies  = Clamp(*value, 1, MAX_COMPANIES); break;
 			}
 		}
 

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -19,6 +19,7 @@
 #include "textbuf_gui.h"
 #include "vehicle_gui.h"
 #include "zoom_func.h"
+#include "core/string_consumer.hpp"
 
 #include "engine_base.h"
 #include "industry.h"
@@ -1078,9 +1079,11 @@ struct SpriteAlignerWindow : Window {
 
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (!str.has_value() || str->empty()) return;
+		if (!str.has_value()) return;
 
-		this->current_sprite = atoi(str->c_str());
+		auto value = ParseInteger(*str);
+		if (!value.has_value()) return;
+		this->current_sprite = *value;
 		if (this->current_sprite >= GetMaxSpriteID()) this->current_sprite = 0;
 		while (GetSpriteType(this->current_sprite) != SpriteType::Normal) {
 			this->current_sprite = (this->current_sprite + 1) % GetMaxSpriteID();

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -609,9 +609,11 @@ struct NewGRFInspectWindow : Window {
 
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (!str.has_value() || str->empty()) return;
+		if (!str.has_value()) return;
 
-		NewGRFInspectWindow::var60params[GetFeatureNum(this->window_number)][this->current_edit_param - 0x60] = std::strtol(str->c_str(), nullptr, 16);
+		auto val = ParseInteger<int32_t>(*str);
+		if (!val.has_value()) return;
+		NewGRFInspectWindow::var60params[GetFeatureNum(this->window_number)][this->current_edit_param - 0x60] = *val;
 		this->SetDirty();
 	}
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -31,6 +31,7 @@
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 #include "zoom_func.h"
+#include "core/string_consumer.hpp"
 
 #include "widgets/newgrf_widget.h"
 #include "widgets/misc_widget.h"
@@ -438,9 +439,10 @@ struct NewGRFParametersWindow : public Window {
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
 		if (!str.has_value() || str->empty()) return;
-		int32_t value = atoi(str->c_str());
+		auto value = ParseInteger<int32_t>(*str);
+		if (!value.has_value()) return;
 		GRFParameterInfo &par_info = this->GetParameterInfo(this->clicked_row);
-		this->grf_config.SetValue(par_info, value);
+		this->grf_config.SetValue(par_info, *value);
 		this->SetDirty();
 	}
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -553,7 +553,13 @@ int openttd_main(std::span<char * const> arguments)
 			scanner->join_server_password = mgo.opt;
 			break;
 		case 'r': ParseResolution(&resolution, mgo.opt); break;
-		case 't': scanner->startyear = TimerGameCalendar::Year(atoi(mgo.opt)); break;
+		case 't':
+			if (auto value = ParseInteger(mgo.opt); value.has_value()) {
+				scanner->startyear = TimerGameCalendar::Year(*value);
+			} else {
+				fmt::print(stderr, "Invalid start year: {}\n", mgo.opt);
+			}
+			break;
 		case 'd': {
 #if defined(_WIN32)
 				CreateConsole();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -80,6 +80,7 @@
 #include "timer/timer_game_realtime.h"
 #include "timer/timer_game_tick.h"
 #include "social_integration.h"
+#include "core/string_consumer.hpp"
 
 #include "linkgraph/linkgraphschedule.h"
 
@@ -272,14 +273,17 @@ static void WriteSavegameInfo(const std::string &name)
  */
 static void ParseResolution(Dimension *res, const char *s)
 {
-	const char *t = strchr(s, 'x');
-	if (t == nullptr) {
+	StringConsumer consumer(std::string_view{s});
+	auto width = consumer.TryReadIntegerBase<uint>(10);
+	auto valid = consumer.ReadIf("x");
+	auto height = consumer.TryReadIntegerBase<uint>(10);
+	if (!width.has_value() || !valid || !height.has_value() || consumer.AnyBytesLeft()) {
 		ShowInfo("Invalid resolution '{}'", s);
 		return;
 	}
 
-	res->width  = std::max(std::strtoul(s, nullptr, 0), 64UL);
-	res->height = std::max(std::strtoul(t + 1, nullptr, 0), 64UL);
+	res->width  = std::max<uint>(*width, 64);
+	res->height = std::max<uint>(*height, 64);
 }
 
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -636,7 +636,13 @@ int openttd_main(std::span<char * const> arguments)
 			_skip_all_newgrf_scanning += 1;
 			break;
 		}
-		case 'G': scanner->generation_seed = std::strtoul(mgo.opt, nullptr, 10); break;
+		case 'G':
+			if (auto value = ParseInteger(mgo.opt); value.has_value()) {
+				scanner->generation_seed = *value;
+			} else {
+				fmt::print(stderr, "Invalid generation seed: {}\n", mgo.opt);
+			}
+			break;
 		case 'c': _config_file = mgo.opt; break;
 		case 'x': scanner->save_config = false; break;
 		case 'X': only_local_path = true; break;

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -34,6 +34,7 @@
 #include "error.h"
 #include "order_cmd.h"
 #include "company_cmd.h"
+#include "core/string_consumer.hpp"
 
 #include "widgets/order_widget.h"
 
@@ -1362,22 +1363,23 @@ public:
 		if (!str.has_value() || str->empty()) return;
 
 		VehicleOrderID sel = this->OrderGetSel();
-		uint value = atoi(str->c_str());
+		auto value = ParseInteger(*str);
+		if (!value.has_value()) return;
 
 		switch (this->vehicle->GetOrder(sel)->GetConditionVariable()) {
 			case OCV_MAX_SPEED:
-				value = ConvertDisplaySpeedToSpeed(value, this->vehicle->type);
+				value = ConvertDisplaySpeedToSpeed(*value, this->vehicle->type);
 				break;
 
 			case OCV_RELIABILITY:
 			case OCV_LOAD_PERCENTAGE:
-				value = Clamp(value, 0, 100);
+				value = Clamp(*value, 0, 100);
 				break;
 
 			default:
 				break;
 		}
-		Command<CMD_MODIFY_ORDER>::Post(STR_ERROR_CAN_T_MODIFY_THIS_ORDER, this->vehicle->tile, this->vehicle->index, sel, MOF_COND_VALUE, Clamp(value, 0, 2047));
+		Command<CMD_MODIFY_ORDER>::Post(STR_ERROR_CAN_T_MODIFY_THIS_ORDER, this->vehicle->tile, this->vehicle->index, sel, MOF_COND_VALUE, Clamp(*value, 0, 2047));
 	}
 
 	void OnDropdownSelect(WidgetID widget, int index) override

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -47,6 +47,10 @@
 /* No clear replacement. */
 #define strtok    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
+/* Use StringConsumer instead. */
+#define sscanf    SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define from_string SAFEGUARD_DO_NOT_USE_THIS_METHOD
+
 /* Use fmt::print instead. */
 #define printf    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define fprintf   SAFEGUARD_DO_NOT_USE_THIS_METHOD

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -51,6 +51,11 @@
 #define sscanf    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define from_string SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
+/* Use ParseInteger or StringConsumer instead. */
+#define atoi      SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define atol      SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define atoll     SAFEGUARD_DO_NOT_USE_THIS_METHOD
+
 /* Use fmt::print instead. */
 #define printf    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define fprintf   SAFEGUARD_DO_NOT_USE_THIS_METHOD

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -55,6 +55,10 @@
 #define atoi      SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define atol      SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define atoll     SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define strtol    SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define strtoll   SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define strtoul   SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define strtoull  SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
 /* Use fmt::print instead. */
 #define printf    SAFEGUARD_DO_NOT_USE_THIS_METHOD

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -25,6 +25,7 @@
 #include "../strings_func.h"
 #include "../timer/timer.h"
 #include "../timer/timer_window.h"
+#include "../core/string_consumer.hpp"
 
 #include "script_gui.h"
 #include "script_log.hpp"
@@ -495,10 +496,10 @@ struct ScriptSettingsWindow : public Window {
 
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
-		if (!str.has_value() || str->empty()) return;
-		int32_t value = atoi(str->c_str());
-
-		SetValue(value);
+		if (!str.has_value()) return;
+		auto value = ParseInteger<int32_t>(*str);
+		if (!value.has_value()) return;
+		SetValue(*value);
 	}
 
 	void OnDropdownSelect(WidgetID widget, int index) override

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -14,6 +14,7 @@
 
 #include "script_info.hpp"
 #include "script_scanner.hpp"
+#include "../core/string_consumer.hpp"
 #include "../3rdparty/fmt/format.h"
 
 #include "../safeguards.h"
@@ -229,8 +230,9 @@ SQInteger ScriptInfo::AddLabels(HSQUIRRELVM vm)
 			sign = -1;
 			key_string++;
 		}
-		int key = atoi(key_string) * sign;
-		config->labels[key] = StrMakeValid(label);
+		auto key = ParseInteger<int>(key_string);
+		if (!key.has_value()) return SQ_ERROR;
+		config->labels[*key * sign] = StrMakeValid(label);
 
 		sq_pop(vm, 2);
 	}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1010,10 +1010,26 @@ static void GraphicsSetLoadConfig(IniFile &ini)
 		if (const IniItem *item = group->GetItem("name"); item != nullptr && item->value) BaseGraphics::ini_data.name = *item->value;
 
 		if (const IniItem *item = group->GetItem("shortname"); item != nullptr && item->value && item->value->size() == 8) {
-			BaseGraphics::ini_data.shortname = std::byteswap<uint32_t>(std::strtoul(item->value->c_str(), nullptr, 16));
+			auto val = ParseInteger<uint32_t>(*item->value, 16);
+			if (val.has_value()) {
+				BaseGraphics::ini_data.shortname = std::byteswap<uint32_t>(*val);
+			} else {
+				ShowErrorMessage(GetEncodedString(STR_CONFIG_ERROR),
+					GetEncodedString(STR_CONFIG_ERROR_INVALID_VALUE, *item->value, BaseGraphics::ini_data.name),
+					WL_CRITICAL);
+			}
 		}
 
-		if (const IniItem *item = group->GetItem("extra_version"); item != nullptr && item->value) BaseGraphics::ini_data.extra_version = std::strtoul(item->value->c_str(), nullptr, 10);
+		if (const IniItem *item = group->GetItem("extra_version"); item != nullptr && item->value) {
+			auto val = ParseInteger<uint32_t>(*item->value);
+			if (val.has_value()) {
+				BaseGraphics::ini_data.extra_version = *val;
+			} else {
+				ShowErrorMessage(GetEncodedString(STR_CONFIG_ERROR),
+					GetEncodedString(STR_CONFIG_ERROR_INVALID_VALUE, *item->value, BaseGraphics::ini_data.name),
+					WL_CRITICAL);
+			}
+		}
 
 		if (const IniItem *item = group->GetItem("extra_params"); item != nullptr && item->value) {
 			auto params = ParseIntList(item->value->c_str());

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -27,6 +27,7 @@
 #include "settings_type.h"
 #include "timetable_cmd.h"
 #include "timetable.h"
+#include "core/string_consumer.hpp"
 
 #include "widgets/timetable_widget.h"
 
@@ -747,7 +748,7 @@ struct TimetableWindow : Window {
 		if (!str.has_value()) return;
 
 		const Vehicle *v = this->vehicle;
-		uint64_t val = str->empty() ? 0 : std::strtoul(str->c_str(), nullptr, 10);
+		uint64_t val = ParseInteger<uint64_t>(*str).value_or(0);
 		auto [order_id, mtf] = PackTimetableArgs(v, this->sel_index, query_widget == WID_VT_CHANGE_SPEED);
 
 		switch (query_widget) {

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -59,6 +59,7 @@
 #include "timer/timer_window.h"
 #include "timer/timer_game_calendar.h"
 #include "help_gui.h"
+#include "core/string_consumer.hpp"
 
 #include "widgets/toolbar_widget.h"
 
@@ -2500,7 +2501,9 @@ struct ScenarioEditorToolbarWindow : Window {
 
 		TimerGameCalendar::Year value;
 		if (!str->empty()) {
-			value = TimerGameCalendar::Year{atoi(str->c_str())};
+			auto val = ParseInteger(*str);
+			if (!val.has_value()) return;
+			value = static_cast<TimerGameCalendar::Year>(*val);
 		} else {
 			/* An empty string means revert to the default */
 			value = TimerGameCalendar::Year{CalendarTime::DEF_START_YEAR.base()};

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -34,6 +34,7 @@
 #include "../debug.h"
 #include "../blitter/factory.hpp"
 #include "../zoom_func.h"
+#include "../core/string_consumer.hpp"
 
 #include "../table/opengl_shader.h"
 #include "../table/sprites.h"
@@ -539,9 +540,13 @@ std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 	if (strncmp(renderer, "llvmpipe", 8) == 0 || strncmp(renderer, "softpipe", 8) == 0) return "Software renderer detected, not using OpenGL";
 #endif
 
-	const char *minor = strchr(ver, '.');
-	_gl_major_ver = atoi(ver);
-	_gl_minor_ver = minor != nullptr ? atoi(minor + 1) : 0;
+	StringConsumer consumer{std::string_view{ver}};
+	_gl_major_ver = consumer.ReadIntegerBase<uint8_t>(10);
+	if (consumer.ReadIf(".")) {
+		_gl_minor_ver = consumer.ReadIntegerBase<uint8_t>(10);
+	} else {
+		_gl_minor_ver = 0;
+	}
 
 #ifdef _WIN32
 	/* Old drivers on Windows (especially if made by Intel) seem to be


### PR DESCRIPTION
## Motivation / Problem

Remove C string parsing.

## Description

* `StringConsumer` is used for the more complex parsing.
* `ParseInteger` is changed to match more the behavior of C string parsing:
    * Leading whitespace is skipped.
    * Trailing whitespace is accepted.
    * But trailing junk is not.

## Limitations

* `fscanf`, `fgets` remain. We need a `FileConsumer` :)
* `strtod` remains. `std::from_chars` is not yet implemented for floats in `libc++` :(

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
