### PR TITLE
Codechange: replace char* with C++ style strings

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1170,7 +1170,7 @@ std::optional<FileHandle> FileHandle::Open(const std::string &filename, std::str
 {
 #if defined(_WIN32)
 	/* Windows also requires mode to be wchar_t. */
-	auto f = _wfopen(OTTD2FS(filename).c_str(), OTTD2FS(std::string{mode}).c_str());
+	auto f = _wfopen(OTTD2FS(filename).c_str(), OTTD2FS(mode).c_str());
 #else
 	auto f = fopen(filename.c_str(), std::string{mode}.c_str());
 #endif /* _WIN32 */

--- a/src/fontdetection.h
+++ b/src/fontdetection.h
@@ -23,7 +23,7 @@
  * @param face The face that has been found.
  * @return The error we encountered.
  */
-FT_Error GetFontByFaceName(const char *font_name, FT_Face *face);
+FT_Error GetFontByFaceName(std::string_view font_name, FT_Face *face);
 
 #endif /* WITH_FREETYPE */
 

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -134,9 +134,9 @@ struct TranslationWriter : LanguageWriter {
 		/* We don't write the length. */
 	}
 
-	void Write(const char *buffer, size_t length) override
+	void Write(std::string_view buffer) override
 	{
-		this->strings.emplace_back(buffer, length);
+		this->strings.emplace_back(buffer);
 	}
 };
 

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -128,7 +128,7 @@ static void AddGrfInfo(std::back_insert_iterator<std::string> &output_iterator, 
 
 
 /** Text messages for various logged actions */
-static const char * const la_text[] = {
+static const std::string_view la_text[] = {
 	"new game started",
 	"game loaded",
 	"GRF config changed",

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -117,8 +117,8 @@ struct SelectGameWindow : public Window {
 		intro_viewport_commands.clear();
 
 		/* Regular expression matching the commands: T, spaces, integer, spaces, flags, spaces, integer */
-		const char *sign_langauge = "^T\\s*([0-9]+)\\s*([-+A-Z0-9]+)\\s*([0-9]+)";
-		std::regex re(sign_langauge, std::regex_constants::icase);
+		static const std::string sign_language = "^T\\s*([0-9]+)\\s*([-+A-Z0-9]+)\\s*([0-9]+)";
+		std::regex re(sign_language, std::regex_constants::icase);
 
 		/* List of signs successfully parsed to delete afterwards. */
 		std::vector<SignID> signs_to_delete;

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -590,7 +590,7 @@ static void FillGrfidMap(const GRFConfigList &lst, GrfIdMap &grfid_map)
 }
 
 static void NewGRFConfirmationCallback(Window *w, bool confirmed);
-static void ShowSavePresetWindow(const char *initial_text);
+static void ShowSavePresetWindow(std::string_view initial_text);
 
 /**
  * Window for showing NewGRF files
@@ -958,13 +958,13 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 			}
 
 			case WID_NS_PRESET_SAVE:
-				ShowSavePresetWindow((this->preset == -1) ? nullptr : this->grf_presets[this->preset].c_str());
+				ShowSavePresetWindow((this->preset == -1) ? std::string_view{} : this->grf_presets[this->preset]);
 				break;
 
 			case WID_NS_PRESET_DELETE:
 				if (this->preset == -1) return;
 
-				DeleteGRFPresetFromConfig(this->grf_presets[this->preset].c_str());
+				DeleteGRFPresetFromConfig(this->grf_presets[this->preset]);
 				this->grf_presets = GetGRFPresetList();
 				this->preset = -1;
 				this->InvalidateData();
@@ -2020,12 +2020,12 @@ struct SavePresetWindow : public Window {
 
 	/**
 	 * Constructor of the save preset window.
-	 * @param initial_text Initial text to display in the edit box, or \c nullptr.
+	 * @param initial_text Initial text to display in the edit box.
 	 */
-	SavePresetWindow(const char *initial_text) : Window(_save_preset_desc), presetname_editbox(32)
+	SavePresetWindow(std::string_view initial_text) : Window(_save_preset_desc), presetname_editbox(32)
 	{
 		this->presets = GetGRFPresetList();
-		if (initial_text != nullptr) {
+		if (!initial_text.empty()) {
 			for (uint i = 0; i < this->presets.size(); i++) {
 				if (this->presets[i] == initial_text) {
 					this->selected = i;
@@ -2044,7 +2044,7 @@ struct SavePresetWindow : public Window {
 
 		this->vscroll->SetCount(this->presets.size());
 		this->SetFocusedWidget(WID_SVP_EDITBOX);
-		if (initial_text != nullptr) this->presetname_editbox.text.Assign(initial_text);
+		this->presetname_editbox.text.Assign(initial_text);
 	}
 
 	~SavePresetWindow()
@@ -2132,7 +2132,7 @@ struct SavePresetWindow : public Window {
  * Open the window for saving a preset.
  * @param initial_text Initial text to display in the edit box, or \c nullptr.
  */
-static void ShowSavePresetWindow(const char *initial_text)
+static void ShowSavePresetWindow(std::string_view initial_text)
 {
 	CloseWindowByClass(WC_SAVE_PRESET);
 	new SavePresetWindow(initial_text);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -104,7 +104,7 @@ bool HandleBootstrap();
 extern void CheckCaches();
 extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid());
 extern void OSOpenBrowser(const std::string &url);
-extern void ShowOSErrorBox(const char *buf, bool system);
+extern void ShowOSErrorBox(std::string_view buf, bool system);
 extern std::string _config_file;
 
 bool _save_config = false;
@@ -118,7 +118,7 @@ NewGRFScanCallback *_request_newgrf_scan_callback = nullptr;
  */
 void UserErrorI(const std::string &str)
 {
-	ShowOSErrorBox(str.c_str(), false);
+	ShowOSErrorBox(str, false);
 	if (VideoDriver::GetInstance() != nullptr) VideoDriver::GetInstance()->Stop();
 
 #ifdef __EMSCRIPTEN__
@@ -140,7 +140,7 @@ void UserErrorI(const std::string &str)
 void FatalErrorI(const std::string &str)
 {
 	if (VideoDriver::GetInstance() == nullptr || VideoDriver::GetInstance()->HasGUI()) {
-		ShowOSErrorBox(str.c_str(), true);
+		ShowOSErrorBox(str, true);
 	}
 
 	/* Set the error message for the crash log and then invoke it. */

--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -130,7 +130,7 @@ public:
 				 "{}\n{}\n{}\n{}",
 				 this->crashlog_filename, this->crashdump_filename, this->savegame_filename, this->screenshot_filename);
 
-		ShowMacDialog(crash_title, message.c_str(), "Quit");
+		ShowMacDialog(crash_title, message, "Quit");
 	}
 
 	/** Buffer to track the long jump set setup. */

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -133,7 +133,7 @@ void ShowMacDialog(std::string_view title, std::string_view message, std::string
  * @param buf error message text.
  * @param system message text originates from OS.
  */
-void ShowOSErrorBox(const char *buf, bool system)
+void ShowOSErrorBox(std::string_view buf, bool system)
 {
 	/* Display the error in the best way possible. */
 	if (system) {

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -39,7 +39,7 @@ static std::tuple<std::string, std::string> SplitFontFamilyAndStyle(std::string_
 	return { std::string(font_name.substr(0, separator)), std::string(font_name.substr(begin)) };
 }
 
-FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
+FT_Error GetFontByFaceName(std::string_view font_name, FT_Face *face)
 {
 	FT_Error err = FT_Err_Cannot_Open_Resource;
 

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -190,7 +190,7 @@ void ShowInfoI(std::string_view str)
 }
 
 #if !defined(__APPLE__)
-void ShowOSErrorBox(const char *buf, bool)
+void ShowOSErrorBox(std::string_view buf, bool)
 {
 	/* All unix systems, except OSX. Only use escape codes on a TTY. */
 	if (isatty(fileno(stderr))) {

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -47,7 +47,7 @@ bool MyShowCursor(bool show, bool toggle)
 	return !show;
 }
 
-void ShowOSErrorBox(const char *buf, bool)
+void ShowOSErrorBox(std::string_view buf, bool)
 {
 	MyShowCursor(true);
 	MessageBox(GetActiveWindow(), OTTD2FS(buf).c_str(), L"Error!", MB_ICONSTOP | MB_TASKMODAL);

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -33,8 +33,8 @@
 
 #include "safeguards.h"
 
-static const char * const SCREENSHOT_NAME = "screenshot"; ///< Default filename of a saved screenshot.
-static const char * const HEIGHTMAP_NAME  = "heightmap";  ///< Default filename of a saved heightmap.
+static const std::string_view SCREENSHOT_NAME = "screenshot"; ///< Default filename of a saved screenshot.
+static const std::string_view HEIGHTMAP_NAME  = "heightmap";  ///< Default filename of a saved heightmap.
 
 std::string _screenshot_format_name;  ///< Extension of the current screenshot format.
 static std::string _screenshot_name;  ///< Filename of the screenshot file.

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -125,16 +125,6 @@ uint BaseSettingEntry::Draw(GameSettings *settings_ptr, int left, int right, int
 /* == SettingEntry methods == */
 
 /**
- * Constructor for a single setting in the 'advanced settings' window
- * @param name Name of the setting in the setting table
- */
-SettingEntry::SettingEntry(const char *name)
-{
-	this->name = name;
-	this->setting = nullptr;
-}
-
-/**
  * Initialization of a setting entry
  * @param level      Page nesting level of this entry
  */

--- a/src/settingentry_gui.h
+++ b/src/settingentry_gui.h
@@ -92,10 +92,10 @@ protected:
 
 /** Standard setting */
 struct SettingEntry : BaseSettingEntry {
-	const char *name;              ///< Name of the setting
-	const IntSettingDesc *setting; ///< Setting description of the setting
+	const std::string_view name; ///< Name of the setting
+	const IntSettingDesc *setting = nullptr; ///< Setting description of the setting
 
-	SettingEntry(const char *name);
+	SettingEntry(std::string_view name) : name(name) {}
 
 	void Init(uint8_t level = 0) override;
 	void ResetAll() override;

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -52,9 +52,9 @@ static const TrackdirBits _enterdir_to_trackdirbits[DIAGDIR_END] = {
 template <typename Tdir, uint items>
 struct SmallSet {
 private:
-	uint n;           // actual number of units
-	bool overflowed;  // did we try to overflow the set?
-	const char *name; // name, used for debugging purposes...
+	uint n = 0; // actual number of units
+	bool overflowed = false; // did we try to overflow the set?
+	const std::string_view name; // name, used for debugging purposes...
 
 	/** Element of set */
 	struct SSdata {
@@ -64,7 +64,7 @@ private:
 
 public:
 	/** Constructor - just set default values and 'name' */
-	SmallSet(const char *name) : n(0), overflowed(false), name(name) { }
+	SmallSet(std::string_view name) : name(name) { }
 
 	/** Reset variables to default values */
 	void Reset()

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -289,7 +289,7 @@ struct LanguageFileWriter : LanguageWriter, FileWriter {
 
 	void WriteHeader(const LanguagePackHeader *header) override
 	{
-		this->Write(reinterpret_cast<const char *>(header), sizeof(*header));
+		this->Write({reinterpret_cast<const char *>(header), sizeof(*header)});
 	}
 
 	void Finalise() override
@@ -298,9 +298,9 @@ struct LanguageFileWriter : LanguageWriter, FileWriter {
 		this->FileWriter::Finalise();
 	}
 
-	void Write(const char *buffer, size_t length) override
+	void Write(std::string_view buffer) override
 	{
-		this->output_stream.write(buffer, length);
+		this->output_stream.write(buffer.data(), buffer.size());
 	}
 };
 

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -117,9 +117,8 @@ struct LanguageWriter {
 	/**
 	 * Write a number of bytes.
 	 * @param buffer The buffer to write.
-	 * @param length The amount of byte to write.
 	 */
-	virtual void Write(const char *buffer, size_t length) = 0;
+	virtual void Write(std::string_view buffer) = 0;
 
 	/**
 	 * Finalise writing the file.

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -718,7 +718,7 @@ void LanguageWriter::WriteLength(size_t length)
 		buffer[offs++] = static_cast<char>(static_cast<uint8_t>((length >> 8) | 0xC0));
 	}
 	buffer[offs++] = static_cast<char>(static_cast<uint8_t>(length & 0xFF));
-	this->Write(buffer, offs);
+	this->Write({buffer, offs});
 }
 
 /**
@@ -803,7 +803,7 @@ void LanguageWriter::WriteLang(const StringData &data)
 			builder.Put(def_str);
 
 			this->WriteLength(output.size());
-			this->Write(output.data(), output.size());
+			this->Write(output);
 		}
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

Mostly simple replacements. Sometimes simplifying constructors.

For the regular expression a `std::string` is made, as it doesn't support `std::string_view`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
