### PR TITLE
Add: [NewGRF] All callbacks returning D0xx strings, have now the option to return any string id via register 0x100.

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -796,7 +796,7 @@ static int DrawAircraftPurchaseInfo(int left, int right, int y, EngineID engine_
  */
 static std::optional<std::string> GetNewGRFAdditionalText(EngineID engine)
 {
-	std::array<int32_t, 6> regs100;
+	std::array<int32_t, 16> regs100;
 	uint16_t callback = GetVehicleCallback(CBID_VEHICLE_ADDITIONAL_TEXT, 0, 0, engine, nullptr, regs100);
 	if (callback == CALLBACK_FAILED || callback == 0x400) return std::nullopt;
 	const GRFFile *grffile = Engine::Get(engine)->GetGRF();

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -801,6 +801,9 @@ static std::optional<std::string> GetNewGRFAdditionalText(EngineID engine)
 	if (callback == CALLBACK_FAILED || callback == 0x400) return std::nullopt;
 	const GRFFile *grffile = Engine::Get(engine)->GetGRF();
 	assert(grffile != nullptr);
+	if (callback == 0x40F) {
+		return GetGRFStringWithTextStack(grffile, static_cast<GRFStringID>(regs100[0]), std::span{regs100}.subspan(1));
+	}
 	if (callback > 0x400) {
 		ErrorUnknownCallbackResult(grffile->grfid, CBID_VEHICLE_ADDITIONAL_TEXT, callback);
 		return std::nullopt;

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -116,10 +116,22 @@ static void GetCargoSuffix(uint cargo, CargoSuffixType cst, const Industry *ind,
 			return;
 
 		} else { // GRF version 8 or higher.
-			if (callback == 0x400) return;
-			if (callback == 0x401) {
-				suffix.display = CSD_CARGO;
-				return;
+			switch (callback) {
+				case 0x400:
+					return;
+				case 0x401:
+					suffix.display = CSD_CARGO;
+					return;
+				case 0x40E:
+					suffix.display = CSD_CARGO_TEXT;
+					suffix.text = GetGRFStringWithTextStack(indspec->grf_prop.grffile, static_cast<GRFStringID>(regs100[0]), std::span{regs100}.subspan(1));
+					return;
+				case 0x40F:
+					suffix.display = CSD_CARGO_AMOUNT_TEXT;
+					suffix.text = GetGRFStringWithTextStack(indspec->grf_prop.grffile, static_cast<GRFStringID>(regs100[0]), std::span{regs100}.subspan(1));
+					return;
+				default:
+					break;
 			}
 			if (callback < 0x400) {
 				suffix.text = GetGRFStringWithTextStack(indspec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback, regs100);
@@ -594,13 +606,16 @@ public:
 					std::array<int32_t, 6> regs100;
 					uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_FUND_MORE_TEXT, 0, 0, nullptr, this->selected_type, INVALID_TILE, regs100);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
-						if (callback_res > 0x400) {
+						std::string str;
+						if (callback_res == 0x40F) {
+							str = GetGRFStringWithTextStack(indsp->grf_prop.grffile, static_cast<GRFStringID>(regs100[0]), std::span{regs100}.subspan(1));
+						} else if (callback_res > 0x400) {
 							ErrorUnknownCallbackResult(indsp->grf_prop.grfid, CBID_INDUSTRY_FUND_MORE_TEXT, callback_res);
 						} else {
-							std::string str = GetGRFStringWithTextStack(indsp->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, regs100);
-							if (!str.empty()) {
-								DrawStringMultiLine(ir, str, TC_YELLOW);
-							}
+							str = GetGRFStringWithTextStack(indsp->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, regs100);
+						}
+						if (!str.empty()) {
+							DrawStringMultiLine(ir, str, TC_YELLOW);
 						}
 					}
 				}
@@ -977,14 +992,17 @@ public:
 			std::array<int32_t, 6> regs100;
 			uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_WINDOW_MORE_TEXT, 0, 0, i, i->type, i->location.tile, regs100);
 			if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
-				if (callback_res > 0x400) {
+				std::string str;
+				if (callback_res == 0x40F) {
+					str = GetGRFStringWithTextStack(ind->grf_prop.grffile, static_cast<GRFStringID>(regs100[0]), std::span{regs100}.subspan(1));
+				} else if (callback_res > 0x400) {
 					ErrorUnknownCallbackResult(ind->grf_prop.grfid, CBID_INDUSTRY_WINDOW_MORE_TEXT, callback_res);
 				} else {
-					std::string str = GetGRFStringWithTextStack(ind->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, regs100);
-					if (!str.empty()) {
-						ir.top += WidgetDimensions::scaled.vsep_wide;
-						ir.top = DrawStringMultiLine(ir, str, TC_YELLOW);
-					}
+					str = GetGRFStringWithTextStack(ind->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, regs100);
+				}
+				if (!str.empty()) {
+					ir.top += WidgetDimensions::scaled.vsep_wide;
+					ir.top = DrawStringMultiLine(ir, str, TC_YELLOW);
 				}
 			}
 		}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -101,7 +101,7 @@ static void GetCargoSuffix(uint cargo, CargoSuffixType cst, const Industry *ind,
 
 	if (indspec->callback_mask.Test(IndustryCallbackMask::CargoSuffix)) {
 		TileIndex t = (cst != CST_FUND) ? ind->location.tile : INVALID_TILE;
-		std::array<int32_t, 6> regs100;
+		std::array<int32_t, 16> regs100;
 		uint16_t callback = GetIndustryCallback(CBID_INDUSTRY_CARGO_SUFFIX, 0, (cst << 8) | cargo, const_cast<Industry *>(ind), ind_type, t, regs100);
 		if (callback == CALLBACK_FAILED) return;
 
@@ -603,7 +603,7 @@ public:
 
 				/* Get the additional purchase info text, if it has not already been queried. */
 				if (indsp->callback_mask.Test(IndustryCallbackMask::FundMoreText)) {
-					std::array<int32_t, 6> regs100;
+					std::array<int32_t, 16> regs100;
 					uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_FUND_MORE_TEXT, 0, 0, nullptr, this->selected_type, INVALID_TILE, regs100);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 						std::string str;
@@ -989,7 +989,7 @@ public:
 
 		/* Get the extra message for the GUI */
 		if (ind->callback_mask.Test(IndustryCallbackMask::WindowMoreText)) {
-			std::array<int32_t, 6> regs100;
+			std::array<int32_t, 16> regs100;
 			uint16_t callback_res = GetIndustryCallback(CBID_INDUSTRY_WINDOW_MORE_TEXT, 0, 0, i, i->type, i->location.tile, regs100);
 			if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 				std::string str;

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -280,8 +280,12 @@ uint16_t GetAirportCallback(CallbackID callback, uint32_t param1, uint32_t param
 StringID GetAirportTextCallback(const AirportSpec *as, uint8_t layout, uint16_t callback)
 {
 	AirportResolverObject object(INVALID_TILE, nullptr, as, layout, (CallbackID)callback);
-	uint16_t cb_res = object.ResolveCallback({});
+	std::array<int32_t, 1> regs100;
+	uint16_t cb_res = object.ResolveCallback(regs100);
 	if (cb_res == CALLBACK_FAILED || cb_res == 0x400) return STR_UNDEFINED;
+	if (cb_res == 0x40F) {
+		return GetGRFStringID(as->grf_prop.grfid, static_cast<GRFStringID>(regs100[0]));
+	}
 	if (cb_res > 0x400) {
 		ErrorUnknownCallbackResult(as->grf_prop.grfid, callback, cb_res);
 		return STR_UNDEFINED;

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -560,7 +560,7 @@ CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, siz
 	ind.psa = nullptr;
 
 	IndustriesResolverObject object(tile, &ind, type, seed, CBID_INDUSTRY_LOCATION, 0, creation_type);
-	std::array<int32_t, 4> regs100;
+	std::array<int32_t, 16> regs100;
 	uint16_t result = object.ResolveCallback(regs100);
 
 	/* Unlike the "normal" cases, not having a valid result means we allow

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -239,7 +239,7 @@ CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind
 	ind.random = initial_random_bits;
 	ind.founder = founder;
 
-	std::array<int32_t, 4> regs100;
+	std::array<int32_t, 16> regs100;
 	uint16_t callback_res = GetIndustryTileCallback(CBID_INDTILE_SHAPE_CHECK, 0, creation_type << 8 | static_cast<uint32_t>(layout_index), gfx, &ind, ind_tile, regs100);
 	if (callback_res == CALLBACK_FAILED) {
 		if (!IsSlopeRefused(GetTileSlope(ind_tile), its->slopes_refused)) return CommandCost();

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -687,7 +687,7 @@ CommandCost PerformStationTileSlopeCheck(TileIndex north_tile, TileIndex cur_til
 			(numtracks << 24) | (plat_len << 16) | (axis == AXIS_Y ? TileX(diff) << 8 | TileY(diff) : TileY(diff) << 8 | TileX(diff)));
 	object.station_scope.axis = axis;
 
-	std::array<int32_t, 4> regs100;
+	std::array<int32_t, 16> regs100;
 	uint16_t cb_res = object.ResolveCallback(regs100);
 
 	/* Failed callback means success. */

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -276,7 +276,7 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 
 		for (TileIndex t : ta) {
 			uint16_t callback = CALLBACK_FAILED;
-			std::array<int32_t, 4> regs100;
+			std::array<int32_t, 16> regs100;
 			if (spec->callback_mask.Test(ObjectCallbackMask::SlopeCheck)) {
 				TileIndex diff = t - tile;
 				callback = GetObjectCallback(CBID_OBJECT_LAND_SLOPE_CHECK, GetTileSlope(t), TileY(diff) << 4 | TileX(diff), spec, nullptr, t, regs100, view);

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -237,7 +237,7 @@ public:
 
 				/* Get the extra message for the GUI */
 				if (spec->callback_mask.Test(ObjectCallbackMask::FundMoreText)) {
-					std::array<int32_t, 6> regs100;
+					std::array<int32_t, 16> regs100;
 					uint16_t callback_res = GetObjectCallback(CBID_OBJECT_FUND_MORE_TEXT, 0, 0, spec, nullptr, INVALID_TILE, regs100, _object_gui.sel_view);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
 						std::string str;

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -240,13 +240,16 @@ public:
 					std::array<int32_t, 6> regs100;
 					uint16_t callback_res = GetObjectCallback(CBID_OBJECT_FUND_MORE_TEXT, 0, 0, spec, nullptr, INVALID_TILE, regs100, _object_gui.sel_view);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
-						if (callback_res > 0x400) {
+						std::string str;
+						if (callback_res == 0x40F) {
+							str = GetGRFStringWithTextStack(spec->grf_prop.grffile, static_cast<GRFStringID>(regs100[0]), std::span{regs100}.subspan(1));
+						} else if (callback_res > 0x400) {
 							ErrorUnknownCallbackResult(spec->grf_prop.grfid, CBID_OBJECT_FUND_MORE_TEXT, callback_res);
 						} else {
-							std::string str = GetGRFStringWithTextStack(spec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, regs100);
-							if (!str.empty()) {
-								tr.top = DrawStringMultiLine(tr, str, TC_ORANGE);
-							}
+							str = GetGRFStringWithTextStack(spec->grf_prop.grffile, GRFSTR_MISC_GRF_TEXT + callback_res, regs100);
+						}
+						if (!str.empty()) {
+							tr.top = DrawStringMultiLine(tr, str, TC_ORANGE);
 						}
 					}
 				}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1599,7 +1599,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 					}
 
 					if (e->info.callback_mask.Test(VehicleCallbackMask::Name)) {
-						std::array<int32_t, 6> regs100;
+						std::array<int32_t, 16> regs100;
 						uint16_t callback = GetVehicleCallback(CBID_VEHICLE_NAME, static_cast<uint32_t>(arg >> 32), 0, e->index, nullptr, regs100);
 						/* Not calling ErrorUnknownCallbackResult due to being inside string processing. */
 						if (callback == 0x40F) {

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1602,7 +1602,13 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 						std::array<int32_t, 6> regs100;
 						uint16_t callback = GetVehicleCallback(CBID_VEHICLE_NAME, static_cast<uint32_t>(arg >> 32), 0, e->index, nullptr, regs100);
 						/* Not calling ErrorUnknownCallbackResult due to being inside string processing. */
-						if (callback != CALLBACK_FAILED && callback < 0x400) {
+						if (callback == 0x40F) {
+							const GRFFile *grffile = e->GetGRF();
+							assert(grffile != nullptr);
+
+							builder += GetGRFStringWithTextStack(grffile, static_cast<GRFStringID>(regs100[0]), std::span{regs100}.subspan(1));
+							break;
+						} else if (callback < 0x400) {
 							const GRFFile *grffile = e->GetGRF();
 							assert(grffile != nullptr);
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -862,15 +862,19 @@ static void GetTileDesc_Town(TileIndex tile, TileDesc &td)
 	td.str = hs->building_name;
 	td.town_can_upgrade = !IsHouseProtected(tile);
 
-	uint16_t callback_res = GetHouseCallback(CBID_HOUSE_CUSTOM_NAME, house_completed ? 1 : 0, 0, house, Town::GetByTile(tile), tile);
+	std::array<int32_t, 1> regs100;
+	uint16_t callback_res = GetHouseCallback(CBID_HOUSE_CUSTOM_NAME, house_completed ? 1 : 0, 0, house, Town::GetByTile(tile), tile, regs100);
 	if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
-		if (callback_res > 0x400) {
+		StringID new_name = STR_NULL;
+		if (callback_res == 0x40F) {
+			new_name = GetGRFStringID(hs->grf_prop.grfid, static_cast<GRFStringID>(regs100[0]));
+		} else if (callback_res > 0x400) {
 			ErrorUnknownCallbackResult(hs->grf_prop.grfid, CBID_HOUSE_CUSTOM_NAME, callback_res);
 		} else {
-			StringID new_name = GetGRFStringID(hs->grf_prop.grfid, GRFSTR_MISC_GRF_TEXT + callback_res);
-			if (new_name != STR_NULL && new_name != STR_UNDEFINED) {
-				td.str = new_name;
-			}
+			new_name = GetGRFStringID(hs->grf_prop.grfid, GRFSTR_MISC_GRF_TEXT + callback_res);
+		}
+		if (new_name != STR_NULL && new_name != STR_UNDEFINED) {
+			td.str = new_name;
 		}
 	}
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1410,15 +1410,19 @@ void DrawHouseInGUI(int x, int y, HouseID house_id, int view)
  */
 static StringID GetHouseName(const HouseSpec *hs)
 {
-	uint16_t callback_res = GetHouseCallback(CBID_HOUSE_CUSTOM_NAME, 1, 0, hs->Index(), nullptr, INVALID_TILE, {}, true);
+	std::array<int32_t, 1> regs100;
+	uint16_t callback_res = GetHouseCallback(CBID_HOUSE_CUSTOM_NAME, 1, 0, hs->Index(), nullptr, INVALID_TILE, regs100, true);
 	if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {
-		if (callback_res > 0x400) {
+		StringID new_name = STR_NULL;
+		if (callback_res == 0x40F) {
+			new_name = GetGRFStringID(hs->grf_prop.grffile->grfid, static_cast<GRFStringID>(regs100[0]));
+		} else if (callback_res > 0x400) {
 			ErrorUnknownCallbackResult(hs->grf_prop.grffile->grfid, CBID_HOUSE_CUSTOM_NAME, callback_res);
 		} else {
-			StringID new_name = GetGRFStringID(hs->grf_prop.grffile->grfid, GRFSTR_MISC_GRF_TEXT + callback_res);
-			if (new_name != STR_NULL && new_name != STR_UNDEFINED) {
-				return new_name;
-			}
+			new_name = GetGRFStringID(hs->grf_prop.grffile->grfid, GRFSTR_MISC_GRF_TEXT + callback_res);
+		}
+		if (new_name != STR_NULL && new_name != STR_UNDEFINED) {
+			return new_name;
 		}
 	}
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1041,7 +1041,8 @@ static CommandCost CheckTrainAttachment(Train *t)
 			 * the loop and after each callback does not need to be cleared here. */
 			t->InvalidateNewGRFCache();
 
-			uint16_t callback = GetVehicleCallbackParent(CBID_TRAIN_ALLOW_WAGON_ATTACH, 0, 0, head->engine_type, t, head);
+			std::array<int32_t, 1> regs100;
+			uint16_t callback = GetVehicleCallbackParent(CBID_TRAIN_ALLOW_WAGON_ATTACH, 0, 0, head->engine_type, t, head, regs100);
 
 			/* Restore original first_engine data */
 			t->gcache.first_engine = first_engine;
@@ -1065,6 +1066,10 @@ static CommandCost CheckTrainAttachment(Train *t)
 						switch (callback) {
 							case 0x400: // allow if railtypes match (always the case for OpenTTD)
 							case 0x401: // allow
+								break;
+
+							case 0x40F:
+								error = GetGRFStringID(head->GetGRFID(), static_cast<GRFStringID>(regs100[0]));
 								break;
 
 							default:    // unknown reason -> disallow

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -617,7 +617,8 @@ CommandCost CmdStartStopVehicle(DoCommandFlags flags, VehicleID veh_id, bool eva
 
 	if (evaluate_startstop_cb) {
 		/* Check if this vehicle can be started/stopped. Failure means 'allow'. */
-		uint16_t callback = GetVehicleCallback(CBID_VEHICLE_START_STOP_CHECK, 0, 0, v->engine_type, v);
+		std::array<int32_t, 1> regs100;
+		uint16_t callback = GetVehicleCallback(CBID_VEHICLE_START_STOP_CHECK, 0, 0, v->engine_type, v, regs100);
 		StringID error = STR_NULL;
 		if (callback != CALLBACK_FAILED) {
 			if (v->GetGRF()->grf_version < 8) {
@@ -629,6 +630,10 @@ CommandCost CmdStartStopVehicle(DoCommandFlags flags, VehicleID veh_id, bool eva
 				} else {
 					switch (callback) {
 						case 0x400: // allow
+							break;
+
+						case 0x40F:
+							error = GetGRFStringID(v->GetGRFID(), static_cast<GRFStringID>(regs100[0]));
 							break;
 
 						default: // unknown reason -> disallow


### PR DESCRIPTION
## Motivation / Problem

There is a hard limit for D0xx strings, which are returned by callbacks.

## Description

This includes/depends on #14222.

* Extend all callbacks currently returning D0xx strings with a new result value to take the stringid from register 0x100.
* This essentially removes the need for D0xx strings entirely.
* The new return value is generally 0x40F.
* The industry cargo suffix callback has an additional 0x40E result matching the current 0x800-0xBFF results.
* If the new result is used, the textstack starts at register 0x101. It intentionally does not start at the high word of 0x100 directly after the stringid.
* While at it, also increase the size of the textstack to 16 register. (15 for new result)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
