### PR TITLE
Change: Reflow text file content incrementally to avoid "hanging"

### DIFF
--- a/src/misc/CMakeLists.txt
+++ b/src/misc/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_files(
+    alternating_iterator.hpp
     binaryheap.hpp
     dbg_helpers.cpp
     dbg_helpers.h

--- a/src/misc/alternating_iterator.hpp
+++ b/src/misc/alternating_iterator.hpp
@@ -1,0 +1,145 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file alternating_iterator.hpp Iterator adaptor that takes items alternating from a middle position. */
+
+#ifndef ALTERNATING_ITERATOR_HPP
+#define ALTERNATING_ITERATOR_HPP
+
+#include <ranges>
+
+/**
+ * Iterator that alternately takes from the "middle" of a range.
+ * @tparam Titer Type of iterator.
+ */
+template <typename Titer>
+class AlternatingIterator {
+public:
+	using value_type = typename Titer::value_type;
+	using difference_type = std::ptrdiff_t;
+	using iterator_category = std::forward_iterator_tag;
+	using pointer = typename Titer::pointer;
+	using reference = typename Titer::reference;
+
+	AlternatingIterator() = default;
+
+	/**
+	 * Construct an AlternatingIterator.
+	 * @param first Iterator to first element.
+	 * @param last Iterator to last element.
+	 * @param middle Iterator to "middle" element, from where to start.
+	 * @param begin Whether this iterator points to the first or last elements.
+	 */
+	AlternatingIterator(Titer first, Titer last, Titer middle, bool begin) : first(first), last(last), middle(middle)
+	{
+		/* Starting from the end is not supported, unless the range is empty. */
+		assert(first == last || middle != last);
+
+		this->position = begin ? 0 : std::distance(this->first, this->last);
+		this->before = middle;
+		this->after = middle;
+		this->next_state = this->before == this->first;
+		this->state = this->next_state;
+	}
+
+	bool operator==(const AlternatingIterator &rhs) const
+	{
+		assert(this->first == rhs.first);
+		assert(this->last == rhs.last);
+		assert(this->middle == rhs.middle);
+		return this->position == rhs.position;
+	}
+
+	std::strong_ordering operator<=>(const AlternatingIterator &rhs) const
+	{
+		assert(this->first == rhs.first);
+		assert(this->last == rhs.last);
+		assert(this->middle == rhs.middle);
+		return this->position <=> rhs.position;
+	}
+
+	inline reference operator*() const
+	{
+		return *this->Base();
+	}
+
+	AlternatingIterator &operator++()
+	{
+		size_t size = static_cast<size_t>(std::distance(this->first, this->last));
+		assert(this->position < size);
+
+		++this->position;
+		if (this->position < size) this->Next();
+
+		return *this;
+	}
+
+	AlternatingIterator operator++(int)
+	{
+		AlternatingIterator result = *this;
+		++*this;
+		return result;
+	}
+
+	inline Titer Base() const
+	{
+		return this->state ? this->after : this->before;
+	}
+
+private:
+	Titer first; ///< Initial first iterator.
+	Titer last; ///< Initial last iterator.
+	Titer middle; ///< Initial middle iterator.
+
+	Titer after; ///< Current iterator after the middle.
+	Titer before; ///< Current iterator before the middle.
+
+	size_t position; ///< Position within the entire range.
+
+	bool next_state; ///< Next state for advancing iterator. If true take from after middle, otherwise take from before middle.
+	bool state; ///< Current state for reading iterator. If true take from after middle, otherwise take from before middle.
+
+	void Next()
+	{
+		this->state = this->next_state;
+		if (this->next_state) {
+			assert(this->after != this->last);
+			++this->after;
+			this->next_state = this->before == this->first;
+		} else {
+			assert(this->before != this->first);
+			--this->before;
+			this->next_state = std::next(this->after) != this->last;
+		}
+	}
+};
+
+template <typename Titer>
+class AlternatingView : public std::ranges::view_interface<AlternatingIterator<Titer>> {
+public:
+	AlternatingView(std::ranges::viewable_range auto &&range, Titer middle) :
+		first(std::ranges::begin(range)), last(std::ranges::end(range)), middle(middle)
+	{
+	}
+
+	auto begin() const
+	{
+		return AlternatingIterator{first, last, middle, true};
+	}
+
+	auto end() const
+	{
+		return AlternatingIterator{first, last, middle, false};
+	}
+
+private:
+	Titer first; ///< Iterator to first element.
+	Titer last; ///< Iterator to last element.
+	Titer middle; ///< Iterator to middle element.
+};
+
+#endif /* ALTERNATING_ITERATOR_HPP */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_test_files(
+    alternating_iterator.cpp
     bitmath_func.cpp
     enum_over_optimisation.cpp
     flatset_type.cpp

--- a/src/tests/alternating_iterator.cpp
+++ b/src/tests/alternating_iterator.cpp
@@ -1,0 +1,48 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file bitmath_func.cpp Test functionality from core/bitmath_func. */
+
+#include "../stdafx.h"
+
+#include "../3rdparty/catch2/catch.hpp"
+
+#include "../misc/alternating_iterator.hpp"
+
+#include "../safeguards.h"
+
+TEST_CASE("AlternatingIterator tests")
+{
+	auto test_case = [&](auto input, std::initializer_list<int> expected) {
+		return std::ranges::equal(input, expected);
+	};
+
+	/* Sequence includes sentinel markers to detect out-of-bounds reads without relying on UB. */
+	std::initializer_list<const int> raw_sequence_even = {INT_MAX, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, INT_MAX};
+	const std::span<const int> sequence_even = std::span{raw_sequence_even.begin() + 1, raw_sequence_even.end() - 1};
+
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 0), { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 1), { 1, 0, 2, 3, 4, 5, 6, 7, 8, 9 }));
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 2), { 2, 1, 3, 0, 4, 5, 6, 7, 8, 9 }));
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 3), { 3, 2, 4, 1, 5, 0, 6, 7, 8, 9 }));
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 4), { 4, 3, 5, 2, 6, 1, 7, 0, 8, 9 }));
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 5), { 5, 4, 6, 3, 7, 2, 8, 1, 9, 0 }));
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 6), { 6, 5, 7, 4, 8, 3, 9, 2, 1, 0 }));
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 7), { 7, 6, 8, 5, 9, 4, 3, 2, 1, 0 }));
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 8), { 8, 7, 9, 6, 5, 4, 3, 2, 1, 0 }));
+	CHECK(test_case(AlternatingView(sequence_even, sequence_even.begin() + 9), { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }));
+
+	/* Sequence includes sentinel markers to detect out-of-bounds reads without relying on UB. */
+	std::initializer_list<const int> raw_sequence_odd = {INT_MAX, 0, 1, 2, 3, 4, INT_MAX};
+	const std::span<const int> sequence_odd = std::span{raw_sequence_odd.begin() + 1, raw_sequence_odd.end() - 1};
+
+	CHECK(test_case(AlternatingView(sequence_odd, sequence_odd.begin() + 0), { 0, 1, 2, 3, 4 }));
+	CHECK(test_case(AlternatingView(sequence_odd, sequence_odd.begin() + 1), { 1, 0, 2, 3, 4 }));
+	CHECK(test_case(AlternatingView(sequence_odd, sequence_odd.begin() + 2), { 2, 1, 3, 0, 4 }));
+	CHECK(test_case(AlternatingView(sequence_odd, sequence_odd.begin() + 3), { 3, 2, 4, 1, 0 }));
+	CHECK(test_case(AlternatingView(sequence_odd, sequence_odd.begin() + 4), { 4, 3, 2, 1, 0 }));
+}

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -37,6 +37,7 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 	bool Monospace() override;
 	void SetFontNames(FontCacheSettings *settings, std::string_view font_name, const void *os_data) override;
 	void ScrollToLine(size_t line);
