### PR TITLE
Codechange: Use more std::string_view

### DIFF
--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -143,24 +143,9 @@ bool BaseSet<T>::FillSetDetails(const IniFile &ini, const std::string &path, con
 			this->LogError(full_filename, fmt::format("md5s.{} field missing", filename));
 			return false;
 		}
-		const char *c = item->value->c_str();
-		for (size_t i = 0; i < file->hash.size() * 2; i++, c++) {
-			uint j;
-			if ('0' <= *c && *c <= '9') {
-				j = *c - '0';
-			} else if ('a' <= *c && *c <= 'f') {
-				j = *c - 'a' + 10;
-			} else if ('A' <= *c && *c <= 'F') {
-				j = *c - 'A' + 10;
-			} else {
-				this->LogError(full_filename, fmt::format("md5s.{} is malformed: {}", filename, *item->value));
-				return false;
-			}
-			if (i % 2 == 0) {
-				file->hash[i / 2] = j << 4;
-			} else {
-				file->hash[i / 2] |= j;
-			}
+		if (!ConvertHexToBytes(*item->value, file->hash)) {
+			this->LogError(full_filename, fmt::format("md5s.{} is malformed: {}", filename, *item->value));
+			return false;
 		}
 
 		/* Then find the warning message when the file's missing */

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -317,7 +317,7 @@ struct IConsoleWindow : Window
 		return ES_HANDLED;
 	}
 
