### PR TITLE
Codechange: Use more std::string_view.

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2846,7 +2846,7 @@ static const SaveLoadFormat _saveload_formats[] = {
  * @param full_name Name of the savegame format. If empty it picks the first available one
  * @return Pair containing reference to SaveLoadFormat struct giving all characteristics of this type of savegame, and a compression level to use.
  */
-static std::pair<const SaveLoadFormat &, uint8_t> GetSavegameFormat(const std::string &full_name)
+static std::pair<const SaveLoadFormat &, uint8_t> GetSavegameFormat(std::string_view full_name)
 {
 	/* Find default savegame format, the highest one with which files can be written. */
 	auto it = std::find_if(std::rbegin(_saveload_formats), std::rend(_saveload_formats), [](const auto &slf) { return slf.init_write != nullptr; });
@@ -2858,12 +2858,12 @@ static std::pair<const SaveLoadFormat &, uint8_t> GetSavegameFormat(const std::s
 		/* Get the ":..." of the compression level out of the way */
 		size_t separator = full_name.find(':');
 		bool has_comp_level = separator != std::string::npos;
-		const std::string name(full_name, 0, has_comp_level ? separator : full_name.size());
+		std::string_view name = has_comp_level ? full_name.substr(0, separator) : full_name;
 
 		for (const auto &slf : _saveload_formats) {
 			if (slf.init_write != nullptr && name.compare(slf.name) == 0) {
 				if (has_comp_level) {
-					auto complevel = std::string_view(full_name).substr(separator + 1);
+					auto complevel = full_name.substr(separator + 1);
 
 					/* Get the level and determine whether all went fine. */
 					auto level = ParseInteger<uint8_t>(complevel);


### PR DESCRIPTION
## Motivation / Problem

Unnecessary `std::string` construction.

## Description

Use `std::string_view` for sub strings.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
