### PR TITLE
Add: [BaseSet, NewGRF] Support alternative sprites for RTL languages.

### DIFF
--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -21,12 +21,12 @@
 static FBlitter_32bppAnim iFBlitter_32bppAnim;
 
 template <BlitterMode mode>
-inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom)
+inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck)
 {
 	const SpriteData *src = (const SpriteData *)bp->sprite;
 
-	const Colour *src_px = reinterpret_cast<const Colour *>(src->data + src->offset[0][zoom]);
-	const uint16_t *src_n = reinterpret_cast<const uint16_t *>(src->data + src->offset[1][zoom]);
+	const Colour *src_px = reinterpret_cast<const Colour *>(src->data + src->offset[0][sck]);
+	const uint16_t *src_n = reinterpret_cast<const uint16_t *>(src->data + src->offset[1][sck]);
 
 	for (uint i = bp->skip_top; i != 0; i--) {
 		src_px = (const Colour *)((const uint8_t *)src_px + *(const uint32_t *)src_px);
@@ -261,22 +261,22 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 	}
 }
 
-void Blitter_32bppAnim::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_32bppAnim::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 {
 	if (_screen_disable_anim) {
 		/* This means our output is not to the screen, so we can't be doing any animation stuff, so use our parent Draw() */
-		Blitter_32bppOptimized::Draw(bp, mode, zoom);
+		Blitter_32bppOptimized::Draw(bp, mode, sck);
 		return;
 	}
 
 	switch (mode) {
 		default: NOT_REACHED();
-		case BlitterMode::Normal: Draw<BlitterMode::Normal>(bp, zoom); return;
-		case BlitterMode::ColourRemap: Draw<BlitterMode::ColourRemap>(bp, zoom); return;
-		case BlitterMode::Transparent: Draw<BlitterMode::Transparent>(bp, zoom); return;
-		case BlitterMode::TransparentRemap: Draw<BlitterMode::TransparentRemap>(bp, zoom); return;
-		case BlitterMode::CrashRemap: Draw<BlitterMode::CrashRemap>(bp, zoom); return;
-		case BlitterMode::BlackRemap: Draw<BlitterMode::BlackRemap>(bp, zoom); return;
+		case BlitterMode::Normal: Draw<BlitterMode::Normal>(bp, sck); return;
+		case BlitterMode::ColourRemap: Draw<BlitterMode::ColourRemap>(bp, sck); return;
+		case BlitterMode::Transparent: Draw<BlitterMode::Transparent>(bp, sck); return;
+		case BlitterMode::TransparentRemap: Draw<BlitterMode::TransparentRemap>(bp, sck); return;
+		case BlitterMode::CrashRemap: Draw<BlitterMode::CrashRemap>(bp, sck); return;
+		case BlitterMode::BlackRemap: Draw<BlitterMode::BlackRemap>(bp, sck); return;
 	}
 }
 

--- a/src/blitter/32bpp_anim.hpp
+++ b/src/blitter/32bpp_anim.hpp
@@ -32,7 +32,7 @@ public:
 		this->palette = _cur_palette;
 	}
 
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
 	void SetPixel(void *video, int x, int y, uint8_t colour) override;
 	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash) override;
@@ -64,7 +64,7 @@ public:
 		return across + (lines * this->anim_buf_pitch);
 	}
 
-	template <BlitterMode mode> void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
+	template <BlitterMode mode> void Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck);
 };
 
 /** Factory for the 32bpp blitter with animation. */

--- a/src/blitter/32bpp_anim_sse4.hpp
+++ b/src/blitter/32bpp_anim_sse4.hpp
@@ -40,9 +40,9 @@ public:
 	void Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck);
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) override
 	{
-		return Blitter_32bppSSE_Base::Encode(sprite_type, sprite, allocator);
+		return Blitter_32bppSSE_Base::Encode(sprite_type, sprite, has_rtl, allocator);
 	}
 	std::string_view GetName() override { return "32bpp-sse4-anim"; }
 	using Blitter_32bppSSE2_Anim::LookupColourInPalette;

--- a/src/blitter/32bpp_anim_sse4.hpp
+++ b/src/blitter/32bpp_anim_sse4.hpp
@@ -37,8 +37,8 @@ private:
 
 public:
 	template <BlitterMode mode, Blitter_32bppSSE_Base::ReadMode read_mode, Blitter_32bppSSE_Base::BlockType bt_last, bool translucent, bool animated>
