### PR TITLE
Codechange: use C-style memory functions less

### DIFF
--- a/src/blitter/8bpp_optimized.cpp
+++ b/src/blitter/8bpp_optimized.cpp
@@ -11,7 +11,6 @@
 #include "../zoom_func.h"
 #include "../settings_type.h"
 #include "../core/math_func.hpp"
-#include "../core/mem_func.hpp"
 #include "8bpp_optimized.hpp"
 
 #include "../safeguards.h"
@@ -96,7 +95,7 @@ void Blitter_8bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Z
 				}
 
 				case BlitterMode::BlackRemap:
-					MemSetT(dst, 0, pixels);
+					std::fill_n(dst, pixels, 0);
 					dst += pixels;
 					break;
 
@@ -112,7 +111,7 @@ void Blitter_8bppOptimized::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Z
 				}
 
 				default:
-					MemCpyT(dst, src, pixels);
+					std::copy_n(src, pixels, dst);
 					dst += pixels; src += pixels;
 					break;
 			}

--- a/src/core/mem_func.hpp
+++ b/src/core/mem_func.hpp
@@ -10,8 +10,6 @@
 #ifndef MEM_FUNC_HPP
 #define MEM_FUNC_HPP
 
-#include "math_func.hpp"
-
 /**
  * Type-safe version of memcpy().
  *

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -9,7 +9,6 @@
 
 #include "stdafx.h"
 #include "core/geometry_func.hpp"
-#include "core/mem_func.hpp"
 #include "landscape.h"
 #include "newgrf_text.h"
 #include "error.h"

--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -8,7 +8,6 @@
 /** @file ini_load.cpp Definition of the #IniLoadFile class, related to reading and storing '*.ini' files. */
 
 #include "stdafx.h"
-#include "core/mem_func.hpp"
 #include "core/string_consumer.hpp"
 #include "ini_type.h"
 #include "string_func.h"

