### PR TITLE
Codechange: replace SQChar with std::string_view (or char)

### DIFF
--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -185,7 +185,7 @@ typedef struct tagSQRegFunction{
 	std::string_view name;
 	SQFUNCTION f;
 	SQInteger nparamscheck;
-	const SQChar *typemask;
+	std::optional<std::string_view> typemask;
 }SQRegFunction;
 
 typedef struct tagSQFunctionInfo {
@@ -235,7 +235,7 @@ SQUserPointer sq_newuserdata(HSQUIRRELVM v,SQUnsignedInteger size);
 void sq_newtable(HSQUIRRELVM v);
 void sq_newarray(HSQUIRRELVM v,SQInteger size);
 void sq_newclosure(HSQUIRRELVM v,SQFUNCTION func,SQUnsignedInteger nfreevars);
-SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheck,const SQChar *typemask);
+SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheck,std::optional<std::string_view> typemask);
 SQRESULT sq_bindenv(HSQUIRRELVM v,SQInteger idx);
 void sq_pushstring(HSQUIRRELVM v, std::string_view str);
 void sq_pushfloat(HSQUIRRELVM v,SQFloat f);

--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -68,7 +68,6 @@ struct SQClass;
 struct SQInstance;
 struct SQDelegable;
 
-typedef char SQChar;
 #define MAX_CHAR 0xFFFF
 
 #define SQUIRREL_VERSION	"Squirrel 2.2.5 stable - With custom OpenTTD modifications"

