### PR TITLE
Fix: Crash/Undefined behaviour in station view window.

### DIFF
--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -1759,6 +1759,7 @@ struct StationViewWindow : public Window {
 	 */
 	StringID SearchNonStop(CargoDataEntry &cd, StationID station, int column)
 	{
+		assert(column < NUM_COLUMNS);
 		CargoDataEntry *parent = cd.GetParent();
 		for (int i = column - 1; i > 0; --i) {
 			if (this->groupings[i] == GR_DESTINATION) {
@@ -1771,7 +1772,7 @@ struct StationViewWindow : public Window {
 			parent = parent->GetParent();
 		}
 
-		if (this->groupings[column + 1] == GR_DESTINATION) {
+		if (column < NUM_COLUMNS - 1 && this->groupings[column + 1] == GR_DESTINATION) {
 			CargoDataSet::iterator begin = cd.Begin();
 			CargoDataSet::iterator end = cd.End();
 			if (begin != end && ++(cd.Begin()) == end && (*(begin))->GetStation() == station) {
@@ -1796,6 +1797,7 @@ struct StationViewWindow : public Window {
 	 */
 	int DrawEntries(CargoDataEntry &entry, const Rect &r, int pos, int maxrows, int column, CargoType cargo = INVALID_CARGO)
 	{
+		assert(column < NUM_COLUMNS);
 		if (this->sortings[column] == CargoSortType::AsGrouping) {
 			if (this->groupings[column] != GR_CARGO) {
 				entry.Resort(CargoSortType::StationString, this->sort_orders[column]);
@@ -1855,7 +1857,7 @@ struct StationViewWindow : public Window {
 				this->SetDisplayedRow(cd);
 			}
 			--pos;
-			if (auto_distributed || column == 0) {
+			if ((auto_distributed || column == 0) && column < NUM_COLUMNS - 1) {
 				pos = this->DrawEntries(cd, r, pos, maxrows, column + 1, cargo);
 			}
 		}


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Crash/Undefined behaviour in station view window.

No column limit was applied when drawing waiting cargo, which could cause out-of-bounds array access.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Limit the displayed column depth to prevent out of bounds access.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
