### PR TITLE
Codechange: Use LRUCache for layouted line cache.

### DIFF
--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -10,11 +10,11 @@
 #ifndef GFX_LAYOUT_H
 #define GFX_LAYOUT_H
 
+#include "misc/lrucache.hpp"
 #include "fontcache.h"
 #include "gfx_func.h"
 #include "core/math_func.hpp"
 
-#include <stack>
 #include <string_view>
 
 /**
@@ -24,11 +24,12 @@
 struct FontState {
 	FontSize fontsize;       ///< Current font size.
 	TextColour cur_colour;   ///< Current text colour.
-
-	std::stack<TextColour, std::vector<TextColour>> colour_stack; ///< Stack of colours to assist with colour switching.
+	std::vector<TextColour> colour_stack; ///< Stack of colours to assist with colour switching.
 
 	FontState() : fontsize(FS_END), cur_colour(TC_INVALID) {}
 	FontState(TextColour colour, FontSize fontsize) : fontsize(fontsize), cur_colour(colour) {}
+
+	auto operator<=>(const FontState &) const = default;
 
 	/**
 	 * Switch to new colour \a c.
@@ -47,8 +48,8 @@ struct FontState {
 	inline void PopColour()
 	{
 		if (colour_stack.empty()) return;
-		SetColour(colour_stack.top());
-		colour_stack.pop();
+		SetColour(colour_stack.back());
+		colour_stack.pop_back();
 	}
 
 	/**
@@ -56,7 +57,7 @@ struct FontState {
 	 */
 	inline void PushColour()
 	{
-		colour_stack.push(this->cur_colour);
+		colour_stack.push_back(this->cur_colour);
 	}
 
 	/**
@@ -66,6 +67,27 @@ struct FontState {
 	inline void SetFontSize(FontSize f)
 	{
 		this->fontsize = f;
+	}
+};
+
+template <typename T> struct std::hash<std::vector<T>> {
+	size_t operator()(const std::vector<T> &vec) const
+	{
+		/* This is not an optimal hash algorithm but in most cases this is empty and therefore the same anyway. */
+		return std::transform_reduce(std::begin(vec), std::end(vec),
+			std::hash<size_t>{}(std::size(vec)),
+			[](const size_t &a, const size_t &b) -> size_t { return a ^ b; },
+			[](const T &x) -> size_t { return std::hash<T>{}(x); });
+	}
+};
+
+template <> struct std::hash<FontState> {
+	std::size_t operator()(const FontState &state) const noexcept
+	{
+		size_t h1 = std::hash<FontSize>{}(state.fontsize);
+		size_t h2 = std::hash<TextColour>{}(state.cur_colour);
+		size_t h3 = std::hash<std::vector<TextColour>>{}(state.colour_stack);
+		return h1 ^ (h2 << 1) ^ (h3 << 2);
 	}
 };
 
@@ -149,20 +171,19 @@ class Layouter : public std::vector<const ParagraphLayouter::Line *> {
 		std::string_view str;    ///< Source string of the line (including colour and font size codes).
 	};
 
-	/** Comparator for std::map */
-	struct LineCacheCompare {
-		using is_transparent = void; ///< Enable map queries with various key types
+	friend struct std::hash<Layouter::LineCacheQuery>;
+	struct LineCacheHash;
 
-		/** Comparison operator for LineCacheKey and LineCacheQuery */
-		template <typename Key1, typename Key2>
-		bool operator()(const Key1 &lhs, const Key2 &rhs) const
+	struct LineCacheEqualTo {
+		using is_transparent = void;
+
+		template <typename Tlhs, typename Trhs>
+		bool operator()(const Tlhs &lhs, const Trhs &rhs) const
 		{
-			if (lhs.state_before.fontsize != rhs.state_before.fontsize) return lhs.state_before.fontsize < rhs.state_before.fontsize;
-			if (lhs.state_before.cur_colour != rhs.state_before.cur_colour) return lhs.state_before.cur_colour < rhs.state_before.cur_colour;
-			if (lhs.state_before.colour_stack != rhs.state_before.colour_stack) return lhs.state_before.colour_stack < rhs.state_before.colour_stack;
-			return lhs.str < rhs.str;
+			return lhs.state_before == rhs.state_before && lhs.str == rhs.str;
 		}
 	};
+
 public:
 	/** Item in the linecache */
 	struct LineCacheItem {
@@ -179,8 +200,8 @@ public:
 		int cached_width = 0; ///< Width used for the cached layout.
 	};
 private:
-	typedef std::map<LineCacheKey, LineCacheItem, LineCacheCompare> LineCache;
-	static LineCache *linecache;
+	using LineCache = LRUCache<LineCacheKey, LineCacheItem, LineCacheHash, LineCacheEqualTo>;
+	static std::unique_ptr<LineCache> linecache;
 
 	static LineCacheItem &GetCachedParagraphLayout(std::string_view str, const FontState &state);
 
@@ -197,10 +218,25 @@ public:
 	static void Initialize();
 	static void ResetFontCache(FontSize size);
 	static void ResetLineCache();
-	static void ReduceLineCache();
 };
 
 ParagraphLayouter::Position GetCharPosInString(std::string_view str, size_t pos, FontSize start_fontsize = FS_NORMAL);
 ptrdiff_t GetCharAtPosition(std::string_view str, int x, FontSize start_fontsize = FS_NORMAL);
