### PR TITLE
Codechange: use std::string_view for FS2OTTD and OTTD2FS

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -475,7 +475,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 
 	_tar_list[this->subdir][filename] = std::string{};
 
-	std::string filename_base = FS2OTTD(std::filesystem::path(OTTD2FS(filename)).filename());
+	std::string filename_base = FS2OTTD(std::filesystem::path(OTTD2FS(filename)).filename().native());
 	SimplifyFileName(filename_base);
 
 	TarHeader th;
@@ -822,7 +822,7 @@ void DetermineBasePaths(std::string_view exe)
 			/* _config_file is not in a folder, so use current directory. */
 			tmp = cwd;
 		} else {
-			tmp = FS2OTTD(std::filesystem::weakly_canonical(std::filesystem::path(OTTD2FS(_config_file))).parent_path());
+			tmp = FS2OTTD(std::filesystem::weakly_canonical(std::filesystem::path(OTTD2FS(_config_file))).parent_path().native());
 		}
 		AppendPathSeparator(tmp);
 		_searchpaths[SP_WORKING_DIR] = tmp;
@@ -1074,7 +1074,7 @@ static uint ScanPath(FileScanner *fs, std::string_view extension, const std::fil
 			if (!recursive) continue;
 			num += ScanPath(fs, extension, dir_entry.path(), basepath_length, recursive);
 		} else if (dir_entry.is_regular_file()) {
-			std::string file = FS2OTTD(dir_entry.path());
+			std::string file = FS2OTTD(dir_entry.path().native());
 			if (!MatchesExtension(extension, file)) continue;
 			if (fs->AddFile(file, basepath_length, {})) num++;
 		}

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -342,7 +342,7 @@ static void FiosGetFileList(SaveLoadOperation fop, bool show_dirs, FiosGetTypeAn
 			FiosItem &fios = file_list.emplace_back();
 			fios.type = FIOS_TYPE_DIR;
 			fios.mtime = 0;
-			fios.name = FS2OTTD(dir_entry.path().filename());
+			fios.name = FS2OTTD(dir_entry.path().filename().native());
 			fios.title = GetString(STR_SAVELOAD_DIRECTORY, fios.name + PATHSEP);
 		}
 

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -386,7 +386,7 @@ void ReconsiderGameScriptLanguage()
 {
 	if (_current_gamestrings_data == nullptr) return;
 
-	std::string language = FS2OTTD(_current_language->file.stem());
+	std::string language = FS2OTTD(_current_language->file.stem().native());
 	for (auto &p : _current_gamestrings_data->compiled_strings) {
 		if (p.language == language) {
 			_current_gamestrings_data->cur_language = &p;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -580,7 +580,7 @@ int openttd_main(std::span<char * const> arguments)
 			if (mgo.opt != nullptr) {
 				_file_to_saveload.name = mgo.opt;
 
-				std::string extension = FS2OTTD(std::filesystem::path(OTTD2FS(_file_to_saveload.name)).extension());
+				std::string extension = FS2OTTD(std::filesystem::path(OTTD2FS(_file_to_saveload.name)).extension().native());
 				auto [ft, _] = FiosGetSavegameListCallback(SLO_LOAD, _file_to_saveload.name, extension);
 				if (ft == FIOS_TYPE_INVALID) {
 					std::tie(ft, _) = FiosGetScenarioListCallback(SLO_LOAD, _file_to_saveload.name, extension);
@@ -614,7 +614,7 @@ int openttd_main(std::span<char * const> arguments)
 				return ret;
 			}
 
-			std::string extension = FS2OTTD(std::filesystem::path(OTTD2FS(mgo.opt)).extension());
+			std::string extension = FS2OTTD(std::filesystem::path(OTTD2FS(mgo.opt)).extension().native());
 			auto [_, title] = FiosGetSavegameListCallback(SLO_LOAD, mgo.opt, extension);
 
 			_load_check_data.Clear();

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -115,7 +115,7 @@ static const char *GetLocalCode()
  * Convert between locales, which from and which to is set in the calling
  * functions OTTD2FS() and FS2OTTD().
  */
-static std::string convert_tofrom_fs(iconv_t convd, const std::string &name)
+static std::string convert_tofrom_fs(iconv_t convd, std::string_view name)
 {
 	/* There are different implementations of iconv. The older ones,
 	 * e.g. SUSv2, pass a const pointer, whereas the newer ones, e.g.
@@ -135,7 +135,7 @@ static std::string convert_tofrom_fs(iconv_t convd, const std::string &name)
 	iconv(convd, nullptr, nullptr, nullptr, nullptr);
 	if (iconv(convd, &inbuf, &inlen, &outbuf, &outlen) == SIZE_MAX) {
 		Debug(misc, 0, "[iconv] error converting '{}'. Errno {}", name, errno);
-		return name;
+		return std::string{name};
 	}
 
 	buf.resize(outbuf - buf.data());
@@ -147,7 +147,7 @@ static std::string convert_tofrom_fs(iconv_t convd, const std::string &name)
  * @param name pointer to a valid string that will be converted
  * @return pointer to a new stringbuffer that contains the converted string
  */
-std::string OTTD2FS(const std::string &name)
+std::string OTTD2FS(std::string_view name)
 {
 	static iconv_t convd = (iconv_t)(-1);
 	if (convd == (iconv_t)(-1)) {
@@ -155,7 +155,7 @@ std::string OTTD2FS(const std::string &name)
 		convd = iconv_open(env, INTERNALCODE);
 		if (convd == (iconv_t)(-1)) {
 			Debug(misc, 0, "[iconv] conversion from codeset '{}' to '{}' unsupported", INTERNALCODE, env);
-			return name;
+			return std::string{name};
 		}
 	}
 
@@ -167,7 +167,7 @@ std::string OTTD2FS(const std::string &name)
  * @param name valid string that will be converted
  * @return pointer to a new stringbuffer that contains the converted string
  */
-std::string FS2OTTD(const std::string &name)
+std::string FS2OTTD(std::string_view name)
 {
 	static iconv_t convd = (iconv_t)(-1);
 	if (convd == (iconv_t)(-1)) {
@@ -175,7 +175,7 @@ std::string FS2OTTD(const std::string &name)
 		convd = iconv_open(INTERNALCODE, env);
 		if (convd == (iconv_t)(-1)) {
 			Debug(misc, 0, "[iconv] conversion from codeset '{}' to '{}' unsupported", env, INTERNALCODE);
-			return name;
+			return std::string{name};
 		}
 	}
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -334,13 +334,13 @@ std::optional<std::string> GetClipboardContents()
  * @see the current code-page comes from video\win32_v.cpp, event-notification
  * WM_INPUTLANGCHANGE
  */
-std::string FS2OTTD(const std::wstring &name)
+std::string FS2OTTD(std::wstring_view name)
 {
-	int name_len = (name.length() >= INT_MAX) ? INT_MAX : (int)name.length();
-	int len = WideCharToMultiByte(CP_UTF8, 0, name.c_str(), name_len, nullptr, 0, nullptr, nullptr);
+	int name_len = (name.length() >= INT_MAX) ? INT_MAX : static_cast<int>(name.length());
+	int len = WideCharToMultiByte(CP_UTF8, 0, name.data(), name_len, nullptr, 0, nullptr, nullptr);
 	if (len <= 0) return std::string();
 	std::string utf8_buf(len, '\0'); // len includes terminating null
-	WideCharToMultiByte(CP_UTF8, 0, name.c_str(), name_len, utf8_buf.data(), len, nullptr, nullptr);
+	WideCharToMultiByte(CP_UTF8, 0, name.data(), name_len, utf8_buf.data(), len, nullptr, nullptr);
 	return utf8_buf;
 }
 
@@ -351,13 +351,13 @@ std::string FS2OTTD(const std::wstring &name)
  * @param console_cp convert to the console encoding instead of the normal system encoding.
  * @return converted string; if failed string is of zero-length
  */
-std::wstring OTTD2FS(const std::string &name)
+std::wstring OTTD2FS(std::string_view name)
 {
-	int name_len = (name.length() >= INT_MAX) ? INT_MAX : (int)name.length();
-	int len = MultiByteToWideChar(CP_UTF8, 0, name.c_str(), name_len, nullptr, 0);
+	int name_len = (name.length() >= INT_MAX) ? INT_MAX : static_cast<int>(name.length());
+	int len = MultiByteToWideChar(CP_UTF8, 0, name.data(), name_len, nullptr, 0);
 	if (len <= 0) return std::wstring();
 	std::wstring system_buf(len, L'\0'); // len includes terminating null
-	MultiByteToWideChar(CP_UTF8, 0, name.c_str(), name_len, system_buf.data(), len);
+	MultiByteToWideChar(CP_UTF8, 0, name.data(), name_len, system_buf.data(), len);
 	return system_buf;
 }
 

--- a/src/signature.cpp
+++ b/src/signature.cpp
@@ -241,7 +241,7 @@ static bool _ValidateSignatureFile(const std::string &filename)
 		return false;
 	}
 
-	std::string dirname = FS2OTTD(std::filesystem::path(OTTD2FS(filename)).parent_path());
+	std::string dirname = FS2OTTD(std::filesystem::path(OTTD2FS(filename)).parent_path().native());
 
 	for (auto &signature : signatures["files"]) {
 		const std::string sig_filename = dirname + PATHSEPCHAR + signature["filename"].get<std::string>();

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -159,14 +159,14 @@ using namespace std::literals::string_view_literals;
 #	if defined(_WIN32)
 		char *getcwd(char *buf, size_t size);
 
-		std::string FS2OTTD(const std::wstring &name);
-		std::wstring OTTD2FS(const std::string &name);
+		std::string FS2OTTD(std::wstring_view name);
+		std::wstring OTTD2FS(std::string_view name);
 #	elif defined(WITH_ICONV)
-		std::string FS2OTTD(const std::string &name);
-		std::string OTTD2FS(const std::string &name);
+		std::string FS2OTTD(std::string_view name);
+		std::string OTTD2FS(std::string_view name);
 #	else
-		template <typename T> std::string FS2OTTD(T name) { return name; }
-		template <typename T> std::string OTTD2FS(T name) { return name; }
+		static inline std::string FS2OTTD(std::string_view name) { return std::string{name}; }
+		static inline std::string OTTD2FS(std::string_view name) { return std::string{name}; }
 #	endif /* _WIN32 or WITH_ICONV */
 #endif /* STRGEN || SETTINGSGEN */
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1979,7 +1979,7 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 {
 	/* Current language pack */
 	size_t total_len = 0;
-	std::unique_ptr<LanguagePack, LanguagePackDeleter> lang_pack(reinterpret_cast<LanguagePack *>(ReadFileToMem(FS2OTTD(lang->file), total_len, 1U << 20).release()));
+	std::unique_ptr<LanguagePack, LanguagePackDeleter> lang_pack(reinterpret_cast<LanguagePack *>(ReadFileToMem(FS2OTTD(lang->file.native()), total_len, 1U << 20).release()));
 	if (!lang_pack) return false;
 
 	/* End of read data (+ terminating zero added in ReadFileToMem()) */
@@ -2027,7 +2027,7 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 
 	_current_language = lang;
 	_current_text_dir = (TextDirection)_current_language->text_dir;
-	_config_language_file = FS2OTTD(_current_language->file.filename());
+	_config_language_file = FS2OTTD(_current_language->file.filename().native());
 	SetCurrentGrfLangID(_current_language->newgrflangid);
 	_langpack.list_separator = GetString(STR_LIST_SEPARATOR);
 
@@ -2156,10 +2156,11 @@ static void FillLanguageList(const std::string &path)
 		lmd.file = dir_entry.path();
 
 		/* Check whether the file is of the correct version */
-		if (!GetLanguageFileHeader(FS2OTTD(lmd.file), &lmd)) {
-			Debug(misc, 3, "{} is not a valid language file", FS2OTTD(lmd.file));
+		std::string file = FS2OTTD(lmd.file.native());
+		if (!GetLanguageFileHeader(file, &lmd)) {
+			Debug(misc, 3, "{} is not a valid language file", file);
 		} else if (GetLanguage(lmd.newgrflangid) != nullptr) {
-			Debug(misc, 3, "{}'s language ID is already known", FS2OTTD(lmd.file));
+			Debug(misc, 3, "{}'s language ID is already known", file);
 		} else {
 			_languages.push_back(std::move(lmd));
 		}
@@ -2193,7 +2194,7 @@ void InitializeLanguagePacks()
 		/* We are trying to find a default language. The priority is by
 		 * configuration file, local environment and last, if nothing found,
 		 * English. */
-		if (_config_language_file == FS2OTTD(lng.file.filename())) {
+		if (_config_language_file == FS2OTTD(lng.file.filename().native())) {
 			chosen_language = &lng;
 			break;
 		}
@@ -2213,7 +2214,7 @@ void InitializeLanguagePacks()
 		chosen_language = (language_fallback != nullptr) ? language_fallback : en_GB_fallback;
 	}
 
-	if (!ReadLanguagePack(chosen_language)) UserError("Can't read language pack '{}'", FS2OTTD(chosen_language->file));
+	if (!ReadLanguagePack(chosen_language)) UserError("Can't read language pack '{}'", FS2OTTD(chosen_language->file.native()));
 }
 
 /**

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -256,7 +256,7 @@ void SurveyConfiguration(nlohmann::json &survey)
 {
 	survey["network"] = _networking ? (_network_server ? "server" : "client") : "no";
 	if (_current_language != nullptr) {
-		survey["language"]["filename"] = FS2OTTD(_current_language->file.filename());
+		survey["language"]["filename"] = FS2OTTD(_current_language->file.filename().native());
 		survey["language"]["name"] = _current_language->name;
 		survey["language"]["isocode"] = _current_language->isocode;
 	}


### PR DESCRIPTION
## Motivation / Problem

Why should we create a new `std::string` just to convert it to something else?

Now if you want to use `FS2OTTD` with a `std::string_view`, you first need to make a `std::string`, i.e. copy it. Though the actual conversion requires a `char*` and length, so `std::string_view` is enough.


## Description

Change the string to string_view for FS2OTTD and OTTD2FS.

The only caveat is that there's not automagic conversion from `std::filesystem::path` to `std::string_view` (or `std::wstring_view`). So, we need to call `.native()` explicitly instead that the same happened implicitly.

I've thought about adding `std::filesystem::path` overloads, but then in address.cpp there's a `gai_strerror` that needs to be explicitly cast to a `std::string_view` or `std::wstring_view` on Windows...


## Limitations

Not sure whether this is the better approach over just `std::string{view}` before calling these functions.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
