### PR TITLE
Codechange: replace memcpy with std::copy_n

### DIFF
--- a/src/3rdparty/md5/md5.cpp
+++ b/src/3rdparty/md5/md5.cpp
@@ -281,7 +281,7 @@ void Md5::Append(const void *data, const size_t nbytes)
 	if (offset) {
 		size_t copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
 
-		memcpy(this->buf + offset, p, copy);
+		std::copy_n(p, copy, this->buf + offset);
 
 		if (offset + copy < 64) return;
 
@@ -294,7 +294,7 @@ void Md5::Append(const void *data, const size_t nbytes)
 	for (; left >= 64; p += 64, left -= 64) this->Process(p);
 
 	/* Process a final partial block. */
-	if (left) memcpy(this->buf, p, left);
+	if (left) std::copy_n(p, left, this->buf);
 }
 
 void Md5::Finish(MD5Hash &digest)

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
@@ -534,7 +534,7 @@ SQFunctionProto *SQFuncState::BuildProto()
 	for(SQUnsignedInteger no = 0; no < _lineinfos.size(); no++) f->_lineinfos[no] = _lineinfos[no];
 	for(SQUnsignedInteger no = 0; no < _defaultparams.size(); no++) f->_defaultparams[no] = _defaultparams[no];
 
-	memcpy(f->_instructions,&_instructions[0],(size_t)_instructions.size()*sizeof(SQInstruction));
+	std::copy_n(&_instructions[0], _instructions.size(), f->_instructions);
 
 	f->_varparams = _varparams;
 

