### PR TITLE
Codefix 26a4da9b01: MinGW compilation failure

### DIFF
--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -37,6 +37,9 @@
 #define vsnprintf SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
 #define strncmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#ifdef strcasecmp
+#undef strcasecmp
+#endif
 #define strcasecmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #ifdef stricmp
 #undef stricmp


### PR DESCRIPTION
## Motivation / Problem

Nightly failing due to MinGW `#define`-ing `strcasecmp`.


## Description

Like with 'stricmp' undefined `strcasecmp`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
