### PR TITLE
Codechange: Remove global state from spritelayout processing.

### DIFF
--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -243,7 +243,8 @@ uint16_t GetAirportTileCallback(CallbackID callback, uint32_t param1, uint32_t p
 
 static void AirportDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, Colours colour)
 {
-	auto dts = group->ProcessRegisters(nullptr);
+	auto processor = group->ProcessRegisters(nullptr);
+	auto dts = processor.GetLayout();
 
 	SpriteID image = dts.ground.sprite;
 	SpriteID pal = dts.ground.pal;

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -243,10 +243,10 @@ uint16_t GetAirportTileCallback(CallbackID callback, uint32_t param1, uint32_t p
 
 static void AirportDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, Colours colour)
 {
-	const DrawTileSprites *dts = group->ProcessRegisters(nullptr);
+	auto dts = group->ProcessRegisters(nullptr);
 
-	SpriteID image = dts->ground.sprite;
-	SpriteID pal   = dts->ground.pal;
+	SpriteID image = dts.ground.sprite;
+	SpriteID pal = dts.ground.pal;
 
 	if (GB(image, 0, SPRITE_WIDTH) != 0) {
 		if (image == SPR_FLAT_WATER_TILE && IsTileOnWater(ti->tile)) {
@@ -256,7 +256,7 @@ static void AirportDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGrou
 		}
 	}
 
-	DrawNewGRFTileSeq(ti, dts, TO_BUILDINGS, 0, GetColourPalette(colour));
+	DrawNewGRFTileSeq(ti, &dts, TO_BUILDINGS, 0, GetColourPalette(colour));
 }
 
 bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts)

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -142,10 +142,9 @@ struct NewGRFSpriteLayout : DrawTileSprites {
 	 * @pre #PrepareLayout() and #ProcessRegisters() need calling first.
 	 * @return result spritelayout
 	 */
-	std::span<DrawTileSeqStruct> GetLayout(PalSpriteID *ground) const
+	DrawTileSpriteSpan GetLayout() const
 	{
-		*ground = result_seq[0].image;
-		return {++result_seq.begin(), result_seq.end()};
+		return {result_seq[0].image, {++result_seq.begin(), result_seq.end()}};
 	}
 
 	std::span<const DrawTileSeqStruct> GetSequence() const override { return {this->seq.begin(), this->seq.end()}; }

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -463,7 +463,8 @@ uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2,
 
 static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, uint8_t stage, HouseID house_id)
 {
-	auto dts = group->ProcessRegisters(&stage);
+	auto processor = group->ProcessRegisters(&stage);
+	auto dts = processor.GetLayout();
 
 	const HouseSpec *hs = HouseSpec::Get(house_id);
 	PaletteID palette = GetColourPalette(hs->random_colour[TileHash2Bit(ti->x, ti->y)]);
@@ -528,7 +529,8 @@ void DrawNewHouseTileInGUI(int x, int y, const HouseSpec *spec, HouseID house_id
 	if (group == nullptr) return;
 
 	uint8_t stage = TOWN_HOUSE_COMPLETED;
-	auto dts = group->ProcessRegisters(&stage);
+	auto processor = group->ProcessRegisters(&stage);
+	auto dts = processor.GetLayout();
 
 	PaletteID palette = GetColourPalette(spec->random_colour[0]);
 	if (spec->callback_mask.Test(HouseCallbackMask::Colour)) {

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -463,7 +463,7 @@ uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2,
 
 static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, uint8_t stage, HouseID house_id)
 {
-	const DrawTileSprites *dts = group->ProcessRegisters(&stage);
+	auto dts = group->ProcessRegisters(&stage);
 
 	const HouseSpec *hs = HouseSpec::Get(house_id);
 	PaletteID palette = GetColourPalette(hs->random_colour[TileHash2Bit(ti->x, ti->y)]);
@@ -475,8 +475,8 @@ static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *grou
 		}
 	}
 
-	SpriteID image = dts->ground.sprite;
-	PaletteID pal  = dts->ground.pal;
+	SpriteID image = dts.ground.sprite;
+	PaletteID pal = dts.ground.pal;
 
 	if (HasBit(image, SPRITE_MODIFIER_CUSTOM_SPRITE)) image += stage;
 	if (HasBit(pal, SPRITE_MODIFIER_CUSTOM_SPRITE)) pal += stage;
@@ -485,7 +485,7 @@ static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *grou
 		DrawGroundSprite(image, GroundSpritePaletteTransform(image, pal, palette));
 	}
 
