### PR TITLE
Codechange: Remove usages of stoi and stol.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2132,9 +2132,9 @@ static bool ConNetworkAuthorizedKey(std::span<std::string_view> argv)
 
 		authorized_key = argv[3];
 		if (StrStartsWithIgnoreCase(authorized_key, "client:")) {
-			std::string id_string(authorized_key.substr(7));
-			authorized_key = NetworkGetPublicKeyOfClient(static_cast<ClientID>(std::stoi(id_string)));
-			if (authorized_key.empty()) {
+			auto value = ParseInteger<uint32_t>(authorized_key.substr(7));
+			if (value.has_value()) authorized_key = NetworkGetPublicKeyOfClient(static_cast<ClientID>(*value));
+			if (!value.has_value() || authorized_key.empty()) {
 				IConsolePrint(CC_ERROR, "You must enter a valid client id; see 'clients'.");
 				return false;
 			}
@@ -2154,8 +2154,8 @@ static bool ConNetworkAuthorizedKey(std::span<std::string_view> argv)
 	}
 
 	if (StrStartsWithIgnoreCase(type, "company:")) {
-		std::string id_string(type.substr(8));
-		Company *c = Company::GetIfValid(std::stoi(id_string) - 1);
+		auto value = ParseInteger<uint32_t>(type.substr(8));
+		Company *c = value.has_value() ? Company::GetIfValid(*value - 1) : nullptr;
 		if (c == nullptr) {
 			IConsolePrint(CC_ERROR, "You must enter a valid company id; see 'companies'.");
 			return false;

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -59,6 +59,13 @@
 #define strtoll   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strtoul   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strtoull  SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define stoi      SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define stol      SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define stoll     SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define stoul     SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define stoull    SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define stoimax   SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define stoumax   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
 /* Use fmt::print instead. */
 #define printf    SAFEGUARD_DO_NOT_USE_THIS_METHOD

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2863,18 +2863,17 @@ static std::pair<const SaveLoadFormat &, uint8_t> GetSavegameFormat(const std::s
 		for (const auto &slf : _saveload_formats) {
 			if (slf.init_write != nullptr && name.compare(slf.name) == 0) {
 				if (has_comp_level) {
-					const std::string complevel(full_name, separator + 1);
+					auto complevel = std::string_view(full_name).substr(separator + 1);
 
 					/* Get the level and determine whether all went fine. */
-					size_t processed;
-					long level = std::stol(complevel, &processed, 10);
-					if (processed == 0 || level != Clamp(level, slf.min_compression, slf.max_compression)) {
+					auto level = ParseInteger<uint8_t>(complevel);
+					if (!level.has_value() || *level != Clamp(*level, slf.min_compression, slf.max_compression)) {
 						ShowErrorMessage(
 							GetEncodedString(STR_CONFIG_ERROR),
 							GetEncodedString(STR_CONFIG_ERROR_INVALID_SAVEGAME_COMPRESSION_LEVEL, complevel),
 							WL_CRITICAL);
 					} else {
-						return {slf, ClampTo<uint8_t>(level)};
+						return {slf, *level};
 					}
 				}
 				return {slf, slf.default_compression};

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -14,6 +14,7 @@
 #include "script_text.hpp"
 #include "script_log.hpp"
 #include "../script_fatalerror.hpp"
+#include "../../core/string_consumer.hpp"
 #include "../../table/control_codes.h"
 
 #include "table/strings.h"
@@ -141,7 +142,9 @@ SQInteger ScriptText::_set(HSQUIRRELVM vm)
 		std::string str = StrMakeValid(view);
 		if (!str.starts_with("param_") || str.size() > 8) return SQ_ERROR;
 
-		k = stoi(str.substr(6));
+		auto key = ParseInteger<int32_t>(str.substr(6));
+		if (!key.has_value()) return SQ_ERROR;
+		k = *key;
 	} else if (sq_gettype(vm, 2) == OT_INTEGER) {
 		SQInteger key;
 		sq_getinteger(vm, 2, &key);


### PR DESCRIPTION
## Motivation / Problem

* There are even more old-style integer parsing methods in the stdlib: `stoi`, `stol`, `stoll`, `stoul`, `stoull`, `stoimax`, `stoumax`.
* For the title game commands there was even a custom implementation.

## Description

* Add them all to `safeguards.h`.
* Use `ParseInteger` instead.
* Use `StringConsumer` for the title game stuff.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
