### PR TITLE
Codechange: use std::string_view for sq_getstring

### DIFF
--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -174,7 +174,7 @@ typedef SQObject HSQOBJECT;
 typedef SQInteger (*SQFUNCTION)(HSQUIRRELVM);
 typedef SQInteger (*SQRELEASEHOOK)(SQUserPointer,SQInteger size);
 typedef void (*SQCOMPILERERROR)(HSQUIRRELVM,const SQChar * /*desc*/,const SQChar * /*source*/,SQInteger /*line*/,SQInteger /*column*/);
-typedef void (*SQPRINTFUNCTION)(HSQUIRRELVM,const std::string &);
+typedef void (*SQPRINTFUNCTION)(HSQUIRRELVM,std::string_view);
 
 typedef SQInteger (*SQWRITEFUNC)(SQUserPointer,SQUserPointer,SQInteger);
 typedef SQInteger (*SQREADFUNC)(SQUserPointer,SQUserPointer,SQInteger);
@@ -250,7 +250,7 @@ SQRESULT sq_getbase(HSQUIRRELVM v,SQInteger idx);
 SQBool sq_instanceof(HSQUIRRELVM v);
 void sq_tostring(HSQUIRRELVM v,SQInteger idx);
 void sq_tobool(HSQUIRRELVM v, SQInteger idx, SQBool *b);
-SQRESULT sq_getstring(HSQUIRRELVM v,SQInteger idx,const SQChar **c);
+SQRESULT sq_getstring(HSQUIRRELVM v,SQInteger idx,std::string_view &str);
 SQRESULT sq_getinteger(HSQUIRRELVM v,SQInteger idx,SQInteger *i);
 SQRESULT sq_getfloat(HSQUIRRELVM v,SQInteger idx,SQFloat *f);
 SQRESULT sq_getbool(HSQUIRRELVM v,SQInteger idx,SQBool *b);

--- a/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
@@ -16,7 +16,6 @@ void sqstd_printcallstack(HSQUIRRELVM v)
 		SQInteger i;
 		SQBool b;
 		SQFloat f;
-		const SQChar *s;
 		SQInteger level=1; //1 is to skip this function that is level 0
 		const SQChar *name=nullptr;
 		SQInteger seq=0;
@@ -66,10 +65,12 @@ void sqstd_printcallstack(HSQUIRRELVM v)
 				case OT_USERPOINTER:
 					pf(v,fmt::format("[{}] USERPOINTER\n",name));
 					break;
-				case OT_STRING:
-					sq_getstring(v,-1,&s);
-					pf(v,fmt::format("[{}] \"{}\"\n",name,s));
+				case OT_STRING: {
+					std::string_view view;
+					sq_getstring(v,-1,view);
+					pf(v,fmt::format("[{}] \"{}\"\n",name,view));
 					break;
+				}
 				case OT_TABLE:
 					pf(v,fmt::format("[{}] TABLE\n",name));
 					break;