+	bool IsTextWrapped() const;
 
 	virtual void LoadTextfile(const std::string &textfile, Subdirectory dir);
 

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -10,6 +10,7 @@
 #ifndef TEXTFILE_GUI_H
 #define TEXTFILE_GUI_H
 
+#include "misc/alternating_iterator.hpp"
 #include "fileio_type.h"
 #include "strings_func.h"
 #include "textfile_type.h"
@@ -28,8 +29,11 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 	bool OnTooltip([[maybe_unused]] Point pt, WidgetID widget, TooltipCloseCondition close_cond) override;
 	void DrawWidget(const Rect &r, WidgetID widget) const override;
 	void OnResize() override;
+	void OnInit() override;
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override;
 	void OnDropdownSelect(WidgetID widget, int index) override;
+	void OnRealtimeTick(uint delta_ms) override;
+	void OnScrollbarScroll(WidgetID widget) override;
 
 	void Reset() override;
 	FontSize DefaultSize() override;
@@ -46,12 +50,13 @@ protected:
 	void ConstructWindow();
 
 	struct Line {
-		int top = 0;                  ///< Top scroll position in visual lines.
-		int bottom = 0;               ///< Bottom scroll position in visual lines.
-		std::string text{};           ///< Contents of the line.
+		int num_lines = 1; ///< Number of visual lines for this line.
+		int wrapped_width = 0;
+		int max_width = -1;
 		TextColour colour = TC_WHITE; ///< Colour to render text line in.
+		std::string text{};           ///< Contents of the line.
 
-		Line(int top, std::string_view text) : top(top), bottom(top + 1), text(text) {}
+		Line(std::string_view text) : text(text) {}
 		Line() {}
 	};
 