+
+template <> struct std::hash<Layouter::LineCacheQuery> {
+	std::size_t operator()(const Layouter::LineCacheQuery &state) const noexcept
+	{
+		size_t h1 = std::hash<std::string_view>{}(state.str);
+		size_t h2 = std::hash<FontState>{}(state.state_before);
+		return h1 ^ (h2 << 1);
+	}
+};
+
+struct Layouter::LineCacheHash {
+	using is_transparent = void;
+
+	std::size_t operator()(const Layouter::LineCacheKey &query) const { return std::hash<Layouter::LineCacheQuery>{}(LineCacheQuery{query.state_before, query.str}); }
+	std::size_t operator()(const Layouter::LineCacheQuery &query) const { return std::hash<Layouter::LineCacheQuery>{}(query); }
+};
 
 #endif /* GFX_LAYOUT_H */

--- a/src/misc/lrucache.hpp
+++ b/src/misc/lrucache.hpp
@@ -16,12 +16,12 @@
 /**
  * Size limited cache with a least recently used eviction strategy.
  * @tparam Tkey Type of the cache key.
- * @tparam Tdata Type of the cache item. The cache will store a pointer of this type.
+ * @tparam Tdata Type of the cache item.
  */
 template <class Tkey, class Tdata>
 class LRUCache {
 private:
-	typedef std::pair<Tkey, std::unique_ptr<Tdata>> Tpair;
+	typedef std::pair<Tkey, Tdata> Tpair;
 	typedef typename std::list<Tpair>::iterator Titer;
 
 	std::list<Tpair> data; ///< Ordered list of all items.
@@ -51,7 +51,7 @@ public:
 	 * @param key Key under which the item should be stored.
 	 * @param item Item to insert.
 	 */
-	void Insert(const Tkey key, std::unique_ptr<Tdata> &&item)
+	void Insert(const Tkey key, Tdata &&item)
 	{
 		if (this->Contains(key)) {
 			/* Replace old value. */
@@ -85,13 +85,14 @@ public:
 	 * @return The item value.
 	 * @note Throws if item not found.
 	 */
-	inline Tdata *Get(const Tkey key)
+	inline const Tdata &Get(const Tkey key)
 	{
-		if (this->lookup.find(key) == this->lookup.end()) throw std::out_of_range("item not found");
+		auto it = this->lookup.find(key);
+		if (it == this->lookup.end()) throw std::out_of_range("item not found");
 		/* Move to front if needed. */
-		this->data.splice(this->data.begin(), this->data, this->lookup[key]);
+		this->data.splice(this->data.begin(), this->data, it->second);
 
-		return this->data.front().second.get();
+		return this->data.front().second;
 	}
 };
 

--- a/src/misc/lrucache.hpp
+++ b/src/misc/lrucache.hpp
@@ -15,17 +15,20 @@
 
 /**
  * Size limited cache with a least recently used eviction strategy.
+ * @note If a comparator is provided, the lookup type is a std::map, otherwise std::unordered_map is used.
  * @tparam Tkey Type of the cache key.
  * @tparam Tdata Type of the cache item.
  */
-template <class Tkey, class Tdata>
+template <class Tkey, class Tdata, class Thash = std::hash<Tkey>, class Tequality = std::equal_to<>>
 class LRUCache {
 private:
-	typedef std::pair<Tkey, Tdata> Tpair;
-	typedef typename std::list<Tpair>::iterator Titer;
+	using PairType = std::pair<Tkey, Tdata>;
+	using StorageType = std::list<PairType>;
+	using IteratorType = StorageType::iterator;
+	using LookupType = std::unordered_map<Tkey, IteratorType, Thash, Tequality>;
 
-	std::list<Tpair> data; ///< Ordered list of all items.
-	std::unordered_map<Tkey, Titer> lookup;  ///< Map of keys to items.
+	StorageType data; ///< Ordered list of all items.
+	LookupType lookup; ///< Map of keys to items.
 
 	const size_t capacity; ///< Number of items to cache.
 
@@ -41,7 +44,7 @@ public:
 	 * @param key The key to search.
 	 * @return True, if the key was found.
 	 */
-	inline bool Contains(const Tkey key)
+	inline bool Contains(const Tkey &key)
 	{
 		return this->lookup.find(key) != this->lookup.end();
 	}
@@ -51,11 +54,12 @@ public:
 	 * @param key Key under which the item should be stored.
 	 * @param item Item to insert.
 	 */
-	void Insert(const Tkey key, Tdata &&item)
+	void Insert(const Tkey &key, Tdata &&item)
 	{
-		if (this->Contains(key)) {
+		auto it = this->lookup.find(key);
+		if (it != this->lookup.end()) {
 			/* Replace old value. */
-			this->lookup[key]->second = std::move(item);
+			it->second->second = std::move(item);
 			return;
 		}
 
@@ -85,7 +89,7 @@ public:
 	 * @return The item value.
 	 * @note Throws if item not found.
 	 */
-	inline const Tdata &Get(const Tkey key)
+	inline const Tdata &Get(const Tkey &key)
 	{
 		auto it = this->lookup.find(key);
 		if (it == this->lookup.end()) throw std::out_of_range("item not found");
@@ -93,6 +97,23 @@ public:
 		this->data.splice(this->data.begin(), this->data, it->second);
 
 		return this->data.front().second;
+	}
+
+	/**
+	 * Get an item from the cache.
+	 * @param key The key to look up.
+	 * @return The item value.
+	 * @note Throws if item not found.
+	 */
+	inline Tdata *GetIfValid(const auto &key)
+	{
+		auto it = this->lookup.find(key);
+		if (it == this->lookup.end()) return nullptr;
+
+		/* Move to front if needed. */
+		this->data.splice(this->data.begin(), this->data, it->second);
+
+		return &this->data.front().second;
 	}
 };
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1234,8 +1234,6 @@ void StateGameLoop()
 	PerformanceMeasurer framerate(PFE_GAMELOOP);
 	PerformanceAccumulator::Reset(PFE_GL_LANDSCAPE);
 
-	Layouter::ReduceLineCache();
-
 	if (_game_mode == GM_EDITOR) {
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 		RunTileLoop();

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -137,10 +137,6 @@ bool GenerateTownName(Randomizer &randomizer, uint32_t *townnameparts, TownNames
 {
 	TownNameParams par(_settings_game.game_creation.town_name);
 
-	/* This function is called very often without entering the gameloop
-	 * in between. So reset layout cache to prevent it from growing too big. */
-	Layouter::ReduceLineCache();
-
 	/* Do not set i too low, since when we run out of names, we loop
 	 * for #tries only one time anyway - then we stop generating more
 	 * towns. Do not set it too high either, since looping through all

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1077,7 +1077,7 @@ void OpenGLBackend::DrawMouseCursor()
 	for (const auto &cs : this->cursor_sprites) {
 		/* Sprites are cached by PopulateCursorCache(). */
 		if (this->cursor_cache.Contains(cs.image.sprite)) {
-			OpenGLSprite *spr = this->cursor_cache.Get(cs.image.sprite);
+			const OpenGLSprite *spr = this->cursor_cache.Get(cs.image.sprite).get();
 
 			this->RenderOglSprite(spr, cs.image.pal,
 					this->cursor_pos.x + cs.pos.x + UnScaleByZoom(spr->x_offs, ZOOM_LVL_GUI),
@@ -1089,10 +1089,10 @@ void OpenGLBackend::DrawMouseCursor()
 
 class OpenGLSpriteAllocator : public SpriteAllocator {
 public:
-	LRUCache<SpriteID, OpenGLSprite> &lru;
+	OpenGLSpriteLRUCache &lru;
 	SpriteID sprite;
 
-	OpenGLSpriteAllocator(LRUCache<SpriteID, OpenGLSprite> &lru, SpriteID sprite) : lru(lru), sprite(sprite) {}
+	OpenGLSpriteAllocator(OpenGLSpriteLRUCache &lru, SpriteID sprite) : lru(lru), sprite(sprite) {}
 protected:
 	void *AllocatePtr(size_t) override { NOT_REACHED(); }
 };
@@ -1274,7 +1274,7 @@ void OpenGLBackend::ReleaseAnimBuffer(const Rect &update_rect)
  * @param y Y position of the sprite.
  * @param zoom Zoom level to use.
  */
-void OpenGLBackend::RenderOglSprite(OpenGLSprite *gl_sprite, PaletteID pal, int x, int y, ZoomLevel zoom)
+void OpenGLBackend::RenderOglSprite(const OpenGLSprite *gl_sprite, PaletteID pal, int x, int y, ZoomLevel zoom)
 {
 	/* Set textures. */
 	bool rgb = gl_sprite->BindTextures();
@@ -1518,7 +1518,7 @@ inline Dimension OpenGLSprite::GetSize(ZoomLevel level) const
  * Bind textures for rendering this sprite.
  * @return True if the sprite has RGBA data.
  */
-bool OpenGLSprite::BindTextures()
+bool OpenGLSprite::BindTextures() const
 {
 	_glActiveTexture(GL_TEXTURE0);
 	_glBindTexture(GL_TEXTURE_2D, this->tex[TEX_RGBA] != 0 ? this->tex[TEX_RGBA] : OpenGLSprite::dummy_tex[TEX_RGBA]);

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -23,6 +23,8 @@ bool HasStringInExtensionList(std::string_view string, std::string_view substrin
 
 class OpenGLSprite;
 
+using OpenGLSpriteLRUCache = LRUCache<SpriteID, std::unique_ptr<OpenGLSprite>>;
+
 /** Platform-independent back-end class for OpenGL video drivers. */
 class OpenGLBackend : public SpriteEncoder {
 private:
@@ -58,7 +60,7 @@ private:
 	GLint  sprite_rgb_loc = 0; ///< Uniform location for RGB mode flag.
 	GLint  sprite_crash_loc = 0; ///< Uniform location for crash remap mode flag.
 
-	LRUCache<SpriteID, OpenGLSprite> cursor_cache; ///< Cache of encoded cursor sprites.
+	OpenGLSpriteLRUCache cursor_cache; ///< Cache of encoded cursor sprites.
 	PaletteID last_sprite_pal = (PaletteID)-1; ///< Last uploaded remap palette.
 	bool clear_cursor_cache = false; ///< A clear of the cursor cache is pending.
 
@@ -74,7 +76,7 @@ private:
 
 	void InternalClearCursorCache();
 
-	void RenderOglSprite(OpenGLSprite *gl_sprite, PaletteID pal, int x, int y, ZoomLevel zoom);
+	void RenderOglSprite(const OpenGLSprite *gl_sprite, PaletteID pal, int x, int y, ZoomLevel zoom);
 
 public:
 	/** Get singleton instance of this class. */
@@ -134,7 +136,7 @@ private:
 	static bool Create();
 	static void Destroy();
 
-	bool BindTextures();
+	bool BindTextures() const;
 
 public:
 	OpenGLSprite(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

To keep the layouted line cache size reasonable, when the size reaches 4096 the entire cache is thrown away, and restarted.

The size of the cache is maintained one per game tick, which means if the game is paused it is not managed.
It is also managed during town name generation, to prevent map generation for increasing the cache size with no limits.

There is a `TODO` that says an LRU cache would be nice but isn't necessary.

We already have an `LRUCache` implementation, used only for `OpenGLSprite`s.

Because clearing the line cache wipes everything, this can cause in-game stutters as all visible text then needs to be layouted again. (Note, I used my favourite 'difficult' font which makes the stuttering more apparent.)

![image](https://github.com/user-attachments/assets/9d914274-7e34-4b4d-9cf5-ae132208b4f9)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Adjust `LRUCache` to move `OpenGLSprite`'s `unique_ptr` requirement to the OpenGL side.
Adjust `LRUCache` to support either `std::unordered_map` and `std::map` with a custom compatator.

Use `LRUCache` for the text layout line cache.

This avoids the need for manually managing the size and because the size is automatically limited the stutters no longer occur.

![image](https://github.com/user-attachments/assets/20610048-4bed-496d-910f-c57f4259d328)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