--- a/src/3rdparty/squirrel/squirrel/sqstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqstate.cpp
@@ -564,7 +564,7 @@ SQString *SQStringTable::Add(std::string_view new_string)
 
 SQString::SQString(std::string_view new_string)
 {
-	memcpy(_val,new_string.data(),new_string.size());
+	std::ranges::copy(new_string, _val);
 	_val[new_string.size()] = '\0';
 	_len = new_string.size();
 	_hash = string_table_hash(new_string);

--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -389,11 +389,11 @@ void Blitter_32bppAnim::CopyFromBuffer(void *video, const void *src, int width, 
 		Colour *dst_pal = dst;
 		uint16_t *anim_pal = anim_line;
 
-		memcpy(static_cast<void *>(dst), usrc, width * sizeof(uint32_t));
+		std::copy_n(usrc, width, reinterpret_cast<uint32_t *>(dst));
 		usrc += width;
 		dst += _screen.pitch;
 		/* Copy back the anim-buffer */
-		memcpy(anim_line, usrc, width * sizeof(uint16_t));
+		std::copy_n(reinterpret_cast<const uint16_t *>(usrc), width, anim_line);
 		usrc = (const uint32_t *)&((const uint16_t *)usrc)[width];
 		anim_line += this->anim_buf_pitch;
 
@@ -428,11 +428,11 @@ void Blitter_32bppAnim::CopyToBuffer(const void *video, void *dst, int width, in
 	const uint16_t *anim_line = this->ScreenToAnimOffset((const uint32_t *)video) + this->anim_buf;
 
 	for (; height > 0; height--) {
-		memcpy(udst, src, width * sizeof(uint32_t));
+		std::copy_n(src, width, udst);
 		src += _screen.pitch;
 		udst += width;
 		/* Copy the anim-buffer */
-		memcpy(udst, anim_line, width * sizeof(uint16_t));
+		std::copy_n(anim_line, width, reinterpret_cast<uint16_t *>(udst));
 		udst = (uint32_t *)&((uint16_t *)udst)[width];
 		anim_line += this->anim_buf_pitch;
 	}
@@ -459,7 +459,7 @@ void Blitter_32bppAnim::ScrollBuffer(void *video, int &left, int &top, int &widt
 		uint tw = width + (scroll_x >= 0 ? -scroll_x : scroll_x);
 		uint th = height - scroll_y;
 		for (; th > 0; th--) {
-			memcpy(dst, src, tw * sizeof(uint16_t));
+			std::copy_n(src, tw, dst);
 			src -= this->anim_buf_pitch;
 			dst -= this->anim_buf_pitch;
 		}

--- a/src/blitter/32bpp_base.cpp
+++ b/src/blitter/32bpp_base.cpp
@@ -51,7 +51,7 @@ void Blitter_32bppBase::CopyFromBuffer(void *video, const void *src, int width, 
 	const uint32_t *usrc = (const uint32_t *)src;
 
 	for (; height > 0; height--) {
-		memcpy(dst, usrc, width * sizeof(uint32_t));
+		std::copy_n(usrc, width, dst);
 		usrc += width;
 		dst += _screen.pitch;
 	}
@@ -63,7 +63,7 @@ void Blitter_32bppBase::CopyToBuffer(const void *video, void *dst, int width, in
 	const uint32_t *src = (const uint32_t *)video;
 
 	for (; height > 0; height--) {
-		memcpy(udst, src, width * sizeof(uint32_t));
+		std::copy_n(src, width, udst);
 		src += _screen.pitch;
 		udst += width;
 	}
@@ -75,7 +75,7 @@ void Blitter_32bppBase::CopyImageToBuffer(const void *video, void *dst, int widt
 	const uint32_t *src = (const uint32_t *)video;
 
 	for (; height > 0; height--) {
-		memcpy(udst, src, width * sizeof(uint32_t));
+		std::copy_n(src, width, udst);
 		src += _screen.pitch;
 		udst += dst_pitch;
 	}
@@ -107,7 +107,7 @@ void Blitter_32bppBase::ScrollBuffer(void *video, int &left, int &top, int &widt
 		}
 
 		for (int h = height; h > 0; h--) {
-			memcpy(dst, src, width * sizeof(uint32_t));
+			std::copy_n(src, width, dst);
 			src -= _screen.pitch;
 			dst -= _screen.pitch;
 		}

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -432,8 +432,8 @@ Sprite *Blitter_32bppOptimized::EncodeInternal(SpriteType sprite_type, const Spr
 		dst->offset[1][z] = offset;
 		offset += lengths[1][z];
 
-		memcpy(dst->data + dst->offset[0][z], dst_px_orig[z].get(), lengths[0][z]);
-		memcpy(dst->data + dst->offset[1][z], dst_n_orig[z].get(), lengths[1][z]);
+		std::copy_n(reinterpret_cast<uint8_t *>(dst_px_orig[z].get()), lengths[0][z], dst->data + dst->offset[0][z]);
+		std::copy_n(reinterpret_cast<uint8_t *>(dst_n_orig[z].get()), lengths[1][z], dst->data + dst->offset[1][z]);
 	}
 
 	return dest_sprite;

--- a/src/blitter/32bpp_sse2.cpp
+++ b/src/blitter/32bpp_sse2.cpp
@@ -57,7 +57,7 @@ Sprite *Blitter_32bppSSE_Base::Encode(SpriteType sprite_type, const SpriteLoader
 	dst_sprite->width = root_sprite.width;
 	dst_sprite->x_offs = root_sprite.x_offs;
 	dst_sprite->y_offs = root_sprite.y_offs;
-	memcpy(dst_sprite->data, &sd, sizeof(SpriteData));
+	std::copy_n(reinterpret_cast<std::byte *>(&sd), sizeof(SpriteData), dst_sprite->data);
 
 	/* Copy colours and determine flags. */
 	bool has_remap = false;
@@ -135,7 +135,7 @@ Sprite *Blitter_32bppSSE_Base::Encode(SpriteType sprite_type, const SpriteLoader
 	if (has_translucency) sd.flags.Set(SpriteFlag::Translucent);
 	if (!has_remap) sd.flags.Set(SpriteFlag::NoRemap);
 	if (!has_anim) sd.flags.Set(SpriteFlag::NoAnim);
-	memcpy(dst_sprite->data, &sd, sizeof(SpriteData));
+	std::copy_n(reinterpret_cast<std::byte *>(&sd), sizeof(SpriteData), dst_sprite->data);
 
 	return dst_sprite;
 }

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -418,11 +418,11 @@ void Blitter_40bppAnim::CopyFromBuffer(void *video, const void *src, int width, 
 	uint8_t *anim_line = ((uint32_t *)video - (uint32_t *)_screen.dst_ptr) + anim_buf;
 
 	for (; height > 0; height--) {
-		memcpy(dst, usrc, width * sizeof(uint32_t));
+		std::copy_n(usrc, width, dst);
 		usrc += width;
 		dst += _screen.pitch;
 		/* Copy back the anim-buffer */
-		memcpy(anim_line, usrc, width * sizeof(uint8_t));
+		std::copy_n(reinterpret_cast<const uint8_t *>(usrc), width, anim_line);
 		usrc = (const uint32_t *)((const uint8_t *)usrc + width);
 		anim_line += _screen.pitch;
 	}
@@ -440,11 +440,11 @@ void Blitter_40bppAnim::CopyToBuffer(const void *video, void *dst, int width, in
 	const uint8_t *anim_line = ((const uint32_t *)video - (uint32_t *)_screen.dst_ptr) + anim_buf;
 
 	for (; height > 0; height--) {
-		memcpy(udst, src, width * sizeof(uint32_t));
+		std::copy_n(src, width, udst);
 		src += _screen.pitch;
 		udst += width;
 		/* Copy the anim-buffer */
-		memcpy(udst, anim_line, width * sizeof(uint8_t));
+		std::copy_n(anim_line, width, reinterpret_cast<uint8_t *>(udst));
 		udst = (uint32_t *)((uint8_t *)udst + width);
 		anim_line += _screen.pitch;
 	}
@@ -494,7 +494,7 @@ void Blitter_40bppAnim::ScrollBuffer(void *video, int &left, int &top, int &widt
 		uint tw = width + (scroll_x >= 0 ? -scroll_x : scroll_x);
 		uint th = height - scroll_y;
 		for (; th > 0; th--) {
-			memcpy(dst, src, tw * sizeof(uint8_t));
+			std::copy_n(src, tw, dst);
 			src -= _screen.pitch;
 			dst -= _screen.pitch;
 		}

--- a/src/blitter/8bpp_base.cpp
+++ b/src/blitter/8bpp_base.cpp
@@ -56,7 +56,7 @@ void Blitter_8bppBase::CopyFromBuffer(void *video, const void *src, int width, i
 	const uint8_t *usrc = (const uint8_t *)src;
 
 	for (; height > 0; height--) {
-		memcpy(dst, usrc, width * sizeof(uint8_t));
+		std::copy_n(usrc, width, dst);
 		usrc += width;
 		dst += _screen.pitch;
 	}
@@ -68,7 +68,7 @@ void Blitter_8bppBase::CopyToBuffer(const void *video, void *dst, int width, int
 	const uint8_t *src = (const uint8_t *)video;
 
 	for (; height > 0; height--) {
-		memcpy(udst, src, width * sizeof(uint8_t));
+		std::copy_n(src, width, udst);
 		src += _screen.pitch;
 		udst += width;
 	}
@@ -80,7 +80,7 @@ void Blitter_8bppBase::CopyImageToBuffer(const void *video, void *dst, int width
 	const uint8_t *src = (const uint8_t *)video;
 
 	for (; height > 0; height--) {
-		memcpy(udst, src, width * sizeof(uint8_t));
+		std::copy_n(src, width, udst);
 		src += _screen.pitch;
 		udst += dst_pitch;
 	}
@@ -112,7 +112,7 @@ void Blitter_8bppBase::ScrollBuffer(void *video, int &left, int &top, int &width
 		}
 
 		for (int h = height; h > 0; h--) {
-			memcpy(dst, src, width * sizeof(uint8_t));
+			std::copy_n(src, width, dst);
 			src -= _screen.pitch;
 			dst -= _screen.pitch;
 		}

--- a/src/blitter/8bpp_optimized.cpp
+++ b/src/blitter/8bpp_optimized.cpp
@@ -225,7 +225,7 @@ Sprite *Blitter_8bppOptimized::Encode(SpriteType sprite_type, const SpriteLoader
 	dest_sprite->width = root_sprite.width;
 	dest_sprite->x_offs = root_sprite.x_offs;
 	dest_sprite->y_offs = root_sprite.y_offs;
-	memcpy(dest_sprite->data, temp_dst, size);
+	std::copy_n(reinterpret_cast<std::byte *>(temp_dst), size, dest_sprite->data);
 
 	return dest_sprite;
 }

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -259,7 +259,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 		if (sockets == nullptr) {
 			this->address_length = (int)runp->ai_addrlen;
 			assert(sizeof(this->address) >= runp->ai_addrlen);
-			memcpy(&this->address, runp->ai_addr, runp->ai_addrlen);
+			std::copy_n(reinterpret_cast<const std::byte *>(runp->ai_addr), runp->ai_addrlen, reinterpret_cast<std::byte *>(&this->address));
 #ifdef __EMSCRIPTEN__
 			/* Emscripten doesn't zero sin_zero, but as we compare addresses
 			 * to see if they are the same address, we need them to be zero'd.

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -58,11 +58,11 @@ public:
 	 * @param address The IP address with port.
 	 * @param address_length The length of the address.
 	 */
-	NetworkAddress(sockaddr *address, int address_length) :
+	NetworkAddress(const sockaddr *address, int address_length) :
 		address_length(address_length),
 		resolved(address_length != 0)
 	{
-		memcpy(&this->address, address, address_length);
+		std::copy_n(reinterpret_cast<const std::byte *>(address), address_length, reinterpret_cast<std::byte *>(&this->address));
 	}
 
 	/**

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -48,7 +48,7 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // Wi
 
 		sockaddr_storage address{};
 		/* iiBroadcast is unusable, because it always seems to be set to 255.255.255.255. */
-		memcpy(&address, &ifo.iiAddress.Address, sizeof(sockaddr));
+		std::copy_n(reinterpret_cast<const std::byte *>(&ifo.iiAddress.Address), sizeof(sockaddr), reinterpret_cast<std::byte *>(&address));
 		reinterpret_cast<sockaddr_in*>(&address)->sin_addr.s_addr = ifo.iiAddress.AddressIn.sin_addr.s_addr | ~ifo.iiNetmask.AddressIn.sin_addr.s_addr;
 		NetworkAddress addr(address, sizeof(sockaddr));
 		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const &elem) -> bool { return elem == addr; })) broadcast->push_back(addr);

--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -203,7 +203,7 @@ void HttpThread()
 
 			/* Copy the buffer out of CURL. OnReceiveData() will free it when done. */
 			std::unique_ptr<char[]> buffer = std::make_unique<char[]>(size * nmemb);
-			memcpy(buffer.get(), ptr, size * nmemb);
+			std::copy_n(ptr, size * nmemb, buffer.get());
 			callback->OnReceiveData(std::move(buffer), size * nmemb);
 
 			return size * nmemb;

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -231,8 +231,7 @@ static const uint MAX_FRAMES     = 64;
 		frame.AddrStack.Mode = AddrModeFlat;
 
 		/* Copy context record as StackWalk64 may modify it. */
-		CONTEXT ctx;
-		memcpy(&ctx, ep->ContextRecord, sizeof(ctx));
+		CONTEXT ctx = *ep->ContextRecord;
 
 		/* Allocate space for symbol info.
 		 * The total initialised size must be sufficient for a null-terminating char at sym_info->Name[sym_info->MaxNameLength],

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -209,7 +209,7 @@ void DoPaletteAnimations();
 void GfxInitPalettes()
 {
 	std::lock_guard<std::recursive_mutex> lock(_palette_mutex);
-	memcpy(&_cur_palette, &_palette, sizeof(_cur_palette));
+	_cur_palette = _palette;
 	DoPaletteAnimations();
 }
 

--- a/src/random_access_file.cpp
+++ b/src/random_access_file.cpp
@@ -146,7 +146,7 @@ void RandomAccessFile::ReadBlock(void *ptr, size_t size)
 {
 	if (this->buffer != this->buffer_end) {
 		size_t to_copy = std::min<size_t>(size, this->buffer_end - this->buffer);
-		memcpy(ptr, this->buffer, to_copy);
+		std::copy_n(this->buffer, to_copy, static_cast<uint8_t *>(ptr));
 		this->buffer += to_copy;
 		size -= to_copy;
 		if (size == 0) return;

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -47,6 +47,9 @@
 #endif
 #define stricmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
+#define memcmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define memcpy SAFEGUARD_DO_NOT_USE_THIS_METHOD
+
 /* Use fgets instead. */
 #define gets      SAFEGUARD_DO_NOT_USE_THIS_METHOD
 

--- a/src/screenshot_bmp.cpp
+++ b/src/screenshot_bmp.cpp
@@ -123,7 +123,7 @@ public:
 			while (n-- != 0) {
 				if (pixelformat == 8) {
 					/* Move to 'line', leave last few pixels in line zeroed */
-					memcpy(line.data(), buff.data() + n * w, w);
+					std::copy_n(buff.data() + n * w, w, line.data());
 				} else {
 					/* Convert from 'native' 32bpp to BMP-like 24bpp.
 					 * Works for both big and little endian machines */

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -134,7 +134,7 @@ public:
 		this->CheckAllocationAllowed(size - oldsize);
 
 		void *new_p = this->DoAlloc(size);
-		memcpy(new_p, p, std::min(oldsize, size));
+		std::copy_n(static_cast<std::byte *>(p), std::min(oldsize, size), static_cast<std::byte *>(new_p));
 		this->Free(p, oldsize);
 
 		return new_p;
@@ -261,7 +261,7 @@ void Squirrel::AddMethod(std::string_view method_name, SQFUNCTION proc, std::str
 
 	if (size != 0) {
 		void *ptr = sq_newuserdata(vm, size);
-		memcpy(ptr, userdata, size);
+		std::copy_n(static_cast<std::byte *>(userdata), size, static_cast<std::byte *>(ptr));
 	}
 
 	sq_newclosure(this->vm, proc, size != 0 ? 1 : 0);


### PR DESCRIPTION
## Motivation / Problem

C-style memory copying.


## Description

Use mostly `std::copy_n`, some assignments where applicable.


## Limitations

Some copies are a bit meh due to the casting that needs to happen, especially in the blitter, squirrel and network code. Not that I'd know a solution for the network code bits, as we can't guarantee the source and destination are the same (sub)type.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
