### PR TITLE
Codechange: unify StrTrimView

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -934,8 +934,7 @@ static bool ConClientNickChange(std::span<std::string_view> argv)
 		return true;
 	}
 
-	std::string client_name(argv[2]);
-	StrTrimInPlace(client_name);
+	std::string client_name{StrTrimView(argv[2])};
 	if (!NetworkIsValidClientName(client_name)) {
 		IConsolePrint(CC_ERROR, "Cannot give a client an empty name.");
 		return true;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -934,7 +934,7 @@ static bool ConClientNickChange(std::span<std::string_view> argv)
 		return true;
 	}
 
-	std::string client_name{StrTrimView(argv[2])};
+	std::string client_name{StrTrimView(argv[2], StringConsumer::WHITESPACE_NO_NEWLINE)};
 	if (!NetworkIsValidClientName(client_name)) {
 		IConsolePrint(CC_ERROR, "Cannot give a client an empty name.");
 		return true;

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -8,6 +8,7 @@
 /** @file console_gui.cpp Handling the GUI of the in-game console. */
 
 #include "stdafx.h"
+#include "core/string_consumer.hpp"
 #include "textbuf_type.h"
 #include "window_gui.h"
 #include "autocompletion.h"
@@ -77,7 +78,7 @@ public:
 private:
 	std::vector<std::string> GetSuggestions(std::string_view prefix, std::string_view query) override
 	{
-		prefix = StrTrimView(prefix);
+		prefix = StrTrimView(prefix, StringConsumer::WHITESPACE_NO_NEWLINE);
 		std::vector<std::string> suggestions;
 
 		/* We only suggest commands or aliases, so we only do it for the first token or an argument to help command. */

--- a/src/core/string_consumer.cpp
+++ b/src/core/string_consumer.cpp
@@ -186,6 +186,9 @@ void StringConsumer::SkipIntegerBase(int base)
 		default:
 			assert(false);
 			break;
+		case 8:
+			this->SkipUntilCharNotIn("01234567");
+			break;
 		case 10:
 			this->SkipUntilCharNotIn("0123456789");
 			break;

--- a/src/core/string_consumer.hpp
+++ b/src/core/string_consumer.hpp
@@ -829,7 +829,7 @@ private:
 		}
 
 		T value{};
-		assert(base == 10 || base == 16); // we only support these bases when skipping
+		assert(base == 8 || base == 10 || base == 16); // we only support these bases when skipping
 		auto result = std::from_chars(src.data(), src.data() + src.size(), value, base);
 		auto len = result.ptr - src.data();
 		if (result.ec == std::errc::result_out_of_range) {

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -8,6 +8,7 @@
 /** @file fileio.cpp Standard In/Out file operations */
 
 #include "stdafx.h"
+#include "core/string_consumer.hpp"
 #include "fileio_func.h"
 #include "spriteloader/spriteloader.hpp"
 #include "debug.h"
@@ -23,7 +24,6 @@
 #include <unistd.h>
 #include <pwd.h>
 #endif
-#include <charconv>
 #include <sys/stat.h>
 #include <filesystem>
 
@@ -514,13 +514,13 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 		std::string size = ExtractString(th.size);
 		size_t skip = 0;
 		if (!size.empty()) {
-			StrTrimInPlace(size);
-			auto [_, err] = std::from_chars(size.data(), size.data() + size.size(), skip, 8);
-			if (err != std::errc()) {
+			auto value = ParseInteger<size_t>(size, 8);
+			if (!value.has_value()) {
 				Debug(misc, 0, "The file '{}' has an invalid size for '{}'", filename, name);
 				fclose(f);
 				return false;
 			}
+			skip = *value;
 		}
 
 		switch (th.typeflag) {

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -63,19 +63,13 @@ LanguageStrings ReadRawLanguageStrings(const std::string &file)
 
 	char buffer[2048];
 	while (to_read != 0 && fgets(buffer, sizeof(buffer), *fh) != nullptr) {
-		size_t len = strlen(buffer);
+		std::string_view view{buffer};
+		ret.lines.emplace_back(StrTrimView(view, StringConsumer::WHITESPACE_OR_NEWLINE));
 
-		/* Remove trailing spaces/newlines from the string. */
-		size_t i = len;
-		while (i > 0 && (buffer[i - 1] == '\r' || buffer[i - 1] == '\n' || buffer[i - 1] == ' ')) i--;
-		buffer[i] = '\0';
-
-		ret.lines.emplace_back(buffer, i);
-
-		if (len > to_read) {
+		if (view.size() > to_read) {
 			to_read = 0;
 		} else {
-			to_read -= len;
+			to_read -= view.size();
 		}
 	}
 

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -96,7 +96,7 @@ static const std::initializer_list<KeycodeNames> _keycode_to_name = {
  */
 static std::optional<uint16_t> ParseCode(std::string_view keystr)
 {
-	keystr = StrTrimView(keystr);
+	keystr = StrTrimView(keystr, StringConsumer::WHITESPACE_NO_NEWLINE);
 	for (const auto &kn : _keycode_to_name) {
 		if (StrEqualsIgnoreCase(keystr, kn.name)) {
 			return kn.keycode;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -9,6 +9,7 @@
 
 #include "../stdafx.h"
 
+#include "../core/string_consumer.hpp"
 #include "../strings_func.h"
 #include "../command_func.h"
 #include "../timer/timer_game_tick.h"

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -9,6 +9,7 @@
 
 #include "../stdafx.h"
 #include "network_gui.h"
+#include "../core/string_consumer.hpp"
 #include "../saveload/saveload.h"
 #include "../saveload/saveload_filter.h"
 #include "../command_func.h"

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -479,13 +479,6 @@ static bool CheckCommandsMatch(std::string_view a, std::string_view b, std::stri
 	return result;
 }
 
-[[nodiscard]] static std::string_view StripTrailingWhitespace(std::string_view str)
-{
-	auto len = str.find_last_not_of("\r\n\t ");
-	if (len == std::string_view::npos) return {};
-	return str.substr(0, len + 1);
-}
-
 void StringReader::HandleString(std::string_view src)
 {
 	/* Ignore blank lines */
@@ -498,7 +491,7 @@ void StringReader::HandleString(std::string_view src)
 	}
 
 	/* Read string name */
-	std::string_view str_name = StripTrailingWhitespace(consumer.ReadUntilChar(':', StringConsumer::KEEP_SEPARATOR));
+	std::string_view str_name = StrTrimView(consumer.ReadUntilChar(':', StringConsumer::KEEP_SEPARATOR), StringConsumer::WHITESPACE_NO_NEWLINE);
 	if (!consumer.ReadCharIf(':')) {
 		StrgenError("Line has no ':' delimiter");
 		return;
@@ -605,7 +598,7 @@ void StringReader::ParseFile()
 		std::optional<std::string> line = this->ReadLine();
 		if (!line.has_value()) return;
 
-		this->HandleString(StripTrailingWhitespace(line.value()));
+		this->HandleString(StrTrimView(line.value(), StringConsumer::WHITESPACE_OR_NEWLINE));
 		_strgen.cur_line++;
 	}
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -225,7 +225,15 @@ bool StrValid(std::span<const char> str)
  */
 void StrTrimInPlace(std::string &str)
 {
-	str = StrTrimView(str);
+	size_t first_pos = str.find_first_not_of(' ');
+	if (first_pos == std::string::npos) {
+		str.clear();
+		return;
+	}
+	str.erase(0, first_pos);
+
+	size_t last_pos = str.find_last_not_of(' ');
+	str.erase(last_pos + 1);
 }
 
 std::string_view StrTrimView(std::string_view str)

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -225,24 +225,24 @@ bool StrValid(std::span<const char> str)
  */
 void StrTrimInPlace(std::string &str)
 {
-	size_t first_pos = str.find_first_not_of(' ');
+	size_t first_pos = str.find_first_not_of(StringConsumer::WHITESPACE_NO_NEWLINE);
 	if (first_pos == std::string::npos) {
 		str.clear();
 		return;
 	}
 	str.erase(0, first_pos);
 
-	size_t last_pos = str.find_last_not_of(' ');
+	size_t last_pos = str.find_last_not_of(StringConsumer::WHITESPACE_NO_NEWLINE);
 	str.erase(last_pos + 1);
 }
 
-std::string_view StrTrimView(std::string_view str)
+std::string_view StrTrimView(std::string_view str, std::string_view characters_to_trim)
 {
-	size_t first_pos = str.find_first_not_of(' ');
+	size_t first_pos = str.find_first_not_of(characters_to_trim);
 	if (first_pos == std::string::npos) {
 		return std::string_view{};
 	}
-	size_t last_pos = str.find_last_not_of(' ');
+	size_t last_pos = str.find_last_not_of(characters_to_trim);
 	return str.substr(first_pos, last_pos - first_pos + 1);
 }
 

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -39,7 +39,7 @@ bool strtolower(std::string &str, std::string::size_type offs = 0);
 
 [[nodiscard]] bool StrValid(std::span<const char> str);
 void StrTrimInPlace(std::string &str);
-[[nodiscard]] std::string_view StrTrimView(std::string_view str);
+[[nodiscard]] std::string_view StrTrimView(std::string_view str, std::string_view characters_to_trim);
 
 [[nodiscard]] bool StrStartsWithIgnoreCase(std::string_view str, std::string_view prefix);
 [[nodiscard]] bool StrEndsWithIgnoreCase(std::string_view str, std::string_view suffix);

--- a/src/tests/string_consumer.cpp
+++ b/src/tests/string_consumer.cpp
@@ -268,9 +268,11 @@ TEST_CASE("StringConsumer - ascii")
 
 TEST_CASE("StringConsumer - parse int")
 {
-	StringConsumer consumer("1 a -a -2 -2 ffffFFFF ffffFFFF -1aaaAAAA -1aaaAAAA +3 1234567890123 1234567890123 1234567890123 ffffFFFFffffFFFE ffffFFFFffffFFFE ffffFFFFffffFFFE ffffFFFFffffFFFE -0x1aaaAAAAaaaaAAAA -1234567890123 "sv);
+	StringConsumer consumer("1 a -a -2 -8 ffffFFFF ffffFFFF -1aaaAAAA -1aaaAAAA +3 1234567890123 1234567890123 1234567890123 ffffFFFFffffFFFE ffffFFFFffffFFFE ffffFFFFffffFFFE ffffFFFFffffFFFE -0x1aaaAAAAaaaaAAAA -1234567890123 "sv);
 	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(1, 1));
 	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(1, 1));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(8) == std::pair<StringConsumer::size_type, uint32_t>(1, 1));
+	CHECK(consumer.PeekIntegerBase<int32_t>(8) == std::pair<StringConsumer::size_type, int32_t>(1, 1));
 	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(1, 1));
 	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(1, 1));
 	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(1, 1));
@@ -279,6 +281,8 @@ TEST_CASE("StringConsumer - parse int")
 	CHECK(consumer.ReadUtf8() == ' ');
 	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(8) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(8) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(1, 0xa));
@@ -287,6 +291,8 @@ TEST_CASE("StringConsumer - parse int")
 	CHECK(consumer.ReadUtf8() == ' ');
 	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(8) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(8) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
@@ -295,6 +301,8 @@ TEST_CASE("StringConsumer - parse int")
 	CHECK(consumer.ReadUtf8() == ' ');
 	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(0) == std::pair<StringConsumer::size_type, int32_t>(2, -2));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(8) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(8) == std::pair<StringConsumer::size_type, int32_t>(2, -2));
 	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(2, -2));
 	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