--- a/src/3rdparty/squirrel/sqstdlib/sqstdmath.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdmath.cpp
@@ -84,7 +84,7 @@ static const std::initializer_list<SQRegFunction> mathlib_funcs = {
 	_DECL_FUNC(exp,2,".n"),
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
 	_DECL_FUNC(srand,2,".n"),
-	_DECL_FUNC(rand,1,nullptr),
+	_DECL_FUNC(rand,1,std::nullopt),
 #endif /* EXPORT_DEFAULT_SQUIRREL_FUNCTIONS */
 	_DECL_FUNC(fabs,2,".n"),
 	_DECL_FUNC(abs,2,".n"),

--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -583,7 +583,7 @@ SQInteger sq_getsize(HSQUIRRELVM v, SQInteger idx)
 	SQObjectPtr &o = stack_get(v, idx);
 	SQObjectType type = type(o);
 	switch(type) {
-	case OT_STRING:		return _string(o)->_len;
+	case OT_STRING:		return _string(o)->View().size();
 	case OT_TABLE:		return _table(o)->CountUsed();
 	case OT_ARRAY:		return _array(o)->Size();
 	case OT_USERDATA:	return _userdata(o)->_size;

--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -385,16 +385,16 @@ SQRESULT sq_setnativeclosurename(HSQUIRRELVM v,SQInteger idx,std::string_view na
 	return sq_throwerror(v,"the object is not a nativeclosure");
 }
 
-SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheck,const SQChar *typemask)
+SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheck,std::optional<std::string_view> typemask)
 {
 	SQObject o = stack_get(v, -1);
 	if(!sq_isnativeclosure(o))
 		return sq_throwerror(v, "native closure expected");
 	SQNativeClosure *nc = _nativeclosure(o);
 	nc->_nparamscheck = nparamscheck;
-	if(typemask) {
+	if(typemask.has_value()) {
 		SQIntVec res;
-		if(!CompileTypemask(res, typemask))
+		if(!CompileTypemask(res, *typemask))
 			return sq_throwerror(v, "invalid typemask");
 		nc->_typecheck.copy(res);
 	}

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -241,26 +241,26 @@ static SQInteger base_type(HSQUIRRELVM v)
 static const std::initializer_list<SQRegFunction> base_funcs={
 	//generic
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
-	{"seterrorhandler",base_seterrorhandler,2, nullptr},
-	{"setdebughook",base_setdebughook,2, nullptr},
-	{"enabledebuginfo",base_enabledebuginfo,2, nullptr},
+	{"seterrorhandler",base_seterrorhandler,2, std::nullopt},
+	{"setdebughook",base_setdebughook,2, std::nullopt},
+	{"enabledebuginfo",base_enabledebuginfo,2, std::nullopt},
 	{"getstackinfos",base_getstackinfos,2, ".n"},
-	{"getroottable",base_getroottable,1, nullptr},
-	{"setroottable",base_setroottable,2, nullptr},
-	{"getconsttable",base_getconsttable,1, nullptr},
-	{"setconsttable",base_setconsttable,2, nullptr},
+	{"getroottable",base_getroottable,1, std::nullopt},
+	{"setroottable",base_setroottable,2, std::nullopt},
+	{"getconsttable",base_getconsttable,1, std::nullopt},
+	{"setconsttable",base_setconsttable,2, std::nullopt},
 #endif
-	{"assert",base_assert,2, nullptr},
-	{"print",base_print,2, nullptr},
+	{"assert",base_assert,2, std::nullopt},
+	{"print",base_print,2, std::nullopt},
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
 	{"compilestring",base_compilestring,-2, ".ss"},
 	{"newthread",base_newthread,2, ".c"},
-	{"suspend",base_suspend,-1, nullptr},
+	{"suspend",base_suspend,-1, std::nullopt},
 #endif
 	{"array",base_array,-2, ".n"},
-	{"type",base_type,2, nullptr},
+	{"type",base_type,2, std::nullopt},
 #ifdef EXPORT_DEFAULT_SQUIRREL_FUNCTIONS
-	{"dummy",base_dummy,0,nullptr},
+	{"dummy",base_dummy,0,std::nullopt},
 #ifndef NO_GARBAGE_COLLECTOR
 	{"collectgarbage",base_collectgarbage,1, "t"},
 #endif
@@ -414,7 +414,7 @@ static SQInteger table_rawget(HSQUIRRELVM v)
 	{"rawset",table_rawset,3, "t"},
 	{"rawdelete",table_rawdelete,2, "t"},
 	{"rawin",container_rawexists,2, "t"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 	{"tostring",default_delegate_tostring,1, "."},
 	{"clear",obj_clear,1, "."},
 };
@@ -622,7 +622,7 @@ static SQInteger array_slice(HSQUIRRELVM v)
 	{"reverse",array_reverse,1, "a"},
 	{"sort",array_sort,-1, "ac"},
 	{"slice",array_slice,-1, "ann"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 	{"tostring",default_delegate_tostring,1, "."},
 	{"clear",obj_clear,1, "."},
 };
@@ -684,7 +684,7 @@ STRING_TOFUNCZ(toupper)
 	{"find",string_find,-2, "s s n "},
 	{"tolower",string_tolower,1, "s"},
 	{"toupper",string_toupper,1, "s"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 };
 
 //INTEGER DEFAULT DELEGATE//////////////////////////
@@ -693,7 +693,7 @@ STRING_TOFUNCZ(toupper)
 	{"tofloat",default_delegate_tofloat,1, "n|b"},
 	{"tostring",default_delegate_tostring,1, "."},
 	{"tochar",number_delegate_tochar,1, "n|b"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 };
 
 //CLOSURE DEFAULT DELEGATE//////////////////////////
@@ -777,7 +777,7 @@ static SQInteger closure_getinfos(HSQUIRRELVM v) {
 	{"pcall",closure_pcall,-1, "c"},
 	{"acall",closure_acall,2, "ca"},
 	{"pacall",closure_pacall,2, "ca"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 	{"tostring",default_delegate_tostring,1, "."},
 	{"bindenv",closure_bindenv,2, "c x|y|t"},
 	{"getinfos",closure_getinfos,1, "c"},
@@ -797,7 +797,7 @@ static SQInteger generator_getstatus(HSQUIRRELVM v)
 
 /* static */ const std::initializer_list<SQRegFunction> SQSharedState::_generator_default_delegate_funcz={
 	{"getstatus",generator_getstatus,1, "g"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 	{"tostring",default_delegate_tostring,1, "."},
 };
 
@@ -882,7 +882,7 @@ static SQInteger thread_getstatus(HSQUIRRELVM v)
 	{"call", thread_call, -1, "v"},
 	{"wakeup", thread_wakeup, -1, "v"},
 	{"getstatus", thread_getstatus, 1, "v"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 	{"tostring",default_delegate_tostring,1, "."},
 };
 
@@ -911,7 +911,7 @@ static SQInteger class_instance(HSQUIRRELVM v)
 	{"getattributes", class_getattributes, 2, "y."},
 	{"setattributes", class_setattributes, 3, "y.."},
 	{"rawin",container_rawexists,2, "y"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 	{"tostring",default_delegate_tostring,1, "."},
 	{"instance",class_instance,1, "y"},
 };
@@ -926,7 +926,7 @@ static SQInteger instance_getclass(HSQUIRRELVM v)
 /* static */ const std::initializer_list<SQRegFunction> SQSharedState::_instance_default_delegate_funcz = {
 	{"getclass", instance_getclass, 1, "x"},
 	{"rawin",container_rawexists,2, "x"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 	{"tostring",default_delegate_tostring,1, "."},
 };
 
@@ -939,7 +939,7 @@ static SQInteger weakref_ref(HSQUIRRELVM v)
 
 /* static */ const std::initializer_list<SQRegFunction> SQSharedState::_weakref_default_delegate_funcz = {
 	{"ref",weakref_ref,1, "r"},
-	{"weakref",obj_delegate_weakref,1, nullptr },
+	{"weakref",obj_delegate_weakref,1, std::nullopt },
 	{"tostring",default_delegate_tostring,1, "."},
 };
 

--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -21,7 +21,7 @@
 bool str2num(std::string_view s,SQObjectPtr &res)
 {
 	if(s.find('.') != std::string_view::npos){
-		SQChar *end;
+		char *end;
 		std::string str{s};
 		SQFloat r = SQFloat(strtod(str.c_str(),&end));
 		if(str.c_str() == end) return false;
@@ -281,7 +281,7 @@ void sq_base_register(HSQUIRRELVM v)
 	sq_pushstring(v,SQUIRREL_VERSION);
 	sq_createslot(v,-3);
 	sq_pushstring(v,"_charsize_");
-	sq_pushinteger(v,sizeof(SQChar));
+	sq_pushinteger(v,sizeof(char));
 	sq_createslot(v,-3);
 	sq_pushstring(v,"_intsize_");
 	sq_pushinteger(v,sizeof(SQInteger));
@@ -369,7 +369,7 @@ static SQInteger obj_clear(HSQUIRRELVM v)
 static SQInteger number_delegate_tochar(HSQUIRRELVM v)
 {
 	SQObject &o=stack_get(v,1);
-	SQChar c = (SQChar)tointeger(o);
+	char c = static_cast<char>(tointeger(o));
 	v->Push(SQString::Create(_ss(v),std::string_view(&c, 1)));
 	return 1;
 }

--- a/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
@@ -88,7 +88,7 @@ public:
 				//do nothing
 			}
 			else {
-				const SQChar *etypename;
+				std::string_view etypename;
 				if(tok > 255) {
 					switch(tok)
 					{
@@ -105,7 +105,7 @@ public:
 						etypename = "FLOAT";
 						break;
 					default:
-						etypename = _lex.Tok2Str(tok);
+						etypename = _lex.Tok2Str(tok).value_or("<unknown>");
 					}
 					throw CompileException(fmt::format("expected '{}'", etypename));
 				}
@@ -116,10 +116,10 @@ public:
 		switch(tok)
 		{
 		case TK_IDENTIFIER:
-			ret = _fs->CreateString(_lex._svalue);
+			ret = _fs->CreateString(_lex.View());
 			break;
 		case TK_STRING_LITERAL:
-			ret = _fs->CreateString(std::string_view(_lex._svalue,_lex._longstr.size()-1));
+			ret = _fs->CreateString(_lex.View());
 			break;
 		case TK_INTEGER:
 			ret = SQObjectPtr(_lex._nvalue);
@@ -594,7 +594,7 @@ public:
 		switch(_token)
 		{
 		case TK_STRING_LITERAL: {
-				_fs->AddInstruction(_OP_LOAD, _fs->PushTarget(), _fs->GetConstant(_fs->CreateString(std::string_view(_lex._svalue,_lex._longstr.size()-1))));
+				_fs->AddInstruction(_OP_LOAD, _fs->PushTarget(), _fs->GetConstant(_fs->CreateString(_lex.View())));
 				Lex();
 			}
 			break;
@@ -614,7 +614,7 @@ public:
 			SQObject id;
 			SQObject constant;
 				switch(_token) {
-					case TK_IDENTIFIER: id = _fs->CreateString(_lex._svalue); break;
+					case TK_IDENTIFIER: id = _fs->CreateString(_lex.View()); break;
 					case TK_THIS: id = _fs->CreateString("this"); break;
 					case TK_CONSTRUCTOR: id = _fs->CreateString("constructor"); break;
 				}
@@ -1099,7 +1099,7 @@ public:
 				val._unVal.fFloat = _lex._fvalue;
 				break;
 			case TK_STRING_LITERAL:
-				val = _fs->CreateString(std::string_view(_lex._svalue,_lex._longstr.size()-1));
+				val = _fs->CreateString(_lex.View());
 				break;
 			case '-':
 				Lex();

--- a/src/3rdparty/squirrel/squirrel/sqlexer.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqlexer.cpp
@@ -305,7 +305,7 @@ SQInteger SQLexer::ReadString(char32_t ndelim,bool verbatim)
 					case 'x': NEXT(); {
 						if(!isxdigit(CUR_CHAR)) throw CompileException("hexadecimal number expected");
 						const SQInteger maxdigits = 4;
-						SQChar temp[maxdigits];
+						char temp[maxdigits];
 						size_t n = 0;
 						while(isxdigit(CUR_CHAR) && n < maxdigits) {
 							temp[n] = CUR_CHAR;
@@ -314,7 +314,7 @@ SQInteger SQLexer::ReadString(char32_t ndelim,bool verbatim)
 						}
 						auto val = ParseInteger(std::string_view{temp, n}, 16);
 						if (!val.has_value()) throw CompileException("hexadecimal number expected");
-						APPEND_CHAR(static_cast<SQChar>(*val));
+						APPEND_CHAR(static_cast<char>(*val));
 					}
 				    break;
 					case 't': APPEND_CHAR('\t'); NEXT(); break;
@@ -357,7 +357,7 @@ SQInteger SQLexer::ReadString(char32_t ndelim,bool verbatim)
 	return TK_STRING_LITERAL;
 }
 
-SQInteger scisodigit(SQChar c) { return c >= '0' && c <= '7'; }
+SQInteger scisodigit(char c) { return c >= '0' && c <= '7'; }
 
 SQInteger isexponent(SQInteger c) { return c == 'e' || c=='E'; }
 
@@ -371,7 +371,6 @@ SQInteger SQLexer::ReadNumber()
 #define TSCIENTIFIC 4
 #define TOCTAL 5
 	SQInteger type = TINT, firstchar = CUR_CHAR;
-	SQChar *sTemp;
 	INIT_TEMP_STRING();
 	NEXT();
 	if(firstchar == '0' && (toupper(CUR_CHAR) == 'X' || scisodigit(CUR_CHAR)) ) {
@@ -417,6 +416,7 @@ SQInteger SQLexer::ReadNumber()
 	case TSCIENTIFIC:
 	case TFLOAT: {
 		std::string str{View()};
+		char *sTemp;
 		_fvalue = (SQFloat)strtod(str.c_str(),&sTemp);
 		return TK_FLOAT;
 	}

--- a/src/3rdparty/squirrel/squirrel/sqlexer.h
+++ b/src/3rdparty/squirrel/squirrel/sqlexer.h
@@ -7,9 +7,9 @@ struct SQLexer
 	~SQLexer();
 	SQLexer(SQSharedState *ss,SQLEXREADFUNC rg,SQUserPointer up);
 	SQInteger Lex();
-	const SQChar *Tok2Str(SQInteger tok);
+	std::optional<std::string_view> Tok2Str(SQInteger tok);
 private:
-	SQInteger GetIDType(SQChar *s);
+	SQInteger GetIDType(std::string_view s);
 	SQInteger ReadString(char32_t ndelim,bool verbatim);
 	SQInteger ReadNumber();
 	void LexBlockComment();
@@ -19,14 +19,12 @@ private:
 	SQTable *_keywords;
 	void INIT_TEMP_STRING() { _longstr.resize(0); }
 	void APPEND_CHAR(char32_t c);
-	void TERMINATE_BUFFER() { _longstr.push_back('\0'); }
 
 public:
 	SQInteger _prevtoken;
 	SQInteger _currentline;
 	SQInteger _lasttokenline;
 	SQInteger _currentcolumn;
-	const SQChar *_svalue;
 	SQInteger _nvalue;
 	SQFloat _fvalue;
 	SQLEXREADFUNC _readf;
@@ -34,6 +32,8 @@ public:
 	char32_t _currdata;
 	SQSharedState *_sharedstate;
 	sqvector<SQChar> _longstr;
+
+	std::string_view View() const { return std::string_view(_longstr._vals, _longstr.size()); }
 };
 
 #endif

--- a/src/3rdparty/squirrel/squirrel/sqlexer.h
+++ b/src/3rdparty/squirrel/squirrel/sqlexer.h
@@ -31,7 +31,7 @@ public:
 	SQUserPointer _up;
 	char32_t _currdata;
 	SQSharedState *_sharedstate;
-	sqvector<SQChar> _longstr;
+	sqvector<char> _longstr;
 
 	std::string_view View() const { return std::string_view(_longstr._vals, _longstr.size()); }
 };

--- a/src/3rdparty/squirrel/squirrel/sqobject.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqobject.cpp
@@ -270,10 +270,13 @@ bool WriteObject(HSQUIRRELVM v,SQUserPointer up,SQWRITEFUNC write,SQObjectPtr &o
 {
 	_CHECK_IO(SafeWrite(v,write,up,&type(o),sizeof(SQObjectType)));
 	switch(type(o)){
-	case OT_STRING:
-		_CHECK_IO(SafeWrite(v,write,up,&_string(o)->_len,sizeof(SQInteger)));
-		_CHECK_IO(SafeWrite(v,write,up,_stringval(o),_string(o)->_len));
+	case OT_STRING: {
+		auto str = _string(o)->Span();
+		SQInteger len = str.size();
+		_CHECK_IO(SafeWrite(v,write,up,&len,sizeof(len)));
+		_CHECK_IO(SafeWrite(v,write,up,str.data(),len));
 		break;
+	}
 	case OT_INTEGER:
 		_CHECK_IO(SafeWrite(v,write,up,&_integer(o),sizeof(SQInteger)));break;
 	case OT_FLOAT:
@@ -294,11 +297,11 @@ bool ReadObject(HSQUIRRELVM v,SQUserPointer up,SQREADFUNC read,SQObjectPtr &o)
 	switch(t){
 	case OT_STRING:{
 		SQInteger len;
-		_CHECK_IO(SafeRead(v,read,up,&len,sizeof(SQInteger)));
+		_CHECK_IO(SafeRead(v,read,up,&len,sizeof(len)));
 		_CHECK_IO(SafeRead(v,read,up,_ss(v)->GetScratchPad(len).data(),len));
 		o=SQString::Create(_ss(v),std::string_view(_ss(v)->GetScratchPad(-1).data(),len));
-				   }
 		break;
+	}
 	case OT_INTEGER:{
 		SQInteger i;
 		_CHECK_IO(SafeRead(v,read,up,&i,sizeof(SQInteger))); o = i; break;

--- a/src/3rdparty/squirrel/squirrel/sqobject.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqobject.cpp
@@ -18,7 +18,7 @@
 #include "../../../safeguards.h"
 
 
-const SQChar *IdType2Name(SQObjectType type)
+std::string_view IdType2Name(SQObjectType type)
 {
 	switch(_RAW_TYPE(type))
 	{
@@ -42,11 +42,11 @@ const SQChar *IdType2Name(SQObjectType type)
 	case _RT_INSTANCE: return "instance";
 	case _RT_WEAKREF: return "weakref";
 	default:
-		return nullptr;
+		NOT_REACHED();
 	}
 }
 
-const SQChar *GetTypeName(const SQObjectPtr &obj1)
+std::string_view GetTypeName(const SQObjectPtr &obj1)
 {
 	return IdType2Name(type(obj1));
 }
@@ -323,7 +323,7 @@ bool ReadObject(HSQUIRRELVM v,SQUserPointer up,SQREADFUNC read,SQObjectPtr &o)
 bool SQClosure::Save(SQVM *v,SQUserPointer up,SQWRITEFUNC write)
 {
 	_CHECK_IO(WriteTag(v,write,up,SQ_CLOSURESTREAM_HEAD));
-	_CHECK_IO(WriteTag(v,write,up,sizeof(SQChar)));
+	_CHECK_IO(WriteTag(v,write,up,sizeof(char)));
 	_CHECK_IO(_funcproto(_function)->Save(v,up,write));
 	_CHECK_IO(WriteTag(v,write,up,SQ_CLOSURESTREAM_TAIL));
 	return true;
@@ -332,7 +332,7 @@ bool SQClosure::Save(SQVM *v,SQUserPointer up,SQWRITEFUNC write)
 bool SQClosure::Load(SQVM *v,SQUserPointer up,SQREADFUNC read,SQObjectPtr &ret)
 {
 	_CHECK_IO(CheckTag(v,read,up,SQ_CLOSURESTREAM_HEAD));
-	_CHECK_IO(CheckTag(v,read,up,sizeof(SQChar)));
+	_CHECK_IO(CheckTag(v,read,up,sizeof(char)));
 	SQObjectPtr func;
 	_CHECK_IO(SQFunctionProto::Load(v,up,read,func));
 	_CHECK_IO(CheckTag(v,read,up,SQ_CLOSURESTREAM_TAIL));

--- a/src/3rdparty/squirrel/squirrel/sqobject.h
+++ b/src/3rdparty/squirrel/squirrel/sqobject.h
@@ -138,7 +138,7 @@ struct SQObjectPtr;
 #define _refcounted(obj) ((obj)._unVal.pRefCounted)
 #define _rawval(obj) ((obj)._unVal.raw)
 
-#define _stringval(obj) (obj)._unVal.pString->_val
+#define _stringval(obj) (obj)._unVal.pString->View()
 #define _userdataval(obj) (obj)._unVal.pUserData->_val
 
 #define tofloat(num) ((type(num)==OT_INTEGER)?(SQFloat)_integer(num):_float(num))

--- a/src/3rdparty/squirrel/squirrel/sqobject.h
+++ b/src/3rdparty/squirrel/squirrel/sqobject.h
@@ -357,7 +357,7 @@ struct SQObjectPtr : public SQObject
 		return *this;
 	}
 	private:
-		SQObjectPtr(const SQChar *){} //safety
+		SQObjectPtr(const char *) = delete; //safety
 };
 
 inline void _Swap(SQObject &a,SQObject &b)
@@ -449,8 +449,8 @@ struct SQDelegable : public CHAINABLE_OBJ {
 SQUnsignedInteger TranslateIndex(const SQObjectPtr &idx);
 typedef sqvector<SQObjectPtr> SQObjectPtrVec;
 typedef sqvector<SQInteger> SQIntVec;
-const SQChar *GetTypeName(const SQObjectPtr &obj1);
-const SQChar *IdType2Name(SQObjectType type);
+std::string_view GetTypeName(const SQObjectPtr &obj1);
+std::string_view IdType2Name(SQObjectType type);
 
 
 

--- a/src/3rdparty/squirrel/squirrel/sqopcodes.h
+++ b/src/3rdparty/squirrel/squirrel/sqopcodes.h
@@ -87,7 +87,7 @@ enum SQOpcode
 };
 
 struct SQInstructionDesc {
-	const SQChar *name;
+	std::string_view name;
 };
 
 struct SQInstruction

--- a/src/3rdparty/squirrel/squirrel/sqstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqstate.cpp
@@ -553,8 +553,7 @@ SQString *SQStringTable::Add(std::string_view new_string)
 	auto slot = string_table_hash(new_string) & (_numofslots-1);
 	SQString *s;
 	for (s = _strings[slot]; s; s = s->_next){
-		if(static_cast<size_t>(s->_len) == len && (!memcmp(new_string.data(),s->_val,len)))
-			return s; //found
+		if(s->View() == new_string) return s; //found
 	}
 
 	SQString *t=(SQString *)SQ_MALLOC(len+sizeof(SQString));
@@ -608,7 +607,7 @@ void SQStringTable::Remove(SQString *bs)
 			else
 				_strings[h] = s->_next;
 			_slotused--;
-			SQInteger slen = s->_len;
+			size_t slen = s->View().size();
 			s->~SQString();
 			SQ_FREE(s,sizeof(SQString) + slen);
 			return;

--- a/src/3rdparty/squirrel/squirrel/sqstate.h
+++ b/src/3rdparty/squirrel/squirrel/sqstate.h
@@ -129,6 +129,6 @@ extern SQObjectPtr _false_;
 extern SQObjectPtr _one_;
 extern SQObjectPtr _minusone_;
 
-bool CompileTypemask(SQIntVec &res,const SQChar *typemask);
+bool CompileTypemask(SQIntVec &res,std::string_view typemask);
 
 #endif //_SQSTATE_H_

--- a/src/3rdparty/squirrel/squirrel/sqstring.h
+++ b/src/3rdparty/squirrel/squirrel/sqstring.h
@@ -18,7 +18,7 @@ public:
 	std::span<char> Span() { return std::span<char>(this->_val, this->_len); }
 private:
 	SQInteger _len;
-	SQChar _val[1];
+	char _val[1];
 };
 
 

--- a/src/3rdparty/squirrel/squirrel/sqstring.h
+++ b/src/3rdparty/squirrel/squirrel/sqstring.h
@@ -12,8 +12,12 @@ public:
 	void Release() override;
 	SQSharedState *_sharedstate;
 	SQString *_next; //chain for the string table
-	SQInteger _len;
 	std::size_t _hash;
+
+	std::string_view View() const { return std::string_view(this->_val, this->_len); }
+	std::span<char> Span() { return std::span<char>(this->_val, this->_len); }
+private:
+	SQInteger _len;
 	SQChar _val[1];
 };
 

--- a/src/3rdparty/squirrel/squirrel/squserdata.h
+++ b/src/3rdparty/squirrel/squirrel/squserdata.h
@@ -31,7 +31,7 @@ struct SQUserData : SQDelegable
 	SQInteger _size;
 	SQRELEASEHOOK _hook;
 	SQUserPointer _typetag;
-	SQChar _val[1];
+	char _val[1];
 };
 
 #endif //_SQUSERDATA_H_

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -197,7 +197,7 @@ bool SQVM::ObjCmp(const SQObjectPtr &o1,const SQObjectPtr &o2,SQInteger &result)
 		SQObjectPtr res;
 		switch(type(o1)){
 		case OT_STRING:
-			_RET_SUCCEED(strcmp(_stringval(o1),_stringval(o2)));
+			_RET_SUCCEED(_stringval(o1).compare(_stringval(o2)));
 		case OT_INTEGER:
 			/* FS#3954: wrong integer comparison */
 			_RET_SUCCEED((_integer(o1)<_integer(o2))?-1:(_integer(o1)==_integer(o2))?0:1);
@@ -1284,9 +1284,10 @@ bool SQVM::FallBackGet(const SQObjectPtr &self,const SQObjectPtr &key,SQObjectPt
 	case OT_STRING:
 		if(sq_isnumeric(key)){
 			SQInteger n=tointeger(key);
-			if(abs((int)n)<_string(self)->_len){
-				if(n<0)n=_string(self)->_len-n;
-				dest=SQInteger(_stringval(self)[n]);
+			std::string_view str = _stringval(self);
+			if(std::abs(n) < static_cast<SQInteger>(str.size())){
+				if(n<0)n=str.size()+n;
+				dest=SQInteger(str[n]);
 				return true;
 			}
 			return false;

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -36,6 +36,7 @@
 #define vsprintf  SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define vsnprintf SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
+#define strcmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strncmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #ifdef strcasecmp
 #undef strcasecmp

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -265,7 +265,7 @@ void Squirrel::AddMethod(std::string_view method_name, SQFUNCTION proc, std::str
 	}
 
 	sq_newclosure(this->vm, proc, size != 0 ? 1 : 0);
-	if (!params.empty()) sq_setparamscheck(this->vm, params.size(), params.data());
+	if (!params.empty()) sq_setparamscheck(this->vm, params.size(), params);
 	sq_setnativeclosurename(this->vm, -1, method_name);
 	sq_newslot(this->vm, -3, SQFalse);
 }


### PR DESCRIPTION
## Motivation / Problem

The use of C-style strings and methods in Squirrel code.


## Description

Includes #14201.

Replace `char *` mostly with `std::string_view` and occasionally with `std::span<char>`.

Replace the remaining `SQChar`s with `char`.


## Limitations

None I can think of. Well... besides the ugly `strtod` construct for parsing floats, but there's not alternative if we want to support clang due to  them being late to the party of supporting `std::from_chars` for doubles.

Also, not quite done yet... lets figure out what the compilers on other platforms complain about; I'm expecting the need of a few `static_cast`s.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
