### PR TITLE
Fix #14216, d030d17: RealSpriteGroups referencing CallbackResultSpriteGroups were always treated as callback-failure.

### DIFF
--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -998,14 +998,14 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 }
 
 
-/* virtual */ ResolverResult VehicleResolverObject::ResolveReal(const RealSpriteGroup &group) const
+/* virtual */ const SpriteGroup *VehicleResolverObject::ResolveReal(const RealSpriteGroup &group) const
 {
 	const Vehicle *v = this->self_scope.v;
 
 	if (v == nullptr) {
 		if (!group.loading.empty()) return group.loading[0];
 		if (!group.loaded.empty()) return group.loaded[0];
-		return std::monostate{};
+		return nullptr;
 	}
 
 	const Order &order = v->First()->current_order;
@@ -1014,7 +1014,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 
 	uint totalsets = static_cast<uint>(in_motion ? group.loaded.size() : group.loading.size());
 
-	if (totalsets == 0) return std::monostate{};
+	if (totalsets == 0) return nullptr;
 
 	uint set = (v->cargo.StoredCount() * totalsets) / std::max<uint16_t>(1u, v->cargo_cap);
 	set = std::min(set, totalsets - 1);

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -64,7 +64,7 @@ struct VehicleResolverObject : public SpecializedResolverObject<VehicleRandomTri
 
 	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0) override;
 
-	ResolverResult ResolveReal(const RealSpriteGroup &group) const override;
+	const SpriteGroup *ResolveReal(const RealSpriteGroup &group) const override;
 
 	GrfSpecFeature GetFeature() const override;
 	uint32_t GetDebugID() const override;

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -120,12 +120,12 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
  * @param group Group to get.
  * @return The available sprite group.
  */
-/* virtual */ ResolverResult ResolverObject::ResolveReal(const RealSpriteGroup &group) const
+/* virtual */ const SpriteGroup *ResolverObject::ResolveReal(const RealSpriteGroup &group) const
 {
 	if (!group.loaded.empty()) return group.loaded[0];
 	if (!group.loading.empty()) return group.loading[0];
 
-	return std::monostate{};
+	return nullptr;
 }
 
 /**
@@ -274,7 +274,10 @@ static bool RangeHighComparator(const DeterministicSpriteGroupRange &range, uint
 
 /* virtual */ ResolverResult RealSpriteGroup::Resolve(ResolverObject &object) const
 {
-	return object.ResolveReal(*this);
+	/* Call the feature specific evaluation via ResultSpriteGroup::ResolveReal.
+	 * The result is either ResultSpriteGroup, CallbackResultSpriteGroup, or nullptr.
+	 */
+	return SpriteGroup::Resolve(object.ResolveReal(*this), object, false);
 }
 
 /**

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -381,7 +381,7 @@ public:
 		return value != nullptr ? *value : CALLBACK_FAILED;
 	}
 
-	virtual ResolverResult ResolveReal(const RealSpriteGroup &group) const;
+	virtual const SpriteGroup *ResolveReal(const RealSpriteGroup &group) const;
 
 	virtual ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, uint8_t relative = 0);
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -519,11 +519,11 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 	return UINT_MAX;
 }
 
-/* virtual */ ResolverResult StationResolverObject::ResolveReal(const RealSpriteGroup &group) const
+/* virtual */ const SpriteGroup *StationResolverObject::ResolveReal(const RealSpriteGroup &group) const
 {
 	if (this->station_scope.st == nullptr || !Station::IsExpected(this->station_scope.st)) {
 		if (!group.loading.empty()) return group.loading[0];
-		return std::monostate{};
+		return nullptr;
 	}
 
 	uint cargo = 0;
@@ -566,7 +566,7 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 	}
 
 	if (!group.loading.empty()) return group.loading[0];
-	return std::monostate{};
+	return nullptr;
 }
 
 GrfSpecFeature StationResolverObject::GetFeature() const

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -75,7 +75,7 @@ struct StationResolverObject : public SpecializedResolverObject<StationRandomTri
 		}
 	}
 
-	ResolverResult ResolveReal(const RealSpriteGroup &group) const override;
+	const SpriteGroup *ResolveReal(const RealSpriteGroup &group) const override;
 
 	GrfSpecFeature GetFeature() const override;
 	uint32_t GetDebugID() const override;


### PR DESCRIPTION
## Motivation / Problem

#14216

* `ResolverObject::ResolveReal` returned `CallbackResultSpriteGroups` as references.
* Noone converted them into `CallbackResult`.

## Description

* Revert `ResolverObject::ResolveReal` to the state before d030d17, returning `const SpriteGroup *`.
* Make `RealSpriteGroup::Resolve` pass the result to the top-level `SpriteGroup::Resolve`, like all non-leaf sprite groups. (`DeterministicSpriteGroup`, `RandomizedSpriteGroup`, `RealSpriteGroup`)


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