-	void InsertTextString(WidgetID, const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end) override
+	void InsertTextString(WidgetID, std::string_view str, bool marked, std::optional<size_t> caret, std::optional<size_t> insert_location, std::optional<size_t> replacement_end) override
 	{
 		if (_iconsole_cmdline.InsertString(str, marked, caret, insert_location, replacement_end)) {
 			_iconsole_tab_completion.Reset();
@@ -340,7 +340,7 @@ struct IConsoleWindow : Window
 		return pt;
 	}
 
-	Rect GetTextBoundingRect(const char *from, const char *to) const override
+	Rect GetTextBoundingRect(size_t from, size_t to) const override
 	{
 		int delta = std::min<int>(this->width - this->line_offset - _iconsole_cmdline.pixels - ICON_RIGHT_BORDERWIDTH, 0);
 

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -96,7 +96,7 @@ struct StringListReader : StringReader {
 	 * @param translation Are we reading a translation?
 	 */
 	StringListReader(StringData &data, const LanguageStrings &strings, bool master, bool translation) :
-			StringReader(data, strings.language.c_str(), master, translation), p(strings.lines.begin()), end(strings.lines.end())
+			StringReader(data, strings.language, master, translation), p(strings.lines.begin()), end(strings.lines.end())
 	{
 	}
 

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1000,7 +1000,7 @@ static void _ShowGenerateLandscape(GenerateLandscapeWindowMode mode)
 
 	if (mode == GLWM_HEIGHTMAP) {
 		/* If the function returns negative, it means there was a problem loading the heightmap */
-		if (!GetHeightmapDimensions(_file_to_saveload.ftype.detailed, _file_to_saveload.name.c_str(), &x, &y)) return;
+		if (!GetHeightmapDimensions(_file_to_saveload.ftype.detailed, _file_to_saveload.name, &x, &y)) return;
 	}
 
 	WindowDesc &desc = (mode == GLWM_HEIGHTMAP) ? _heightmap_load_desc : _generate_landscape_desc;

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -70,7 +70,9 @@ extern Palette _cur_palette; ///< Current palette
 
 void HandleToolbarHotkey(int hotkey);
 void HandleKeypress(uint keycode, char32_t key);
-void HandleTextInput(const char *str, bool marked = false, const char *caret = nullptr, const char *insert_location = nullptr, const char *replacement_end = nullptr);
+void HandleTextInput(std::string_view str, bool marked = false,
+		std::optional<size_t> caret = std::nullopt,
+		std::optional<size_t> insert_location = std::nullopt, std::optional<size_t> replacement_end = std::nullopt);
 void HandleCtrlChanged();
 void HandleMouseEvents();
 void UpdateWindows();

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -418,15 +418,14 @@ void Layouter::ReduceLineCache()
  * Get the leading corner of a character in a single-line string relative
  * to the start of the string.
  * @param str String containing the character.
- * @param ch Pointer to the character in the string.
+ * @param pos Index to the character in the string.
  * @param start_fontsize Font size to start the text with.
  * @return Upper left corner of the glyph associated with the character.
  */
-ParagraphLayouter::Position GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize)
+ParagraphLayouter::Position GetCharPosInString(std::string_view str, size_t pos, FontSize start_fontsize)
 {
-	/* Ensure "ch" is inside "str" or at the exact end. */
-	assert(ch >= str.data() && (ch - str.data()) <= static_cast<ptrdiff_t>(str.size()));
-	auto it_ch = str.begin() + (ch - str.data());
+	assert(pos <= str.size());
+	auto it_ch = str.begin() + pos;
 
 	Layouter layout(str, INT32_MAX, start_fontsize);
 	return layout.GetCharPosition(it_ch);

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -197,7 +197,7 @@ public:
 	static void ReduceLineCache();
 };
 
-ParagraphLayouter::Position GetCharPosInString(std::string_view str, const char *ch, FontSize start_fontsize = FS_NORMAL);
+ParagraphLayouter::Position GetCharPosInString(std::string_view str, size_t pos, FontSize start_fontsize = FS_NORMAL);
 ptrdiff_t GetCharAtPosition(std::string_view str, int x, FontSize start_fontsize = FS_NORMAL);
 
 #endif /* GFX_LAYOUT_H */

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -13,6 +13,7 @@
 #include "ini_type.h"
 #include "string_func.h"
 #include "window_gui.h"
+#include "core/string_consumer.hpp"
 
 #include "safeguards.h"
 
@@ -90,56 +91,49 @@ static const std::initializer_list<KeycodeNames> _keycode_to_name = {
 
 /**
  * Try to parse a single part of a keycode.
- * @param start Start of the string to parse.
- * @param end End of the string to parse.
- * @return A keycode if a match is found or 0.
+ * @param keystr Input.
+ * @return A keycode if a match is found.
  */
-static uint16_t ParseCode(const char *start, const char *end)
+static std::optional<uint16_t> ParseCode(std::string_view keystr)
 {
-	assert(start <= end);
-	while (start < end && *start == ' ') start++;
-	while (end > start && *end == ' ') end--;
-	std::string_view str{start, end};
+	keystr = StrTrimView(keystr);
 	for (const auto &kn : _keycode_to_name) {
-		if (StrEqualsIgnoreCase(str, kn.name)) {
+		if (StrEqualsIgnoreCase(keystr, kn.name)) {
 			return kn.keycode;
 		}
 	}
-	if (end - start == 1) {
-		if (*start >= 'a' && *start <= 'z') return *start - ('a'-'A');
+	if (keystr.size() == 1) {
+		auto c = keystr[0];
+		if (c >= 'a' && c <= 'z') return c - ('a'-'A');
 		/* Ignore invalid keycodes */
-		if (*(const uint8_t *)start < 128) return *start;
+		if (static_cast<uint8_t>(c) < 128) return c;
 	}
-	return 0;
+	return std::nullopt;
 }
 
 /**
  * Parse a string representation of a keycode.
- * @param start Start of the input.
- * @param end End of the input.
- * @return A valid keycode or 0.
+ * @param keystr Input.
+ * @return A valid keycode or std::nullopt.
  */
-static uint16_t ParseKeycode(const char *start, const char *end)
+static std::optional<uint16_t> ParseKeycode(std::string_view keystr)
 {
-	assert(start <= end);
+	if (keystr.empty()) return std::nullopt;
+	StringConsumer consumer{keystr};
 	uint16_t keycode = 0;
-	for (;;) {
-		const char *cur = start;
-		while (*cur != '+' && cur != end) cur++;
-		uint16_t code = ParseCode(start, cur);
-		if (code == 0) return 0;
-		if (code & WKC_SPECIAL_KEYS) {
+	while (consumer.AnyBytesLeft()) {
+		auto cur = consumer.ReadUntilChar('+', StringConsumer::SKIP_ONE_SEPARATOR);
+		auto code = ParseCode(cur);
+		if (!code.has_value()) return std::nullopt;
+		if (*code & WKC_SPECIAL_KEYS) {
 			/* Some completely wrong keycode we don't support. */
-			if (code & ~WKC_SPECIAL_KEYS) return 0;
-			keycode |= code;
+			if (*code & ~WKC_SPECIAL_KEYS) return std::nullopt;
+			keycode |= *code;
 		} else {
 			/* Ignore the code if it has more then 1 letter. */
-			if (keycode & ~WKC_SPECIAL_KEYS) return 0;
-			keycode |= code;
+			if (keycode & ~WKC_SPECIAL_KEYS) return std::nullopt;
+			keycode |= *code;
 		}
-		if (cur == end) break;
-		assert(cur < end);
-		start = cur + 1;
 	}
 	return keycode;
 }
@@ -149,15 +143,13 @@ static uint16_t ParseKeycode(const char *start, const char *end)
  * @param hotkey The hotkey object to add the keycodes to
  * @param value The string to parse
  */
-static void ParseHotkeys(Hotkey &hotkey, const char *value)
+static void ParseHotkeys(Hotkey &hotkey, std::string_view value)
 {
-	const char *start = value;
-	while (*start != '\0') {
-		const char *end = start;
-		while (*end != '\0' && *end != ',') end++;
-		uint16_t keycode = ParseKeycode(start, end);
-		if (keycode != 0) hotkey.AddKeycode(keycode);
-		start = (*end == ',') ? end + 1: end;
+	StringConsumer consumer{value};
+	while (consumer.AnyBytesLeft()) {
+		auto keystr = consumer.ReadUntilChar(',', StringConsumer::SKIP_ONE_SEPARATOR);
+		auto keycode = ParseKeycode(keystr);
+		if (keycode.has_value()) hotkey.AddKeycode(*keycode);
 	}
 }
 
@@ -282,7 +274,7 @@ void HotkeyList::Load(const IniFile &ini)
 		const IniItem *item = group->GetItem(hotkey.name);
 		if (item != nullptr) {
 			hotkey.keycodes.clear();
-			if (item->value.has_value()) ParseHotkeys(hotkey, item->value->c_str());
+			if (item->value.has_value()) ParseHotkeys(hotkey, *item->value);
 		}
 	}
 }

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1540,7 +1540,7 @@ bool GenerateLandscape(uint8_t mode)
 
 	if (mode == GWM_HEIGHTMAP) {
 		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_HEIGHTMAP);
-		if (!LoadHeightmap(_file_to_saveload.ftype.detailed, _file_to_saveload.name.c_str())) {
+		if (!LoadHeightmap(_file_to_saveload.ftype.detailed, _file_to_saveload.name)) {
 			return false;
 		}
 		IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -813,7 +813,7 @@ Point QueryString::GetCaretPosition(const Window *w, WidgetID wid) const
  * @param to End of the string range.
  * @return Rectangle encompassing the string range, relative to the window.
  */
-Rect QueryString::GetBoundingRect(const Window *w, WidgetID wid, const char *from, const char *to) const
+Rect QueryString::GetBoundingRect(const Window *w, WidgetID wid, size_t from, size_t to) const
 {
 	const NWidgetLeaf *wi = w->GetWidget<NWidgetLeaf>(wid);
 

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -135,7 +135,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	}
 
 	std::string os_file = OTTD2FS(filename);
-	CFAutoRelease<CFURLRef> url(CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8*)os_file.c_str(), os_file.length(), false));
+	CFAutoRelease<CFURLRef> url(CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8*)os_file.data(), os_file.length(), false));
 
 	if (MusicSequenceFileLoad(_sequence, url.get(), kMusicSequenceFile_AnyType, 0) != noErr) {
 		Debug(driver, 0, "cocoa_m: Failed to load MIDI file");

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -1043,25 +1043,19 @@ std::string MidiFile::GetSMFFile(const MusicSongInfo &song)
 
 	if (song.filetype != MTT_MPSMIDI) return std::string();
 
-	char basename[MAX_PATH];
+	std::string tempdirname = FioGetDirectory(Searchpath::SP_AUTODOWNLOAD_DIR, Subdirectory::BASESET_DIR);
 	{
-		const char *fnstart = strrchr(song.filename.c_str(), PATHSEPCHAR);
-		if (fnstart == nullptr) {
-			fnstart = song.filename.c_str();
-		} else {
-			fnstart++;
-		}
+		std::string_view basename{song.filename};
+		auto fnstart = basename.rfind(PATHSEPCHAR);
+		if (fnstart != std::string_view::npos) basename.remove_prefix(fnstart + 1);
 
 		/* Remove all '.' characters from filename */
-		char *wp = basename;
-		for (const char *rp = fnstart; *rp != '\0'; rp++) {
-			if (*rp != '.') *wp++ = *rp;
+		tempdirname.reserve(tempdirname.size() + basename.size());
+		for (auto c : basename) {
+			if (c != '.') tempdirname.append(1, c);
 		}
-		*wp++ = '\0';
 	}
 
-	std::string tempdirname = FioGetDirectory(Searchpath::SP_AUTODOWNLOAD_DIR, Subdirectory::BASESET_DIR);
-	tempdirname += basename;
 	AppendPathSeparator(tempdirname);
 	FioCreateDirectory(tempdirname);
 

--- a/src/network/core/http_winhttp.cpp
+++ b/src/network/core/http_winhttp.cpp
@@ -254,7 +254,7 @@ void NetworkHTTPRequest::Connect()
 	} else {
 		/* When the payload starts with a '{', it is a JSON payload. */
 		LPCWSTR content_type = data.starts_with("{") ? L"Content-Type: application/json\r\n" : L"Content-Type: application/x-www-form-urlencoded\r\n";
-		WinHttpSendRequest(this->request, content_type, -1, const_cast<char *>(data.c_str()), static_cast<DWORD>(data.size()), static_cast<DWORD>(data.size()), reinterpret_cast<DWORD_PTR>(this));
+		WinHttpSendRequest(this->request, content_type, -1, const_cast<char *>(data.data()), static_cast<DWORD>(data.size()), static_cast<DWORD>(data.size()), reinterpret_cast<DWORD_PTR>(this));
 	}
 }
 

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -76,7 +76,7 @@ std::optional<std::string> ContentInfo::GetTextfile(TextfileType type) const
 			break;
 		case CONTENT_TYPE_NEWGRF: {
 			const GRFConfig *gc = FindGRFConfig(std::byteswap(this->unique_id), FGCM_EXACT, &this->md5sum);
-			tmp = gc != nullptr ? gc->filename.c_str() : nullptr;
+			if (gc != nullptr) tmp = gc->filename;
 			break;
 		}
 		case CONTENT_TYPE_BASE_GRAPHICS:

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -718,7 +718,7 @@ NetworkGame *NetworkAddServer(std::string_view connection_string, bool manually,
 void GetBindAddresses(NetworkAddressList *addresses, uint16_t port)
 {
 	for (const auto &iter : _network_bind_list) {
-		addresses->emplace_back(iter.c_str(), port);
+		addresses->emplace_back(iter, port);
 	}
 
 	/* No address, so bind to everything. */

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1155,7 +1155,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		this->preset = index;
 
 		if (index != -1) {
-			this->actives = LoadGRFPresetFromConfig(this->grf_presets[index].c_str());
+			this->actives = LoadGRFPresetFromConfig(this->grf_presets[index]);
 		}
 		this->avails.ForceRebuild();
 
@@ -1170,7 +1170,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 	{
 		if (!str.has_value()) return;
 
-		SaveGRFPresetToConfig(str->c_str(), this->actives);
+		SaveGRFPresetToConfig(*str, this->actives);
 		this->grf_presets = GetGRFPresetList();
 
 		/* Switch to this preset */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1186,7 +1186,7 @@ void SwitchToMode(SwitchMode new_mode)
 			break;
 
 		case SM_SAVE_HEIGHTMAP: // Save heightmap.
-			MakeHeightmapScreenshot(_file_to_saveload.name.c_str());
+			MakeHeightmapScreenshot(_file_to_saveload.name);
 			CloseWindowById(WC_SAVELOAD, 0);
 			break;
 

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -224,7 +224,7 @@ std::optional<std::string> GetClipboardContents()
 void OSOpenBrowser(const std::string &url)
 {
 	/* Implementation in pre.js */
-	EM_ASM({ if (window["openttd_open_url"]) window.openttd_open_url($0, $1) }, url.c_str(), url.size());
+	EM_ASM({ if (window["openttd_open_url"]) window.openttd_open_url($0, $1) }, url.data(), url.size());
 }
 #elif !defined( __APPLE__)
 void OSOpenBrowser(const std::string &url)

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -428,7 +428,7 @@ void Win32SetCurrentLocaleName(std::string iso_code)
 		}
 	}
 
-	MultiByteToWideChar(CP_UTF8, 0, iso_code.c_str(), -1, _cur_iso_locale, static_cast<int>(std::size(_cur_iso_locale)));
+	MultiByteToWideChar(CP_UTF8, 0, iso_code.data(), static_cast<int>(iso_code.size()), _cur_iso_locale, static_cast<int>(std::size(_cur_iso_locale)));
 }
 
 int OTTDStringCompare(std::string_view s1, std::string_view s2)
@@ -461,11 +461,11 @@ int OTTDStringCompare(std::string_view s1, std::string_view s2)
 
 	/* CompareStringEx takes UTF-16 strings, even in ANSI-builds. */
 	if (_CompareStringEx != nullptr) {
-		int result = _CompareStringEx(_cur_iso_locale, LINGUISTIC_IGNORECASE | SORT_DIGITSASNUMBERS, str_s1.c_str(), len_s1, str_s2.c_str(), len_s2, nullptr, nullptr, 0);
+		int result = _CompareStringEx(_cur_iso_locale, LINGUISTIC_IGNORECASE | SORT_DIGITSASNUMBERS, str_s1.data(), len_s1, str_s2.data(), len_s2, nullptr, nullptr, 0);
 		if (result != 0) return result;
 	}
 
-	return CompareString(MAKELCID(_current_language->winlangid, SORT_DEFAULT), NORM_IGNORECASE, str_s1.c_str(), len_s1, str_s2.c_str(), len_s2);
+	return CompareString(MAKELCID(_current_language->winlangid, SORT_DEFAULT), NORM_IGNORECASE, str_s1.data(), len_s1, str_s2.data(), len_s2);
 }
 
 /**

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -28,8 +28,8 @@ template <typename Tpf> void DumpState(Tpf &pf1, Tpf &pf2)
 	auto f2 = FileHandle::Open("yapf2.txt"sv, "wt");
 	assert(f1.has_value());
 	assert(f2.has_value());
-	fwrite(dmp1.m_out.c_str(), 1, dmp1.m_out.size(), *f1);
-	fwrite(dmp2.m_out.c_str(), 1, dmp2.m_out.size(), *f2);
+	fwrite(dmp1.m_out.data(), 1, dmp1.m_out.size(), *f1);
+	fwrite(dmp2.m_out.data(), 1, dmp2.m_out.size(), *f2);
 }
 
 template <class Types>

--- a/src/querystring_gui.h
+++ b/src/querystring_gui.h
@@ -45,7 +45,7 @@ public:
 	void HandleEditBox(Window *w, WidgetID wid);
 
 	Point GetCaretPosition(const Window *w, WidgetID wid) const;
-	Rect GetBoundingRect(const Window *w, WidgetID wid, const char *from, const char *to) const;
+	Rect GetBoundingRect(const Window *w, WidgetID wid, size_t from, size_t to) const;
 	ptrdiff_t GetCharAtPosition(const Window *w, WidgetID wid, const Point &pt) const;
 };
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1043,7 +1043,7 @@ static void SlStdString(void *ptr, VarType conv)
 		case SLA_SAVE: {
 			size_t len = str->length();
 			SlWriteArrayLength(len);
-			SlCopyBytes(const_cast<void *>(static_cast<const void *>(str->c_str())), len);
+			SlCopyBytes(const_cast<void *>(static_cast<const void *>(str->data())), len);
 			break;
 		}
 

--- a/src/script/script_info_dummy.cpp
+++ b/src/script/script_info_dummy.cpp
@@ -42,7 +42,7 @@ void Script_CreateDummyInfo(HSQUIRRELVM vm, std::string_view type, std::string_v
 	sq_pushroottable(vm);
 
 	/* Load and run the script */
-	if (SQ_SUCCEEDED(sq_compilebuffer(vm, dummy_script.c_str(), dummy_script.size(), "dummy", SQTrue))) {
+	if (SQ_SUCCEEDED(sq_compilebuffer(vm, dummy_script.data(), dummy_script.size(), "dummy", SQTrue))) {
 		sq_push(vm, -2);
 		if (SQ_SUCCEEDED(sq_call(vm, 1, SQFalse, SQTrue))) {
 			sq_pop(vm, 1);
@@ -101,7 +101,7 @@ void Script_CreateDummy(HSQUIRRELVM vm, StringID string, std::string_view type)
 
 	/* 3) Finally we load and run the script */
 	sq_pushroottable(vm);
-	if (SQ_SUCCEEDED(sq_compilebuffer(vm, dummy_script.c_str(), dummy_script.size(), "dummy", SQTrue))) {
+	if (SQ_SUCCEEDED(sq_compilebuffer(vm, dummy_script.data(), dummy_script.size(), "dummy", SQTrue))) {
 		sq_push(vm, -2);
 		if (SQ_SUCCEEDED(sq_call(vm, 1, SQFalse, SQTrue))) {
 			sq_pop(vm, 1);

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -215,8 +215,8 @@ static bool IsSameScript(const ContentInfo &ci, bool md5sum, ScriptInfo *info, S
 			if (tar.second.tar_filename != iter->first) continue;
 
 			/* Check the extension. */
-			const char *ext = strrchr(tar.first.c_str(), '.');
-			if (ext == nullptr || !StrEqualsIgnoreCase(ext, ".nut")) continue;
+			auto ext = tar.first.rfind('.');
+			if (ext == std::string_view::npos || !StrEqualsIgnoreCase(tar.first.substr(ext), ".nut")) continue;
 
 			checksum.AddFile(tar.first, 0, tar_filename);
 		}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1125,7 +1125,7 @@ static GRFConfigList GRFLoadConfig(const IniFile &ini, std::string_view grpname,
 			}
 
 			ShowErrorMessage(GetEncodedString(STR_CONFIG_ERROR),
-				GetEncodedString(STR_CONFIG_ERROR_INVALID_GRF, filename.empty() ? item.name.c_str() : filename, reason),
+				GetEncodedString(STR_CONFIG_ERROR_INVALID_GRF, filename.empty() ? item.name : filename, reason),
 				WL_CRITICAL);
 			continue;
 		}
@@ -1559,7 +1559,7 @@ GRFConfigList LoadGRFPresetFromConfig(std::string_view config_name)
 	section += config_name;
 
 	ConfigIniFile ini(_config_file);
-	GRFConfigList config = GRFLoadConfig(ini, section.c_str(), false);
+	GRFConfigList config = GRFLoadConfig(ini, section, false);
 
 	return config;
 }
@@ -1576,7 +1576,7 @@ void SaveGRFPresetToConfig(std::string_view config_name, GRFConfigList &config)
 	section += config_name;
 
 	ConfigIniFile ini(_config_file);
-	GRFSaveConfig(ini, section.c_str(), config);
+	GRFSaveConfig(ini, section, config);
 	ini.SaveToDisk(_config_file);
 }
 

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -23,7 +23,7 @@
 
 StrgenState _strgen;
 static bool _translated;              ///< Whether the current language is not the master language
-static const char *_cur_ident;
+static std::string_view _cur_ident;
 static ParsedCommandStruct _cur_pcs;
 static size_t _cur_argidx;
 
@@ -759,7 +759,7 @@ void LanguageWriter::WriteLang(const StringData &data)
 
 			std::string output;
 			StringBuilder builder(output);
-			_cur_ident = ls->name.c_str();
+			_cur_ident = ls->name;
 			_strgen.cur_line = ls->line;
 
 			/* Produce a message if a string doesn't have a translation. */

--- a/src/tests/test_script_admin.cpp
+++ b/src/tests/test_script_admin.cpp
@@ -64,7 +64,7 @@ static std::optional<std::string> TestScriptAdminMakeJSON(std::string_view squir
 	sq_pop(vm, 1);
 
 	/* Compile the snippet. */
-	REQUIRE(sq_compilebuffer(vm, buffer.c_str(), buffer.size(), "test", SQTrue) == SQ_OK);
+	REQUIRE(sq_compilebuffer(vm, buffer.data(), buffer.size(), "test", SQTrue) == SQ_OK);
 	/* Execute the snippet, capturing the return value. */
 	sq_pushroottable(vm);
 	REQUIRE(sq_call(vm, 1, SQTrue, SQTrue) == SQ_OK);

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -154,21 +154,21 @@ bool Textbuf::InsertChar(char32_t key)
  * @param replacement_end Replace all characters from #insert_location up to this location with the new string.
  * @return True on successful change of Textbuf, or false otherwise.
  */
-bool Textbuf::InsertString(const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end)
+bool Textbuf::InsertString(std::string_view str, bool marked, std::optional<size_t> caret, std::optional<size_t> insert_location, std::optional<size_t> replacement_end)
 {
 	uint16_t insertpos = (marked && this->marklength != 0) ? this->markpos : this->caretpos;
-	if (insert_location != nullptr) {
-		insertpos = insert_location - this->buf.data();
+	if (insert_location.has_value()) {
+		insertpos = static_cast<uint16_t>(*insert_location);
 		if (insertpos >= this->buf.size()) return false;
 
-		if (replacement_end != nullptr) {
-			this->DeleteText(insertpos, replacement_end - this->buf.data(), str == nullptr);
+		if (replacement_end.has_value()) {
+			this->DeleteText(insertpos, static_cast<uint16_t>(*replacement_end), str.empty());
 		}
 	} else {
-		if (marked) this->DiscardMarkedText(str == nullptr);
+		if (marked) this->DiscardMarkedText(str.empty());
 	}
 
-	if (str == nullptr) return false;
+	if (str.empty()) return false;
 
 	uint16_t chars = 0;
 	uint16_t bytes;
@@ -192,7 +192,7 @@ bool Textbuf::InsertString(const char *str, bool marked, const char *caret, cons
 	if (bytes == 0) return false;
 
 	/* Move caret if needed. */
-	if (str <= caret && caret <= str + bytes) this->caretpos = insertpos + (caret - str);
+	if (caret.has_value()) this->caretpos = insertpos + static_cast<uint16_t>(*caret);
 
 	if (marked) {
 		this->markpos = insertpos;
@@ -202,7 +202,7 @@ bool Textbuf::InsertString(const char *str, bool marked, const char *caret, cons
 	this->buf.insert(insertpos, str, bytes);
 
 	this->chars += chars;
-	if (!marked && caret == nullptr) this->caretpos += bytes;
+	if (!marked && !caret.has_value()) this->caretpos += bytes;
 	assert(this->buf.size() < this->max_bytes);
 	assert(this->chars <= this->max_chars);
 
@@ -225,7 +225,7 @@ bool Textbuf::InsertClipboard()
 	auto contents = GetClipboardContents();
 	if (!contents.has_value()) return false;
 
-	return this->InsertString(contents.value().c_str(), false);
+	return this->InsertString(contents.value(), false);
 }
 
 /**
@@ -303,7 +303,7 @@ void Textbuf::UpdateWidth()
 /** Update pixel position of the caret. */
 void Textbuf::UpdateCaretPosition()
 {
-	const auto pos = GetCharPosInString(this->buf, &this->buf[this->caretpos], FS_NORMAL);
+	const auto pos = GetCharPosInString(this->buf, this->caretpos, FS_NORMAL);
 	this->caretxoffs = _current_text_dir == TD_LTR ? pos.left : pos.right;
 }
 
@@ -311,8 +311,8 @@ void Textbuf::UpdateCaretPosition()
 void Textbuf::UpdateMarkedText()
 {
 	if (this->markend != 0) {
-		const auto pos = GetCharPosInString(this->buf, &this->buf[this->markpos], FS_NORMAL);
-		const auto end = GetCharPosInString(this->buf, &this->buf[this->markend], FS_NORMAL);
+		const auto pos = GetCharPosInString(this->buf, this->markpos, FS_NORMAL);
+		const auto end = GetCharPosInString(this->buf, this->markend, FS_NORMAL);
 		this->markxoffs = std::min(pos.left, end.left);
 		this->marklength = std::max(pos.right, end.right) - this->markxoffs;
 	} else {

--- a/src/textbuf_type.h
+++ b/src/textbuf_type.h
@@ -49,7 +49,9 @@ struct Textbuf {
 	bool InsertClipboard();
 
 	bool InsertChar(char32_t key);
-	bool InsertString(const char *str, bool marked, const char *caret = nullptr, const char *insert_location = nullptr, const char *replacement_end = nullptr);
+	bool InsertString(std::string_view str, bool marked,
+			std::optional<size_t> caret = std::nullopt,
+			std::optional<size_t> insert_location = std::nullopt, std::optional<size_t> replacement_end = std::nullopt);
 
 	bool DeleteChar(uint16_t keycode);
 	bool MovePos(uint16_t keycode);

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -247,7 +247,7 @@ void VideoDriver_Cocoa::EditBoxLostFocus()
 {
 	[ [ this->cocoaview inputContext ] performSelectorOnMainThread:@selector(discardMarkedText) withObject:nil waitUntilDone:[ NSThread isMainThread ] ];
 	/* Clear any marked string from the current edit box. */
-	HandleTextInput(nullptr, true);
+	HandleTextInput({}, true);
 }
 
 /**

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -346,8 +346,8 @@ static LRESULT HandleIMEComposition(HWND hwnd, WPARAM wParam, LPARAM lParam)
 
 			/* Transmit text to windowing system. */
 			if (len > 0) {
-				HandleTextInput(nullptr, true); // Clear marked string.
-				HandleTextInput(FS2OTTD(str).c_str());
+				HandleTextInput({}, true); // Clear marked string.
+				HandleTextInput(FS2OTTD(str));
 			}
 			SetCompositionPos(hwnd);
 
@@ -380,9 +380,9 @@ static LRESULT HandleIMEComposition(HWND hwnd, WPARAM wParam, LPARAM lParam)
 					++caret;
 				}
 
-				HandleTextInput(utf8_buf, true, utf8_buf + caret.GetByteOffset());
+				HandleTextInput(utf8_buf, true, caret.GetByteOffset());
 			} else {
-				HandleTextInput(nullptr, true);
+				HandleTextInput({}, true);
 			}
 
 			lParam &= ~(GCS_COMPSTR | GCS_COMPATTR | GCS_COMPCLAUSE | GCS_CURSORPOS | GCS_DELTASTART);
@@ -400,7 +400,7 @@ static void CancelIMEComposition(HWND hwnd)
 	if (hIMC != nullptr) ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
 	ImmReleaseContext(hwnd, hIMC);
 	/* Clear any marked string from the current edit box. */
-	HandleTextInput(nullptr, true);
+	HandleTextInput({}, true);
 }
 
 static bool IsDarkModeEnabled()
@@ -597,7 +597,7 @@ LRESULT CALLBACK WndProcGdi(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 		case WM_IME_ENDCOMPOSITION:
 			/* Clear any pending composition string. */
-			HandleTextInput(nullptr, true);
+			HandleTextInput({}, true);
 			if (DrawIMECompositionString()) return 0;
 			break;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -390,7 +390,7 @@ void Window::UpdateQueryStringSize()
  * @param to End of the string range.
  * @return Rectangle encompassing the string range, relative to the window.
  */
-/* virtual */ Rect Window::GetTextBoundingRect(const char *from, const char *to) const
+/* virtual */ Rect Window::GetTextBoundingRect(size_t from, size_t to) const
 {
 	if (this->nested_focus != nullptr && this->nested_focus->type == WWT_EDITBOX) {
 		return this->GetQueryString(this->nested_focus->GetIndex())->GetBoundingRect(this, this->nested_focus->GetIndex(), from, to);
@@ -2647,7 +2647,7 @@ void HandleCtrlChanged()
  * @param wid Edit box widget.
  * @param str Text string to insert.
  */
-/* virtual */ void Window::InsertTextString(WidgetID wid, const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end)
+/* virtual */ void Window::InsertTextString(WidgetID wid, std::string_view str, bool marked, std::optional<size_t> caret, std::optional<size_t> insert_location, std::optional<size_t> replacement_end)
 {
 	QueryString *query = this->GetQueryString(wid);
 	if (query == nullptr) return;
@@ -2664,7 +2664,7 @@ void HandleCtrlChanged()
  * @param marked Is the input a marked composition string from an IME?
  * @param caret Move the caret to this point in the insertion string.
  */
-void HandleTextInput(const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end)
+void HandleTextInput(std::string_view str, bool marked, std::optional<size_t> caret, std::optional<size_t> insert_location, std::optional<size_t> replacement_end)
 {
 	if (!EditBoxInGlobalFocus()) return;
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -342,7 +342,7 @@ public:
 
 	virtual const struct Textbuf *GetFocusedTextbuf() const;
 	virtual Point GetCaretPosition() const;
-	virtual Rect GetTextBoundingRect(const char *from, const char *to) const;
+	virtual Rect GetTextBoundingRect(size_t from, size_t to) const;
 	virtual ptrdiff_t GetTextCharacterAtPosition(const Point &pt) const;
 
 	void InitNested(WindowNumber number = 0);
@@ -497,7 +497,7 @@ public:
 	bool SetFocusedWidget(WidgetID widget_index);
 
 	EventState HandleEditBoxKey(WidgetID wid, char32_t key, uint16_t keycode);
-	virtual void InsertTextString(WidgetID wid, const char *str, bool marked, const char *caret, const char *insert_location, const char *replacement_end);
+	virtual void InsertTextString(WidgetID wid, std::string_view str, bool marked, std::optional<size_t> caret, std::optional<size_t> insert_location, std::optional<size_t> replacement_end);
 
 	void HandleButtonClick(WidgetID widget);
 	int GetRowFromWidget(int clickpos, WidgetID widget, int padding, int line_height = -1) const;


### PR DESCRIPTION
## Motivation / Problem

C string crusade.

## Description

* Replace `char *` with `std::string_view`.
* Replace pointers into strings with indices.
* Use `StringConsumer` for parsing.
* Remove `c_str`, if no longer needed: `std::string_view{str.c_str()}`.
* Use `data` instead of `c_str`, if no NUL termination is required.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
