### PR TITLE
Codechange: reduce char* usage

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -16,7 +16,7 @@
 	FatalError("NOT_REACHED triggered at line {} of {}", location.line(), location.file_name());
 }
 
-[[noreturn]] void AssertFailedError(const char *expression, const std::source_location location)
+[[noreturn]] void AssertFailedError(std::string_view expression, const std::source_location location)
 {
 	FatalError("Assertion failed at line {} of {}: {}", location.line(), location.file_name(), expression);
 }

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -260,7 +260,7 @@ static const uint MAX_FRAMES     = 64;
 			}
 
 			/* Get module name. */
-			const char *mod_name = "???";
+			std::string_view mod_name = "???";
 
 			IMAGEHLP_MODULE64 module;
 			module.SizeOfStruct = sizeof(module);
@@ -269,7 +269,7 @@ static const uint MAX_FRAMES     = 64;
 			}
 
 			/* Print module and instruction pointer. */
-			std::string message = fmt::format("{:20s} {:X}",  mod_name, frame.AddrPC.Offset);
+			std::string message = fmt::format("{:20s} {:X}", mod_name, frame.AddrPC.Offset);
 
 			/* Get symbol name and line info if possible. */
 			DWORD64 offset;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -289,7 +289,7 @@ static bool LoadIntList(std::optional<std::string_view> str, void *array, int ne
 	auto opt_items = ParseIntList(*str);
 	if (!opt_items.has_value() || opt_items->size() != (size_t)nelems) return false;
 
-	char *p = static_cast<char *>(array);
+	std::byte *p = static_cast<std::byte *>(array);
 	for (auto item : *opt_items) {
 		WriteValue(p, type, item);
 		p += elem_size;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -295,7 +295,7 @@ char (&ArraySizeHelper(T (&array)[N]))[N];
 #endif /* __GNUC__ || __clang__ */
 
 [[noreturn]] void NOT_REACHED(const std::source_location location = std::source_location::current());
-[[noreturn]] void AssertFailedError(const char *expression, const std::source_location location = std::source_location::current());
+[[noreturn]] void AssertFailedError(std::string_view expression, const std::source_location location = std::source_location::current());
 
 /* For non-debug builds with assertions enabled use the special assertion handler. */
 #if defined(NDEBUG) && defined(WITH_ASSERT)


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

Two parts...
* There are cases where `char *` is used to calculate byte offsets. Better use `std::byte` for that, to denote it's not just a 'character'.
* Replace a few `char*` with `std::string_view`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
