### PR TITLE
Codechange: use more std::string_views in squirrel

### DIFF
--- a/cmake/scripts/SquirrelExport.cmake
+++ b/cmake/scripts/SquirrelExport.cmake
@@ -341,7 +341,7 @@ foreach(LINE IN LISTS SOURCE_LINES)
         endif()
 
         string(APPEND SQUIRREL_EXPORT "\n")
-        string(APPEND SQUIRREL_EXPORT "\ntemplate <> SQInteger PushClassName<${CLS}, ScriptType::${APIUC}>(HSQUIRRELVM vm) { sq_pushstring(vm, \"${API_CLS}\", -1); return 1; }")
+        string(APPEND SQUIRREL_EXPORT "\ntemplate <> SQInteger PushClassName<${CLS}, ScriptType::${APIUC}>(HSQUIRRELVM vm) { sq_pushstring(vm, \"${API_CLS}\"); return 1; }")
         string(APPEND SQUIRREL_EXPORT "\n")
 
         # Then do the registration functions of the class.

--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -304,8 +304,8 @@ SQRESULT sq_clear(HSQUIRRELVM v,SQInteger idx);
 /*calls*/
 SQRESULT sq_call(HSQUIRRELVM v,SQInteger params,SQBool retval,SQBool raiseerror, int suspend = -1);
 SQRESULT sq_resume(HSQUIRRELVM v,SQBool retval,SQBool raiseerror);
-const SQChar *sq_getlocal(HSQUIRRELVM v,SQUnsignedInteger level,SQUnsignedInteger idx);
-const SQChar *sq_getfreevariable(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger nval);
+std::optional<std::string_view> sq_getlocal(HSQUIRRELVM v,SQUnsignedInteger level,SQUnsignedInteger idx);
+std::optional<std::string_view> sq_getfreevariable(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger nval);
 SQRESULT sq_throwerror(HSQUIRRELVM v,std::string_view err);
 void sq_reseterror(HSQUIRRELVM v);
 void sq_getlasterror(HSQUIRRELVM v);
@@ -316,7 +316,7 @@ void sq_pushobject(HSQUIRRELVM v,HSQOBJECT obj);
 void sq_addref(HSQUIRRELVM v,HSQOBJECT *po);
 SQBool sq_release(HSQUIRRELVM v,HSQOBJECT *po);
 void sq_resetobject(HSQOBJECT *po);
-const SQChar *sq_objtostring(HSQOBJECT *o);
+std::optional<std::string_view> sq_objtostring(HSQOBJECT *o);
 SQBool sq_objtobool(HSQOBJECT *o);
 SQInteger sq_objtointeger(HSQOBJECT *o);
 SQFloat sq_objtofloat(HSQOBJECT *o);
@@ -361,7 +361,7 @@ void sq_setdebughook(HSQUIRRELVM v);
 
 /* Limit the total number of ops that can be consumed by an operation */
 struct SQOpsLimiter {
-	SQOpsLimiter(HSQUIRRELVM v, SQInteger ops, const char *label);
+	SQOpsLimiter(HSQUIRRELVM v, SQInteger ops, std::string_view label);
 	~SQOpsLimiter();
 private:
 	HSQUIRRELVM _v;

--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -164,9 +164,9 @@ typedef struct tagSQObject
 }SQObject;
 
 typedef struct tagSQStackInfos{
-	const SQChar* funcname;
-	const SQChar* source;
-	SQInteger line;
+	std::string_view funcname;
+	std::string_view source;
+	SQInteger line = -1;
 }SQStackInfos;
 
 typedef struct SQVM* HSQUIRRELVM;
