### PR TITLE
Codechange: replace memmove with std::move(_backwards)

### DIFF
--- a/src/3rdparty/squirrel/squirrel/squtils.h
+++ b/src/3rdparty/squirrel/squirrel/squtils.h
@@ -93,7 +93,7 @@ public:
 	{
 		_vals[idx].~T();
 		if(idx < (_size - 1)) {
-			memmove(static_cast<void *>(&_vals[idx]), &_vals[idx+1], sizeof(T) * (_size - (size_t)idx - 1));
+			std::move(&_vals[idx + 1], &_vals[_size], &_vals[idx]);
 		}
 		_size--;
 	}

--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -458,11 +458,7 @@ void Blitter_32bppAnim::ScrollBuffer(void *video, int &left, int &top, int &widt
 
 		uint tw = width + (scroll_x >= 0 ? -scroll_x : scroll_x);
 		uint th = height - scroll_y;
-		for (; th > 0; th--) {
-			std::copy_n(src, tw, dst);
-			src -= this->anim_buf_pitch;
-			dst -= this->anim_buf_pitch;
-		}
+		Blitter::MovePixels(src, dst, tw, th, -this->anim_buf_pitch);
 	} else {
 		/* Calculate pointers */
 		dst = this->anim_buf + left + top * this->anim_buf_pitch;
@@ -475,15 +471,9 @@ void Blitter_32bppAnim::ScrollBuffer(void *video, int &left, int &top, int &widt
 			src -= scroll_x;
 		}
 
-		/* the y-displacement may be 0 therefore we have to use memmove,
-		 * because source and destination may overlap */
 		uint tw = width + (scroll_x >= 0 ? -scroll_x : scroll_x);
 		uint th = height + scroll_y;
-		for (; th > 0; th--) {
-			memmove(dst, src, tw * sizeof(uint16_t));
-			src += this->anim_buf_pitch;
-			dst += this->anim_buf_pitch;
-		}
+		Blitter::MovePixels(src, dst, tw, th, this->anim_buf_pitch);
 	}
 
 	Blitter_32bppBase::ScrollBuffer(video, left, top, width, height, scroll_x, scroll_y);

--- a/src/blitter/32bpp_base.cpp
+++ b/src/blitter/32bpp_base.cpp
@@ -106,11 +106,7 @@ void Blitter_32bppBase::ScrollBuffer(void *video, int &left, int &top, int &widt
 			width += scroll_x;
 		}
 
-		for (int h = height; h > 0; h--) {
-			std::copy_n(src, width, dst);
-			src -= _screen.pitch;
-			dst -= _screen.pitch;
-		}
+		Blitter::MovePixels(src, dst, width, height, -_screen.pitch);
 	} else {
 		/* Calculate pointers */
 		dst = (uint32_t *)video + left + top * _screen.pitch;
@@ -130,13 +126,7 @@ void Blitter_32bppBase::ScrollBuffer(void *video, int &left, int &top, int &widt
 			width += scroll_x;
 		}
 
-		/* the y-displacement may be 0 therefore we have to use memmove,
-		 * because source and destination may overlap */
-		for (int h = height; h > 0; h--) {
-			memmove(dst, src, width * sizeof(uint32_t));
-			src += _screen.pitch;
-			dst += _screen.pitch;
-		}
+		Blitter::MovePixels(src, dst, width, height, _screen.pitch);
 	}
 }
 

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -493,11 +493,7 @@ void Blitter_40bppAnim::ScrollBuffer(void *video, int &left, int &top, int &widt
 
 		uint tw = width + (scroll_x >= 0 ? -scroll_x : scroll_x);
 		uint th = height - scroll_y;
-		for (; th > 0; th--) {
-			std::copy_n(src, tw, dst);
-			src -= _screen.pitch;
-			dst -= _screen.pitch;
-		}
+		Blitter::MovePixels(src, dst, tw, th, -_screen.pitch);
 	} else {
 		/* Calculate pointers */
 		dst = anim_buf + left + top * _screen.pitch;
@@ -510,15 +506,9 @@ void Blitter_40bppAnim::ScrollBuffer(void *video, int &left, int &top, int &widt
 			src -= scroll_x;
 		}
 
-		/* the y-displacement may be 0 therefore we have to use memmove,
-		 * because source and destination may overlap */
 		uint tw = width + (scroll_x >= 0 ? -scroll_x : scroll_x);
 		uint th = height + scroll_y;
-		for (; th > 0; th--) {
-			memmove(dst, src, tw * sizeof(uint8_t));
-			src += _screen.pitch;
-			dst += _screen.pitch;
-		}
+		Blitter::MovePixels(src, dst, tw, th, _screen.pitch);
 	}
 
 	Blitter_32bppBase::ScrollBuffer(video, left, top, width, height, scroll_x, scroll_y);

