### PR TITLE
Add: [BaseSet] Allow basesets to set minor and patch versions in obg/obs/obm files.

### DIFF
--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -63,7 +63,7 @@ struct BaseSet {
 	std::string url;               ///< URL for information about the base set
 	TranslatedStrings description; ///< Description of the base set
 	uint32_t shortname = 0; ///< Four letter short variant of the name
-	uint32_t version = 0; ///< The version of this base set
+	std::vector<uint32_t> version; ///< The version of this base set
 	bool fallback = false; ///< This set is a fallback set, i.e. it should be used only as last resort
 
 	std::array<MD5File, BaseSet<T>::NUM_FILES> files{}; ///< All files part of this set

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -16,8 +16,9 @@
 #include "3rdparty/md5/md5.h"
 #include <unordered_map>
 
-/* Forward declare these; can't do 'struct X' in functions as older GCCs barf on that */
 struct IniFile;
+struct IniGroup;
+struct IniItem;
 struct ContentInfo;
 
 /** Structure holding filename and MD5 information about a single file */
@@ -95,6 +96,9 @@ struct BaseSet {
 	{
 		return BaseSet<T>::NUM_FILES - this->valid_files;
 	}
+
+	void LogError(std::string_view full_filename, std::string_view detail, int level = 0) const;
+	const IniItem *GetMandatoryItem(std::string_view full_filename, const IniGroup &group, std::string_view name) const;
 
 	bool FillSetDetails(const IniFile &ini, const std::string &path, const std::string &full_filename, bool allow_empty_filename = true);
 	void CopyCompatibleConfig([[maybe_unused]] const T &src) {}

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -354,20 +354,21 @@ GraphicsSet::~GraphicsSet() = default;
 
 bool GraphicsSet::FillSetDetails(const IniFile &ini, const std::string &path, const std::string &full_filename)
 {
-	bool ret = this->BaseSet<GraphicsSet>::FillSetDetails(ini, path, full_filename, false);
-	if (ret) {
-		const IniGroup *metadata = ini.GetGroup("metadata");
-		assert(metadata != nullptr); /* ret can't be true if metadata isn't present. */
-		const IniItem *item;
+	if (!this->BaseSet<GraphicsSet>::FillSetDetails(ini, path, full_filename, false)) return false;
 
-		fetch_metadata("palette");
-		this->palette = ((*item->value)[0] == 'D' || (*item->value)[0] == 'd') ? PAL_DOS : PAL_WINDOWS;
+	const IniGroup *metadata = ini.GetGroup("metadata");
+	assert(metadata != nullptr); /* already checked by the inherited FillSetDetails. */
+	const IniItem *item;
 
-		/* Get optional blitter information. */
-		item = metadata->GetItem("blitter");
-		this->blitter = (item != nullptr && (*item->value)[0] == '3') ? BLT_32BPP : BLT_8BPP;
-	}
-	return ret;
+	item = this->GetMandatoryItem(full_filename, *metadata, "palette");
+	if (item == nullptr) return false;
+	this->palette = ((*item->value)[0] == 'D' || (*item->value)[0] == 'd') ? PAL_DOS : PAL_WINDOWS;
+
+	/* Get optional blitter information. */
+	item = metadata->GetItem("blitter");
+	this->blitter = (item != nullptr && (*item->value)[0] == '3') ? BLT_32BPP : BLT_8BPP;
+
+	return true;
 }
 
 /**

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -12,6 +12,7 @@
 #include "debug.h"
 #include "fileio_func.h"
 #include "screenshot_type.h"
+#include "3rdparty/fmt/ranges.h"
 
 #include <png.h>
 
@@ -83,7 +84,7 @@ public:
 
 		std::string message;
 		message.reserve(1024);
-		format_append(message, "Graphics set: {} ({})\n", BaseGraphics::GetUsedSet()->name, BaseGraphics::GetUsedSet()->version);
+		format_append(message, "Graphics set: {} ({})\n", BaseGraphics::GetUsedSet()->name, fmt::join(BaseGraphics::GetUsedSet()->version, "."));
 		message += "NewGRFs:\n";
 		if (_game_mode != GM_MENU) {
 			for (const auto &c : _grfconfig) {

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -18,6 +18,7 @@
 #include "timer/timer_game_tick.h"
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_game_economy.h"
+#include "3rdparty/fmt/ranges.h"
 
 #include "currency.h"
 #include "fontcache.h"
@@ -274,7 +275,7 @@ void SurveyConfiguration(nlohmann::json &survey)
 		survey["video_info"] = VideoDriver::GetInstance()->GetInfoString();
 	}
 	if (BaseGraphics::GetUsedSet() != nullptr) {
-		survey["graphics_set"] = fmt::format("{}.{}", BaseGraphics::GetUsedSet()->name, BaseGraphics::GetUsedSet()->version);
+		survey["graphics_set"] = fmt::format("{}.{}", BaseGraphics::GetUsedSet()->name, fmt::join(BaseGraphics::GetUsedSet()->version, "."));
 		const GRFConfig *extra_cfg = BaseGraphics::GetUsedSet()->GetExtraConfig();
 		if (extra_cfg != nullptr && !extra_cfg->param.empty()) {
 			survey["graphics_set_parameters"] = std::span<const uint32_t>(extra_cfg->param);
@@ -283,10 +284,10 @@ void SurveyConfiguration(nlohmann::json &survey)
 		}
 	}
 	if (BaseMusic::GetUsedSet() != nullptr) {
-		survey["music_set"] = fmt::format("{}.{}", BaseMusic::GetUsedSet()->name, BaseMusic::GetUsedSet()->version);
+		survey["music_set"] = fmt::format("{}.{}", BaseMusic::GetUsedSet()->name, fmt::join(BaseMusic::GetUsedSet()->version, "."));
 	}
 	if (BaseSounds::GetUsedSet() != nullptr) {
-		survey["sound_set"] = fmt::format("{}.{}", BaseSounds::GetUsedSet()->name, BaseSounds::GetUsedSet()->version);
+		survey["sound_set"] = fmt::format("{}.{}", BaseSounds::GetUsedSet()->name, fmt::join(BaseSounds::GetUsedSet()->version, "."));
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

* BaseSets have a "version" field in the obg/obs/obm metadata. It is used by OpenTTD to select the newest version. Thus the version must be comparable/sortable.
* BaseSets were meant to use a simple integer for versioning; the same way as NewGRF, AI and GS do.
* Unfortunately OpenTTD relied on libc to do the validation, and thus there are BaseSets with invalid versions:
  ```
  dbg: [grf:1] Checking .../content_download/baseset/holiday_island_music_pack-1.2/holiday.obm for base music set
  dbg: [grf:0] Base musicset detail loading: version field is invalid: 1.2
  ```
* Libc only extracted the first number. Thus versions like "1.1" and "1.2" compared equal. OpenTTD could not pick the newer one.
* BaNaNaS does very little obg/obs/obm validation.
* With improved string validation, OpenTTD now rejects these BaseSets as invalid. They are not shown in-game, and treated as "not downloaded".
* All affected BaseSets use two or three numbers separated by dots. There are no prerelease postfixes or similar.

## Description

* Improve the error output.
  * Use "misc" category instead of "grf".
  * Always mention the obg/obs/obm filename in the error message:
    ```
    dbg: [misc:0] Loading base musicset details failed: .../content_download/baseset/descent_soundtrack-1.2/descent.obm
    dbg: [misc:0]   md5s.game18.mid field missing
    ```
* Add support for versions matching `\d+(\.\d+)*`
* Comparison/sorting is done lexicographic.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
