### PR TITLE
Change: Remove the limit of 20 parameters to a Script Text string.

### DIFF
--- a/bin/game/compat_14.nut
+++ b/bin/game/compat_14.nut
@@ -9,6 +9,9 @@
 
 GSBridge.GetBridgeID <- GSBridge.GetBridgeType;
 
+/* Emulate old GSText parameter padding behaviour */
+GSText.SCRIPT_TEXT_MAX_PARAMETERS <- 20;
+
 class GSCompat14 {
 	function Text(text)
 	{

--- a/src/game/game_instance.cpp
+++ b/src/game/game_instance.cpp
@@ -50,9 +50,9 @@ void GameInstance::RegisterAPI()
 	/* Register all classes */
 	SQGS_RegisterAll(*this->engine);
 
-	RegisterGameTranslation(*this->engine);
-
 	if (!this->LoadCompatibilityScripts(GAME_DIR, GameInfo::ApiVersions)) this->Died();
+
+	RegisterGameTranslation(*this->engine);
 }
 
 int GameInstance::GetSetting(const std::string &name)

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -376,6 +376,8 @@ void RegisterGameTranslation(Squirrel &engine)
 
 	sq_pop(vm, 2);
 
+	ScriptText::SetPadParameterCount(vm);
+
 	ReconsiderGameScriptLanguage();
 }
 

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -75,8 +75,6 @@ private:
  */
 class ScriptText : public Text {
 public:
-	static const int SCRIPT_TEXT_MAX_PARAMETERS = 20; ///< The maximum amount of parameters you can give to one object.
-
 #ifndef DOXYGEN_API
 	/**
 	 * The constructor wrapper from Squirrel.
@@ -128,10 +126,15 @@ public:
 	 */
 	EncodedString GetEncodedText() override;
 
+	/**
+	 * @api -all
+	 */
+	static void SetPadParameterCount(HSQUIRRELVM vm);
+
 private:
 	using ScriptTextRef = ScriptObjectRef<ScriptText>;
 	using ScriptTextList = std::vector<ScriptText *>;
-	using Param = std::variant<SQInteger, std::string, ScriptTextRef>;
+	using Param = std::variant<std::monostate, SQInteger, std::string, ScriptTextRef>;
 
 	struct ParamCheck {
 		StringIndexInTab owner;
@@ -149,8 +152,9 @@ private:
 	using ParamSpan = std::span<ParamCheck>;
 
 	StringIndexInTab string;
-	std::array<Param, SCRIPT_TEXT_MAX_PARAMETERS> param = {};
-	int paramc = 0;
+	std::vector<Param> param{};
+
+	static inline int pad_parameter_count = 0; ///< Pad parameters for relaxed string validation.
 
 	/**
 	 * Internal function to recursively fill a list of parameters.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

There used to be a global limit of 20 string parameters, and this also was applied to Game Script text parameters.

Global parameters, and the limit, has been removed, but the Game Script limit is still there.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove the Game Script limit. The fixed size array is now a vector.

For compatibility with previous behaviour, the script constant SCRIPT_TEXT_MAX_PARAMETERS is now implemented via the compatibility scripts and is applied to pre-version 15 scripts.

This compatibility is to allow scripts which forget to set parameters to still produce some text and not abort.


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