@@ -190,8 +190,8 @@ typedef struct tagSQRegFunction{
 
 typedef struct tagSQFunctionInfo {
 	SQUserPointer funcid;
-	const SQChar *name;
-	const SQChar *source;
+	std::string_view name;
+	std::string_view source;
 }SQFunctionInfo;
 
 

--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -306,8 +306,7 @@ SQRESULT sq_call(HSQUIRRELVM v,SQInteger params,SQBool retval,SQBool raiseerror,
 SQRESULT sq_resume(HSQUIRRELVM v,SQBool retval,SQBool raiseerror);
 const SQChar *sq_getlocal(HSQUIRRELVM v,SQUnsignedInteger level,SQUnsignedInteger idx);
 const SQChar *sq_getfreevariable(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger nval);
-SQRESULT sq_throwerror(HSQUIRRELVM v,const SQChar *err, SQInteger len = -1);
-inline SQRESULT sq_throwerror(HSQUIRRELVM v, std::string_view err) { return sq_throwerror(v, err.data(), err.size()); }
+SQRESULT sq_throwerror(HSQUIRRELVM v,std::string_view err);
 void sq_reseterror(HSQUIRRELVM v);
 void sq_getlasterror(HSQUIRRELVM v);
 

--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -259,7 +259,7 @@ SQRESULT sq_getuserdata(HSQUIRRELVM v,SQInteger idx,SQUserPointer *p,SQUserPoint
 SQRESULT sq_settypetag(HSQUIRRELVM v,SQInteger idx,SQUserPointer typetag);
 SQRESULT sq_gettypetag(HSQUIRRELVM v,SQInteger idx,SQUserPointer *typetag);
 void sq_setreleasehook(HSQUIRRELVM v,SQInteger idx,SQRELEASEHOOK hook);
-SQChar *sq_getscratchpad(HSQUIRRELVM v,SQInteger minsize);
+std::span<char> sq_getscratchpad(HSQUIRRELVM v,SQInteger minsize);
 SQRESULT sq_getfunctioninfo(HSQUIRRELVM v,SQInteger idx,SQFunctionInfo *fi);
 SQRESULT sq_getclosureinfo(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger *nparams,SQUnsignedInteger *nfreevars);
 SQRESULT sq_setnativeclosurename(HSQUIRRELVM v,SQInteger idx,std::string_view name);

--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -237,8 +237,7 @@ void sq_newarray(HSQUIRRELVM v,SQInteger size);
 void sq_newclosure(HSQUIRRELVM v,SQFUNCTION func,SQUnsignedInteger nfreevars);
 SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheck,const SQChar *typemask);
 SQRESULT sq_bindenv(HSQUIRRELVM v,SQInteger idx);
-void sq_pushstring(HSQUIRRELVM v,const SQChar *s,SQInteger len);
-inline void sq_pushstring(HSQUIRRELVM v, std::string_view str, SQInteger len = -1) { sq_pushstring(v, str.data(), len == -1 ? str.size() : len); }
+void sq_pushstring(HSQUIRRELVM v, std::string_view str);
 void sq_pushfloat(HSQUIRRELVM v,SQFloat f);
 void sq_pushinteger(HSQUIRRELVM v,SQInteger n);
 void sq_pushbool(HSQUIRRELVM v,SQBool b);

--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -173,7 +173,7 @@ typedef struct SQVM* HSQUIRRELVM;
 typedef SQObject HSQOBJECT;
 typedef SQInteger (*SQFUNCTION)(HSQUIRRELVM);
 typedef SQInteger (*SQRELEASEHOOK)(SQUserPointer,SQInteger size);
-typedef void (*SQCOMPILERERROR)(HSQUIRRELVM,const SQChar * /*desc*/,const SQChar * /*source*/,SQInteger /*line*/,SQInteger /*column*/);
+typedef void (*SQCOMPILERERROR)(HSQUIRRELVM,std::string_view /*desc*/,std::string_view /*source*/,SQInteger /*line*/,SQInteger /*column*/);
 typedef void (*SQPRINTFUNCTION)(HSQUIRRELVM,std::string_view);
 
 typedef SQInteger (*SQWRITEFUNC)(SQUserPointer,SQUserPointer,SQInteger);
@@ -213,8 +213,8 @@ SQInteger sq_getvmstate(HSQUIRRELVM v);
 void sq_decreaseops(HSQUIRRELVM v, int amount);
 
 /*compiler*/
-SQRESULT sq_compile(HSQUIRRELVM v,SQLEXREADFUNC read,SQUserPointer p,const SQChar *sourcename,SQBool raiseerror);
-SQRESULT sq_compilebuffer(HSQUIRRELVM v,const SQChar *s,SQInteger size,const SQChar *sourcename,SQBool raiseerror);
+SQRESULT sq_compile(HSQUIRRELVM v,SQLEXREADFUNC read,SQUserPointer p,std::string_view sourcename,SQBool raiseerror);
+SQRESULT sq_compilebuffer(HSQUIRRELVM v,std::string_view buffer,std::string_view sourcename,SQBool raiseerror);
 void sq_enabledebuginfo(HSQUIRRELVM v, SQBool enable);
 void sq_notifyallexceptions(HSQUIRRELVM v, SQBool enable);
 void sq_setcompilererrorhandler(HSQUIRRELVM v,SQCOMPILERERROR f);

--- a/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
@@ -132,7 +132,7 @@ static SQInteger _sqstd_aux_printerror(HSQUIRRELVM v)
 	return 0;
 }
 
-void _sqstd_compiler_error(HSQUIRRELVM v,const SQChar *sErr,const SQChar *sSource,SQInteger line,SQInteger column)
+void _sqstd_compiler_error(HSQUIRRELVM v,std::string_view sErr,std::string_view sSource,SQInteger line,SQInteger column)
 {
 	SQPRINTFUNCTION pf = sq_getprintfunc(v);
 	if(pf) {

--- a/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
@@ -17,7 +17,6 @@ void sqstd_printcallstack(HSQUIRRELVM v)
 		SQBool b;
 		SQFloat f;
 		SQInteger level=1; //1 is to skip this function that is level 0
-		const SQChar *name=nullptr;
 		SQInteger seq=0;
 		pf(v,"\nCALLSTACK\n");
 		while(SQ_SUCCEEDED(sq_stackinfos(v,level,&si)))
@@ -46,8 +45,9 @@ void sqstd_printcallstack(HSQUIRRELVM v)
 
 		for(level=0;level<10;level++){
 			seq=0;
-			while((name = sq_getlocal(v,level,seq)))
-			{
+			std::optional<std::string_view> opt;
+			while ((opt = sq_getlocal(v,level,seq)).has_value()) {
+				std::string_view name = *opt;
 				seq++;
 				switch(sq_gettype(v,-1))
 				{

--- a/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
@@ -21,21 +21,17 @@ void sqstd_printcallstack(HSQUIRRELVM v)
 		pf(v,"\nCALLSTACK\n");
 		while(SQ_SUCCEEDED(sq_stackinfos(v,level,&si)))
 		{
-			const SQChar *fn="unknown";
-			const SQChar *src="unknown";
-			if(si.funcname)fn=si.funcname;
-			if(si.source) {
+			std::string_view fn="unknown";
+			std::string_view src="unknown";
+			if(!si.funcname.empty())fn=si.funcname;
+			if(!si.source.empty()) {
 				/* We don't want to bother users with absolute paths to all AI files.
 				 * Since the path only reaches NoAI code in a formatted string we have
 				 * to strip it here. Let's hope nobody installs openttd in a subdirectory
 				 * of a directory named /ai/. */
-				src = strstr(si.source, "\\ai\\");
-				if (!src) src = strstr(si.source, "/ai/");
-				if (src) {
-					src += 4;
-				} else {
-					src = si.source;
-				}
+				auto p = si.source.find("\\ai\\");
+				if (p == std::string_view::npos) p = si.source.find("/ai/");
+				src = (p == std::string_view::npos) ? si.source : si.source.substr(p + 4);
 			}
 			pf(v,fmt::format("*FUNCTION [{}()] {} line [{}]\n",fn,src,si.line));
 			level++;

--- a/src/3rdparty/squirrel/sqstdlib/sqstdmath.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdmath.cpp
@@ -99,7 +99,7 @@ SQRESULT sqstd_register_mathlib(HSQUIRRELVM v)
 {
 	SQInteger i=0;
 	while(mathlib_funcs[i].name!=nullptr)	{
-		sq_pushstring(v,mathlib_funcs[i].name,-1);
+		sq_pushstring(v,mathlib_funcs[i].name);
 		sq_newclosure(v,mathlib_funcs[i].f,0);
 		sq_setparamscheck(v,mathlib_funcs[i].nparamscheck,mathlib_funcs[i].typemask);
 		sq_setnativeclosurename(v,-1,mathlib_funcs[i].name);
@@ -107,11 +107,11 @@ SQRESULT sqstd_register_mathlib(HSQUIRRELVM v)
 		i++;
 	}
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
-	sq_pushstring(v,"RAND_MAX",-1);
+	sq_pushstring(v,"RAND_MAX");
 	sq_pushinteger(v,RAND_MAX);
 	sq_createslot(v,-3);
 #endif /* EXPORT_DEFAULT_SQUIRREL_FUNCTIONS */
-	sq_pushstring(v,"PI",-1);
+	sq_pushstring(v,"PI");
 	sq_pushfloat(v,(SQFloat)M_PI);
 	sq_createslot(v,-3);
 	return SQ_OK;

--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -930,9 +930,9 @@ void sq_resetobject(HSQOBJECT *po)
 	po->_unVal.pUserPointer=nullptr;po->_type=OT_NULL;
 }
 
-SQRESULT sq_throwerror(HSQUIRRELVM v,const SQChar *err, SQInteger len)
+SQRESULT sq_throwerror(HSQUIRRELVM v,std::string_view error)
 {
-	v->_lasterror=SQString::Create(_ss(v),err, len);
+	v->_lasterror=SQString::Create(_ss(v),error);
 	return -1;
 }
 

--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -132,7 +132,7 @@ void sq_close(HSQUIRRELVM v)
 	sq_delete(ss, SQSharedState);
 }
 
-SQRESULT sq_compile(HSQUIRRELVM v,SQLEXREADFUNC read,SQUserPointer p,const SQChar *sourcename,SQBool raiseerror)
+SQRESULT sq_compile(HSQUIRRELVM v,SQLEXREADFUNC read,SQUserPointer p,std::string_view sourcename,SQBool raiseerror)
 {
 	SQObjectPtr o;
 	if(Compile(v, read, p, sourcename, o, raiseerror != 0, _ss(v)->_debuginfo)) {
@@ -1261,8 +1261,8 @@ char32_t buf_lexfeed(SQUserPointer file)
 	return consumer.AnyBytesLeft() ? consumer.ReadUtf8(-1) : 0;
 }
 
-SQRESULT sq_compilebuffer(HSQUIRRELVM v,const SQChar *s,SQInteger size,const SQChar *sourcename,SQBool raiseerror) {
-	StringConsumer consumer(s, size);
+SQRESULT sq_compilebuffer(HSQUIRRELVM v,std::string_view buffer,std::string_view sourcename,SQBool raiseerror) {
+	StringConsumer consumer{buffer};
 	return sq_compile(v, buf_lexfeed, &consumer, sourcename, raiseerror);
 }
 

--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -210,11 +210,9 @@ void sq_pushnull(HSQUIRRELVM v)
 	v->Push(_null_);
 }
 
-void sq_pushstring(HSQUIRRELVM v,const SQChar *s,SQInteger len)
+void sq_pushstring(HSQUIRRELVM v,std::string_view s)
 {
-	if(s)
-		v->Push(SQObjectPtr(SQString::Create(_ss(v), s, len)));
-	else v->Push(_null_);
+	v->Push(SQObjectPtr(SQString::Create(_ss(v), s)));
 }
 
 void sq_pushinteger(HSQUIRRELVM v,SQInteger n)

--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -1074,7 +1074,7 @@ SQRESULT sq_readclosure(HSQUIRRELVM v,SQREADFUNC r,SQUserPointer up)
 	return SQ_OK;
 }
 
-SQChar *sq_getscratchpad(HSQUIRRELVM v,SQInteger minsize)
+std::span<char> sq_getscratchpad(HSQUIRRELVM v,SQInteger minsize)
 {
 	return _ss(v)->GetScratchPad(minsize);
 }

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -188,7 +188,7 @@ static SQInteger base_compilestring(HSQUIRRELVM v)
 	if(nargs>2){
 		sq_getstring(v,3,name);
 	}
-	if(SQ_SUCCEEDED(sq_compilebuffer(v,src,size,name,SQFalse)))
+	if(SQ_SUCCEEDED(sq_compilebuffer(v,src.substr(0, size),name,SQFalse)))
 		return 1;
 	else
 		return SQ_ERROR;

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -233,7 +233,7 @@ static SQInteger base_array(HSQUIRRELVM v)
 static SQInteger base_type(HSQUIRRELVM v)
 {
 	SQObjectPtr &o = stack_get(v,2);
-	v->Push(SQString::Create(_ss(v),GetTypeName(o),-1));
+	v->Push(SQString::Create(_ss(v),GetTypeName(o)));
 	return 1;
 }
 
@@ -372,7 +372,7 @@ static SQInteger number_delegate_tochar(HSQUIRRELVM v)
 {
 	SQObject &o=stack_get(v,1);
 	SQChar c = (SQChar)tointeger(o);
-	v->Push(SQString::Create(_ss(v),(const SQChar *)&c,1));
+	v->Push(SQString::Create(_ss(v),std::string_view(&c, 1)));
 	return 1;
 }
 
@@ -642,7 +642,7 @@ static SQInteger string_slice(HSQUIRRELVM v)
 	if(eidx < 0)eidx = slen + eidx;
 	if(eidx < sidx)	return sq_throwerror(v,"wrong indexes");
 	if(eidx > slen)	return sq_throwerror(v,"slice out of range");
-	v->Push(SQString::Create(_ss(v),&_stringval(o)[sidx],eidx-sidx));
+	v->Push(SQString::Create(_ss(v),std::string_view(&_stringval(o)[sidx],eidx-sidx)));
 	return 1;
 }
 
@@ -750,19 +750,19 @@ static SQInteger closure_getinfos(HSQUIRRELVM v) {
 			_array(params)->Set((SQInteger)n,f->_parameters[n]);
 		}
 		if(f->_varparams) {
-			_array(params)->Set(nparams-1,SQString::Create(_ss(v),"...",-1));
+			_array(params)->Set(nparams-1,SQString::Create(_ss(v),"..."));
 		}
-		res->NewSlot(SQString::Create(_ss(v),"native",-1),false);
-		res->NewSlot(SQString::Create(_ss(v),"name",-1),f->_name);
-		res->NewSlot(SQString::Create(_ss(v),"src",-1),f->_sourcename);
-		res->NewSlot(SQString::Create(_ss(v),"parameters",-1),params);
-		res->NewSlot(SQString::Create(_ss(v),"varargs",-1),f->_varparams);
+		res->NewSlot(SQString::Create(_ss(v),"native"),false);
+		res->NewSlot(SQString::Create(_ss(v),"name"),f->_name);
+		res->NewSlot(SQString::Create(_ss(v),"src"),f->_sourcename);
+		res->NewSlot(SQString::Create(_ss(v),"parameters"),params);
+		res->NewSlot(SQString::Create(_ss(v),"varargs"),f->_varparams);
 	}
 	else { //OT_NATIVECLOSURE
 		SQNativeClosure *nc = _nativeclosure(o);
-		res->NewSlot(SQString::Create(_ss(v),"native",-1),true);
-		res->NewSlot(SQString::Create(_ss(v),"name",-1),nc->_name);
-		res->NewSlot(SQString::Create(_ss(v),"paramscheck",-1),nc->_nparamscheck);
+		res->NewSlot(SQString::Create(_ss(v),"native"),true);
+		res->NewSlot(SQString::Create(_ss(v),"name"),nc->_name);
+		res->NewSlot(SQString::Create(_ss(v),"paramscheck"),nc->_nparamscheck);
 		SQObjectPtr typecheck;
 		if(!nc->_typecheck.empty()) {
 			typecheck =
@@ -771,7 +771,7 @@ static SQInteger closure_getinfos(HSQUIRRELVM v) {
 					_array(typecheck)->Set((SQInteger)n,nc->_typecheck[n]);
 			}
 		}
-		res->NewSlot(SQString::Create(_ss(v),"typecheck",-1),typecheck);
+		res->NewSlot(SQString::Create(_ss(v),"typecheck"),typecheck);
 	}
 	v->Push(res);
 	return 1;

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -669,9 +669,9 @@ static SQInteger string_find(HSQUIRRELVM v)
 	SQObject str=stack_get(v,1); \
 	SQInteger len=_string(str)->_len; \
 	const SQChar *sThis=_stringval(str); \
-	SQChar *sNew=(_ss(v)->GetScratchPad(len)); \
+	std::span<char> sNew=(_ss(v)->GetScratchPad(len)); \
 	for(SQInteger i=0;i<len;i++) sNew[i]=func(sThis[i]); \
-	v->Push(SQString::Create(_ss(v),sNew,len)); \
+	v->Push(SQString::Create(_ss(v),std::string_view(sNew.data(), len))); \
 	return 1; \
 }
 

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -111,20 +111,20 @@ static SQInteger base_getstackinfos(HSQUIRRELVM v)
 		if(si.funcname)fn = si.funcname;
 		if(si.source)src = si.source;
 		sq_newtable(v);
-		sq_pushstring(v, "func", -1);
-		sq_pushstring(v, fn, -1);
+		sq_pushstring(v, "func");
+		sq_pushstring(v, fn);
 		sq_createslot(v, -3);
-		sq_pushstring(v, "src", -1);
-		sq_pushstring(v, src, -1);
+		sq_pushstring(v, "src");
+		sq_pushstring(v, src);
 		sq_createslot(v, -3);
-		sq_pushstring(v, "line", -1);
+		sq_pushstring(v, "line");
 		sq_pushinteger(v, si.line);
 		sq_createslot(v, -3);
-		sq_pushstring(v, "locals", -1);
+		sq_pushstring(v, "locals");
 		sq_newtable(v);
 		seq=0;
 		while ((name = sq_getlocal(v, level, seq))) {
-			sq_pushstring(v, name, -1);
+			sq_pushstring(v, name);
 			sq_push(v, -2);
 			sq_createslot(v, -4);
 			sq_pop(v, 1);
@@ -272,23 +272,23 @@ void sq_base_register(HSQUIRRELVM v)
 	SQInteger i=0;
 	sq_pushroottable(v);
 	while(base_funcs[i].name!=nullptr) {
-		sq_pushstring(v,base_funcs[i].name,-1);
+		sq_pushstring(v,base_funcs[i].name);
 		sq_newclosure(v,base_funcs[i].f,0);
 		sq_setnativeclosurename(v,-1,base_funcs[i].name);
 		sq_setparamscheck(v,base_funcs[i].nparamscheck,base_funcs[i].typemask);
 		sq_createslot(v,-3);
 		i++;
 	}
-	sq_pushstring(v,"_version_",-1);
-	sq_pushstring(v,SQUIRREL_VERSION,-1);
+	sq_pushstring(v,"_version_");
+	sq_pushstring(v,SQUIRREL_VERSION);
 	sq_createslot(v,-3);
-	sq_pushstring(v,"_charsize_",-1);
+	sq_pushstring(v,"_charsize_");
 	sq_pushinteger(v,sizeof(SQChar));
 	sq_createslot(v,-3);
-	sq_pushstring(v,"_intsize_",-1);
+	sq_pushstring(v,"_intsize_");
 	sq_pushinteger(v,sizeof(SQInteger));
 	sq_createslot(v,-3);
-	sq_pushstring(v,"_floatsize_",-1);
+	sq_pushstring(v,"_floatsize_");
 	sq_pushinteger(v,sizeof(SQFloat));
 	sq_createslot(v,-3);
 	sq_pop(v,1);
@@ -872,13 +872,13 @@ static SQInteger thread_getstatus(HSQUIRRELVM v)
 	SQObjectPtr &o = stack_get(v,1);
 	switch(sq_getvmstate(_thread(o))) {
 		case SQ_VMSTATE_IDLE:
-			sq_pushstring(v,"idle",-1);
+			sq_pushstring(v,"idle");
 		break;
 		case SQ_VMSTATE_RUNNING:
-			sq_pushstring(v,"running",-1);
+			sq_pushstring(v,"running");
 		break;
 		case SQ_VMSTATE_SUSPENDED:
-			sq_pushstring(v,"suspended",-1);
+			sq_pushstring(v,"suspended");
 		break;
 		default:
 			return sq_throwerror(v,"internal VM error");

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -102,12 +102,11 @@ static SQInteger base_getstackinfos(HSQUIRRELVM v)
 	SQInteger level;
 	SQStackInfos si;
 	SQInteger seq = 0;
-	const SQChar *name = nullptr;
 	sq_getinteger(v, -1, &level);
 	if (SQ_SUCCEEDED(sq_stackinfos(v, level, &si)))
 	{
-		const SQChar *fn = "unknown";
-		const SQChar *src = "unknown";
+		std::string_view fn = "unknown";
+		std::string_view src = "unknown";
 		if(si.funcname)fn = si.funcname;
 		if(si.source)src = si.source;
 		sq_newtable(v);
@@ -123,8 +122,9 @@ static SQInteger base_getstackinfos(HSQUIRRELVM v)
 		sq_pushstring(v, "locals");
 		sq_newtable(v);
 		seq=0;
-		while ((name = sq_getlocal(v, level, seq))) {
-			sq_pushstring(v, name);
+		std::optional<std::string_view> name;
+		while ((name = sq_getlocal(v, level, seq)).has_value()) {
+			sq_pushstring(v, *name);
 			sq_push(v, -2);
 			sq_createslot(v, -4);
 			sq_pop(v, 1);

--- a/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
@@ -57,7 +57,7 @@ typedef sqvector<ExpState> ExpStateVec;
 class SQCompiler
 {
 public:
-	SQCompiler(SQVM *v, SQLEXREADFUNC rg, SQUserPointer up, const SQChar* sourcename, bool raiseerror, bool lineinfo) : _token(0), _fs(nullptr), _lex(_ss(v), rg, up), _debugline(0), _debugop(0)
+	SQCompiler(SQVM *v, SQLEXREADFUNC rg, SQUserPointer up, std::string_view sourcename, bool raiseerror, bool lineinfo) : _token(0), _fs(nullptr), _lex(_ss(v), rg, up), _debugline(0), _debugop(0)
 	{
 		_vm=v;
 		_sourcename = SQString::Create(_ss(v), sourcename);
@@ -1346,7 +1346,7 @@ private:
 	SQVM *_vm;
 };
 
-bool Compile(SQVM *vm,SQLEXREADFUNC rg, SQUserPointer up, const SQChar *sourcename, SQObjectPtr &out, bool raiseerror, bool lineinfo)
+bool Compile(SQVM *vm,SQLEXREADFUNC rg, SQUserPointer up, std::string_view sourcename, SQObjectPtr &out, bool raiseerror, bool lineinfo)
 {
 	SQCompiler p(vm, rg, up, sourcename, raiseerror, lineinfo);
 	return p.Compile(out);

--- a/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
@@ -123,7 +123,7 @@ public:
 			ret = _fs->CreateString(_lex._svalue);
 			break;
 		case TK_STRING_LITERAL:
-			ret = _fs->CreateString(_lex._svalue,_lex._longstr.size()-1);
+			ret = _fs->CreateString(std::string_view(_lex._svalue,_lex._longstr.size()-1));
 			break;
 		case TK_INTEGER:
 			ret = SQObjectPtr(_lex._nvalue);
@@ -598,7 +598,7 @@ public:
 		switch(_token)
 		{
 		case TK_STRING_LITERAL: {
-				_fs->AddInstruction(_OP_LOAD, _fs->PushTarget(), _fs->GetConstant(_fs->CreateString(_lex._svalue,_lex._longstr.size()-1)));
+				_fs->AddInstruction(_OP_LOAD, _fs->PushTarget(), _fs->GetConstant(_fs->CreateString(std::string_view(_lex._svalue,_lex._longstr.size()-1))));
 				Lex();
 			}
 			break;
@@ -1103,7 +1103,7 @@ public:
 				val._unVal.fFloat = _lex._fvalue;
 				break;
 			case TK_STRING_LITERAL:
-				val = _fs->CreateString(_lex._svalue,_lex._longstr.size()-1);
+				val = _fs->CreateString(std::string_view(_lex._svalue,_lex._longstr.size()-1));
 				break;
 			case '-':
 				Lex();

--- a/src/3rdparty/squirrel/squirrel/sqcompiler.h
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.h
@@ -73,5 +73,5 @@ struct SQVM;
 
 using CompileException = std::runtime_error;
 
-bool Compile(SQVM *vm, SQLEXREADFUNC rg, SQUserPointer up, const SQChar *sourcename, SQObjectPtr &out, bool raiseerror, bool lineinfo);
+bool Compile(SQVM *vm, SQLEXREADFUNC rg, SQUserPointer up, std::string_view sourcename, SQObjectPtr &out, bool raiseerror, bool lineinfo);
 #endif //_SQCOMPILER_H_

--- a/src/3rdparty/squirrel/squirrel/sqdebug.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqdebug.cpp
@@ -101,15 +101,15 @@ void SQVM::Raise_CompareError(const SQObject &o1, const SQObject &o2)
 
 void SQVM::Raise_ParamTypeError(SQInteger nparam,SQInteger typemask,SQInteger type)
 {
-	SQObjectPtr exptypes = SQString::Create(_ss(this), "", -1);
+	SQObjectPtr exptypes = SQString::Create(_ss(this), "");
 	SQInteger found = 0;
 	for(SQInteger i=0; i<16; i++)
 	{
 		SQInteger mask = 0x00000001LL << i;
 		if(typemask & (mask)) {
-			if(found>0) StringCat(exptypes,SQString::Create(_ss(this), "|", -1), exptypes);
+			if(found>0) StringCat(exptypes,SQString::Create(_ss(this), "|"), exptypes);
 			found ++;
-			StringCat(exptypes,SQString::Create(_ss(this), IdType2Name((SQObjectType)mask), -1), exptypes);
+			StringCat(exptypes,SQString::Create(_ss(this), IdType2Name((SQObjectType)mask)), exptypes);
 		}
 	}
 	Raise_Error(fmt::format("parameter {} has an invalid type '{}' ; expected: '{}'", nparam, IdType2Name((SQObjectType)type), _stringval(exptypes)));

--- a/src/3rdparty/squirrel/squirrel/sqdebug.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqdebug.cpp
@@ -37,7 +37,7 @@ SQRESULT sq_stackinfos(HSQUIRRELVM v, SQInteger level, SQStackInfos *si)
 {
 	SQInteger cssize = v->_callsstacksize;
 	if (cssize > level) {
-		memset(si, 0, sizeof(SQStackInfos));
+		*si = {};
 		SQVM::CallInfo &ci = v->_callsstack[cssize-level-1];
 		switch (type(ci._closure)) {
 		case OT_CLOSURE:{

--- a/src/3rdparty/squirrel/squirrel/sqfuncproto.h
+++ b/src/3rdparty/squirrel/squirrel/sqfuncproto.h
@@ -114,7 +114,7 @@ public:
 		this->~SQFunctionProto();
 		sq_vm_free(this,size);
 	}
-	const SQChar* GetLocal(SQVM *v,SQUnsignedInteger stackbase,SQUnsignedInteger nseq,SQUnsignedInteger nop);
+	std::optional<std::string_view> GetLocal(SQVM *v,SQUnsignedInteger stackbase,SQUnsignedInteger nseq,SQUnsignedInteger nop);
 	SQInteger GetLine(SQInstruction *curr);
 	bool Save(SQVM *v,SQUserPointer up,SQWRITEFUNC write);
 	static bool Load(SQVM *v,SQUserPointer up,SQREADFUNC read,SQObjectPtr &ret);

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
@@ -499,9 +499,9 @@ void SQFuncState::AddInstruction(SQInstruction &i)
 	_instructions.push_back(i);
 }
 
-SQObject SQFuncState::CreateString(const SQChar *s,SQInteger len)
+SQObject SQFuncState::CreateString(std::string_view s)
 {
-	SQObjectPtr ns(SQString::Create(_sharedstate,s,len));
+	SQObjectPtr ns(SQString::Create(_sharedstate,s));
 	_table(_strings)->NewSlot(ns,(SQInteger)1);
 	return std::move(ns);
 }

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.h
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.h
@@ -43,7 +43,7 @@ struct SQFuncState
 	SQInteger TopTarget();
 	SQInteger GetUpTarget(SQInteger n);
 	bool IsLocal(SQUnsignedInteger stkpos);
-	SQObject CreateString(const SQChar *s,SQInteger len = -1);
+	SQObject CreateString(std::string_view s);
 	SQObject CreateTable();
 	bool IsConstant(const SQObject &name,SQObject &e);
 	SQInteger _returnexp;

--- a/src/3rdparty/squirrel/squirrel/sqobject.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqobject.cpp
@@ -51,16 +51,16 @@ const SQChar *GetTypeName(const SQObjectPtr &obj1)
 	return IdType2Name(type(obj1));
 }
 
-SQString *SQString::Create(SQSharedState *ss,const SQChar *s,SQInteger len)
+SQString *SQString::Create(SQSharedState *ss,std::string_view s)
 {
-	SQString *str=ADD_STRING(ss,s,len);
+	SQString *str=ss->_stringtable->Add(s);
 	str->_sharedstate=ss;
 	return str;
 }
 
 void SQString::Release()
 {
-	REMOVE_STRING(_sharedstate,this);
+	_sharedstate->_stringtable->Remove(this);
 }
 
 SQInteger SQString::Next(const SQObjectPtr &refpos, SQObjectPtr &outkey, SQObjectPtr &outval)

--- a/src/3rdparty/squirrel/squirrel/sqobject.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqobject.cpp
@@ -298,8 +298,8 @@ bool ReadObject(HSQUIRRELVM v,SQUserPointer up,SQREADFUNC read,SQObjectPtr &o)
 	case OT_STRING:{
 		SQInteger len;
 		_CHECK_IO(SafeRead(v,read,up,&len,sizeof(SQInteger)));
-		_CHECK_IO(SafeRead(v,read,up,_ss(v)->GetScratchPad(len),len));
-		o=SQString::Create(_ss(v),_ss(v)->GetScratchPad(-1),len);
+		_CHECK_IO(SafeRead(v,read,up,_ss(v)->GetScratchPad(len).data(),len));
+		o=SQString::Create(_ss(v),std::string_view(_ss(v)->GetScratchPad(-1).data(),len));
 				   }
 		break;
 	case OT_INTEGER:{

--- a/src/3rdparty/squirrel/squirrel/sqobject.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqobject.cpp
@@ -202,24 +202,21 @@ void SQArray::Extend(const SQArray *a){
 			Append(a->_values[i]);
 }
 
-const SQChar* SQFunctionProto::GetLocal(SQVM *vm,SQUnsignedInteger stackbase,SQUnsignedInteger nseq,SQUnsignedInteger nop)
+std::optional<std::string_view> SQFunctionProto::GetLocal(SQVM *vm,SQUnsignedInteger stackbase,SQUnsignedInteger nseq,SQUnsignedInteger nop)
 {
 	SQUnsignedInteger nvars=_nlocalvarinfos;
-	const SQChar *res=nullptr;
 	if(nvars>=nseq){
 		for(SQUnsignedInteger i=0;i<nvars;i++){
-			if(_localvarinfos[i]._start_op<=nop && _localvarinfos[i]._end_op>=nop)
-			{
+			if(_localvarinfos[i]._start_op<=nop && _localvarinfos[i]._end_op>=nop) {
 				if(nseq==0){
 					vm->Push(vm->_stack[stackbase+_localvarinfos[i]._pos]);
-					res=_stringval(_localvarinfos[i]._name);
-					break;
+					return _stringval(_localvarinfos[i]._name);
 				}
 				nseq--;
 			}
 		}
 	}
-	return res;
+	return std::nullopt;
 }
 
 SQInteger SQFunctionProto::GetLine(SQInstruction *curr)

--- a/src/3rdparty/squirrel/squirrel/sqstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqstate.cpp
@@ -547,33 +547,34 @@ void SQStringTable::AllocNodes(SQInteger size)
 	memset(_strings,0,sizeof(SQString*)*(size_t)_numofslots);
 }
 
-SQString *SQStringTable::Add(const SQChar *news,SQInteger len)
+static const std::hash<std::string_view> string_table_hash{};
+
+SQString *SQStringTable::Add(std::string_view new_string)
 {
-	if(len<0)
-		len = (SQInteger)strlen(news);
-	SQHash h = ::_hashstr(news,(size_t)len)&(_numofslots-1);
+	size_t len = new_string.size();
+	auto slot = string_table_hash(new_string) & (_numofslots-1);
 	SQString *s;
-	for (s = _strings[h]; s; s = s->_next){
-		if(s->_len == len && (!memcmp(news,s->_val,(size_t)len)))
+	for (s = _strings[slot]; s; s = s->_next){
+		if(static_cast<size_t>(s->_len) == len && (!memcmp(new_string.data(),s->_val,len)))
 			return s; //found
 	}
 
 	SQString *t=(SQString *)SQ_MALLOC(len+sizeof(SQString));
-	new (t) SQString(news, len);
-	t->_next = _strings[h];
-	_strings[h] = t;
+	new (t) SQString(new_string);
+	t->_next = _strings[slot];
+	_strings[slot] = t;
 	_slotused++;
 	if (_slotused > _numofslots)  /* too crowded? */
 		Resize(_numofslots*2);
 	return t;
 }
 
-SQString::SQString(const SQChar *news, SQInteger len)
+SQString::SQString(std::string_view new_string)
 {
-	memcpy(_val,news,(size_t)len);
-	_val[len] = '\0';
-	_len = len;
-	_hash = ::_hashstr(news,(size_t)len);
+	memcpy(_val,new_string.data(),new_string.size());
+	_val[new_string.size()] = '\0';
+	_len = new_string.size();
+	_hash = string_table_hash(new_string);
 	_next = nullptr;
 	_sharedstate = nullptr;
 }

--- a/src/3rdparty/squirrel/squirrel/sqstate.h
+++ b/src/3rdparty/squirrel/squirrel/sqstate.h
@@ -13,7 +13,7 @@ struct SQStringTable
 {
 	SQStringTable();
 	~SQStringTable();
-	SQString *Add(const SQChar *,SQInteger len);
+	SQString *Add(std::string_view str);
 	void Remove(SQString *);
 private:
 	void Resize(SQInteger size);
@@ -48,9 +48,6 @@ private:
 	RefNode *_freelist;
 	RefNode **_buckets;
 };
-
-#define ADD_STRING(ss,str,len) ss->_stringtable->Add(str,len)
-#define REMOVE_STRING(ss,bstr) ss->_stringtable->Remove(bstr)
 
 struct SQObjectPtr;
 

--- a/src/3rdparty/squirrel/squirrel/sqstate.h
+++ b/src/3rdparty/squirrel/squirrel/sqstate.h
@@ -59,7 +59,7 @@ struct SQSharedState
 	SQSharedState();
 	~SQSharedState();
 public:
-	SQChar* GetScratchPad(SQInteger size);
+	std::span<char> GetScratchPad(SQInteger size);
 	SQInteger GetMetaMethodIdxByName(const SQObjectPtr &name);
 	void DelayFinalFree(SQCollectable *collectable);
 #ifndef NO_GARBAGE_COLLECTOR
@@ -109,8 +109,7 @@ public:
 	bool _debuginfo;
 	bool _notifyallexceptions;
 private:
-	SQChar *_scratchpad;
-	SQInteger _scratchpadsize;
+	std::vector<char> _scratchpad;
 };
 
 #define _sp(s) (_sharedstate->GetScratchPad(s))

--- a/src/3rdparty/squirrel/squirrel/sqstring.h
+++ b/src/3rdparty/squirrel/squirrel/sqstring.h
@@ -2,28 +2,18 @@
 #ifndef _SQSTRING_H_
 #define _SQSTRING_H_
 
-inline SQHash _hashstr (const SQChar *s, size_t l)
-{
-		SQHash h = (SQHash)l;  /* seed */
-		size_t step = (l>>5)|1;  /* if string is too long, don't hash all its chars */
-		for (; l>=step; l-=step)
-			h = h ^ ((h<<5)+(h>>2)+(unsigned short)*(s++));
-		return h;
-}
-
 struct SQString : public SQRefCounted
 {
-	SQString(const SQChar *news, SQInteger len);
+	SQString(std::string_view str);
 	~SQString(){}
 public:
-	static SQString *Create(SQSharedState *ss, const SQChar *, SQInteger len = -1 );
-	static SQString *Create(SQSharedState *ss, std::string_view str) { return Create(ss, str.data(), str.size()); }
+	static SQString *Create(SQSharedState *ss, std::string_view str);
 	SQInteger Next(const SQObjectPtr &refpos, SQObjectPtr &outkey, SQObjectPtr &outval);
 	void Release() override;
 	SQSharedState *_sharedstate;
 	SQString *_next; //chain for the string table
 	SQInteger _len;
-	SQHash _hash;
+	std::size_t _hash;
 	SQChar _val[1];
 };
 

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -302,11 +302,7 @@ bool SQVM::StringCat(const SQObjectPtr &str,const SQObjectPtr &obj,SQObjectPtr &
 	SQObjectPtr a, b;
 	ToString(str, a);
 	ToString(obj, b);
-	SQInteger l = _string(a)->_len , ol = _string(b)->_len;
-	SQChar *s = _sp(l + ol + 1);
-	memcpy(s, _stringval(a), (size_t)l);
-	memcpy(s + l, _stringval(b), (size_t)ol);
-	dest = SQString::Create(_ss(this), _spval, l + ol);
+	dest = SQString::Create(_ss(this), fmt::format("{}{}", _stringval(a), _stringval(b)));
 	return true;
 }
 

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -117,7 +117,6 @@ SQVM::SQVM(SQSharedState *ss)
 	_in_stackoverflow = false;
 	_ops_till_suspend = 0;
 	_ops_till_suspend_error_threshold = INT64_MIN;
-	_ops_till_suspend_error_label = nullptr;
 	_callsstack = nullptr;
 	_callsstacksize = 0;
 	_alloccallsstacksize = 0;

--- a/src/3rdparty/squirrel/squirrel/sqvm.h
+++ b/src/3rdparty/squirrel/squirrel/sqvm.h
@@ -169,7 +169,7 @@ public:
 	SQBool _can_suspend;
 	SQInteger _ops_till_suspend;
 	SQInteger _ops_till_suspend_error_threshold;
-	const char *_ops_till_suspend_error_label;
+	std::string_view _ops_till_suspend_error_label;
 	SQBool _in_stackoverflow;
 
 	bool ShouldSuspend()

--- a/src/ai/ai_info.cpp
+++ b/src/ai/ai_info.cpp
@@ -27,7 +27,7 @@ static bool CheckAPIVersion(const std::string &api_version)
 	return std::ranges::find(AIInfo::ApiVersions, api_version) != std::end(AIInfo::ApiVersions);
 }
 
-template <> SQInteger PushClassName<AIInfo, ScriptType::AI>(HSQUIRRELVM vm) { sq_pushstring(vm, "AIInfo", -1); return 1; }
+template <> SQInteger PushClassName<AIInfo, ScriptType::AI>(HSQUIRRELVM vm) { sq_pushstring(vm, "AIInfo"); return 1; }
 
 /* static */ void AIInfo::RegisterAPI(Squirrel &engine)
 {

--- a/src/game/game_info.cpp
+++ b/src/game/game_info.cpp
@@ -25,7 +25,7 @@ static bool CheckAPIVersion(const std::string &api_version)
 	return std::ranges::find(GameInfo::ApiVersions, api_version) != std::end(GameInfo::ApiVersions);
 }
 
-template <> SQInteger PushClassName<GameInfo, ScriptType::GS>(HSQUIRRELVM vm) { sq_pushstring(vm, "GSInfo", -1); return 1; }
+template <> SQInteger PushClassName<GameInfo, ScriptType::GS>(HSQUIRRELVM vm) { sq_pushstring(vm, "GSInfo"); return 1; }
 
 /* static */ void GameInfo::RegisterAPI(Squirrel &engine)
 {

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -357,12 +357,12 @@ void RegisterGameTranslation(Squirrel &engine)
 
 	HSQUIRRELVM vm = engine.GetVM();
 	sq_pushroottable(vm);
-	sq_pushstring(vm, "GSText", -1);
+	sq_pushstring(vm, "GSText");
 	if (SQ_FAILED(sq_get(vm, -2))) return;
 
 	int idx = 0;
 	for (const auto &p : _current_gamestrings_data->string_names) {
-		sq_pushstring(vm, p, -1);
+		sq_pushstring(vm, p);
 		sq_pushinteger(vm, idx);
 		sq_rawset(vm, -3);
 		idx++;

--- a/src/script/api/ai/ai_controller.hpp.sq
+++ b/src/script/api/ai/ai_controller.hpp.sq
@@ -7,7 +7,7 @@
 
 #include "../script_controller.hpp"
 
-template <> SQInteger PushClassName<ScriptController, ScriptType::AI>(HSQUIRRELVM vm) { sq_pushstring(vm, "AIController", -1); return 1; }
+template <> SQInteger PushClassName<ScriptController, ScriptType::AI>(HSQUIRRELVM vm) { sq_pushstring(vm, "AIController"); return 1; }
 
 void SQAIController_Register(Squirrel &engine)
 {

--- a/src/script/api/game/game_controller.hpp.sq
+++ b/src/script/api/game/game_controller.hpp.sq
@@ -7,7 +7,7 @@
 
 #include "../script_controller.hpp"
 
-template <> SQInteger PushClassName<ScriptController, ScriptType::GS>(HSQUIRRELVM vm) { sq_pushstring(vm, "GSController", -1); return 1; }
+template <> SQInteger PushClassName<ScriptController, ScriptType::GS>(HSQUIRRELVM vm) { sq_pushstring(vm, "GSController"); return 1; }
 
 void SQGSController_Register(Squirrel &engine)
 {

--- a/src/script/api/script_controller.cpp
+++ b/src/script/api/script_controller.cpp
@@ -125,7 +125,7 @@ ScriptController::ScriptController(::CompanyID company) :
 
 		/* Load the library in a 'fake' namespace, so we can link it to the name the user requested */
 		sq_pushroottable(vm);
-		sq_pushstring(vm, fake_class, -1);
+		sq_pushstring(vm, fake_class);
 		sq_newclass(vm, SQFalse);
 		/* Load the library */
 		if (!engine->LoadScript(vm, lib->GetMainScript(), false)) {
@@ -140,11 +140,11 @@ ScriptController::ScriptController(::CompanyID company) :
 
 	/* Find the real class inside the fake class (like 'sets.Vector') */
 	sq_pushroottable(vm);
-	sq_pushstring(vm, fake_class, -1);
+	sq_pushstring(vm, fake_class);
 	if (SQ_FAILED(sq_get(vm, -2))) {
 		throw sq_throwerror(vm, "internal error assigning library class");
 	}
-	sq_pushstring(vm, lib->GetInstanceName(), -1);
+	sq_pushstring(vm, lib->GetInstanceName());
 	if (SQ_FAILED(sq_get(vm, -2))) {
 		throw sq_throwerror(vm, fmt::format("unable to find class '{}' in the library '{}' version {}", lib->GetInstanceName(), library, version));
 	}
@@ -156,7 +156,7 @@ ScriptController::ScriptController(::CompanyID company) :
 
 	/* Now link the name the user wanted to our 'fake' class */
 	sq_pushobject(vm, parent);
-	sq_pushstring(vm, class_name, -1);
+	sq_pushstring(vm, class_name);
 	sq_pushobject(vm, obj);
 	sq_newclass(vm, SQTrue);
 	sq_newslot(vm, -3, SQFalse);

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -139,7 +139,7 @@ static bool ScriptEventAdminPortReadValue(HSQUIRRELVM vm, nlohmann::json &json)
 
 		case nlohmann::json::value_t::string: {
 			auto value = json.get<std::string>();
-			sq_pushstring(vm, value.data(), value.size());
+			sq_pushstring(vm, value);
 			break;
 		}
 
@@ -152,7 +152,7 @@ static bool ScriptEventAdminPortReadValue(HSQUIRRELVM vm, nlohmann::json &json)
 			sq_newtable(vm);
 
 			for (auto &[key, value] : json.items()) {
-				sq_pushstring(vm, key.data(), key.size());
+				sq_pushstring(vm, key);
 
 				if (!ScriptEventAdminPortReadValue(vm, value)) {
 					return false;

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -84,7 +84,7 @@ SQInteger ScriptText::_SetParam(int parameter, HSQUIRRELVM vm)
 
 			/* Validate if it is a GSText instance */
 			sq_pushroottable(vm);
-			sq_pushstring(vm, "GSText", -1);
+			sq_pushstring(vm, "GSText");
 			sq_get(vm, -2);
 			sq_pushobject(vm, instance);
 			if (sq_instanceof(vm) != SQTrue) return SQ_ERROR;
@@ -171,9 +171,9 @@ void ScriptText::SetPadParameterCount(HSQUIRRELVM vm)
 
 	SQInteger top = sq_gettop(vm);
 	sq_pushroottable(vm);
-	sq_pushstring(vm, "GSText", -1);
+	sq_pushstring(vm, "GSText");
 	if (!SQ_FAILED(sq_get(vm, -2))) {
-		sq_pushstring(vm, "SCRIPT_TEXT_MAX_PARAMETERS", -1);
+		sq_pushstring(vm, "SCRIPT_TEXT_MAX_PARAMETERS");
 		if (!SQ_FAILED(sq_get(vm, -2))) {
 			SQInteger value;
 			if (!SQ_FAILED(sq_getinteger(vm, -1, &value))) {

--- a/src/script/script_info_dummy.cpp
+++ b/src/script/script_info_dummy.cpp
@@ -42,7 +42,7 @@ void Script_CreateDummyInfo(HSQUIRRELVM vm, std::string_view type, std::string_v
 	sq_pushroottable(vm);
 
 	/* Load and run the script */
-	if (SQ_SUCCEEDED(sq_compilebuffer(vm, dummy_script.data(), dummy_script.size(), "dummy", SQTrue))) {
+	if (SQ_SUCCEEDED(sq_compilebuffer(vm, dummy_script, "dummy", SQTrue))) {
 		sq_push(vm, -2);
 		if (SQ_SUCCEEDED(sq_call(vm, 1, SQFalse, SQTrue))) {
 			sq_pop(vm, 1);
@@ -101,7 +101,7 @@ void Script_CreateDummy(HSQUIRRELVM vm, StringID string, std::string_view type)
 
 	/* 3) Finally we load and run the script */
 	sq_pushroottable(vm);
-	if (SQ_SUCCEEDED(sq_compilebuffer(vm, dummy_script.data(), dummy_script.size(), "dummy", SQTrue))) {
+	if (SQ_SUCCEEDED(sq_compilebuffer(vm, dummy_script, "dummy", SQTrue))) {
 		sq_push(vm, -2);
 		if (SQ_SUCCEEDED(sq_call(vm, 1, SQFalse, SQTrue))) {
 			sq_pop(vm, 1);

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -649,7 +649,7 @@ bool ScriptInstance::IsPaused()
 		ScriptData *data;
 
 		bool operator()(const SQInteger &value) { sq_pushinteger(this->vm, value); return true; }
-		bool operator()(const std::string &value) { sq_pushstring(this->vm, value, -1); return true; }
+		bool operator()(const std::string &value) { sq_pushstring(this->vm, value); return true; }
 		bool operator()(const SQBool &value) { sq_pushbool(this->vm, value); return true; }
 		bool operator()(const SQSaveLoadType &type)
 		{
@@ -778,7 +778,7 @@ bool ScriptInstance::CallLoad()
 	/* Go to the instance-root */
 	sq_pushobject(vm, *this->instance);
 	/* Find the function-name inside the script */
-	sq_pushstring(vm, "Load", -1);
+	sq_pushstring(vm, "Load");
 	/* Change the "Load" string in a function pointer */
 	sq_get(vm, -2);
 	/* Push the main instance as "this" object */

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -257,7 +257,7 @@ void Squirrel::AddMethod(std::string_view method_name, SQFUNCTION proc, std::str
 {
 	ScriptAllocatorScope alloc_scope(this);
 
-	sq_pushstring(this->vm, method_name, -1);
+	sq_pushstring(this->vm, method_name);
 
 	if (size != 0) {
 		void *ptr = sq_newuserdata(vm, size);
@@ -274,7 +274,7 @@ void Squirrel::AddConst(std::string_view var_name, int value)
 {
 	ScriptAllocatorScope alloc_scope(this);
 
-	sq_pushstring(this->vm, var_name, -1);
+	sq_pushstring(this->vm, var_name);
 	sq_pushinteger(this->vm, value);
 	sq_newslot(this->vm, -3, SQTrue);
 }
@@ -283,7 +283,7 @@ void Squirrel::AddConst(std::string_view var_name, bool value)
 {
 	ScriptAllocatorScope alloc_scope(this);
 
-	sq_pushstring(this->vm, var_name, -1);
+	sq_pushstring(this->vm, var_name);
 	sq_pushbool(this->vm, value);
 	sq_newslot(this->vm, -3, SQTrue);
 }
@@ -293,7 +293,7 @@ void Squirrel::AddClassBegin(std::string_view class_name)
 	ScriptAllocatorScope alloc_scope(this);
 
 	sq_pushroottable(this->vm);
-	sq_pushstring(this->vm, class_name, -1);
+	sq_pushstring(this->vm, class_name);
 	sq_newclass(this->vm, SQFalse);
 }
 
@@ -302,8 +302,8 @@ void Squirrel::AddClassBegin(std::string_view class_name, std::string_view paren
 	ScriptAllocatorScope alloc_scope(this);
 
 	sq_pushroottable(this->vm);
-	sq_pushstring(this->vm, class_name, -1);
-	sq_pushstring(this->vm, parent_class, -1);
+	sq_pushstring(this->vm, class_name);
+	sq_pushstring(this->vm, parent_class);
 	if (SQ_FAILED(sq_get(this->vm, -3))) {
 		Debug(misc, 0, "[squirrel] Failed to initialize class '{}' based on parent class '{}'", class_name, parent_class);
 		Debug(misc, 0, "[squirrel] Make sure that '{}' exists before trying to define '{}'", parent_class, class_name);
@@ -329,7 +329,7 @@ bool Squirrel::MethodExists(HSQOBJECT instance, std::string_view method_name)
 	/* Go to the instance-root */
 	sq_pushobject(this->vm, instance);
 	/* Find the function-name inside the script */
-	sq_pushstring(this->vm, method_name, -1);
+	sq_pushstring(this->vm, method_name);
 	if (SQ_FAILED(sq_get(this->vm, -2))) {
 		sq_settop(this->vm, top);
 		return false;
@@ -388,7 +388,7 @@ bool Squirrel::CallMethod(HSQOBJECT instance, std::string_view method_name, HSQO
 	/* Go to the instance-root */
 	sq_pushobject(this->vm, instance);
 	/* Find the function-name inside the script */
-	sq_pushstring(this->vm, method_name, -1);
+	sq_pushstring(this->vm, method_name);
 	if (SQ_FAILED(sq_get(this->vm, -2))) {
 		Debug(misc, 0, "[squirrel] Could not find '{}' in the class", method_name);
 		sq_settop(this->vm, top);
@@ -445,9 +445,9 @@ bool Squirrel::CallBoolMethod(HSQOBJECT instance, std::string_view method_name, 
 
 	if (prepend_API_name) {
 		std::string prepended_class_name = fmt::format("{}{}", engine->GetAPIName(), class_name);
-		sq_pushstring(vm, prepended_class_name, -1);
+		sq_pushstring(vm, prepended_class_name);
 	} else {
-		sq_pushstring(vm, class_name, -1);
+		sq_pushstring(vm, class_name);
 	}
 
 	if (SQ_FAILED(sq_get(vm, -2))) {

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -179,7 +179,7 @@ size_t Squirrel::GetAllocatedMemory() const noexcept
 }
 
 
-void Squirrel::CompileError(HSQUIRRELVM vm, const SQChar *desc, const SQChar *source, SQInteger line, SQInteger column)
+void Squirrel::CompileError(HSQUIRRELVM vm, std::string_view desc, std::string_view source, SQInteger line, SQInteger column)
 {
 	std::string msg = fmt::format("Error {}:{}/{}: {}", source, line, column, desc);
 

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -411,8 +411,11 @@ bool Squirrel::CallStringMethod(HSQOBJECT instance, std::string_view method_name
 {
 	HSQOBJECT ret;
 	if (!this->CallMethod(instance, method_name, &ret, suspend)) return false;
-	if (ret._type != OT_STRING) return false;
-	*res = StrMakeValid(ObjectToString(&ret));
+
+	auto str = ObjectToString(&ret);
+	if (!str.has_value()) return false;
+
+	*res = StrMakeValid(*str);
 	return true;
 }
 

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -207,7 +207,7 @@ public:
 	/**
 	 * Convert a Squirrel-object to a string.
 	 */
-	static std::string_view ObjectToString(HSQOBJECT *ptr) { return sq_objtostring(ptr); }
+	static std::optional<std::string_view> ObjectToString(HSQOBJECT *ptr) { return sq_objtostring(ptr); }
 
 	/**
 	 * Convert a Squirrel-object to an integer.

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -55,7 +55,7 @@ protected:
 	/**
 	 * The CompileError handler.
 	 */
-	static void CompileError(HSQUIRRELVM vm, const SQChar *desc, const SQChar *source, SQInteger line, SQInteger column);
+	static void CompileError(HSQUIRRELVM vm, std::string_view desc, std::string_view source, SQInteger line, SQInteger column);
 
 	/**
 	 * The RunError handler.

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -61,7 +61,7 @@ namespace SQConvert {
 		static inline int Set(HSQUIRRELVM vm, std::optional<std::string> res)
 		{
 			if (res.has_value()) {
-				sq_pushstring(vm, res.value(), -1);
+				sq_pushstring(vm, res.value());
 			} else {
 				sq_pushnull(vm);
 			}

--- a/src/script/squirrel_std.cpp
+++ b/src/script/squirrel_std.cpp
@@ -48,13 +48,9 @@ SQInteger SquirrelStd::require(HSQUIRRELVM vm)
 	/* Get the script-name of the current file, so we can work relative from it */
 	SQStackInfos si;
 	sq_stackinfos(vm, 1, &si);
-	if (si.source == nullptr) {
-		Debug(misc, 0, "[squirrel] Couldn't detect the script-name of the 'require'-caller; this should never happen!");
-		return SQ_ERROR;
-	}
 
 	/* Keep the dir, remove the rest */
-	std::string path = si.source;
+	std::string path{si.source};
 	auto p = path.find_last_of(PATHSEPCHAR);
 	/* Keep the PATHSEPCHAR there, remove the rest */
 	if (p != std::string::npos) path.erase(p + 1);

--- a/src/tests/test_script_admin.cpp
+++ b/src/tests/test_script_admin.cpp
@@ -64,7 +64,7 @@ static std::optional<std::string> TestScriptAdminMakeJSON(std::string_view squir
 	sq_pop(vm, 1);
 
 	/* Compile the snippet. */
-	REQUIRE(sq_compilebuffer(vm, buffer.data(), buffer.size(), "test", SQTrue) == SQ_OK);
+	REQUIRE(sq_compilebuffer(vm, buffer, "test", SQTrue) == SQ_OK);
 	/* Execute the snippet, capturing the return value. */
 	sq_pushroottable(vm);
 	REQUIRE(sq_call(vm, 1, SQTrue, SQTrue) == SQ_OK);

--- a/src/tests/test_script_admin.cpp
+++ b/src/tests/test_script_admin.cpp
@@ -58,7 +58,7 @@ static std::optional<std::string> TestScriptAdminMakeJSON(std::string_view squir
 
 	/* Insert an (empty) class for testing. */
 	sq_pushroottable(vm);
-	sq_pushstring(vm, "DummyClass", -1);
+	sq_pushstring(vm, "DummyClass");
 	sq_newclass(vm, SQFalse);
 	sq_newslot(vm, -3, SQFalse);
 	sq_pop(vm, 1);


### PR DESCRIPTION
## Motivation / Problem

C-style strings are harder to work with, and since we've rooted them out of most of the main code... squirrel stands out like a sore thumb.

Especially the inclusion of `safeguards.h` means that not allowing certain C-style string functions becomes harder.


## Description

In many places replace `SQChar *` (aka `char *`) with `std::string_view` or `std::span<char>` in case the string needs to be modifiable.


## Limitations

This is not a complete transformation for squirrel, that PR would become way too big.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