-	void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck);
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 
 	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override
 	{

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -23,20 +23,20 @@ static FBlitter_32bppOptimized iFBlitter_32bppOptimized;
  *
  * @tparam mode blitter mode
  * @param bp further blitting parameters
- * @param zoom zoom level at which we are drawing
+ * @param sck sprite collection key to draw
  */
 template <BlitterMode mode, bool Tpal_to_rgb>
-inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom)
+inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck)
 {
 	const SpriteData *src = (const SpriteData *)bp->sprite;
 
 	/* src_px : each line begins with uint32_t n = 'number of bytes in this line',
 	 *          then n times is the Colour struct for this line */
-	const Colour *src_px = reinterpret_cast<const Colour *>(src->data + src->offset[0][zoom]);
+	const Colour *src_px = reinterpret_cast<const Colour *>(src->data + src->offset[0][sck]);
 	/* src_n  : each line begins with uint32_t n = 'number of bytes in this line',
 	 *          then interleaved stream of 'm' and 'n' channels. 'm' is remap,
 	 *          'n' is number of bytes with the same alpha channel class */
-	const uint16_t *src_n = reinterpret_cast<const uint16_t *>(src->data + src->offset[1][zoom]);
+	const uint16_t *src_n = reinterpret_cast<const uint16_t *>(src->data + src->offset[1][sck]);
 
 	/* skip upper lines in src_px and src_n */
 	for (uint i = bp->skip_top; i != 0; i--) {
@@ -257,32 +257,32 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 }
 
 template <bool Tpal_to_rgb>
-void Blitter_32bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_32bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 {
 	switch (mode) {
 		default: NOT_REACHED();
-		case BlitterMode::Normal: Draw<BlitterMode::Normal, Tpal_to_rgb>(bp, zoom); return;
-		case BlitterMode::ColourRemap: Draw<BlitterMode::ColourRemap, Tpal_to_rgb>(bp, zoom); return;
-		case BlitterMode::Transparent: Draw<BlitterMode::Transparent, Tpal_to_rgb>(bp, zoom); return;
-		case BlitterMode::TransparentRemap: Draw<BlitterMode::TransparentRemap, Tpal_to_rgb>(bp, zoom); return;
-		case BlitterMode::CrashRemap: Draw<BlitterMode::CrashRemap, Tpal_to_rgb>(bp, zoom); return;
-		case BlitterMode::BlackRemap: Draw<BlitterMode::BlackRemap, Tpal_to_rgb>(bp, zoom); return;
+		case BlitterMode::Normal: Draw<BlitterMode::Normal, Tpal_to_rgb>(bp, sck); return;
+		case BlitterMode::ColourRemap: Draw<BlitterMode::ColourRemap, Tpal_to_rgb>(bp, sck); return;
+		case BlitterMode::Transparent: Draw<BlitterMode::Transparent, Tpal_to_rgb>(bp, sck); return;
+		case BlitterMode::TransparentRemap: Draw<BlitterMode::TransparentRemap, Tpal_to_rgb>(bp, sck); return;
+		case BlitterMode::CrashRemap: Draw<BlitterMode::CrashRemap, Tpal_to_rgb>(bp, sck); return;
+		case BlitterMode::BlackRemap: Draw<BlitterMode::BlackRemap, Tpal_to_rgb>(bp, sck); return;
 	}
 }
 
-template void Blitter_32bppOptimized::Draw<true>(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom);
-template void Blitter_32bppOptimized::Draw<false>(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom);
+template void Blitter_32bppOptimized::Draw<true>(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck);
+template void Blitter_32bppOptimized::Draw<false>(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck);
 
 /**
  * Draws a sprite to a (screen) buffer. Calls adequate templated function.
  *
  * @param bp further blitting parameters
  * @param mode blitter mode
- * @param zoom zoom level at which we are drawing
+ * @param sck sprite collection key to draw
  */
-void Blitter_32bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_32bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 {
-	this->Draw<false>(bp, mode, zoom);
+	this->Draw<false>(bp, mode, sck);
 }
 
 template <bool Tpal_to_rgb>
@@ -316,16 +316,16 @@ Sprite *Blitter_32bppOptimized::EncodeInternal(SpriteType sprite_type, const Spr
 		if (zoom_max == zoom_min) zoom_max = ZoomLevel::Max;
 	}
 
-	for (ZoomLevel z = zoom_min; z <= zoom_max; z++) {
-		const SpriteLoader::Sprite *src_orig = &sprite[z];
+	for (auto sck : SpriteCollKeyRange(zoom_min, zoom_max)) {
+		const SpriteLoader::Sprite *src_orig = &sprite[sck];
 
 		uint size = src_orig->height * src_orig->width;
 
-		dst_px_orig[z] = std::make_unique<Colour[]>(size + src_orig->height * 2);
-		dst_n_orig[z]  = std::make_unique<uint16_t[]>(size * 2 + src_orig->height * 4 * 2);
+		dst_px_orig[sck] = std::make_unique<Colour[]>(size + src_orig->height * 2);
+		dst_n_orig[sck] = std::make_unique<uint16_t[]>(size * 2 + src_orig->height * 4 * 2);
 
-		uint32_t *dst_px_ln = reinterpret_cast<uint32_t *>(dst_px_orig[z].get());
-		uint32_t *dst_n_ln  = reinterpret_cast<uint32_t *>(dst_n_orig[z].get());
+		uint32_t *dst_px_ln = reinterpret_cast<uint32_t *>(dst_px_orig[sck].get());
+		uint32_t *dst_n_ln = reinterpret_cast<uint32_t *>(dst_n_orig[sck].get());
 
 		const SpriteLoader::CommonPixel *src = (const SpriteLoader::CommonPixel *)src_orig->data;
 
@@ -406,13 +406,13 @@ Sprite *Blitter_32bppOptimized::EncodeInternal(SpriteType sprite_type, const Spr
 			dst_n_ln =  (uint32_t *)dst_n;
 		}
 
-		lengths[0][z] = reinterpret_cast<uint8_t *>(dst_px_ln) - reinterpret_cast<uint8_t *>(dst_px_orig[z].get()); // all are aligned to 4B boundary
-		lengths[1][z] = reinterpret_cast<uint8_t *>(dst_n_ln) - reinterpret_cast<uint8_t *>(dst_n_orig[z].get());
+		lengths[0][sck] = reinterpret_cast<uint8_t *>(dst_px_ln) - reinterpret_cast<uint8_t *>(dst_px_orig[sck].get()); // all are aligned to 4B boundary
+		lengths[1][sck] = reinterpret_cast<uint8_t *>(dst_n_ln) - reinterpret_cast<uint8_t *>(dst_n_orig[sck].get());
 	}
 
 	uint len = 0; // total length of data
-	for (ZoomLevel z = zoom_min; z <= zoom_max; z++) {
-		len += lengths[0][z] + lengths[1][z];
+	for (auto sck : SpriteCollKeyRange(zoom_min, zoom_max)) {
+		len += lengths[0][sck] + lengths[1][sck];
 	}
 
 	Sprite *dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite) + sizeof(SpriteData) + len);
@@ -426,14 +426,14 @@ Sprite *Blitter_32bppOptimized::EncodeInternal(SpriteType sprite_type, const Spr
 	SpriteData *dst = (SpriteData *)dest_sprite->data;
 
 	uint32_t offset = 0;
-	for (ZoomLevel z = zoom_min; z <= zoom_max; z++) {
-		dst->offset[0][z] = offset;
-		offset += lengths[0][z];
-		dst->offset[1][z] = offset;
-		offset += lengths[1][z];
+	for (auto sck : SpriteCollKeyRange(zoom_min, zoom_max)) {
+		dst->offset[0][sck] = offset;
+		offset += lengths[0][sck];
+		dst->offset[1][sck] = offset;
+		offset += lengths[1][sck];
 
-		std::copy_n(reinterpret_cast<uint8_t *>(dst_px_orig[z].get()), lengths[0][z], dst->data + dst->offset[0][z]);
-		std::copy_n(reinterpret_cast<uint8_t *>(dst_n_orig[z].get()), lengths[1][z], dst->data + dst->offset[1][z]);
+		std::copy_n(reinterpret_cast<uint8_t *>(dst_px_orig[sck].get()), lengths[0][sck], dst->data + dst->offset[0][sck]);
+		std::copy_n(reinterpret_cast<uint8_t *>(dst_n_orig[sck].get()), lengths[1][sck], dst->data + dst->offset[1][sck]);
 	}
 
 	return dest_sprite;

--- a/src/blitter/32bpp_optimized.hpp
+++ b/src/blitter/32bpp_optimized.hpp
@@ -21,15 +21,15 @@ public:
 		uint8_t data[];                      ///< Data, all zoomlevels.
 	};
 
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "32bpp-optimized"; }
 
-	template <BlitterMode mode, bool Tpal_to_rgb = false> void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
+	template <BlitterMode mode, bool Tpal_to_rgb = false> void Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck);
 
 protected:
-	template <bool Tpal_to_rgb> void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom);
+	template <bool Tpal_to_rgb> void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck);
 	template <bool Tpal_to_rgb> Sprite *EncodeInternal(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator);
 };
 

--- a/src/blitter/32bpp_optimized.hpp
+++ b/src/blitter/32bpp_optimized.hpp
@@ -22,7 +22,7 @@ public:
 	};
 
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "32bpp-optimized"; }
 
@@ -30,7 +30,7 @@ public:
 
 protected:
 	template <bool Tpal_to_rgb> void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck);
-	template <bool Tpal_to_rgb> Sprite *EncodeInternal(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator);
+	template <bool Tpal_to_rgb> Sprite *EncodeInternal(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator);
 };
 
 /** Factory for the optimised 32 bpp blitter (without palette animation). */