@@ -302,10 +310,14 @@ TEST_CASE("StringConsumer - parse int")
 	CHECK(consumer.TryReadIntegerBase<uint32_t>(10) == std::nullopt);
 	CHECK(consumer.ReadIntegerBase<uint32_t>(10) == 0);
 	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(8) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(8) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.TryReadIntegerBase<uint32_t>(8) == std::nullopt);
+	CHECK(consumer.TryReadIntegerBase<int32_t>(8) == std::nullopt);
 	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
-	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(2, -2));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(2, -8));
 	CHECK(consumer.TryReadIntegerBase<uint32_t>(10) == std::nullopt);
-	CHECK(consumer.ReadIntegerBase<int32_t>(10) == -2);
+	CHECK(consumer.ReadIntegerBase<int32_t>(10) == -8);
 	CHECK(consumer.ReadUtf8() == ' ');
 	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(8, 0xffffffff));
 	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
@@ -324,6 +336,8 @@ TEST_CASE("StringConsumer - parse int")
 	CHECK(consumer.TryReadIntegerBase<uint32_t>(16) == std::nullopt);
 	CHECK(consumer.ReadIntegerBase<int32_t>(16) == -0x1aaaaaaa);
 	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(8) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(8) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
 	consumer.SkipIntegerBase(10);

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -14,6 +14,7 @@
 #include "../string_func.h"
 #include "../strings_func.h"
 #include "../core/string_builder.hpp"