@@ -117,10 +118,10 @@ static SQInteger _sqstd_aux_printerror(HSQUIRRELVM v)
 {
 	SQPRINTFUNCTION pf = sq_getprintfunc(v);
 	if(pf) {
-		const SQChar *sErr = nullptr;
+		std::string_view error;
 		if(sq_gettop(v)>=1) {
-			if(SQ_SUCCEEDED(sq_getstring(v,2,&sErr)))	{
-				pf(v,fmt::format("\nAN ERROR HAS OCCURRED [{}]\n",sErr));
+			if(SQ_SUCCEEDED(sq_getstring(v,2,error))) {
+				pf(v,fmt::format("\nAN ERROR HAS OCCURRED [{}]\n",error));
 			}
 			else{
 				pf(v,"\nAN ERROR HAS OCCURRED [unknown]\n");

--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -553,11 +553,11 @@ SQRESULT sq_getbool(HSQUIRRELVM v,SQInteger idx,SQBool *b)
 	return SQ_ERROR;
 }
 
-SQRESULT sq_getstring(HSQUIRRELVM v,SQInteger idx,const SQChar **c)
+SQRESULT sq_getstring(HSQUIRRELVM v,SQInteger idx,std::string_view &str)
 {
 	SQObjectPtr *o = nullptr;
 	_GETSAFE_OBJ(v, idx, OT_STRING,o);
-	*c = _stringval(*o);
+	str = _stringval(*o);
 	return SQ_OK;
 }
 

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -170,9 +170,9 @@ static SQInteger get_slice_params(HSQUIRRELVM v,SQInteger &sidx,SQInteger &eidx,
 
 static SQInteger base_print(HSQUIRRELVM v)
 {
-	const SQChar *str;
+	std::string_view str;
 	sq_tostring(v,2);
-	sq_getstring(v,-1,&str);
+	sq_getstring(v,-1,str);
 	if(_ss(v)->_printfunc) _ss(v)->_printfunc(v,str);
 	return 0;
 }
@@ -181,12 +181,12 @@ static SQInteger base_print(HSQUIRRELVM v)
 static SQInteger base_compilestring(HSQUIRRELVM v)
 {
 	SQInteger nargs=sq_gettop(v);
-	const SQChar *src=nullptr,*name="unnamedbuffer";
+	std::string_view src, name="unnamedbuffer";
 	SQInteger size;
-	sq_getstring(v,2,&src);
+	sq_getstring(v,2,src);
 	size=sq_getsize(v,2);
 	if(nargs>2){
-		sq_getstring(v,3,&name);
+		sq_getstring(v,3,name);
 	}
 	if(SQ_SUCCEEDED(sq_compilebuffer(v,src,size,name,SQFalse)))
 		return 1;
@@ -649,13 +649,13 @@ static SQInteger string_slice(HSQUIRRELVM v)
 static SQInteger string_find(HSQUIRRELVM v)
 {
 	SQInteger top,start_idx=0;
-	const SQChar *str,*substr,*ret;
-	if(((top=sq_gettop(v))>1) && SQ_SUCCEEDED(sq_getstring(v,1,&str)) && SQ_SUCCEEDED(sq_getstring(v,2,&substr))){
+	std::string_view str,substr;
+	if(((top=sq_gettop(v))>1) && SQ_SUCCEEDED(sq_getstring(v,1,str)) && SQ_SUCCEEDED(sq_getstring(v,2,substr))){
 		if(top>2)sq_getinteger(v,3,&start_idx);
 		if((sq_getsize(v,1)>start_idx) && (start_idx>=0)){
-			ret=strstr(&str[start_idx],substr);
-			if(ret){
-				sq_pushinteger(v,(SQInteger)(ret-str));
+			auto ret = str.find(substr, start_idx);
+			if(ret != std::string_view::npos){
+				sq_pushinteger(v,static_cast<SQInteger>(ret));
 				return 1;
 			}
 		}

--- a/src/script/api/script_admin.cpp
+++ b/src/script/api/script_admin.cpp
@@ -45,10 +45,10 @@ bool ScriptAdminMakeJSON(nlohmann::json &json, HSQUIRRELVM vm, SQInteger index, 
 		}
 
 		case OT_STRING: {
-			const SQChar *buf;
-			sq_getstring(vm, index, &buf);
+			std::string_view view;
+			sq_getstring(vm, index, view);
 
-			json = std::string(buf);
+			json = view;
 			return true;
 		}
 
@@ -78,9 +78,9 @@ bool ScriptAdminMakeJSON(nlohmann::json &json, HSQUIRRELVM vm, SQInteger index, 
 			sq_pushnull(vm);
 			while (SQ_SUCCEEDED(sq_next(vm, index - 1))) {
 				sq_tostring(vm, -2);
-				const SQChar *buf;
-				sq_getstring(vm, -1, &buf);
-				std::string key = std::string(buf);
+				std::string_view view;
+				sq_getstring(vm, -1, view);
+				std::string key{view};
 				sq_pop(vm, 1);
 
 				nlohmann::json value;

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -60,10 +60,10 @@ SQInteger ScriptText::_SetParam(int parameter, HSQUIRRELVM vm)
 
 	switch (sq_gettype(vm, -1)) {
 		case OT_STRING: {
-			const SQChar *value;
-			sq_getstring(vm, -1, &value);
+			std::string_view view;
+			sq_getstring(vm, -1, view);
 
-			this->param[parameter] = StrMakeValid(value);
+			this->param[parameter] = StrMakeValid(view);
 			break;
 		}
 
@@ -135,10 +135,10 @@ SQInteger ScriptText::_set(HSQUIRRELVM vm)
 	int32_t k;
 
 	if (sq_gettype(vm, 2) == OT_STRING) {
-		const SQChar *key_string;
-		sq_getstring(vm, 2, &key_string);
+		std::string_view view;
+		sq_getstring(vm, 2, view);
 
-		std::string str = StrMakeValid(key_string);
+		std::string str = StrMakeValid(view);
 		if (!str.starts_with("param_") || str.size() > 8) return SQ_ERROR;
 
 		k = stoi(str.substr(6));

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -40,10 +40,10 @@ ScriptStorage::~ScriptStorage() = default;
  * @param error_msg Is this an error message?
  * @param message The actual message text.
  */
-static void PrintFunc(bool error_msg, const std::string &message)
+static void PrintFunc(bool error_msg, std::string_view message)
 {
 	/* Convert to OpenTTD internal capable string */
-	ScriptController::Print(error_msg, message);
+	ScriptController::Print(error_msg, std::string{message});
 }
 
 ScriptInstance::ScriptInstance(std::string_view api_name)
@@ -383,9 +383,9 @@ static const SaveLoad _script_byte[] = {
 				_script_sl_byte = SQSL_STRING;
 				SlObject(nullptr, _script_byte);
 			}
-			const SQChar *buf;
-			sq_getstring(vm, index, &buf);
-			size_t len = strlen(buf) + 1;
+			std::string_view view;
+			sq_getstring(vm, index, view);
+			size_t len = view.size() + 1;
 			if (len >= 255) {
 				ScriptLog::Error("Maximum string length is 254 chars. No data saved.");
 				return false;
@@ -393,7 +393,7 @@ static const SaveLoad _script_byte[] = {
 			if (!test) {
 				_script_sl_byte = (uint8_t)len;
 				SlObject(nullptr, _script_byte);
-				SlCopy(const_cast<char *>(buf), len, SLE_CHAR);
+				SlCopy(const_cast<char *>(view.data()), len, SLE_CHAR);
 			}
 			return true;
 		}
@@ -678,10 +678,10 @@ bool ScriptInstance::IsPaused()
 				case SQSL_INSTANCE: {
 					SQInteger top = sq_gettop(this->vm);
 					LoadObjects(this->vm, this->data);
-					const SQChar *buf;
-					sq_getstring(this->vm, -1, &buf);
+					std::string_view view;
+					sq_getstring(this->vm, -1, view);
 					Squirrel *engine = static_cast<Squirrel *>(sq_getforeignptr(this->vm));
-					std::string class_name = fmt::format("{}{}", engine->GetAPIName(), buf);
+					std::string class_name = fmt::format("{}{}", engine->GetAPIName(), view);
 					sq_pushroottable(this->vm);
 					sq_pushstring(this->vm, class_name);
 					if (SQ_FAILED(sq_get(this->vm, -2))) throw Script_FatalError(fmt::format("'{}' doesn't exist", class_name));

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -194,7 +194,7 @@ void Squirrel::CompileError(HSQUIRRELVM vm, const SQChar *desc, const SQChar *so
 	}
 }
 
-void Squirrel::ErrorPrintFunc(HSQUIRRELVM vm, const std::string &s)
+void Squirrel::ErrorPrintFunc(HSQUIRRELVM vm, std::string_view s)
 {
 	/* Check if we have a custom print function */
 	SQPrintFunc *func = ((Squirrel *)sq_getforeignptr(vm))->print_func;
@@ -205,7 +205,7 @@ void Squirrel::ErrorPrintFunc(HSQUIRRELVM vm, const std::string &s)
 	}
 }
 
-void Squirrel::RunError(HSQUIRRELVM vm, const SQChar *error)
+void Squirrel::RunError(HSQUIRRELVM vm, std::string_view error)
 {
 	/* Set the print function to something that prints to stderr */
 	SQPRINTFUNCTION pf = sq_getprintfunc(vm);
@@ -229,11 +229,11 @@ void Squirrel::RunError(HSQUIRRELVM vm, const SQChar *error)
 
 SQInteger Squirrel::_RunError(HSQUIRRELVM vm)
 {
-	const SQChar *sErr = nullptr;
+	std::string_view view;
 
 	if (sq_gettop(vm) >= 1) {
-		if (SQ_SUCCEEDED(sq_getstring(vm, -1, &sErr))) {
-			Squirrel::RunError(vm, sErr);
+		if (SQ_SUCCEEDED(sq_getstring(vm, -1, view))) {
+			Squirrel::RunError(vm, view);
 			return 0;
 		}
 	}
@@ -242,7 +242,7 @@ SQInteger Squirrel::_RunError(HSQUIRRELVM vm)
 	return 0;
 }
 
-void Squirrel::PrintFunc(HSQUIRRELVM vm, const std::string &s)
+void Squirrel::PrintFunc(HSQUIRRELVM vm, std::string_view s)
 {
 	/* Check if we have a custom print function */
 	SQPrintFunc *func = ((Squirrel *)sq_getforeignptr(vm))->print_func;

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -26,7 +26,7 @@ class Squirrel {
 	friend class ScriptInstance;
 
 private:
-	typedef void (SQPrintFunc)(bool error_msg, const std::string &message);
+	using SQPrintFunc = void (bool error_msg, std::string_view message);
 
 	HSQUIRRELVM vm;          ///< The VirtualMachine instance for squirrel
 	void *global_pointer;    ///< Can be set by who ever initializes Squirrel
@@ -60,17 +60,17 @@ protected:
 	/**
 	 * The RunError handler.
 	 */
-	static void RunError(HSQUIRRELVM vm, const SQChar *error);
+	static void RunError(HSQUIRRELVM vm, std::string_view error);
 
 	/**
 	 * If a user runs 'print' inside a script, this function gets the params.
 	 */
-	static void PrintFunc(HSQUIRRELVM vm, const std::string &s);
+	static void PrintFunc(HSQUIRRELVM vm, std::string_view s);
 
 	/**
 	 * If an error has to be print, this function is called.
 	 */
-	static void ErrorPrintFunc(HSQUIRRELVM vm, const std::string &s);
+	static void ErrorPrintFunc(HSQUIRRELVM vm, std::string_view s);
 
 public:
 	Squirrel(std::string_view api_name);

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -110,9 +110,9 @@ namespace SQConvert {
 			/* Convert what-ever there is as parameter to a string */
 			sq_tostring(vm, index);
 
-			const SQChar *tmp;
-			sq_getstring(vm, -1, &tmp);
-			std::string result = StrMakeValid(tmp);
+			std::string_view view;
+			sq_getstring(vm, -1, view);
+			std::string result = StrMakeValid(view);
 			sq_poptop(vm);
 			return result;
 		}

--- a/src/script/squirrel_std.cpp
+++ b/src/script/squirrel_std.cpp
@@ -41,9 +41,9 @@ SQInteger SquirrelStd::max(HSQUIRRELVM vm)
 SQInteger SquirrelStd::require(HSQUIRRELVM vm)
 {
 	SQInteger top = sq_gettop(vm);
-	const SQChar *filename;
+	std::string_view filename;
 
-	sq_getstring(vm, 2, &filename);
+	sq_getstring(vm, 2, filename);
 
 	/* Get the script-name of the current file, so we can work relative from it */
 	SQStackInfos si;


### PR DESCRIPTION
## Motivation / Problem

C-style strings, or in this case also... `strlen`.


## Description

Let `sq_getstring` return (byref) a `std::string_view` instead of a `char **`.


## Limitations

Even though `SQString` has a length, that is not (yet) used to create the `std::string_view`. That would require changing `_stringval`, which incurs many further refactors within Squirrel, which I've opted to skip for this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
