### PR TITLE
Codechange: Use EnumBitSet instead of Vector to record received content types.

### DIFF
--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -33,6 +33,7 @@ enum ContentType : uint8_t {
 	CONTENT_TYPE_END,               ///< Helper to mark the end of the types
 	INVALID_CONTENT_TYPE       = 0xFF, ///< Invalid/uninitialized content
 };
+using ContentTypes = EnumBitSet<ContentType, uint16_t, CONTENT_TYPE_END>;
 
 /** Enum with all types of TCP content packets. The order MUST not be changed **/
 enum PacketContentType : uint8_t {

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -187,7 +187,7 @@ void BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(const ContentInf
 /** Window for showing the download status of content */
 struct NetworkContentDownloadStatusWindow : public BaseNetworkContentDownloadStatusWindow {
 private:
-	std::vector<ContentType> receivedTypes{}; ///< Types we received so we can update their cache
+	ContentTypes received_types{}; ///< Types we received so we can update their cache
 
 public:
 	/**
@@ -202,7 +202,7 @@ public:
 	void Close([[maybe_unused]] int data = 0) override
 	{
 		TarScanner::Modes modes{};
-		for (auto ctype : this->receivedTypes) {
+		for (auto ctype : this->received_types) {
 			switch (ctype) {
 				case CONTENT_TYPE_AI:
 				case CONTENT_TYPE_AI_LIBRARY:
@@ -236,7 +236,7 @@ public:
 		TarScanner::DoScan(modes);
 
 		/* Tell all the backends about what we've downloaded */
-		for (auto ctype : this->receivedTypes) {
+		for (auto ctype : this->received_types) {
 			switch (ctype) {
 				case CONTENT_TYPE_AI:
 				case CONTENT_TYPE_AI_LIBRARY:
@@ -301,7 +301,7 @@ public:
 	void OnDownloadProgress(const ContentInfo &ci, int bytes) override
 	{
 		BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(ci, bytes);
-		include(this->receivedTypes, ci.type);
+		this->received_types.Set(ci.type);
 
 		/* When downloading is finished change cancel in ok */
 		if (this->downloaded_bytes == this->total_bytes) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When downloading content, a `std::vector` is maintained to list the received `ContentType`s that need their cache updating.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

`ContentType` is an enum with a limit range of values.

Replace the `std::vector` with an `EnumBitSet` of `ContentType`s instead.

Also replace camelCase name with snake_case name.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

I assumed that the order that content is received does not matter. Iterating an EnumBitSet will always iterate in enum-value order.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
