### PR TITLE
Codechange: simplify getting the value of a NewGRF property

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -270,14 +270,6 @@ char (&ArraySizeHelper(T (&array)[N]))[N];
  */
 #define lengthof(array) (sizeof(ArraySizeHelper(array)))
 
-/**
- * Gets the size of a variable within a class.
- * @param base     The class the variable is in.
- * @param variable The variable to get the size of.
- * @return the size of the variable
- */
-#define cpp_sizeof(base, variable) (sizeof(std::declval<base>().variable))
-
 
 /* take care of some name clashes on MacOS */
 #if defined(__APPLE__)

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -13,10 +13,10 @@
 #include "../newgrf_roadstop.h"
 
 /* Helper for filling property tables */
-#define NIP(prop, base, variable, type, name) { name, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->variable); }, cpp_sizeof(base, variable), prop, type }
+#define NIP(prop, base_class, variable, type, name) { name, [] (const void *b) -> uint32_t { return static_cast<const base_class *>(b)->variable; }, prop, type }
 
 /* Helper for filling callback tables */
-#define NIC(cb_id, base, variable, bit) { #cb_id, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->variable); }, cpp_sizeof(base, variable), bit, cb_id }
+#define NIC(cb_id, base_class, variable, bit) { #cb_id, [] (const void *b) -> uint32_t { return static_cast<const base_class *>(b)->variable.base(); }, bit, cb_id }
 
 /* Helper for filling variable tables */
 #define NIV(var, name) { name, var }
@@ -270,8 +270,8 @@ static const NIFeature _nif_industrytile = {
 
 
 /*** NewGRF industries ***/
-#define NIP_PRODUCED_CARGO(prop, base, slot, type, name) { name, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->GetProduced(slot).cargo); }, sizeof(CargoType), prop, type }
-#define NIP_ACCEPTED_CARGO(prop, base, slot, type, name) { name, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->GetAccepted(slot).cargo); }, sizeof(CargoType), prop, type }
+#define NIP_PRODUCED_CARGO(prop, base_class, slot, type, name) { name, [] (const void *b) -> uint32_t { return static_cast<const base_class *>(b)->GetProduced(slot).cargo; }, prop, type }
+#define NIP_ACCEPTED_CARGO(prop, base_class, slot, type, name) { name, [] (const void *b) -> uint32_t { return static_cast<const base_class *>(b)->GetAccepted(slot).cargo; }, prop, type }
 
 static const NIProperty _nip_industries[] = {
 	NIP_PRODUCED_CARGO(0x25, Industry,  0, NIT_CARGO, "produced cargo 0"),


### PR DESCRIPTION
## Motivation / Problem

Initially getting rid of rarely used things in `stdafx.h`, finding `cpp_sizeof` that's only used in one file.

Then looking at the code, and getting the realisation that it can be done much simpler. Why define/pass a function that returns the address of a variable, and put that and the number of bytes to read into a structure of properties, to then *only* call that function to get the address and use the size to read data from that address? If you already define a function, why not let that function just return the value?


## Description

Replace `NIOffsetProc` and `read_size` with `NIReadProc` that just returns the value of the variable that would be read otherwise.

Remove `cpp_sizeof` from `stdafx.h`.


## Limitations

No reasonable ones I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
