### PR TITLE
Codechange: Make more use of std::byte for generic buffers.

### DIFF
--- a/src/fontcache/truetypefontcache.h
+++ b/src/fontcache/truetypefontcache.h
@@ -29,7 +29,7 @@ protected:
 
 	/** Container for information about a glyph. */
 	struct GlyphEntry {
-		std::unique_ptr<uint8_t[]> data; ///< The loaded sprite.
+		std::unique_ptr<std::byte[]> data; ///< The loaded sprite.
 		uint8_t width = 0; ///< The width of the glyph.
 
 		Sprite *GetSprite() { return reinterpret_cast<Sprite *>(data.get()); }

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -19,7 +19,7 @@
 
 struct MixerChannel {
 	/* pointer to allocated buffer memory */
-	std::shared_ptr<std::vector<uint8_t>> memory;
+	std::shared_ptr<std::vector<std::byte>> memory;
 
 	/* current position in memory */
 	uint32_t pos;
@@ -180,7 +180,7 @@ MixerChannel *MxAllocateChannel()
 	return mc;
 }
 
-void MxSetChannelRawSrc(MixerChannel *mc, const std::shared_ptr<std::vector<uint8_t>> &mem, uint rate, bool is16bit)
+void MxSetChannelRawSrc(MixerChannel *mc, const std::shared_ptr<std::vector<std::byte>> &mem, uint rate, bool is16bit)
 {
 	mc->memory = mem;
 	mc->frac_pos = 0;

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -24,7 +24,7 @@ bool MxInitialize(uint rate);
 void MxMixSamples(void *buffer, uint samples);
 
 MixerChannel *MxAllocateChannel();
-void MxSetChannelRawSrc(MixerChannel *mc, const std::shared_ptr<std::vector<uint8_t>> &mem, uint rate, bool is16bit);
+void MxSetChannelRawSrc(MixerChannel *mc, const std::shared_ptr<std::vector<std::byte>> &mem, uint rate, bool is16bit);
 void MxSetChannelVolume(MixerChannel *mc, uint volume, float pan);
 void MxActivateChannel(MixerChannel*);
 void MxCloseAllChannels();

--- a/src/sound_type.h
+++ b/src/sound_type.h
@@ -17,7 +17,7 @@ enum class SoundSource : uint8_t {
 };
 
 struct SoundEntry {
-	std::shared_ptr<std::vector<uint8_t>> data;
+	std::shared_ptr<std::vector<std::byte>> data;
 	class RandomAccessFile *file;
 	size_t file_offset;
 	size_t file_size;

--- a/src/soundloader.cpp
+++ b/src/soundloader.cpp
@@ -26,7 +26,7 @@ bool LoadSoundData(SoundEntry &sound, bool new_format, SoundID sound_id, const s
 	if (sound.file_size == 0 || sound.file_size > SIZE_MAX - 2) return false;
 
 	size_t pos = sound.file->GetPos();
-	sound.data = std::make_shared<std::vector<uint8_t>>();
+	sound.data = std::make_shared<std::vector<std::byte>>();
 	for (auto &loader : ProviderManager<SoundLoader>::GetProviders()) {
 		sound.file->SeekTo(pos, SEEK_SET);
 		if (loader->Load(sound, new_format, *sound.data)) break;

--- a/src/soundloader_opus.cpp
+++ b/src/soundloader_opus.cpp
@@ -32,7 +32,7 @@ public:
 	static constexpr size_t DECODE_BUFFER_SAMPLES = 5760 * 2;
 	static constexpr size_t DECODE_BUFFER_BYTES = DECODE_BUFFER_SAMPLES * sizeof(opus_int16);
 
-	bool Load(SoundEntry &sound, bool new_format, std::vector<uint8_t> &data) override
+	bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) override
 	{
 		if (!new_format) return false;
 

--- a/src/soundloader_raw.cpp
+++ b/src/soundloader_raw.cpp
@@ -22,7 +22,7 @@ public:
 	static constexpr uint16_t RAW_SAMPLE_RATE = 11025; ///< Sample rate of raw pcm samples.
 	static constexpr uint8_t RAW_SAMPLE_BITS = 8; ///< Bit depths of raw pcm samples.
 
-	bool Load(SoundEntry &sound, bool new_format, std::vector<uint8_t> &data) override
+	bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) override
 	{
 		/* Raw sounds are apecial case for the jackhammer sound (name in Windows sample.cat is "Corrupt sound")
 		 * It's not a RIFF file, but raw PCM data.
@@ -42,7 +42,7 @@ public:
 
 		/* Convert 8-bit samples from unsigned to signed. */
 		for (auto &sample : data) {
-			sample = sample - 128;
+			sample ^= std::byte{0x80};
 		}
 
 		return true;

--- a/src/soundloader_type.h
+++ b/src/soundloader_type.h
@@ -26,7 +26,7 @@ public:
 		ProviderManager<SoundLoader>::Unregister(*this);
 	}
 
-	virtual bool Load(SoundEntry &sound, bool new_format, std::vector<uint8_t> &data) = 0;
+	virtual bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) = 0;
 };
 
 #endif /* SOUNDLOADER_TYPE_H */

--- a/src/soundloader_wav.cpp
+++ b/src/soundloader_wav.cpp
@@ -23,7 +23,7 @@ public:
 
 	static constexpr uint16_t DEFAULT_SAMPLE_RATE = 11025;
 
-	bool Load(SoundEntry &sound, bool new_format, std::vector<uint8_t> &data) override
+	bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) override
 	{
 		RandomAccessFile &file = *sound.file;
 
@@ -71,7 +71,7 @@ public:
 					case 8:
 						/* Convert 8-bit samples from unsigned to signed. */
 						for (auto &sample : data) {
-							sample = sample - 128;
+							sample ^= std::byte{0x80};
 						}
 						break;
 

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -899,7 +899,7 @@ void *CacheSpriteAllocator::AllocatePtr(size_t mem_req)
 
 void *UniquePtrSpriteAllocator::AllocatePtr(size_t size)
 {
-	this->data = std::make_unique<uint8_t[]>(size);
+	this->data = std::make_unique<std::byte[]>(size);
 	return this->data.get();
 }
 

--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -34,7 +34,7 @@ extern uint _sprite_cache_size;
 /** SpriteAllocator that allocates memory via a unique_ptr array. */
 class UniquePtrSpriteAllocator : public SpriteAllocator {
 public:
-	std::unique_ptr<uint8_t[]> data;
+	std::unique_ptr<std::byte[]> data;
 protected:
 	void *AllocatePtr(size_t size) override;
 };


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

518a34c286 started using `std::byte` for generic buffers.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

* Use `std::byte` instead of `uint8_t` for font glyph data. This is opaque, and cast to `Sprite *` on use.
* Use `std::byte` instead of `uint8_t` for sound data, which could be `int8_t` or `int16_t`, and is cast as such on use.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

`std::start_lifetime_as` is not available yet.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
