### PR TITLE
Codechange: simplify some squirrel code

### DIFF
--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -182,7 +182,7 @@ typedef SQInteger (*SQREADFUNC)(SQUserPointer,SQUserPointer,SQInteger);
 typedef char32_t (*SQLEXREADFUNC)(SQUserPointer);
 
 typedef struct tagSQRegFunction{
-	const SQChar *name;
+	std::string_view name;
 	SQFUNCTION f;
 	SQInteger nparamscheck;
 	const SQChar *typemask;

--- a/src/3rdparty/squirrel/sqstdlib/sqstdmath.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdmath.cpp
@@ -67,7 +67,7 @@ SINGLE_ARG_FUNC(ceil, 1)
 SINGLE_ARG_FUNC(exp, 100)
 
 #define _DECL_FUNC(name,nparams,tycheck) {#name,math_##name,nparams,tycheck}
-static SQRegFunction mathlib_funcs[] = {
+static const std::initializer_list<SQRegFunction> mathlib_funcs = {
 	_DECL_FUNC(sqrt,2,".n"),
 	_DECL_FUNC(sin,2,".n"),
 	_DECL_FUNC(cos,2,".n"),
@@ -88,7 +88,6 @@ static SQRegFunction mathlib_funcs[] = {
 #endif /* EXPORT_DEFAULT_SQUIRREL_FUNCTIONS */
 	_DECL_FUNC(fabs,2,".n"),
 	_DECL_FUNC(abs,2,".n"),
-	{nullptr,nullptr,0,nullptr},
 };
 
 #ifndef M_PI
@@ -97,14 +96,12 @@ static SQRegFunction mathlib_funcs[] = {
 
 SQRESULT sqstd_register_mathlib(HSQUIRRELVM v)
 {
-	SQInteger i=0;
-	while(mathlib_funcs[i].name!=nullptr)	{
-		sq_pushstring(v,mathlib_funcs[i].name);
-		sq_newclosure(v,mathlib_funcs[i].f,0);
-		sq_setparamscheck(v,mathlib_funcs[i].nparamscheck,mathlib_funcs[i].typemask);
-		sq_setnativeclosurename(v,-1,mathlib_funcs[i].name);
+	for(auto &func : mathlib_funcs) {
+		sq_pushstring(v,func.name);
+		sq_newclosure(v,func.f,0);
+		sq_setparamscheck(v,func.nparamscheck,func.typemask);
+		sq_setnativeclosurename(v,-1,func.name);
 		sq_createslot(v,-3);
-		i++;
 	}
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
 	sq_pushstring(v,"RAND_MAX");

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -237,7 +237,7 @@ static SQInteger base_type(HSQUIRRELVM v)
 	return 1;
 }
 
-static SQRegFunction base_funcs[]={
+static const std::initializer_list<SQRegFunction> base_funcs={
 	//generic
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
 	{"seterrorhandler",base_seterrorhandler,2, nullptr},
@@ -264,20 +264,17 @@ static SQRegFunction base_funcs[]={
 	{"collectgarbage",base_collectgarbage,1, "t"},
 #endif
 #endif
-	{nullptr,nullptr,0,nullptr}
 };
 
 void sq_base_register(HSQUIRRELVM v)
 {
-	SQInteger i=0;
 	sq_pushroottable(v);
-	while(base_funcs[i].name!=nullptr) {
-		sq_pushstring(v,base_funcs[i].name);
-		sq_newclosure(v,base_funcs[i].f,0);
-		sq_setnativeclosurename(v,-1,base_funcs[i].name);
-		sq_setparamscheck(v,base_funcs[i].nparamscheck,base_funcs[i].typemask);
+	for(auto &func : base_funcs) {
+		sq_pushstring(v,func.name);
+		sq_newclosure(v,func.f,0);
+		sq_setnativeclosurename(v,-1,func.name);
+		sq_setparamscheck(v,func.nparamscheck,func.typemask);
 		sq_createslot(v,-3);
-		i++;
 	}
 	sq_pushstring(v,"_version_");
 	sq_pushstring(v,SQUIRREL_VERSION);
@@ -410,7 +407,7 @@ static SQInteger table_rawget(HSQUIRRELVM v)
 }
 
 
-SQRegFunction SQSharedState::_table_default_delegate_funcz[]={
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_table_default_delegate_funcz={
 	{"len",default_delegate_len,1, "t"},
 	{"rawget",table_rawget,2, "t"},
 	{"rawset",table_rawset,3, "t"},
@@ -419,7 +416,6 @@ SQRegFunction SQSharedState::_table_default_delegate_funcz[]={
 	{"weakref",obj_delegate_weakref,1, nullptr },
 	{"tostring",default_delegate_tostring,1, "."},
 	{"clear",obj_clear,1, "."},
-	{nullptr,nullptr,0,nullptr}
 };
 
 //ARRAY DEFAULT DELEGATE///////////////////////////////////////
@@ -612,7 +608,7 @@ static SQInteger array_slice(HSQUIRRELVM v)
 
 }
 
-SQRegFunction SQSharedState::_array_default_delegate_funcz[]={
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_array_default_delegate_funcz={
 	{"len",default_delegate_len,1, "a"},
 	{"append",array_append,2, "a"},
 	{"extend",array_extend,2, "aa"},
@@ -628,7 +624,6 @@ SQRegFunction SQSharedState::_array_default_delegate_funcz[]={
 	{"weakref",obj_delegate_weakref,1, nullptr },
 	{"tostring",default_delegate_tostring,1, "."},
 	{"clear",obj_clear,1, "."},
-	{nullptr,nullptr,0,nullptr}
 };
 
 //STRING DEFAULT DELEGATE//////////////////////////
@@ -679,7 +674,7 @@ static SQInteger string_find(HSQUIRRELVM v)
 STRING_TOFUNCZ(tolower)
 STRING_TOFUNCZ(toupper)
 
-SQRegFunction SQSharedState::_string_default_delegate_funcz[]={
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_string_default_delegate_funcz={
 	{"len",default_delegate_len,1, "s"},
 	{"tointeger",default_delegate_tointeger,1, "s"},
 	{"tofloat",default_delegate_tofloat,1, "s"},
@@ -689,17 +684,15 @@ SQRegFunction SQSharedState::_string_default_delegate_funcz[]={
 	{"tolower",string_tolower,1, "s"},
 	{"toupper",string_toupper,1, "s"},
 	{"weakref",obj_delegate_weakref,1, nullptr },
-	{nullptr,nullptr,0,nullptr}
 };
 
 //INTEGER DEFAULT DELEGATE//////////////////////////
-SQRegFunction SQSharedState::_number_default_delegate_funcz[]={
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_number_default_delegate_funcz={
 	{"tointeger",default_delegate_tointeger,1, "n|b"},
 	{"tofloat",default_delegate_tofloat,1, "n|b"},
 	{"tostring",default_delegate_tostring,1, "."},
 	{"tochar",number_delegate_tochar,1, "n|b"},
 	{"weakref",obj_delegate_weakref,1, nullptr },
-	{nullptr,nullptr,0,nullptr}
 };
 
 //CLOSURE DEFAULT DELEGATE//////////////////////////
@@ -778,7 +771,7 @@ static SQInteger closure_getinfos(HSQUIRRELVM v) {
 }
 
 
-SQRegFunction SQSharedState::_closure_default_delegate_funcz[]={
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_closure_default_delegate_funcz={
 	{"call",closure_call,-1, "c"},
 	{"pcall",closure_pcall,-1, "c"},
 	{"acall",closure_acall,2, "ca"},
@@ -787,7 +780,6 @@ SQRegFunction SQSharedState::_closure_default_delegate_funcz[]={
 	{"tostring",default_delegate_tostring,1, "."},
 	{"bindenv",closure_bindenv,2, "c x|y|t"},
 	{"getinfos",closure_getinfos,1, "c"},
-	{nullptr,nullptr,0,nullptr}
 };
 
 //GENERATOR DEFAULT DELEGATE
@@ -802,11 +794,10 @@ static SQInteger generator_getstatus(HSQUIRRELVM v)
 	return 1;
 }
 
-SQRegFunction SQSharedState::_generator_default_delegate_funcz[]={
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_generator_default_delegate_funcz={
 	{"getstatus",generator_getstatus,1, "g"},
 	{"weakref",obj_delegate_weakref,1, nullptr },
 	{"tostring",default_delegate_tostring,1, "."},
-	{nullptr,nullptr,0,nullptr}
 };
 
 //THREAD DEFAULT DELEGATE
@@ -886,13 +877,12 @@ static SQInteger thread_getstatus(HSQUIRRELVM v)
 	return 1;
 }
 
-SQRegFunction SQSharedState::_thread_default_delegate_funcz[] = {
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_thread_default_delegate_funcz = {
 	{"call", thread_call, -1, "v"},
 	{"wakeup", thread_wakeup, -1, "v"},
 	{"getstatus", thread_getstatus, 1, "v"},
 	{"weakref",obj_delegate_weakref,1, nullptr },
 	{"tostring",default_delegate_tostring,1, "."},
-	{nullptr,nullptr,0,nullptr},
 };
 
 static SQInteger class_getattributes(HSQUIRRELVM v)
@@ -916,14 +906,13 @@ static SQInteger class_instance(HSQUIRRELVM v)
 	return SQ_ERROR;
 }
 
-SQRegFunction SQSharedState::_class_default_delegate_funcz[] = {
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_class_default_delegate_funcz = {
 	{"getattributes", class_getattributes, 2, "y."},
 	{"setattributes", class_setattributes, 3, "y.."},
 	{"rawin",container_rawexists,2, "y"},
 	{"weakref",obj_delegate_weakref,1, nullptr },
 	{"tostring",default_delegate_tostring,1, "."},
 	{"instance",class_instance,1, "y"},
-	{nullptr,nullptr,0,nullptr}
 };
 
 static SQInteger instance_getclass(HSQUIRRELVM v)
@@ -933,12 +922,11 @@ static SQInteger instance_getclass(HSQUIRRELVM v)
 	return SQ_ERROR;
 }
 
-SQRegFunction SQSharedState::_instance_default_delegate_funcz[] = {
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_instance_default_delegate_funcz = {
 	{"getclass", instance_getclass, 1, "x"},
 	{"rawin",container_rawexists,2, "x"},
 	{"weakref",obj_delegate_weakref,1, nullptr },
 	{"tostring",default_delegate_tostring,1, "."},
-	{nullptr,nullptr,0,nullptr}
 };
 
 static SQInteger weakref_ref(HSQUIRRELVM v)
@@ -948,11 +936,10 @@ static SQInteger weakref_ref(HSQUIRRELVM v)
 	return 1;
 }
 
-SQRegFunction SQSharedState::_weakref_default_delegate_funcz[] = {
+/* static */ const std::initializer_list<SQRegFunction> SQSharedState::_weakref_default_delegate_funcz = {
 	{"ref",weakref_ref,1, "r"},
 	{"weakref",obj_delegate_weakref,1, nullptr },
 	{"tostring",default_delegate_tostring,1, "."},
-	{nullptr,nullptr,0,nullptr}
 };
 
 

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
@@ -110,11 +110,6 @@ SQFuncState::SQFuncState(SQSharedState *ss,SQFuncState *parent)
 
 }
 
-void SQFuncState::Error(const SQChar *err)
-{
-	throw CompileException(err);
-}
-
 #ifdef _DEBUG_DUMP
 void SQFuncState::Dump(SQFunctionProto *func)
 {
@@ -234,7 +229,7 @@ SQInteger SQFuncState::GetConstant(const SQObject &cons)
 		_nliterals++;
 		if(_nliterals > MAX_LITERALS) {
 			val.Null();
-			Error("internal compiler error: too many literals");
+			throw CompileException("internal compiler error: too many literals");
 		}
 	}
 	return _integer(val);
@@ -264,7 +259,7 @@ SQInteger SQFuncState::AllocStackPos()
 	SQInteger npos=_vlocals.size();
 	_vlocals.push_back(SQLocalVarInfo());
 	if(_vlocals.size()>((SQUnsignedInteger)_stacksize)) {
-		if(_stacksize>MAX_FUNC_STACKSIZE) Error("internal compiler error: too many locals");
+		if(_stacksize>MAX_FUNC_STACKSIZE) throw CompileException("internal compiler error: too many locals");
 		_stacksize=_vlocals.size();
 	}
 	return npos;

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.h
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.h
@@ -11,7 +11,6 @@ struct SQFuncState
 #ifdef _DEBUG_DUMP
 	void Dump(SQFunctionProto *func);
 #endif
-	[[noreturn]] void Error(const SQChar *err);
 	SQFuncState *PushChildState(SQSharedState *ss);
 	void PopChildState();
 	void AddInstruction(SQOpcode _op,SQInteger arg0=0,SQInteger arg1=0,SQInteger arg2=0,SQInteger arg3=0){SQInstruction i(_op,arg0,arg1,arg2,arg3);AddInstruction(i);}

--- a/src/3rdparty/squirrel/squirrel/sqlexer.h
+++ b/src/3rdparty/squirrel/squirrel/sqlexer.h
@@ -6,7 +6,6 @@ struct SQLexer
 {
 	~SQLexer();
 	SQLexer(SQSharedState *ss,SQLEXREADFUNC rg,SQUserPointer up);
-	[[noreturn]] void Error(const SQChar *err);
 	SQInteger Lex();
 	const SQChar *Tok2Str(SQInteger tok);
 private:

--- a/src/3rdparty/squirrel/squirrel/sqstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqstate.cpp
@@ -75,18 +75,16 @@ bool CompileTypemask(SQIntVec &res,const SQChar *typemask)
 	return true;
 }
 
-SQTable *CreateDefaultDelegate(SQSharedState *ss,SQRegFunction *funcz)
+SQTable *CreateDefaultDelegate(SQSharedState *ss,const std::initializer_list<SQRegFunction> &funcz)
 {
-	SQInteger i=0;
 	SQTable *t=SQTable::Create(ss,0);
-	while(funcz[i].name!=nullptr){
-		SQNativeClosure *nc = SQNativeClosure::Create(ss,funcz[i].f);
-		nc->_nparamscheck = funcz[i].nparamscheck;
-		nc->_name = SQString::Create(ss,funcz[i].name);
-		if(funcz[i].typemask && !CompileTypemask(nc->_typecheck,funcz[i].typemask))
+	for (auto &func : funcz) {
+		SQNativeClosure *nc = SQNativeClosure::Create(ss,func.f);
+		nc->_nparamscheck = func.nparamscheck;
+		nc->_name = SQString::Create(ss,func.name);
+		if(func.typemask && !CompileTypemask(nc->_typecheck,func.typemask))
 			return nullptr;
-		t->NewSlot(SQString::Create(ss,funcz[i].name),nc);
-		i++;
+		t->NewSlot(SQString::Create(ss,func.name),nc);
 	}
 	return t;
 }

--- a/src/3rdparty/squirrel/squirrel/sqstate.h
+++ b/src/3rdparty/squirrel/squirrel/sqstate.h
@@ -81,25 +81,25 @@ public:
 #endif
 	SQObjectPtr _root_vm;
 	SQObjectPtr _table_default_delegate;
-	static SQRegFunction _table_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _table_default_delegate_funcz;
 	SQObjectPtr _array_default_delegate;
-	static SQRegFunction _array_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _array_default_delegate_funcz;
 	SQObjectPtr _string_default_delegate;
-	static SQRegFunction _string_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _string_default_delegate_funcz;
 	SQObjectPtr _number_default_delegate;
-	static SQRegFunction _number_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _number_default_delegate_funcz;
 	SQObjectPtr _generator_default_delegate;
-	static SQRegFunction _generator_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _generator_default_delegate_funcz;
 	SQObjectPtr _closure_default_delegate;
-	static SQRegFunction _closure_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _closure_default_delegate_funcz;
 	SQObjectPtr _thread_default_delegate;
-	static SQRegFunction _thread_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _thread_default_delegate_funcz;
 	SQObjectPtr _class_default_delegate;
-	static SQRegFunction _class_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _class_default_delegate_funcz;
 	SQObjectPtr _instance_default_delegate;
-	static SQRegFunction _instance_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _instance_default_delegate_funcz;
 	SQObjectPtr _weakref_default_delegate;
-	static SQRegFunction _weakref_default_delegate_funcz[];
+	static const std::initializer_list<SQRegFunction> _weakref_default_delegate_funcz;
 
 	SQCOMPILERERROR _compilererrorhandler;
 	SQPRINTFUNCTION _printfunc;


### PR DESCRIPTION
## Motivation / Problem

Trying to get rid of C-style strings in Squirrel code, there are some `Error` functions that only call `throw CompileException(str)`. That's fine on its own, but... throwing that exception (`std::runtime_exception`) requires either `std::string` or `const char *` and importantly not `std::string_view`.

Furthermore there are some loops that terminate on a field being `nullptr`. That field being a `char *`. Why not use ranges for loops instead?


## Description

Direct inline `throw CompileException` instead of the `Error` indirection. No need to make a choice between `char *` and `std::string` any more.

Use `std::initializer_list` and ranged for loops, to remove the `nullptr` termination of some lists. While doing so, change the type of the field to `std::string_view`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
