### PR TITLE
Codechange: misc char* related changes

### DIFF
--- a/src/core/string_builder.cpp
+++ b/src/core/string_builder.cpp
@@ -113,13 +113,13 @@ void BaseStringBuilder::PutChar(char c)
 void BaseStringBuilder::PutUtf8(char32_t c)
 {
 	auto [buf, len] = EncodeUtf8(c);
-	this->PutBuffer(buf, len);
+	this->PutBuffer({buf, len});
 }
 
 /**
  * Append buffer.
  */
-void StringBuilder::PutBuffer(const char *str, size_type len)
+void StringBuilder::PutBuffer(std::span<const char> str)
 {
-	this->dest->append(str, len);
+	this->dest->append(str.data(), str.size());
 }

--- a/src/core/string_builder.hpp
+++ b/src/core/string_builder.hpp
@@ -26,17 +26,12 @@ public:
 	/**
 	 * Append buffer.
 	 */
-	virtual void PutBuffer(const char *str, size_type len) = 0;
-
-	/**
-	 * Append span.
-	 */
-	void PutBuffer(std::span<const char> str) { this->PutBuffer(str.data(), str.size()); }
+	virtual void PutBuffer(std::span<const char> str) = 0;
 
 	/**
 	 * Append string.
 	 */
-	void Put(std::string_view str) { this->PutBuffer(str.data(), str.size()); }
+	void Put(std::string_view str) { this->PutBuffer(str); }
 
 	void PutUint8(uint8_t value);
 	void PutSint8(int8_t value);
@@ -60,7 +55,7 @@ public:
 		auto result = std::to_chars(buf.data(), buf.data() + buf.size(), value, base);
 		if (result.ec != std::errc{}) return;
 		size_type len = result.ptr - buf.data();
-		this->PutBuffer(buf.data(), len);
+		this->PutBuffer({buf.data(), len});
 	}
 };
 
@@ -93,8 +88,7 @@ public:
 	 */
 	[[nodiscard]] std::string &GetString() noexcept { return *dest; }
 
-	using BaseStringBuilder::PutBuffer;
-	void PutBuffer(const char *str, size_type len) override;
+	void PutBuffer(std::span<const char> str) override;
 
 	/**
 	 * Append string.

--- a/src/core/string_consumer.hpp
+++ b/src/core/string_consumer.hpp
@@ -63,10 +63,6 @@ public:
 	 * Construct parser with data from span.
 	 */
 	explicit StringConsumer(std::span<const char> src) : src(src.data(), src.size()) {}
-	/**
-	 * Construct parser with data from buffer.
-	 */
-	StringConsumer(const char *src, size_type len) : src(src, len) {}
 
 	/**
 	 * Check whether any bytes left to read.

--- a/src/core/string_inplace.cpp
+++ b/src/core/string_inplace.cpp
@@ -32,12 +32,12 @@
 /**
  * Append buffer.
  */
-void InPlaceBuilder::PutBuffer(const char *str, size_type len)
+void InPlaceBuilder::PutBuffer(std::span<const char> str)
 {
 	auto unused = this->GetBytesUnused();
-	if (len > unused) NOT_REACHED();
-	std::copy(str, str + len, this->dest.data() + this->position);
-	this->position += len;
+	if (str.size() > unused) NOT_REACHED();
+	std::ranges::copy(str, this->dest.data() + this->position);
+	this->position += str.size();
 }
 
 /**

--- a/src/core/string_inplace.hpp
+++ b/src/core/string_inplace.hpp
@@ -47,8 +47,7 @@ public:
 	[[nodiscard]] bool AnyBytesUnused() const noexcept;
 	[[nodiscard]] size_type GetBytesUnused() const noexcept;
 
-	using BaseStringBuilder::PutBuffer;
-	void PutBuffer(const char *str, size_type len) override;
+	void PutBuffer(std::span<const char> str) override;
 
 	/**
 	 * Implementation of std::back_insert_iterator for non-growing destination buffer.

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -657,6 +657,9 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
  * @note defined in the OS related files (win32.cpp, unix.cpp etc)
  */
 extern void DetermineBasePaths(std::string_view exe);
