### PR TITLE
Fix #13854: 40bpp-anim blitter recolouring failed for 32bpp pixels without mask channel.

### DIFF
--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -377,8 +377,11 @@ void Blitter_40bppAnim::DrawColourMappingRect(void *dst, int width, int height, 
 		const uint8_t *remap = GetNonSprite(pal, SpriteType::Recolour) + 1;
 		do {
 			for (int i = 0; i != width; i++) {
-				if (*anim == 0) *udst = MakeGrey(*udst);
-				*anim = remap[*anim];
+				if (*anim == 0) {
+					*udst = MakeGrey(*udst);
+				} else {
+					*anim = remap[*anim];
+				}
 				udst++;
 				anim++;
 			}
@@ -389,7 +392,7 @@ void Blitter_40bppAnim::DrawColourMappingRect(void *dst, int width, int height, 
 		const uint8_t *remap = GetNonSprite(pal, SpriteType::Recolour) + 1;
 		do {
 			for (int i = 0; i != width; i++) {
-				*anim = remap[*anim];
+				if (*anim != 0) *anim = remap[*anim];
 				anim++;
 			}
 			anim = anim - width + _screen.pitch;


### PR DESCRIPTION
## Motivation / Problem

#13854

## Description

* For 8bpp blitters the mask channel is never zero.
* For 32bpp blitters the mask channel is zero for pure 32bpp pixels.
* The 40bpp-anim blitter also applied recolouring to mask channel zeros, which the recolouring may map to some non-sense.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
