### PR TITLE
Codechange: Clean up static variables.

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -575,7 +575,7 @@ public:
 		CheckRedrawStationCoverage(this);
 	}
 
-	IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
 		this->InvalidateData();
 	}};
 };

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -635,7 +635,7 @@ struct CheatWindow : Window {
 		this->SetDirty();
 	}
 
-	IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::MONTH, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::MONTH, TimerGameCalendar::Priority::NONE}, [this](auto) {
 		this->SetDirty();
 	}};
 };

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -812,7 +812,7 @@ void OnTick_Companies()
  * A year has passed, update the economic data of all companies, and perhaps show the
  * financial overview window of the local company.
  */
-static IntervalTimer<TimerGameEconomy> _economy_companies_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::COMPANY}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_companies_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::COMPANY}, [](auto)
 {
 	/* Copy statistics */
 	for (Company *c : Company::Iterate()) {

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -540,7 +540,7 @@ struct CompanyFinancesWindow : Window {
 	 * Check on a regular interval if the maximum amount of money has changed.
 	 * If it has, rescale the window to fit the new amount.
 	 */
-	IntervalTimer<TimerWindow> rescale_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> rescale_interval = {std::chrono::seconds(3), [this](auto) {
 		const Company *c = Company::Get(this->window_number);
 		if (c->money > CompanyFinancesWindow::max_money) {
 			CompanyFinancesWindow::max_money = std::max(c->money * 2, CompanyFinancesWindow::max_money * 4);
@@ -1991,7 +1991,7 @@ struct CompanyInfrastructureWindow : Window
 		}
 	}
 
-	IntervalTimer<TimerWindow> redraw_interval = {std::chrono::seconds(1), [this](auto) {
+	const IntervalTimer<TimerWindow> redraw_interval = {std::chrono::seconds(1), [this](auto) {
 		this->UpdateInfrastructureList();
 		this->SetWidgetDirty(WID_CI_LIST);
 	}};
@@ -2433,7 +2433,7 @@ struct CompanyWindow : Window
 	}
 
 	/** Redraw the window on a regular interval. */
-	IntervalTimer<TimerWindow> redraw_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> redraw_interval = {std::chrono::seconds(3), [this](auto) {
 		this->SetDirty();
 	}};
 
@@ -2579,7 +2579,7 @@ struct BuyCompanyWindow : Window {
 	/**
 	 * Check on a regular interval if the company value has changed.
 	 */
-	IntervalTimer<TimerWindow> rescale_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> rescale_interval = {std::chrono::seconds(3), [this](auto) {
 		/* Value can't change when in bankruptcy. */
 		if (!this->hostile_takeover) return;
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -57,7 +57,7 @@ static uint _script_current_depth; ///< Depth of scripts running (used to abort 
 static std::string _scheduled_monthly_script; ///< Script scheduled to execute by the 'schedule' console command (empty if no script is scheduled).
 
 /** Timer that runs every month of game time for the 'schedule' console command. */
-static IntervalTimer<TimerGameCalendar> _scheduled_monthly_timer = {{TimerGameCalendar::MONTH, TimerGameCalendar::Priority::NONE}, [](auto) {
+static const IntervalTimer<TimerGameCalendar> _scheduled_monthly_timer = {{TimerGameCalendar::MONTH, TimerGameCalendar::Priority::NONE}, [](auto) {
 	if (_scheduled_monthly_script.empty()) {
 		return;
 	}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2225,11 +2225,11 @@ static void OutputContentState(const ContentInfo &ci)
 
 static bool ConContent(std::span<std::string_view> argv)
 {
-	static ContentCallback *cb = nullptr;
-	if (cb == nullptr) {
-		cb = new ConsoleContentCallback();
-		_network_content_client.AddCallback(cb);
-	}
+	[[maybe_unused]] static ContentCallback *const cb = []() {
+			auto res = new ConsoleContentCallback();
+			_network_content_client.AddCallback(res);
+			return res;
+		}();
 
 	if (argv.size() <= 1) {
 		IConsolePrint(CC_HELP, "Query, select and download content. Usage: 'content update|upgrade|select [id]|unselect [all|id]|state [filter]|download'.");

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2036,7 +2036,7 @@ static bool ConSayClient(std::span<std::string_view> argv)
 }
 
 /** All the known authorized keys with their name. */
-static std::vector<std::pair<std::string_view, NetworkAuthorizedKeys *>> _console_cmd_authorized_keys{
+static const std::initializer_list<std::pair<std::string_view, NetworkAuthorizedKeys *>> _console_cmd_authorized_keys{
 	{ "admin", &_settings_client.network.admin_authorized_keys },
 	{ "rcon", &_settings_client.network.rcon_authorized_keys },
 	{ "server", &_settings_client.network.server_authorized_keys },

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -220,7 +220,7 @@ struct IConsoleWindow : Window
 	}
 
 	/** Check on a regular interval if the console buffer needs truncating. */
-	IntervalTimer<TimerWindow> truncate_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> truncate_interval = {std::chrono::seconds(3), [this](auto) {
 		assert(this->height >= 0 && this->line_height > 0);
 		size_t visible_lines = static_cast<size_t>(this->height / this->line_height);
 

--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -143,7 +143,7 @@ uint64_t GetMaskOfAllowedCurrencies()
 /**
  * Verify if the currency chosen by the user is about to be converted to Euro
  */
-static IntervalTimer<TimerGameCalendar> _check_switch_to_euro({TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _check_switch_to_euro({TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [](auto)
 {
 	if (_currency_specs[_settings_game.locale.currency].to_euro != CF_NOEURO &&
 			_currency_specs[_settings_game.locale.currency].to_euro != CF_ISEURO &&

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -940,7 +940,7 @@ static void ResetDisasterDelay()
 	_disaster_delay = GB(Random(), 0, 9) + 730;
 }
 
-static IntervalTimer<TimerGameEconomy> _economy_disaster_daily({TimerGameEconomy::DAY, TimerGameEconomy::Priority::DISASTER}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_disaster_daily({TimerGameEconomy::DAY, TimerGameEconomy::Priority::DISASTER}, [](auto)
 {
 	if (--_disaster_delay != 0) return;
 

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -481,7 +481,7 @@ public:
 		CheckRedrawStationCoverage(this);
 	}
 
-	IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
 		this->InvalidateData();
 	}};
 };

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -293,7 +293,7 @@ struct DropdownWindow : Window {
 	}
 
 	/** Rate limit how fast scrolling happens. */
-	IntervalTimer<TimerWindow> scroll_interval = {std::chrono::milliseconds(30), [this](auto) {
+	const IntervalTimer<TimerWindow> scroll_interval = {std::chrono::milliseconds(30), [this](auto) {
 		if (this->scrolling == 0) return;
 
 		if (this->vscroll->UpdatePosition(this->scrolling)) this->SetDirty();

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1969,7 +1969,7 @@ void LoadUnloadStation(Station *st)
 /**
  * Every calendar month update of inflation.
  */
-static IntervalTimer<TimerGameCalendar> _calendar_inflation_monthly({TimerGameCalendar::MONTH, TimerGameCalendar::Priority::COMPANY}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _calendar_inflation_monthly({TimerGameCalendar::MONTH, TimerGameCalendar::Priority::COMPANY}, [](auto)
 {
 	if (_settings_game.economy.inflation) {
 		AddInflation();
@@ -1980,7 +1980,7 @@ static IntervalTimer<TimerGameCalendar> _calendar_inflation_monthly({TimerGameCa
 /**
  * Every economy month update of company economic data, plus economy fluctuations.
  */
-static IntervalTimer<TimerGameEconomy> _economy_companies_monthly({ TimerGameEconomy::MONTH, TimerGameEconomy::Priority::COMPANY }, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_companies_monthly({ TimerGameEconomy::MONTH, TimerGameEconomy::Priority::COMPANY }, [](auto)
 {
 	CompaniesGenStatistics();
 	CompaniesPayInterest();

--- a/src/effectvehicle.cpp
+++ b/src/effectvehicle.cpp
@@ -540,7 +540,7 @@ struct EffectProcs {
 };
 
 /** Per-EffectVehicleType handling. */
-static std::array<EffectProcs, EV_END> _effect_procs = {{
+static const std::array<EffectProcs, EV_END> _effect_procs = {{
 	{ ChimneySmokeInit,   ChimneySmokeTick,   TO_INDUSTRIES }, // EV_CHIMNEY_SMOKE
 	{ SteamSmokeInit,     SteamSmokeTick,     TO_INVALID    }, // EV_STEAM_SMOKE
 	{ DieselSmokeInit,    DieselSmokeTick,    TO_INVALID    }, // EV_DIESEL_SMOKE

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -959,7 +959,7 @@ static bool IsVehicleTypeDisabled(VehicleType type, bool ai)
 }
 
 /** Daily check to offer an exclusive engine preview to the companies. */
-static IntervalTimer<TimerGameCalendar> _calendar_engines_daily({TimerGameCalendar::DAY, TimerGameCalendar::Priority::ENGINE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _calendar_engines_daily({TimerGameCalendar::DAY, TimerGameCalendar::Priority::ENGINE}, [](auto)
 {
 	for (Company *c : Company::Iterate()) {
 		c->avail_railtypes = AddDateIntroducedRailTypes(c->avail_railtypes, TimerGameCalendar::date);
@@ -1192,7 +1192,7 @@ void CalendarEnginesMonthlyLoop()
 	}
 }
 
-static IntervalTimer<TimerGameCalendar> _calendar_engines_monthly({TimerGameCalendar::MONTH, TimerGameCalendar::Priority::ENGINE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _calendar_engines_monthly({TimerGameCalendar::MONTH, TimerGameCalendar::Priority::ENGINE}, [](auto)
 {
 	CalendarEnginesMonthlyLoop();
 });

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -129,7 +129,7 @@ bool FioCheckFileExists(std::string_view filename, Subdirectory subdir)
  * @param filename the file to test.
  * @return true if and only if the file exists.
  */
-bool FileExists(const std::string &filename)
+bool FileExists(std::string_view filename)
 {
 	std::error_code ec;
 	return std::filesystem::exists(OTTD2FS(filename), ec);

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -27,7 +27,7 @@ void SanitizeFilename(std::string &filename);
 void AppendPathSeparator(std::string &buf);
 void DeterminePaths(std::string_view exe, bool only_local_path);
 std::unique_ptr<char[]> ReadFileToMem(const std::string &filename, size_t &lenp, size_t maxsize);
-bool FileExists(const std::string &filename);
+bool FileExists(std::string_view filename);
 bool ExtractTar(const std::string &tar_filename, Subdirectory subdir);
 
 extern std::string _personal_dir; ///< custom directory for personal settings, saves, newgrf, etc.

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -716,7 +716,7 @@ FiosNumberedSaveName::FiosNumberedSaveName(const std::string &prefix) : prefix(p
 	static std::string _prefix; ///< Static as the lambda needs access to it.
 
 	/* Callback for FiosFileScanner. */
-	static FiosGetTypeAndNameProc *proc = [](SaveLoadOperation, std::string_view file, std::string_view ext) {
+	static FiosGetTypeAndNameProc *const proc = [](SaveLoadOperation, std::string_view file, std::string_view ext) {
 		if (StrEqualsIgnoreCase(ext, ".sav") && file.starts_with(_prefix)) return std::tuple(FIOS_TYPE_FILE, std::string{});
 		return std::tuple(FIOS_TYPE_INVALID, std::string{});
 	};

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -457,7 +457,7 @@ struct FramerateWindow : Window {
 	}
 
 	/** Update the window on a regular interval. */
-	IntervalTimer<TimerWindow> update_interval = {std::chrono::milliseconds(100), [this](auto) {
+	const IntervalTimer<TimerWindow> update_interval = {std::chrono::milliseconds(100), [this](auto) {
 		this->UpdateData();
 		this->SetDirty();
 	}};
@@ -838,7 +838,7 @@ struct FrametimeGraphWindow : Window {
 	}
 
 	/** Update the scaling on a regular interval. */
-	IntervalTimer<TimerWindow> update_interval = {std::chrono::milliseconds(500), [this](auto) {
+	const IntervalTimer<TimerWindow> update_interval = {std::chrono::milliseconds(500), [this](auto) {
 		this->UpdateScale();
 	}};
 

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1212,7 +1212,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 	}
 
 	/** Update the payment rates on a regular interval. */
-	IntervalTimer<TimerWindow> update_payment_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> update_payment_interval = {std::chrono::seconds(3), [this](auto) {
 		this->UpdatePaymentRates();
 	}};
 

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -252,7 +252,7 @@ void ShowEndGameChart()
 	new EndGameWindow(_endgame_desc);
 }
 
-static IntervalTimer<TimerGameCalendar> _check_end_game({TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _check_end_game({TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [](auto)
 {
 	/* 0 = never */
 	if (_settings_game.game_creation.ending_year == 0) return;

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -3002,7 +3002,7 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
  * For small maps, it implies that less than one change per month is required, while on bigger maps,
  * it would be way more. The daily loop handles those changes.
  */
-static IntervalTimer<TimerGameEconomy> _economy_industries_daily({TimerGameEconomy::DAY, TimerGameEconomy::Priority::INDUSTRY}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_industries_daily({TimerGameEconomy::DAY, TimerGameEconomy::Priority::INDUSTRY}, [](auto)
 {
 	_economy.industry_daily_change_counter += _economy.industry_daily_increment;
 
@@ -3044,7 +3044,7 @@ static IntervalTimer<TimerGameEconomy> _economy_industries_daily({TimerGameEcono
 	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, IDIWD_PRODUCTION_CHANGE);
 });
 
-static IntervalTimer<TimerGameEconomy> _economy_industries_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::INDUSTRY}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_industries_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::INDUSTRY}, [](auto)
 {
 	Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -737,7 +737,7 @@ public:
 		if (success && !_settings_client.gui.persistent_buildingtools) ResetObjectToPlace();
 	}
 
-	IntervalTimer<TimerWindow> update_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> update_interval = {std::chrono::seconds(3), [this](auto) {
 		if (_game_mode == GM_EDITOR) return;
 		if (this->selected_type == IT_INVALID) return;
 
@@ -1872,7 +1872,7 @@ public:
 	}
 
 	/** Rebuild the industry list on a regular interval. */
-	IntervalTimer<TimerWindow> rebuild_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> rebuild_interval = {std::chrono::seconds(3), [this](auto) {
 		this->industries.ForceResort();
 		this->BuildSortIndustriesList();
 	}};

--- a/src/ini_type.h
+++ b/src/ini_type.h
@@ -48,7 +48,7 @@ struct IniGroup {
 
 /** Ini file that only supports loading. */
 struct IniLoadFile {
-	using IniGroupNameList = std::initializer_list<std::string_view>;
+	using IniGroupNameList = std::initializer_list<const std::string_view>;
 
 	std::list<IniGroup> groups; ///< all groups in the ini
 	std::string comment;                  ///< last comment in file

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -238,7 +238,7 @@ struct MainWindow : Window
 	}
 
 	/** Refresh the link-graph overlay on a regular interval. */
-	IntervalTimer<TimerWindow> refresh_interval = {std::chrono::milliseconds(7650), [this](auto) {
+	const IntervalTimer<TimerWindow> refresh_interval = {std::chrono::milliseconds(7650), [this](auto) {
 		RefreshLinkGraph();
 	}};
 

--- a/src/misc/dbg_helpers.h
+++ b/src/misc/dbg_helpers.h
@@ -178,7 +178,7 @@ struct DumpTarget {
 	/** Dump nested object (or only its name if this instance is already known). */
 	template <typename S> void WriteStructT(std::string_view name, const S *s)
 	{
-		static size_t type_id = ++LastTypeId();
+		static const size_t type_id = ++LastTypeId();
 
 		if (s == nullptr) {
 			/* No need to dump nullptr struct. */
@@ -201,7 +201,7 @@ struct DumpTarget {
 	/** Dump nested object (or only its name if this instance is already known). */
 	template <typename S> void WriteStructT(std::string_view name, const std::deque<S> *s)
 	{
-		static size_t type_id = ++LastTypeId();
+		static const size_t type_id = ++LastTypeId();
 
 		if (s == nullptr) {
 			/* No need to dump nullptr struct. */

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -465,7 +465,7 @@ struct AboutWindow : public Window {
 	 *
 	 * The interval of 2100ms is chosen to maintain parity: 2100 / GetCharacterHeight(FS_NORMAL) = 150ms.
 	 */
-	IntervalTimer<TimerWindow> scroll_interval = {std::chrono::milliseconds(2100) / GetCharacterHeight(FS_NORMAL), [this](uint count) {
+	const IntervalTimer<TimerWindow> scroll_interval = {std::chrono::milliseconds(2100) / GetCharacterHeight(FS_NORMAL), [this](uint count) {
 		this->text_position -= count;
 		/* If the last text has scrolled start a new from the start */
 		if (this->text_position < (int)(this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->pos_y - std::size(_credits) * this->line_height)) {

--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -29,19 +29,19 @@
 
 #if defined(UNIX)
 /** List of certificate bundles, depending on OS. Taken from: https://go.dev/src/crypto/x509/root_linux.go. */
-static auto _certificate_files = {
-	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
-	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
-	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
-	"/etc/pki/tls/cacert.pem",                           // OpenELEC
-	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
-	"/etc/ssl/cert.pem",                                 // Alpine Linux
+static constexpr std::initializer_list<std::string_view> _certificate_files = {
+	"/etc/ssl/certs/ca-certificates.crt"sv,                // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt"sv,                  // Fedora/RHEL 6
+	"/etc/ssl/ca-bundle.pem"sv,                            // OpenSUSE
+	"/etc/pki/tls/cacert.pem"sv,                           // OpenELEC
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"sv, // CentOS/RHEL 7
+	"/etc/ssl/cert.pem"sv,                                 // Alpine Linux
 };
 /** List of certificate directories, depending on OS. Taken from: https://go.dev/src/crypto/x509/root_linux.go. */
-static auto _certificate_directories = {
-	"/etc/ssl/certs",                                    // SLES10/SLES11, https://golang.org/issue/12139
-	"/etc/pki/tls/certs",                                // Fedora/RHEL
-	"/system/etc/security/cacerts",                      // Android
+static constexpr std::initializer_list<std::string_view> _certificate_directories = {
+	"/etc/ssl/certs"sv,                                    // SLES10/SLES11, https://golang.org/issue/12139
+	"/etc/pki/tls/certs"sv,                                // Fedora/RHEL
+	"/system/etc/security/cacerts"sv,                      // Android
 };
 #endif /* UNIX */
 

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -165,7 +165,7 @@ void NetworkUndrawChatMessage()
 }
 
 /** Check if a message is expired on a regular interval. */
-static IntervalTimer<TimerWindow> network_message_expired_interval(std::chrono::seconds(1), [](auto) {
+static const IntervalTimer<TimerWindow> network_message_expired_interval(std::chrono::seconds(1), [](auto) {
 	auto now = std::chrono::steady_clock::now();
 	for (auto &cmsg : _chatmsg_list) {
 		/* Message has expired, remove from the list */

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -110,7 +110,7 @@ inline auto MakeCallbackTable(std::index_sequence<i...>) noexcept
 }
 
 /** Type-erased table of callbacks. */
-static auto _callback_table = MakeCallbackTable(std::make_index_sequence<_callback_tuple_size>{});
+static const auto _callback_table = MakeCallbackTable(std::make_index_sequence<_callback_tuple_size>{});
 
 template <typename T> struct CallbackArgsHelper;
 template <typename... Targs>

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -833,7 +833,7 @@ public:
 	}
 
 	/** Refresh the online servers on a regular interval. */
-	IntervalTimer<TimerWindow> refresh_interval = {std::chrono::seconds(30), [this](uint) {
+	const IntervalTimer<TimerWindow> refresh_interval = {std::chrono::seconds(30), [this](uint) {
 		if (!this->searched_internet) return;
 
 		_network_coordinator_client.GetListing();

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1864,14 +1864,14 @@ static void NetworkCheckRestartMapYear()
 }
 
 /** Calendar yearly "callback". Called whenever the calendar year changes. */
-static IntervalTimer<TimerGameCalendar> _calendar_network_yearly({ TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE }, [](auto) {
+static const IntervalTimer<TimerGameCalendar> _calendar_network_yearly({ TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE }, [](auto) {
 	if (!_network_server) return;
 
 	NetworkCheckRestartMapYear();
 });
 
 /** Economy yearly "callback". Called whenever the economy year changes. */
-static IntervalTimer<TimerGameEconomy> _economy_network_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_network_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::NONE}, [](auto)
 {
 	if (!_network_server) return;
 
@@ -1879,7 +1879,7 @@ static IntervalTimer<TimerGameEconomy> _economy_network_yearly({TimerGameEconomy
 });
 
 /** Quarterly "callback". Called whenever the economy quarter changes. */
-static IntervalTimer<TimerGameEconomy> _network_quarterly({TimerGameEconomy::QUARTER, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _network_quarterly({TimerGameEconomy::QUARTER, TimerGameEconomy::Priority::NONE}, [](auto)
 {
 	if (!_network_server) return;
 
@@ -1888,7 +1888,7 @@ static IntervalTimer<TimerGameEconomy> _network_quarterly({TimerGameEconomy::QUA
 });
 
 /** Economy monthly "callback". Called whenever the economy month changes. */
-static IntervalTimer<TimerGameEconomy> _network_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _network_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::NONE}, [](auto)
 {
 	if (!_network_server) return;
 
@@ -1897,7 +1897,7 @@ static IntervalTimer<TimerGameEconomy> _network_monthly({TimerGameEconomy::MONTH
 });
 
 /** Economy weekly "callback". Called whenever the economy week changes. */
-static IntervalTimer<TimerGameEconomy> _network_weekly({TimerGameEconomy::WEEK, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _network_weekly({TimerGameEconomy::WEEK, TimerGameEconomy::Priority::NONE}, [](auto)
 {
 	if (!_network_server) return;
 
@@ -1905,7 +1905,7 @@ static IntervalTimer<TimerGameEconomy> _network_weekly({TimerGameEconomy::WEEK, 
 });
 
 /** Daily "callback". Called whenever the economy date changes. */
-static IntervalTimer<TimerGameEconomy> _economy_network_daily({TimerGameEconomy::DAY, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_network_daily({TimerGameEconomy::DAY, TimerGameEconomy::Priority::NONE}, [](auto)
 {
 	if (!_network_server) return;
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -251,21 +251,6 @@ static uint32_t GetRailContinuationInfo(TileIndex tile)
 
 
 /**
- * Station variable cache
- * This caches 'expensive' station variable lookups which iterate over
- * several tiles that may be called multiple times per Resolve().
- */
-static struct {
-	uint32_t v40;
-	uint32_t v41;
-	uint32_t v45;
-	uint32_t v46;
-	uint32_t v47;
-	uint32_t v49;
-	uint8_t valid; ///< Bits indicating what variable is valid (for each bit, \c 0 is invalid, \c 1 is valid).
-} _svc;
-
-/**
  * Get the town scope associated with a station, if it exists.
  * On the first call, the town scope is created (if possible).
  * @return Town scope, if available.
@@ -322,31 +307,31 @@ TownScopeResolver *StationResolverObject::GetTown()
 	switch (variable) {
 		/* Calculated station variables */
 		case 0x40:
-			if (!HasBit(_svc.valid, 0)) { _svc.v40 = GetPlatformInfoHelper(this->tile, false, false, false); SetBit(_svc.valid, 0); }
-			return _svc.v40;
+			if (!this->cache.v40.has_value()) this->cache.v40 = GetPlatformInfoHelper(this->tile, false, false, false);
+			return *this->cache.v40;
 
 		case 0x41:
-			if (!HasBit(_svc.valid, 1)) { _svc.v41 = GetPlatformInfoHelper(this->tile, true,  false, false); SetBit(_svc.valid, 1); }
-			return _svc.v41;
+			if (!this->cache.v41.has_value()) this->cache.v41 = GetPlatformInfoHelper(this->tile, true,  false, false);
+			return *this->cache.v41;
 
 		case 0x42: return GetTerrainType(this->tile) | (GetReverseRailTypeTranslation(GetRailType(this->tile), this->statspec->grf_prop.grffile) << 8);
 		case 0x43: return GetCompanyInfo(this->st->owner); // Station owner
 		case 0x44: return HasStationReservation(this->tile) ? 7 : 4; // PBS status
 		case 0x45:
-			if (!HasBit(_svc.valid, 2)) { _svc.v45 = GetRailContinuationInfo(this->tile); SetBit(_svc.valid, 2); }
-			return _svc.v45;
+			if (!this->cache.v45.has_value()) this->cache.v45 = GetRailContinuationInfo(this->tile);
+			return *this->cache.v45;
 
 		case 0x46:
-			if (!HasBit(_svc.valid, 3)) { _svc.v46 = GetPlatformInfoHelper(this->tile, false, false, true); SetBit(_svc.valid, 3); }
-			return _svc.v46;
+			if (!this->cache.v46.has_value()) this->cache.v46 = GetPlatformInfoHelper(this->tile, false, false, true);
+			return *this->cache.v46;
 
 		case 0x47:
-			if (!HasBit(_svc.valid, 4)) { _svc.v47 = GetPlatformInfoHelper(this->tile, true,  false, true); SetBit(_svc.valid, 4); }
-			return _svc.v47;
+			if (!this->cache.v47.has_value()) this->cache.v47 = GetPlatformInfoHelper(this->tile, true,  false, true);
+			return *this->cache.v47;
 
 		case 0x49:
-			if (!HasBit(_svc.valid, 5)) { _svc.v49 = GetPlatformInfoHelper(this->tile, false, true, false); SetBit(_svc.valid, 5); }
-			return _svc.v49;
+			if (!this->cache.v49.has_value()) this->cache.v49 = GetPlatformInfoHelper(this->tile, false, true, false);
+			return *this->cache.v49;
 
 		case 0x4A: // Animation frame of tile
 			return GetAnimationFrame(this->tile);
@@ -593,9 +578,6 @@ StationResolverObject::StationResolverObject(const StationSpec *statspec, BaseSt
 	: SpecializedResolverObject<StationRandomTriggers>(statspec->grf_prop.grffile, callback, callback_param1, callback_param2),
 	station_scope(*this, statspec, base_station, tile)
 {
-	/* Invalidate all cached vars */
-	_svc.valid = 0;
-
 	CargoType ctype = CargoGRFFileProps::SG_DEFAULT_NA;
 
 	if (this->station_scope.st == nullptr) {

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -31,6 +31,21 @@ struct StationScopeResolver : public ScopeResolver {
 	Axis axis;                          ///< Station axis, used only for the slope check callback.
 
 	/**
+	 * Station variable cache
+	 * This caches 'expensive' station variable lookups which iterate over
+	 * several tiles that may be called multiple times per Resolve().
+	 */
+	struct Cache {
+		std::optional<uint32_t> v40;
+		std::optional<uint32_t> v41;
+		std::optional<uint32_t> v45;
+		std::optional<uint32_t> v46;
+		std::optional<uint32_t> v47;
+		std::optional<uint32_t> v49;
+	};
+	mutable Cache cache;
+
+	/**
 	 * Constructor for station scopes.
 	 * @param ro Surrounding resolver.
 	 * @param statspec Station (type) specification.

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -317,7 +317,7 @@ static WindowDesc &GetNewsWindowLayout(NewsStyle style)
 /**
  * Per-NewsType data
  */
-static NewsTypeData _news_type_data[] = {
+static const NewsTypeData _news_type_data[] = {
 	/*            name,                           age, sound,          */
 	NewsTypeData("news_display.arrival_player",    60, SND_1D_APPLAUSE ),  ///< NewsType::ArrivalCompany
 	NewsTypeData("news_display.arrival_other",     60, SND_1D_APPLAUSE ),  ///< NewsType::ArrivalOther

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -652,7 +652,7 @@ struct NewsWindow : Window {
 	 *
 	 * The interval of 210ms is chosen to maintain 15ms at normal zoom: 210 / GetCharacterHeight(FS_NORMAL) = 15ms.
 	 */
-	IntervalTimer<TimerWindow> scroll_interval = {std::chrono::milliseconds(210) / GetCharacterHeight(FS_NORMAL), [this](uint count) {
+	const IntervalTimer<TimerWindow> scroll_interval = {std::chrono::milliseconds(210) / GetCharacterHeight(FS_NORMAL), [this](uint count) {
 		int newtop = std::max(this->top - 2 * static_cast<int>(count), _screen.height - this->height - this->status_height - this->chat_height);
 		this->SetWindowTop(newtop);
 	}};

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -151,16 +151,18 @@ void OSOpenBrowser(const std::string &url)
 /**
  * Determine and return the current user's locale.
  */
-std::optional<std::string_view> GetCurrentLocale(const char *)
+std::optional<std::string> GetCurrentLocale(const char *)
 {
-	static char retbuf[32] = { '\0' };
 	NSUserDefaults *defs = [ NSUserDefaults standardUserDefaults ];
 	NSArray *languages = [ defs objectForKey:@"AppleLanguages" ];
 	NSString *preferredLang = [ languages objectAtIndex:0 ];
 	/* preferredLang is either 2 or 5 characters long ("xx" or "xx_YY"). */
 
-	[ preferredLang getCString:retbuf maxLength:32 encoding:NSASCIIStringEncoding ];
-
+	std::string retbuf{32, '\0'};
+	[ preferredLang getCString:retbuf.data() maxLength:retbuf.size() encoding:NSASCIIStringEncoding ];
+	auto end = retbuf.find('\0');
+	if (end == 0) return std::nullopt;
+	if (end != std::string::npos) retbuf.erase(end);
 	return retbuf;
 }
 

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -145,7 +145,7 @@ static CGFloat SpriteFontGetWidth(void *ref_con)
 	return GetGlyphWidth(fs, c);
 }
 
-static CTRunDelegateCallbacks _sprite_font_callback = {
+static const CTRunDelegateCallbacks _sprite_font_callback = {
 	kCTRunDelegateCurrentVersion, nullptr, nullptr, nullptr,
 	&SpriteFontGetWidth
 };
@@ -330,7 +330,7 @@ void MacOSSetCurrentLocaleName(std::string_view iso_code)
  */
 int MacOSStringCompare(std::string_view s1, std::string_view s2)
 {
-	static bool supported = MacOSVersionIsAtLeast(10, 5, 0);
+	static const bool supported = MacOSVersionIsAtLeast(10, 5, 0);
 	if (!supported) return 0;
 
 	CFStringCompareFlags flags = kCFCompareCaseInsensitive | kCFCompareNumerically | kCFCompareLocalized | kCFCompareWidthInsensitive | kCFCompareForcedOrdering;
@@ -354,7 +354,7 @@ int MacOSStringCompare(std::string_view s1, std::string_view s2)
  */
 int MacOSStringContains(std::string_view str, std::string_view value, bool case_insensitive)
 {
-	static bool supported = MacOSVersionIsAtLeast(10, 5, 0);
+	static const bool supported = MacOSVersionIsAtLeast(10, 5, 0);
 	if (!supported) return -1;
 
 	CFStringCompareFlags flags = kCFCompareLocalized | kCFCompareWidthInsensitive;

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -89,7 +89,7 @@ bool FiosIsHiddenFile(const std::filesystem::path &path)
 #include "../../debug.h"
 #include "../../string_func.h"
 
-std::optional<std::string_view> GetCurrentLocale(const char *param);
+std::optional<std::string> GetCurrentLocale(const char *param);
 
 #define INTERNALCODE "UTF-8"
 
@@ -98,7 +98,7 @@ std::optional<std::string_view> GetCurrentLocale(const char *param);
  * variables. MacOSX is hardcoded, other OS's are dynamic. If no suitable
  * locale can be found, don't do any conversion ""
  */
-static std::string_view GetLocalCode()
+static std::string GetLocalCode()
 {
 #if defined(__APPLE__)
 	return "UTF-8-MAC";
@@ -108,7 +108,8 @@ static std::string_view GetLocalCode()
 	if (!locale.has_value()) return "";
 	auto pos = locale->find('.');
 	if (pos == std::string_view::npos) return "";
-	return locale->substr(pos + 1);
+	locale.erase(0, pos + 1);
+	return locale;
 #endif
 }
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -395,7 +395,7 @@ wchar_t *convert_to_fs(std::string_view src, std::span<wchar_t> dst_buf)
 }
 
 /** Determine the current user's locale. */
-std::optional<std::string_view> GetCurrentLocale(const char *)
+std::optional<std::string> GetCurrentLocale(const char *)
 {
 	const LANGID userUiLang = GetUserDefaultUILanguage();
 	const LCID userUiLocale = MAKELCID(userUiLang, SORT_DEFAULT);
@@ -407,8 +407,7 @@ std::optional<std::string_view> GetCurrentLocale(const char *)
 		return nullptr;
 	}
 	/* Format it as 'en_us'. */
-	static char retbuf[6] = {lang[0], lang[1], '_', country[0], country[1], 0};
-	return retbuf;
+	return fmt::format("{}_{}", std::string_view{lang, 2}, std::string_view{country, 2});
 }
 
 

--- a/src/pathfinder/yapf/yapf_type.hpp
+++ b/src/pathfinder/yapf/yapf_type.hpp
@@ -66,7 +66,7 @@ static constexpr EndSegmentReasons ESRF_ABORT_PF_MASK = {
 
 inline std::string ValueStr(EndSegmentReasons flags)
 {
-	static const std::initializer_list<std::string_view> end_segment_reason_names = {
+	static const std::initializer_list<const std::string_view> end_segment_reason_names = {
 		"DEAD_END", "RAIL_TYPE", "INFINITE_LOOP", "SEGMENT_TOO_LONG", "CHOICE_FOLLOWS",
 		"DEPOT", "WAYPOINT", "STATION", "SAFE_TILE",
 		"PATH_TOO_LONG", "FIRST_TWO_WAY_RED", "LOOK_AHEAD_END", "TARGET_REACHED"

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -222,11 +222,11 @@ private:
 
 	GUIBadgeClasses badge_classes;
 
-	IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
 		this->SetDirty();
 	}};
 
-	IntervalTimer<TimerWindow> refresh_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> refresh_interval = {std::chrono::seconds(3), [this](auto) {
 		RefreshUsedTypeList();
 	}};
 };

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1916,7 +1916,7 @@ struct FenceOffset {
 };
 
 /** Offsets for drawing fences */
-static FenceOffset _fence_offsets[] = {
+static const FenceOffset _fence_offsets[] = {
 	{ CORNER_INVALID,  0,  1, 16,  1 }, // RFO_FLAT_X_NW
 	{ CORNER_INVALID,  1,  0,  1, 16 }, // RFO_FLAT_Y_NE
 	{ CORNER_W,        8,  8,  1,  1 }, // RFO_FLAT_LEFT

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2002,7 +2002,7 @@ void ResetSignalVariant(int32_t)
 	}
 }
 
-static IntervalTimer<TimerGameCalendar> _check_reset_signal({TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _check_reset_signal({TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [](auto)
 {
 	if (TimerGameCalendar::year != _settings_client.gui.semaphore_build_before) return;
 

--- a/src/screenshot_pcx.cpp
+++ b/src/screenshot_pcx.cpp
@@ -153,4 +153,4 @@ public:
 	}
 };
 
-static ScreenshotProvider_Pcx s_screenshot_provider_pcx;
+static const ScreenshotProvider_Pcx s_screenshot_provider_pcx;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1425,7 +1425,7 @@ void LoadFromConfig(bool startup)
 		}
 
 		if (generic_version < IFV_AUTOSAVE_RENAME && IsConversionNeeded(generic_ini, "gui", "autosave", "autosave_interval", &old_item)) {
-			static std::vector<std::string_view> _old_autosave_interval{"off", "monthly", "quarterly", "half year", "yearly"};
+			static constexpr std::initializer_list<std::string_view> _old_autosave_interval{"off"sv, "monthly"sv, "quarterly"sv, "half year"sv, "yearly"sv};
 			auto old_value = OneOfManySettingDesc::ParseSingleValue(*old_item->value, _old_autosave_interval).value_or(-1);
 
 			switch (old_value) {

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -448,7 +448,7 @@ static bool CheckRoadSide(int32_t &)
 static std::optional<uint32_t> ConvertLandscape(std::string_view value)
 {
 	/* try with the old values */
-	static std::vector<std::string_view> _old_landscape_values{"normal", "hilly", "desert", "candy"};
+	static constexpr std::initializer_list<std::string_view> _old_landscape_values{"normal"sv, "hilly"sv, "desert"sv, "candy"sv};
 	return OneOfManySettingDesc::ParseSingleValue(value, _old_landscape_values);
 }
 

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -308,7 +308,7 @@ struct SignListWindow : Window, SignList {
 	}
 
 	/** Resort the sign listing on a regular interval. */
-	IntervalTimer<TimerWindow> rebuild_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> rebuild_interval = {std::chrono::seconds(3), [this](auto) {
 		this->BuildSortSignList();
 		this->SetDirty();
 	}};

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -730,12 +730,12 @@ protected:
 	}
 
 	/** Blink the industries (if selected) on a regular interval. */
-	IntervalTimer<TimerWindow> blink_interval = {std::chrono::milliseconds(450), [this](auto) {
+	const IntervalTimer<TimerWindow> blink_interval = {std::chrono::milliseconds(450), [this](auto) {
 		Blink();
 	}};
 
 	/** Update the whole map on a regular interval. */
-	IntervalTimer<TimerWindow> refresh_interval = {std::chrono::milliseconds(930), [this](auto) {
+	const IntervalTimer<TimerWindow> refresh_interval = {std::chrono::milliseconds(930), [this](auto) {
 		ForceRefresh();
 	}};
 

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -55,7 +55,7 @@ struct LegendAndColour {
 };
 
 /** Link stat colours shown in legenda. */
-static uint8_t _linkstat_colours_in_legenda[] = {0, 1, 3, 5, 7, 9, 11};
+static const uint8_t _linkstat_colours_in_legenda[] = {0, 1, 3, 5, 7, 9, 11};
 
 static const int NUM_NO_COMPANY_ENTRIES = 4; ///< Number of entries in the owner legend that are not companies.
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4225,7 +4225,7 @@ void OnTick_Station()
 }
 
 /** Economy monthly loop for stations. */
-static IntervalTimer<TimerGameEconomy> _economy_stations_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::STATION}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_stations_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::STATION}, [](auto)
 {
 	for (Station *st : Station::Iterate()) {
 		for (GoodsEntry &ge : st->goods) {

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -192,7 +192,7 @@ struct StatusBarWindow : Window {
 	}
 
 	/** Move information on the ticker slowly from one side to the other. */
-	IntervalTimer<TimerWindow> ticker_scroll_interval = {std::chrono::milliseconds(15), [this](uint count) {
+	const IntervalTimer<TimerWindow> ticker_scroll_interval = {std::chrono::milliseconds(15), [this](uint count) {
 		if (_pause_mode.Any()) return;
 
 		if (this->ticker_scroll < TICKER_STOP) {
@@ -205,7 +205,7 @@ struct StatusBarWindow : Window {
 		this->SetWidgetDirty(WID_S_MIDDLE);
 	}};
 
-	IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [this](auto) {
 		this->SetWidgetDirty(WID_S_LEFT);
 	}};
 };

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -422,7 +422,7 @@ bool FindSubsidyCargoDestination(CargoType cargo_type, Source src)
 }
 
 /** Perform the economy monthly update of open subsidies, and try to create a new one. */
-static IntervalTimer<TimerGameEconomy> _economy_subsidies_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::SUBSIDY}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_subsidies_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::SUBSIDY}, [](auto)
 {
 	bool modified = false;
 

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -89,7 +89,7 @@ void RemoveTextEffect(TextEffectID te_id)
 }
 
 /** Slowly move text effects upwards. */
-IntervalTimer<TimerWindow> move_all_text_effects_interval = {std::chrono::milliseconds(30), [](uint count) {
+const IntervalTimer<TimerWindow> move_all_text_effects_interval = {std::chrono::milliseconds(30), [](uint count) {
 	if (_pause_mode.Any() && _game_mode != GM_EDITOR && _settings_game.construction.command_pause_level <= CMDPL_NO_CONSTRUCTION) return;
 
 	for (TextEffect &te : _text_effects) {

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -863,7 +863,7 @@ std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, std:
 
 	std::string_view base_path = filename.substr(0, slash + 1);
 
-	static const std::initializer_list<std::string_view> extensions{
+	static const std::initializer_list<const std::string_view> extensions{
 		"txt",
 		"md",
 #if defined(WITH_ZLIB)

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -802,7 +802,7 @@ struct TimetableWindow : Window {
 	/**
 	 * In real-time mode, the timetable GUI shows relative times and needs to be redrawn every second.
 	 */
-	IntervalTimer<TimerGameTick> redraw_interval = { { TimerGameTick::Priority::NONE, Ticks::TICKS_PER_SECOND }, [this](auto) {
+	const IntervalTimer<TimerGameTick> redraw_interval = { { TimerGameTick::Priority::NONE, Ticks::TICKS_PER_SECOND }, [this](auto) {
 		if (_settings_client.gui.timetable_mode == TimetableMode::Seconds) {
 			this->SetDirty();
 		}

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2104,7 +2104,7 @@ struct MainToolbarWindow : Window {
 	}
 
 	/** Refresh the state of pause / game-speed on a regular interval.*/
-	IntervalTimer<TimerWindow> refresh_interval = {std::chrono::milliseconds(30), [this](auto) {
+	const IntervalTimer<TimerWindow> refresh_interval = {std::chrono::milliseconds(30), [this](auto) {
 		if (this->IsWidgetLowered(WID_TN_PAUSE) != _pause_mode.Any()) {
 			this->ToggleWidgetLoweredState(WID_TN_PAUSE);
 			this->SetWidgetDirty(WID_TN_PAUSE);
@@ -2471,7 +2471,7 @@ struct ScenarioEditorToolbarWindow : Window {
 	}
 
 	/** Refresh the state of pause / game-speed on a regular interval.*/
-	IntervalTimer<TimerWindow> refresh_interval = {std::chrono::milliseconds(30), [this](auto) {
+	const IntervalTimer<TimerWindow> refresh_interval = {std::chrono::milliseconds(30), [this](auto) {
 		if (this->IsWidgetLowered(WID_TE_PAUSE) != _pause_mode.Any()) {
 			this->ToggleWidgetLoweredState(WID_TE_PAUSE);
 			this->SetDirty();

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -4040,7 +4040,7 @@ CommandCost CheckforTownRating(DoCommandFlags flags, Town *t, TownRatingCheckTyp
 	return CommandCost();
 }
 
-static IntervalTimer<TimerGameEconomy> _economy_towns_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::TOWN}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_towns_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::TOWN}, [](auto)
 {
 	for (Town *t : Town::Iterate()) {
 		/* Check for active town actions and decrement their counters. */
@@ -4067,7 +4067,7 @@ static IntervalTimer<TimerGameEconomy> _economy_towns_monthly({TimerGameEconomy:
 	}
 });
 
-static IntervalTimer<TimerGameEconomy> _economy_towns_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::TOWN}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_towns_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::TOWN}, [](auto)
 {
 	/* Increment house ages */
 	for (const auto t : Map::Iterate()) {

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -332,7 +332,7 @@ public:
 	}
 
 	/** Redraw the whole window on a regular interval. */
-	IntervalTimer<TimerWindow> redraw_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> redraw_interval = {std::chrono::seconds(3), [this](auto) {
 		this->SetDirty();
 	}};
 
@@ -605,7 +605,7 @@ public:
 		Command<CMD_RENAME_TOWN>::Post(STR_ERROR_CAN_T_RENAME_TOWN, static_cast<TownID>(this->window_number), *str);
 	}
 
-	IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [this](auto) {
 		/* Refresh after possible snowline change */
 		this->SetDirty();
 	}};
@@ -987,7 +987,7 @@ public:
 	}
 
 	/** Redraw the whole window on a regular interval. */
-	IntervalTimer<TimerWindow> rebuild_interval = {std::chrono::seconds(3), [this](auto) {
+	const IntervalTimer<TimerWindow> rebuild_interval = {std::chrono::seconds(3), [this](auto) {
 		this->BuildSortTownList();
 		this->SetDirty();
 	}};
@@ -1775,7 +1775,7 @@ struct BuildHouseWindow : public PickerWindow {
 		Command<CMD_PLACE_HOUSE>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), this->house_protected);
 	}
 
-	IntervalTimer<TimerWindow> view_refresh_interval = {std::chrono::milliseconds(2500), [this](auto) {
+	const IntervalTimer<TimerWindow> view_refresh_interval = {std::chrono::milliseconds(2500), [this](auto) {
 		/* There are four different 'views' that are random based on house tile position. As this is not
 		 * user-controllable, instead we automatically cycle through them. */
 		HousePickerCallbacks::sel_view = (HousePickerCallbacks::sel_view + 1) % 4;

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -961,7 +961,7 @@ static void MakeCatalanTownName(StringBuilder &builder, uint32_t seed)
 typedef void TownNameGenerator(StringBuilder &builder, uint32_t seed);
 
 /** Town name generators */
-static TownNameGenerator *_town_name_generators[] = {
+static TownNameGenerator *const _town_name_generators[] = {
 	MakeEnglishOriginalTownName,  // replaces first 4 characters of name
 	MakeFrenchTownName,
 	MakeGermanTownName,

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2987,7 +2987,7 @@ void Vehicle::RemoveFromShared()
 	this->previous_shared = nullptr;
 }
 
-static IntervalTimer<TimerGameEconomy> _economy_vehicles_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::VEHICLE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_vehicles_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::VEHICLE}, [](auto)
 {
 	for (Vehicle *v : Vehicle::Iterate()) {
 		if (v->IsPrimaryVehicle()) {

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2391,13 +2391,13 @@ extern void DrawRoadVehDetails(const Vehicle *v, const Rect &r);
 extern void DrawShipDetails(const Vehicle *v, const Rect &r);
 extern void DrawAircraftDetails(const Aircraft *v, const Rect &r);
 
-static StringID _service_interval_dropdown_calendar[] = {
+static const StringID _service_interval_dropdown_calendar[] = {
 	STR_VEHICLE_DETAILS_DEFAULT,
 	STR_VEHICLE_DETAILS_DAYS,
 	STR_VEHICLE_DETAILS_PERCENT,
 };
 
-static StringID _service_interval_dropdown_wallclock[] = {
+static const StringID _service_interval_dropdown_wallclock[] = {
 	STR_VEHICLE_DETAILS_DEFAULT,
 	STR_VEHICLE_DETAILS_MINUTES,
 	STR_VEHICLE_DETAILS_PERCENT,

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -442,7 +442,7 @@ static void SetDarkModeForWindow(HWND hWnd, bool dark_mode)
 	 * reason, the code uses dynamic loading and ignores any errors for a best-effort result. */
 	static LibraryLoader _dwmapi("dwmapi.dll");
 	typedef HRESULT(WINAPI *PFNDWMSETWINDOWATTRIBUTE)(HWND, DWORD, LPCVOID, DWORD);
-	static PFNDWMSETWINDOWATTRIBUTE DwmSetWindowAttribute = _dwmapi.GetFunction("DwmSetWindowAttribute");
+	static const PFNDWMSETWINDOWATTRIBUTE DwmSetWindowAttribute = _dwmapi.GetFunction("DwmSetWindowAttribute");
 
 	if (DwmSetWindowAttribute != nullptr) {
 		/* Contrary to the published documentation, DWMWA_USE_IMMERSIVE_DARK_MODE does not change the

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -3559,7 +3559,7 @@ struct ViewportSSCSS {
 };
 
 /** List of sorters ordered from best to worst. */
-static ViewportSSCSS _vp_sprite_sorters[] = {
+static const ViewportSSCSS _vp_sprite_sorters[] = {
 #ifdef WITH_SSE
 	{ &ViewportSortParentSpritesSSE41Checker, &ViewportSortParentSpritesSSE41 },
 #endif

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3039,7 +3039,7 @@ void CallWindowRealtimeTickEvent(uint delta_ms)
 }
 
 /** Update various of window-related information on a regular interval. */
-static IntervalTimer<TimerWindow> window_interval(std::chrono::milliseconds(30), [](auto) {
+static const IntervalTimer<TimerWindow> window_interval(std::chrono::milliseconds(30), [](auto) {
 	extern int _caret_timer;
 	_caret_timer += 3;
 	CursorTick();
@@ -3050,12 +3050,12 @@ static IntervalTimer<TimerWindow> window_interval(std::chrono::milliseconds(30),
 });
 
 /** Blink the window highlight colour constantly. */
-static IntervalTimer<TimerWindow> highlight_interval(std::chrono::milliseconds(450), [](auto) {
+static const IntervalTimer<TimerWindow> highlight_interval(std::chrono::milliseconds(450), [](auto) {
 	_window_highlight_colour = !_window_highlight_colour;
 });
 
 /** Blink all windows marked with a white border. */
-static IntervalTimer<TimerWindow> white_border_interval(std::chrono::milliseconds(30), [](auto) {
+static const IntervalTimer<TimerWindow> white_border_interval(std::chrono::milliseconds(30), [](auto) {
 	if (_network_dedicated) return;
 
 	for (Window *w : Window::Iterate()) {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2671,14 +2671,6 @@ void HandleTextInput(std::string_view str, bool marked, std::optional<size_t> ca
 }
 
 /**
- * Local counter that is incremented each time an mouse input event is detected.
- * The counter is used to stop auto-scrolling.
- * @see HandleAutoscroll()
- * @see HandleMouseEvents()
- */
-static int _input_events_this_tick = 0;
-
-/**
  * If needed and switched on, perform auto scrolling (automatically
  * moving window contents when mouse is near edge of the window).
  */
@@ -2904,14 +2896,6 @@ void HandleMouseEvents()
 	 * But there is no company related window open anyway, so _current_company is not used. */
 	assert(HasModalProgress() || IsLocalCompany());
 
-	/* Handle sprite picker before any GUI interaction */
-	if (_newgrf_debug_sprite_picker.mode == SPM_REDRAW && _input_events_this_tick == 0) {
-		/* We are done with the last draw-frame, so we know what sprites we
-		 * clicked on. Reset the picker mode and invalidate the window. */
-		_newgrf_debug_sprite_picker.mode = SPM_NONE;
-		InvalidateWindowData(WC_SPRITE_ALIGNER, 0, 1);
-	}
-
 	static std::chrono::steady_clock::time_point double_click_time = {};
 	static Point double_click_pos = {0, 0};
 
@@ -2927,18 +2911,15 @@ void HandleMouseEvents()
 		double_click_time = std::chrono::steady_clock::now();
 		double_click_pos = _cursor.pos;
 		_left_button_clicked = true;
-		_input_events_this_tick++;
 	} else if (_right_button_clicked) {
 		_right_button_clicked = false;
 		click = MC_RIGHT;
-		_input_events_this_tick++;
 	}
 
 	int mousewheel = 0;
 	if (_cursor.wheel) {
 		mousewheel = _cursor.wheel;
 		_cursor.wheel = 0;
-		_input_events_this_tick++;
 	}
 
 	static std::chrono::steady_clock::time_point hover_time = {};
@@ -2954,7 +2935,6 @@ void HandleMouseEvents()
 		} else if (!_mouse_hovering) {
 			if (std::chrono::steady_clock::now() > hover_time + std::chrono::milliseconds(_settings_client.gui.hover_delay_ms)) {
 				click = MC_HOVER;
-				_input_events_this_tick++;
 				_mouse_hovering = true;
 				hover_time = std::chrono::steady_clock::now();
 			}
@@ -3017,11 +2997,12 @@ void InputLoop()
 	/* Process scheduled window deletion. */
 	Window::DeleteClosedWindows();
 
-	if (_input_events_this_tick != 0) {
-		/* The input loop is called only once per GameLoop() - so we can clear the counter here */
-		_input_events_this_tick = 0;
-		/* there were some inputs this tick, don't scroll ??? */
-		return;
+	/* Handle sprite picker before any GUI interaction */
+	if (_newgrf_debug_sprite_picker.mode == SPM_REDRAW) {
+		/* We are done with the last draw-frame, so we know what sprites we
+		 * clicked on. Reset the picker mode and invalidate the window. */
+		_newgrf_debug_sprite_picker.mode = SPM_NONE;
+		InvalidateWindowData(WC_SPRITE_ALIGNER, 0, 1);
 	}
 
 	/* HandleMouseEvents was already called for this tick */


### PR DESCRIPTION
## Motivation / Problem

We use static variables in various places.
* If they are `const`, they are generally okay.
* If they store global state, they are also okay.
* If they are used to store temporary data, they are not okay.

## Description

* Add `const` wherever possible.
* Store temporary data on the stack or the heap.
* Make correct use of "static variables are initialised once":
    * `GetCurrentLocale` for win32 was wrong. It determined the locale every time, but the result was filled only once.
    * Other places track in a separate variable, whether a static was initialised.
* Remove unused static variables.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
