### PR TITLE
Fix 51a7edd: NewGRF debug sprite picker was broken.

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3026,14 +3026,6 @@ void InputLoop()
 	/* Process scheduled window deletion. */
 	Window::DeleteClosedWindows();
 
-	/* Handle sprite picker before any GUI interaction */
-	if (_newgrf_debug_sprite_picker.mode == SPM_REDRAW) {
-		/* We are done with the last draw-frame, so we know what sprites we
-		 * clicked on. Reset the picker mode and invalidate the window. */
-		_newgrf_debug_sprite_picker.mode = SPM_NONE;
-		InvalidateWindowData(WC_SPRITE_ALIGNER, 0, 1);
-	}
-
 	/* HandleMouseEvents was already called for this tick */
 	HandleMouseEvents();
 }
@@ -3117,6 +3109,13 @@ void UpdateWindows()
 	NetworkDrawChatMessage();
 	/* Redraw mouse cursor in case it was hidden */
 	DrawMouseCursor();
+
+	if (_newgrf_debug_sprite_picker.mode == SPM_REDRAW) {
+		/* We are done with the last draw-frame, so we know what sprites we
+		 * clicked on. Reset the picker mode and invalidate the window. */
+		_newgrf_debug_sprite_picker.mode = SPM_NONE;
+		InvalidateWindowData(WC_SPRITE_ALIGNER, 0, 1);
+	}
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

51a7edd was a bit too magical.
Turns out, `HandleMouseEvents` is called from a lot of places, many before `InputLoop`.

* `_input_events_this_tick` actually had *some* effect: `HandleMouseEvents` was skipped, if there were actual input events that tick,

## Description

* `HandleMouseEvents` is still called one time more than before 51a7edd, but extra calls to it are okay.
* The sprite picker stuff is now moved to `UpdateWindows`, which is actually related to redrawing, in contrast to `HandleMouseEvents`/`InputLoop` before.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
