### PR TITLE
Fix 66733e2a: Textbuf was broken, and did not insert any input.

### DIFF
--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -199,7 +199,7 @@ bool Textbuf::InsertString(std::string_view str, bool marked, std::optional<size
 		this->markend = insertpos + bytes;
 	}
 
-	this->buf.insert(insertpos, str, bytes);
+	this->buf.insert(insertpos, str.substr(0, bytes));
 
 	this->chars += chars;
 	if (!marked && !caret.has_value()) this->caretpos += bytes;


### PR DESCRIPTION
## Motivation / Problem

* Replacing `char *` with `std::string_view` picked a different overload of `std::string::insert`.
* This resulted in `substr(bytes)` being inserted instead of `substr(0, bytes)`.

## Description

Fix the `insert` call.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
