### PR TITLE
Codechange: Cache layouted text for the last used width.

### DIFF
--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -135,7 +135,7 @@ public:
  *
  * It also accounts for the memory allocations and frees.
  */
-class Layouter : public std::vector<std::unique_ptr<const ParagraphLayouter::Line>> {
+class Layouter : public std::vector<const ParagraphLayouter::Line *> {
 	std::string_view string; ///< Pointer to the original string.
 
 	/** Key into the linecache */
@@ -174,6 +174,9 @@ public:
 
 		FontState state_after;     ///< Font state after the line.
 		std::unique_ptr<ParagraphLayouter> layout = nullptr; ///< Layout of the line.
+
+		std::vector<std::unique_ptr<const ParagraphLayouter::Line>> cached_layout{}; ///< Cached results of line layouting.
+		int cached_width = 0; ///< Width used for the cached layout.
 	};
 private:
 	typedef std::map<LineCacheKey, LineCacheItem, LineCacheCompare> LineCache;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Layouting text can be quite expensive, though the actual cost depends on the platform and the selected fonts.

During layouting we store a line cache, which remembers how each string should be broken up into runs.

However the actual layout which says which pixel positions to use is not remembered, and must be recalculated each time a string is measured and/or drawn.

With readme open:
![image](https://github.com/user-attachments/assets/a9090c0f-a34d-4359-a130-44ae87597a8e)
Without readme open:
![image](https://github.com/user-attachments/assets/2dbcb247-bfdb-4e71-9b58-9395c60e582f)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a layout cache to the line cache. This remembers the last layouted (max) width and its layout, so that if the max width does not change, the line does not need to layouted again.

Depending on font selection, and the amount of text being displayed, this can significantly reduce rendering times.

With readme open:
![image](https://github.com/user-attachments/assets/e3554905-dace-4953-a444-d91600911d84)
Without readme open:
![image](https://github.com/user-attachments/assets/52e201bd-d7c5-4e38-9b2b-d1a15cbf6363)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