--- a/src/blitter/32bpp_simple.cpp
+++ b/src/blitter/32bpp_simple.cpp
@@ -115,9 +115,9 @@ void Blitter_32bppSimple::DrawColourMappingRect(void *dst, int width, int height
 	Debug(misc, 0, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
 }
 
-Sprite *Blitter_32bppSimple::Encode(SpriteType, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
+Sprite *Blitter_32bppSimple::Encode(SpriteType, const SpriteLoader::SpriteCollection &sprite, bool, SpriteAllocator &allocator)
 {
-	const auto &root_sprite = sprite.Root();
+	const auto &root_sprite = sprite.Root(false);
 	Blitter_32bppSimple::Pixel *dst;
 	Sprite *dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite) + static_cast<size_t>(root_sprite.height) * static_cast<size_t>(root_sprite.width) * sizeof(*dst));
 
@@ -125,6 +125,7 @@ Sprite *Blitter_32bppSimple::Encode(SpriteType, const SpriteLoader::SpriteCollec
 	dest_sprite->width = root_sprite.width;
 	dest_sprite->x_offs = root_sprite.x_offs;
 	dest_sprite->y_offs = root_sprite.y_offs;
+	dest_sprite->has_rtl = false;
 
 	dst = reinterpret_cast<Blitter_32bppSimple::Pixel *>(dest_sprite->data);
 	SpriteLoader::CommonPixel *src = reinterpret_cast<SpriteLoader::CommonPixel *>(root_sprite.data);

--- a/src/blitter/32bpp_simple.cpp
+++ b/src/blitter/32bpp_simple.cpp
@@ -19,13 +19,13 @@
 /** Instantiation of the simple 32bpp blitter factory. */
 static FBlitter_32bppSimple iFBlitter_32bppSimple;
 
-void Blitter_32bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_32bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 {
 	const Blitter_32bppSimple::Pixel *src, *src_line;
 	Colour *dst, *dst_line;
 
 	/* Find where to start reading in the source sprite */
-	src_line = (const Blitter_32bppSimple::Pixel *)bp->sprite + (bp->skip_top * bp->sprite_width + bp->skip_left) * ScaleByZoom(1, zoom);
+	src_line = (const Blitter_32bppSimple::Pixel *)bp->sprite + (bp->skip_top * bp->sprite_width + bp->skip_left) * ScaleByZoom(1, sck.zoom);
 	dst_line = (Colour *)bp->dst + bp->top * bp->pitch + bp->left;
 
 	for (int y = 0; y < bp->height; y++) {
@@ -33,7 +33,7 @@ void Blitter_32bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoo
 		dst_line += bp->pitch;
 
 		src = src_line;
-		src_line += bp->sprite_width * ScaleByZoom(1, zoom);
+		src_line += bp->sprite_width * ScaleByZoom(1, sck.zoom);
 
 		for (int x = 0; x < bp->width; x++) {
 			switch (mode) {
@@ -82,7 +82,7 @@ void Blitter_32bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoo
 					break;
 			}
 			dst++;
-			src += ScaleByZoom(1, zoom);
+			src += ScaleByZoom(1, sck.zoom);
 		}
 	}
 }

--- a/src/blitter/32bpp_simple.hpp
+++ b/src/blitter/32bpp_simple.hpp
@@ -26,7 +26,7 @@ class Blitter_32bppSimple : public Blitter_32bppBase {
 public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "32bpp-simple"; }
 };

--- a/src/blitter/32bpp_simple.hpp
+++ b/src/blitter/32bpp_simple.hpp
@@ -24,7 +24,7 @@ class Blitter_32bppSimple : public Blitter_32bppBase {
 		uint8_t v;  ///< Brightness-channel
 	};
 public:
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
 	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 

--- a/src/blitter/32bpp_sse2.cpp
+++ b/src/blitter/32bpp_sse2.cpp
@@ -37,9 +37,9 @@ Sprite *Blitter_32bppSSE_Base::Encode(SpriteType sprite_type, const SpriteLoader
 	/* Calculate sizes and allocate. */
 	SpriteData sd{};
 	uint all_sprites_size = 0;
-	for (ZoomLevel z = zoom_min; z <= zoom_max; z++) {
-		const SpriteLoader::Sprite *src_sprite = &sprite[z];
-		auto &info = sd.infos[z];
+	for (auto sck : SpriteCollKeyRange(zoom_min, zoom_max)) {
+		const SpriteLoader::Sprite *src_sprite = &sprite[sck];
+		auto &info = sd.infos[sck];
 		info.sprite_width = src_sprite->width;
 		info.sprite_offset = all_sprites_size;
 		info.sprite_line_size = sizeof(Colour) * src_sprite->width + sizeof(uint32_t) * META_LENGTH;
@@ -63,10 +63,10 @@ Sprite *Blitter_32bppSSE_Base::Encode(SpriteType sprite_type, const SpriteLoader
 	bool has_remap = false;
 	bool has_anim = false;
 	bool has_translucency = false;
-	for (ZoomLevel z = zoom_min; z <= zoom_max; z++) {
-		const SpriteLoader::Sprite *src_sprite = &sprite[z];
+	for (auto sck : SpriteCollKeyRange(zoom_min, zoom_max)) {
+		const SpriteLoader::Sprite *src_sprite = &sprite[sck];
 		const SpriteLoader::CommonPixel *src = (const SpriteLoader::CommonPixel *) src_sprite->data;
-		const auto &info = sd.infos[z];
+		const auto &info = sd.infos[sck];
 		Colour *dst_rgba_line = reinterpret_cast<Colour *>(&dst_sprite->data[sizeof(SpriteData) + info.sprite_offset]);
 		MapValue *dst_mv = reinterpret_cast<MapValue *>(&dst_sprite->data[sizeof(SpriteData) + info.mv_offset]);
 		for (uint y = src_sprite->height; y != 0; y--) {

--- a/src/blitter/32bpp_sse2.hpp
+++ b/src/blitter/32bpp_sse2.hpp
@@ -77,7 +77,7 @@ public:
 		uint8_t data[]; ///< Data, all zoomlevels.
 	};
 
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator);
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator);
 };
 
 /** The SSE2 32 bpp blitter (without palette animation). */
@@ -87,9 +87,9 @@ public:
 	template <BlitterMode mode, Blitter_32bppSSE_Base::ReadMode read_mode, Blitter_32bppSSE_Base::BlockType bt_last, bool translucent>
 	void Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck);
 
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) override
 	{
-		return Blitter_32bppSSE_Base::Encode(sprite_type, sprite, allocator);
+		return Blitter_32bppSSE_Base::Encode(sprite_type, sprite, has_rtl, allocator);
 	}
 
 	std::string_view GetName() override { return "32bpp-sse2"; }

--- a/src/blitter/32bpp_sse2.hpp
+++ b/src/blitter/32bpp_sse2.hpp
@@ -83,9 +83,9 @@ public:
 /** The SSE2 32 bpp blitter (without palette animation). */
 class Blitter_32bppSSE2 : public Blitter_32bppSimple, public Blitter_32bppSSE_Base {
 public:
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	template <BlitterMode mode, Blitter_32bppSSE_Base::ReadMode read_mode, Blitter_32bppSSE_Base::BlockType bt_last, bool translucent>
-	void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
+	void Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck);
 
 	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override
 	{

--- a/src/blitter/32bpp_sse4.hpp
+++ b/src/blitter/32bpp_sse4.hpp
@@ -29,9 +29,9 @@
 /** The SSE4 32 bpp blitter (without palette animation). */
 class Blitter_32bppSSE4 : public Blitter_32bppSSSE3 {
 public:
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	template <BlitterMode mode, Blitter_32bppSSE_Base::ReadMode read_mode, Blitter_32bppSSE_Base::BlockType bt_last, bool translucent>
-	void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
+	void Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck);
 	std::string_view GetName() override { return "32bpp-sse4"; }
 };
 

--- a/src/blitter/32bpp_sse_func.hpp
+++ b/src/blitter/32bpp_sse_func.hpp
@@ -208,17 +208,17 @@ INTERNAL_LINKAGE inline __m128i AdjustBrightnessOfTwoPixels([[maybe_unused]] __m
  *
  * @tparam mode blitter mode
  * @param bp further blitting parameters
- * @param zoom zoom level at which we are drawing
+ * @param sck sprite collection key to draw
  */
 IGNORE_UNINITIALIZED_WARNING_START
 template <BlitterMode mode, Blitter_32bppSSE2::ReadMode read_mode, Blitter_32bppSSE2::BlockType bt_last, bool translucent>
 GNU_TARGET(SSE_TARGET)
 #if (SSE_VERSION == 2)
-inline void Blitter_32bppSSE2::Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom)
+inline void Blitter_32bppSSE2::Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck)
 #elif (SSE_VERSION == 3)
-inline void Blitter_32bppSSSE3::Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom)
+inline void Blitter_32bppSSSE3::Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck)
 #elif (SSE_VERSION == 4)
-inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom)
+inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck)
 #endif
 {
 	const uint8_t * const remap = bp->remap;
@@ -227,7 +227,7 @@ inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 
 	/* Find where to start reading in the source sprite. */
 	const SpriteData * const sd = (const SpriteData *) bp->sprite;
-	const SpriteInfo * const si = &sd->infos[zoom];
+	const SpriteInfo *const si = &sd->infos[sck];
 	const MapValue *src_mv_line = (const MapValue *) &sd->data[si->mv_offset] + bp->skip_top * si->sprite_width;
 	const Colour *src_rgba_line = (const Colour *) ((const uint8_t *) &sd->data[si->sprite_offset] + bp->skip_top * si->sprite_line_size);
 
@@ -453,14 +453,14 @@ IGNORE_UNINITIALIZED_WARNING_STOP
  *
  * @param bp further blitting parameters
  * @param mode blitter mode
- * @param zoom zoom level at which we are drawing
+ * @param sck sprite collection key to draw
  */
 #if (SSE_VERSION == 2)
-void Blitter_32bppSSE2::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_32bppSSE2::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 #elif (SSE_VERSION == 3)
-void Blitter_32bppSSSE3::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_32bppSSSE3::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 #elif (SSE_VERSION == 4)
-void Blitter_32bppSSE4::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_32bppSSE4::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 #endif
 {
 	switch (mode) {
@@ -469,14 +469,14 @@ void Blitter_32bppSSE4::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomL
 bm_normal:
 				const BlockType bt_last = (BlockType) (bp->width & 1);
 				switch (bt_last) {
-					default:     Draw<BlitterMode::Normal, RM_WITH_SKIP, BT_EVEN, true>(bp, zoom); return;
-					case BT_ODD: Draw<BlitterMode::Normal, RM_WITH_SKIP, BT_ODD, true>(bp, zoom); return;
+					default:     Draw<BlitterMode::Normal, RM_WITH_SKIP, BT_EVEN, true>(bp, sck); return;
+					case BT_ODD: Draw<BlitterMode::Normal, RM_WITH_SKIP, BT_ODD, true>(bp, sck); return;
 				}
 			} else {
 				if (((const Blitter_32bppSSE_Base::SpriteData *) bp->sprite)->flags.Test(SpriteFlag::Translucent)) {
-					Draw<BlitterMode::Normal, RM_WITH_MARGIN, BT_NONE, true>(bp, zoom);
+					Draw<BlitterMode::Normal, RM_WITH_MARGIN, BT_NONE, true>(bp, sck);
 				} else {
-					Draw<BlitterMode::Normal, RM_WITH_MARGIN, BT_NONE, false>(bp, zoom);
+					Draw<BlitterMode::Normal, RM_WITH_MARGIN, BT_NONE, false>(bp, sck);
 				}
 				return;
 			}
@@ -485,14 +485,14 @@ bm_normal:
 		case BlitterMode::ColourRemap:
 			if (((const Blitter_32bppSSE_Base::SpriteData *) bp->sprite)->flags.Test(SpriteFlag::NoRemap)) goto bm_normal;
 			if (bp->skip_left != 0 || bp->width <= MARGIN_REMAP_THRESHOLD) {
-				Draw<BlitterMode::ColourRemap, RM_WITH_SKIP, BT_NONE, true>(bp, zoom); return;
+				Draw<BlitterMode::ColourRemap, RM_WITH_SKIP, BT_NONE, true>(bp, sck); return;
 			} else {
-				Draw<BlitterMode::ColourRemap, RM_WITH_MARGIN, BT_NONE, true>(bp, zoom); return;
+				Draw<BlitterMode::ColourRemap, RM_WITH_MARGIN, BT_NONE, true>(bp, sck); return;
 			}
-		case BlitterMode::Transparent: Draw<BlitterMode::Transparent, RM_NONE, BT_NONE, true>(bp, zoom); return;
-		case BlitterMode::TransparentRemap: Draw<BlitterMode::TransparentRemap, RM_NONE, BT_NONE, true>(bp, zoom); return;
-		case BlitterMode::CrashRemap: Draw<BlitterMode::CrashRemap, RM_NONE, BT_NONE, true>(bp, zoom); return;
-		case BlitterMode::BlackRemap: Draw<BlitterMode::BlackRemap, RM_NONE, BT_NONE, true>(bp, zoom); return;
+		case BlitterMode::Transparent: Draw<BlitterMode::Transparent, RM_NONE, BT_NONE, true>(bp, sck); return;
+		case BlitterMode::TransparentRemap: Draw<BlitterMode::TransparentRemap, RM_NONE, BT_NONE, true>(bp, sck); return;
+		case BlitterMode::CrashRemap: Draw<BlitterMode::CrashRemap, RM_NONE, BT_NONE, true>(bp, sck); return;
+		case BlitterMode::BlackRemap: Draw<BlitterMode::BlackRemap, RM_NONE, BT_NONE, true>(bp, sck); return;
 	}
 }
 #endif /* FULL_ANIMATION */

--- a/src/blitter/32bpp_sse_type.h
+++ b/src/blitter/32bpp_sse_type.h
@@ -28,7 +28,7 @@
 #endif
 
 #define META_LENGTH 2 ///< Number of uint32_t inserted before each line of pixels in a sprite.
-#define MARGIN_NORMAL_THRESHOLD (zoom == ZoomLevel::Out8x ? 8 : 4) ///< Minimum width to use margins with BlitterMode::Normal.
+#define MARGIN_NORMAL_THRESHOLD (sck.zoom == ZoomLevel::Out8x ? 8 : 4) ///< Minimum width to use margins with BlitterMode::Normal.
 #define MARGIN_REMAP_THRESHOLD 4 ///< Minimum width to use margins with BlitterMode::ColourRemap.
 
 typedef union alignas(16) um128i {

--- a/src/blitter/32bpp_ssse3.hpp
+++ b/src/blitter/32bpp_ssse3.hpp
@@ -29,9 +29,9 @@
 /** The SSSE3 32 bpp blitter (without palette animation). */
 class Blitter_32bppSSSE3 : public Blitter_32bppSSE2 {
 public:
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	template <BlitterMode mode, Blitter_32bppSSE_Base::ReadMode read_mode, Blitter_32bppSSE_Base::BlockType bt_last, bool translucent>
-	void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
+	void Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck);
 	std::string_view GetName() override { return "32bpp-ssse3"; }
 };
 

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -400,9 +400,9 @@ void Blitter_40bppAnim::DrawColourMappingRect(void *dst, int width, int height, 
 	}
 }
 
