### PR TITLE
Codechange: replace last strncmp uses

### DIFF
--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -73,9 +73,9 @@ bool SetFallbackFont(FontCacheSettings *settings, const std::string &language_is
 			if (((symbolic_traits & kCTFontMonoSpaceTrait) == kCTFontMonoSpaceTrait) != callback->Monospace()) continue;
 
 			/* Get font name. */
-			char name[128];
+			char buffer[128];
 			CFAutoRelease<CFStringRef> font_name((CFStringRef)CTFontDescriptorCopyAttribute(font, kCTFontDisplayNameAttribute));
-			CFStringGetCString(font_name.get(), name, lengthof(name), kCFStringEncodingUTF8);
+			CFStringGetCString(font_name.get(), buffer, std::size(buffer), kCFStringEncodingUTF8);
 
 			/* Serif fonts usually look worse on-screen with only small
 			 * font sizes. As such, we try for a sans-serif font first.
@@ -84,7 +84,8 @@ bool SetFallbackFont(FontCacheSettings *settings, const std::string &language_is
 
 			/* There are some special fonts starting with an '.' and the last
 			 * resort font that aren't usable. Skip them. */
-			if (name[0] == '.' || strncmp(name, "LastResort", 10) == 0) continue;
+			std::string_view name{buffer};
+			if (name.starts_with(".") || name.starts_with("LastResort")) continue;
 
 			/* Save result. */
 			callback->SetFontNames(settings, name);

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -21,33 +21,33 @@
 #define calloc    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define realloc   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
-/* Use std::string instead. */
+/* Use std::string/std::string_view instead. */
 #define strdup    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strndup   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
-/* Use strecpy instead. */
 #define strcpy    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strncpy   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
-/* Use std::string concatenation/fmt::format instead. */
 #define strcat    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strncat   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
-/* Use fmt::format instead. */
 #define sprintf   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define snprintf  SAFEGUARD_DO_NOT_USE_THIS_METHOD
-
-/* Use fmt::format instead. */
 #define vsprintf  SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define vsnprintf SAFEGUARD_DO_NOT_USE_THIS_METHOD
+
+#define strncmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define strcasecmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#ifdef stricmp
+#undef stricmp
+#endif
+#define stricmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
 /* Use fgets instead. */
 #define gets      SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
-/* No clear replacement. */
-#define strtok    SAFEGUARD_DO_NOT_USE_THIS_METHOD
-
 /* Use StringConsumer instead. */
+#define strtok    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define sscanf    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define from_string SAFEGUARD_DO_NOT_USE_THIS_METHOD
 


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

Replace `strncmp` with `starts_with` of `std::string_view`.
Also use `std::any_of`/`std::all_of` instead of `memcmp`, and remove some magic numbers.


## Limitations

`strcmp` still exists, but that's being worked on.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