@@ -100,11 +105,29 @@ protected:
 
 private:
 	uint search_iterator = 0; ///< Iterator for the font check search.
-	uint max_length = 0; ///< Maximum length of unwrapped text line.
+	int max_width = 0; ///< Maximum length of unwrapped text line.
+	size_t num_lines = 0; ///< Number of lines of text, taking account of wrapping.
 
-	uint ReflowContent();
-	uint GetContentHeight();
-	void SetupScrollbars(bool force_reflow);
+	using LineIterator = std::vector<Line>::iterator;
+	using ReflowIterator = AlternatingIterator<LineIterator>;
+
+	ReflowIterator reflow_iter; ///< Current iterator for reflow.
+	ReflowIterator reflow_end; ///< End iterator for reflow.
+
+	LineIterator visible_first; ///< Iterator to first visible element.
+	LineIterator visible_last; ///< Iterator to last visible element.
+
+	enum class ReflowState : uint8_t {
+		None, ///< Nothing has been reflowed.
+		Reflowed, ///< Content has been reflowed.
+		VisibleReflowed, ///< Visible content has been reflowed.
+	};
+
+	std::vector<TextfileWindow::Line>::iterator GetIteratorFromPosition(int pos);
+	void UpdateVisibleIterators();
+	void ReflowContent();
+	ReflowState ContinueReflow();
+	void SetupScrollbars();
 	const Hyperlink *GetHyperlink(Point pt) const;
 
 	void AfterLoadMarkdown();

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -240,6 +240,7 @@ static void ScrollbarClickPositioning(Window *w, NWidgetScrollbar *sb, int x, in
 
 	if (changed) {
 		/* Position changed so refresh the window */
+		w->OnScrollbarScroll(sb->GetIndex());
 		w->SetDirty();
 	} else {
 		/* No change so only refresh this scrollbar */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3042,11 +3042,20 @@ void InputLoop()
 	HandleMouseEvents();
 }
 
+static std::chrono::time_point<std::chrono::steady_clock> _realtime_tick_start;
+
+bool CanContinueRealtimeTick()
+{
+	auto now = std::chrono::steady_clock::now();
+	return std::chrono::duration_cast<std::chrono::milliseconds>(now - _realtime_tick_start).count() < (MILLISECONDS_PER_TICK * 3 / 4);
+}
+
 /**
  * Dispatch OnRealtimeTick event over all windows
  */
 void CallWindowRealtimeTickEvent(uint delta_ms)
 {
+	_realtime_tick_start = std::chrono::steady_clock::now();
 	for (Window *w : Window::Iterate()) {
 		w->OnRealtimeTick(delta_ms);
 	}

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -818,7 +818,10 @@ static void DispatchMouseWheelEvent(Window *w, NWidgetCore *nwid, int wheel)
 	if (nwid->type == NWID_VSCROLLBAR) {
 		NWidgetScrollbar *sb = static_cast<NWidgetScrollbar *>(nwid);
 		if (sb->GetCount() > sb->GetCapacity()) {
-			if (sb->UpdatePosition(wheel)) w->SetDirty();
+			if (sb->UpdatePosition(wheel)) {
+				w->OnScrollbarScroll(nwid->GetIndex());
+				w->SetDirty();
+			}
 		}
 		return;
 	}
@@ -826,7 +829,10 @@ static void DispatchMouseWheelEvent(Window *w, NWidgetCore *nwid, int wheel)
 	/* Scroll the widget attached to the scrollbar. */
 	Scrollbar *sb = (nwid->GetScrollbarIndex() >= 0 ? w->GetScrollbar(nwid->GetScrollbarIndex()) : nullptr);
 	if (sb != nullptr && sb->GetCount() > sb->GetCapacity()) {
-		if (sb->UpdatePosition(wheel)) w->SetDirty();
+		if (sb->UpdatePosition(wheel)) {
+			w->OnScrollbarScroll(nwid->GetScrollbarIndex());
+			w->SetDirty();
+		}
 	}
 }
 
@@ -2342,7 +2348,10 @@ static void HandleScrollbarScrolling(Window *w)
 	if (sb->disp_flags.Any({NWidgetDisplayFlag::ScrollbarUp, NWidgetDisplayFlag::ScrollbarDown})) {
 		if (_scroller_click_timeout == 1) {
 			_scroller_click_timeout = 3;
-			if (sb->UpdatePosition(rtl == sb->disp_flags.Test(NWidgetDisplayFlag::ScrollbarUp) ? 1 : -1)) w->SetDirty();
+			if (sb->UpdatePosition(rtl == sb->disp_flags.Test(NWidgetDisplayFlag::ScrollbarUp) ? 1 : -1)) {
+				w->OnScrollbarScroll(w->mouse_capture_widget);
+				w->SetDirty();
+			}
 		}
 		return;
 	}
@@ -2353,7 +2362,10 @@ static void HandleScrollbarScrolling(Window *w)
 
 	int pos = RoundDivSU((i + _scrollbar_start_pos) * range, std::max(1, _scrollbar_size));
 	if (rtl) pos = range - pos;
-	if (sb->SetPosition(pos)) w->SetDirty();
+	if (sb->SetPosition(pos)) {
+		w->OnScrollbarScroll(w->mouse_capture_widget);
+		w->SetDirty();
+	}
 }
 
 /**

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -712,6 +712,13 @@ public:
 	virtual void OnScroll([[maybe_unused]] Point delta) {}
 
 	/**
+	 * Notify window that a scrollbar position has been updated.
+	 * @note Only called when the user scrolls, not if a window moves its scrollbar.
+	 * @param widget the scrollbar widget index.
+	 */
+	virtual void OnScrollbarScroll([[maybe_unused]] WidgetID widget) {}
+
+	/**
 	 * The mouse is currently moving over the window or has just moved outside
 	 * of the window. In the latter case pt is (-1, -1).
 	 * @param pt     the point inside the window that the mouse hovers over.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When opening a text file, the text content is reflowed (layouted) to find the number of lines needed for line wrapping.

When resizing the window the reflowing is done again for the entire text for the new size.

With some fonts, reflowing can be expensive and can appear to cause hangs.

This is not really noticable with the default OpenTTD Sans Mono font, although stutters do occur. The clip was made with "Noto Sans Mono"

[2025-05-14 19-04-53.webm](https://github.com/user-attachments/assets/ab8b6687-8e58-4f03-b68c-a433fed428e2)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of reflowing the entire content at start, or on each resize, reflow the content incrementally.

Reflowing starts at the current scroll position and alternately reflows lines both forwards and backwards, so that viewing and scrolling will "probably" have reflowed the most-likely-to-be-viewed next lines.

While reflowing, the window will also try to maintain the current position within the text, so resizing no longer moves the viewer to a different location.

[2025-05-14 19-05-41.webm](https://github.com/user-attachments/assets/911442c3-a54e-428c-91d9-934b139b391d)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