-Sprite *Blitter_40bppAnim::Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
+Sprite *Blitter_40bppAnim::Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator)
 {
-	return this->EncodeInternal<false>(sprite_type, sprite, allocator);
+	return this->EncodeInternal<false>(sprite_type, sprite, has_rtl, allocator);
 }
 
 

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -87,20 +87,20 @@ void Blitter_40bppAnim::DrawLine(void *video, int x, int y, int x2, int y2, int 
  *
  * @tparam mode blitter mode
  * @param bp further blitting parameters
- * @param zoom zoom level at which we are drawing
+ * @param sck sprite collection key to draw
  */
 template <BlitterMode mode>
-inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom)
+inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck)
 {
 	const SpriteData *src = (const SpriteData *)bp->sprite;
 
 	/* src_px : each line begins with uint32_t n = 'number of bytes in this line',
 	 *          then n times is the Colour struct for this line */
-	const Colour *src_px = reinterpret_cast<const Colour *>(src->data + src->offset[0][zoom]);
+	const Colour *src_px = reinterpret_cast<const Colour *>(src->data + src->offset[0][sck]);
 	/* src_n  : each line begins with uint32_t n = 'number of bytes in this line',
 	 *          then interleaved stream of 'm' and 'n' channels. 'm' is remap,
 	 *          'n' is number of bytes with the same alpha channel class */
-	const uint16_t *src_n = reinterpret_cast<const uint16_t *>(src->data + src->offset[1][zoom]);
+	const uint16_t *src_n = reinterpret_cast<const uint16_t *>(src->data + src->offset[1][sck]);
 
 	/* skip upper lines in src_px and src_n */
 	for (uint i = bp->skip_top; i != 0; i--) {
@@ -325,26 +325,26 @@ inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
  *
  * @param bp further blitting parameters
  * @param mode blitter mode
- * @param zoom zoom level at which we are drawing
+ * @param sck sprite collection key to draw
  */
-void Blitter_40bppAnim::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_40bppAnim::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 {
 	assert(_screen.dst_ptr != nullptr);
 
 	if (_screen_disable_anim || VideoDriver::GetInstance()->GetAnimBuffer() == nullptr) {
 		/* This means our output is not to the screen, so we can't be doing any animation stuff, so use our parent Draw() */
-		Blitter_32bppOptimized::Draw<true>(bp, mode, zoom);
+		Blitter_32bppOptimized::Draw<true>(bp, mode, sck);
 		return;
 	}
 
 	switch (mode) {
 		default: NOT_REACHED();
-		case BlitterMode::Normal: Draw<BlitterMode::Normal>(bp, zoom); return;
-		case BlitterMode::ColourRemap: Draw<BlitterMode::ColourRemap>(bp, zoom); return;
-		case BlitterMode::Transparent: Draw<BlitterMode::Transparent>(bp, zoom); return;
-		case BlitterMode::TransparentRemap: Draw<BlitterMode::TransparentRemap>(bp, zoom); return;
-		case BlitterMode::CrashRemap: Draw<BlitterMode::CrashRemap>(bp, zoom); return;
-		case BlitterMode::BlackRemap: Draw<BlitterMode::BlackRemap>(bp, zoom); return;
+		case BlitterMode::Normal: Draw<BlitterMode::Normal>(bp, sck); return;
+		case BlitterMode::ColourRemap: Draw<BlitterMode::ColourRemap>(bp, sck); return;
+		case BlitterMode::Transparent: Draw<BlitterMode::Transparent>(bp, sck); return;
+		case BlitterMode::TransparentRemap: Draw<BlitterMode::TransparentRemap>(bp, sck); return;
+		case BlitterMode::CrashRemap: Draw<BlitterMode::CrashRemap>(bp, sck); return;
+		case BlitterMode::BlackRemap: Draw<BlitterMode::BlackRemap>(bp, sck); return;
 	}
 }
 

--- a/src/blitter/40bpp_anim.hpp
+++ b/src/blitter/40bpp_anim.hpp
@@ -25,7 +25,7 @@ public:
 	void CopyToBuffer(const void *video, void *dst, int width, int height) override;
 	void CopyImageToBuffer(const void *video, void *dst, int width, int height, int dst_pitch) override;
 	void ScrollBuffer(void *video, int &left, int &top, int &width, int &height, int scroll_x, int scroll_y) override;
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
 	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 	size_t BufferSize(uint width, uint height) override;
@@ -34,7 +34,7 @@ public:
 
 	std::string_view GetName()  override { return "40bpp-anim"; }
 
-	template <BlitterMode mode> void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
+	template <BlitterMode mode> void Draw(const Blitter::BlitterParams *bp, SpriteCollKey sck);
 
 protected:
 	static inline Colour RealizeBlendedColour(uint8_t anim, Colour c)

--- a/src/blitter/40bpp_anim.hpp
+++ b/src/blitter/40bpp_anim.hpp
@@ -27,7 +27,7 @@ public:
 	void ScrollBuffer(void *video, int &left, int &top, int &width, int &height, int scroll_x, int scroll_y) override;
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) override;
 	size_t BufferSize(uint width, uint height) override;
 	Blitter::PaletteAnimation UsePaletteAnimation() override;
 	bool NeedsAnimationBuffer() override;

--- a/src/blitter/8bpp_optimized.cpp
+++ b/src/blitter/8bpp_optimized.cpp
@@ -18,11 +18,11 @@
 /** Instantiation of the 8bpp optimised blitter factory. */
 static FBlitter_8bppOptimized iFBlitter_8bppOptimized;
 
-void Blitter_8bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_8bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 {
 	/* Find the offset of this zoom-level */
 	const SpriteData *sprite_src = (const SpriteData *)bp->sprite;
-	uint offset = sprite_src->offset[zoom];
+	uint offset = sprite_src->offset[sck];
 
 	/* Find where to start reading in the source sprite */
 	const uint8_t *src = sprite_src->data + offset;
@@ -136,8 +136,8 @@ Sprite *Blitter_8bppOptimized::Encode(SpriteType sprite_type, const SpriteLoader
 		if (zoom_max == zoom_min) zoom_max = ZoomLevel::Max;
 	}
 
-	for (ZoomLevel i = zoom_min; i <= zoom_max; i++) {
-		memory += sprite[i].width * sprite[i].height;
+	for (auto sck : SpriteCollKeyRange(zoom_min, zoom_max)) {
+		memory += sprite[sck].width * sprite[sck].height;
 	}
 
 	/* We have no idea how much memory we really need, so just guess something */
@@ -151,11 +151,11 @@ Sprite *Blitter_8bppOptimized::Encode(SpriteType sprite_type, const SpriteLoader
 	uint8_t *dst = temp_dst->data;
 
 	/* Make the sprites per zoom-level */
-	for (ZoomLevel i = zoom_min; i <= zoom_max; i++) {
-		const SpriteLoader::Sprite &src_orig = sprite[i];
+	for (auto sck : SpriteCollKeyRange(zoom_min, zoom_max)) {
+		const SpriteLoader::Sprite &src_orig = sprite[sck];
 		/* Store the index table */
 		uint offset = dst - temp_dst->data;
-		temp_dst->offset[i] = offset;
+		temp_dst->offset[sck] = offset;
 
 		/* cache values, because compiler can't cache it */
 		int scaled_height = src_orig.height;

--- a/src/blitter/8bpp_optimized.hpp
+++ b/src/blitter/8bpp_optimized.hpp
@@ -22,7 +22,7 @@ public:
 		uint8_t data[];                   ///< Data, all zoomlevels.
 	};
 
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "8bpp-optimized"; }

--- a/src/blitter/8bpp_optimized.hpp
+++ b/src/blitter/8bpp_optimized.hpp
@@ -23,7 +23,7 @@ public:
 	};
 
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "8bpp-optimized"; }
 };

--- a/src/blitter/8bpp_simple.cpp
+++ b/src/blitter/8bpp_simple.cpp
@@ -16,13 +16,13 @@
 /** Instantiation of the simple 8bpp blitter factory. */
 static FBlitter_8bppSimple iFBlitter_8bppSimple;
 
-void Blitter_8bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
+void Blitter_8bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck)
 {
 	const uint8_t *src, *src_line;
 	uint8_t *dst, *dst_line;
 
 	/* Find where to start reading in the source sprite */
-	src_line = (const uint8_t *)bp->sprite + (bp->skip_top * bp->sprite_width + bp->skip_left) * ScaleByZoom(1, zoom);
+	src_line = (const uint8_t *)bp->sprite + (bp->skip_top * bp->sprite_width + bp->skip_left) * ScaleByZoom(1, sck.zoom);
 	dst_line = (uint8_t *)bp->dst + bp->top * bp->pitch + bp->left;
 
 	for (int y = 0; y < bp->height; y++) {
@@ -30,7 +30,7 @@ void Blitter_8bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoom
 		dst_line += bp->pitch;
 
 		src = src_line;
-		src_line += bp->sprite_width * ScaleByZoom(1, zoom);
+		src_line += bp->sprite_width * ScaleByZoom(1, sck.zoom);
 
 		for (int x = 0; x < bp->width; x++) {
 			uint colour = 0;
@@ -56,7 +56,7 @@ void Blitter_8bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoom
 			}
 			if (colour != 0) *dst = colour;
 			dst++;
-			src += ScaleByZoom(1, zoom);
+			src += ScaleByZoom(1, sck.zoom);
 		}
 	}
 }

--- a/src/blitter/8bpp_simple.cpp
+++ b/src/blitter/8bpp_simple.cpp
@@ -61,9 +61,9 @@ void Blitter_8bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Spri
 	}
 }
 
-Sprite *Blitter_8bppSimple::Encode(SpriteType, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
+Sprite *Blitter_8bppSimple::Encode(SpriteType, const SpriteLoader::SpriteCollection &sprite, bool, SpriteAllocator &allocator)
 {
-	const auto &root_sprite = sprite.Root();
+	const auto &root_sprite = sprite.Root(false);
 	Sprite *dest_sprite;
 	dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite) + static_cast<size_t>(root_sprite.height) * static_cast<size_t>(root_sprite.width));
 