--- a/src/language.h
+++ b/src/language.h
@@ -24,22 +24,22 @@ static const uint8_t MAX_NUM_CASES   = 16; ///< Maximum number of supported case
 struct LanguagePackHeader {
 	static const uint32_t IDENT = 0x474E414C; ///< Identifier for OpenTTD language files, big endian for "LANG"
 
-	uint32_t ident;       ///< 32-bits identifier
-	uint32_t version;     ///< 32-bits of auto generated version info which is basically a hash of strings.h
-	char name[32];      ///< the international name of this language
-	char own_name[32];  ///< the localized name of this language
-	char isocode[16];   ///< the ISO code for the language (not country code)
-	uint16_t offsets[TEXT_TAB_END]; ///< the offsets
+	uint32_t ident = 0; ///< 32-bits identifier
+	uint32_t version = 0; ///< 32-bits of auto generated version info which is basically a hash of strings.h
+	char name[32] = ""; ///< the international name of this language
+	char own_name[32] = ""; ///< the localized name of this language
+	char isocode[16] = ""; ///< the ISO code for the language (not country code)
+	uint16_t offsets[TEXT_TAB_END] = {}; ///< the offsets
 
 	/** Thousand separator used for anything not currencies */
-	char digit_group_separator[8];
+	char digit_group_separator[8] = ",";
 	/** Thousand separator used for currencies */
-	char digit_group_separator_currency[8];
+	char digit_group_separator_currency[8] = ",";
 	/** Decimal separator */
-	char digit_decimal_separator[8];
-	uint16_t missing;     ///< number of missing strings.
-	uint8_t plural_form;   ///< plural form index
-	uint8_t text_dir;      ///< default direction of the text
+	char digit_decimal_separator[8] = ".";
+	uint16_t missing = 0; ///< number of missing strings.
+	uint8_t plural_form = 0; ///< plural form index
+	uint8_t text_dir = 0; ///< default direction of the text
 	/**
 	 * Windows language ID:
 	 * Windows cannot and will not convert isocodes to something it can use to
@@ -48,14 +48,14 @@ struct LanguagePackHeader {
 	 * what language it is in "Windows". The ID is the 'locale identifier' on:
 	 *   http://msdn.microsoft.com/en-us/library/ms776294.aspx
 	 */
-	uint16_t winlangid;   ///< windows language id
-	uint8_t newgrflangid; ///< newgrf language id
-	uint8_t num_genders;  ///< the number of genders of this language
-	uint8_t num_cases;    ///< the number of cases of this language
-	uint8_t pad[3];        ///< pad header to be a multiple of 4
+	uint16_t winlangid = 0; ///< windows language id
+	uint8_t newgrflangid = 0; ///< newgrf language id
+	uint8_t num_genders = 0; ///< the number of genders of this language
+	uint8_t num_cases = 0; ///< the number of cases of this language
+	uint8_t pad[3] = {}; ///< pad header to be a multiple of 4
 
-	char genders[MAX_NUM_GENDERS][CASE_GENDER_LEN]; ///< the genders used by this translation
-	char cases[MAX_NUM_CASES][CASE_GENDER_LEN];     ///< the cases used by this translation
+	char genders[MAX_NUM_GENDERS][CASE_GENDER_LEN] = {}; ///< the genders used by this translation
+	char cases[MAX_NUM_CASES][CASE_GENDER_LEN] = {}; ///< the cases used by this translation
 
 	bool IsValid() const;
 	bool IsReasonablyFinished() const;

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -18,7 +18,6 @@
 #include "midi.h"
 #include "../base_media_base.h"
 #include "../base_media_music.h"
-#include "../core/mem_func.hpp"
 #include <mutex>
 
 #include "../safeguards.h"
@@ -48,7 +47,7 @@ static struct {
 	MidiFile next_file;              ///< upcoming file to play
 	PlaybackSegment next_segment;    ///< segment info for upcoming file
 
-	uint8_t channel_volumes[16]; ///< last seen volume controller values in raw data
+	std::array<uint8_t, 16> channel_volumes; ///< last seen volume controller values in raw data
 } _midi;
 
 static FMusicDriver_Win32 iFMusicDriver_Win32;
@@ -163,7 +162,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 			_midi.do_start = 0;
 			_midi.current_block = 0;
 
-			MemSetT<uint8_t>(_midi.channel_volumes, 127, lengthof(_midi.channel_volumes));
+			_midi.channel_volumes.fill(127);
 			/* Invalidate current volume. */
 			_midi.current_volume = UINT8_MAX;
 			volume_throttle = 0;

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -19,7 +19,6 @@
 #include "gfx_func.h"
 #include "zoom_func.h"
 #include "core/random_func.hpp"
-#include "core/mem_func.hpp"
 #include "error.h"
 #include "core/geometry_func.hpp"
 #include "string_func.h"
@@ -439,7 +438,7 @@ void MusicSystem::SaveCustomPlaylist(PlaylistChoices pl)
 	}
 
 	size_t num = 0;