--- a/src/blitter/8bpp_base.cpp
+++ b/src/blitter/8bpp_base.cpp
@@ -111,11 +111,7 @@ void Blitter_8bppBase::ScrollBuffer(void *video, int &left, int &top, int &width
 			width += scroll_x;
 		}
 
-		for (int h = height; h > 0; h--) {
-			std::copy_n(src, width, dst);
-			src -= _screen.pitch;
-			dst -= _screen.pitch;
-		}
+		Blitter::MovePixels(src, dst, width, height, -_screen.pitch);
 	} else {
 		/* Calculate pointers */
 		dst = (uint8_t *)video + left + top * _screen.pitch;
@@ -135,13 +131,7 @@ void Blitter_8bppBase::ScrollBuffer(void *video, int &left, int &top, int &width
 			width += scroll_x;
 		}
 
-		/* the y-displacement may be 0 therefore we have to use memmove,
-		 * because source and destination may overlap */
-		for (int h = height; h > 0; h--) {
-			memmove(dst, src, width * sizeof(uint8_t));
-			src += _screen.pitch;
-			dst += _screen.pitch;
-		}
+		Blitter::MovePixels(src, dst, width, height, _screen.pitch);
 	}
 }
 

--- a/src/blitter/base.hpp
+++ b/src/blitter/base.hpp
@@ -207,6 +207,8 @@ public:
 	virtual ~Blitter() = default;
 
 	template <typename SetPixelT> void DrawLineGeneric(int x, int y, int x2, int y2, int screen_width, int screen_height, int width, int dash, SetPixelT set_pixel);
+
+	template <typename T> static void MovePixels(const T *src, T *dst, size_t width, size_t height, ptrdiff_t pitch);
 };
 
 #endif /* BLITTER_BASE_HPP */

--- a/src/blitter/common.hpp
+++ b/src/blitter/common.hpp
@@ -192,4 +192,24 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 	}
 }
 
+template <typename T>
+/* static */ void Blitter::MovePixels(const T *src, T *dst, size_t width, size_t height, ptrdiff_t pitch)
+{
+	if (src == dst) return;
+
+	if (src < dst) {
+		for (size_t i = 0; i < height; ++i) {
+			std::move_backward(src, src + width, dst + width);
+			src += pitch;
+			dst += pitch;
+		}
+	} else {
+		for (size_t i = 0; i < height; ++i) {
+			std::move(src, src + width, dst);
+			src += pitch;
+			dst += pitch;
+		}
+	}
+}
+
 #endif /* BLITTER_COMMON_HPP */

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -49,6 +49,7 @@
 
 #define memcmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define memcpy SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define memmove SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define memset SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
 /* Use fgets instead. */

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -426,7 +426,7 @@ public:
 
 		if (IsSavegameVersionBefore(SLV_85)) {
 			/* We want to insert some liveries somewhere in between. This means some have to be moved. */
-			memmove(&c->livery[LS_FREIGHT_WAGON], &c->livery[LS_PASSENGER_WAGON_MONORAIL], (LS_END - LS_FREIGHT_WAGON) * sizeof(c->livery[0]));
+			std::move_backward(&c->livery[LS_FREIGHT_WAGON - 2], &c->livery[LS_END - 2], &c->livery[LS_END]);
 			c->livery[LS_PASSENGER_WAGON_MONORAIL] = c->livery[LS_MONORAIL];
 			c->livery[LS_PASSENGER_WAGON_MAGLEV]   = c->livery[LS_MAGLEV];
 		}

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -803,7 +803,8 @@ static void CompactSpriteCache()
 			GetSpriteCache(i)->ptr = s->data; // Adjust sprite array entry
 			/* Swap this and the next block */
 			temp = *s;
-			memmove(s, next, next->size);
+			std::byte *p = reinterpret_cast<std::byte *>(next);
+			std::move(p, &p[next->size], reinterpret_cast<std::byte *>(s));
 			s = NextBlock(s);
 			*s = temp;
 


### PR DESCRIPTION
## Motivation / Problem

Use of C-style memory methods.


## Description

Use `std::move` or `std::move_backwards` instead of `memmove`.


## Limitations

I'm not 100% sure the blitters need `std::move_backwards`, or whether they actually need `std::move` (or maybe even both).


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
