### PR TITLE
Codechange: Access temporary storage only through ResolverObject.

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -796,7 +796,8 @@ static int DrawAircraftPurchaseInfo(int left, int right, int y, EngineID engine_
  */
 static std::optional<std::string> GetNewGRFAdditionalText(EngineID engine)
 {
-	uint16_t callback = GetVehicleCallback(CBID_VEHICLE_ADDITIONAL_TEXT, 0, 0, engine, nullptr);
+	std::array<int32_t, 6> regs100;
+	uint16_t callback = GetVehicleCallback(CBID_VEHICLE_ADDITIONAL_TEXT, 0, 0, engine, nullptr, regs100);
 	if (callback == CALLBACK_FAILED || callback == 0x400) return std::nullopt;
 	const GRFFile *grffile = Engine::Get(engine)->GetGRF();
 	assert(grffile != nullptr);
@@ -805,7 +806,7 @@ static std::optional<std::string> GetNewGRFAdditionalText(EngineID engine)
 		return std::nullopt;
 	}
 
-	return GetGRFStringWithTextStack(grffile, GRFSTR_MISC_GRF_TEXT + callback, 6);
+	return GetGRFStringWithTextStack(grffile, GRFSTR_MISC_GRF_TEXT + callback, regs100);
 }
 
 /**

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2804,11 +2804,12 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
 
 	bool callback_enabled = indspec->callback_mask.Test(monthly ? IndustryCallbackMask::MonthlyProdChange : IndustryCallbackMask::ProductionChange);
 	if (callback_enabled) {
-		uint16_t res = GetIndustryCallback(monthly ? CBID_INDUSTRY_MONTHLYPROD_CHANGE : CBID_INDUSTRY_PRODUCTION_CHANGE, 0, Random(), i, i->type, i->location.tile);
+		std::array<int32_t, 1> regs100;
+		uint16_t res = GetIndustryCallback(monthly ? CBID_INDUSTRY_MONTHLYPROD_CHANGE : CBID_INDUSTRY_PRODUCTION_CHANGE, 0, Random(), i, i->type, i->location.tile, regs100);
 		if (res != CALLBACK_FAILED) { // failed callback means "do nothing"
 			suppress_message = HasBit(res, 7);
 			/* Get the custom message if any */
