### PR TITLE
Codechange: Turn _grow_town_result into a local variable in GrowTownAtRoad.

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -228,9 +228,6 @@ Money HouseSpec::GetRemovalCost() const
 	return (_price[PR_CLEAR_HOUSE] * this->removal_cost) >> 8;
 }
 
-/* Local */
-static int _grow_town_result;
-
 static bool TryBuildTownHouse(Town *t, TileIndex tile);
 static Town *CreateRandomTown(uint attempts, uint32_t townnameparts, TownSize size, bool city, TownLayout layout);
 
@@ -1797,18 +1794,19 @@ static bool GrowTownAtRoad(Town *t, TileIndex tile)
 	/* Number of times to search.
 	 * Better roads, 2X2 and 3X3 grid grow quite fast so we give
 	 * them a little handicap. */
+	int iterations;
 	switch (t->layout) {
 		case TL_BETTER_ROADS:
-			_grow_town_result = 10 + t->cache.num_houses * 2 / 9;
+			iterations = 10 + t->cache.num_houses * 2 / 9;
 			break;
 
 		case TL_3X3_GRID:
 		case TL_2X2_GRID:
-			_grow_town_result = 10 + t->cache.num_houses * 1 / 9;
+			iterations = 10 + t->cache.num_houses * 1 / 9;
 			break;
 
 		default:
-			_grow_town_result = 10 + t->cache.num_houses * 4 / 9;
+			iterations = 10 + t->cache.num_houses * 4 / 9;
 			break;
 	}
 
@@ -1820,7 +1818,7 @@ static bool GrowTownAtRoad(Town *t, TileIndex tile)
 			case TownGrowthResult::Succeed:
 				return true;
 			case TownGrowthResult::SearchStopped:
-				_grow_town_result = 0;
+				iterations = 0;
 				break;
 			default:
 				break;
@@ -1862,7 +1860,7 @@ static bool GrowTownAtRoad(Town *t, TileIndex tile)
 		}
 
 		/* Max number of times is checked. */
-	} while (--_grow_town_result >= 0);
+	} while (--iterations >= 0);
 
 	return false;
 }


### PR DESCRIPTION
## Motivation / Problem

`_grow_town_result` is currently a global variable, which is
* reset at the start of `GrowTownAtRoad`,
* assigned by various functions called during `GrowTownAtRoad`, and
* checked and adjusted in `GrowTownAtRoad` again.

Quite a mess.

## Description

* `GrowTownWithExtraHouse`, `GrowTownWithRoad`, `GrowTownWithBridge` and `GrowTownWithTunnel` only assign `_grow_town_result`, if they also return `true`. So remove the assignment from these functions and put it on the callers side.
* This puts all assignments of `_grow_town_result` into `GrowTownInTile`. Again remove all assignments from `GrowTownInTile`, and instead return the "desired new value", so the caller `GrowTownAtRoad` can deal with it.
* Now `_grow_town_result` is only used in `GrowTownAtRoad`, so turn it into a local variable.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
