### PR TITLE
Fix #14234, 16b4e73: Skip PLURAL data if parameter is invalid.

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -765,6 +765,16 @@ static int DeterminePluralForm(int64_t count, uint plural_form)
 	}
 }
 
+static void SkipStringChoice(StringConsumer &consumer)
+{
+	uint n = consumer.ReadUint8();
+	uint len = 0;
+	for (uint i = 0; i != n; i++) {
+		len += consumer.ReadUint8();
+	}
+	consumer.Skip(len);
+}
+
 static void ParseStringChoice(StringConsumer &consumer, uint form, StringBuilder &builder)
 {
 	/* <NUM> {Length of each string} {each string} */
@@ -1196,6 +1206,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 					if (v != nullptr) {
 						ParseStringChoice(consumer, DeterminePluralForm(static_cast<int64_t>(*v), plural_form), builder);
 					} else {
+						SkipStringChoice(consumer);
 						builder += "(invalid PLURAL parameter)";
 					}
 					break;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #14234, the game can crash when formatting a string (in this case, related to a station)

In this case this happens because a NewGRF references strings in invalid contexts. One of these strings tried to use a plural form, and because the parameter is missing, the processing the plural is skipped.

This unfortunately then leaves the data of the plural itself in the string buffer, which will be read as regular characters. If a NUL character is reached, the game will assert. Before StringConsumer, the NUL character would simply have terminated string processing, thus hiding this error.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Fixed this situation by skipping the data of a plural even if the parameter is invalid.

The NewGRF still uses an incorrect string, and the output is still (presumably) not intended.

But it doesn't crash now.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Skipping GENDER may need something similar.

EDIT: Looks like in the case of GENDER it's still processed, just with the first gender.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
