### PR TITLE
Codechange: use std::string_view for std::getenv

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -733,8 +733,8 @@ static std::string GetHomeDir()
 	find_directory(B_USER_SETTINGS_DIRECTORY, &path);
 	return std::string(path.Path());
 #else
-	const char *home_env = std::getenv("HOME"); // Stack var, shouldn't be freed
-	if (home_env != nullptr) return std::string(home_env);
+	auto home_env = GetEnv("HOME"); // Stack var, shouldn't be freed
+	if (home_env.has_value()) return std::string(*home_env);
 
 	const struct passwd *pw = getpwuid(getuid());
 	if (pw != nullptr) return std::string(pw->pw_dir);
@@ -751,9 +751,8 @@ void DetermineBasePaths(std::string_view exe)
 	std::string tmp;
 	const std::string homedir = GetHomeDir();
 #ifdef USE_XDG
-	const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
-	if (xdg_data_home != nullptr) {
-		tmp = xdg_data_home;
+	if (auto xdg_data_home = GetEnv("XDG_DATA_HOME"); xdg_data_home.has_value()) {
+		tmp = *xdg_data_home;
 		tmp += PATHSEP;
 		tmp += PERSONAL_DIR[0] == '.' ? &PERSONAL_DIR[1] : PERSONAL_DIR;
 		AppendPathSeparator(tmp);
@@ -882,9 +881,8 @@ void DeterminePaths(std::string_view exe, bool only_local_path)
 #ifdef USE_XDG
 	std::string config_home;
 	std::string homedir = GetHomeDir();
-	const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
-	if (xdg_config_home != nullptr) {
-		config_home = xdg_config_home;
+	if (auto xdg_config_home = GetEnv("XDG_CONFIG_HOME"); xdg_config_home.has_value()) {
+		config_home = *xdg_config_home;
 		config_home += PATHSEP;
 		config_home += PERSONAL_DIR[0] == '.' ? &PERSONAL_DIR[1] : PERSONAL_DIR;
 	} else if (!homedir.empty()) {

--- a/src/network/core/config.cpp
+++ b/src/network/core/config.cpp
@@ -16,25 +16,13 @@
 #include "../../safeguards.h"
 
 /**
- * Get the environment variable using std::getenv and when it is an empty string (or nullptr), return a fallback value instead.
- * @param variable The environment variable to read from.
- * @param fallback The fallback in case the environment variable is not set.
- * @return The environment value, or when that does not exist the given fallback value.
- */
-static std::string_view GetEnv(const char *variable, std::string_view fallback)
-{
-	const char *value = std::getenv(variable);
-	return StrEmpty(value) ? fallback : value;
-}
-
-/**
  * Get the connection string for the game coordinator from the environment variable OTTD_COORDINATOR_CS,
  * or when it has not been set a hard coded default DNS hostname of the production server.
  * @return The game coordinator's connection string.
  */
 std::string_view NetworkCoordinatorConnectionString()
 {
-	return GetEnv("OTTD_COORDINATOR_CS", "coordinator.openttd.org");
+	return GetEnv("OTTD_COORDINATOR_CS").value_or("coordinator.openttd.org");
 }
 
 /**
@@ -44,7 +32,7 @@ std::string_view NetworkCoordinatorConnectionString()
  */
 std::string_view NetworkStunConnectionString()
 {
-	return GetEnv("OTTD_STUN_CS", "stun.openttd.org");
+	return GetEnv("OTTD_STUN_CS").value_or("stun.openttd.org");
 }
 
 /**
@@ -54,7 +42,7 @@ std::string_view NetworkStunConnectionString()
  */
 std::string_view NetworkContentServerConnectionString()
 {
-	return GetEnv("OTTD_CONTENT_SERVER_CS", "content.openttd.org");
+	return GetEnv("OTTD_CONTENT_SERVER_CS").value_or("content.openttd.org");
 }
 
 /**
@@ -64,7 +52,7 @@ std::string_view NetworkContentServerConnectionString()
  */
 std::string_view NetworkContentMirrorUriString()
 {
-	return GetEnv("OTTD_CONTENT_MIRROR_URI", "https://binaries.openttd.org/bananas");
+	return GetEnv("OTTD_CONTENT_MIRROR_URI").value_or("https://binaries.openttd.org/bananas");
 }
 
 /**
@@ -74,5 +62,5 @@ std::string_view NetworkContentMirrorUriString()
  */
 std::string_view NetworkSurveyUriString()
 {
-	return GetEnv("OTTD_SURVEY_URI", "https://survey-participate.openttd.org/");
+	return GetEnv("OTTD_SURVEY_URI").value_or("https://survey-participate.openttd.org/");
 }

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -151,7 +151,7 @@ void OSOpenBrowser(const std::string &url)
 /**
  * Determine and return the current user's locale.
  */
-const char *GetCurrentLocale(const char *)
+std::optional<std::string_view> GetCurrentLocale(const char *)
 {
 	static char retbuf[32] = { '\0' };
 	NSUserDefaults *defs = [ NSUserDefaults standardUserDefaults ];

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -395,7 +395,7 @@ wchar_t *convert_to_fs(std::string_view src, std::span<wchar_t> dst_buf)
 }
 
 /** Determine the current user's locale. */
-const char *GetCurrentLocale(const char *)
+std::optional<std::string_view> GetCurrentLocale(const char *)
 {
 	const LANGID userUiLang = GetUserDefaultUILanguage();
 	const LCID userUiLocale = MAKELCID(userUiLang, SORT_DEFAULT);

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -97,7 +97,7 @@ struct FileStringReader : StringReader {
 	{
 		this->StringReader::ParseFile();
 
-		if (StrEmpty(_strgen.lang.name) || StrEmpty(_strgen.lang.own_name) || StrEmpty(_strgen.lang.isocode)) {
+		if (*_strgen.lang.name == '\0' || *_strgen.lang.own_name == '\0' || *_strgen.lang.isocode == '\0') {
 			FatalError("Language must include ##name, ##ownname and ##isocode");
 		}
 	}

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -843,3 +843,15 @@ public:
 #endif /* defined(WITH_COCOA) && !defined(STRGEN) && !defined(SETTINGSGEN) */
 
 #endif
+
+/**
+ * Get the environment variable using std::getenv and when it is an empty string (or nullptr), return \c std::nullopt instead.
+ * @param variable The environment variable to read from.
+ * @return The environment value, or \c std::nullopt.
+ */
+std::optional<std::string_view> GetEnv(const char *variable)
+{
+	auto val = std::getenv(variable);
+	if (val == nullptr || *val == '\0') return std::nullopt;
+	return val;
+}

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -58,18 +58,6 @@ struct CaseInsensitiveComparator {
 	bool operator()(std::string_view s1, std::string_view s2) const { return StrCompareIgnoreCase(s1, s2) < 0; }
 };
 
-/**
- * Check if a string buffer is empty.
- *
- * @param s The pointer to the first element of the buffer
- * @return true if the buffer starts with the terminating null-character or
- *         if the given pointer points to nullptr else return false
- */
-inline bool StrEmpty(const char *s)
-{
-	return s == nullptr || s[0] == '\0';
-}
-
 bool IsValidChar(char32_t key, CharSetFilter afilter);
 
 size_t Utf8StringLength(std::string_view str);

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -167,4 +167,6 @@ inline bool IsWhitespace(char32_t c)
 #include <sys/param.h>
 #endif
 
+std::optional<std::string_view> GetEnv(const char *variable);
+
 #endif /* STRING_FUNC_H */


### PR DESCRIPTION
## Motivation / Problem

C-style string mangling, `std::getenv` in this case.


## Description

`std::getenv` returns a `nullptr`, or some C-style string. This string might also be empty, in which case it's essentially equivalent to `nullptr`. Introduce `GetEnv` that returns `std::optional<std::string_view>` to hide this mess, and make it easier to use the strings later on.

This removes the last instance of `StrEmpty` that also needs the check for `nullptr`, so the three others are just replaced by a simple `'\0'` check.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