-			if (HasBit(res, 8)) str = MapGRFStringID(indspec->grf_prop.grfid, GRFStringID(GB(GetRegister(0x100), 0, 16)));
+			if (HasBit(res, 8)) str = MapGRFStringID(indspec->grf_prop.grfid, GRFStringID(GB(regs100[0], 0, 16)));
 			res = GB(res, 0, 4);
 			switch (res) {
 				default: NOT_REACHED();
@@ -2826,7 +2827,7 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
 					increment = res == 0x0D ? -1 : 1;
 					break;
 				case 0xF:                         // Set production to third byte of register 0x100
-					i->prod_level = Clamp(GB(GetRegister(0x100), 16, 8), PRODLEVEL_MINIMUM, PRODLEVEL_MAXIMUM);
+					i->prod_level = Clamp(GB(regs100[0], 16, 8), PRODLEVEL_MINIMUM, PRODLEVEL_MAXIMUM);
 					recalculate_multipliers = true;
 					break;
 			}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -101,13 +101,14 @@ static void GetCargoSuffix(uint cargo, CargoSuffixType cst, const Industry *ind,
 
 	if (indspec->callback_mask.Test(IndustryCallbackMask::CargoSuffix)) {
 		TileIndex t = (cst != CST_FUND) ? ind->location.tile : INVALID_TILE;
-		uint16_t callback = GetIndustryCallback(CBID_INDUSTRY_CARGO_SUFFIX, 0, (cst << 8) | cargo, const_cast<Industry *>(ind), ind_type, t);
+		std::array<int32_t, 6> regs100;
+		uint16_t callback = GetIndustryCallback(CBID_INDUSTRY_CARGO_SUFFIX, 0, (cst << 8) | cargo, const_cast<Industry *>(ind), ind_type, t, regs100);
 		if (callback == CALLBACK_FAILED) return;
 
 		if (indspec->grf_prop.grffile->grf_version < 8) {
 			if (GB(callback, 0, 8) == 0xFF) return;
 			if (callback < 0x400) {
-				suffix.text = GetGRFStringWithTextStack(indspec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback, 6);
+				suffix.text = GetGRFStringWithTextStack(indspec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback, regs100);
 				suffix.display = CSD_CARGO_AMOUNT_TEXT;
 				return;
 			}
@@ -121,12 +122,12 @@ static void GetCargoSuffix(uint cargo, CargoSuffixType cst, const Industry *ind,
 				return;
 			}
 			if (callback < 0x400) {
-				suffix.text = GetGRFStringWithTextStack(indspec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback, 6);
+				suffix.text = GetGRFStringWithTextStack(indspec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback, regs100);
 				suffix.display = CSD_CARGO_AMOUNT_TEXT;
 				return;
 			}
 			if (callback >= 0x800 && callback < 0xC00) {
-				suffix.text = GetGRFStringWithTextStack(indspec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback - 0x800, 6);
+				suffix.text = GetGRFStringWithTextStack(indspec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback - 0x800, regs100);
 				suffix.display = CSD_CARGO_TEXT;
 				return;
 			}
@@ -590,12 +591,13 @@ public:
 
 				/* Get the additional purchase info text, if it has not already been queried. */
 				if (indsp->callback_mask.Test(IndustryCallbackMask::FundMoreText)) {
-					uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_FUND_MORE_TEXT, 0, 0, nullptr, this->selected_type, INVALID_TILE);
+					std::array<int32_t, 6> regs100;
+					uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_FUND_MORE_TEXT, 0, 0, nullptr, this->selected_type, INVALID_TILE, regs100);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 						if (callback_res > 0x400) {
 							ErrorUnknownCallbackResult(indsp->grf_prop.grfid, CBID_INDUSTRY_FUND_MORE_TEXT, callback_res);
 						} else {
-							std::string str = GetGRFStringWithTextStack(indsp->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, 6);
+							std::string str = GetGRFStringWithTextStack(indsp->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, regs100);
 							if (!str.empty()) {
 								DrawStringMultiLine(ir, str, TC_YELLOW);
 							}
@@ -972,12 +974,13 @@ public:
 
 		/* Get the extra message for the GUI */
 		if (ind->callback_mask.Test(IndustryCallbackMask::WindowMoreText)) {
-			uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_WINDOW_MORE_TEXT, 0, 0, i, i->type, i->location.tile);
+			std::array<int32_t, 6> regs100;
+			uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_WINDOW_MORE_TEXT, 0, 0, i, i->type, i->location.tile, regs100);
 			if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 				if (callback_res > 0x400) {
 					ErrorUnknownCallbackResult(ind->grf_prop.grfid, CBID_INDUSTRY_WINDOW_MORE_TEXT, callback_res);
 				} else {
-					std::string str = GetGRFStringWithTextStack(ind->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, 6);
+					std::string str = GetGRFStringWithTextStack(ind->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, regs100);
 					if (!str.empty()) {
 						ir.top += WidgetDimensions::scaled.vsep_wide;
 						ir.top = DrawStringMultiLine(ir, str, TC_YELLOW);

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -264,10 +264,10 @@ SpriteID GetCustomAirportSprite(const AirportSpec *as, uint8_t layout)
 	return group->sprite;
 }
 
-uint16_t GetAirportCallback(CallbackID callback, uint32_t param1, uint32_t param2, Station *st, TileIndex tile)
+uint16_t GetAirportCallback(CallbackID callback, uint32_t param1, uint32_t param2, Station *st, TileIndex tile, std::span<int32_t> regs100)
 {
 	AirportResolverObject object(tile, st, AirportSpec::Get(st->airport.type), st->airport.layout, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 /**
@@ -280,7 +280,7 @@ uint16_t GetAirportCallback(CallbackID callback, uint32_t param1, uint32_t param
 StringID GetAirportTextCallback(const AirportSpec *as, uint8_t layout, uint16_t callback)
 {
 	AirportResolverObject object(INVALID_TILE, nullptr, as, layout, (CallbackID)callback);
-	uint16_t cb_res = object.ResolveCallback();
+	uint16_t cb_res = object.ResolveCallback({});
 	if (cb_res == CALLBACK_FAILED || cb_res == 0x400) return STR_UNDEFINED;
 	if (cb_res > 0x400) {
 		ErrorUnknownCallbackResult(as->grf_prop.grfid, callback, cb_res);

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -276,7 +276,7 @@ bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts)
 		return false;
 	}
 
-	auto processor = group->ProcessRegisters(nullptr);
+	auto processor = group->ProcessRegisters(object, nullptr);
 	auto dts = processor.GetLayout();
 	AirportDrawTileLayout(ti, dts, Company::Get(st->owner)->colour);
 	return true;

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -235,10 +235,10 @@ uint32_t AirportTileResolverObject::GetDebugID() const
 	return this->tiles_scope.ats->grf_prop.local_id;
 }
 
-uint16_t GetAirportTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, const AirportTileSpec *ats, Station *st, TileIndex tile, [[maybe_unused]] int extra_data = 0)
+static uint16_t GetAirportTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, const AirportTileSpec *ats, Station *st, TileIndex tile, std::span<int32_t> regs100 = {})
 {
 	AirportTileResolverObject object(ats, tile, st, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 static void AirportDrawTileLayout(const TileInfo *ti, const DrawTileSpriteSpan &dts, Colours colour)
@@ -282,8 +282,14 @@ bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts)
 	return true;
 }
 
+/* Simple wrapper for GetAirportTileCallback to keep the animation unified. */
+static uint16_t GetSimpleAirportTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, const AirportTileSpec *ats, Station *st, TileIndex tile, int)
+{
+	return GetAirportTileCallback(callback, param1, param2, ats, st, tile);
+}
+
 /** Helper class for animation control. */
-struct AirportTileAnimationBase : public AnimationBase<AirportTileAnimationBase, AirportTileSpec, Station, int, GetAirportTileCallback, TileAnimationFrameAnimationHelper<Station> > {
+struct AirportTileAnimationBase : public AnimationBase<AirportTileAnimationBase, AirportTileSpec, Station, int, GetSimpleAirportTileCallback, TileAnimationFrameAnimationHelper<Station>> {
 	static constexpr CallbackID cb_animation_speed      = CBID_AIRPTILE_ANIMATION_SPEED;
 	static constexpr CallbackID cb_animation_next_frame = CBID_AIRPTILE_ANIMATION_NEXT_FRAME;
 

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -241,11 +241,8 @@ uint16_t GetAirportTileCallback(CallbackID callback, uint32_t param1, uint32_t p
 	return object.ResolveCallback();
 }
 
-static void AirportDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, Colours colour)
+static void AirportDrawTileLayout(const TileInfo *ti, const DrawTileSpriteSpan &dts, Colours colour)
 {
-	auto processor = group->ProcessRegisters(nullptr);
-	auto dts = processor.GetLayout();
-
 	SpriteID image = dts.ground.sprite;
 	SpriteID pal = dts.ground.pal;
 
@@ -279,7 +276,9 @@ bool DrawNewAirportTile(TileInfo *ti, Station *st, const AirportTileSpec *airts)
 		return false;
 	}
 
-	AirportDrawTileLayout(ti, group, Company::Get(st->owner)->colour);
+	auto processor = group->ProcessRegisters(nullptr);
+	auto dts = processor.GetLayout();
+	AirportDrawTileLayout(ti, dts, Company::Get(st->owner)->colour);
 	return true;
 }
 

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -153,12 +153,13 @@ SpriteID GetCanalSprite(CanalFeature feature, TileIndex tile)
  * @param param2   Callback parameter 2.
  * @param feature  For which feature to run the callback.
  * @param tile     Tile index of canal.
+ * @param[out] regs100 Additional result values from registers 100+
  * @return Callback result or #CALLBACK_FAILED if the callback failed.
  */
-static uint16_t GetCanalCallback(CallbackID callback, uint32_t param1, uint32_t param2, CanalFeature feature, TileIndex tile)
+static uint16_t GetCanalCallback(CallbackID callback, uint32_t param1, uint32_t param2, CanalFeature feature, TileIndex tile, std::span<int32_t> regs100 = {})
 {
 	CanalResolverObject object(feature, tile, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 /**

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -62,10 +62,10 @@ SpriteID GetCustomCargoSprite(const CargoSpec *cs)
 }
 
 
-uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2, const CargoSpec *cs)
+uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2, const CargoSpec *cs, std::span<int32_t> regs100)
 {
 	CargoResolverObject object(cs, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 /**

--- a/src/newgrf_cargo.h
+++ b/src/newgrf_cargo.h
@@ -19,7 +19,7 @@ struct CargoSpec;
 struct GRFFile;
 
 SpriteID GetCustomCargoSprite(const CargoSpec *cs);
-uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2, const CargoSpec *cs);
+uint16_t GetCargoCallback(CallbackID callback, uint32_t param1, uint32_t param2, const CargoSpec *cs, std::span<int32_t> regs100 = {});
 CargoType GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit = false);
 
 std::span<const CargoLabel> GetClimateDependentCargoTranslationTable();

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -684,13 +684,13 @@ void SpriteLayoutProcessor::ProcessRegisters(uint8_t resolved_var10, uint32_t re
 
 					if (result.IsParentSprite()) {
 						if (flags & TLF_BB_XY_OFFSET) {
-							result.delta_x += static_cast<int32_t>(GetRegister(regs->delta.parent[0]));
-							result.delta_y += static_cast<int32_t>(GetRegister(regs->delta.parent[1]));
+							result.delta_x += GetRegister(regs->delta.parent[0]);
+							result.delta_y += GetRegister(regs->delta.parent[1]);
 						}
-						if (flags & TLF_BB_Z_OFFSET)    result.delta_z += static_cast<int32_t>(GetRegister(regs->delta.parent[2]));
+						if (flags & TLF_BB_Z_OFFSET) result.delta_z += GetRegister(regs->delta.parent[2]);
 					} else {
-						if (flags & TLF_CHILD_X_OFFSET) result.delta_x += static_cast<int32_t>(GetRegister(regs->delta.child[0]));
-						if (flags & TLF_CHILD_Y_OFFSET) result.delta_y += static_cast<int32_t>(GetRegister(regs->delta.child[1]));
+						if (flags & TLF_CHILD_X_OFFSET) result.delta_x += GetRegister(regs->delta.child[0]);
+						if (flags & TLF_CHILD_Y_OFFSET) result.delta_y += GetRegister(regs->delta.child[1]);
 					}
 				}
 			}

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -651,10 +651,11 @@ SpriteLayoutProcessor::SpriteLayoutProcessor(const NewGRFSpriteLayout &raw_layou
 
 /**
  * Evaluates the register modifiers and integrates them into the preprocessed sprite layout.
+ * @param object ResolverObject owning the temporary storage.
  * @param resolved_var10  The value of var10 the action-1-2-3 chain was evaluated for.
  * @param resolved_sprite Result sprite of the action-1-2-3 chain.
  */
-void SpriteLayoutProcessor::ProcessRegisters(uint8_t resolved_var10, uint32_t resolved_sprite)
+void SpriteLayoutProcessor::ProcessRegisters(const ResolverObject &object, uint8_t resolved_var10, uint32_t resolved_sprite)
 {
 	assert(this->raw_layout != nullptr);
 	const TileLayoutRegisters *regs = this->raw_layout->registers.empty() ? nullptr : this->raw_layout->registers.data();
@@ -669,12 +670,12 @@ void SpriteLayoutProcessor::ProcessRegisters(uint8_t resolved_var10, uint32_t re
 			uint8_t var10 = (flags & TLF_SPRITE_VAR10) ? regs->sprite_var10 : (ground && this->separate_ground ? 1 : 0);
 			if (var10 == resolved_var10) {
 				/* Apply registers */
-				if ((flags & TLF_DODRAW) && GetRegister(regs->dodraw) == 0) {
+				if ((flags & TLF_DODRAW) && object.GetRegister(regs->dodraw) == 0) {
 					result.image.sprite = 0;
 				} else {
 					if (HasBit(result.image.sprite, SPRITE_MODIFIER_CUSTOM_SPRITE)) result.image.sprite += resolved_sprite;
 					if (flags & TLF_SPRITE) {
-						int16_t offset = (int16_t)GetRegister(regs->sprite); // mask to 16 bits to avoid trouble
+						int16_t offset = static_cast<int16_t>(object.GetRegister(regs->sprite)); // mask to 16 bits to avoid trouble
 						if (!HasBit(result.image.sprite, SPRITE_MODIFIER_CUSTOM_SPRITE) || (offset >= 0 && offset < regs->max_sprite_offset)) {
 							result.image.sprite += offset;
 						} else {
@@ -684,13 +685,13 @@ void SpriteLayoutProcessor::ProcessRegisters(uint8_t resolved_var10, uint32_t re
 
 					if (result.IsParentSprite()) {
 						if (flags & TLF_BB_XY_OFFSET) {
-							result.delta_x += GetRegister(regs->delta.parent[0]);
-							result.delta_y += GetRegister(regs->delta.parent[1]);
+							result.delta_x += object.GetRegister(regs->delta.parent[0]);
+							result.delta_y += object.GetRegister(regs->delta.parent[1]);
 						}
-						if (flags & TLF_BB_Z_OFFSET) result.delta_z += GetRegister(regs->delta.parent[2]);
+						if (flags & TLF_BB_Z_OFFSET) result.delta_z += object.GetRegister(regs->delta.parent[2]);
 					} else {
-						if (flags & TLF_CHILD_X_OFFSET) result.delta_x += GetRegister(regs->delta.child[0]);
-						if (flags & TLF_CHILD_Y_OFFSET) result.delta_y += GetRegister(regs->delta.child[1]);
+						if (flags & TLF_CHILD_X_OFFSET) result.delta_x += object.GetRegister(regs->delta.child[0]);
+						if (flags & TLF_CHILD_Y_OFFSET) result.delta_y += object.GetRegister(regs->delta.child[1]);
 					}
 				}
 			}
@@ -704,7 +705,7 @@ void SpriteLayoutProcessor::ProcessRegisters(uint8_t resolved_var10, uint32_t re
 				/* Apply registers */
 				if (HasBit(result.image.pal, SPRITE_MODIFIER_CUSTOM_SPRITE)) result.image.pal += resolved_sprite;
 				if (flags & TLF_PALETTE) {
-					int16_t offset = (int16_t)GetRegister(regs->palette); // mask to 16 bits to avoid trouble
+					int16_t offset = static_cast<int16_t>(object.GetRegister(regs->palette)); // mask to 16 bits to avoid trouble
 					if (!HasBit(result.image.pal, SPRITE_MODIFIER_CUSTOM_SPRITE) || (offset >= 0 && offset < regs->max_palette_offset)) {
 						result.image.pal += offset;
 					} else {

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -463,11 +463,12 @@ uint32_t GetCompanyInfo(CompanyID owner, const Livery *l)
 /**
  * Get the error message from a shape/location/slope check callback result.
  * @param cb_res Callback result to translate. If bit 10 is set this is a standard error message, otherwise a NewGRF provided string.
+ * @param textstack Text parameter stack.
  * @param grffile NewGRF to use to resolve a custom error message.
  * @param default_error Error message to use for the generic error.
  * @return CommandCost indicating success or the error message.
  */
-CommandCost GetErrorMessageFromLocationCallbackResult(uint16_t cb_res, const GRFFile *grffile, StringID default_error)
+CommandCost GetErrorMessageFromLocationCallbackResult(uint16_t cb_res, std::span<const int32_t> textstack, const GRFFile *grffile, StringID default_error)
 {
 	CommandCost res;
 
@@ -478,7 +479,7 @@ CommandCost GetErrorMessageFromLocationCallbackResult(uint16_t cb_res, const GRF
 		if (!IsLocalCompany()) return res;
 
 		StringID stringid = GetGRFStringID(grffile->grfid, GRFSTR_MISC_GRF_TEXT + cb_res);
-		auto params = GetGRFSringTextStackParameters(grffile, stringid, 4);
+		auto params = GetGRFSringTextStackParameters(grffile, stringid, textstack);
 		res.SetEncodedMessage(GetEncodedStringWithArgs(stringid, params));
 	} else {
 		switch (cb_res) {

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -159,7 +159,7 @@ public:
 	 */
 	SetBitIterator<uint8_t, uint32_t> Var10Values() const { return this->var10_values; }
 
-	void ProcessRegisters(uint8_t resolved_var10, uint32_t resolved_sprite);
+	void ProcessRegisters(const struct ResolverObject &object, uint8_t resolved_var10, uint32_t resolved_sprite);
 
 	/**
 	 * Returns the result spritelayout after preprocessing.

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -304,7 +304,7 @@ uint32_t GetTerrainType(TileIndex tile, TileContext context = TCX_NORMAL);
 TileIndex GetNearbyTile(uint8_t parameter, TileIndex tile, bool signed_offsets = true, Axis axis = INVALID_AXIS);
 uint32_t GetNearbyTileInformation(TileIndex tile, bool grf_version8);
 uint32_t GetCompanyInfo(CompanyID owner, const struct Livery *l = nullptr);
-CommandCost GetErrorMessageFromLocationCallbackResult(uint16_t cb_res, const GRFFile *grffile, StringID default_error);
+CommandCost GetErrorMessageFromLocationCallbackResult(uint16_t cb_res, std::span<const int32_t> textstack, const GRFFile *grffile, StringID default_error);
 
 void ErrorUnknownCallbackResult(uint32_t grfid, uint16_t cbid, uint16_t cb_res);
 bool ConvertBooleanCallback(const struct GRFFile *grffile, uint16_t cbid, uint16_t cb_res);

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1183,12 +1183,13 @@ bool UsesWagonOverride(const Vehicle *v)
  * @param param2   Second parameter of the callback
  * @param engine   Engine type of the vehicle to evaluate the callback for
  * @param v        The vehicle to evaluate the callback for, or nullptr if it doesn't exist yet
+ * @param[out] regs100 Additional result values from registers 100+
  * @return The value the callback returned, or CALLBACK_FAILED if it failed
  */
-uint16_t GetVehicleCallback(CallbackID callback, uint32_t param1, uint32_t param2, EngineID engine, const Vehicle *v)
+uint16_t GetVehicleCallback(CallbackID callback, uint32_t param1, uint32_t param2, EngineID engine, const Vehicle *v, std::span<int32_t> regs100)
 {
 	VehicleResolverObject object(engine, v, VehicleResolverObject::WO_UNCACHED, false, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 /**
@@ -1199,13 +1200,14 @@ uint16_t GetVehicleCallback(CallbackID callback, uint32_t param1, uint32_t param
  * @param engine   Engine type of the vehicle to evaluate the callback for
  * @param v        The vehicle to evaluate the callback for, or nullptr if it doesn't exist yet
  * @param parent   The vehicle to use for parent scope
+ * @param[out] regs100 Additional result values from registers 100+
  * @return The value the callback returned, or CALLBACK_FAILED if it failed
  */
-uint16_t GetVehicleCallbackParent(CallbackID callback, uint32_t param1, uint32_t param2, EngineID engine, const Vehicle *v, const Vehicle *parent)
+uint16_t GetVehicleCallbackParent(CallbackID callback, uint32_t param1, uint32_t param2, EngineID engine, const Vehicle *v, const Vehicle *parent, std::span<int32_t> regs100)
 {
 	VehicleResolverObject object(engine, v, VehicleResolverObject::WO_NONE, false, callback, param1, param2);
 	object.parent_scope.SetVehicle(parent);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1099,7 +1099,6 @@ static void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction d
 	bool sprite_stack = EngInfo(engine)->misc_flags.Test(EngineMiscFlag::SpriteStack);
 	uint max_stack = sprite_stack ? static_cast<uint>(std::size(result->seq)) : 1;
 	for (uint stack = 0; stack < max_stack; ++stack) {
-		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);
 		const auto *group = object.Resolve<ResultSpriteGroup>();
 		int32_t reg100 = sprite_stack ? object.GetRegister(0x100) : 0;
@@ -1142,7 +1141,6 @@ static void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, En
 	bool sprite_stack = e->info.misc_flags.Test(EngineMiscFlag::SpriteStack);
 	uint max_stack = sprite_stack ? static_cast<uint>(std::size(result->seq)) : 1;
 	for (uint stack = 0; stack < max_stack; ++stack) {
-		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);
 		const auto *group = object.Resolve<ResultSpriteGroup>();
 		int32_t reg100 = sprite_stack ? object.GetRegister(0x100) : 0;

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -325,7 +325,7 @@ static uint8_t MapAircraftMovementAction(const Aircraft *v)
 			if (this->self_scope.v != nullptr && (relative != this->cached_relative_count || count == 0)) {
 				/* Note: This caching only works as long as the VSG_SCOPE_RELATIVE cannot be used in
 				 *       VarAct2 with procedure calls. */
-				if (count == 0) count = GetRegister(0x100);
+				if (count == 0) count = this->GetRegister(0x100);
 
 				const Vehicle *v = nullptr;
 				switch (GB(relative, 6, 2)) {
@@ -621,14 +621,14 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			if (object->ro.callback == CBID_NO_CALLBACK || object->ro.callback == CBID_RANDOM_TRIGGER || object->ro.callback == CBID_TRAIN_ALLOW_WAGON_ATTACH ||
 					object->ro.callback == CBID_VEHICLE_START_STOP_CHECK || object->ro.callback == CBID_VEHICLE_32DAY_CALLBACK || object->ro.callback == CBID_VEHICLE_COLOUR_MAPPING ||
 					object->ro.callback == CBID_VEHICLE_SPAWN_VISUAL_EFFECT) {
-				Vehicle *u = v->Move(GetRegister(0x10F));
+				Vehicle *u = v->Move(object->ro.GetRegister(0x10F));
 				if (u == nullptr) return 0; // available, but zero
 
 				if (parameter == 0x5F) {
 					/* This seems to be the only variable that makes sense to access via var 61, but is not handled by VehicleGetVariable */
 					return (u->random_bits << 8) | u->waiting_random_triggers.base();
 				} else {
-					return VehicleGetVariable(u, object, parameter, GetRegister(0x10E), available);
+					return VehicleGetVariable(u, object, parameter, object->ro.GetRegister(0x10E), available);
 				}
 			}
 			/* Not available */
@@ -1102,7 +1102,7 @@ static void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction d
 		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);
 		const auto *group = object.Resolve<ResultSpriteGroup>();
-		int32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
+		int32_t reg100 = sprite_stack ? object.GetRegister(0x100) : 0;
 		if (group != nullptr && group->num_sprites != 0) {
 			result->seq[result->count].sprite = group->sprite + (direction % group->num_sprites);
 			result->seq[result->count].pal    = GB(reg100, 0, 16); // zero means default recolouring
@@ -1145,7 +1145,7 @@ static void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, En
 		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);
 		const auto *group = object.Resolve<ResultSpriteGroup>();
-		int32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
+		int32_t reg100 = sprite_stack ? object.GetRegister(0x100) : 0;
 		if (group != nullptr && group->num_sprites != 0) {
 			result->seq[result->count].sprite = group->sprite + (rotor_pos % group->num_sprites);
 			result->seq[result->count].pal    = GB(reg100, 0, 16); // zero means default recolouring

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -621,7 +621,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			if (object->ro.callback == CBID_NO_CALLBACK || object->ro.callback == CBID_RANDOM_TRIGGER || object->ro.callback == CBID_TRAIN_ALLOW_WAGON_ATTACH ||
 					object->ro.callback == CBID_VEHICLE_START_STOP_CHECK || object->ro.callback == CBID_VEHICLE_32DAY_CALLBACK || object->ro.callback == CBID_VEHICLE_COLOUR_MAPPING ||
 					object->ro.callback == CBID_VEHICLE_SPAWN_VISUAL_EFFECT) {
-				Vehicle *u = v->Move((int32_t)GetRegister(0x10F));
+				Vehicle *u = v->Move(GetRegister(0x10F));
 				if (u == nullptr) return 0; // available, but zero
 
 				if (parameter == 0x5F) {
@@ -1102,7 +1102,7 @@ static void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction d
 		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);
 		const auto *group = object.Resolve<ResultSpriteGroup>();
-		uint32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
+		int32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
 		if (group != nullptr && group->num_sprites != 0) {
 			result->seq[result->count].sprite = group->sprite + (direction % group->num_sprites);
 			result->seq[result->count].pal    = GB(reg100, 0, 16); // zero means default recolouring
@@ -1145,7 +1145,7 @@ static void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, En
 		object.ResetState();
 		object.callback_param1 = image_type | (stack << 8);
 		const auto *group = object.Resolve<ResultSpriteGroup>();
-		uint32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
+		int32_t reg100 = sprite_stack ? GetRegister(0x100) : 0;
 		if (group != nullptr && group->num_sprites != 0) {
 			result->seq[result->count].sprite = group->sprite + (rotor_pos % group->num_sprites);
 			result->seq[result->count].pal    = GB(reg100, 0, 16); // zero means default recolouring

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -92,8 +92,8 @@ struct GRFFile;
 
 void SetEngineGRF(EngineID engine, const struct GRFFile *file);
 
-uint16_t GetVehicleCallback(CallbackID callback, uint32_t param1, uint32_t param2, EngineID engine, const Vehicle *v);
-uint16_t GetVehicleCallbackParent(CallbackID callback, uint32_t param1, uint32_t param2, EngineID engine, const Vehicle *v, const Vehicle *parent);
+uint16_t GetVehicleCallback(CallbackID callback, uint32_t param1, uint32_t param2, EngineID engine, const Vehicle *v, std::span<int32_t> regs100 = {});
+uint16_t GetVehicleCallbackParent(CallbackID callback, uint32_t param1, uint32_t param2, EngineID engine, const Vehicle *v, const Vehicle *parent, std::span<int32_t> regs100 = {});
 bool UsesWagonOverride(const Vehicle *v);
 
 /* Handler to Evaluate callback 36. If the callback fails (i.e. most of the

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -161,9 +161,10 @@ GenericResolverObject::GenericResolverObject(bool ai_callback, CallbackID callba
  * @param object  pre-populated resolver object
  * @param param1_grfv7 callback_param1 for GRFs up to version 7.
  * @param param1_grfv8 callback_param1 for GRFs from version 8 on.
+ * @param[out] regs100 Additional result values from registers 100+
  * @return answering GRFFile and callback value if successful, or CALLBACK_FAILED
  */
-static std::pair<const GRFFile *, uint16_t> GetGenericCallbackResult(uint8_t feature, ResolverObject &object, uint32_t param1_grfv7, uint32_t param1_grfv8)
+static std::pair<const GRFFile *, uint16_t> GetGenericCallbackResult(uint8_t feature, ResolverObject &object, uint32_t param1_grfv7, uint32_t param1_grfv8, std::span<int32_t> regs100 = {})
 {
 	assert(feature < lengthof(_gcl));
 
@@ -173,7 +174,7 @@ static std::pair<const GRFFile *, uint16_t> GetGenericCallbackResult(uint8_t fea
 		object.root_spritegroup = it.group;
 		/* Set callback param based on GRF version. */
 		object.callback_param1 = it.file->grf_version >= 8 ? param1_grfv8 : param1_grfv7;
-		uint16_t result = object.ResolveCallback();
+		uint16_t result = object.ResolveCallback(regs100);
 		if (result == CALLBACK_FAILED) continue;
 
 		return {it.file, result};

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -389,8 +389,8 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 			if (!IsValidCargoType(cargo_type)) return 0;
 
 			/* Extract tile offset. */
-			int8_t x_offs = GB(GetRegister(0x100), 0, 8);
-			int8_t y_offs = GB(GetRegister(0x100), 8, 8);
+			int8_t x_offs = GB(this->ro.GetRegister(0x100), 0, 8);
+			int8_t y_offs = GB(this->ro.GetRegister(0x100), 8, 8);
 			TileIndex testtile = Map::WrapToMap(this->tile + TileDiffXY(x_offs, y_offs));
 
 			StationFinder stations(TileArea(testtile, 1, 1));

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -507,7 +507,7 @@ void DrawNewHouseTile(TileInfo *ti, HouseID house_id)
 	if (group != nullptr) {
 		/* Limit the building stage to the number of stages supplied. */
 		uint8_t stage = GetHouseBuildingStage(ti->tile);
-		auto processor = group->ProcessRegisters(&stage);
+		auto processor = group->ProcessRegisters(object, &stage);
 		auto dts = processor.GetLayout();
 		DrawTileLayout(ti, dts, stage, house_id);
 	}
@@ -528,7 +528,7 @@ void DrawNewHouseTileInGUI(int x, int y, const HouseSpec *spec, HouseID house_id
 	if (group == nullptr) return;
 
 	uint8_t stage = TOWN_HOUSE_COMPLETED;
-	auto processor = group->ProcessRegisters(&stage);
+	auto processor = group->ProcessRegisters(object, &stage);
 	auto dts = processor.GetLayout();
 
 	PaletteID palette = GetColourPalette(spec->random_colour[0]);

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -453,12 +453,12 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 	return UINT_MAX;
 }
 
-uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, HouseID house_id, Town *town, TileIndex tile,
+uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, HouseID house_id, Town *town, TileIndex tile, std::span<int32_t> regs100,
 		bool not_yet_constructed, uint8_t initial_random_bits, CargoTypes watched_cargo_triggers, int view)
 {
 	HouseResolverObject object(house_id, tile, town, callback, param1, param2,
 			not_yet_constructed, initial_random_bits, watched_cargo_triggers, view);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 static void DrawTileLayout(const TileInfo *ti, const DrawTileSpriteSpan &dts, uint8_t stage, HouseID house_id)
@@ -533,7 +533,7 @@ void DrawNewHouseTileInGUI(int x, int y, const HouseSpec *spec, HouseID house_id
 
 	PaletteID palette = GetColourPalette(spec->random_colour[0]);
 	if (spec->callback_mask.Test(HouseCallbackMask::Colour)) {
-		uint16_t callback = GetHouseCallback(CBID_HOUSE_COLOUR, 0, 0, house_id, nullptr, INVALID_TILE, true, view);
+		uint16_t callback = GetHouseCallback(CBID_HOUSE_COLOUR, 0, 0, house_id, nullptr, INVALID_TILE, {}, true, view);
 		if (callback != CALLBACK_FAILED) {
 			/* If bit 14 is set, we should use a 2cc colour map, else use the callback value. */
 			palette = HasBit(callback, 14) ? GB(callback, 0, 8) + SPR_2CCMAP_BASE : callback;
@@ -554,9 +554,9 @@ void DrawNewHouseTileInGUI(int x, int y, const HouseSpec *spec, HouseID house_id
 }
 
 /* Simple wrapper for GetHouseCallback to keep the animation unified. */
-uint16_t GetSimpleHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, const HouseSpec *spec, Town *town, TileIndex tile, CargoTypes extra_data)
+static uint16_t GetSimpleHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, const HouseSpec *spec, Town *town, TileIndex tile, CargoTypes extra_data)
 {
-	return GetHouseCallback(callback, param1, param2, spec - HouseSpec::Get(0), town, tile, false, 0, extra_data);
+	return GetHouseCallback(callback, param1, param2, spec - HouseSpec::Get(0), town, tile, {}, false, 0, extra_data);
 }
 
 /** Helper class for animation control. */

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -461,11 +461,8 @@ uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2,
 	return object.ResolveCallback();
 }
 
-static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, uint8_t stage, HouseID house_id)
+static void DrawTileLayout(const TileInfo *ti, const DrawTileSpriteSpan &dts, uint8_t stage, HouseID house_id)
 {
-	auto processor = group->ProcessRegisters(&stage);
-	auto dts = processor.GetLayout();
-
 	const HouseSpec *hs = HouseSpec::Get(house_id);
 	PaletteID palette = GetColourPalette(hs->random_colour[TileHash2Bit(ti->x, ti->y)]);
 	if (hs->callback_mask.Test(HouseCallbackMask::Colour)) {
@@ -510,7 +507,9 @@ void DrawNewHouseTile(TileInfo *ti, HouseID house_id)
 	if (group != nullptr) {
 		/* Limit the building stage to the number of stages supplied. */
 		uint8_t stage = GetHouseBuildingStage(ti->tile);
-		DrawTileLayout(ti, group, stage, house_id);
+		auto processor = group->ProcessRegisters(&stage);
+		auto dts = processor.GetLayout();
+		DrawTileLayout(ti, dts, stage, house_id);
 	}
 }
 

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -104,7 +104,7 @@ void AnimateNewHouseTile(TileIndex tile);
 void TriggerHouseAnimation_ConstructionStageChanged(TileIndex tile, bool first_call);
 void TriggerHouseAnimation_WatchedCargoAccepted(TileIndex tile, CargoTypes trigger_cargoes);
 
-uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, HouseID house_id, Town *town, TileIndex tile,
+uint16_t GetHouseCallback(CallbackID callback, uint32_t param1, uint32_t param2, HouseID house_id, Town *town, TileIndex tile, std::span<int32_t> regs100 = {},
 		bool not_yet_constructed = false, uint8_t initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0, int view = 0);
 
 bool CanDeleteHouse(TileIndex tile);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -524,12 +524,13 @@ uint32_t IndustriesResolverObject::GetDebugID() const
  * @param industry The industry to do the callback for.
  * @param type The type of industry to do the callback for.
  * @param tile The tile associated with the callback.
+ * @param[out] regs100 Additional result values from registers 100+
  * @return The callback result.
  */
-uint16_t GetIndustryCallback(CallbackID callback, uint32_t param1, uint32_t param2, Industry *industry, IndustryType type, TileIndex tile)
+uint16_t GetIndustryCallback(CallbackID callback, uint32_t param1, uint32_t param2, Industry *industry, IndustryType type, TileIndex tile, std::span<int32_t> regs100)
 {
 	IndustriesResolverObject object(tile, industry, type, 0, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 /**
@@ -559,7 +560,7 @@ CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, siz
 	ind.psa = nullptr;
 
 	IndustriesResolverObject object(tile, &ind, type, seed, CBID_INDUSTRY_LOCATION, 0, creation_type);
-	uint16_t result = object.ResolveCallback();
+	uint16_t result = object.ResolveCallback({});
 
 	/* Unlike the "normal" cases, not having a valid result means we allow
 	 * the building of the industry, as that's how it's done in TTDP. */

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -115,7 +115,7 @@ static uint32_t GetClosestIndustry(TileIndex tile, IndustryType type, const Indu
  */
 static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_set_id, uint8_t layout_filter, bool town_filter, const Industry *current)
 {
-	uint32_t grf_id = GetRegister(0x100);  ///< Get the GRFID of the definition to look for in register 100h
+	uint32_t grf_id = static_cast<uint32_t>(GetRegister(0x100)); ///< Get the GRFID of the definition to look for in register 100h
 	IndustryType industry_type;
 	uint32_t closest_dist = UINT32_MAX;
 	uint8_t count = 0;
@@ -311,7 +311,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t param_set_id, uint8
 			uint8_t layout_filter = 0;
 			bool town_filter = false;
 			if (variable == 0x68) {
-				uint32_t reg = GetRegister(0x101);
+				int32_t reg = GetRegister(0x101);
 				layout_filter = GB(reg, 0, 8);
 				town_filter = HasBit(reg, 8);
 			}
@@ -598,7 +598,7 @@ uint32_t GetIndustryProbabilityCallback(IndustryType type, IndustryAvailabilityC
 
 static int32_t DerefIndProd(int field, bool use_register)
 {
-	return use_register ? (int32_t)GetRegister(field) : field;
+	return use_register ? GetRegister(field) : field;
 }
 
 /**

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -560,13 +560,14 @@ CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, siz
 	ind.psa = nullptr;
 
 	IndustriesResolverObject object(tile, &ind, type, seed, CBID_INDUSTRY_LOCATION, 0, creation_type);
-	uint16_t result = object.ResolveCallback({});
+	std::array<int32_t, 4> regs100;
+	uint16_t result = object.ResolveCallback(regs100);
 
 	/* Unlike the "normal" cases, not having a valid result means we allow
 	 * the building of the industry, as that's how it's done in TTDP. */
 	if (result == CALLBACK_FAILED) return CommandCost();
 
-	return GetErrorMessageFromLocationCallbackResult(result, indspec->grf_prop.grffile, STR_ERROR_SITE_UNSUITABLE);
+	return GetErrorMessageFromLocationCallbackResult(result, regs100, indspec->grf_prop.grffile, STR_ERROR_SITE_UNSUITABLE);
 }
 
 /**

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -86,7 +86,7 @@ enum IndustryAvailabilityCallType : uint8_t {
 };
 
 /* in newgrf_industry.cpp */
-uint16_t GetIndustryCallback(CallbackID callback, uint32_t param1, uint32_t param2, Industry *industry, IndustryType type, TileIndex tile);
+uint16_t GetIndustryCallback(CallbackID callback, uint32_t param1, uint32_t param2, Industry *industry, IndustryType type, TileIndex tile, std::span<int32_t> regs100 = {});
 uint32_t GetIndustryIDAtOffset(TileIndex new_tile, const Industry *i, uint32_t cur_grfid);
 void IndustryProductionCallback(Industry *ind, int reason);
 CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, size_t layout, uint32_t seed, uint16_t initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type);

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -158,11 +158,8 @@ uint32_t IndustryTileResolverObject::GetDebugID() const
 	return GetIndustryTileSpec(gfx)->grf_prop.local_id;
 }
 
-static void IndustryDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, Colours rnd_colour, uint8_t stage)
+static void IndustryDrawTileLayout(const TileInfo *ti, const DrawTileSpriteSpan &dts, Colours rnd_colour, uint8_t stage)
 {
-	auto processor = group->ProcessRegisters(&stage);
-	auto dts = processor.GetLayout();
-
 	SpriteID image = dts.ground.sprite;
 	PaletteID pal = dts.ground.pal;
 
@@ -211,7 +208,9 @@ bool DrawNewIndustryTile(TileInfo *ti, Industry *i, IndustryGfx gfx, const Indus
 
 	/* Limit the building stage to the number of stages supplied. */
 	uint8_t stage = GetIndustryConstructionStage(ti->tile);
-	IndustryDrawTileLayout(ti, group, i->random_colour, stage);
+	auto processor = group->ProcessRegisters(&stage);
+	auto dts = processor.GetLayout();
+	IndustryDrawTileLayout(ti, dts, i->random_colour, stage);
 	return true;
 }
 

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -239,7 +239,8 @@ CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind
 	ind.random = initial_random_bits;
 	ind.founder = founder;
 
-	uint16_t callback_res = GetIndustryTileCallback(CBID_INDTILE_SHAPE_CHECK, 0, creation_type << 8 | (uint32_t)layout_index, gfx, &ind, ind_tile);
+	std::array<int32_t, 4> regs100;
+	uint16_t callback_res = GetIndustryTileCallback(CBID_INDTILE_SHAPE_CHECK, 0, creation_type << 8 | static_cast<uint32_t>(layout_index), gfx, &ind, ind_tile, regs100);
 	if (callback_res == CALLBACK_FAILED) {
 		if (!IsSlopeRefused(GetTileSlope(ind_tile), its->slopes_refused)) return CommandCost();
 		return CommandCost(STR_ERROR_SITE_UNSUITABLE);
@@ -249,7 +250,7 @@ CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind
 		return CommandCost(STR_ERROR_SITE_UNSUITABLE);
 	}
 
-	return GetErrorMessageFromLocationCallbackResult(callback_res, its->grf_prop.grffile, STR_ERROR_SITE_UNSUITABLE);
+	return GetErrorMessageFromLocationCallbackResult(callback_res, regs100, its->grf_prop.grffile, STR_ERROR_SITE_UNSUITABLE);
 }
 
 /* Simple wrapper for GetHouseCallback to keep the animation unified. */

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -208,7 +208,7 @@ bool DrawNewIndustryTile(TileInfo *ti, Industry *i, IndustryGfx gfx, const Indus
 
 	/* Limit the building stage to the number of stages supplied. */
 	uint8_t stage = GetIndustryConstructionStage(ti->tile);
-	auto processor = group->ProcessRegisters(&stage);
+	auto processor = group->ProcessRegisters(object, &stage);
 	auto dts = processor.GetLayout();
 	IndustryDrawTileLayout(ti, dts, i->random_colour, stage);
 	return true;

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -179,13 +179,13 @@ static void IndustryDrawTileLayout(const TileInfo *ti, const DrawTileSpriteSpan 
 	DrawNewGRFTileSeq(ti, &dts, TO_INDUSTRIES, stage, GetColourPalette(rnd_colour));
 }
 
-uint16_t GetIndustryTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, IndustryGfx gfx_id, Industry *industry, TileIndex tile)
+uint16_t GetIndustryTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, IndustryGfx gfx_id, Industry *industry, TileIndex tile, std::span<int32_t> regs100)
 {
 	assert(industry != nullptr && IsValidTile(tile));
 	assert(industry->index == IndustryID::Invalid() || IsTileType(tile, MP_INDUSTRY));
 
 	IndustryTileResolverObject object(gfx_id, tile, industry, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 bool DrawNewIndustryTile(TileInfo *ti, Industry *i, IndustryGfx gfx, const IndustryTileSpec *inds)

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -58,7 +58,7 @@ struct IndustryTileResolverObject : public SpecializedResolverObject<IndustryRan
 };
 
 bool DrawNewIndustryTile(TileInfo *ti, Industry *i, IndustryGfx gfx, const IndustryTileSpec *inds);
-uint16_t GetIndustryTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, IndustryGfx gfx_id, Industry *industry, TileIndex tile);
+uint16_t GetIndustryTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, IndustryGfx gfx_id, Industry *industry, TileIndex tile, std::span<int32_t> regs100 = {});
 CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind_tile, const IndustryTileSpec *its, IndustryType type, IndustryGfx gfx, size_t layout_index, uint16_t initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type);
 
 void AnimateNewIndustryTile(TileIndex tile);

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -225,15 +225,16 @@ static uint32_t GetClosestObject(TileIndex tile, ObjectType type, const Object *
 
 /**
  * Implementation of var 65
+ * @param object ResolverObject owning the temporary storage.
  * @param local_id Parameter given to the callback, which is the set id, or the local id, in our terminology.
  * @param grfid    The object's GRFID.
  * @param tile     The tile to look from.
  * @param current  Object for which the inquiry is made
  * @return The formatted answer to the callback : rr(reserved) cc(count) dddd(manhattan distance of closest sister)
  */
-static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t local_id, uint32_t grfid, TileIndex tile, const Object *current)
+static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &object, uint8_t local_id, uint32_t grfid, TileIndex tile, const Object *current)
 {
-	uint32_t grf_id = static_cast<uint32_t>(GetRegister(0x100)); // Get the GRFID of the definition to look for in register 100h
+	uint32_t grf_id = static_cast<uint32_t>(object.GetRegister(0x100)); // Get the GRFID of the definition to look for in register 100h
 	uint32_t idx;
 
 	/* Determine what will be the object type to look for */
@@ -361,7 +362,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t local_id, uint32_t 
 		}
 
 		/* Count of object, distance of closest instance */
-		case 0x64: return GetCountAndDistanceOfClosestInstance(parameter, this->ro.grffile->grfid, this->tile, this->obj);
+		case 0x64: return GetCountAndDistanceOfClosestInstance(this->ro, parameter, this->ro.grffile->grfid, this->tile, this->obj);
 
 		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->spec->badges, parameter);
 	}

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -233,7 +233,7 @@ static uint32_t GetClosestObject(TileIndex tile, ObjectType type, const Object *
  */
 static uint32_t GetCountAndDistanceOfClosestInstance(uint8_t local_id, uint32_t grfid, TileIndex tile, const Object *current)
 {
-	uint32_t grf_id = GetRegister(0x100);  // Get the GRFID of the definition to look for in register 100h
+	uint32_t grf_id = static_cast<uint32_t>(GetRegister(0x100)); // Get the GRFID of the definition to look for in register 100h
 	uint32_t idx;
 
 	/* Determine what will be the object type to look for */

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -429,12 +429,13 @@ uint32_t ObjectResolverObject::GetDebugID() const
  * @param o        The object to call the callback for.
  * @param tile     The tile the callback is called for.
  * @param view     The view of the object (only used when o == nullptr).
+ * @param[out] regs100 Additional result values from registers 100+
  * @return The result of the callback.
  */
-uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2, const ObjectSpec *spec, Object *o, TileIndex tile, uint8_t view)
+uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2, const ObjectSpec *spec, Object *o, TileIndex tile, std::span<int32_t> regs100, uint8_t view)
 {
 	ObjectResolverObject object(spec, o, tile, view, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 /**

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -439,13 +439,11 @@ uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2
 /**
  * Draw an group of sprites on the map.
  * @param ti    Information about the tile to draw on.
- * @param group The group of sprites to draw.
+ * @param dts   The sprite layout to draw.
  * @param spec  Object spec to draw.
  */
-static void DrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, const ObjectSpec *spec)
+static void DrawTileLayout(const TileInfo *ti, const DrawTileSpriteSpan &dts, const ObjectSpec *spec)
 {
-	auto processor = group->ProcessRegisters(nullptr);
-	auto dts = processor.GetLayout();
 	PaletteID palette = (spec->flags.Test(ObjectFlag::Uses2CC) ? SPR_2CCMAP_BASE : PALETTE_RECOLOUR_START) + Object::GetByTile(ti->tile)->colour;
 
 	SpriteID image = dts.ground.sprite;
@@ -477,7 +475,9 @@ void DrawNewObjectTile(TileInfo *ti, const ObjectSpec *spec)
 	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return;
 
-	DrawTileLayout(ti, group, spec);
+	auto processor = group->ProcessRegisters(nullptr);
+	auto dts = processor.GetLayout();
+	DrawTileLayout(ti, dts, spec);
 }
 
 /**

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -476,7 +476,7 @@ void DrawNewObjectTile(TileInfo *ti, const ObjectSpec *spec)
 	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return;
 
-	auto processor = group->ProcessRegisters(nullptr);
+	auto processor = group->ProcessRegisters(object, nullptr);
 	auto dts = processor.GetLayout();
 	DrawTileLayout(ti, dts, spec);
 }
@@ -494,7 +494,7 @@ void DrawNewObjectTileInGUI(int x, int y, const ObjectSpec *spec, uint8_t view)
 	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return;
 
-	auto processor = group->ProcessRegisters(nullptr);
+	auto processor = group->ProcessRegisters(object, nullptr);
 	auto dts = processor.GetLayout();
 
 	PaletteID palette;

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -165,7 +165,7 @@ private:
 /** Class containing information relating to object classes. */
 using ObjectClass = NewGRFClass<ObjectSpec, ObjectClassID, OBJECT_CLASS_MAX>;
 
-uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2, const ObjectSpec *spec, Object *o, TileIndex tile, uint8_t view = 0);
+uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2, const ObjectSpec *spec, Object *o, TileIndex tile, std::span<int32_t> regs100 = {}, uint8_t view = 0);
 
 void DrawNewObjectTile(TileInfo *ti, const ObjectSpec *spec);
 void DrawNewObjectTileInGUI(int x, int y, const ObjectSpec *spec, uint8_t view);

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -293,7 +293,7 @@ void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec,
 	RoadStopResolverObject object(spec, nullptr, INVALID_TILE, roadtype, type, view);
 	const auto *group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return;
-	auto processor = group->ProcessRegisters(nullptr);
+	auto processor = group->ProcessRegisters(object, nullptr);
 	auto dts = processor.GetLayout();
 
 	PaletteID palette = GetCompanyPalette(_local_company);
@@ -349,7 +349,7 @@ std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadS
 	RoadStopResolverObject object(spec, st, ti->tile, INVALID_ROADTYPE, type, view);
 	auto group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return std::nullopt;
-	return group->ProcessRegisters(nullptr);
+	return group->ProcessRegisters(object, nullptr);
 }
 
 /** Wrapper for animation control, see GetRoadStopCallback. */

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -303,7 +303,7 @@ void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec,
 
 	RoadStopDrawModes draw_mode;
 	if (spec->flags.Test(RoadStopSpecFlag::DrawModeRegister)) {
-		draw_mode = static_cast<RoadStopDrawMode>(GetRegister(0x100));
+		draw_mode = static_cast<RoadStopDrawMode>(object.GetRegister(0x100));
 	} else {
 		draw_mode = spec->draw_mode;
 	}

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -269,10 +269,10 @@ TownScopeResolver *RoadStopResolverObject::GetTown()
 	return &*this->town_scope;
 }
 
-uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t param2, const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view)
+uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t param2, const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view, std::span<int32_t> regs100)
 {
 	RoadStopResolverObject object(roadstopspec, st, tile, roadtype, type, view, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 /**
@@ -344,11 +344,14 @@ void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec,
 	DrawCommonTileSeqInGUI(x, y, &dts, 0, 0, palette, true);
 }
 
-std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view)
+std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view, std::span<int32_t> regs100)
 {
 	RoadStopResolverObject object(spec, st, ti->tile, INVALID_ROADTYPE, type, view);
 	auto group = object.Resolve<TileLayoutSpriteGroup>();
 	if (group == nullptr) return std::nullopt;
+	for (uint i = 0; i < regs100.size(); ++i) {
+		regs100[i] = object.GetRegister(0x100 + i);
+	}
 	return group->ProcessRegisters(object, nullptr);
 }
 

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -344,10 +344,12 @@ void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec,
 	DrawCommonTileSeqInGUI(x, y, &dts, 0, 0, palette, true);
 }
 
-const TileLayoutSpriteGroup *GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view)
+std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view)
 {
 	RoadStopResolverObject object(spec, st, ti->tile, INVALID_ROADTYPE, type, view);
-	return object.Resolve<TileLayoutSpriteGroup>();
+	auto group = object.Resolve<TileLayoutSpriteGroup>();
+	if (group == nullptr) return std::nullopt;
+	return group->ProcessRegisters(nullptr);
 }
 
 /** Wrapper for animation control, see GetRoadStopCallback. */

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -163,7 +163,7 @@ struct RoadStopSpec : NewGRFSpecBase<RoadStopClassID> {
 
 using RoadStopClass = NewGRFClass<RoadStopSpec, RoadStopClassID, ROADSTOP_CLASS_MAX>;
 
-const TileLayoutSpriteGroup *GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view);
+std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view);
 void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec, StationType type, int view);
 
 uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t param2, const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view);

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -163,10 +163,10 @@ struct RoadStopSpec : NewGRFSpecBase<RoadStopClassID> {
 
 using RoadStopClass = NewGRFClass<RoadStopSpec, RoadStopClassID, ROADSTOP_CLASS_MAX>;
 
-std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view);
+std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view, std::span<int32_t> regs100 = {});
 void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec, StationType type, int view);
 
-uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t param2, const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view);
+uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t param2, const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, RoadType roadtype, StationType type, uint8_t view, std::span<int32_t> regs100 = {});
 
 void AnimateRoadStopTile(TileIndex tile);
 uint8_t GetRoadStopTileAnimationSpeed(TileIndex tile);

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -284,10 +284,11 @@ static bool RangeHighComparator(const DeterministicSpriteGroupRange &range, uint
  * Process registers and the construction stage into the sprite layout.
  * The passed construction stage might get reset to zero, if it gets incorporated into the layout
  * during the preprocessing.
+ * @param object ResolverObject owning the temporary storage.
  * @param[in,out] stage Construction stage (0-3), or nullptr if not applicable.
  * @return sprite layout to draw.
  */
-SpriteLayoutProcessor TileLayoutSpriteGroup::ProcessRegisters(uint8_t *stage) const
+SpriteLayoutProcessor TileLayoutSpriteGroup::ProcessRegisters(const ResolverObject &object, uint8_t *stage) const
 {
 	if (!this->dts.NeedsPreprocessing()) {
 		if (stage != nullptr && this->dts.consistent_max_offset > 0) *stage = GetConstructionStageOffset(*stage, this->dts.consistent_max_offset);
@@ -296,7 +297,7 @@ SpriteLayoutProcessor TileLayoutSpriteGroup::ProcessRegisters(uint8_t *stage) co
 
 	uint8_t actual_stage = stage != nullptr ? *stage : 0;
 	SpriteLayoutProcessor result(this->dts, 0, 0, 0, actual_stage, false);
-	result.ProcessRegisters(0, 0);
+	result.ProcessRegisters(object, 0, 0);
 
 	/* Stage has been processed by PrepareLayout(), set it to zero. */
 	if (stage != nullptr) *stage = 0;

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -18,7 +18,7 @@
 SpriteGroupPool _spritegroup_pool("SpriteGroup");
 INSTANTIATE_POOL_METHODS(SpriteGroup)
 
-TemporaryStorageArray<int32_t, 0x110> _temp_store;
+/* static */ TemporaryStorageArray<int32_t, 0x110> ResolverObject::temp_store;
 
 
 /**
@@ -39,11 +39,9 @@ TemporaryStorageArray<int32_t, 0x110> _temp_store;
 	auto profiler = std::ranges::find(_newgrf_profilers, grf, &NewGRFProfiler::grffile);
 
 	if (profiler == _newgrf_profilers.end() || !profiler->active) {
-		if (top_level) _temp_store.ClearChanges();
 		return group->Resolve(object);
 	} else if (top_level) {
 		profiler->BeginResolve(object);
-		_temp_store.ClearChanges();
 		auto result = group->Resolve(object);
 		profiler->EndResolve(result);
 		return result;

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -64,7 +64,7 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
 
 		case 0x5F: return (scope->GetRandomBits() << 8) | scope->GetRandomTriggers();
 
-		case 0x7D: return _temp_store.GetValue(parameter);
+		case 0x7D: return object.GetRegister(parameter);
 
 		case 0x7F:
 			if (object.grffile == nullptr) return 0;
@@ -140,7 +140,7 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
 /* Evaluate an adjustment for a variable of the given size.
  * U is the unsigned type and S is the signed type to use. */
 template <typename U, typename S>
-static U EvalAdjustT(const DeterministicSpriteGroupAdjust &adjust, ScopeResolver *scope, U last_value, uint32_t value)
+static U EvalAdjustT(const DeterministicSpriteGroupAdjust &adjust, ResolverObject &object, ScopeResolver *scope, U last_value, uint32_t value)
 {
 	value >>= adjust.shift_num;
 	value  &= adjust.and_mask;
@@ -166,7 +166,7 @@ static U EvalAdjustT(const DeterministicSpriteGroupAdjust &adjust, ScopeResolver
 		case DSGA_OP_AND:  return last_value & value;
 		case DSGA_OP_OR:   return last_value | value;
 		case DSGA_OP_XOR:  return last_value ^ value;
-		case DSGA_OP_STO:  _temp_store.StoreValue((U)value, (S)last_value); return last_value;
+		case DSGA_OP_STO:  object.SetRegister((U)value, (S)last_value); return last_value;
 		case DSGA_OP_RST:  return value;
 		case DSGA_OP_STOP: scope->StorePSA((U)value, (S)last_value); return last_value;
 		case DSGA_OP_ROR:  return std::rotr<uint32_t>((U)last_value, (U)value & 0x1F); // mask 'value' to 5 bits, which should behave the same on all architectures.
@@ -214,9 +214,9 @@ static bool RangeHighComparator(const DeterministicSpriteGroupRange &range, uint
 		}
 
 		switch (this->size) {
-			case DSG_SIZE_BYTE:  value = EvalAdjustT<uint8_t,  int8_t> (adjust, scope, last_value, value); break;
-			case DSG_SIZE_WORD:  value = EvalAdjustT<uint16_t, int16_t>(adjust, scope, last_value, value); break;
-			case DSG_SIZE_DWORD: value = EvalAdjustT<uint32_t, int32_t>(adjust, scope, last_value, value); break;
+			case DSG_SIZE_BYTE:  value = EvalAdjustT<uint8_t,  int8_t> (adjust, object, scope, last_value, value); break;
+			case DSG_SIZE_WORD:  value = EvalAdjustT<uint16_t, int16_t>(adjust, object, scope, last_value, value); break;
+			case DSG_SIZE_DWORD: value = EvalAdjustT<uint32_t, int32_t>(adjust, object, scope, last_value, value); break;
 			default: NOT_REACHED();
 		}
 		last_value = value;

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -307,13 +307,16 @@ public:
 	ResolverObject(const GRFFile *grffile, CallbackID callback = CBID_NO_CALLBACK, uint32_t callback_param1 = 0, uint32_t callback_param2 = 0)
 		: default_scope(*this), callback(callback), callback_param1(callback_param1), callback_param2(callback_param2), grffile(grffile), root_spritegroup(nullptr)
 	{
-		this->ResetState();
 	}
 
 	virtual ~ResolverObject() = default;
 
 	ResolverResult DoResolve()
 	{
+		temp_store.ClearChanges();
+		this->last_value = 0;
+		this->used_random_triggers = 0;
+		this->reseed.fill(0);
 		return SpriteGroup::Resolve(this->root_spritegroup, *this);
 	}
 
@@ -432,19 +435,6 @@ public:
 			sum |= this->reseed[vsg];
 		}
 		return sum;
-	}
-
-	/**
-	 * Resets the dynamic state of the resolver object.
-	 * To be called before resolving an Action-1-2-3 chain.
-	 */
-	void ResetState()
-	{
-		temp_store.ClearChanges();
-		this->last_value = 0;
-		this->waiting_random_triggers = 0;
-		this->used_random_triggers = 0;
-		this->reseed.fill(0);
 	}
 
 	/**

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -327,6 +327,30 @@ struct ResolverObject {
 
 	ScopeResolver default_scope; ///< Default implementation of the grf scope.
 
+	/**
+	 * Gets the value of a so-called newgrf "register".
+	 * @param i index of the register
+	 * @return the value of the register
+	 * @pre i < 0x110
+	 */
+	inline int32_t GetRegister(uint i) const
+	{
+		extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
+		return _temp_store.GetValue(i);
+	}
+
+	/**
+	 * Sets the value of a so-called newgrf "register".
+	 * @param i index of the register
+	 * @param value the value of the register
+	 * @pre i < 0x110
+	 */
+	inline void SetRegister(uint i, int32_t value)
+	{
+		extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
+		_temp_store.StoreValue(i, value);
+	}
+
 	CallbackID callback{}; ///< Callback being resolved.
 	uint32_t callback_param1 = 0; ///< First parameter (var 10) of the callback.
 	uint32_t callback_param2 = 0; ///< Second parameter (var 18) of the callback.

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -27,7 +27,7 @@
  * @pre i < 0x110
  * @return the value of the register
  */
-inline uint32_t GetRegister(uint i)
+inline int32_t GetRegister(uint i)
 {
 	extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
 	return _temp_store.GetValue(i);

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -293,6 +293,10 @@ struct ScopeResolver {
  * to get the results of callbacks, rerandomisations or normal sprite lookups.
  */
 struct ResolverObject {
+private:
+	static TemporaryStorageArray<int32_t, 0x110> temp_store;
+
+public:
 	/**
 	 * Resolver constructor.
 	 * @param grffile NewGRF file associated with the object (or \c nullptr if none).
@@ -323,8 +327,7 @@ struct ResolverObject {
 	 */
 	inline int32_t GetRegister(uint i) const
 	{
-		extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
-		return _temp_store.GetValue(i);
+		return temp_store.GetValue(i);
 	}
 
 	/**
@@ -335,8 +338,7 @@ struct ResolverObject {
 	 */
 	inline void SetRegister(uint i, int32_t value)
 	{
-		extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
-		_temp_store.StoreValue(i, value);
+		temp_store.StoreValue(i, value);
 	}
 
 	CallbackID callback{}; ///< Callback being resolved.
@@ -438,6 +440,7 @@ public:
 	 */
 	void ResetState()
 	{
+		temp_store.ClearChanges();
 		this->last_value = 0;
 		this->waiting_random_triggers = 0;
 		this->used_random_triggers = 0;

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -260,7 +260,7 @@ struct TileLayoutSpriteGroup : SpriteGroup {
 
 	NewGRFSpriteLayout dts{};
 
-	SpriteLayoutProcessor ProcessRegisters(uint8_t *stage) const;
+	SpriteLayoutProcessor ProcessRegisters(const ResolverObject &object, uint8_t *stage) const;
 };
 
 struct IndustryProductionSpriteGroup : SpriteGroup {

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -688,14 +688,15 @@ CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_til
 			(numtracks << 24) | (plat_len << 16) | (axis == AXIS_Y ? TileX(diff) << 8 | TileY(diff) : TileY(diff) << 8 | TileX(diff)));
 	object.station_scope.axis = axis;
 
-	uint16_t cb_res = object.ResolveCallback({});
+	std::array<int32_t, 4> regs100;
+	uint16_t cb_res = object.ResolveCallback(regs100);
 
 	/* Failed callback means success. */
 	if (cb_res == CALLBACK_FAILED) return CommandCost();
 
 	/* The meaning of bit 10 is inverted for a grf version < 8. */
 	if (statspec->grf_prop.grffile->grf_version < 8) ToggleBit(cb_res, 10);
-	return GetErrorMessageFromLocationCallbackResult(cb_res, statspec->grf_prop.grffile, STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
+	return GetErrorMessageFromLocationCallbackResult(cb_res, regs100, statspec->grf_prop.grffile, STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
 }
 
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -655,7 +655,7 @@ SpriteID GetCustomStationFoundationRelocation(const StationSpec *statspec, BaseS
 
 	const auto *group = object.Resolve<ResultSpriteGroup>();
 	/* Note: SpriteGroup::Resolve zeroes all registers, so register 0x100 is initialised to 0. (compatibility) */
-	uint32_t offset = static_cast<uint32_t>(GetRegister(0x100));
+	uint32_t offset = static_cast<uint32_t>(object.GetRegister(0x100));
 	if (group == nullptr || group->num_sprites <= offset) return 0;
 
 	return group->sprite + offset;

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -662,10 +662,10 @@ SpriteID GetCustomStationFoundationRelocation(const StationSpec *statspec, BaseS
 }
 
 
-uint16_t GetStationCallback(CallbackID callback, uint32_t param1, uint32_t param2, const StationSpec *statspec, BaseStation *st, TileIndex tile)
+uint16_t GetStationCallback(CallbackID callback, uint32_t param1, uint32_t param2, const StationSpec *statspec, BaseStation *st, TileIndex tile, std::span<int32_t> regs100)
 {
 	StationResolverObject object(statspec, st, tile, callback, param1, param2);
-	return object.ResolveCallback();
+	return object.ResolveCallback(regs100);
 }
 
 /**
@@ -688,7 +688,7 @@ CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_til
 			(numtracks << 24) | (plat_len << 16) | (axis == AXIS_Y ? TileX(diff) << 8 | TileY(diff) : TileY(diff) << 8 | TileX(diff)));
 	object.station_scope.axis = axis;
 
-	uint16_t cb_res = object.ResolveCallback();
+	uint16_t cb_res = object.ResolveCallback({});
 
 	/* Failed callback means success. */
 	if (cb_res == CALLBACK_FAILED) return CommandCost();

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -635,7 +635,7 @@ void GetCustomStationRelocation(SpriteLayoutProcessor &processor, const StationS
 		object.callback_param1 = var10;
 		const auto *group = object.Resolve<ResultSpriteGroup>();
 		if (group == nullptr || group->num_sprites == 0) continue;
-		processor.ProcessRegisters(var10, group->sprite - SPR_RAIL_PLATFORM_Y_FRONT);
+		processor.ProcessRegisters(object, var10, group->sprite - SPR_RAIL_PLATFORM_Y_FRONT);
 	}
 }
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -627,6 +627,18 @@ SpriteID GetCustomStationRelocation(const StationSpec *statspec, BaseStation *st
 	return group->sprite - SPR_RAIL_PLATFORM_Y_FRONT;
 }
 
+void GetCustomStationRelocation(SpriteLayoutProcessor &processor, const StationSpec *statspec, BaseStation *st, TileIndex tile)
+{
+	StationResolverObject object(statspec, st, tile, CBID_NO_CALLBACK);
+	for (uint8_t var10 : processor.Var10Values()) {
+		object.ResetState();
+		object.callback_param1 = var10;
+		const auto *group = object.Resolve<ResultSpriteGroup>();
+		if (group == nullptr || group->num_sprites == 0) continue;
+		processor.ProcessRegisters(var10, group->sprite - SPR_RAIL_PLATFORM_Y_FRONT);
+	}
+}
+
 /**
  * Resolve the sprites for custom station foundations.
  * @param statspec Station spec
@@ -820,10 +832,7 @@ bool DrawStationTile(int x, int y, RailType railtype, Axis axis, StationClassID 
 		/* Sprite layout which needs preprocessing */
 		bool separate_ground = statspec->flags.Test(StationSpecFlag::SeparateGround);
 		processor = SpriteLayoutProcessor(*layout, total_offset, rti->fallback_railtype, 0, 0, separate_ground);
-		for (uint8_t var10 : processor.Var10Values()) {
-			uint32_t var10_relocation = GetCustomStationRelocation(statspec, nullptr, INVALID_TILE, var10);
-			processor.ProcessRegisters(var10, var10_relocation);
-		}
+		GetCustomStationRelocation(processor, statspec, nullptr, INVALID_TILE);
 		tmp_rail_layout = processor.GetLayout();
 		sprites = &tmp_rail_layout;
 		total_offset = 0;

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -631,7 +631,6 @@ void GetCustomStationRelocation(SpriteLayoutProcessor &processor, const StationS
 {
 	StationResolverObject object(statspec, st, tile, CBID_NO_CALLBACK);
 	for (uint8_t var10 : processor.Var10Values()) {
-		object.ResetState();
 		object.callback_param1 = var10;
 		const auto *group = object.Resolve<ResultSpriteGroup>();
 		if (group == nullptr || group->num_sprites == 0) continue;

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -655,7 +655,7 @@ SpriteID GetCustomStationFoundationRelocation(const StationSpec *statspec, BaseS
 
 	const auto *group = object.Resolve<ResultSpriteGroup>();
 	/* Note: SpriteGroup::Resolve zeroes all registers, so register 0x100 is initialised to 0. (compatibility) */
-	auto offset = GetRegister(0x100);
+	uint32_t offset = static_cast<uint32_t>(GetRegister(0x100));
 	if (group == nullptr || group->num_sprites <= offset) return 0;
 
 	return group->sprite + offset;

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -208,6 +208,7 @@ inline bool IsWaypointClass(const StationClass &cls)
 uint32_t GetPlatformInfo(Axis axis, uint8_t tile, int platforms, int length, int x, int y, bool centred);
 
 SpriteID GetCustomStationRelocation(const StationSpec *statspec, BaseStation *st, TileIndex tile, uint32_t var10 = 0);
+void GetCustomStationRelocation(SpriteLayoutProcessor &processor, const StationSpec *statspec, BaseStation *st, TileIndex tile);
 SpriteID GetCustomStationFoundationRelocation(const StationSpec *statspec, BaseStation *st, TileIndex tile, uint layout, uint edge_info);
 uint16_t GetStationCallback(CallbackID callback, uint32_t param1, uint32_t param2, const StationSpec *statspec, BaseStation *st, TileIndex tile);
 CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_tile, const StationSpec *statspec, Axis axis, uint8_t plat_len, uint8_t numtracks);

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -210,7 +210,7 @@ uint32_t GetPlatformInfo(Axis axis, uint8_t tile, int platforms, int length, int
 SpriteID GetCustomStationRelocation(const StationSpec *statspec, BaseStation *st, TileIndex tile, uint32_t var10 = 0);
 void GetCustomStationRelocation(SpriteLayoutProcessor &processor, const StationSpec *statspec, BaseStation *st, TileIndex tile);
 SpriteID GetCustomStationFoundationRelocation(const StationSpec *statspec, BaseStation *st, TileIndex tile, uint layout, uint edge_info);
-uint16_t GetStationCallback(CallbackID callback, uint32_t param1, uint32_t param2, const StationSpec *statspec, BaseStation *st, TileIndex tile);
+uint16_t GetStationCallback(CallbackID callback, uint32_t param1, uint32_t param2, const StationSpec *statspec, BaseStation *st, TileIndex tile, std::span<int32_t> regs100 = {});
 CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_tile, const StationSpec *statspec, Axis axis, uint8_t plat_len, uint8_t numtracks);
 
 /* Allocate a StationSpec to a Station. This is called once per build operation. */

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -680,15 +680,10 @@ struct TextRefStack {
 	uint8_t position = 0;
 	const GRFFile *grffile = nullptr;
 
-	TextRefStack(const GRFFile *grffile, uint8_t num_entries) : grffile(grffile)
+	TextRefStack(const GRFFile *grffile, std::span<const int32_t> textstack) : grffile(grffile)
 	{
-		extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
-
-		assert(num_entries < sizeof(uint32_t) * std::size(stack));
-
 		auto stack_it = this->stack.begin();
-		for (uint i = 0; i < num_entries; i++) {
-			uint32_t value = _temp_store.GetValue(0x100 + i);
+		for (int32_t value : textstack) {
 			for (uint j = 0; j < 32; j += 8) {
 				*stack_it++ = GB(value, j, 8);
 			}
@@ -960,10 +955,10 @@ static void HandleNewGRFStringControlCodes(std::string_view str, TextRefStack &s
  * Process the text ref stack for a GRF String and return its parameters.
  * @param grffile GRFFile of string.
  * @param stringid StringID of string.
- * @param num_entries Number of temporary storage registers to import.
+ * @param textstack Text parameter stack.
  * @returns Parameters for GRF string.
  */
-std::vector<StringParameter> GetGRFSringTextStackParameters(const GRFFile *grffile, StringID stringid, uint8_t num_entries)
+std::vector<StringParameter> GetGRFSringTextStackParameters(const GRFFile *grffile, StringID stringid, std::span<const int32_t> textstack)
 {
 	if (stringid == INVALID_STRING_ID) return {};
 
@@ -972,7 +967,7 @@ std::vector<StringParameter> GetGRFSringTextStackParameters(const GRFFile *grffi
 	std::vector<StringParameter> params;
 	params.reserve(20);
 
-	TextRefStack stack{grffile, num_entries};
+	TextRefStack stack{grffile, textstack};
 	HandleNewGRFStringControlCodes(str, stack, params);
 
 	return params;
@@ -982,12 +977,12 @@ std::vector<StringParameter> GetGRFSringTextStackParameters(const GRFFile *grffi
  * Format a GRF string using the text ref stack for parameters.
  * @param grffile GRFFile of string.
  * @param grfstringid GRFStringID of string.
- * @param num_entries Number of temporary storage registers to import.
+ * @param textstack Text parameter stack.
  * @returns Formatted string.
  */
-std::string GetGRFStringWithTextStack(const struct GRFFile *grffile, GRFStringID grfstringid, uint8_t num_entries)
+std::string GetGRFStringWithTextStack(const struct GRFFile *grffile, GRFStringID grfstringid, std::span<const int32_t> textstack)
 {
 	StringID stringid = GetGRFStringID(grffile->grfid, grfstringid);
-	auto params = GetGRFSringTextStackParameters(grffile, stringid, num_entries);
+	auto params = GetGRFSringTextStackParameters(grffile, stringid, textstack);
 	return GetStringWithArgs(stringid, params);
 }

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -28,7 +28,7 @@ void AddGRFTextToList(GRFTextWrapper &list, std::string_view text_to_add);
 
 bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version);
 
-std::vector<StringParameter> GetGRFSringTextStackParameters(const struct GRFFile *grffile, StringID stringid, uint8_t num_entries);
-std::string GetGRFStringWithTextStack(const struct GRFFile *grffile, GRFStringID grfstringid, uint8_t num_entries);
+std::vector<StringParameter> GetGRFSringTextStackParameters(const struct GRFFile *grffile, StringID stringid, std::span<const int32_t> textstack);
+std::string GetGRFStringWithTextStack(const struct GRFFile *grffile, GRFStringID grfstringid, std::span<const int32_t> textstack);
 
 #endif /* NEWGRF_TEXT_H */

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -36,7 +36,7 @@
 		/* Get a variable from the persistent storage */
 		case 0x7C: {
 			/* Check the persistent storage for the GrfID stored in register 100h. */
-			uint32_t grfid = static_cast<uint32_t>(GetRegister(0x100));
+			uint32_t grfid = static_cast<uint32_t>(this->ro.GetRegister(0x100));
 			if (grfid == 0xFFFFFFFF) {
 				if (this->ro.grffile == nullptr) return 0;
 				grfid = this->ro.grffile->grfid;
@@ -132,7 +132,7 @@
 	if (this->ro.grffile == nullptr) return;
 
 	/* Check the persistent storage for the GrfID stored in register 100h. */
-	uint32_t grfid = static_cast<uint32_t>(GetRegister(0x100));
+	uint32_t grfid = static_cast<uint32_t>(this->ro.GetRegister(0x100));
 
 	/* A NewGRF can only write in the persistent storage associated to its own GRFID. */
 	if (grfid == 0xFFFFFFFF) grfid = this->ro.grffile->grfid;

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -36,7 +36,7 @@
 		/* Get a variable from the persistent storage */
 		case 0x7C: {
 			/* Check the persistent storage for the GrfID stored in register 100h. */
-			uint32_t grfid = GetRegister(0x100);
+			uint32_t grfid = static_cast<uint32_t>(GetRegister(0x100));
 			if (grfid == 0xFFFFFFFF) {
 				if (this->ro.grffile == nullptr) return 0;
 				grfid = this->ro.grffile->grfid;
@@ -132,7 +132,7 @@
 	if (this->ro.grffile == nullptr) return;
 
 	/* Check the persistent storage for the GrfID stored in register 100h. */
-	uint32_t grfid = GetRegister(0x100);
+	uint32_t grfid = static_cast<uint32_t>(GetRegister(0x100));
 
 	/* A NewGRF can only write in the persistent storage associated to its own GRFID. */
 	if (grfid == 0xFFFFFFFF) grfid = this->ro.grffile->grfid;

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -278,7 +278,7 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 			uint16_t callback = CALLBACK_FAILED;
 			if (spec->callback_mask.Test(ObjectCallbackMask::SlopeCheck)) {
 				TileIndex diff = t - tile;
-				callback = GetObjectCallback(CBID_OBJECT_LAND_SLOPE_CHECK, GetTileSlope(t), TileY(diff) << 4 | TileX(diff), spec, nullptr, t, view);
+				callback = GetObjectCallback(CBID_OBJECT_LAND_SLOPE_CHECK, GetTileSlope(t), TileY(diff) << 4 | TileX(diff), spec, nullptr, t, {}, view);
 			}
 
 			if (callback == CALLBACK_FAILED) {

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -276,9 +276,10 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 
 		for (TileIndex t : ta) {
 			uint16_t callback = CALLBACK_FAILED;
+			std::array<int32_t, 4> regs100;
 			if (spec->callback_mask.Test(ObjectCallbackMask::SlopeCheck)) {
 				TileIndex diff = t - tile;
-				callback = GetObjectCallback(CBID_OBJECT_LAND_SLOPE_CHECK, GetTileSlope(t), TileY(diff) << 4 | TileX(diff), spec, nullptr, t, {}, view);
+				callback = GetObjectCallback(CBID_OBJECT_LAND_SLOPE_CHECK, GetTileSlope(t), TileY(diff) << 4 | TileX(diff), spec, nullptr, t, regs100, view);
 			}
 
 			if (callback == CALLBACK_FAILED) {
@@ -286,7 +287,7 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 			} else {
 				/* The meaning of bit 10 is inverted for a grf version < 8. */
 				if (spec->grf_prop.grffile->grf_version < 8) ToggleBit(callback, 10);
-				CommandCost ret = GetErrorMessageFromLocationCallbackResult(callback, spec->grf_prop.grffile, STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
+				CommandCost ret = GetErrorMessageFromLocationCallbackResult(callback, regs100, spec->grf_prop.grffile, STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
 				if (ret.Failed()) return ret;
 			}
 		}

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -237,12 +237,13 @@ public:
 
 				/* Get the extra message for the GUI */
 				if (spec->callback_mask.Test(ObjectCallbackMask::FundMoreText)) {
-					uint16_t callback_res = GetObjectCallback(CBID_OBJECT_FUND_MORE_TEXT, 0, 0, spec, nullptr, INVALID_TILE, {}, _object_gui.sel_view);
+					std::array<int32_t, 6> regs100;
+					uint16_t callback_res = GetObjectCallback(CBID_OBJECT_FUND_MORE_TEXT, 0, 0, spec, nullptr, INVALID_TILE, regs100, _object_gui.sel_view);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 						if (callback_res > 0x400) {
 							ErrorUnknownCallbackResult(spec->grf_prop.grfid, CBID_OBJECT_FUND_MORE_TEXT, callback_res);
 						} else {
-							std::string str = GetGRFStringWithTextStack(spec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, 6);
+							std::string str = GetGRFStringWithTextStack(spec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, regs100);
 							if (!str.empty()) {
 								tr.top = DrawStringMultiLine(tr, str, TC_ORANGE);
 							}

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -237,7 +237,7 @@ public:
 
 				/* Get the extra message for the GUI */
 				if (spec->callback_mask.Test(ObjectCallbackMask::FundMoreText)) {
-					uint16_t callback_res = GetObjectCallback(CBID_OBJECT_FUND_MORE_TEXT, 0, 0, spec, nullptr, INVALID_TILE, _object_gui.sel_view);
+					uint16_t callback_res = GetObjectCallback(CBID_OBJECT_FUND_MORE_TEXT, 0, 0, spec, nullptr, INVALID_TILE, {}, _object_gui.sel_view);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 						if (callback_res > 0x400) {
 							ErrorUnknownCallbackResult(spec->grf_prop.grfid, CBID_OBJECT_FUND_MORE_TEXT, callback_res);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3327,10 +3327,11 @@ draw_default_foundation:
 		if (stopspec != nullptr) {
 			stop_draw_mode = stopspec->draw_mode;
 			st = BaseStation::GetByTile(ti->tile);
-			auto result = GetRoadStopLayout(ti, stopspec, st, type, view);
+			std::array<int32_t, 1> regs100;
+			auto result = GetRoadStopLayout(ti, stopspec, st, type, view, regs100);
 			if (result.has_value()) {
 				if (stopspec->flags.Test(RoadStopSpecFlag::DrawModeRegister)) {
-					stop_draw_mode = static_cast<RoadStopDrawMode>(GetRegister(0x100));
+					stop_draw_mode = static_cast<RoadStopDrawMode>(regs100[0]);
 				}
 				if (type == StationType::RoadWaypoint && stop_draw_mode.Test(RoadStopDrawMode::WaypGround)) {
 					draw_ground = true;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3270,10 +3270,7 @@ draw_default_foundation:
 			/* Sprite layout which needs preprocessing */
 			bool separate_ground = statspec->flags.Test(StationSpecFlag::SeparateGround);
 			processor = SpriteLayoutProcessor(*layout, total_offset, rti->fallback_railtype, 0, 0, separate_ground);
-			for (uint8_t var10 : processor.Var10Values()) {
-				uint32_t var10_relocation = GetCustomStationRelocation(statspec, st, ti->tile, var10);
-				processor.ProcessRegisters(var10, var10_relocation);
-			}
+			GetCustomStationRelocation(processor, statspec, st, ti->tile);
 			tmp_layout = processor.GetLayout();
 			t = &tmp_layout;
 			total_offset = 0;
@@ -3330,15 +3327,15 @@ draw_default_foundation:
 		if (stopspec != nullptr) {
 			stop_draw_mode = stopspec->draw_mode;
 			st = BaseStation::GetByTile(ti->tile);
-			const TileLayoutSpriteGroup *group = GetRoadStopLayout(ti, stopspec, st, type, view);
-			if (group != nullptr) {
+			auto result = GetRoadStopLayout(ti, stopspec, st, type, view);
+			if (result.has_value()) {
 				if (stopspec->flags.Test(RoadStopSpecFlag::DrawModeRegister)) {
 					stop_draw_mode = static_cast<RoadStopDrawMode>(GetRegister(0x100));
 				}
 				if (type == StationType::RoadWaypoint && stop_draw_mode.Test(RoadStopDrawMode::WaypGround)) {
 					draw_ground = true;
 				}
-				processor = group->ProcessRegisters(nullptr);
+				processor = std::move(*result);
 				tmp_layout = processor.GetLayout();
 				t = &tmp_layout;
 			}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1599,13 +1599,14 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 					}
 
 					if (e->info.callback_mask.Test(VehicleCallbackMask::Name)) {
-						uint16_t callback = GetVehicleCallback(CBID_VEHICLE_NAME, static_cast<uint32_t>(arg >> 32), 0, e->index, nullptr);
+						std::array<int32_t, 6> regs100;
+						uint16_t callback = GetVehicleCallback(CBID_VEHICLE_NAME, static_cast<uint32_t>(arg >> 32), 0, e->index, nullptr, regs100);
 						/* Not calling ErrorUnknownCallbackResult due to being inside string processing. */
 						if (callback != CALLBACK_FAILED && callback < 0x400) {
 							const GRFFile *grffile = e->GetGRF();
 							assert(grffile != nullptr);
 
-							builder += GetGRFStringWithTextStack(grffile, GRFSTR_MISC_GRF_TEXT + callback, 6);
+							builder += GetGRFStringWithTextStack(grffile, GRFSTR_MISC_GRF_TEXT + callback, regs100);
 							break;
 						}
 					}

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -813,7 +813,7 @@ void AddAcceptedCargoOfHouse(TileIndex tile, HouseID house, const HouseSpec *hs,
 
 	/* Check for custom accepted cargo types */
 	if (hs->callback_mask.Test(HouseCallbackMask::AcceptCargo)) {
-		uint16_t callback = GetHouseCallback(CBID_HOUSE_ACCEPT_CARGO, 0, 0, house, t, tile, tile == INVALID_TILE);
+		uint16_t callback = GetHouseCallback(CBID_HOUSE_ACCEPT_CARGO, 0, 0, house, t, tile, {}, tile == INVALID_TILE);
 		if (callback != CALLBACK_FAILED) {
 			/* Replace accepted cargo types with translated values from callback */
 			accepts[0] = GetCargoTranslation(GB(callback,  0, 5), hs->grf_prop.grffile);
@@ -824,7 +824,7 @@ void AddAcceptedCargoOfHouse(TileIndex tile, HouseID house, const HouseSpec *hs,
 
 	/* Check for custom cargo acceptance */
 	if (hs->callback_mask.Test(HouseCallbackMask::CargoAcceptance)) {
-		uint16_t callback = GetHouseCallback(CBID_HOUSE_CARGO_ACCEPTANCE, 0, 0, house, t, tile, tile == INVALID_TILE);
+		uint16_t callback = GetHouseCallback(CBID_HOUSE_CARGO_ACCEPTANCE, 0, 0, house, t, tile, {}, tile == INVALID_TILE);
 		if (callback != CALLBACK_FAILED) {
 			AddAcceptedCargoSetMask(accepts[0], GB(callback, 0, 4), acceptance, always_accepted);
 			AddAcceptedCargoSetMask(accepts[1], GB(callback, 4, 4), acceptance, always_accepted);
@@ -2864,7 +2864,7 @@ static bool TryBuildTownHouse(Town *t, TileIndex tile)
 		uint8_t random_bits = Random();
 
 		if (hs->callback_mask.Test(HouseCallbackMask::AllowConstruction)) {
-			uint16_t callback_res = GetHouseCallback(CBID_HOUSE_ALLOW_CONSTRUCTION, 0, 0, house, t, tile, true, random_bits);
+			uint16_t callback_res = GetHouseCallback(CBID_HOUSE_ALLOW_CONSTRUCTION, 0, 0, house, t, tile, {}, true, random_bits);
 			if (callback_res != CALLBACK_FAILED && !Convert8bitBooleanCallback(hs->grf_prop.grffile, CBID_HOUSE_ALLOW_CONSTRUCTION, callback_res)) continue;
 		}
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1410,7 +1410,7 @@ void DrawHouseInGUI(int x, int y, HouseID house_id, int view)
  */
 static StringID GetHouseName(const HouseSpec *hs)
 {
-	uint16_t callback_res = GetHouseCallback(CBID_HOUSE_CUSTOM_NAME, 1, 0, hs->Index(), nullptr, INVALID_TILE, true);
+	uint16_t callback_res = GetHouseCallback(CBID_HOUSE_CUSTOM_NAME, 1, 0, hs->Index(), nullptr, INVALID_TILE, {}, true);
 	if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 		if (callback_res > 0x400) {
 			ErrorUnknownCallbackResult(hs->grf_prop.grffile->grfid, CBID_HOUSE_CUSTOM_NAME, callback_res);
@@ -1602,7 +1602,7 @@ static CargoTypes GetProducedCargoOfHouse(const HouseSpec *hs)
 	CargoTypes produced{};
 	if (hs->callback_mask.Test(HouseCallbackMask::ProduceCargo)) {
 		for (uint i = 0; i < 256; i++) {
-			uint16_t callback = GetHouseCallback(CBID_HOUSE_PRODUCE_CARGO, i, 0, hs->Index(), nullptr, INVALID_TILE, true);
+			uint16_t callback = GetHouseCallback(CBID_HOUSE_PRODUCE_CARGO, i, 0, hs->Index(), nullptr, INVALID_TILE, {}, true);
 
 			if (callback == CALLBACK_FAILED || callback == CALLBACK_HOUSEPRODCARGO_END) break;
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2701,10 +2701,12 @@ static const int8_t _vehicle_smoke_pos[8] = {
  */
 static void SpawnAdvancedVisualEffect(const Vehicle *v)
 {
-	uint16_t callback = GetVehicleCallback(CBID_VEHICLE_SPAWN_VISUAL_EFFECT, 0, Random(), v->engine_type, v);
+	std::array<int32_t, 4> regs100;
+	uint16_t callback = GetVehicleCallback(CBID_VEHICLE_SPAWN_VISUAL_EFFECT, 0, Random(), v->engine_type, v, regs100);
 	if (callback == CALLBACK_FAILED) return;
 
 	uint count = GB(callback, 0, 2);
+	assert(count <= std::size(regs100));
 	bool auto_center = HasBit(callback, 13);
 	bool auto_rotate = !HasBit(callback, 14);
 
@@ -2725,7 +2727,7 @@ static void SpawnAdvancedVisualEffect(const Vehicle *v)
 	int8_t y_center = _vehicle_smoke_pos[t_dir] * l_center;
 
 	for (uint i = 0; i < count; i++) {
-		int32_t reg = GetRegister(0x100 + i);
+		int32_t reg = regs100[i];
 		uint type = GB(reg,  0, 8);
 		int8_t x    = GB(reg,  8, 8);
 		int8_t y    = GB(reg, 16, 8);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2725,7 +2725,7 @@ static void SpawnAdvancedVisualEffect(const Vehicle *v)
 	int8_t y_center = _vehicle_smoke_pos[t_dir] * l_center;
 
 	for (uint i = 0; i < count; i++) {
-		uint32_t reg = GetRegister(0x100 + i);
+		int32_t reg = GetRegister(0x100 + i);
 		uint type = GB(reg,  0, 8);
 		int8_t x    = GB(reg,  8, 8);
 		int8_t y    = GB(reg, 16, 8);


### PR DESCRIPTION
## Motivation / Problem

Long road to multithreaded sprite resolving.

## Description

This includes/depends on #14221.

* Remove global `GetRegister` and other direct accesses to `_temp_store`.
* Instead add `GetRegister` and `SetRegister` as members to `ResolverObject`.
* While the `ResolverObject` is still alive/in scope, use these members to access the temporary storage.
* Extend `GetXxxCallback` to return 100+x registers by copy (only as many as needed).

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
