### PR TITLE
Codechange: remove last (hidden) users of memset

### DIFF
--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -143,8 +143,7 @@ static HFONT HFontFromFont(Font *font)
 {
 	if (font->fc->GetOSHandle() != nullptr) return CreateFontIndirect(reinterpret_cast<PLOGFONT>(const_cast<void *>(font->fc->GetOSHandle())));
 
-	LOGFONT logfont;
-	ZeroMemory(&logfont, sizeof(LOGFONT));
+	LOGFONT logfont{};
 	logfont.lfHeight = font->fc->GetHeight();
 	logfont.lfWeight = FW_NORMAL;
 	logfont.lfCharSet = DEFAULT_CHARSET;
@@ -249,12 +248,10 @@ static bool UniscribeShapeRun(const UniscribeParagraphLayoutFactory::CharType *b
 static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutFactory::CharType *buff, int32_t length)
 {
 	/* Itemize text. */
-	SCRIPT_CONTROL control;
-	ZeroMemory(&control, sizeof(SCRIPT_CONTROL));
+	SCRIPT_CONTROL control{};
 	control.uDefaultLanguage = _current_language->winlangid;
 
-	SCRIPT_STATE state;
-	ZeroMemory(&state, sizeof(SCRIPT_STATE));
+	SCRIPT_STATE state{};
 	state.uBidiLevel = _current_text_dir == TD_RTL ? 1 : 0;
 
 	std::vector<SCRIPT_ITEM> items(16);

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -49,6 +49,7 @@
 
 #define memcmp SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define memcpy SAFEGUARD_DO_NOT_USE_THIS_METHOD
+#define memset SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
 /* Use fgets instead. */
 #define gets      SAFEGUARD_DO_NOT_USE_THIS_METHOD


### PR DESCRIPTION
## Motivation / Problem

Use of C-style memory functions.


## Description

When trying to add `memset` to safeguards in #14244, that failed to compile for Windows because there were some hidden users of `memset`. This replaces them with value initialisation.


## Limitations

I hope it builds.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
