### PR TITLE
Codechange: remove most uses of memset

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqstate.cpp
@@ -538,7 +538,7 @@ void SQStringTable::AllocNodes(SQInteger size)
 {
 	_numofslots = size;
 	_strings = (SQString**)SQ_MALLOC(sizeof(SQString*)*_numofslots);
-	memset(_strings,0,sizeof(SQString*)*(size_t)_numofslots);
+	std::fill_n(_strings, _numofslots, nullptr);
 }
 
 static const std::hash<std::string_view> string_table_hash{};

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -424,7 +424,6 @@ Sprite *Blitter_32bppOptimized::EncodeInternal(SpriteType sprite_type, const Spr
 	dest_sprite->y_offs = root_sprite.y_offs;
 
 	SpriteData *dst = (SpriteData *)dest_sprite->data;
-	memset(dst, 0, sizeof(*dst));
 
 	uint32_t offset = 0;
 	for (ZoomLevel z = zoom_min; z <= zoom_max; z++) {

--- a/src/blitter/8bpp_base.cpp
+++ b/src/blitter/8bpp_base.cpp
@@ -43,9 +43,10 @@ void Blitter_8bppBase::DrawLine(void *video, int x, int y, int x2, int y2, int s
 
 void Blitter_8bppBase::DrawRect(void *video, int width, int height, uint8_t colour)
 {
+	std::byte *p = static_cast<std::byte *>(video);
 	do {
-		memset(video, colour, width);
-		video = (uint8_t *)video + _screen.pitch;
+		std::fill_n(p, width, static_cast<std::byte>(colour));
+		p += _screen.pitch;
 	} while (--height);
 }
 

--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -18,5 +18,5 @@ Cheats _cheats;
 /** Reinitialise all the cheats. */
 void InitializeCheats()
 {
-	memset(&_cheats, 0, sizeof(Cheats));
+	_cheats = {};
 }

--- a/src/cheat_type.h
+++ b/src/cheat_type.h
@@ -14,8 +14,8 @@
  * Info about each of the cheats.
  */
 struct Cheat {
-	bool been_used; ///< has this cheat been used before?
-	bool value;     ///< tells if the bool cheat is active or not
+	bool been_used = false; ///< has this cheat been used before?
+	bool value = false; ///< tells if the bool cheat is active or not
 };
 
 /**
@@ -24,15 +24,15 @@ struct Cheat {
  * Only add new entries at the end of the struct!
  */
 struct Cheats {
-	Cheat magic_bulldozer;  ///< dynamite industries, objects
-	Cheat switch_company;   ///< change to another company
-	Cheat money;            ///< get rich or poor
-	Cheat crossing_tunnels; ///< allow tunnels that cross each other
-	Cheat no_jetcrash;      ///< no jet will crash on small airports anymore
-	Cheat change_date;      ///< changes date ingame
-	Cheat setup_prod;       ///< setup raw-material production in game
-	Cheat edit_max_hl;      ///< edit the maximum heightlevel; this is a cheat because of the fact that it needs to reset NewGRF game state and doing so as a simple configuration breaks the expectation of many
-	Cheat station_rating;   ///< Fix station ratings at 100%
+	Cheat magic_bulldozer{}; ///< dynamite industries, objects
+	Cheat switch_company{};  ///< change to another company
+	Cheat money{}; ///< get rich or poor
+	Cheat crossing_tunnels{}; ///< allow tunnels that cross each other
+	Cheat no_jetcrash{}; ///< no jet will crash on small airports anymore
+	Cheat change_date{}; ///< changes date ingame
+	Cheat setup_prod{}; ///< setup raw-material production in game
+	Cheat edit_max_hl{}; ///< edit the maximum heightlevel; this is a cheat because of the fact that it needs to reset NewGRF game state and doing so as a simple configuration breaks the expectation of many
+	Cheat station_rating{}; ///< Fix station ratings at 100%
 };
 
 extern Cheats _cheats;

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -131,7 +131,7 @@ void MxMixSamples(void *buffer, uint samples)
 	}
 
 	/* Clear the buffer */
-	memset(buffer, 0, sizeof(int16_t) * 2 * samples);
+	std::fill_n(static_cast<int16_t *>(buffer), 2 * samples, 0);
 
 	{
 		std::lock_guard<std::mutex> lock{ _music_stream_mutex };

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -270,7 +270,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 			 */
 			if (this->address.ss_family == AF_INET) {
 				sockaddr_in *address_ipv4 = (sockaddr_in *)&this->address;
-				memset(address_ipv4->sin_zero, 0, sizeof(address_ipv4->sin_zero));
+				std::ranges::fill(address_ipv4->sin_zero, 0);
 			}
 #endif
 			break;

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -202,8 +202,7 @@ bool NetworkAddress::IsInNetmask(std::string_view netmask)
 SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *sockets, LoopProc func)
 {
 	struct addrinfo *ai;
-	struct addrinfo hints;
-	memset(&hints, 0, sizeof (hints));
+	struct addrinfo hints{};
 	hints.ai_family   = family;
 	hints.ai_flags    = flags;
 	hints.ai_socktype = socktype;

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -27,10 +27,10 @@ using SocketList = std::map<SOCKET, NetworkAddress>;    ///< Type for a mapping 
  */
 class NetworkAddress {
 private:
-	std::string hostname;     ///< The hostname
-	int address_length;       ///< The length of the resolved address
-	sockaddr_storage address; ///< The resolved address
-	bool resolved;            ///< Whether the address has been (tried to be) resolved
+	std::string hostname{}; ///< The hostname
+	int address_length{}; ///< The length of the resolved address
+	sockaddr_storage address{}; ///< The resolved address
+	bool resolved = false; ///< Whether the address has been (tried to be) resolved
 
 	/**
 	 * Helper function to resolve something to a socket.
@@ -62,7 +62,6 @@ public:
 		address_length(address_length),
 		resolved(address_length != 0)
 	{
-		memset(&this->address, 0, sizeof(this->address));
 		memcpy(&this->address, address, address_length);
 	}
 
@@ -81,8 +80,6 @@ public:
 			hostname.remove_suffix(1);
 		}
 		this->hostname = hostname;
-
-		memset(&this->address, 0, sizeof(this->address));
 		this->address.ss_family = family;
 		this->SetPort(port);
 	}

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -222,8 +222,7 @@ void TCPConnecter::Resolve()
 	/* Port is already guaranteed part of the connection_string. */
 	NetworkAddress address = ParseConnectionString(this->connection_string, 0);
 
-	addrinfo hints;
-	memset(&hints, 0, sizeof(hints));
+	addrinfo hints{};
 	hints.ai_family = AF_UNSPEC;
 	hints.ai_flags = AI_ADDRCONFIG;
 	hints.ai_socktype = SOCK_STREAM;

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -76,8 +76,7 @@ public:
 	static void AcceptClient(SOCKET ls)
 	{
 		for (;;) {
-			struct sockaddr_storage sin;
-			memset(&sin, 0, sizeof(sin));
+			struct sockaddr_storage sin{};
 			socklen_t sin_len = sizeof(sin);
 			SOCKET s = accept(ls, (struct sockaddr*)&sin, &sin_len);
 			if (s == INVALID_SOCKET) return;

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -113,8 +113,7 @@ void NetworkUDPSocketHandler::ReceivePackets()
 {
 	for (auto &s : this->sockets) {
 		for (int i = 0; i < 1000; i++) { // Do not infinitely loop when DoSing with UDP
-			struct sockaddr_storage client_addr;
-			memset(&client_addr, 0, sizeof(client_addr));
+			struct sockaddr_storage client_addr{};
 
 			/* The limit is UDP_MTU, but also allocate that much as we need to read the whole packet in one go. */
 			Packet p(this, UDP_MTU, UDP_MTU);

--- a/src/object_base.h
+++ b/src/object_base.h
@@ -45,7 +45,7 @@ struct Object : ObjectPool::PoolItem<&_object_pool> {
 	static inline void IncTypeCount(ObjectType type)
 	{
 		assert(type < NUM_OBJECTS);
-		counts[type]++;
+		Object::counts[type]++;
 	}
 
 	/**
@@ -56,7 +56,7 @@ struct Object : ObjectPool::PoolItem<&_object_pool> {
 	static inline void DecTypeCount(ObjectType type)
 	{
 		assert(type < NUM_OBJECTS);
-		counts[type]--;
+		Object::counts[type]--;
 	}
 
 	/**
@@ -67,17 +67,17 @@ struct Object : ObjectPool::PoolItem<&_object_pool> {
 	static inline uint16_t GetTypeCount(ObjectType type)
 	{
 		assert(type < NUM_OBJECTS);
-		return counts[type];
+		return Object::counts[type];
 	}
 
 	/** Resets object counts. */
 	static inline void ResetTypeCounts()
 	{
-		memset(&counts, 0, sizeof(counts));
+		Object::counts.fill(0);
 	}
 
 protected:
-	static uint16_t counts[NUM_OBJECTS]; ///< Number of objects per type ingame
+	static std::array<uint16_t, NUM_OBJECTS> counts; ///< Number of objects per type ingame
 };
 
 /**

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -45,7 +45,7 @@
 
 ObjectPool _object_pool("Object");
 INSTANTIATE_POOL_METHODS(Object)
-uint16_t Object::counts[NUM_OBJECTS];
+/* static */ std::array<uint16_t, NUM_OBJECTS> Object::counts;
 
 /**
  * Get the object associated with a tile.

--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -159,8 +159,7 @@ static sigset_t SetSignals(void(*handler)(int))
 		sigaddset(&sigs, signum);
 	}
 
-	struct sigaction sa;
-	memset(&sa, 0, sizeof(sa));
+	struct sigaction sa{};
 	sa.sa_flags = SA_RESTART;
 
 	sigemptyset(&sa.sa_mask);

--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -146,8 +146,7 @@ static sigset_t SetSignals(void(*handler)(int))
 		sigaddset(&sigs, signum);
 	}
 
-	struct sigaction sa;
-	memset(&sa, 0, sizeof(sa));
+	struct sigaction sa{};
 	sa.sa_flags = SA_RESTART;
 
 	sigemptyset(&sa.sa_mask);

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -212,8 +212,7 @@ static const uint MAX_FRAMES     = 64;
 		proc.pSymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_FAIL_CRITICAL_ERRORS | SYMOPT_UNDNAME);
 
 		/* Initialize starting stack frame from context record. */
-		STACKFRAME64 frame;
-		memset(&frame, 0, sizeof(frame));
+		STACKFRAME64 frame{};
 #ifdef _M_AMD64
 		frame.AddrPC.Offset = ep->ContextRecord->Rip;
 		frame.AddrFrame.Offset = ep->ContextRecord->Rbp;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2557,7 +2557,7 @@ struct NoCompSaveFilter : SaveFilter {
 
 /** Filter using Zlib compression. */
 struct ZlibLoadFilter : LoadFilter {
-	z_stream z;                        ///< Stream state we are reading from.
+	z_stream z{}; ///< Stream state we are reading from.
 	uint8_t fread_buf[MEMORY_CHUNK_SIZE]; ///< Buffer for reading from the file.
 
 	/**
@@ -2566,7 +2566,6 @@ struct ZlibLoadFilter : LoadFilter {
 	 */
 	ZlibLoadFilter(std::shared_ptr<LoadFilter> chain) : LoadFilter(std::move(chain))
 	{
-		memset(&this->z, 0, sizeof(this->z));
 		if (inflateInit(&this->z) != Z_OK) SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_INTERNAL_ERROR, "cannot initialize decompressor");
 	}
 
@@ -2601,7 +2600,7 @@ struct ZlibLoadFilter : LoadFilter {
 
 /** Filter using Zlib compression. */
 struct ZlibSaveFilter : SaveFilter {
-	z_stream z; ///< Stream state we are writing to.
+	z_stream z{}; ///< Stream state we are writing to.
 	uint8_t fwrite_buf[MEMORY_CHUNK_SIZE]; ///< Buffer for writing to the file.
 
 	/**
@@ -2611,7 +2610,6 @@ struct ZlibSaveFilter : SaveFilter {
 	 */
 	ZlibSaveFilter(std::shared_ptr<SaveFilter> chain, uint8_t compression_level) : SaveFilter(std::move(chain))
 	{
-		memset(&this->z, 0, sizeof(this->z));
 		if (deflateInit(&this->z, compression_level) != Z_OK) SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_INTERNAL_ERROR, "cannot initialize compressor");
 	}
 

--- a/src/saveload/settings_sl.cpp
+++ b/src/saveload/settings_sl.cpp
@@ -25,7 +25,7 @@
  */
 void PrepareOldDiffCustom()
 {
-	memset(_old_diff_custom, 0, sizeof(_old_diff_custom));
+	_old_diff_custom.fill(0);
 }
 
 /**

--- a/src/screenshot_pcx.cpp
+++ b/src/screenshot_pcx.cpp
@@ -45,7 +45,6 @@ public:
 	{
 		uint maxlines;
 		uint y;
-		PcxHeader pcx;
 		bool success;
 
 		if (pixelformat == 32) {
@@ -58,9 +57,8 @@ public:
 		if (!of.has_value()) return false;
 		auto &f = *of;
 
-		memset(&pcx, 0, sizeof(pcx));
-
 		/* setup pcx header */
+		PcxHeader pcx{};
 		pcx.manufacturer = 10;
 		pcx.version = 5;
 		pcx.rle = 1;

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -75,8 +75,7 @@ public:
 
 		/* Try to add some game metadata to the PNG screenshot so
 		 * it's more useful for debugging and archival purposes. */
-		png_text_struct text[2];
-		memset(text, 0, sizeof(text));
+		png_text_struct text[2]{};
 		text[0].key = const_cast<char *>("Software");
 		text[0].text = const_cast<char *>(_openttd_revision.c_str());
 		text[0].text_length = _openttd_revision.size();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -281,15 +281,15 @@ static std::optional<std::vector<uint32_t>> ParseIntList(std::string_view str)
 static bool LoadIntList(std::optional<std::string_view> str, void *array, int nelems, VarType type)
 {
 	size_t elem_size = SlVarSize(type);
+	std::byte *p = static_cast<std::byte *>(array);
 	if (!str.has_value()) {
-		memset(array, 0, nelems * elem_size);
+		std::fill_n(p, nelems * elem_size, static_cast<std::byte>(0));
 		return true;
 	}
 
 	auto opt_items = ParseIntList(*str);
 	if (!opt_items.has_value() || opt_items->size() != (size_t)nelems) return false;
 
-	std::byte *p = static_cast<std::byte *>(array);
 	for (auto item : *opt_items) {
 		WriteValue(p, type, item);
 		p += elem_size;

--- a/src/settings_table.h
+++ b/src/settings_table.h
@@ -39,6 +39,6 @@ extern SettingTable _win32_settings;
 
 static const uint GAME_DIFFICULTY_NUM = 18;
 extern const std::array<std::string, GAME_DIFFICULTY_NUM> _old_diff_settings;
-extern uint16_t _old_diff_custom[GAME_DIFFICULTY_NUM];
+extern std::array<uint16_t, GAME_DIFFICULTY_NUM> _old_diff_custom;
 
 #endif /* SETTINGS_TABLE_H */

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -448,7 +448,7 @@ static void *ReadRecolourSprite(SpriteFile &file, size_t file_pos, uint num, Spr
 		uint8_t *dest_tmp = new uint8_t[std::max(RECOLOUR_SPRITE_SIZE, num)];
 
 		/* Only a few recolour sprites are less than 257 bytes */
-		if (num < RECOLOUR_SPRITE_SIZE) memset(dest_tmp, 0, RECOLOUR_SPRITE_SIZE);
+		if (num < RECOLOUR_SPRITE_SIZE) std::fill_n(dest_tmp, RECOLOUR_SPRITE_SIZE, 0);
 		file.ReadBlock(dest_tmp, num);
 
 		/* The data of index 0 is never used; "literal 00" according to the (New)GRF specs. */

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -31,7 +31,7 @@ using SpriteComponents = EnumBitSet<SpriteComponent, uint8_t, SpriteComponent::E
  */
 template <class T>
 class SpriteCollMap {
-	std::array<T, to_underlying(ZoomLevel::End)> data;
+	std::array<T, to_underlying(ZoomLevel::End)> data{};
 public:
 	inline constexpr T &operator[](const ZoomLevel &zoom) { return this->data[to_underlying(zoom)]; }
 	inline constexpr const T &operator[](const ZoomLevel &zoom) const { return this->data[to_underlying(zoom)]; }

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -10,7 +10,7 @@
 [pre-amble]
 const std::array<std::string, GAME_DIFFICULTY_NUM> _old_diff_settings{"max_no_competitors", "competitor_start_time", "number_towns", "industry_density", "max_loan", "initial_interest", "vehicle_costs", "competitor_speed", "competitor_intelligence", "vehicle_breakdowns", "subsidy_multiplier", "construction_cost", "terrain_type", "quantity_sea_lakes", "economy", "line_reverse_mode", "disasters", "town_council_tolerance"};
 
-uint16_t _old_diff_custom[GAME_DIFFICULTY_NUM];
+std::array<uint16_t, GAME_DIFFICULTY_NUM> _old_diff_custom;
 uint8_t _old_diff_level;                                 ///< Old difficulty level from old savegames
 
 static void DifficultyNoiseChange(int32_t new_value);

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -680,8 +680,7 @@ static std::vector<char> Gunzip(std::span<char> input)
 	static const int BLOCKSIZE = 8192;
 	std::vector<char> output;
 
-	z_stream z;
-	memset(&z, 0, sizeof(z));
+	z_stream z{};
 	z.next_in = reinterpret_cast<Bytef *>(input.data());
 	z.avail_in = static_cast<uInt>(input.size());
 

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -203,7 +203,7 @@ static bool CreateMainSurface(uint w, uint h)
 	_screen.dst_ptr = _allegro_screen->line[0];
 
 	/* Initialise the screen so we don't blit garbage to the screen */
-	memset(_screen.dst_ptr, 0, static_cast<size_t>(_screen.height) * _screen.pitch);
+	std::fill_n(static_cast<std::byte *>(_screen.dst_ptr), static_cast<size_t>(_screen.height) * _screen.pitch, static_cast<std::byte>(0));
 
 	/* Set the mouse at the place where we expect it */
 	poll_mouse();

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -152,9 +152,7 @@ bool VideoDriver_Win32Base::MakeWindow(bool full_screen, bool resize)
 	}
 
 	if (full_screen) {
-		DEVMODE settings;
-
-		memset(&settings, 0, sizeof(settings));
+		DEVMODE settings{};
 		settings.dmSize = sizeof(settings);
 		settings.dmFields =
 			DM_BITSPERPEL |


### PR DESCRIPTION
## Motivation / Problem

`memset` is from `#include <cstrings>`, so shouldn't really be used in C++ code.


## Description

Replace `memset` with:
* `std::fill_n`
* `std::ranges::fill`
* `std::array.fill` (including conversion to `std::array`.
* initialisation of the variable using `{}`


## Limitations

None I can think of. Except the use of `MemSetT` by dmusic.cpp, which still requires `memset` to be used there.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