@@ -71,6 +71,7 @@ Sprite *Blitter_8bppSimple::Encode(SpriteType, const SpriteLoader::SpriteCollect
 	dest_sprite->width = root_sprite.width;
 	dest_sprite->x_offs = root_sprite.x_offs;
 	dest_sprite->y_offs = root_sprite.y_offs;
+	dest_sprite->has_rtl = false;
 
 	/* Copy over only the 'remap' channel, as that is what we care about in 8bpp */
 	uint8_t *dst = reinterpret_cast<uint8_t *>(dest_sprite->data);

--- a/src/blitter/8bpp_simple.hpp
+++ b/src/blitter/8bpp_simple.hpp
@@ -17,7 +17,7 @@
 class Blitter_8bppSimple final : public Blitter_8bppBase {
 public:
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "8bpp-simple"; }
 };

--- a/src/blitter/8bpp_simple.hpp
+++ b/src/blitter/8bpp_simple.hpp
@@ -16,7 +16,7 @@
 /** Most trivial 8bpp blitter. */
 class Blitter_8bppSimple final : public Blitter_8bppBase {
 public:
-	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
+	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) override;
 	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 
 	std::string_view GetName() override { return "8bpp-simple"; }

--- a/src/blitter/base.hpp
+++ b/src/blitter/base.hpp
@@ -67,7 +67,7 @@ public:
 	/**
 	 * Draw an image to the screen, given an amount of params defined above.
 	 */
-	virtual void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) = 0;
+	virtual void Draw(Blitter::BlitterParams *bp, BlitterMode mode, SpriteCollKey sck) = 0;
 
 	/**
 	 * Draw a colourtable to the screen. This is: the colour of the screen is read

--- a/src/blitter/null.cpp
+++ b/src/blitter/null.cpp
@@ -15,16 +15,17 @@
 /** Instantiation of the null blitter factory. */
 static FBlitter_Null iFBlitter_Null;
 
-Sprite *Blitter_Null::Encode(SpriteType, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)
+Sprite *Blitter_Null::Encode(SpriteType, const SpriteLoader::SpriteCollection &sprite, bool, SpriteAllocator &allocator)
 {
 	Sprite *dest_sprite;
 	dest_sprite = allocator.Allocate<Sprite>(sizeof(*dest_sprite));
 
-	const auto &root_sprite = sprite.Root();
+	const auto &root_sprite = sprite.Root(false);
 	dest_sprite->height = root_sprite.height;
 	dest_sprite->width = root_sprite.width;
 	dest_sprite->x_offs = root_sprite.x_offs;
 	dest_sprite->y_offs = root_sprite.y_offs;
+	dest_sprite->has_rtl = false;
 
 	return dest_sprite;
 }

--- a/src/blitter/null.hpp
+++ b/src/blitter/null.hpp
@@ -16,7 +16,7 @@
 class Blitter_Null : public Blitter {
 public:
 	uint8_t GetScreenDepth() override { return 0; }
-	void Draw(Blitter::BlitterParams *, BlitterMode, ZoomLevel) override {};
+	void Draw(Blitter::BlitterParams *, BlitterMode, SpriteCollKey) override {};
 	void DrawColourMappingRect(void *, int, int, PaletteID) override {};
 	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 	void *MoveTo(void *, int, int) override { return nullptr; };

--- a/src/blitter/null.hpp
+++ b/src/blitter/null.hpp
@@ -18,7 +18,7 @@ public:
 	uint8_t GetScreenDepth() override { return 0; }
 	void Draw(Blitter::BlitterParams *, BlitterMode, SpriteCollKey) override {};
 	void DrawColourMappingRect(void *, int, int, PaletteID) override {};
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) override;
 	void *MoveTo(void *, int, int) override { return nullptr; };
 	void SetPixel(void *, int, int, uint8_t) override {};
 	void DrawRect(void *, int, int, uint8_t) override {};

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -242,8 +242,8 @@ const Sprite *FreeTypeFontCache::InternalGetGlyph(GlyphID key, bool aa)
 
 	/* FreeType has rendered the glyph, now we allocate a sprite and copy the image into it */
 	SpriteLoader::SpriteCollection spritecollection;
-	SpriteLoader::Sprite &sprite = spritecollection.Root();
-	sprite.AllocateData(SpriteCollKey::Root(), static_cast<size_t>(width) * height);
+	SpriteLoader::Sprite &sprite = spritecollection.Root(false);
+	sprite.AllocateData(SpriteCollKey::Root(false), static_cast<size_t>(width) * height);
 	sprite.colours = SpriteComponent::Palette;
 	if (aa) sprite.colours.Set(SpriteComponent::Alpha);
 	sprite.width = width;
@@ -273,7 +273,7 @@ const Sprite *FreeTypeFontCache::InternalGetGlyph(GlyphID key, bool aa)
 	}
 
 	UniquePtrSpriteAllocator allocator;
-	BlitterFactory::GetCurrentBlitter()->Encode(SpriteType::Font, spritecollection, allocator);
+	BlitterFactory::GetCurrentBlitter()->Encode(SpriteType::Font, spritecollection, false, allocator);
 
 	GlyphEntry new_glyph;
 	new_glyph.data = std::move(allocator.data);

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -242,8 +242,8 @@ const Sprite *FreeTypeFontCache::InternalGetGlyph(GlyphID key, bool aa)
 
 	/* FreeType has rendered the glyph, now we allocate a sprite and copy the image into it */
 	SpriteLoader::SpriteCollection spritecollection;
-	SpriteLoader::Sprite &sprite = spritecollection[ZoomLevel::Min];
-	sprite.AllocateData(ZoomLevel::Min, static_cast<size_t>(width) * height);
+	SpriteLoader::Sprite &sprite = spritecollection.Root();
+	sprite.AllocateData(SpriteCollKey::Root(), static_cast<size_t>(width) * height);
 	sprite.colours = SpriteComponent::Palette;
 	if (aa) sprite.colours.Set(SpriteComponent::Alpha);
 	sprite.width = width;

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1167,7 +1167,7 @@ static void GfxBlitter(const Sprite * const sprite, int x, int y, BlitterMode mo
 		}
 	}
 
-	BlitterFactory::GetCurrentBlitter()->Draw(&bp, mode, zoom);
+	BlitterFactory::GetCurrentBlitter()->Draw(&bp, mode, SpriteCollKey{zoom});
 }
 
 /**

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1167,7 +1167,7 @@ static void GfxBlitter(const Sprite * const sprite, int x, int y, BlitterMode mo
 		}
 	}
 
-	BlitterFactory::GetCurrentBlitter()->Draw(&bp, mode, SpriteCollKey{zoom});
+	BlitterFactory::GetCurrentBlitter()->Draw(&bp, mode, SpriteCollKey{zoom, _current_text_dir == TD_RTL});
 }
 
 /**

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -229,8 +229,8 @@ const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
 	if (width > MAX_GLYPH_DIM || height > MAX_GLYPH_DIM) UserError("Font glyph is too large");
 
 	SpriteLoader::SpriteCollection spritecollection;
-	SpriteLoader::Sprite &sprite = spritecollection.Root();
-	sprite.AllocateData(SpriteCollKey::Root(), width * height);
+	SpriteLoader::Sprite &sprite = spritecollection.Root(false);
+	sprite.AllocateData(SpriteCollKey::Root(false), width * height);
 	sprite.colours = SpriteComponent::Palette;
 	if (use_aa) sprite.colours.Set(SpriteComponent::Alpha);
 	sprite.width = width;
@@ -278,7 +278,7 @@ const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
 	}
 
 	UniquePtrSpriteAllocator allocator;
-	BlitterFactory::GetCurrentBlitter()->Encode(SpriteType::Font, spritecollection, allocator);
+	BlitterFactory::GetCurrentBlitter()->Encode(SpriteType::Font, spritecollection, false, allocator);
 
 	GlyphEntry new_glyph;
 	new_glyph.data = std::move(allocator.data);

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -229,8 +229,8 @@ const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
 	if (width > MAX_GLYPH_DIM || height > MAX_GLYPH_DIM) UserError("Font glyph is too large");
 
 	SpriteLoader::SpriteCollection spritecollection;
-	SpriteLoader::Sprite &sprite = spritecollection[ZoomLevel::Min];
-	sprite.AllocateData(ZoomLevel::Min, width * height);
+	SpriteLoader::Sprite &sprite = spritecollection.Root();
+	sprite.AllocateData(SpriteCollKey::Root(), width * height);
 	sprite.colours = SpriteComponent::Palette;
 	if (use_aa) sprite.colours.Set(SpriteComponent::Alpha);
 	sprite.width = width;

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -224,8 +224,8 @@ void Win32FontCache::ClearFontCache()
 
 	/* GDI has rendered the glyph, now we allocate a sprite and copy the image into it. */
 	SpriteLoader::SpriteCollection spritecollection;
