### PR TITLE
Codefix: Fix compilation with DEBUG_DUMP_COMMANDS.

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1126,7 +1126,7 @@ void NetworkGameLoop()
 			if (TimerGameEconomy::date == next_date && TimerGameEconomy::date_fract == next_date_fract) {
 				if (cp != nullptr) {
 					NetworkSendCommand(cp->cmd, cp->err_msg, nullptr, cp->company, cp->data);
-					Debug(desync, 0, "Injecting: {:08x}; {:02x}; {:02x}; {:08x}; {} ({})", TimerGameEconomy::date, TimerGameEconomy::date_fract, (int)_current_company, cp->cmd, FormatArrayAsHex(cp->data), GetCommandName(cp->cmd));
+					Debug(desync, 0, "Injecting: {:08x}; {:02x}; {:02x}; {:08x}; {} ({})", TimerGameEconomy::date, TimerGameEconomy::date_fract, _current_company.base(), cp->cmd, FormatArrayAsHex(cp->data), GetCommandName(cp->cmd));
 					delete cp;
 					cp = nullptr;
 				}
@@ -1187,7 +1187,7 @@ void NetworkGameLoop()
 				cp->data.clear();
 				for (size_t i = 0; i + 1 < args.size(); i += 2) {
 					uint8_t e = 0;
-					std::from_chars(buffer + i, buffer + i + 2, e, 16);
+					std::from_chars(args.data() + i, args.data() + i + 2, e, 16);
 					cp->data.push_back(e);
 				}
 			} else if (consumer.ReadIf("join: ")) {


### PR DESCRIPTION
## Motivation / Problem

If the define `DEBUG_DUMP_COMMANDS` is enabled, OpenTTD does no longer compile.

## Description

Fix compilation.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
