### PR TITLE
Codefix: always add space between * and const for consistency

### DIFF
--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -114,7 +114,7 @@ static auto _callback_table = MakeCallbackTable(std::make_index_sequence<_callba
 
 template <typename T> struct CallbackArgsHelper;
 template <typename... Targs>
-struct CallbackArgsHelper<void(*const)(Commands, const CommandCost &, Targs...)> {
+struct CallbackArgsHelper<void(* const)(Commands, const CommandCost &, Targs...)> {
 	using Args = std::tuple<std::decay_t<Targs>...>;
 };
 

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -46,13 +46,13 @@ bool SetFallbackFont(FontCacheSettings *settings, const std::string &language_is
 	lang_codes[0] = CFStringCreateWithCString(kCFAllocatorDefault, lang.c_str(), kCFStringEncodingUTF8);
 	lang_codes[1] = CFSTR("en");
 	CFArrayRef lang_arr = CFArrayCreate(kCFAllocatorDefault, (const void **)lang_codes, lengthof(lang_codes), &kCFTypeArrayCallBacks);
-	CFAutoRelease<CFDictionaryRef> lang_attribs(CFDictionaryCreate(kCFAllocatorDefault, const_cast<const void **>(reinterpret_cast<const void *const *>(&kCTFontLanguagesAttribute)), (const void **)&lang_arr, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+	CFAutoRelease<CFDictionaryRef> lang_attribs(CFDictionaryCreate(kCFAllocatorDefault, const_cast<const void **>(reinterpret_cast<const void * const *>(&kCTFontLanguagesAttribute)), (const void **)&lang_arr, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 	CFAutoRelease<CTFontDescriptorRef> lang_desc(CTFontDescriptorCreateWithAttributes(lang_attribs.get()));
 	CFRelease(lang_arr);
 	CFRelease(lang_codes[0]);
 
 	/* Get array of all font descriptors for the wanted language. */
-	CFAutoRelease<CFSetRef> mandatory_attribs(CFSetCreate(kCFAllocatorDefault, const_cast<const void **>(reinterpret_cast<const void *const *>(&kCTFontLanguagesAttribute)), 1, &kCFTypeSetCallBacks));
+	CFAutoRelease<CFSetRef> mandatory_attribs(CFSetCreate(kCFAllocatorDefault, const_cast<const void **>(reinterpret_cast<const void * const *>(&kCTFontLanguagesAttribute)), 1, &kCFTypeSetCallBacks));
 	CFAutoRelease<CFArrayRef> descs(CTFontDescriptorCreateMatchingFontDescriptors(lang_desc.get(), mandatory_attribs.get()));
 
 	bool result = false;

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -438,10 +438,10 @@ CommandCost CmdRemoveStoryPageElement(DoCommandFlags flags, StoryPageElementID p
 CommandCost CmdStoryPageButton(DoCommandFlags flags, TileIndex tile, StoryPageElementID page_element_id, VehicleID reference)
 {
 	if (!StoryPageElement::IsValidID(page_element_id)) return CMD_ERROR;
-	const StoryPageElement *const pe = StoryPageElement::Get(page_element_id);
+	const StoryPageElement * const pe = StoryPageElement::Get(page_element_id);
 
 	/* Check the player belongs to the company that owns the page. */
-	const StoryPage *const sp = StoryPage::Get(pe->page);
+	const StoryPage * const sp = StoryPage::Get(pe->page);
 	if (sp->company != CompanyID::Invalid() && sp->company != _current_company) return CMD_ERROR;
 
 	switch (pe->type) {

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -890,7 +890,7 @@ public:
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
 	{
-		const StoryPageElement *const pe = StoryPageElement::GetIfValid(this->active_button_id);
+		const StoryPageElement * const pe = StoryPageElement::GetIfValid(this->active_button_id);
 		if (pe == nullptr || pe->type != SPET_BUTTON_TILE) {
 			ResetObjectToPlace();
 			this->active_button_id = StoryPageElementID::Invalid();
@@ -904,7 +904,7 @@ public:
 
 	bool OnVehicleSelect(const Vehicle *v) override
 	{
-		const StoryPageElement *const pe = StoryPageElement::GetIfValid(this->active_button_id);
+		const StoryPageElement * const pe = StoryPageElement::GetIfValid(this->active_button_id);
 		if (pe == nullptr || pe->type != SPET_BUTTON_VEHICLE) {
 			ResetObjectToPlace();
 			this->active_button_id = StoryPageElementID::Invalid();


### PR DESCRIPTION
## Motivation / Problem

Inconsistency in coding style w.r.t. `const` after `*`.


## Description

Take the prevalent one as gospel and change `*const` to `* const`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