-	DrawNewGRFTileSeq(ti, dts, TO_HOUSES, stage, palette);
+	DrawNewGRFTileSeq(ti, &dts, TO_HOUSES, stage, palette);
 }
 
 void DrawNewHouseTile(TileInfo *ti, HouseID house_id)
@@ -528,7 +528,7 @@ void DrawNewHouseTileInGUI(int x, int y, const HouseSpec *spec, HouseID house_id
 	if (group == nullptr) return;
 
 	uint8_t stage = TOWN_HOUSE_COMPLETED;
-	const DrawTileSprites *dts = group->ProcessRegisters(&stage);
+	auto dts = group->ProcessRegisters(&stage);
 
 	PaletteID palette = GetColourPalette(spec->random_colour[0]);
 	if (spec->callback_mask.Test(HouseCallbackMask::Colour)) {
@@ -539,8 +539,8 @@ void DrawNewHouseTileInGUI(int x, int y, const HouseSpec *spec, HouseID house_id
 		}
 	}
 
-	SpriteID image = dts->ground.sprite;
-	PaletteID pal = dts->ground.pal;
+	SpriteID image = dts.ground.sprite;
+	PaletteID pal = dts.ground.pal;
 
 	if (HasBit(image, SPRITE_MODIFIER_CUSTOM_SPRITE)) image += stage;
 	if (HasBit(pal, SPRITE_MODIFIER_CUSTOM_SPRITE)) pal += stage;
@@ -549,7 +549,7 @@ void DrawNewHouseTileInGUI(int x, int y, const HouseSpec *spec, HouseID house_id
 		DrawSprite(image, GroundSpritePaletteTransform(image, pal, palette), x, y);
 	}
 
-	DrawNewGRFTileSeqInGUI(x, y, dts, stage, palette);
+	DrawNewGRFTileSeqInGUI(x, y, &dts, stage, palette);
 }
 
 /* Simple wrapper for GetHouseCallback to keep the animation unified. */

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -160,7 +160,8 @@ uint32_t IndustryTileResolverObject::GetDebugID() const
 
 static void IndustryDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, Colours rnd_colour, uint8_t stage)
 {
-	auto dts = group->ProcessRegisters(&stage);
+	auto processor = group->ProcessRegisters(&stage);
+	auto dts = processor.GetLayout();
 
 	SpriteID image = dts.ground.sprite;
 	PaletteID pal = dts.ground.pal;

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -160,10 +160,10 @@ uint32_t IndustryTileResolverObject::GetDebugID() const
 
 static void IndustryDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, Colours rnd_colour, uint8_t stage)
 {
-	const DrawTileSprites *dts = group->ProcessRegisters(&stage);
+	auto dts = group->ProcessRegisters(&stage);
 
-	SpriteID image = dts->ground.sprite;
-	PaletteID pal  = dts->ground.pal;
+	SpriteID image = dts.ground.sprite;
+	PaletteID pal = dts.ground.pal;
 
 	if (HasBit(image, SPRITE_MODIFIER_CUSTOM_SPRITE)) image += stage;
 	if (HasBit(pal, SPRITE_MODIFIER_CUSTOM_SPRITE)) pal += stage;
@@ -178,7 +178,7 @@ static void IndustryDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGro
 		}
 	}
 
