### PR TITLE
Codechange: Use GrfSpecFeature type instead of uint8_t.

### DIFF
--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -207,16 +207,6 @@ enum PriceCategory : uint8_t {
 	PCAT_CONSTRUCTION, ///< Price is affected by "construction cost" difficulty setting
 };
 
-/**
- * Describes properties of price bases.
- */
-struct PriceBaseSpec {
-	Money start_price;      ///< Default value at game start, before adding multipliers.
-	PriceCategory category; ///< Price is affected by certain difficulty settings.
-	uint grf_feature;       ///< GRF Feature that decides whether price multipliers apply locally or globally, #GSF_END if none.
-	Price fallback_price;   ///< Fallback price multiplier for new prices but old grfs.
-};
-
 /** The "steps" in loan size, in British Pounds! */
 static const int LOAN_INTERVAL = 10000;
 /** The size of loan for a new company, in British Pounds! */

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1461,7 +1461,7 @@ static void FinalisePriceBaseMultipliers()
 {
 	extern const PriceBaseSpec _price_base_specs[];
 	/** Features, to which '_grf_id_overrides' applies. Currently vehicle features only. */
-	static const uint32_t override_features = (1 << GSF_TRAINS) | (1 << GSF_ROADVEHICLES) | (1 << GSF_SHIPS) | (1 << GSF_AIRCRAFT);
+	static constexpr GrfSpecFeatures override_features{GSF_TRAINS, GSF_ROADVEHICLES, GSF_SHIPS, GSF_AIRCRAFT};
 
 	/* Evaluate grf overrides */
 	int num_grfs = (uint)_grf_files.size();
@@ -1485,13 +1485,13 @@ static void FinalisePriceBaseMultipliers()
 		GRFFile &source = _grf_files[i];
 		GRFFile &dest = _grf_files[grf_overrides[i]];
 
-		uint32_t features = (source.grf_features | dest.grf_features) & override_features;
-		source.grf_features |= features;
-		dest.grf_features |= features;
+		GrfSpecFeatures features = (source.grf_features | dest.grf_features) & override_features;
+		source.grf_features.Set(features);
+		dest.grf_features.Set(features);
 
 		for (Price p = PR_BEGIN; p < PR_END; p++) {
 			/* No price defined -> nothing to do */
-			if (!HasBit(features, _price_base_specs[p].grf_feature) || source.price_base_multipliers[p] == INVALID_PRICE_MODIFIER) continue;
+			if (!features.Test(_price_base_specs[p].grf_feature) || source.price_base_multipliers[p] == INVALID_PRICE_MODIFIER) continue;
 			Debug(grf, 3, "'{}' overrides price base multiplier {} of '{}'", source.filename, p, dest.filename);
 			dest.price_base_multipliers[p] = source.price_base_multipliers[p];
 		}
@@ -1503,13 +1503,13 @@ static void FinalisePriceBaseMultipliers()
 		GRFFile &source = _grf_files[i];
 		GRFFile &dest = _grf_files[grf_overrides[i]];
 
-		uint32_t features = (source.grf_features | dest.grf_features) & override_features;
-		source.grf_features |= features;
-		dest.grf_features |= features;
+		GrfSpecFeatures features = (source.grf_features | dest.grf_features) & override_features;
+		source.grf_features.Set(features);
+		dest.grf_features.Set(features);
 
 		for (Price p = PR_BEGIN; p < PR_END; p++) {
 			/* Already a price defined -> nothing to do */
-			if (!HasBit(features, _price_base_specs[p].grf_feature) || dest.price_base_multipliers[p] != INVALID_PRICE_MODIFIER) continue;
+			if (!features.Test(_price_base_specs[p].grf_feature) || dest.price_base_multipliers[p] != INVALID_PRICE_MODIFIER) continue;
 			Debug(grf, 3, "Price base multiplier {} from '{}' propagated to '{}'", p, source.filename, dest.filename);
 			dest.price_base_multipliers[p] = source.price_base_multipliers[p];
 		}
@@ -1521,12 +1521,12 @@ static void FinalisePriceBaseMultipliers()
 		GRFFile &source = _grf_files[i];
 		GRFFile &dest = _grf_files[grf_overrides[i]];
 
-		uint32_t features = (source.grf_features | dest.grf_features) & override_features;
-		source.grf_features |= features;
-		dest.grf_features |= features;
+		GrfSpecFeatures features = (source.grf_features | dest.grf_features) & override_features;
+		source.grf_features.Set(features);
+		dest.grf_features.Set(features);
 
 		for (Price p = PR_BEGIN; p < PR_END; p++) {
-			if (!HasBit(features, _price_base_specs[p].grf_feature)) continue;
+			if (!features.Test(_price_base_specs[p].grf_feature)) continue;
 			if (source.price_base_multipliers[p] != dest.price_base_multipliers[p]) {
 				Debug(grf, 3, "Price base multiplier {} from '{}' propagated to '{}'", p, dest.filename, source.filename);
 			}
@@ -1556,7 +1556,7 @@ static void FinalisePriceBaseMultipliers()
 				/* No multiplier was set; set it to a neutral value */
 				price_base_multipliers[p] = 0;
 			} else {
-				if (!HasBit(file.grf_features, _price_base_specs[p].grf_feature)) {
+				if (!file.grf_features.Test(_price_base_specs[p].grf_feature)) {
 					/* The grf does not define any objects of the feature,
 					 * so it must be a difficulty setting. Apply it globally */
 					Debug(grf, 3, "'{}' sets global price base multiplier {}", file.filename, p);

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -95,6 +95,8 @@ enum GrfSpecFeature : uint8_t {
 	GSF_FAKE_TOWNS = GSF_END, ///< Fake town GrfSpecFeature for NewGRF debugging (parent scope)
 	GSF_FAKE_END,             ///< End of the fake features
 
+	GSF_ORIGINAL_STRINGS = 0x48,
+
 	GSF_INVALID = 0xFF,       ///< An invalid spec feature
 };
 using GrfSpecFeatures = EnumBitSet<GrfSpecFeature, uint32_t, GrfSpecFeature::GSF_END>;
@@ -153,7 +155,7 @@ struct GRFFile {
 	int traininfo_vehicle_pitch = 0; ///< Vertical offset for drawing train images in depot GUI and vehicle details
 	uint traininfo_vehicle_width = 0; ///< Width (in pixels) of a 8/8 train vehicle in depot GUI and vehicle details
 
-	uint32_t grf_features = 0; ///< Bitset of GrfSpecFeature the grf uses
+	GrfSpecFeatures grf_features{}; ///< Bitset of GrfSpecFeature the grf uses
 	PriceMultipliers price_base_multipliers{}; ///< Price base multipliers as set by the grf.
 
 	GRFFile(const struct GRFConfig &config);
@@ -188,6 +190,16 @@ struct GRFLoadedFeatures {
 	uint64_t used_liveries;     ///< Bitmask of #LiveryScheme used by the defined engines.
 	ShoreReplacement shore;   ///< In which way shore sprites were replaced.
 	TramReplacement tram;     ///< In which way tram depots were replaced.
+};
+
+/**
+ * Describes properties of price bases.
+ */
+struct PriceBaseSpec {
+	Money start_price; ///< Default value at game start, before adding multipliers.
+	PriceCategory category; ///< Price is affected by certain difficulty settings.
+	GrfSpecFeature grf_feature; ///< GRF Feature that decides whether price multipliers apply locally or globally, #GSF_END if none.
+	Price fallback_price; ///< Fallback price multiplier for new prices but old grfs.
 };
 
 /**

--- a/src/newgrf/newgrf_act0.cpp
+++ b/src/newgrf/newgrf_act0.cpp
@@ -109,7 +109,7 @@ std::vector<BadgeID> ReadBadgeList(ByteReader &buf, GrfSpecFeature feature)
 	return badges;
 }
 
-bool HandleChangeInfoResult(std::string_view caller, ChangeInfoResult cir, uint8_t feature, uint8_t property)
+bool HandleChangeInfoResult(std::string_view caller, ChangeInfoResult cir, GrfSpecFeature feature, uint8_t property)
 {
 	switch (cir) {
 		default: NOT_REACHED();
@@ -204,7 +204,7 @@ static void FeatureChangeInfo(ByteReader &buf)
 	}
 
 	/* Mark the feature as used by the grf */
-	SetBit(_cur_gps.grffile->grf_features, feature);
+	_cur_gps.grffile->grf_features.Set(feature);
 
 	while (numprops-- && buf.HasData()) {
 		uint8_t prop = buf.ReadByte();

--- a/src/newgrf/newgrf_act1.cpp
+++ b/src/newgrf/newgrf_act1.cpp
@@ -32,7 +32,7 @@ static void NewSpriteSet(ByteReader &buf)
 	 *                         In that case, use num-dirs=4.
 	 */
 
-	uint8_t  feature   = buf.ReadByte();
+	GrfSpecFeature feature{buf.ReadByte()};
 	uint16_t num_sets  = buf.ReadByte();
 	uint16_t first_set = 0;
 

--- a/src/newgrf/newgrf_act2.cpp
+++ b/src/newgrf/newgrf_act2.cpp
@@ -60,7 +60,7 @@ void MapSpriteMappingRecolour(PalSpriteID *grf_sprite)
  * @param[out] max_palette_offset Optionally returns the number of sprites in the spriteset of the palette. (0 if no spritset)
  * @return Read TileLayoutFlags.
  */
-TileLayoutFlags ReadSpriteLayoutSprite(ByteReader &buf, bool read_flags, bool invert_action1_flag, bool use_cur_spritesets, int feature, PalSpriteID *grf_sprite, uint16_t *max_sprite_offset, uint16_t *max_palette_offset)
+TileLayoutFlags ReadSpriteLayoutSprite(ByteReader &buf, bool read_flags, bool invert_action1_flag, bool use_cur_spritesets, GrfSpecFeature feature, PalSpriteID *grf_sprite, uint16_t *max_sprite_offset, uint16_t *max_palette_offset)
 {
 	grf_sprite->sprite = buf.ReadWord();
 	grf_sprite->pal = buf.ReadWord();
@@ -171,7 +171,7 @@ static void ReadSpriteLayoutRegisters(ByteReader &buf, TileLayoutFlags flags, bo
  * @param dts                  Layout container to output into
  * @return True on error (GRF was disabled).
  */
-bool ReadSpriteLayout(ByteReader &buf, uint num_building_sprites, bool use_cur_spritesets, uint8_t feature, bool allow_var10, bool no_z_position, NewGRFSpriteLayout *dts)
+bool ReadSpriteLayout(ByteReader &buf, uint num_building_sprites, bool use_cur_spritesets, GrfSpecFeature feature, bool allow_var10, bool no_z_position, NewGRFSpriteLayout *dts)
 {
 	bool has_flags = HasBit(num_building_sprites, 6);
 	ClrBit(num_building_sprites, 6);
@@ -314,7 +314,7 @@ static const SpriteGroup *GetGroupFromGroupID(uint8_t setid, uint8_t type, uint1
  * @param spriteid Raw value from the GRF for the new spritegroup; describes either the return value or the referenced spritegroup.
  * @return Created spritegroup.
  */
-static const SpriteGroup *CreateGroupFromGroupID(uint8_t feature, uint8_t setid, uint8_t type, uint16_t spriteid)
+static const SpriteGroup *CreateGroupFromGroupID(GrfSpecFeature feature, uint8_t setid, uint8_t type, uint16_t spriteid)
 {
 	if (HasBit(spriteid, 15)) return GetCallbackResultGroup(spriteid);
 
@@ -348,7 +348,7 @@ static void NewSpriteGroup(ByteReader &buf)
 	 * V feature-specific-data (huge mess, don't even look it up --pasky) */
 	const SpriteGroup *act_group = nullptr;
 
-	uint8_t feature = buf.ReadByte();
+	GrfSpecFeature feature{buf.ReadByte()};
 	if (feature >= GSF_END) {
 		GrfMsg(1, "NewSpriteGroup: Unsupported feature 0x{:02X}, skipping", feature);
 		return;

--- a/src/newgrf/newgrf_act3.cpp
+++ b/src/newgrf/newgrf_act3.cpp
@@ -33,7 +33,7 @@
 #include "../safeguards.h"
 
 
-static CargoType TranslateCargo(uint8_t feature, uint8_t ctype)
+static CargoType TranslateCargo(GrfSpecFeature feature, uint8_t ctype)
 {
 	/* Special cargo types for purchase list and stations */
 	if ((feature == GSF_STATIONS || feature == GSF_ROADSTOPS) && ctype == 0xFE) return CargoGRFFileProps::SG_DEFAULT_NA;
@@ -75,7 +75,7 @@ static bool IsValidGroupID(uint16_t groupid, std::string_view function)
 	return true;
 }
 
-static void VehicleMapSpriteGroup(ByteReader &buf, uint8_t feature, uint8_t idcount)
+static void VehicleMapSpriteGroup(ByteReader &buf, GrfSpecFeature feature, uint8_t idcount)
 {
 	static std::vector<EngineID> last_engines; // Engine IDs are remembered in case the next action is a wagon override.
 	bool wagover = false;
@@ -104,7 +104,7 @@ static void VehicleMapSpriteGroup(ByteReader &buf, uint8_t feature, uint8_t idco
 			/* No engine could be allocated?!? Deal with it. Okay,
 			 * this might look bad. Also make sure this NewGRF
 			 * gets disabled, as a half loaded one is bad. */
-			HandleChangeInfoResult("VehicleMapSpriteGroup", CIR_INVALID_ID, 0, 0);
+			HandleChangeInfoResult("VehicleMapSpriteGroup", CIR_INVALID_ID, feature, 0);
 			return;
 		}
 
@@ -714,7 +714,7 @@ static void FeatureMapSpriteGroup(ByteReader &buf)
 	 * W cid           cargo ID (sprite group ID) for this type of cargo
 	 * W def-cid       default cargo ID (sprite group ID) */
 
-	uint8_t feature = buf.ReadByte();
+	GrfSpecFeature feature{buf.ReadByte()};
 	uint8_t idcount = buf.ReadByte();
 
 	if (feature >= GSF_END) {
@@ -736,7 +736,7 @@ static void FeatureMapSpriteGroup(ByteReader &buf)
 	}
 
 	/* Mark the feature as used by the grf (generic callbacks do not count) */
-	SetBit(_cur_gps.grffile->grf_features, feature);
+	_cur_gps.grffile->grf_features.Set(feature);
 
 	GrfMsg(6, "FeatureMapSpriteGroup: Feature 0x{:02X}, {} ids", feature, idcount);
 

--- a/src/newgrf/newgrf_act4.cpp
+++ b/src/newgrf/newgrf_act4.cpp
@@ -48,8 +48,8 @@ static void FeatureNewName(ByteReader &buf)
 
 	bool new_scheme = _cur_gps.grffile->grf_version >= 7;
 
-	uint8_t feature  = buf.ReadByte();
-	if (feature >= GSF_END && feature != 0x48) {
+	GrfSpecFeature feature{buf.ReadByte()};
+	if (feature >= GSF_END && feature != GSF_ORIGINAL_STRINGS) {
 		GrfMsg(1, "FeatureNewName: Unsupported feature 0x{:02X}, skipping", feature);
 		return;
 	}

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -234,11 +234,11 @@ static void ParamSet(ByteReader &buf)
 			} else {
 				/* GRF Resource Management */
 				uint8_t  op      = src1;
-				uint8_t  feature = GB(data, 8, 8);
+				GrfSpecFeature feature{static_cast<uint8_t>(GB(data, 8, 8))};
 				uint16_t count   = GB(data, 16, 16);
 
 				if (_cur_gps.stage == GLS_RESERVE) {
-					if (feature == 0x08) {
+					if (feature == GSF_GLOBALVAR) {
 						/* General sprites */
 						if (op == 0) {
 							/* Check if the allocated sprites will fit below the original sprite limit */
@@ -258,10 +258,10 @@ static void ParamSet(ByteReader &buf)
 					src1 = 0;
 				} else if (_cur_gps.stage == GLS_ACTIVATION) {
 					switch (feature) {
-						case 0x00: // Trains
-						case 0x01: // Road Vehicles
-						case 0x02: // Ships
-						case 0x03: // Aircraft
+						case GSF_TRAINS:
+						case GSF_ROADVEHICLES:
+						case GSF_SHIPS:
+						case GSF_AIRCRAFT:
 							if (!_settings_game.vehicle.dynamic_engines) {
 								src1 = PerformGRM({std::begin(_grm_engines) + _engine_offsets[feature], _engine_counts[feature]}, count, op, target, "vehicles");
 								if (_cur_gps.skip_sprites == -1) return;
@@ -280,7 +280,7 @@ static void ParamSet(ByteReader &buf)
 							}
 							break;
 
-						case 0x08: // General sprites
+						case GSF_GLOBALVAR: // General sprites
 							switch (op) {
 								case 0:
 									/* Return space reserved during reservation stage */
@@ -298,7 +298,7 @@ static void ParamSet(ByteReader &buf)
 							}
 							break;
 
-						case 0x0B: // Cargo
+						case GSF_CARGOES: // Cargo
 							/* There are two ranges: one for cargo IDs and one for cargo bitmasks */
 							src1 = PerformGRM(_grm_cargoes, count, op, target, "cargoes");
 							if (_cur_gps.skip_sprites == -1) return;

--- a/src/newgrf/newgrf_internal.h
+++ b/src/newgrf/newgrf_internal.h
@@ -95,7 +95,7 @@ public:
 	 * @param numsets Number of sets to define.
 	 * @param numents Number of sprites per set to define.
 	 */
-	void AddSpriteSets(uint8_t feature, SpriteID first_sprite, uint first_set, uint numsets, uint numents)
+	void AddSpriteSets(GrfSpecFeature feature, SpriteID first_sprite, uint first_set, uint numsets, uint numents)
 	{
 		assert(feature < GSF_END);
 		for (uint i = 0; i < numsets; i++) {
@@ -111,7 +111,7 @@ public:
 	 * @return true if there are any valid sets.
 	 * @note Spritesets with zero sprites are valid to allow callback-failures.
 	 */
-	bool HasValidSpriteSets(uint8_t feature) const
+	bool HasValidSpriteSets(GrfSpecFeature feature) const
 	{
 		assert(feature < GSF_END);
 		return !this->spritesets[feature].empty();
@@ -124,7 +124,7 @@ public:
 	 * @return true if the set is valid.
 	 * @note Spritesets with zero sprites are valid to allow callback-failures.
 	 */
-	bool IsValidSpriteSet(uint8_t feature, uint set) const
+	bool IsValidSpriteSet(GrfSpecFeature feature, uint set) const
 	{
 		assert(feature < GSF_END);
 		return this->spritesets[feature].find(set) != this->spritesets[feature].end();
@@ -136,7 +136,7 @@ public:
 	 * @param set Set to query.
 	 * @return First sprite of the set.
 	 */
-	SpriteID GetSprite(uint8_t feature, uint set) const
+	SpriteID GetSprite(GrfSpecFeature feature, uint set) const
 	{
 		assert(IsValidSpriteSet(feature, set));
 		return this->spritesets[feature].find(set)->second.sprite;
@@ -148,7 +148,7 @@ public:
 	 * @param set Set to query.
 	 * @return Number of sprites in the set.
 	 */
-	uint GetNumEnts(uint8_t feature, uint set) const
+	uint GetNumEnts(GrfSpecFeature feature, uint set) const
 	{
 		assert(IsValidSpriteSet(feature, set));
 		return this->spritesets[feature].find(set)->second.num_sprites;
@@ -192,13 +192,13 @@ void SkipBadgeList(ByteReader &buf);
 std::vector<BadgeID> ReadBadgeList(ByteReader &buf, GrfSpecFeature feature);
 
 void MapSpriteMappingRecolour(PalSpriteID *grf_sprite);
-TileLayoutFlags ReadSpriteLayoutSprite(ByteReader &buf, bool read_flags, bool invert_action1_flag, bool use_cur_spritesets, int feature, PalSpriteID *grf_sprite, uint16_t *max_sprite_offset = nullptr, uint16_t *max_palette_offset = nullptr);
-bool ReadSpriteLayout(ByteReader &buf, uint num_building_sprites, bool use_cur_spritesets, uint8_t feature, bool allow_var10, bool no_z_position, NewGRFSpriteLayout *dts);
+TileLayoutFlags ReadSpriteLayoutSprite(ByteReader &buf, bool read_flags, bool invert_action1_flag, bool use_cur_spritesets, GrfSpecFeature feature, PalSpriteID *grf_sprite, uint16_t *max_sprite_offset = nullptr, uint16_t *max_palette_offset = nullptr);
+bool ReadSpriteLayout(ByteReader &buf, uint num_building_sprites, bool use_cur_spritesets, GrfSpecFeature feature, bool allow_var10, bool no_z_position, NewGRFSpriteLayout *dts);
 
 GRFFile *GetFileByGRFID(uint32_t grfid);
 GRFError *DisableGrf(StringID message = {}, GRFConfig *config = nullptr);
 void DisableStaticNewGRFInfluencingNonStaticNewGRFs(GRFConfig &c);
-bool HandleChangeInfoResult(std::string_view caller, ChangeInfoResult cir, uint8_t feature, uint8_t property);
+bool HandleChangeInfoResult(std::string_view caller, ChangeInfoResult cir, GrfSpecFeature feature, uint8_t property);
 uint32_t GetParamVal(uint8_t param, uint32_t *cond_val);
 void GRFUnsafe(ByteReader &);
 

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -28,7 +28,7 @@ struct GenericScopeResolver : public ScopeResolver {
 	uint8_t count;
 	uint8_t station_size;
 
-	uint8_t feature;
+	GrfSpecFeature feature;
 
 	/**
 	 * Generic scope resolver.
@@ -105,7 +105,7 @@ void ResetGenericCallbacks()
  * @param file The GRF of the callback.
  * @param group The sprite group of the callback.
  */
-void AddGenericCallback(uint8_t feature, const GRFFile *file, const SpriteGroup *group)
+void AddGenericCallback(GrfSpecFeature feature, const GRFFile *file, const SpriteGroup *group)
 {
 	if (feature >= lengthof(_gcl)) {
 		GrfMsg(5, "AddGenericCallback: Unsupported feature 0x{:02X}", feature);
@@ -164,7 +164,7 @@ GenericResolverObject::GenericResolverObject(bool ai_callback, CallbackID callba
  * @param[out] regs100 Additional result values from registers 100+
  * @return answering GRFFile and callback value if successful, or CALLBACK_FAILED
  */
-static std::pair<const GRFFile *, uint16_t> GetGenericCallbackResult(uint8_t feature, ResolverObject &object, uint32_t param1_grfv7, uint32_t param1_grfv8, std::span<int32_t> regs100 = {})
+static std::pair<const GRFFile *, uint16_t> GetGenericCallbackResult(GrfSpecFeature feature, ResolverObject &object, uint32_t param1_grfv7, uint32_t param1_grfv8, std::span<int32_t> regs100 = {})
 {
 	assert(feature < lengthof(_gcl));
 
@@ -199,7 +199,7 @@ static std::pair<const GRFFile *, uint16_t> GetGenericCallbackResult(uint8_t fea
  * @param station_size 'Station size' to pass to callback. (Variable 88)
  * @return answering GRFFile and callback value if successful, or CALLBACK_FAILED
  */
-std::pair<const GRFFile *, uint16_t> GetAiPurchaseCallbackResult(uint8_t feature, CargoType cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size)
+std::pair<const GRFFile *, uint16_t> GetAiPurchaseCallbackResult(GrfSpecFeature feature, CargoType cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size)
 {
 	GenericResolverObject object(true, CBID_GENERIC_AI_PURCHASE_SELECTION);
 

--- a/src/newgrf_generic.h
+++ b/src/newgrf_generic.h
@@ -45,9 +45,9 @@ static const IndustryType IT_AI_UNKNOWN = 0xFE; ///< The AI has no specific indu
 static const IndustryType IT_AI_TOWN    = 0xFF; ///< The AI actually wants to transport to/from a town, not an industry.
 
 void ResetGenericCallbacks();
-void AddGenericCallback(uint8_t feature, const GRFFile *file, const SpriteGroup *group);
+void AddGenericCallback(GrfSpecFeature feature, const GRFFile *file, const SpriteGroup *group);
 
-std::pair<const GRFFile *, uint16_t> GetAiPurchaseCallbackResult(uint8_t feature, CargoType cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size);
+std::pair<const GRFFile *, uint16_t> GetAiPurchaseCallbackResult(GrfSpecFeature feature, CargoType cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size);
 void AmbientSoundEffectCallback(TileIndex tile);
 
 /** Play an ambient sound effect for an empty tile. */

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -11,6 +11,7 @@
 #define NEWGRF_STORAGE_H
 
 #include "core/pool_type.hpp"
+#include "newgrf.h"
 #include "tile_type.h"
 
 /**
@@ -31,7 +32,7 @@ enum PersistentStorageMode : uint8_t {
  */
 struct BasePersistentStorageArray {
 	uint32_t grfid = 0; ///< GRFID associated to this persistent storage. A value of zero means "default".
-	uint8_t feature = 0; ///< NOSAVE: Used to identify in the owner of the array in debug output.
+	GrfSpecFeature feature = GSF_INVALID; ///< NOSAVE: Used to identify in the owner of the array in debug output.
 	TileIndex tile = INVALID_TILE; ///< NOSAVE: Used to identify in the owner of the array in debug output.
 
 	virtual ~BasePersistentStorageArray();
@@ -197,7 +198,7 @@ extern PersistentStoragePool _persistent_storage_pool;
  */
 struct PersistentStorage : PersistentStorageArray<int32_t, 256>, PersistentStoragePool::PoolItem<&_persistent_storage_pool> {
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
-	PersistentStorage(const uint32_t new_grfid, uint8_t feature, TileIndex tile)
+	PersistentStorage(const uint32_t new_grfid, GrfSpecFeature feature, TileIndex tile)
 	{
 		this->grfid = new_grfid;
 		this->feature = feature;

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -220,7 +220,7 @@ struct INDYChunkHandler : ChunkHandler {
 			if (IsSavegameVersionBefore(SLV_161) && !IsSavegameVersionBefore(SLV_76)) {
 				/* Store the old persistent storage. The GRFID will be added later. */
 				assert(PersistentStorage::CanAllocateItem());
-				i->psa = new PersistentStorage(0, 0, TileIndex{});
+				i->psa = new PersistentStorage(0, GSF_INVALID, TileIndex{});
 				std::copy(std::begin(_old_ind_persistent_storage.storage), std::end(_old_ind_persistent_storage.storage), std::begin(i->psa->storage));
 			}
 			if (IsSavegameVersionBefore(SLV_EXTEND_INDUSTRY_CARGO_SLOTS)) {

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -399,7 +399,7 @@ public:
 		if (IsSavegameVersionBefore(SLV_161) && !IsSavegameVersionBefore(SLV_145) && st->facilities.Test(StationFacility::Airport)) {
 			/* Store the old persistent storage. The GRFID will be added later. */
 			assert(PersistentStorage::CanAllocateItem());
-			st->airport.psa = new PersistentStorage(0, 0, TileIndex{});
+			st->airport.psa = new PersistentStorage(0, GSF_INVALID, TileIndex{});
 			std::copy(std::begin(_old_st_persistent_storage.storage), std::end(_old_st_persistent_storage.storage), std::begin(st->airport.psa->storage));
 		}
 

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -35,7 +35,7 @@ struct PSACChunkHandler : ChunkHandler {
 
 		while ((index = SlIterateArray()) != -1) {
 			assert(PersistentStorage::CanAllocateItem());
-			PersistentStorage *ps = new (PersistentStorageID(index)) PersistentStorage(0, 0, TileIndex{});
+			PersistentStorage *ps = new (PersistentStorageID(index)) PersistentStorage(0, GSF_INVALID, TileIndex{});
 			SlObject(ps, slt);
 		}
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

GRF feature is often loaded as a byte into a `uint8_t`, or passed a some other type.

The `GrfSpecFeature` type exists for this.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `GrfSpecFeature` in place of `uint8_t` or `int`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