+#include "../core/string_consumer.hpp"
 #include "../table/control_codes.h"
 
 #include "table/strings.h"
@@ -398,7 +399,8 @@ static const std::vector<std::pair<std::string, std::string>> _str_trim_testcase
 	{"a  ", "a"},
 	{"  a   ", "a"},
 	{"  a  b  c  ", "a  b  c"},
-	{"   ", ""}
+	{"   ", ""},
+	{"  \r\f\t  ", ""},
 };
 
 TEST_CASE("StrTrimInPlace")
@@ -411,7 +413,7 @@ TEST_CASE("StrTrimInPlace")
 
 TEST_CASE("StrTrimView") {
 	for (const auto& [input, expected] : _str_trim_testcases) {
-		CHECK(StrTrimView(input) == expected);
+		CHECK(StrTrimView(input, StringConsumer::WHITESPACE_NO_NEWLINE) == expected);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

https://github.com/OpenTTD/OpenTTD/pull/14186#discussion_r2072110988
Or basically that there are three `StrTrim` variants that do roughly the same, but not quite. Why not just unify them?


## Description

Replace `StrTrimInPlace(str)` with `str = StrTrimView(str)`, or trim the view before assigning to `std::string`, or use `ParseInteger` if all you do is trimming and then parsing the remainder as an integer. The caveat being that it read an octal, so add octal support to `ParseInteger`.

Change `StrTrimView` to require an extra parameter for the characters to trim, and generally use `StringConsumer::WHITESPACE_NO_NEWLINE`.

Replace `StripTrailingWhitespace` with `StrTrimView` and `StringConsumer::WHITESPACE_OR_NEWLINE` in strgen, as it won't hurt to remove white space in front of a string name (it shouldn't have been there, but it won't really harm anything). Also do the same for GameText, as that's basically strgen but for GS texts.


## Limitations

Left the constants in `StringConsumer`, so they need to be included. Could put them in string_type.h, but that removes the scoping.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
