### PR TITLE
Codefix: StartNewThread uses char* after returning

### DIFF
--- a/src/os/macosx/macos.h
+++ b/src/os/macosx/macos.h
@@ -36,7 +36,7 @@ inline bool MacOSVersionIsAtLeast(long major, long minor, long bugfix)
 
 bool IsMonospaceFont(CFStringRef name);
 
-void MacOSSetThreadName(const char *name);
+void MacOSSetThreadName(const std::string &name);
 
 uint64_t MacOSGetPhysicalMemory();
 

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -242,15 +242,15 @@ bool IsMonospaceFont(CFStringRef name)
  * Set the name of the current thread for the debugger.
  * @param name The new name of the current thread.
  */
-void MacOSSetThreadName(const char *name)
+void MacOSSetThreadName(const std::string &name)
 {
 	if (MacOSVersionIsAtLeast(10, 6, 0)) {
-		pthread_setname_np(name);
+		pthread_setname_np(name.c_str());
 	}
 
 	NSThread *cur = [ NSThread currentThread ];
 	if (cur != nil && [ cur respondsToSelector:@selector(setName:) ]) {
-		[ cur performSelector:@selector(setName:) withObject:[ NSString stringWithUTF8String:name ] ];
+		[ cur performSelector:@selector(setName:) withObject:[ NSString stringWithUTF8String:name.c_str() ] ];
 	}
 }
 

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -243,12 +243,12 @@ void OSOpenBrowser(const std::string &url)
 }
 #endif /* __APPLE__ */
 
-void SetCurrentThreadName([[maybe_unused]] const char *threadName)
+void SetCurrentThreadName([[maybe_unused]] const std::string &thread_name)
 {
 #if defined(__GLIBC__)
-	if (threadName) pthread_setname_np(pthread_self(), threadName);
+	pthread_setname_np(pthread_self(), thread_name.c_str());
 #endif /* defined(__GLIBC__) */
 #if defined(__APPLE__)
-	MacOSSetThreadName(threadName);
+	MacOSSetThreadName(thread_name);
 #endif /* defined(__APPLE__) */
 }

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -520,11 +520,11 @@ PACK_N(struct THREADNAME_INFO {
 /**
  * Signal thread name to any attached debuggers.
  */
-void SetCurrentThreadName(const char *threadName)
+void SetCurrentThreadName(const std::string &thread_name)
 {
 	THREADNAME_INFO info;
 	info.dwType = 0x1000;
-	info.szName = threadName;
+	info.szName = thread_name.c_str();
 	info.dwThreadID = -1;
 	info.dwFlags = 0;
 
@@ -537,5 +537,5 @@ void SetCurrentThreadName(const char *threadName)
 #pragma warning(pop)
 }
 #else
-void SetCurrentThreadName(const char *) {}
+void SetCurrentThreadName(const std::string &) {}
 #endif

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -15,7 +15,6 @@ bool MyShowCursor(bool show, bool toggle = false);
 char *convert_from_fs(const std::wstring_view src, std::span<char> dst_buf);
 wchar_t *convert_to_fs(std::string_view src, std::span<wchar_t> dst_buf);
 
-void Win32SetCurrentLocaleName(const char *iso_code);
 int OTTDStringCompare(std::string_view s1, std::string_view s2);
 int Win32StringContains(std::string_view str, std::string_view value, bool case_insensitive);
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -30,7 +30,7 @@ inline void CSleep(int milliseconds)
  * Name the thread this function is called on for the debugger.
  * @param name Name to set for the thread..
  */
-void SetCurrentThreadName(const char *name);
+void SetCurrentThreadName(const std::string &name);
 
 
 /**
@@ -44,13 +44,13 @@ void SetCurrentThreadName(const char *name);
  * @return True if the thread was successfully started, false otherwise.
  */
 template <class TFn, class... TArgs>
-inline bool StartNewThread(std::thread *thr, const char *name, TFn&& _Fx, TArgs&&... _Ax)
+inline bool StartNewThread(std::thread *thr, std::string_view name, TFn&& _Fx, TArgs&&... _Ax)
 {
 	try {
 		static std::mutex thread_startup_mutex;
 		std::lock_guard<std::mutex> lock(thread_startup_mutex);
 
-		std::thread t([] (const char *name, TFn&& F, TArgs&&... A) {
+		std::thread t([] (std::string name, TFn&& F, TArgs&&... A) {
 				/* Delay starting the thread till the main thread is finished
 				 * with the administration. This prevent race-conditions on
 				 * startup. */
@@ -68,7 +68,7 @@ inline bool StartNewThread(std::thread *thr, const char *name, TFn&& _Fx, TArgs&
 				} catch (...) {
 					NOT_REACHED();
 				}
-			}, name, std::forward<TFn>(_Fx), std::forward<TArgs>(_Ax)...);
+			}, std::string{name}, std::forward<TFn>(_Fx), std::forward<TArgs>(_Ax)...);
 
 		if (thr != nullptr) {
 			*thr = std::move(t);


### PR DESCRIPTION
## Motivation / Problem

If I were to do:
```
std::string thread_name = fmt::format("thread: {}", n);
StartNewThread(&thread, thread_name.c_str(), &function);
```

The `StartNewThread` function would be accessing the thread name after the thread has been started. But it might already have gone out of scope.

Also, the many C-style strings in this bit of code.


## Description

Pass the thread name as `std::string` into the thread.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