-	SpriteLoader::Sprite &sprite = spritecollection[ZoomLevel::Min];
-	sprite.AllocateData(ZoomLevel::Min, width * height);
+	SpriteLoader::Sprite &sprite = spritecollection.Root();
+	sprite.AllocateData(SpriteCollKey::Root(), width * height);
 	sprite.colours = SpriteComponent::Palette;
 	if (aa) sprite.colours.Set(SpriteComponent::Alpha);
 	sprite.width = width;

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -224,8 +224,8 @@ void Win32FontCache::ClearFontCache()
 
 	/* GDI has rendered the glyph, now we allocate a sprite and copy the image into it. */
 	SpriteLoader::SpriteCollection spritecollection;
-	SpriteLoader::Sprite &sprite = spritecollection.Root();
-	sprite.AllocateData(SpriteCollKey::Root(), width * height);
+	SpriteLoader::Sprite &sprite = spritecollection.Root(false);
+	sprite.AllocateData(SpriteCollKey::Root(false), width * height);
 	sprite.colours = SpriteComponent::Palette;
 	if (aa) sprite.colours.Set(SpriteComponent::Alpha);
 	sprite.width = width;
@@ -264,7 +264,7 @@ void Win32FontCache::ClearFontCache()
 	}
 
 	UniquePtrSpriteAllocator allocator;
-	BlitterFactory::GetCurrentBlitter()->Encode(SpriteType::Font, spritecollection, allocator);
+	BlitterFactory::GetCurrentBlitter()->Encode(SpriteType::Font, spritecollection, false, allocator);
 
 	GlyphEntry new_glyph;
 	new_glyph.data = std::move(allocator.data);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1420,6 +1420,7 @@ struct GameOptionsWindow : Window {
 				CheckForMissingGlyphs();
 				ClearAllCachedNames();
 				UpdateAllVirtCoords();
+				VideoDriver::GetInstance()->ClearSystemSprites(); // relevant if _current_text_dir changes
 				CheckBlitter();
 				ReInitAllWindows(false);
 				break;

--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -19,6 +19,7 @@ struct Sprite {
 	uint16_t width;  ///< Width of the sprite.
 	int16_t x_offs;  ///< Number of pixels to shift the sprite to the right.
 	int16_t y_offs;  ///< Number of pixels to shift the sprite downwards.
+	bool has_rtl; ///< Whether the sprite is textdir aware.
 	std::byte data[]; ///< Sprite data.
 };
 

--- a/src/spriteloader/grf.hpp
+++ b/src/spriteloader/grf.hpp
@@ -17,7 +17,7 @@ class SpriteLoaderGrf : public SpriteLoader {
 	uint8_t container_ver;
 public:
 	SpriteLoaderGrf(uint8_t container_ver) : container_ver(container_ver) {}
-	ZoomLevels LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags, ZoomLevels &avail_8bpp, ZoomLevels &avail_32bpp) override;
+	SpriteCollKeys LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags, SpriteCollKeys &avail_8bpp, SpriteCollKeys &avail_32bpp) override;
 };
 
 #endif /* SPRITELOADER_GRF_HPP */

--- a/src/spriteloader/makeindexed.cpp
+++ b/src/spriteloader/makeindexed.cpp
@@ -48,12 +48,12 @@ static void Convert32bppTo8bpp(SpriteLoader::Sprite &sprite)
 	}
 }
 
