### PR TITLE
Codechange: some char related cleanups

### DIFF
--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -312,7 +312,7 @@ static SOCKET ListenLoopProc(addrinfo *runp)
 
 	int on = 1;
 	if (runp->ai_family == AF_INET6 &&
-			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&on, sizeof(on)) == -1) {
+			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char *>(&on), sizeof(on)) == -1) {
 		Debug(net, 3, "Could not disable IPv4 over IPv6: {}", NetworkError::GetLast().AsString());
 	}
 

--- a/src/network/core/os_abstraction.cpp
+++ b/src/network/core/os_abstraction.cpp
@@ -155,8 +155,8 @@ bool SetNoDelay([[maybe_unused]] SOCKET d)
 	return true;
 #else
 	int flags = 1;
-	/* The (const char*) cast is needed for windows */
-	return setsockopt(d, IPPROTO_TCP, TCP_NODELAY, (const char *)&flags, sizeof(flags)) == 0;
+	/* The (const char *) cast is needed for windows */
+	return setsockopt(d, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char *>(&flags), sizeof(flags)) == 0;
 #endif
 }
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1278,7 +1278,7 @@ bool NetworkValidateClientName(std::string &client_name)
  * Convenience method for NetworkValidateClientName on _settings_client.network.client_name.
  * It trims the client name and checks whether it is empty. When it is empty
  * an error message is shown to the GUI user.
- * See \c NetworkValidateClientName(char*) for details about the functionality.
+ * See \c NetworkValidateClientName(std::string&) for details about the functionality.
  * @return True iff the client name is valid.
  */
 bool NetworkValidateOurClientName()

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -122,7 +122,7 @@ static std::string convert_tofrom_fs(iconv_t convd, std::string_view name)
 	 * e.g. SUSv2, pass a const pointer, whereas the newer ones, e.g.
 	 * IEEE 1003.1 (2004), pass a non-const pointer. */
 #ifdef HAVE_NON_CONST_ICONV
