### PR TITLE
Fix #14256, dfd9fbf873: Company finance windows not updated when paused.

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -39,6 +39,7 @@
 #include "timer/timer.h"
 #include "timer/timer_game_economy.h"
 #include "timer/timer_game_tick.h"
+#include "timer/timer_window.h"
 
 #include "widgets/statusbar_widget.h"
 
@@ -219,8 +220,7 @@ void InvalidateCompanyWindows(const Company *company)
 /**
  * Refresh all company finance windows previously marked dirty.
  */
-void InvalidateCompanyWindows()
-{
+static const IntervalTimer<TimerWindow> invalidate_company_windows_interval(std::chrono::milliseconds(1), [](auto) {
 	for (CompanyID cid : _dirty_company_finances) {
 		if (cid == _local_company) SetWindowWidgetDirty(WC_STATUS_BAR, 0, WID_S_RIGHT);
 		Window *w = FindWindowById(WC_FINANCES, cid);
@@ -233,8 +233,8 @@ void InvalidateCompanyWindows()
 		}
 		SetWindowWidgetDirty(WC_COMPANY, cid, WID_C_DESC_COMPANY_VALUE);
 	}
-	_dirty_company_finances = {};
-}
+	_dirty_company_finances.Reset();
+});
 
 /**
  * Get the amount of money that a company has available, or INT64_MAX

--- a/src/company_gui.h
+++ b/src/company_gui.h
@@ -23,7 +23,6 @@ void ShowCompanyFinances(CompanyID company);
 void ShowCompany(CompanyID company);
 
 void InvalidateCompanyWindows(const Company *c);
-void InvalidateCompanyWindows();
 void CloseCompanyWindows(CompanyID company);
 void DirtyCompanyInfrastructureWindows(CompanyID company);
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1244,7 +1244,6 @@ void StateGameLoop()
 
 		CallWindowGameTickEvent();
 		NewsLoop();
-		InvalidateCompanyWindows();
 	} else {
 		if (_debug_desync_level > 2 && TimerGameEconomy::date_fract == 0 && (TimerGameEconomy::date.base() & 0x1F) == 0) {
 			/* Save the desync savegame if needed. */
@@ -1281,7 +1280,6 @@ void StateGameLoop()
 
 		CallWindowGameTickEvent();
 		NewsLoop();
-		InvalidateCompanyWindows();
 		cur_company.Restore();
 	}
 


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #14256, company finance windows are not updated when the game is paused.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Refresh company finance windows via a WindowTimer instead of in game loop.

As the invalidation affects multiple windows this is a global timer instead of window-specific.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