+
+/** Mimicks the getcwd from POSIX for Windows. */
+char *getcwd(char *buf, size_t size);
 #else /* defined(_WIN32) */
 
 /**

--- a/src/newgrf/newgrf_bytereader.h
+++ b/src/newgrf/newgrf_bytereader.h
@@ -18,7 +18,7 @@ class OTTDByteReaderSignal { };
 class ByteReader {
 	StringConsumer consumer;
 public:
-	ByteReader(const uint8_t *data, size_t len) : consumer(reinterpret_cast<const char *>(data), len) { }
+	ByteReader(const uint8_t *data, size_t len) : consumer(std::string_view{reinterpret_cast<const char *>(data), len}) { }
 
 	const uint8_t *ReadBytes(size_t size)
 	{

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -369,13 +369,13 @@ std::wstring OTTD2FS(std::string_view name)
  * @param dst_buf span of valid char buffer that will receive the converted string
  * @return pointer to dst_buf. If conversion fails the string is of zero-length
  */
-char *convert_from_fs(const std::wstring_view src, std::span<char> dst_buf)
+std::string_view convert_from_fs(const std::wstring_view src, std::span<char> dst_buf)
 {
 	/* Convert UTF-16 string to UTF-8. */
 	int len = WideCharToMultiByte(CP_UTF8, 0, src.data(), static_cast<int>(src.size()), dst_buf.data(), static_cast<int>(dst_buf.size() - 1U), nullptr, nullptr);
 	dst_buf[len] = '\0';
 
-	return dst_buf.data();
+	return std::string_view(dst_buf.data(), len);
 }
 
 

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -12,7 +12,7 @@
 
 bool MyShowCursor(bool show, bool toggle = false);
 
-char *convert_from_fs(const std::wstring_view src, std::span<char> dst_buf);
+std::string_view convert_from_fs(const std::wstring_view src, std::span<char> dst_buf);
 wchar_t *convert_to_fs(std::string_view src, std::span<wchar_t> dst_buf);
 
 void Win32SetCurrentLocaleName(const char *iso_code);

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -157,8 +157,6 @@ using namespace std::literals::string_view_literals;
 
 #if !defined(STRGEN) && !defined(SETTINGSGEN)
 #	if defined(_WIN32)
-		char *getcwd(char *buf, size_t size);
-
 		std::string FS2OTTD(std::wstring_view name);
 		std::wstring OTTD2FS(std::string_view name);
 #	elif defined(WITH_ICONV)

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -364,7 +364,7 @@ static LRESULT HandleIMEComposition(HWND hwnd, WPARAM wParam, LPARAM lParam)
 
 			if (len > 0) {
 				static char utf8_buf[1024];
-				convert_from_fs(str.c_str(), utf8_buf);
+				convert_from_fs(str, utf8_buf);
 
 				/* Convert caret position from bytes in the input string to a position in the UTF-8 encoded string. */
 				LONG caret_bytes = ImmGetCompositionString(hIMC, GCS_CURSORPOS, nullptr, 0);


### PR DESCRIPTION
## Motivation / Problem

C-style strings.


## Description

1. Remove the `char*` variant of `StringConsumer`, pass a `std::string_view` when needed.
2. `convert_from_fs` returns `char *` when all users of it accept `std::string_view`. Furthermore, since the parameter is a `std::string_view` don't call `.c_str()` when calling it.
3. `char *getcwd(char *, size_t)` is used only in fileio.cpp, yet defined in stdafx.h. Move it to fileio.cpp.
4. The `StringBuilder`s have a `PutBuffer(char *, size_t)` variant. Use `std::span` instead.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