-ZoomLevels SpriteLoaderMakeIndexed::LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool, uint8_t control_flags, ZoomLevels &avail_8bpp, ZoomLevels &avail_32bpp)
+SpriteCollKeys SpriteLoaderMakeIndexed::LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool, uint8_t control_flags, SpriteCollKeys &avail_8bpp, SpriteCollKeys &avail_32bpp)
 {
-	ZoomLevels avail = this->baseloader.LoadSprite(sprite, file, file_pos, sprite_type, true, control_flags, avail_8bpp, avail_32bpp);
+	SpriteCollKeys avail = this->baseloader.LoadSprite(sprite, file, file_pos, sprite_type, true, control_flags, avail_8bpp, avail_32bpp);
 
-	for (ZoomLevel zoom = ZoomLevel::Begin; zoom != ZoomLevel::End; zoom++) {
-		if (avail.Test(zoom)) Convert32bppTo8bpp(sprite[zoom]);
+	for (auto sck : SpriteCollKeyRange(ZoomLevel::Min, ZoomLevel::Max)) {
+		if (avail.Test(sck)) Convert32bppTo8bpp(sprite[sck]);
 	}
 
 	return avail;

--- a/src/spriteloader/makeindexed.cpp
+++ b/src/spriteloader/makeindexed.cpp
@@ -52,7 +52,7 @@ SpriteCollKeys SpriteLoaderMakeIndexed::LoadSprite(SpriteLoader::SpriteCollectio
 {
 	SpriteCollKeys avail = this->baseloader.LoadSprite(sprite, file, file_pos, sprite_type, true, control_flags, avail_8bpp, avail_32bpp);
 
-	for (auto sck : SpriteCollKeyRange(ZoomLevel::Min, ZoomLevel::Max)) {
+	for (auto sck : SpriteCollKeyRange(ZoomLevel::Min, ZoomLevel::Max, true)) {
 		if (avail.Test(sck)) Convert32bppTo8bpp(sprite[sck]);
 	}
 

--- a/src/spriteloader/makeindexed.h
+++ b/src/spriteloader/makeindexed.h
@@ -17,7 +17,7 @@ class SpriteLoaderMakeIndexed : public SpriteLoader {
 	SpriteLoader &baseloader;
 public:
 	SpriteLoaderMakeIndexed(SpriteLoader &baseloader) : baseloader(baseloader) {}
-	ZoomLevels LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags, ZoomLevels &avail_8bpp, ZoomLevels &avail_32bpp) override;
+	SpriteCollKeys LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, uint8_t control_flags, SpriteCollKeys &avail_8bpp, SpriteCollKeys &avail_32bpp) override;
 };
 
 #endif /* SPRITELOADER_MAKEINDEXED_H */

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -31,27 +31,30 @@ using SpriteComponents = EnumBitSet<SpriteComponent, uint8_t, SpriteComponent::E
  */
 class SpriteCollKey {
 public:
+	bool rtl;
 	ZoomLevel zoom;
 
-	inline constexpr explicit SpriteCollKey(ZoomLevel zoom) : zoom(zoom) {}
+	inline constexpr SpriteCollKey(ZoomLevel zoom, bool rtl) : rtl(rtl), zoom(zoom) {}
 
 	inline constexpr bool operator==(const SpriteCollKey &rhs) const = default;
 	inline constexpr std::strong_ordering operator<=>(const SpriteCollKey &rhs) const = default;
 
-	static SpriteCollKey Root() { return SpriteCollKey(ZoomLevel::Min); }
+	static SpriteCollKey Root(bool rtl) { return SpriteCollKey(ZoomLevel::Min, rtl); }
 };
 
 /**
  * Set of sprite collection keys.
  */
 class SpriteCollKeys {
-	ZoomLevels keys;
+	ZoomLevels ltr, rtl;
 public:
 	inline constexpr SpriteCollKeys() = default;
-	inline constexpr void Set(const SpriteCollKey &sck) { this->keys.Set(sck.zoom); }
-	inline constexpr bool Test(const SpriteCollKey &sck) const { return this->keys.Test(sck.zoom); }
-	inline constexpr bool Any() const { return this->keys.Any(); }
-	inline constexpr bool None() const { return this->keys.None(); }
+	inline constexpr void Set(const SpriteCollKey &sck) { (sck.rtl ? this->rtl : this->ltr).Set(sck.zoom); }
+	inline constexpr bool Test(const SpriteCollKey &sck) const { return (sck.rtl ? this->rtl : this->ltr).Test(sck.zoom); }
+	inline constexpr bool AnyLtr() const { return this->ltr.Any(); }
+	inline constexpr bool AnyRtl() const { return this->rtl.Any(); }
+	inline constexpr bool NoLtr() const { return this->ltr.None(); }
+	inline constexpr bool NoRtl() const { return this->rtl.None(); }
 };
 
 /**
@@ -59,13 +62,13 @@ public:
  */
 template <class T>
 class SpriteCollMap {
-	std::array<T, to_underlying(ZoomLevel::End)> data{};
+	std::array<T, to_underlying(ZoomLevel::End)> ltr{}, rtl{};
 public:
-	inline constexpr T &operator[](const SpriteCollKey &sck) { return this->data[to_underlying(sck.zoom)]; }
-	inline constexpr const T &operator[](const SpriteCollKey &sck) const { return this->data[to_underlying(sck.zoom)]; }
+	inline constexpr T &operator[](const SpriteCollKey &sck) { return (sck.rtl ? this->rtl : this->ltr)[to_underlying(sck.zoom)]; }
+	inline constexpr const T &operator[](const SpriteCollKey &sck) const { return (sck.rtl ? this->rtl : this->ltr)[to_underlying(sck.zoom)]; }
 
-	T &Root() { return this->data[to_underlying(ZoomLevel::Min)]; }
-	const T &Root() const { return this->data[to_underlying(ZoomLevel::Min)]; }
+	T &Root(bool rtl) { return (rtl ? this->rtl : this->ltr)[to_underlying(ZoomLevel::Min)]; }
+	const T &Root(bool rtl) const { return (rtl ? this->rtl : this->ltr)[to_underlying(ZoomLevel::Min)]; }
 };
 
 /**
@@ -74,6 +77,7 @@ public:
 class SpriteCollKeyRange {
 public:
 	class Iterator {
+		ZoomLevel zoom_min, zoom_max;
 		SpriteCollKey pos;
 	public:
 		using value_type = SpriteCollKey;
@@ -82,14 +86,19 @@ public:
 		using pointer = void;
 		using reference = void;
 
-		Iterator(SpriteCollKey pos) : pos(pos) {}
+		Iterator(ZoomLevel zoom_min, ZoomLevel zoom_max, SpriteCollKey pos) : zoom_min(zoom_min), zoom_max(zoom_max), pos(pos) {}
 		bool operator==(const Iterator &rhs) const { return this->pos == rhs.pos; }
 		std::strong_ordering operator<=>(const Iterator &rhs) const { return this->pos <=> rhs.pos; }
 		const SpriteCollKey &operator*() const { return this->pos; }
 
 		Iterator& operator++()
 		{
-			++this->pos.zoom;
+			if (!this->pos.rtl && this->pos.zoom == this->zoom_max) {
+				this->pos.zoom = this->zoom_min;
+				this->pos.rtl = true;
+			} else {
+				++this->pos.zoom;
+			}
 			return *this;
 		}
 
@@ -102,7 +111,12 @@ public:
 
 		Iterator& operator--()
 		{
-			--this->pos.zoom;
+			if (this->pos.zoom == this->zoom_min) {
+				this->pos.zoom = this->zoom_max;
+				this->pos.rtl = false;
+			} else {
+				--this->pos.zoom;
+			}
 			return *this;
 		}
 
@@ -114,12 +128,13 @@ public:
 		}
 	};
 
-	SpriteCollKeyRange(ZoomLevel zoom_min, ZoomLevel zoom_max) : zoom_min(zoom_min), zoom_max(zoom_max) {}
-	Iterator begin() const { return Iterator{SpriteCollKey{this->zoom_min}}; }
-	Iterator end() const { return ++Iterator{SpriteCollKey{this->zoom_max}}; }
+	SpriteCollKeyRange(ZoomLevel zoom_min, ZoomLevel zoom_max, bool has_rtl) : zoom_min(zoom_min), zoom_max(zoom_max), has_rtl(has_rtl) {}
+	Iterator begin() const { return Iterator{this->zoom_min, this->zoom_max, SpriteCollKey{this->zoom_min, false}}; }
+	Iterator end() const { return ++Iterator{this->zoom_min, this->zoom_max, SpriteCollKey{this->zoom_max, this->has_rtl}}; }
 
 private:
 	ZoomLevel zoom_min, zoom_max;
+	bool has_rtl;
 };
 
 /** Interface for the loader of our sprites. */
@@ -221,7 +236,7 @@ public:
 	/**
 	 * Convert a sprite from the loader to our own format.
 	 */
-	virtual Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) = 0;
+	virtual Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) = 0;
 
 	/**
 	 * Get the value which the height and width on a sprite have to be aligned by.

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1441,7 +1441,7 @@ OpenGLSprite::OpenGLSprite(SpriteType sprite_type, const SpriteLoader::SpriteCol
 
 	/* Upload texture data. */
 	for (ZoomLevel zoom = ZoomLevel::Min; zoom <= (sprite_type == SpriteType::Font ? ZoomLevel::Min : ZoomLevel::Max); ++zoom) {
-		const auto &src_sprite = sprite[zoom];
+		const auto &src_sprite = sprite[SpriteCollKey{zoom}];
 		this->Update(src_sprite.width, src_sprite.height, to_underlying(zoom), src_sprite.data);
 	}
 

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -108,7 +108,7 @@ public:
 
 	bool Is32BppSupported() override { return true; }
 	uint GetSpriteAlignment() override { return 1u << to_underlying(ZoomLevel::Max); }
-	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
+	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool has_rtl, SpriteAllocator &allocator) override;
 };
 
 
@@ -139,7 +139,7 @@ private:
 	bool BindTextures() const;
 
 public:
-	OpenGLSprite(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite);
+	OpenGLSprite(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, bool rtl);
 
 	/* No support for moving/copying the textures is implemented. */
 	OpenGLSprite(const OpenGLSprite&) = delete;


### PR DESCRIPTION
## Motivation / Problem

Some GUI sprites depend on the text direction.
* For example: With the original baseset and openttd.grf, the fast forward button always points to the right.
* Exactly which sprites must be text-direction-aware depends on how they are drawn, i.e. only the baseset can know that.
* To support proper text-direction-aware sprites, the baseset needs to method to define alternative sprites for right-to-left.

## Description

* Use the same mechanism as for bit-depths and zoom-levels. Add a RTL flag to sprites. I picked bit 4 in the sprite info byte.
    * The flag is only supported for "normal" sprites. It is ignored for "font" and "mapgen" sprites.
    * Sprites with an explicit direction in their name, e.g. arrows, should not provide any RTL sprites. OpenTTD selects the sprite with the required direction.
* Both LTR and RTL sprites are stored in the spritecache. If there are no RTL-specific sprites, they share the same pixel data.
* OpenGL textures are only created for the current text direction. Thus they must be reset, if the text direction changes.
* GUI code can test RTL-awareness via `GetSprite(...)->has_rtl`, if it needs to. Currently this is not used in the PR.
* If a GRF with RTL sprites is loaded in an older version of OpenTTD, OpenTTD will use the first sprite of the zoom level, and ignore further ones. So, if the LTR sprite comes first, it works just fine.
  ```
  dbg: [sprite:1] Ignoring duplicate zoom level sprite 1605 from openttd
  ```

LTR:
![image](https://github.com/user-attachments/assets/72348ab5-3461-4893-b3d0-18b899b8d711)
RTL: Button order is reversed. Fast-forward sprite is mirrored.
![image](https://github.com/user-attachments/assets/417cee3f-643c-4454-bf09-bdeb26a50af6)

## Limitations

* For using this in openttd.grf, this needs a new grfcodec release. (OpenTTD/grfcodec#46)
* <s>The fast-forward sprite included here is just a test sprite, and I intend to remove it for the non-draft version, so that some artist can make a PR with a properly shaded sprite.</s>

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
