### PR TITLE
Codechange: replace even more char* with std::string_view

### DIFF
--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -19,7 +19,7 @@ typedef void (*OGLProc)();
 typedef OGLProc (*GetOGLProcAddressProc)(const char *proc);
 
 bool IsOpenGLVersionAtLeast(uint8_t major, uint8_t minor);
-const char *FindStringInExtensionList(const char *string, const char *substring);
+bool HasStringInExtensionList(std::string_view string, std::string_view substring);
 
 class OpenGLSprite;
 

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1379,13 +1379,13 @@ static void LoadWGLExtensions()
 			/* Get list of WGL extensions. */
 			PFNWGLGETEXTENSIONSSTRINGARBPROC wglGetExtensionsStringARB = (PFNWGLGETEXTENSIONSSTRINGARBPROC)wglGetProcAddress("wglGetExtensionsStringARB");
 			if (wglGetExtensionsStringARB != nullptr) {
-				const char *wgl_exts = wglGetExtensionsStringARB(dc);
+				std::string_view wgl_exts = wglGetExtensionsStringARB(dc);
 				/* Bind supported functions. */
-				if (FindStringInExtensionList(wgl_exts, "WGL_ARB_create_context") != nullptr) {
+				if (HasStringInExtensionList(wgl_exts, "WGL_ARB_create_context")) {
 					_wglCreateContextAttribsARB = (PFNWGLCREATECONTEXTATTRIBSARBPROC)wglGetProcAddress("wglCreateContextAttribsARB");
 				}
-				_hasWGLARBCreateContextProfile = FindStringInExtensionList(wgl_exts, "WGL_ARB_create_context_profile") != nullptr;
-				if (FindStringInExtensionList(wgl_exts, "WGL_EXT_swap_control") != nullptr) {
+				_hasWGLARBCreateContextProfile = HasStringInExtensionList(wgl_exts, "WGL_ARB_create_context_profile");
+				if (HasStringInExtensionList(wgl_exts, "WGL_EXT_swap_control")) {
 					_wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
 				}
 			}


### PR DESCRIPTION
## Motivation / Problem

C-style string handling.


## Description

~GameText had a function to remove trailing spaces and newlines from a line and strgen also has similar code, so put it into string_func and use this in both cases. This does mean that GameText will now also trim trailing tabs.~

In OpenGL there are a lot of casts to `const char *` and inconsistent  checks against `nullptr`. Most of these casts were for the same call, so add a wrapper that simply returns an optional with string_view. It won't remove all `char *`s, but at least quite a few are out of mind.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
