### PR TITLE
Change: Remove Apply button from NewGRF config window when unneeded.

### DIFF
--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -641,7 +641,8 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		this->vscroll2 = this->GetScrollbar(WID_NS_SCROLL2BAR);
 
 		this->GetWidget<NWidgetStacked>(WID_NS_SHOW_REMOVE)->SetDisplayedPlane(this->editable ? 0 : 1);
-		this->GetWidget<NWidgetStacked>(WID_NS_SHOW_APPLY)->SetDisplayedPlane(this->editable ? 0 : this->show_params ? 1 : SZSP_HORIZONTAL);
+		this->GetWidget<NWidgetStacked>(WID_NS_SHOW_EDIT)->SetDisplayedPlane(this->editable ? 0 : (this->show_params ? 1 : SZSP_HORIZONTAL));
+		this->GetWidget<NWidgetStacked>(WID_NS_SHOW_APPLY)->SetDisplayedPlane(this->editable && this->execute ? 0 : SZSP_VERTICAL);
 		this->FinishInitNested(WN_GAME_OPTIONS_NEWGRF_STATE);
 
 		this->querystrings[WID_NS_FILTER] = &this->filter_editbox;
@@ -1085,19 +1086,14 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 			case WID_NS_APPLY_CHANGES: // Apply changes made to GRF list
 				if (!this->editable) break;
-				if (this->execute) {
-					ShowQuery(
-						GetEncodedString(STR_NEWGRF_POPUP_CAUTION_CAPTION),
-						GetEncodedString(STR_NEWGRF_CONFIRMATION_TEXT),
-						this,
-						NewGRFConfirmationCallback
-					);
-				} else {
-					CopyGRFConfigList(this->orig_list, this->actives, true);
-					ResetGRFConfig(false);
-					ReloadNewGRFData();
-					this->InvalidateData(GOID_NEWGRF_CHANGES_APPLIED);
-				}
+
+				ShowQuery(
+					GetEncodedString(STR_NEWGRF_POPUP_CAUTION_CAPTION),
+					GetEncodedString(STR_NEWGRF_CONFIRMATION_TEXT),
+					this,
+					NewGRFConfirmationCallback
+				);
+
 				this->CloseChildWindows(WC_QUERY_STRING); // Remove the parameter query window
 				break;
 
@@ -1237,11 +1233,6 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				/* Changes have been made to the list of active NewGRFs */
 				this->modified = true;
 
-				break;
-
-			case GOID_NEWGRF_CHANGES_APPLIED:
-				/* No changes have been made to the list of active NewGRFs since the last time the changes got applied */
-				this->modified = false;
 				break;
 		}
 
@@ -1866,7 +1857,7 @@ static constexpr NWidgetPart _nested_newgrf_infopanel_widgets[] = {
 		EndContainer(),
 
 		/* Right side, config buttons. */
-		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_NS_SHOW_APPLY),
+		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_NS_SHOW_EDIT),
 			NWidget(NWID_HORIZONTAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.hsep_wide, 0),
 				NWidget(NWID_VERTICAL),
 					NWidget(WWT_PUSHTXTBTN, COLOUR_YELLOW, WID_NS_SET_PARAMETERS), SetFill(1, 0), SetResize(1, 0),
@@ -1874,8 +1865,10 @@ static constexpr NWidgetPart _nested_newgrf_infopanel_widgets[] = {
 					NWidget(WWT_PUSHTXTBTN, COLOUR_YELLOW, WID_NS_TOGGLE_PALETTE), SetFill(1, 0), SetResize(1, 0),
 							SetStringTip(STR_NEWGRF_SETTINGS_TOGGLE_PALETTE, STR_NEWGRF_SETTINGS_TOGGLE_PALETTE_TOOLTIP),
 				EndContainer(),
-				NWidget(WWT_PUSHTXTBTN, COLOUR_YELLOW, WID_NS_APPLY_CHANGES), SetFill(1, 0), SetResize(1, 0),
-						SetStringTip(STR_NEWGRF_SETTINGS_APPLY_CHANGES),
+				NWidget(NWID_SELECTION, INVALID_COLOUR, WID_NS_SHOW_APPLY),
+					NWidget(WWT_PUSHTXTBTN, COLOUR_YELLOW, WID_NS_APPLY_CHANGES), SetFill(1, 0), SetResize(1, 0),
+							SetStringTip(STR_NEWGRF_SETTINGS_APPLY_CHANGES),
+				EndContainer(),
 			EndContainer(),
 			NWidget(WWT_PUSHTXTBTN, COLOUR_YELLOW, WID_NS_VIEW_PARAMETERS), SetFill(1, 0), SetResize(1, 0),
 					SetStringTip(STR_NEWGRF_SETTINGS_SHOW_PARAMETERS),

--- a/src/widgets/newgrf_widget.h
+++ b/src/widgets/newgrf_widget.h
@@ -59,7 +59,8 @@ enum NewGRFStateWidgets : WidgetID {
 	WID_NS_CONTENT_DOWNLOAD,  ///< Open content download (available NewGRFs).
 	WID_NS_CONTENT_DOWNLOAD2, ///< Open content download (active NewGRFs).
 	WID_NS_SHOW_REMOVE,       ///< Select active list buttons (0 = normal, 1 = simple layout).
-	WID_NS_SHOW_APPLY,        ///< Select display of the buttons below the 'details'.
+	WID_NS_SHOW_EDIT,         ///< Select display of the buttons below the 'details'.
+	WID_NS_SHOW_APPLY,        ///< Select display of the apply button.
 };
 
 /** Widgets of the #SavePresetWindow class. */

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -733,7 +733,6 @@ enum GameOptionsInvalidationData : uint8_t {
 	GOID_NEWGRF_CURRENT_LOADED,  ///< The current list of active NewGRF has been loaded.
 	GOID_NEWGRF_LIST_EDITED,     ///< List of active NewGRFs is being edited.
 	GOID_NEWGRF_CHANGES_MADE,    ///< Changes have been made to a given NewGRF either through the palette or its parameters.
-	GOID_NEWGRF_CHANGES_APPLIED, ///< The active NewGRF list changes have been applied.
 };
 
 struct Window;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When configuring NewGRFs outside of a game, the changes are always applied when the window is closed, even if the Apply button is not used.

This might give the impression that pressing Apply is needed, and changes will not otherwise be applied, but that is not the case.

The Apply button only needs appear during a game when changes are not automatically applied.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove the unnecessary and misleading Apply button when configuring NewGRFs for a new game.

The Apply button is still visible when configuring NewGRFs in a running game.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
