### PR TITLE
Codechange: reduce usage of memcmp

### DIFF
--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -183,6 +183,8 @@ union ColourRGBA {
 	 * @param data The colour in the correct packed format.
 	 */
 	constexpr ColourRGBA(uint data = 0) : data(data) { }
+
+	bool operator==(const ColourRGBA &other) const { return this->data == other.data; };
 };
 
 /** Packed colour union to access the alpha, red, green, and blue channels from a 32 bit number for big-endian systems. */
@@ -206,6 +208,8 @@ union ColourARGB {
 	 * @param data The colour in the correct packed format.
 	 */
 	constexpr ColourARGB(uint data = 0) : data(data) { }
+
+	bool operator==(const ColourARGB &other) const { return this->data == other.data; };
 };
 
 /** Packed colour union to access the alpha, red, green, and blue channels from a 32 bit number for little-endian systems. */
@@ -229,6 +233,8 @@ union ColourBGRA {
 	 * @param data The colour in the correct packed format.
 	 */
 	constexpr ColourBGRA(uint data = 0) : data(data) { }
+
+	bool operator==(const ColourBGRA &other) const { return this->data == other.data; };
 };
 
 #if defined(__EMSCRIPTEN__)

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -198,7 +198,7 @@ static bool ReadTrackChunk(FileHandle &file, MidiFile &target)
 	if (fread(buf, sizeof(magic), 1, file) != 1) {
 		return false;
 	}
-	if (memcmp(magic, buf, sizeof(magic)) != 0) {
+	if (!std::ranges::equal(magic, buf)) {
 		return false;
 	}
 

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -253,7 +253,6 @@ void DoPaletteAnimations()
 	Blitter *blitter = BlitterFactory::GetCurrentBlitter();
 	const Colour *s;
 	const ExtraPaletteValues *ev = &_extra_palette_values;
-	Colour old_val[PALETTE_ANIM_SIZE];
 	const uint old_tc = palette_animation_counter;
 	uint j;
 
@@ -261,10 +260,12 @@ void DoPaletteAnimations()
 		palette_animation_counter = 0;
 	}
 
-	Colour *palette_pos = &_cur_palette.palette[PALETTE_ANIM_START];  // Points to where animations are taking place on the palette
+	std::span<Colour> current_palette{&_cur_palette.palette[PALETTE_ANIM_START], PALETTE_ANIM_SIZE};
 	/* Makes a copy of the current animation palette in old_val,
 	 * so the work on the current palette could be compared, see if there has been any changes */
-	memcpy(old_val, palette_pos, sizeof(old_val));
+	std::array<Colour, PALETTE_ANIM_SIZE> original_palette;
+	std::ranges::copy(current_palette, original_palette.begin());
+	auto palette_pos = current_palette.begin(); // Points to where animations are taking place on the palette
 
 	/* Fizzy Drink bubbles animation */
 	s = ev->fizzy_drink;
@@ -344,7 +345,7 @@ void DoPaletteAnimations()
 
 	if (blitter != nullptr && blitter->UsePaletteAnimation() == Blitter::PaletteAnimation::None) {
 		palette_animation_counter = old_tc;
-	} else if (_cur_palette.count_dirty == 0 && memcmp(old_val, &_cur_palette.palette[PALETTE_ANIM_START], sizeof(old_val)) != 0) {
+	} else if (_cur_palette.count_dirty == 0 && !std::ranges::equal(current_palette, original_palette)) {
 		/* Did we changed anything on the palette? Seems so.  Mark it as dirty */
 		_cur_palette.first_dirty = PALETTE_ANIM_START;
 		_cur_palette.count_dirty = PALETTE_ANIM_SIZE;


### PR DESCRIPTION
## Motivation / Problem

C-style functions.


## Description

For settingsgen rewrite the logic for comparing files to use C++ constructs (`fread` -> `ifstream`, `memcmp` -> `std::equal`, etc).

In the other cases replace `memcmp` with `std::ranges::equal`.
For the palette code also change to `std::array` and `std::ranges::copy` for populating the backup.


## Limitations

There is `memcmp` left in `3rdparty` and one in `address.h` for comparing `sockaddr_storage_t` for which I don't have a clue what alternative we might be able to use.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