-	DrawNewGRFTileSeq(ti, dts, TO_INDUSTRIES, stage, GetColourPalette(rnd_colour));
+	DrawNewGRFTileSeq(ti, &dts, TO_INDUSTRIES, stage, GetColourPalette(rnd_colour));
 }
 
 uint16_t GetIndustryTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, IndustryGfx gfx_id, Industry *industry, TileIndex tile)

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -444,7 +444,8 @@ uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2
  */
 static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, const ObjectSpec *spec)
 {
-	auto dts = group->ProcessRegisters(nullptr);
+	auto processor = group->ProcessRegisters(nullptr);
+	auto dts = processor.GetLayout();
 	PaletteID palette = (spec->flags.Test(ObjectFlag::Uses2CC) ? SPR_2CCMAP_BASE : PALETTE_RECOLOUR_START) + Object::GetByTile(ti->tile)->colour;
 
 	SpriteID image = dts.ground.sprite;
@@ -492,7 +493,8 @@ void DrawNewObjectTileInGUI(int x, int y, const ObjectSpec *spec, uint8_t view)
 	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return;
 
-	auto dts = group->ProcessRegisters(nullptr);
+	auto processor = group->ProcessRegisters(nullptr);
+	auto dts = processor.GetLayout();
 
 	PaletteID palette;
 	if (Company::IsValidID(_local_company)) {

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -444,11 +444,11 @@ uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2
  */
 static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, const ObjectSpec *spec)
 {
-	const DrawTileSprites *dts = group->ProcessRegisters(nullptr);
+	auto dts = group->ProcessRegisters(nullptr);
 	PaletteID palette = (spec->flags.Test(ObjectFlag::Uses2CC) ? SPR_2CCMAP_BASE : PALETTE_RECOLOUR_START) + Object::GetByTile(ti->tile)->colour;
 
-	SpriteID image = dts->ground.sprite;
-	PaletteID pal  = dts->ground.pal;
+	SpriteID image = dts.ground.sprite;
+	PaletteID pal = dts.ground.pal;
 
 	if (GB(image, 0, SPRITE_WIDTH) != 0) {
 		/* If the ground sprite is the default flat water sprite, draw also canal/river borders
@@ -460,7 +460,7 @@ static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *grou
 		}
 	}
 
-	DrawNewGRFTileSeq(ti, dts, TO_STRUCTURES, 0, palette);
+	DrawNewGRFTileSeq(ti, &dts, TO_STRUCTURES, 0, palette);
 }
 
 /**
@@ -492,7 +492,7 @@ void DrawNewObjectTileInGUI(int x, int y, const ObjectSpec *spec, uint8_t view)
 	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return;
 
-	const DrawTileSprites *dts = group->ProcessRegisters(nullptr);
+	auto dts = group->ProcessRegisters(nullptr);
 
 	PaletteID palette;
 	if (Company::IsValidID(_local_company)) {
@@ -508,14 +508,14 @@ void DrawNewObjectTileInGUI(int x, int y, const ObjectSpec *spec, uint8_t view)
 		palette = spec->flags.Test(ObjectFlag::Uses2CC) ? SPR_2CCMAP_BASE : PALETTE_RECOLOUR_START;
 	}
 
-	SpriteID image = dts->ground.sprite;
-	PaletteID pal  = dts->ground.pal;
+	SpriteID image = dts.ground.sprite;
+	PaletteID pal = dts.ground.pal;
 
 	if (GB(image, 0, SPRITE_WIDTH) != 0) {
 		DrawSprite(image, GroundSpritePaletteTransform(image, pal, palette), x, y);
 	}
 
-	DrawNewGRFTileSeqInGUI(x, y, dts, 0, palette);
+	DrawNewGRFTileSeqInGUI(x, y, &dts, 0, palette);
 }
 
 /**

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -293,7 +293,8 @@ void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec,
 	RoadStopResolverObject object(spec, nullptr, INVALID_TILE, roadtype, type, view);
 	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return;
-	auto dts = group->ProcessRegisters(nullptr);
+	auto processor = group->ProcessRegisters(nullptr);
+	auto dts = processor.GetLayout();
 
 	PaletteID palette = GetCompanyPalette(_local_company);
 

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -293,12 +293,12 @@ void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec,
 	RoadStopResolverObject object(spec, nullptr, INVALID_TILE, roadtype, type, view);
 	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return;
-	const DrawTileSprites *dts = group->ProcessRegisters(nullptr);
+	auto dts = group->ProcessRegisters(nullptr);
 
 	PaletteID palette = GetCompanyPalette(_local_company);
 
-	SpriteID image = dts->ground.sprite;
-	PaletteID pal  = dts->ground.pal;
+	SpriteID image = dts.ground.sprite;
+	PaletteID pal = dts.ground.pal;
 
 	RoadStopDrawModes draw_mode;
 	if (spec->flags.Test(RoadStopSpecFlag::DrawModeRegister)) {
@@ -340,7 +340,7 @@ void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec,
 		}
 	}
 
-	DrawCommonTileSeqInGUI(x, y, dts, 0, 0, palette, true);
+	DrawCommonTileSeqInGUI(x, y, &dts, 0, 0, palette, true);
 }
 
 const TileLayoutSpriteGroup *GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view)

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -287,19 +287,19 @@ static bool RangeHighComparator(const DeterministicSpriteGroupRange &range, uint
  * @param[in,out] stage Construction stage (0-3), or nullptr if not applicable.
  * @return sprite layout to draw.
  */
-DrawTileSpriteSpan TileLayoutSpriteGroup::ProcessRegisters(uint8_t *stage) const
+SpriteLayoutProcessor TileLayoutSpriteGroup::ProcessRegisters(uint8_t *stage) const
 {
 	if (!this->dts.NeedsPreprocessing()) {
 		if (stage != nullptr && this->dts.consistent_max_offset > 0) *stage = GetConstructionStageOffset(*stage, this->dts.consistent_max_offset);
-		return {this->dts.ground, this->dts.seq};
+		return SpriteLayoutProcessor(this->dts);
 	}
 
 	uint8_t actual_stage = stage != nullptr ? *stage : 0;
-	this->dts.PrepareLayout(0, 0, 0, actual_stage, false);
-	this->dts.ProcessRegisters(0, 0, false);
+	SpriteLayoutProcessor result(this->dts, 0, 0, 0, actual_stage, false);
+	result.ProcessRegisters(0, 0);
 
 	/* Stage has been processed by PrepareLayout(), set it to zero. */
 	if (stage != nullptr) *stage = 0;
 
-	return this->dts.GetLayout();
+	return result;
 }

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -287,21 +287,19 @@ static bool RangeHighComparator(const DeterministicSpriteGroupRange &range, uint
  * @param[in,out] stage Construction stage (0-3), or nullptr if not applicable.
  * @return sprite layout to draw.
  */
-const DrawTileSprites *TileLayoutSpriteGroup::ProcessRegisters(uint8_t *stage) const
+DrawTileSpriteSpan TileLayoutSpriteGroup::ProcessRegisters(uint8_t *stage) const
 {
 	if (!this->dts.NeedsPreprocessing()) {
 		if (stage != nullptr && this->dts.consistent_max_offset > 0) *stage = GetConstructionStageOffset(*stage, this->dts.consistent_max_offset);
-		return &this->dts;
+		return {this->dts.ground, this->dts.seq};
 	}
 
-	static DrawTileSpriteSpan result;
 	uint8_t actual_stage = stage != nullptr ? *stage : 0;
 	this->dts.PrepareLayout(0, 0, 0, actual_stage, false);
 	this->dts.ProcessRegisters(0, 0, false);
-	result.seq = this->dts.GetLayout(&result.ground);
 
 	/* Stage has been processed by PrepareLayout(), set it to zero. */
 	if (stage != nullptr) *stage = 0;
 
-	return &result;
+	return this->dts.GetLayout();
 }

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -260,7 +260,7 @@ struct TileLayoutSpriteGroup : SpriteGroup {
 
 	NewGRFSpriteLayout dts{};
 
-	const DrawTileSprites *ProcessRegisters(uint8_t *stage) const;
+	DrawTileSpriteSpan ProcessRegisters(uint8_t *stage) const;
 };
 
 struct IndustryProductionSpriteGroup : SpriteGroup {

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -260,7 +260,7 @@ struct TileLayoutSpriteGroup : SpriteGroup {
 
 	NewGRFSpriteLayout dts{};
 
-	DrawTileSpriteSpan ProcessRegisters(uint8_t *stage) const;
+	SpriteLayoutProcessor ProcessRegisters(uint8_t *stage) const;
 };
 
 struct IndustryProductionSpriteGroup : SpriteGroup {

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -842,7 +842,7 @@ bool DrawStationTile(int x, int y, RailType railtype, Axis axis, StationClassID 
 			layout->ProcessRegisters(var10, var10_relocation, separate_ground);
 		}
 
-		tmp_rail_layout.seq = layout->GetLayout(&tmp_rail_layout.ground);
+		tmp_rail_layout = layout->GetLayout();
 		sprites = &tmp_rail_layout;
 		total_offset = 0;
 	} else {

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -821,6 +821,7 @@ bool DrawStationTile(int x, int y, RailType railtype, Axis axis, StationClassID 
 	uint32_t relocation = 0;
 	uint32_t ground_relocation = 0;
 	const NewGRFSpriteLayout *layout = nullptr;
+	SpriteLayoutProcessor processor; // owns heap, borrowed by tmp_rail_layout and sprites
 	DrawTileSpriteSpan tmp_rail_layout;
 
 	if (statspec->renderdata.empty()) {
@@ -836,13 +837,12 @@ bool DrawStationTile(int x, int y, RailType railtype, Axis axis, StationClassID 
 	if (layout != nullptr) {
 		/* Sprite layout which needs preprocessing */
 		bool separate_ground = statspec->flags.Test(StationSpecFlag::SeparateGround);
-		uint32_t var10_values = layout->PrepareLayout(total_offset, rti->fallback_railtype, 0, 0, separate_ground);
-		for (uint8_t var10 : SetBitIterator(var10_values)) {
+		processor = SpriteLayoutProcessor(*layout, total_offset, rti->fallback_railtype, 0, 0, separate_ground);
+		for (uint8_t var10 : processor.Var10Values()) {
 			uint32_t var10_relocation = GetCustomStationRelocation(statspec, nullptr, INVALID_TILE, var10);
-			layout->ProcessRegisters(var10, var10_relocation, separate_ground);
+			processor.ProcessRegisters(var10, var10_relocation);
 		}
-
-		tmp_rail_layout = layout->GetLayout();
+		tmp_rail_layout = processor.GetLayout();
 		sprites = &tmp_rail_layout;
 		total_offset = 0;
 	} else {

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -58,8 +58,7 @@ struct DrawTileSprites {
 struct DrawTileSpriteSpan : DrawTileSprites {
 	std::span<const DrawTileSeqStruct> seq; ///< Child sprites,
 
-	template <size_t N>
-	DrawTileSpriteSpan(PalSpriteID ground, const DrawTileSeqStruct (&seq)[N]) : DrawTileSprites(ground), seq(std::begin(seq), std::end(seq)) {}
+	DrawTileSpriteSpan(PalSpriteID ground, std::span<const DrawTileSeqStruct> seq) : DrawTileSprites(ground), seq(seq) {}
 	DrawTileSpriteSpan(PalSpriteID ground) : DrawTileSprites(ground) {};
 	DrawTileSpriteSpan() = default;
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3076,7 +3076,7 @@ bool SplitGroundSpriteForOverlay(const TileInfo *ti, SpriteID *ground, RailTrack
 static void DrawTile_Station(TileInfo *ti)
 {
 	const NewGRFSpriteLayout *layout = nullptr;
-	DrawTileSpriteSpan tmp_rail_layout;
+	DrawTileSpriteSpan tmp_layout;
 	const DrawTileSprites *t = nullptr;
 	int32_t total_offset;
 	const RailTypeInfo *rti = nullptr;
@@ -3273,8 +3273,8 @@ draw_default_foundation:
 				uint32_t var10_relocation = GetCustomStationRelocation(statspec, st, ti->tile, var10);
 				layout->ProcessRegisters(var10, var10_relocation, separate_ground);
 			}
-			tmp_rail_layout.seq = layout->GetLayout(&tmp_rail_layout.ground);
-			t = &tmp_rail_layout;
+			tmp_layout = layout->GetLayout();
+			t = &tmp_layout;
 			total_offset = 0;
 		} else if (statspec != nullptr) {
 			/* Simple sprite layout */
@@ -3337,7 +3337,8 @@ draw_default_foundation:
 				if (type == StationType::RoadWaypoint && stop_draw_mode.Test(RoadStopDrawMode::WaypGround)) {
 					draw_ground = true;
 				}
-				t = group->ProcessRegisters(nullptr);
+				tmp_layout = group->ProcessRegisters(nullptr);
+				t = &tmp_layout;
 			}
 		}
 


### PR DESCRIPTION
## Motivation / Problem

Long road to multithreaded sprite resolving.

## Description

* `TileLayoutSpriteGroup::ProcessRegisters` returns a reference to a `static DrawTileSpriteSpan`. This struct is tiny, so just return it on the stack.
* `NewGRFSpriteLayout` needs a `std::vector<DrawTileSeqStruct>` for advanced spritelayout with registers. Move this to a separate class, which owns the allocation. This is just one heap allocation per drawn tile, it can even properly `reserve` the size.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