-	MemSetT(settings_pl, 0, NUM_SONGS_PLAYLIST);
+	std::fill_n(settings_pl, NUM_SONGS_PLAYLIST, 0);
 
 	for (const auto &song : this->standard_playlists[pl]) {
 		/* Music set indices in the settings playlist are 1-based, 0 means unused slot */

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -18,7 +18,6 @@
 #include "newgrf_callbacks.h"
 #include "newgrf_text_type.h"
 #include "core/bitmath_func.hpp"
-#include "core/mem_func.hpp"
 
 /**
  * List of different canal 'features'.

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -11,7 +11,6 @@
 #include "../../debug.h"
 #include "../../blitter/factory.hpp"
 #include "../../core/math_func.hpp"
-#include "../../core/mem_func.hpp"
 #include "../../error_func.h"
 #include "../../fileio_func.h"
 #include "../../fontcache.h"
@@ -368,8 +367,7 @@ void LoadWin32Font(FontSize fs)
 	std::string font = GetFontCacheFontName(fs);
 	if (font.empty()) return;
 
-	LOGFONT logfont;
-	MemSetT(&logfont, 0);
+	LOGFONT logfont{};
 	logfont.lfPitchAndFamily = fs == FS_MONO ? FIXED_PITCH : VARIABLE_PITCH;
 	logfont.lfCharSet = DEFAULT_CHARSET;
 	logfont.lfOutPrecision = OUT_OUTLINE_PRECIS;

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -13,7 +13,6 @@
 #include "../strings_type.h"
 #include "../misc/getoptdata.h"
 #include "../ini_type.h"
-#include "../core/mem_func.hpp"
 #include "../error_func.h"
 
 #include <filesystem>

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -19,7 +19,6 @@
 #include "settings_type.h"
 #include "blitter/factory.hpp"
 #include "core/math_func.hpp"
-#include "core/mem_func.hpp"
 #include "video/video_driver.hpp"
 #include "spritecache.h"
 #include "spritecache_internal.h"

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -9,7 +9,6 @@
 
 #include "../stdafx.h"
 #include "../core/endian_func.hpp"
-#include "../core/mem_func.hpp"
 #include "../error_func.h"
 #include "../string_func.h"
 #include "../strings_type.h"

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -10,6 +10,7 @@
 #include "../stdafx.h"
 #include "../core/endian_func.hpp"
 #include "../core/mem_func.hpp"
+#include "../core/math_func.hpp"
 #include "../error_func.h"
 #include "../string_func.h"
 #include "../core/string_builder.hpp"
@@ -588,10 +589,7 @@ void StringReader::ParseFile()
 	_strgen.file = this->file;
 
 	/* For each new file we parse, reset the genders, and language codes. */
-	MemSetT(&_strgen.lang, 0);
-	strecpy(_strgen.lang.digit_group_separator, ",");
-	strecpy(_strgen.lang.digit_group_separator_currency, ",");
-	strecpy(_strgen.lang.digit_decimal_separator, ".");
+	_strgen.lang = {};
 
 	_strgen.cur_line = 1;
 	while (this->data.next_string_id < this->data.max_strings) {

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -25,7 +25,6 @@
 #include "../../debug.h"
 #include "../../core/geometry_func.hpp"
 #include "../../core/math_func.hpp"
-#include "../../core/mem_func.hpp"
 #include "cocoa_ogl.h"
 #include "cocoa_wnd.h"
 #include "../../blitter/factory.hpp"

--- a/src/video/sdl2_default_v.cpp
+++ b/src/video/sdl2_default_v.cpp
@@ -18,7 +18,6 @@
 #include "../progress.h"
 #include "../core/random_func.hpp"
 #include "../core/math_func.hpp"
-#include "../core/mem_func.hpp"
 #include "../core/geometry_func.hpp"
 #include "../fileio_func.h"
 #include "../framerate_type.h"

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -15,7 +15,6 @@
 #include "../progress.h"
 #include "../core/random_func.hpp"
 #include "../core/math_func.hpp"
-#include "../core/mem_func.hpp"
 #include "../core/geometry_func.hpp"
 #include "../core/utf8.hpp"
 #include "../fileio_func.h"


### PR DESCRIPTION
## Motivation / Problem

The use of C-style memory functions, like `memset` and `memcpy`. But scope to just `MemCpyT` and `MemSetT` (all functions of `core/mem_func.hpp`). In my opinion these broadly fall in the C-style string class of functions as you need to include `<cstring> for them.

Including `core/mem_func.hpp` when nothing is using it.


## Description

Replace with either:
* `std::fill_n`
* `std::copy_n`
* `std::array`
* C++ object initialisation, see e.g. https://godbolt.org/z/v99ddEbaq for the `LOGFONT` change.

Remove the `core/mem_func.hpp` includes (except for `dmusic.cpp`, see limitations).


## Limitations

I haven't tackled `dmusic.cpp` as that's going to be annoying without being able to compile locally.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
