### PR TITLE
Codechange: more string view changes

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1190,15 +1190,13 @@ static bool ConExec(std::span<std::string_view> argv)
 	_script_current_depth++;
 	uint script_depth = _script_current_depth;
 
-	char cmdline[ICON_CMDLN_SIZE];
-	while (fgets(cmdline, sizeof(cmdline), *script_file) != nullptr) {
+	char buffer[ICON_CMDLN_SIZE];
+	while (fgets(buffer, sizeof(buffer), *script_file) != nullptr) {
 		/* Remove newline characters from the executing script */
-		for (char *cmdptr = cmdline; *cmdptr != '\0'; cmdptr++) {
-			if (*cmdptr == '\n' || *cmdptr == '\r') {
-				*cmdptr = '\0';
-				break;
-			}
-		}
+		std::string_view cmdline{buffer};
+		auto last_non_newline = cmdline.find_last_not_of("\r\n");
+		if (last_non_newline != std::string_view::npos) cmdline = cmdline.substr(0, last_non_newline + 1);
+
 		IConsoleCmdExec(cmdline);
 		/* Ensure that we are still on the same depth or that we returned via 'return'. */
 		assert(_script_current_depth == script_depth || _script_current_depth == script_depth - 1);

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -38,7 +38,7 @@ extern bool FiosIsHiddenFile(const std::filesystem::path &path);
 extern void FiosGetDrives(FileList &file_list);
 
 /* get the name of an oldstyle savegame */
-extern std::string GetOldSaveGameName(const std::string &file);
+extern std::string GetOldSaveGameName(std::string_view file);
 
 /**
  * Compare two FiosItem's. Used with sort when sorting the file list.
@@ -240,7 +240,7 @@ bool FiosDelete(std::string_view name)
 	return FioRemove(FiosMakeSavegameName(name));
 }
 
-typedef std::tuple<FiosType, std::string> FiosGetTypeAndNameProc(SaveLoadOperation fop, const std::string &filename, std::string_view ext);
+typedef std::tuple<FiosType, std::string> FiosGetTypeAndNameProc(SaveLoadOperation fop, std::string_view filename, std::string_view ext);
 
 /**
  * Scanner to scan for a particular type of FIOS file.
@@ -377,9 +377,10 @@ static void FiosGetFileList(SaveLoadOperation fop, bool show_dirs, FiosGetTypeAn
  * @param subdir the sub directory to search in
  * @return The file title.
  */
-static std::string GetFileTitle(const std::string &file, Subdirectory subdir)
+static std::string GetFileTitle(std::string_view file, Subdirectory subdir)
 {
-	auto f = FioFOpenFile(file + ".title", "r", subdir);
+	std::string filename = fmt::format("{}.title", file);
+	auto f = FioFOpenFile(filename, "r", subdir);
 	if (!f.has_value()) return {};
 
 	char title[80];
@@ -398,7 +399,7 @@ static std::string GetFileTitle(const std::string &file, Subdirectory subdir)
  * @see FiosGetFileList
  * @see FiosGetSavegameList
  */
-std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, std::string_view file, std::string_view ext)
 {
 	/* Show savegame files
 	 * .SAV OpenTTD saved game
@@ -447,7 +448,7 @@ void FiosGetSavegameList(SaveLoadOperation fop, bool show_dirs, FileList &file_l
  * @see FiosGetFileList
  * @see FiosGetScenarioList
  */
-std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, std::string_view file, std::string_view ext)
 {
 	/* Show scenario files
 	 * .SCN OpenTTD style scenario file
@@ -488,7 +489,7 @@ void FiosGetScenarioList(SaveLoadOperation fop, bool show_dirs, FileList &file_l
 	FiosGetFileList(fop, show_dirs, &FiosGetScenarioListCallback, subdir, file_list);
 }
 
-std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation, const std::string &file, std::string_view ext)
+std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation, std::string_view file, std::string_view ext)
 {
 	/* Show heightmap files
 	 * .PNG PNG Based heightmap files
@@ -553,7 +554,7 @@ void FiosGetHeightmapList(SaveLoadOperation fop, bool show_dirs, FileList &file_
  * @param file Name of the file to check.
  * @return a FIOS_TYPE_JSON type of the found file, FIOS_TYPE_INVALID if not a valid JSON file, and the title of the file (if any).
  */
-static std::tuple<FiosType, std::string> FiosGetTownDataListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext)
+static std::tuple<FiosType, std::string> FiosGetTownDataListCallback(SaveLoadOperation fop, std::string_view file, std::string_view ext)
 {
 	if (fop == SLO_LOAD) {
 		if (StrEqualsIgnoreCase(ext, ".json")) {
@@ -715,7 +716,7 @@ FiosNumberedSaveName::FiosNumberedSaveName(const std::string &prefix) : prefix(p
 	static std::string _prefix; ///< Static as the lambda needs access to it.
 
 	/* Callback for FiosFileScanner. */
-	static FiosGetTypeAndNameProc *proc = [](SaveLoadOperation, const std::string &file, std::string_view ext) {
+	static FiosGetTypeAndNameProc *proc = [](SaveLoadOperation, std::string_view file, std::string_view ext) {
 		if (StrEqualsIgnoreCase(ext, ".sav") && file.starts_with(_prefix)) return std::tuple(FIOS_TYPE_FILE, std::string{});
 		return std::tuple(FIOS_TYPE_INVALID, std::string{});
 	};

--- a/src/fios.h
+++ b/src/fios.h
@@ -116,9 +116,9 @@ bool FiosDelete(std::string_view name);
 std::string FiosMakeHeightmapName(std::string_view name);
 std::string FiosMakeSavegameName(std::string_view name);
 
-std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext);
-std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext);
-std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, std::string_view file, std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, std::string_view file, std::string_view ext);
+std::tuple<FiosType, std::string> FiosGetHeightmapListCallback(SaveLoadOperation fop, std::string_view file, std::string_view ext);
 
 void ScanScenarios();
 std::optional<std::string_view> FindScenario(const ContentInfo &ci, bool md5sum);

--- a/src/misc/getoptdata.h
+++ b/src/misc/getoptdata.h
@@ -22,18 +22,18 @@ struct OptionData {
 	OptionDataType type; ///< The type of option.
 	char id; ///< Unique identification of this option data, often the same as #shortname.
 	char shortname = '\0'; ///< Short option letter if available, else use \c '\0'.
-	const char *longname = nullptr; ///< Long option name including '-'/'--' prefix, use \c nullptr if not available.
+	std::string_view longname{}; ///< Long option name including '-'/'--' prefix, leave empty if not available.
 };
 
 /** Data storage for parsing command line options. */
 struct GetOptData {
 	using OptionSpan = std::span<const OptionData>;
-	using ArgumentSpan = std::span<char * const>;
+	using ArgumentSpan = std::span<std::string_view>;
 
 	ArgumentSpan arguments; ///< Remaining command line arguments.
 	const OptionSpan options; ///< Command line option descriptions.
-	const char *opt = nullptr; ///< Option value, if available (else \c nullptr).
-	const char *cont = nullptr; ///< Next call to #GetOpt should start here (in the middle of an argument).
+	std::string_view opt; ///< Option value, if available (else empty).
+	std::string_view cont; ///< Next call to #GetOpt should start here (in the middle of an argument).
 
 	/**
 	 * Constructor of the data store.

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -497,7 +497,7 @@ static std::vector<OptionData> CreateOptions()
  * @param arguments The command line arguments passed to the application.
  * @return 0 when there is no error.
  */
-int openttd_main(std::span<char * const> arguments)
+int openttd_main(std::span<std::string_view> arguments)
 {
 	_game_session_stats.start_time = std::chrono::steady_clock::now();
 	_game_session_stats.savegame_size = std::nullopt;
@@ -541,7 +541,7 @@ int openttd_main(std::span<char * const> arguments)
 			blitter = "null";
 			dedicated = true;
 			SetDebugString("net=4", ShowInfoI);
-			if (mgo.opt != nullptr) {
+			if (!mgo.opt.empty()) {
 				scanner->dedicated_host = ParseFullConnectionString(mgo.opt, scanner->dedicated_port);
 			}
 			break;
@@ -564,7 +564,7 @@ int openttd_main(std::span<char * const> arguments)
 #if defined(_WIN32)
 				CreateConsole();
 #endif
-				if (mgo.opt != nullptr) SetDebugString(mgo.opt, ShowInfoI);
+				if (!mgo.opt.empty()) SetDebugString(mgo.opt, ShowInfoI);
 				break;
 			}
 		case 'e':
@@ -577,7 +577,7 @@ int openttd_main(std::span<char * const> arguments)
 			}
 			break;
 		case 'g':
-			if (mgo.opt != nullptr) {
+			if (!mgo.opt.empty()) {
 				_file_to_saveload.name = mgo.opt;
 
 				std::string extension = FS2OTTD(std::filesystem::path(OTTD2FS(_file_to_saveload.name)).extension().native());
@@ -609,7 +609,7 @@ int openttd_main(std::span<char * const> arguments)
 			break;
 		case 'q': {
 			DeterminePaths(arguments[0], only_local_path);
-			if (StrEmpty(mgo.opt)) {
+			if (mgo.opt.empty()) {
 				ret = 1;
 				return ret;
 			}

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -271,9 +271,9 @@ static void WriteSavegameInfo(const std::string &name)
  * @param res variable to store the resolution in.
  * @param s   the string to decompose.
  */
-static void ParseResolution(Dimension *res, const char *s)
+static void ParseResolution(Dimension &res, std::string_view s)
 {
-	StringConsumer consumer(std::string_view{s});
+	StringConsumer consumer(s);
 	auto width = consumer.TryReadIntegerBase<uint>(10);
 	auto valid = consumer.ReadIf("x");
 	auto height = consumer.TryReadIntegerBase<uint>(10);
@@ -282,8 +282,8 @@ static void ParseResolution(Dimension *res, const char *s)
 		return;
 	}
 
-	res->width  = std::max<uint>(*width, 64);
-	res->height = std::max<uint>(*height, 64);
+	res.width  = std::max<uint>(*width, 64);
+	res.height = std::max<uint>(*height, 64);
 }
 
 
@@ -552,7 +552,7 @@ int openttd_main(std::span<char * const> arguments)
 		case 'p':
 			scanner->join_server_password = mgo.opt;
 			break;
-		case 'r': ParseResolution(&resolution, mgo.opt); break;
+		case 'r': ParseResolution(resolution, mgo.opt); break;
 		case 't':
 			if (auto value = ParseInteger(mgo.opt); value.has_value()) {
 				scanner->startyear = TimerGameCalendar::Year(*value);

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -83,7 +83,7 @@ extern PauseModes _pause_mode;
 void AskExitGame();
 void AskExitToGameMenu();
 
-int openttd_main(std::span<char * const> arguments);
+int openttd_main(std::span<std::string_view> arguments);
 void StateGameLoop();
 void HandleExitGameRequest();
 

--- a/src/os/macosx/osx_main.cpp
+++ b/src/os/macosx/osx_main.cpp
@@ -26,13 +26,16 @@ void CocoaReleaseAutoreleasePool();
 int CDECL main(int argc, char *argv[])
 {
 	/* Make sure our arguments contain only valid UTF-8 characters. */
-	for (int i = 0; i < argc; i++) StrMakeValidInPlace(argv[i]);
+	std::vector<std::string_view> params;
+	for (int i = 0; i < argc; ++i) {
+		StrMakeValidInPlace(argv[i]);
+		params.emplace_back(argv[i]);
+	}
 
 	CocoaSetupAutoreleasePool();
 	/* This is passed if we are launched by double-clicking */
-	if (argc >= 2 && strncmp(argv[1], "-psn", 4) == 0) {
-		argv[1] = nullptr;
-		argc = 1;
+	if (params.size() >= 2 && params[1].starts_with("-psn")) {
+		params.resize(1);
 	}
 
 	CrashLog::InitialiseCrashLog();
@@ -41,7 +44,7 @@ int CDECL main(int argc, char *argv[])
 
 	signal(SIGPIPE, SIG_IGN);
 
-	int ret = openttd_main(std::span(argv, argc));
+	int ret = openttd_main(params);
 
 	CocoaReleaseAutoreleasePool();
 

--- a/src/os/unix/unix_main.cpp
+++ b/src/os/unix/unix_main.cpp
@@ -21,7 +21,11 @@
 int CDECL main(int argc, char *argv[])
 {
 	/* Make sure our arguments contain only valid UTF-8 characters. */
-	for (int i = 0; i < argc; i++) StrMakeValidInPlace(argv[i]);
+	std::vector<std::string_view> params;
+	for (int i = 0; i < argc; ++i) {
+		StrMakeValidInPlace(argv[i]);
+		params.emplace_back(argv[i]);
+	}
 
 	CrashLog::InitialiseCrashLog();
 
@@ -29,5 +33,5 @@ int CDECL main(int argc, char *argv[])
 
 	signal(SIGPIPE, SIG_IGN);
 
-	return openttd_main(std::span(argv, argc));
+	return openttd_main(params);
 }

--- a/src/os/windows/win32_main.cpp
+++ b/src/os/windows/win32_main.cpp
@@ -12,37 +12,31 @@
 #include <mmsystem.h>
 #include "../../openttd.h"
 #include "../../core/random_func.hpp"
+#include "../../core/string_consumer.hpp"
 #include "../../string_func.h"
 #include "../../crashlog.h"
 #include "../../debug.h"
 
 #include "../../safeguards.h"
 
-static auto ParseCommandLine(char *line)
+static auto ParseCommandLine(std::string_view line)
 {
-	std::vector<char *> arguments;
-	for (;;) {
-		/* skip whitespace */
-		while (*line == ' ' || *line == '\t') line++;
+	std::vector<std::string_view> arguments;
 
-		/* end? */
-		if (*line == '\0') break;
+	StringConsumer consumer{line};
+	while (consumer.AnyBytesLeft()) {
+		consumer.SkipUntilCharNotIn(StringConsumer::WHITESPACE_NO_NEWLINE);
+		if (!consumer.AnyBytesLeft()) break;
 
-		/* special handling when quoted */
-		if (*line == '"') {
-			arguments.push_back(++line);
-			while (*line != '"') {
-				if (*line == '\0') return arguments;
-				line++;
-			}
+		std::string_view argument;
+		if (consumer.ReadIf("\"")) {
+			/* special handling when quoted */
+			argument = consumer.ReadUntil("\"", StringConsumer::SKIP_ONE_SEPARATOR);
 		} else {
-			arguments.push_back(line);
-			while (*line != ' ' && *line != '\t') {
-				if (*line == '\0') return arguments;
-				line++;
-			}
+			argument = consumer.ReadUntilCharIn(StringConsumer::WHITESPACE_NO_NEWLINE);
 		}
-		*line++ = '\0';
+
+		arguments.push_back(argument);
 	};
 
 	return arguments;
@@ -57,8 +51,8 @@ int APIENTRY WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 
 	CrashLog::InitialiseCrashLog();
 
-	/* Convert the command line to UTF-8. */
-	std::string cmdline = FS2OTTD(GetCommandLine());
+	/* Convert the command line to valid UTF-8. */
+	std::string cmdline = StrMakeValid(FS2OTTD(GetCommandLine()));
 
 	/* Set the console codepage to UTF-8. */
 	SetConsoleOutputCP(CP_UTF8);
@@ -72,11 +66,7 @@ int APIENTRY WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 	/* setup random seed to something quite random */
 	SetRandomSeed(GetTickCount());
 
-	auto arguments = ParseCommandLine(cmdline.data());
-
-	/* Make sure our arguments contain only valid UTF-8 characters. */
-	for (auto argument : arguments) StrMakeValidInPlace(argument);
-
+	auto arguments = ParseCommandLine(cmdline);
 	int ret = openttd_main(arguments);
 
 	/* Restore system timer resolution. */

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -231,7 +231,7 @@ static std::tuple<SavegameType, std::string> DetermineOldSavegameTypeAndName(Fil
 
 typedef bool LoadOldMainProc(LoadgameState &ls);
 
-bool LoadOldSaveGame(const std::string &file)
+bool LoadOldSaveGame(std::string_view file)
 {
 	LoadgameState ls{};
 
@@ -282,7 +282,7 @@ bool LoadOldSaveGame(const std::string &file)
 	return true;
 }
 
-std::string GetOldSaveGameName(const std::string &file)
+std::string GetOldSaveGameName(std::string_view file)
 {
 	auto f = FioFOpenFile(file, "rb", NO_DIRECTORY);
 	if (!f.has_value()) return {};

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2889,7 +2889,7 @@ static std::pair<const SaveLoadFormat &, uint8_t> GetSavegameFormat(const std::s
 /* actual loader/saver function */
 void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settings);
 extern bool AfterLoadGame();
-extern bool LoadOldSaveGame(const std::string &file);
+extern bool LoadOldSaveGame(std::string_view file);
 
 /**
  * Reset all settings to their default, so any settings missing in the savegame
@@ -3250,7 +3250,7 @@ SaveOrLoadResult LoadWithFilter(std::shared_ptr<LoadFilter> reader)
  * @param threaded True when threaded saving is allowed
  * @return Return the result of the action. #SL_OK, #SL_ERROR, or #SL_REINIT ("unload" the game)
  */
-SaveOrLoadResult SaveOrLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileType dft, Subdirectory sb, bool threaded)
+SaveOrLoadResult SaveOrLoad(std::string_view filename, SaveLoadOperation fop, DetailedFileType dft, Subdirectory sb, bool threaded)
 {
 	/* An instance of saving is already active, so don't go saving again */
 	if (_sl.saveinprogress && fop == SLO_SAVE && dft == DFT_GAME_FILE && threaded) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -439,7 +439,7 @@ std::string GenerateDefaultSaveName();
 void SetSaveLoadError(StringID str);
 EncodedString GetSaveLoadErrorType();
 EncodedString GetSaveLoadErrorMessage();
-SaveOrLoadResult SaveOrLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileType dft, Subdirectory sb, bool threaded = true);
+SaveOrLoadResult SaveOrLoad(std::string_view filename, SaveLoadOperation fop, DetailedFileType dft, Subdirectory sb, bool threaded = true);
 void WaitTillSaved();
 void ProcessAsyncSaveFinish();
 void DoExitSave();

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -403,7 +403,9 @@ int CDECL main(int argc, char *argv[])
 	std::optional<std::string_view> before_file;
 	std::optional<std::string_view> after_file;
 
-	GetOptData mgo(std::span(argv + 1, argc - 1), _opts);
+	std::vector<std::string_view> params;
+	for (int i = 1; i < argc; ++i) params.emplace_back(argv[i]);
+	GetOptData mgo(params, _opts);
 	for (;;) {
 		int i = mgo.GetOpt();
 		if (i == -1) break;

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -904,7 +904,7 @@ void *UniquePtrSpriteAllocator::AllocatePtr(size_t size)
  */
 static void *HandleInvalidSpriteRequest(SpriteID sprite, SpriteType requested, SpriteCache *sc, SpriteAllocator *allocator)
 {
-	static const char * const sprite_types[] = {
+	static const std::string_view sprite_types[] = {
 		"normal",        // SpriteType::Normal
 		"map generator", // SpriteType::MapGen
 		"character",     // SpriteType::Font

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -1835,7 +1835,7 @@ struct StationViewWindow : public Window {
 				DrawString(text.left, text.right, y, GetString(str, cargo, cd.GetCount(), station));
 
 				if (column < NUM_COLUMNS - 1) {
-					const char *sym = nullptr;
+					std::string_view sym;
 					if (cd.GetNumChildren() > 0) {
 						sym = "-";
 					} else if (auto_distributed && str != STR_STATION_VIEW_RESERVED) {
@@ -1850,7 +1850,7 @@ struct StationViewWindow : public Window {
 							}
 						}
 					}
-					if (sym != nullptr) DrawString(shrink.left, shrink.right, y, sym, TC_YELLOW);
+					if (!sym.empty()) DrawString(shrink.left, shrink.right, y, sym, TC_YELLOW);
 				}
 				this->SetDisplayedRow(cd);
 			}

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -322,7 +322,9 @@ int CDECL main(int argc, char *argv[])
 	std::filesystem::path src_dir(".");
 	std::filesystem::path dest_dir;
 
-	GetOptData mgo(std::span(argv + 1, argc - 1), _opts);
+	std::vector<std::string_view> params;
+	for (int i = 1; i < argc; ++i) params.emplace_back(argv[i]);
+	GetOptData mgo(params, _opts);
 	for (;;) {
 		int i = mgo.GetOpt();
 		if (i == -1) break;

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -160,8 +160,8 @@ static const CmdStruct _cmd_structs[] = {
 /** Description of a plural form */
 struct PluralForm {
 	size_t plural_count;     ///< The number of plural forms
-	const char *description; ///< Human readable description of the form
-	const char *names;       ///< Plural names
+	std::string_view description; ///< Human readable description of the form
+	std::string_view names; ///< Plural names
 };
 
 /** The maximum number of plurals. */
@@ -199,7 +199,7 @@ static const PluralForm _plural_forms[] = {
  * a = array, i.e. list of strings
  */
  /** All pragmas used */
-static const char * const _pragmas[][4] = {
+static const std::string_view _pragmas[][4] = {
 	/*  name         flags  default   description */
 	{ "name",        "0",   "",       "English name for the language" },
 	{ "ownname",     "t",   "",       "Localised name for the language" },

--- a/src/tar_type.h
+++ b/src/tar_type.h
@@ -19,8 +19,8 @@ struct TarFileListEntry {
 	size_t position;
 };
 
-typedef std::map<std::string, std::string> TarList; ///< Map of tar file to tar directory.
-typedef std::map<std::string, TarFileListEntry> TarFileList;
+using TarList = std::map<std::string, std::string, std::less<>>; ///< Map of tar file to tar directory.
+using TarFileList = std::map<std::string, TarFileListEntry, std::less<>> ;
 extern std::array<TarList, NUM_SUBDIRS> _tar_list;
 extern TarFileList _tar_filelist[NUM_SUBDIRS];
 


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

Remove some C-style strings in favour of `std::string_view`.

Replace some `const std::string &` in favour of `std::string_view`; these will be called with a `std::string_view` in a later PR.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