-	char *inbuf = const_cast<char*>(name.data());
+	char *inbuf = const_cast<char *>(name.data());
 #else
 	const char *inbuf = name.data();
 #endif

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -657,7 +657,7 @@ enum VarTypes : uint16_t {
 	SLE_VAR_NULL  =  9 << 4, ///< useful to write zeros in savegame.
 	SLE_VAR_STR   = 12 << 4, ///< string pointer
 	SLE_VAR_STRQ  = 13 << 4, ///< string pointer enclosed in quotes
-	SLE_VAR_NAME  = 14 << 4, ///< old custom name to be converted to a char pointer
+	SLE_VAR_NAME  = 14 << 4, ///< old custom name to be converted to a string pointer
 	/* 1 more possible memory-primitives */
 
 	/* Shortcut values */

--- a/src/sortlist_type.h
+++ b/src/sortlist_type.h
@@ -39,7 +39,7 @@ struct Filtering {
  * @tparam P Tyoe of data passed as additional parameter to the sort function.
  * @tparam F Type of data fed as additional value to the filter function. @see FilterFunction
  */
-template <typename T, typename P = std::nullptr_t, typename F = const char*>
+template <typename T, typename P = std::nullptr_t, typename F = std::string_view>
 class GUIList : public std::vector<T> {
 public:
 	using SortFunction = std::conditional_t<std::is_same_v<P, std::nullptr_t>, bool (const T&, const T&), bool (const T&, const T&, const P)>; ///< Signature of sort function.

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -5,7 +5,7 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file string.cpp Handling of C-type strings (char*). */
+/** @file string.cpp Handling of strings (std::string/std::string_view). */
 
 #include "stdafx.h"
 #include "debug.h"

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -25,10 +25,6 @@ void StrMakeValidInPlace(char *str, StringValidationSettings settings = StringVa
 void StrMakeValidInPlace(std::string &str, StringValidationSettings settings = StringValidationSetting::ReplaceWithQuestionMark);
 
 [[nodiscard]] std::string StrMakeValid(std::string_view str, StringValidationSettings settings = StringValidationSetting::ReplaceWithQuestionMark);
-[[nodiscard]] inline std::string StrMakeValid(const char *str, StringValidationSettings settings = StringValidationSetting::ReplaceWithQuestionMark)
-{
-	return StrMakeValid(std::string_view(str), settings);
-}
 [[nodiscard]] inline std::string StrMakeValid(std::string &&str, StringValidationSettings settings = StringValidationSetting::ReplaceWithQuestionMark)
 {
 	StrMakeValidInPlace(str, settings);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -273,7 +273,7 @@ struct LanguagePackDeleter {
 	void operator()(LanguagePack *langpack)
 	{
 		/* LanguagePack is in fact reinterpreted char[], we need to reinterpret it back to free it properly. */
-		delete[] reinterpret_cast<char*>(langpack);
+		delete[] reinterpret_cast<char *>(langpack);
 	}
 };
 

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -47,30 +47,6 @@ TEST_CASE("StrCompareIgnoreCase - std::string")
 	CHECK(StrCompareIgnoreCase(std::string{"aa"}, std::string{"a"}) > 0);
 }
 
-TEST_CASE("StrCompareIgnoreCase - char pointer")
-{
-	/* Same string, with different cases. */
-	CHECK(StrCompareIgnoreCase("", "") == 0);
-	CHECK(StrCompareIgnoreCase("a", "a") == 0);
-	CHECK(StrCompareIgnoreCase("a", "A") == 0);
-	CHECK(StrCompareIgnoreCase("A", "a") == 0);
-	CHECK(StrCompareIgnoreCase("A", "A") == 0);
-
-	/* Not the same string. */
-	CHECK(StrCompareIgnoreCase("", "b") < 0);
-	CHECK(StrCompareIgnoreCase("a", "") > 0);
-
-	CHECK(StrCompareIgnoreCase("a", "b") < 0);
-	CHECK(StrCompareIgnoreCase("b", "a") > 0);
-	CHECK(StrCompareIgnoreCase("a", "B") < 0);
-	CHECK(StrCompareIgnoreCase("b", "A") > 0);
-	CHECK(StrCompareIgnoreCase("A", "b") < 0);
-	CHECK(StrCompareIgnoreCase("B", "a") > 0);
-
-	CHECK(StrCompareIgnoreCase("a", "aa") < 0);
-	CHECK(StrCompareIgnoreCase("aa", "a") > 0);
-}
-
 TEST_CASE("StrCompareIgnoreCase - std::string_view")
 {
 	/*
@@ -78,7 +54,7 @@ TEST_CASE("StrCompareIgnoreCase - std::string_view")
 	 * which does not guarantee the termination that would be required by
 	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
 	 * or strcasecmp would fail if it does not account for the length of the
-	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * view. Thus, contrary to the string tests, this uses the same base
 	 * string but gets different sections to trigger these corner cases.
 	 */
 	std::string_view base{"aaAbB"};
@@ -123,24 +99,6 @@ TEST_CASE("StrEqualsIgnoreCase - std::string")
 	CHECK(!StrEqualsIgnoreCase(std::string{"aa"}, std::string{"a"}));
 }
 
-TEST_CASE("StrEqualsIgnoreCase - char pointer")
-{
-	/* Same string, with different cases. */
-	CHECK(StrEqualsIgnoreCase("", ""));
-	CHECK(StrEqualsIgnoreCase("a", "a"));
-	CHECK(StrEqualsIgnoreCase("a", "A"));
-	CHECK(StrEqualsIgnoreCase("A", "a"));
-	CHECK(StrEqualsIgnoreCase("A", "A"));
-
-	/* Not the same string. */
-	CHECK(!StrEqualsIgnoreCase("", "b"));
-	CHECK(!StrEqualsIgnoreCase("a", ""));
-	CHECK(!StrEqualsIgnoreCase("a", "b"));
-	CHECK(!StrEqualsIgnoreCase("b", "a"));
-	CHECK(!StrEqualsIgnoreCase("a", "aa"));
-	CHECK(!StrEqualsIgnoreCase("aa", "a"));
-}
-
 TEST_CASE("StrEqualsIgnoreCase - std::string_view")
 {
 	/*
@@ -148,7 +106,7 @@ TEST_CASE("StrEqualsIgnoreCase - std::string_view")
 	 * which does not guarantee the termination that would be required by
 	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
 	 * or strcasecmp would fail if it does not account for the length of the
-	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * view. Thus, contrary to the string tests, this uses the same base
 	 * string but gets different sections to trigger these corner cases.
 	 */
 	std::string_view base{"aaAb"};
@@ -196,31 +154,6 @@ TEST_CASE("StrStartsWithIgnoreCase - std::string")
 	CHECK(!StrStartsWithIgnoreCase(std::string{"a"}, std::string{"aa"}));
 }
 
-TEST_CASE("StrStartsWithIgnoreCase - char pointer")
-{
-	/* Everything starts with an empty prefix. */
-	CHECK(StrStartsWithIgnoreCase("", ""));
-	CHECK(StrStartsWithIgnoreCase("a", ""));
-
-	/* Equals string, ignoring case. */
-	CHECK(StrStartsWithIgnoreCase("a", "a"));
-	CHECK(StrStartsWithIgnoreCase("a", "A"));
-	CHECK(StrStartsWithIgnoreCase("A", "a"));
-	CHECK(StrStartsWithIgnoreCase("A", "A"));
-
-	/* Starts with same, ignoring case. */
-	CHECK(StrStartsWithIgnoreCase("ab", "a"));
-	CHECK(StrStartsWithIgnoreCase("ab", "A"));
-	CHECK(StrStartsWithIgnoreCase("Ab", "a"));
-	CHECK(StrStartsWithIgnoreCase("Ab", "A"));
-
-	/* Does not start the same. */
-	CHECK(!StrStartsWithIgnoreCase("", "b"));
-	CHECK(!StrStartsWithIgnoreCase("a", "b"));
-	CHECK(!StrStartsWithIgnoreCase("b", "a"));
-	CHECK(!StrStartsWithIgnoreCase("a", "aa"));
-}
-
 TEST_CASE("StrStartsWithIgnoreCase - std::string_view")
 {
 	/*
@@ -228,7 +161,7 @@ TEST_CASE("StrStartsWithIgnoreCase - std::string_view")
 	 * which does not guarantee the termination that would be required by
 	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
 	 * or strcasecmp would fail if it does not account for the length of the
-	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * view. Thus, contrary to the string tests, this uses the same base
 	 * string but gets different sections to trigger these corner cases.
 	 */
 	std::string_view base{"aabAb"};
@@ -283,31 +216,6 @@ TEST_CASE("StrEndsWithIgnoreCase - std::string")
 	CHECK(!StrEndsWithIgnoreCase(std::string{"a"}, std::string{"aa"}));
 }
 
-TEST_CASE("StrEndsWithIgnoreCase - char pointer")
-{
-	/* Everything ends with an empty prefix. */
-	CHECK(StrEndsWithIgnoreCase("", ""));
-	CHECK(StrEndsWithIgnoreCase("a", ""));
-
-	/* Equals string, ignoring case. */
-	CHECK(StrEndsWithIgnoreCase("a", "a"));
-	CHECK(StrEndsWithIgnoreCase("a", "A"));
-	CHECK(StrEndsWithIgnoreCase("A", "a"));
-	CHECK(StrEndsWithIgnoreCase("A", "A"));
-
-	/* Ends with same, ignoring case. */
-	CHECK(StrEndsWithIgnoreCase("ba", "a"));
-	CHECK(StrEndsWithIgnoreCase("ba", "A"));
-	CHECK(StrEndsWithIgnoreCase("bA", "a"));
-	CHECK(StrEndsWithIgnoreCase("bA", "A"));
-
-	/* Does not end the same. */
-	CHECK(!StrEndsWithIgnoreCase("", "b"));
-	CHECK(!StrEndsWithIgnoreCase("a", "b"));
-	CHECK(!StrEndsWithIgnoreCase("b", "a"));
-	CHECK(!StrEndsWithIgnoreCase("a", "aa"));
-}
-
 TEST_CASE("StrEndsWithIgnoreCase - std::string_view")
 {
 	/*
@@ -315,7 +223,7 @@ TEST_CASE("StrEndsWithIgnoreCase - std::string_view")
 	 * which does not guarantee the termination that would be required by
 	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
 	 * or strcasecmp would fail if it does not account for the length of the
-	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * view. Thus, contrary to the string tests, this uses the same base
 	 * string but gets different sections to trigger these corner cases.
 	 */
 	std::string_view base{"aabAba"};


### PR DESCRIPTION
## Motivation / Problem

* tests with `char *` for `std::string-view` functions, for which a `std:string_view` test-variant exists.
* `char*` instead of `char *`.
* comments mentioning `char *` when something else is meant.
* `StrMakeValid` `char*` variant is not used any more.


## Description

Remove tests/unused method, amend coding style and comments.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
