### PR TITLE
Codechange: replace char* in descriptions with std::string_view

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -84,7 +84,7 @@ static constexpr NWidgetPart _nested_ai_config_widgets[] = {
 
 /** Window definition for the configure AI window. */
 static WindowDesc _ai_config_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	{},
 	_nested_ai_config_widgets

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -618,7 +618,7 @@ static constexpr NWidgetPart _nested_build_airport_widgets[] = {
 };
 
 static WindowDesc _build_airport_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_airport_widgets

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -42,7 +42,7 @@ static constexpr NWidgetPart _background_widgets[] = {
  * Window description for the background window to prevent smearing.
  */
 static WindowDesc _background_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_background_widgets
@@ -78,7 +78,7 @@ static constexpr NWidgetPart _nested_bootstrap_errmsg_widgets[] = {
 
 /** Window description for the error window. */
 static WindowDesc _bootstrap_errmsg_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
 	{WindowDefaultFlag::Modal, WindowDefaultFlag::NoClose},
 	_nested_bootstrap_errmsg_widgets
@@ -135,7 +135,7 @@ static constexpr NWidgetPart _nested_bootstrap_download_status_window_widgets[] 
 
 /** Window description for the download window */
 static WindowDesc _bootstrap_download_status_window_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	{WindowDefaultFlag::Modal, WindowDefaultFlag::NoClose},
 	_nested_bootstrap_download_status_window_widgets
@@ -187,7 +187,7 @@ static constexpr NWidgetPart _bootstrap_query_widgets[] = {
 
 /** The window description for the query. */
 static WindowDesc _bootstrap_query_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_CONFIRM_POPUP_QUERY, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_bootstrap_query_widgets

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1708,7 +1708,7 @@ public:
 
 /** Company manager face selection window description */
 static WindowDesc _select_company_manager_face_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_COMPANY_MANAGER_FACE, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_select_company_manager_face_widgets
@@ -2616,7 +2616,7 @@ static constexpr NWidgetPart _nested_buy_company_widgets[] = {
 };
 
 static WindowDesc _buy_company_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_BUY_COMPANY, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_buy_company_widgets

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -137,7 +137,7 @@ static constexpr NWidgetPart _nested_console_window_widgets[] = {
 };
 
 static WindowDesc _console_window_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_CONSOLE, WC_NONE,
 	{},
 	_nested_console_window_widgets

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -196,7 +196,7 @@ static constexpr NWidgetPart _nested_set_date_widgets[] = {
 
 /** Description of the date setting window. */
 static WindowDesc _set_date_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_SET_DATE, WC_NONE,
 	{},
 	_nested_set_date_widgets

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -507,7 +507,7 @@ static constexpr NWidgetPart _nested_build_dock_station_widgets[] = {
 };
 
 static WindowDesc _build_dock_station_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_dock_station_widgets
@@ -602,7 +602,7 @@ static constexpr NWidgetPart _nested_build_docks_depot_widgets[] = {
 };
 
 static WindowDesc _build_docks_depot_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_docks_depot_widgets

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -65,7 +65,7 @@ static constexpr NWidgetPart _nested_dropdown_menu_widgets[] = {
 };
 
 static WindowDesc _dropdown_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_DROPDOWN_MENU, WC_NONE,
 	WindowDefaultFlag::NoFocus,
 	_nested_dropdown_menu_widgets

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -141,7 +141,7 @@ struct EnginePreviewWindow : Window {
 };
 
 static WindowDesc _engine_preview_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_ENGINE_PREVIEW, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_engine_preview_widgets

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -44,7 +44,7 @@ static constexpr NWidgetPart _nested_errmsg_widgets[] = {
 };
 
 static WindowDesc _errmsg_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	{},
 	_nested_errmsg_widgets
@@ -64,7 +64,7 @@ static constexpr NWidgetPart _nested_errmsg_face_widgets[] = {
 };
 
 static WindowDesc _errmsg_face_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	{},
 	_nested_errmsg_face_widgets

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -975,14 +975,14 @@ struct GenerateLandscapeWindow : public Window {
 };
 
 static WindowDesc _generate_landscape_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	{},
 	_nested_generate_landscape_widgets
 );
 
 static WindowDesc _heightmap_load_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	{},
 	_nested_heightmap_load_widgets
@@ -1282,7 +1282,7 @@ static constexpr NWidgetPart _nested_create_scenario_widgets[] = {
 };
 
 static WindowDesc _create_scenario_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	{},
 	_nested_create_scenario_widgets
@@ -1308,7 +1308,7 @@ static constexpr NWidgetPart _nested_generate_progress_widgets[] = {
 
 
 static WindowDesc _generate_progress_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_MODAL_PROGRESS, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_nested_generate_progress_widgets

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -440,25 +440,25 @@ static constexpr auto _nested_goal_question_widgets_error    = NestedGoalWidgets
 
 static WindowDesc _goal_question_list_desc[] = {
 	{
-		WDP_CENTER, nullptr, 0, 0,
+		WDP_CENTER, {}, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WindowDefaultFlag::Construction,
 		_nested_goal_question_widgets_question,
 	},
 	{
-		WDP_CENTER, nullptr, 0, 0,
+		WDP_CENTER, {}, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WindowDefaultFlag::Construction,
 		_nested_goal_question_widgets_info,
 	},
 	{
-		WDP_CENTER, nullptr, 0, 0,
+		WDP_CENTER, {}, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WindowDefaultFlag::Construction,
 		_nested_goal_question_widgets_warning,
 	},
 	{
-		WDP_CENTER, nullptr, 0, 0,
+		WDP_CENTER, {}, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WindowDefaultFlag::Construction,
 		_nested_goal_question_widgets_error,

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -202,7 +202,7 @@ static constexpr NWidgetPart _nested_helpwin_widgets[] = {
 };
 
 static WindowDesc _helpwin_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_HELPWIN, WC_NONE,
 	{},
 	_nested_helpwin_widgets

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -214,14 +214,14 @@ static constexpr NWidgetPart _nested_highscore_widgets[] = {
 };
 
 static WindowDesc _highscore_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_HIGHSCORE, WC_NONE,
 	{},
 	_nested_highscore_widgets
 );
 
 static WindowDesc _endgame_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_ENDSCREEN, WC_NONE,
 	{},
 	_nested_highscore_widgets

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -443,7 +443,7 @@ static constexpr NWidgetPart _nested_select_game_widgets[] = {
 };
 
 static WindowDesc _select_game_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_SELECT_GAME, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_nested_select_game_widgets

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -522,7 +522,7 @@ struct MainWindow : Window
 };
 
 static WindowDesc _main_window_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_MAIN_WINDOW, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_nested_main_window_widgets,

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -58,7 +58,7 @@ static constexpr NWidgetPart _nested_land_info_widgets[] = {
 };
 
 static WindowDesc _land_info_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_LAND_INFO, WC_NONE,
 	{},
 	_nested_land_info_widgets
@@ -336,7 +336,7 @@ static constexpr NWidgetPart _nested_about_widgets[] = {
 };
 
 static WindowDesc _about_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	{},
 	_nested_about_widgets
@@ -591,7 +591,7 @@ static constexpr NWidgetPart _nested_tooltips_widgets[] = {
 };
 
 static WindowDesc _tool_tips_desc(
-	WDP_MANUAL, nullptr, 0, 0, // Coordinates and sizes are not used,
+	WDP_MANUAL, {}, 0, 0, // Coordinates and sizes are not used,
 	WC_TOOLTIPS, WC_NONE,
 	{WindowDefaultFlag::NoFocus, WindowDefaultFlag::NoClose},
 	_nested_tooltips_widgets
@@ -991,7 +991,7 @@ static constexpr NWidgetPart _nested_query_string_widgets[] = {
 };
 
 static WindowDesc _query_string_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	{},
 	_nested_query_string_widgets
@@ -1130,7 +1130,7 @@ static constexpr NWidgetPart _nested_query_widgets[] = {
 };
 
 static WindowDesc _query_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_CONFIRM_POPUP_QUERY, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_query_widgets

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -661,7 +661,7 @@ static constexpr NWidgetPart _nested_music_track_selection_widgets[] = {
 };
 
 static WindowDesc _music_track_selection_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_MUSIC_TRACK_SELECTION, WC_NONE,
 	{},
 	_nested_music_track_selection_widgets

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -427,7 +427,7 @@ static constexpr NWidgetPart _nested_chat_window_widgets[] = {
 
 /** The description of the chat window. */
 static WindowDesc _chat_window_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_SEND_NETWORK_MSG, WC_NONE,
 	{},
 	_nested_chat_window_widgets

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -99,7 +99,7 @@ static constexpr NWidgetPart _nested_network_content_download_status_window_widg
 
 /** Window description for the download window */
 static WindowDesc _network_content_download_status_window_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_network_content_download_status_window_widgets

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1203,7 +1203,7 @@ static constexpr NWidgetPart _nested_network_start_server_window_widgets[] = {
 };
 
 static WindowDesc _network_start_server_window_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_NETWORK_WINDOW, WC_NONE,
 	{},
 	_nested_network_start_server_window_widgets
@@ -2159,7 +2159,7 @@ static constexpr NWidgetPart _nested_network_join_status_window_widgets[] = {
 };
 
 static WindowDesc _network_join_status_window_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_network_join_status_window_widgets
@@ -2266,7 +2266,7 @@ static constexpr NWidgetPart _nested_network_ask_relay_widgets[] = {
 };
 
 static WindowDesc _network_ask_relay_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_NETWORK_ASK_RELAY, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_network_ask_relay_widgets
@@ -2364,7 +2364,7 @@ static constexpr NWidgetPart _nested_network_ask_survey_widgets[] = {
 };
 
 static WindowDesc _network_ask_survey_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_NETWORK_ASK_SURVEY, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_network_ask_survey_widgets

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -2152,7 +2152,7 @@ static constexpr NWidgetPart _nested_scan_progress_widgets[] = {
 
 /** Description of the widgets and other settings of the window. */
 static WindowDesc _scan_progress_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_MODAL_PROGRESS, WC_NONE,
 	{},
 	_nested_scan_progress_widgets

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -127,7 +127,7 @@ static constexpr NWidgetPart _nested_normal_news_widgets[] = {
 };
 
 static WindowDesc _normal_news_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_normal_news_widgets
@@ -175,7 +175,7 @@ static constexpr NWidgetPart _nested_vehicle_news_widgets[] = {
 };
 
 static WindowDesc _vehicle_news_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_vehicle_news_widgets
@@ -220,7 +220,7 @@ static constexpr NWidgetPart _nested_company_news_widgets[] = {
 };
 
 static WindowDesc _company_news_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_company_news_widgets
@@ -254,7 +254,7 @@ static constexpr NWidgetPart _nested_thin_news_widgets[] = {
 };
 
 static WindowDesc _thin_news_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_thin_news_widgets
@@ -290,7 +290,7 @@ static constexpr NWidgetPart _nested_small_news_widgets[] = {
 };
 
 static WindowDesc _small_news_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_small_news_widgets

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -339,7 +339,7 @@ static constexpr NWidgetPart _nested_osk_widgets[] = {
 };
 
 static WindowDesc _osk_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_OSK, WC_NONE,
 	{},
 	_nested_osk_widgets

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1697,7 +1697,7 @@ static constexpr NWidgetPart _nested_signal_builder_widgets[] = {
 
 /** Signal selection window description */
 static WindowDesc _signal_builder_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_BUILD_SIGNAL, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_signal_builder_widgets
@@ -1778,7 +1778,7 @@ static constexpr NWidgetPart _nested_build_depot_widgets[] = {
 };
 
 static WindowDesc _build_depot_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_depot_widgets

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1167,7 +1167,7 @@ static constexpr NWidgetPart _nested_build_road_depot_widgets[] = {
 };
 
 static WindowDesc _build_road_depot_desc(
-	WDP_AUTO, nullptr, 0, 0,
+	WDP_AUTO, {}, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_road_depot_widgets

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -592,7 +592,7 @@ void StringSettingDesc::MakeValueValid(std::string &str) const
  * @param object The object the setting is to be saved in.
  * @param str The string to save.
  */
-void StringSettingDesc::Write(const void *object, const std::string &str) const
+void StringSettingDesc::Write(const void *object, std::string_view str) const
 {
 	reinterpret_cast<std::string *>(GetVariableAddress(object, this->save))->assign(str);
 }
@@ -665,7 +665,7 @@ void IntSettingDesc::ParseValue(const IniItem *item, void *object) const
 
 void StringSettingDesc::ParseValue(const IniItem *item, void *object) const
 {
-	std::string str = (item == nullptr) ? this->def : item->value.value_or("");
+	std::string str{(item == nullptr) ? this->def : item->value.value_or("")};
 	this->MakeValueValid(str);
 	this->Write(object, str);
 }
@@ -675,7 +675,7 @@ void ListSettingDesc::ParseValue(const IniItem *item, void *object) const
 	std::optional<std::string_view> str;
 	if (item != nullptr) {
 		str = item->value;
-	} else if (this->def != nullptr) {
+	} else if (!this->def.empty()) {
 		str = this->def;
 	}
 	void *ptr = GetVariableAddress(object, this->save);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -184,7 +184,7 @@ const uint16_t INIFILE_VERSION = (IniFileVersion)(IFV_MAX_VERSION - 1); ///< Cur
  * @param many full domain of values the ONEofMANY setting can have
  * @return the integer index of the full-list, or std::nullopt if not found
  */
-std::optional<uint32_t> OneOfManySettingDesc::ParseSingleValue(std::string_view str, const std::vector<std::string> &many)
+std::optional<uint32_t> OneOfManySettingDesc::ParseSingleValue(std::string_view str, std::span<const std::string_view> many)
 {
 	StringConsumer consumer{str};
 	auto digit = consumer.TryReadIntegerBase<uint32_t>(10);
@@ -217,7 +217,7 @@ std::optional<bool> BoolSettingDesc::ParseSingleValue(std::string_view str)
  * of separated by a whitespace, tab or | character
  * @return the 'fully' set integer, or std::nullopt if a set is not found
  */
-static std::optional<uint32_t> LookupManyOfMany(const std::vector<std::string> &many, std::string_view str)
+static std::optional<uint32_t> LookupManyOfMany(std::span<const std::string_view> many, std::string_view str)
 {
 	static const std::string_view separators{" \t|"};
 
@@ -334,7 +334,7 @@ std::string OneOfManySettingDesc::FormatSingleValue(uint id) const
 	if (id >= this->many.size()) {
 		return fmt::format("{}", id);
 	}
-	return this->many[id];
+	return std::string{this->many[id]};
 }
 
 std::string OneOfManySettingDesc::FormatValue(const void *object) const
@@ -1425,7 +1425,7 @@ void LoadFromConfig(bool startup)
 		}
 
 		if (generic_version < IFV_AUTOSAVE_RENAME && IsConversionNeeded(generic_ini, "gui", "autosave", "autosave_interval", &old_item)) {
-			static std::vector<std::string> _old_autosave_interval{"off", "monthly", "quarterly", "half year", "yearly"};
+			static std::vector<std::string_view> _old_autosave_interval{"off", "monthly", "quarterly", "half year", "yearly"};
 			auto old_value = OneOfManySettingDesc::ParseSingleValue(*old_item->value, _old_autosave_interval).value_or(-1);
 
 			switch (old_value) {

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2149,7 +2149,7 @@ static constexpr NWidgetPart _nested_cust_currency_widgets[] = {
 };
 
 static WindowDesc _cust_currency_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_CUSTOM_CURRENCY, WC_NONE,
 	{},
 	_nested_cust_currency_widgets

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -323,12 +323,12 @@ struct StringSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(const std::string &value);
 
-	StringSettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, const char *def,
+	StringSettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, std::string_view def,
 			uint32_t max_length, PreChangeCheck pre_check, PostChangeCallback post_callback) :
-		SettingDesc(save, flags, startup), def(def == nullptr ? "" : def), max_length(max_length),
+		SettingDesc(save, flags, startup), def(def), max_length(max_length),
 			pre_check(pre_check), post_callback(post_callback) {}
 
-	std::string def;                   ///< Default value given when none is present
+	std::string_view def; ///< Default value given when none is present
 	uint32_t max_length;                 ///< Maximum length of the string, 0 means no maximum length
 	PreChangeCheck *pre_check;         ///< Callback to check for the validity of the setting.
 	PostChangeCallback *post_callback; ///< Callback when the setting has been changed.
@@ -345,15 +345,15 @@ struct StringSettingDesc : SettingDesc {
 
 private:
 	void MakeValueValid(std::string &str) const;
-	void Write(const void *object, const std::string &str) const;
+	void Write(const void *object, std::string_view str) const;
 };
 
 /** List/array settings. */
 struct ListSettingDesc : SettingDesc {
-	ListSettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, const char *def) :
+	ListSettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, std::string_view def) :
 		SettingDesc(save, flags, startup), def(def) {}
 
-	const char *def;        ///< default value given when none is present
+	std::string_view def; ///< default value given when none is present
 
 	std::string FormatValue(const void *object) const override;
 	void ParseValue(const IniItem *item, void *object) const override;

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -274,17 +274,17 @@ struct OneOfManySettingDesc : IntSettingDesc {
 			Tmax max, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback,
 			GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, GetValueParamsCallback get_value_params_cb,
-			GetDefaultValueCallback get_def_cb, std::initializer_list<const char *> many, OnConvert *many_cnvt) :
+			GetDefaultValueCallback get_def_cb, std::initializer_list<std::string_view> many, OnConvert *many_cnvt) :
 		IntSettingDesc(save, flags, startup, def, 0, max, 0, str, str_help, str_val, cat,
 			pre_check, post_callback, get_title_cb, get_help_cb, get_value_params_cb, get_def_cb, nullptr), many_cnvt(many_cnvt)
 	{
 		for (auto one : many) this->many.push_back(one);
 	}
 
-	std::vector<std::string> many; ///< possible values for this type
+	std::vector<std::string_view> many; ///< possible values for this type
 	OnConvert *many_cnvt;          ///< callback procedure when loading value mechanism fails
 
-	static std::optional<uint32_t> ParseSingleValue(std::string_view str, const std::vector<std::string> &many);
+	static std::optional<uint32_t> ParseSingleValue(std::string_view str, std::span<const std::string_view> many);
 	std::string FormatSingleValue(uint id) const;
 
 	int32_t ParseValue(std::string_view str) const override;
@@ -298,7 +298,7 @@ struct ManyOfManySettingDesc : OneOfManySettingDesc {
 		Tdef def, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 		PreChangeCheck pre_check, PostChangeCallback post_callback,
 		GetTitleCallback get_title_cb, GetHelpCallback get_help_cb, GetValueParamsCallback get_value_params_cb,
-		GetDefaultValueCallback get_def_cb, std::initializer_list<const char *> many, OnConvert *many_cnvt) :
+		GetDefaultValueCallback get_def_cb, std::initializer_list<std::string_view> many, OnConvert *many_cnvt) :
 		OneOfManySettingDesc(save, flags, startup, def, (1 << many.size()) - 1, str, str_help,
 			str_val, cat, pre_check, post_callback, get_title_cb, get_help_cb, get_value_params_cb, get_def_cb, many, many_cnvt) {}
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -448,7 +448,7 @@ static bool CheckRoadSide(int32_t &)
 static std::optional<uint32_t> ConvertLandscape(std::string_view value)
 {
 	/* try with the old values */
-	static std::vector<std::string> _old_landscape_values{"normal", "hilly", "desert", "candy"};
+	static std::vector<std::string_view> _old_landscape_values{"normal", "hilly", "desert", "candy"};
 	return OneOfManySettingDesc::ParseSingleValue(value, _old_landscape_values);
 }
 

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -544,7 +544,7 @@ static constexpr NWidgetPart _nested_query_sign_edit_widgets[] = {
 };
 
 static WindowDesc _query_sign_edit_desc(
-	WDP_CENTER, nullptr, 0, 0,
+	WDP_CENTER, {}, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_query_sign_edit_widgets

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -219,7 +219,7 @@ static constexpr NWidgetPart _nested_main_status_widgets[] = {
 };
 
 static WindowDesc _main_status_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_STATUS_BAR, WC_NONE,
 	{WindowDefaultFlag::NoFocus, WindowDefaultFlag::NoClose},
 	_nested_main_status_widgets

--- a/src/table/settings/currency_settings.ini
+++ b/src/table/settings/currency_settings.ini
@@ -61,7 +61,7 @@ max      = CalendarTime::MAX_YEAR
 [SDT_SSTR]
 var      = prefix
 type     = SLE_STRQ
-def      = nullptr
+def      = """"
 
 [SDT_SSTR]
 var      = suffix

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -12,7 +12,7 @@ static void TownFoundingChanged(int32_t new_value);
 static void ChangeTimekeepingUnits(int32_t new_value);
 static void ChangeMinutesPerYear(int32_t new_value);
 
-static constexpr std::initializer_list<const char*> _place_houses{"forbidden", "allowed", "fully constructed"};
+static constexpr std::initializer_list<std::string_view> _place_houses{"forbidden"sv, "allowed"sv, "fully constructed"sv};
 
 static const SettingVariant _economy_settings_table[] = {
 [post-amble]

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -9,7 +9,7 @@
 ; Game settings are everything related to vehicles, stations, orders, etc.
 
 [pre-amble]
-static constexpr std::initializer_list<const char*> _roadsides{"left", "right"};
+static constexpr std::initializer_list<std::string_view> _roadsides{"left"sv, "right"sv};
 
 static void StationSpreadChanged(int32_t new_value);
 static void UpdateConsists(int32_t new_value);

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -17,9 +17,9 @@ static void InvalidateNewGRFChangeWindows(int32_t new_value);
 static void ZoomMinMaxChanged(int32_t new_value);
 static void SpriteZoomMinChanged(int32_t new_value);
 
-static constexpr std::initializer_list<const char*> _osk_activation{"disabled", "double", "single", "immediately"};
-static constexpr std::initializer_list<const char*> _savegame_date{"long", "short", "iso"};
-static constexpr std::initializer_list<const char*> _right_click_close{"no", "yes", "except sticky"};
+static constexpr std::initializer_list<std::string_view> _osk_activation{"disabled"sv, "double"sv, "single"sv, "immediately"sv};
+static constexpr std::initializer_list<std::string_view> _savegame_date{"long"sv, "short"sv, "iso"sv};
+static constexpr std::initializer_list<std::string_view> _right_click_close{"no"sv, "yes"sv, "except sticky"sv};
 
 static const SettingVariant _gui_settings_table[] = {
 [post-amble]

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -176,7 +176,7 @@ var      = locale.digit_group_separator
 type     = SLE_STRQ
 from     = SLV_118
 flags    = SettingFlag::NoNetworkSync
-def      = nullptr
+def      = """"
 post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
@@ -185,7 +185,7 @@ var      = locale.digit_group_separator_currency
 type     = SLE_STRQ
 from     = SLV_118
 flags    = SettingFlag::NoNetworkSync
-def      = nullptr
+def      = """"
 post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
@@ -194,6 +194,6 @@ var      = locale.digit_decimal_separator
 type     = SLE_STRQ
 from     = SLV_126
 flags    = SettingFlag::NoNetworkSync
-def      = nullptr
+def      = """"
 post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -12,8 +12,8 @@ static std::pair<StringParameter, StringParameter> SettingsValueVelocityUnit(con
 
 uint8_t _old_units;                                      ///< Old units from old savegames
 
-static constexpr std::initializer_list<const char*> _locale_currencies{"GBP", "USD", "EUR", "JPY", "ATS", "BEF", "CHF", "CZK", "DEM", "DKK", "ESP", "FIM", "FRF", "GRD", "HUF", "ISK", "ITL", "NLG", "NOK", "PLN", "RON", "RUR", "SIT", "SEK", "TRY", "SKK", "BRL", "EEK", "LTL", "KRW", "ZAR", "custom", "GEL", "IRR", "RUB", "MXN", "NTD", "CNY", "HKD", "INR", "IDR", "MYR", "LVL", "PTE", "UAH"};
-static constexpr std::initializer_list<const char*> _locale_units{"imperial", "metric", "si", "gameunits", "knots"};
+static constexpr std::initializer_list<std::string_view> _locale_currencies{"GBP"sv, "USD"sv, "EUR"sv, "JPY"sv, "ATS"sv, "BEF"sv, "CHF"sv, "CZK"sv, "DEM"sv, "DKK"sv, "ESP"sv, "FIM"sv, "FRF"sv, "GRD"sv, "HUF"sv, "ISK"sv, "ITL"sv, "NLG"sv, "NOK"sv, "PLN"sv, "RON"sv, "RUR"sv, "SIT"sv, "SEK"sv, "TRY"sv, "SKK"sv, "BRL"sv, "EEK"sv, "LTL"sv, "KRW"sv, "ZAR"sv, "custom"sv, "GEL"sv, "IRR"sv, "RUB"sv, "MXN"sv, "NTD"sv, "CNY"sv, "HKD"sv, "INR"sv, "IDR"sv, "MYR"sv, "LVL"sv, "PTE"sv, "UAH"sv};
+static constexpr std::initializer_list<std::string_view> _locale_units{"imperial"sv, "metric"sv, "si"sv, "gameunits"sv, "knots"sv};
 
 static_assert(_locale_currencies.size() == CURRENCY_END);
 

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -10,9 +10,9 @@
 [pre-amble]
 extern std::string _config_language_file;
 
-static constexpr std::initializer_list<const char*> _support8bppmodes{"no", "system", "hardware"};
-static constexpr std::initializer_list<const char*> _display_opt_modes{"SHOW_TOWN_NAMES", "SHOW_STATION_NAMES", "SHOW_SIGNS", "FULL_ANIMATION", "", "FULL_DETAIL", "WAYPOINTS", "SHOW_COMPETITOR_SIGNS"};
-static constexpr std::initializer_list<const char*> _facility_display_opt_modes{"TRAIN", "TRUCK_STOP", "BUS_STOP", "AIRPORT", "DOCK", "", "GHOST"};
+static constexpr std::initializer_list<std::string_view> _support8bppmodes{"no"sv, "system"sv, "hardware"sv};
+static constexpr std::initializer_list<std::string_view> _display_opt_modes{"SHOW_TOWN_NAMES"sv, "SHOW_STATION_NAMES"sv, "SHOW_SIGNS"sv, "FULL_ANIMATION"sv, ""sv, "FULL_DETAIL"sv, "WAYPOINTS"sv, "SHOW_COMPETITOR_SIGNS"sv};
+static constexpr std::initializer_list<std::string_view> _facility_display_opt_modes{"TRAIN"sv, "TRUCK_STOP"sv, "BUS_STOP"sv, "AIRPORT"sv, "DOCK"sv, ""sv, "GHOST"sv};
 
 #ifdef WITH_COCOA
 extern bool _allow_hidpi_window;

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -111,48 +111,48 @@ cat      = SC_BASIC
 name     = ""soundsset""
 type     = SLE_STRQ
 var      = BaseSounds::ini_set
-def      = nullptr
+def      = """"
 cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""musicset""
 type     = SLE_STRQ
 var      = BaseMusic::ini_set
-def      = nullptr
+def      = """"
 cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""videodriver""
 type     = SLE_STRQ
 var      = _ini_videodriver
-def      = nullptr
+def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""musicdriver""
 type     = SLE_STRQ
 var      = _ini_musicdriver
-def      = nullptr
+def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""sounddriver""
 type     = SLE_STRQ
 var      = _ini_sounddriver
-def      = nullptr
+def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""blitter""
 type     = SLE_STRQ
 var      = _ini_blitter
-def      = nullptr
+def      = """"
 
 [SDTG_SSTR]
 name     = ""language""
 type     = SLE_STR
 var      = _config_language_file
-def      = nullptr
+def      = """"
 cat      = SC_BASIC
 
 ; workaround for implicit lengthof() in SDTG_LIST
@@ -168,14 +168,14 @@ cat      = SC_BASIC
 name     = ""screenshot_format""
 type     = SLE_STR
 var      = _screenshot_format_name
-def      = nullptr
+def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""savegame_format""
 type     = SLE_STR
 var      = _savegame_format
-def      = nullptr
+def      = """"
 cat      = SC_EXPERT
 
 [SDTG_BOOL]
@@ -188,28 +188,28 @@ ifdef    = HAS_TRUETYPE_FONT
 name     = ""small_font""
 type     = SLE_STR
 var      = _fcsettings.small.font
-def      = nullptr
+def      = """"
 
 [SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""medium_font""
 type     = SLE_STR
 var      = _fcsettings.medium.font
-def      = nullptr
+def      = """"
 
 [SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""large_font""
 type     = SLE_STR
 var      = _fcsettings.large.font
-def      = nullptr
+def      = """"
 
 [SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""mono_font""
 type     = SLE_STR
 var      = _fcsettings.mono.font
-def      = nullptr
+def      = """"
 
 [SDTG_VAR]
 ifdef    = HAS_TRUETYPE_FONT
@@ -308,14 +308,14 @@ cat      = SC_BASIC
 name     = ""keyboard""
 type     = SLE_STR
 var      = _keyboard_opt[0]
-def      = nullptr
+def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""keyboard_caps""
 type     = SLE_STR
 var      = _keyboard_opt[1]
-def      = nullptr
+def      = """"
 cat      = SC_EXPERT
 
 [SDTG_VAR]

--- a/src/table/settings/multimedia_settings.ini
+++ b/src/table/settings/multimedia_settings.ini
@@ -132,14 +132,14 @@ cat      = SC_BASIC
 var      = music.custom_1
 type     = SLE_UINT8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
-def      = nullptr
+def      = """"
 cat      = SC_BASIC
 
 [SDTC_LIST]
 var      = music.custom_2
 type     = SLE_UINT8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
-def      = nullptr
+def      = """"
 cat      = SC_BASIC
 
 [SDTC_BOOL]

--- a/src/table/settings/network_private_settings.ini
+++ b/src/table/settings/network_private_settings.ini
@@ -47,7 +47,7 @@ var      = network.client_name
 type     = SLE_STR
 length   = NETWORK_CLIENT_NAME_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
-def      = nullptr
+def      = """"
 pre_cb   = NetworkValidateClientName
 post_cb  = NetworkUpdateClientName
 cat      = SC_BASIC
@@ -57,7 +57,7 @@ var      = network.server_name
 type     = SLE_STR
 length   = NETWORK_NAME_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
-def      = nullptr
+def      = """"
 pre_cb   = NetworkValidateServerName
 post_cb  = [](auto) { UpdateClientConfigValues(); }
 cat      = SC_BASIC
@@ -67,7 +67,7 @@ var      = network.connect_to_ip
 type     = SLE_STR
 length   = 0
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
-def      = nullptr
+def      = """"
 
 [SDTC_SSTR]
 var      = network.last_joined

--- a/src/table/settings/network_private_settings.ini
+++ b/src/table/settings/network_private_settings.ini
@@ -7,8 +7,8 @@
 ; Network settings as stored in the private configuration file ("private.cfg").
 
 [pre-amble]
-static constexpr std::initializer_list<const char*> _use_relay_service{"never", "ask", "allow"};
-static constexpr std::initializer_list<const char*> _participate_survey{"ask", "no", "yes"};
+static constexpr std::initializer_list<std::string_view> _use_relay_service{"never"sv, "ask"sv, "allow"sv};
+static constexpr std::initializer_list<std::string_view> _participate_survey{"ask"sv, "no"sv, "yes"sv};
 
 static const SettingVariant _network_private_settings_table[] = {
 [post-amble]

--- a/src/table/settings/network_secrets_settings.ini
+++ b/src/table/settings/network_secrets_settings.ini
@@ -39,7 +39,7 @@ var      = network.server_password
 type     = SLE_STR
 length   = NETWORK_PASSWORD_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
-def      = nullptr
+def      = """"
 pre_cb   = ReplaceAsteriskWithEmptyPassword
 post_cb  = [](auto) { NetworkServerUpdateGameInfo(); }
 cat      = SC_BASIC
@@ -49,7 +49,7 @@ var      = network.rcon_password
 type     = SLE_STR
 length   = NETWORK_PASSWORD_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
-def      = nullptr
+def      = """"
 pre_cb   = ReplaceAsteriskWithEmptyPassword
 cat      = SC_BASIC
 
@@ -58,7 +58,7 @@ var      = network.admin_password
 type     = SLE_STR
 length   = NETWORK_PASSWORD_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
-def      = nullptr
+def      = """"
 cat      = SC_BASIC
 
 [SDTC_SSTR]
@@ -66,7 +66,7 @@ var      = network.client_secret_key
 type     = SLE_STR
 length   = NETWORK_SECRET_KEY_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
-def      = nullptr
+def      = """"
 ; Prevent the user from setting the secret key from the console using 'setting'
 pre_cb   = [](auto) { return false; }
 
@@ -75,7 +75,7 @@ var      = network.client_public_key
 type     = SLE_STR
 length   = NETWORK_SECRET_KEY_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
-def      = nullptr
+def      = """"
 ; Prevent the user from setting the public key from the console using 'setting'
 pre_cb   = [](auto) { return false; }
 
@@ -84,11 +84,11 @@ var      = network.server_invite_code
 type     = SLE_STR
 length   = NETWORK_INVITE_CODE_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
-def      = nullptr
+def      = """"
 
 [SDTC_SSTR]
 var      = network.server_invite_code_secret
 type     = SLE_STR
 length   = NETWORK_INVITE_CODE_SECRET_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
-def      = nullptr
+def      = """"

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -10,7 +10,7 @@
 static void UpdateClientConfigValues();
 void ChangeNetworkRestartTime(bool reset);
 
-static constexpr std::initializer_list<const char*> _server_game_type{"local", "public", "invite-only"};
+static constexpr std::initializer_list<std::string_view> _server_game_type{"local"sv, "public"sv, "invite-only"sv};
 
 static const SettingVariant _network_settings_table[] = {
 [post-amble]

--- a/src/table/settings/news_display_settings.ini
+++ b/src/table/settings/news_display_settings.ini
@@ -7,7 +7,7 @@
 ; News display settings as stored in the main configuration file ("openttd.cfg").
 
 [pre-amble]
-static constexpr std::initializer_list<const char*> _news_display{ "off", "summarized", "full"};
+static constexpr std::initializer_list<std::string_view> _news_display{"off"sv, "summarized"sv, "full"sv};
 
 static const SettingVariant _news_display_settings_table[] = {
 [post-amble]

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -14,8 +14,8 @@
 ; be saved in their new place.
 
 [pre-amble]
-static constexpr std::initializer_list<const char*> _town_names{"english", "french", "german", "american", "latin", "silly", "swedish", "dutch", "finnish", "polish", "slovak", "norwegian", "hungarian", "austrian", "romanian", "czech", "swiss", "danish", "turkish", "italian", "catalan"};
-static constexpr std::initializer_list<const char*> _climates{"temperate", "arctic", "tropic", "toyland"};
+static constexpr std::initializer_list<std::string_view> _town_names{"english"sv, "french"sv, "german"sv, "american"sv, "latin"sv, "silly"sv, "swedish"sv, "dutch"sv, "finnish"sv, "polish"sv, "slovak"sv, "norwegian"sv, "hungarian"sv, "austrian"sv, "romanian"sv, "czech"sv, "swiss"sv, "danish"sv, "turkish"sv, "italian"sv, "catalan"sv};
+static constexpr std::initializer_list<std::string_view> _climates{"temperate"sv, "arctic"sv, "tropic"sv, "toyland"sv};
 
 static const SettingVariant _old_gameopt_settings_table[] = {
 /* In version 4 a new difficulty setting has been added to the difficulty settings,

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -75,7 +75,7 @@ type     = SLE_FILE_I16 | SLE_VAR_U16
 flags    = SettingFlag::NotInConfig
 var      = _old_diff_custom
 length   = 17
-def      = nullptr
+def      = """"
 to       = SLV_4
 
 [SDTG_LIST]
@@ -86,7 +86,7 @@ type     = SLE_UINT16
 flags    = SettingFlag::NotInConfig
 var      = _old_diff_custom
 length   = 18
-def      = nullptr
+def      = """"
 full     = nullptr
 from     = SLV_4
 

--- a/src/tests/test_window_desc.cpp
+++ b/src/tests/test_window_desc.cpp
@@ -32,11 +32,11 @@ private:
 
 TEST_CASE("WindowDesc - ini_key uniqueness")
 {
-	std::set<std::string> seen;
+	std::set<std::string_view> seen;
 
 	for (const WindowDesc *window_desc : *_window_descs) {
 
-		if (window_desc->ini_key == nullptr) continue;
+		if (window_desc->ini_key.empty()) continue;
 
 		CAPTURE(window_desc->ini_key);
 		CHECK((seen.find(window_desc->ini_key) == std::end(seen)));
@@ -49,7 +49,7 @@ TEST_CASE("WindowDesc - ini_key validity")
 {
 	const WindowDesc *window_desc = GENERATE(from_range(std::begin(*_window_descs), std::end(*_window_descs)));
 
-	bool has_inikey = window_desc->ini_key != nullptr;
+	bool has_inikey = !window_desc->ini_key.empty();
 	bool has_widget = std::any_of(std::begin(window_desc->nwid_parts), std::end(window_desc->nwid_parts), [](const NWidgetPart &part) { return part.type == WWT_DEFSIZEBOX || part.type == WWT_STICKYBOX; });
 
 	INFO(fmt::format("{}:{}", window_desc->source_location.file_name(), window_desc->source_location.line()));

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2242,7 +2242,7 @@ static constexpr NWidgetPart _nested_toolbar_normal_widgets[] = {
 };
 
 static WindowDesc _toolb_normal_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
 	{WindowDefaultFlag::NoFocus, WindowDefaultFlag::NoClose},
 	_nested_toolbar_normal_widgets,
@@ -2585,7 +2585,7 @@ static constexpr NWidgetPart _nested_toolb_scen_widgets[] = {
 };
 
 static WindowDesc _toolb_scen_desc(
-	WDP_MANUAL, nullptr, 0, 0,
+	WDP_MANUAL, {}, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
 	{WindowDefaultFlag::NoFocus, WindowDefaultFlag::NoClose},
 	_nested_toolb_scen_widgets,

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -104,7 +104,7 @@ std::vector<WindowDesc*> *_window_descs = nullptr;
 std::string _windows_file;
 
 /** Window description constructor. */
-WindowDesc::WindowDesc(WindowPosition def_pos, const char *ini_key, int16_t def_width_trad, int16_t def_height_trad,
+WindowDesc::WindowDesc(WindowPosition def_pos, std::string_view ini_key, int16_t def_width_trad, int16_t def_height_trad,
 			WindowClass window_class, WindowClass parent_class, WindowDefaultFlags flags,
 			const std::span<const NWidgetPart> nwid_parts, HotkeyList *hotkeys,
 			const std::source_location location) :
@@ -156,7 +156,7 @@ void WindowDesc::LoadFromConfig()
 	IniFile ini;
 	ini.LoadFromDisk(_windows_file, NO_DIRECTORY);
 	for (WindowDesc *wd : *_window_descs) {
-		if (wd->ini_key == nullptr) continue;
+		if (wd->ini_key.empty()) continue;
 		IniLoadWindowSettings(ini, wd->ini_key, wd);
 	}
 }
@@ -166,8 +166,7 @@ void WindowDesc::LoadFromConfig()
  */
 static bool DescSorter(WindowDesc * const &a, WindowDesc * const &b)
 {
-	if (a->ini_key != nullptr && b->ini_key != nullptr) return strcmp(a->ini_key, b->ini_key) < 0;
-	return a->ini_key != nullptr;
+	return a->ini_key < b->ini_key;
 }
 
 /**
@@ -181,7 +180,7 @@ void WindowDesc::SaveToConfig()
 	IniFile ini;
 	ini.LoadFromDisk(_windows_file, NO_DIRECTORY);
 	for (WindowDesc *wd : *_window_descs) {
-		if (wd->ini_key == nullptr) continue;
+		if (wd->ini_key.empty()) continue;
 		IniSaveWindowSettings(ini, wd->ini_key, wd);
 	}
 	ini.SaveToDisk(_windows_file);

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -166,7 +166,7 @@ struct HotkeyList;
  */
 struct WindowDesc {
 
-	WindowDesc(WindowPosition default_pos, const char *ini_key, int16_t def_width_trad, int16_t def_height_trad,
+	WindowDesc(WindowPosition default_pos, std::string_view ini_key, int16_t def_width_trad, int16_t def_height_trad,
 			WindowClass window_class, WindowClass parent_class, WindowDefaultFlags flags,
 			const std::span<const NWidgetPart> nwid_parts, HotkeyList *hotkeys = nullptr,
 			const std::source_location location = std::source_location::current());
@@ -177,7 +177,7 @@ struct WindowDesc {
 	const WindowPosition default_pos; ///< Preferred position of the window. @see WindowPosition()
 	const WindowClass cls; ///< Class of the window, @see WindowClass.
 	const WindowClass parent_cls; ///< Class of the parent window. @see WindowClass
-	const char *ini_key; ///< Key to store window defaults in openttd.cfg. \c nullptr if nothing shall be stored.
+	const std::string_view ini_key; ///< Key to store window defaults in openttd.cfg. An empty string if nothing shall be stored.
 	const WindowDefaultFlags flags; ///< Flags. @see WindowDefaultFlag
 	const std::span<const NWidgetPart> nwid_parts; ///< Span of nested widget parts describing the window.
 	const HotkeyList *hotkeys; ///< Hotkeys for the window.


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

The `ini_key` of windows and default of string-ish settings allowed for `nullptr` to denote nothing, but an empty string is equally powerful. So, replace the `char *` with `std::string_view` and `nullptr` with an empty string(view).

Also the lookup tables for x-of-many settings used `char*`, so change these to `std::string_view` as well. Apparently a `std::initializer_list<std::string_view>` cannot be initialised with basic strings in `constexpr`, but for `static_assert` `constexpr` was needed. Adding `sv` literals makes it `constexpr`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
