### PR TITLE
Add: [Script] Default button in query string to reset an integer setting

### DIFF
--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -325,7 +325,7 @@ struct GSConfigWindow : public Window {
 					}
 				} else if (!bool_item && !config_item.complete_labels) {
 					/* Display a query box so users can enter a custom value. */
-					ShowQueryString(GetString(STR_JUST_INT, old_val), STR_CONFIG_SETTING_QUERY_CAPTION, INT32_DIGITS_WITH_SIGN_AND_TERMINATION, this, CS_NUMERAL_SIGNED, {});
+					ShowQueryString(GetString(STR_JUST_INT, old_val), STR_CONFIG_SETTING_QUERY_CAPTION, INT32_DIGITS_WITH_SIGN_AND_TERMINATION, this, CS_NUMERAL_SIGNED, QueryStringFlag::EnableDefault);
 				}
 				this->SetDirty();
 				break;
@@ -347,10 +347,17 @@ struct GSConfigWindow : public Window {
 
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
+		/* The user pressed cancel */
 		if (!str.has_value()) return;
-		auto value = ParseInteger<int32_t>(*str, 10, true);
-		if (!value.has_value()) return;
-		this->SetValue(*value);
+
+		if (!str->empty()) {
+			auto value = ParseInteger<int32_t>(*str, 10, true);
+			if (!value.has_value()) return;
+
+			this->SetValue(*value);
+		} else {
+			this->SetDefaultValue();
+		}
 	}
 
 	void OnDropdownSelect(WidgetID widget, int index, int) override
@@ -417,6 +424,14 @@ private:
 		const ScriptConfigItem &config_item = *this->visible_settings[this->clicked_row];
 		if (_game_mode == GM_NORMAL && !config_item.flags.Test(ScriptConfigFlag::InGame)) return;
 		this->gs_config->SetSetting(config_item.name, value);
+		this->SetDirty();
+	}
+
+	void SetDefaultValue()
+	{
+		const ScriptConfigItem &config_item = *this->visible_settings[this->clicked_row];
+		if (_game_mode == GM_NORMAL && !config_item.flags.Test(ScriptConfigFlag::InGame)) return;
+		this->gs_config->ResetSetting(config_item.name);
 		this->SetDirty();
 	}
 };

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -106,6 +106,16 @@ void ScriptConfig::ResetSettings()
 	this->settings.clear();
 }
 
+void ScriptConfig::ResetSetting(std::string_view name)
+{
+	if (this->info == nullptr) return;
+
+	const ScriptConfigItem *config_item = this->info->GetConfigItem(name);
+	if (config_item == nullptr) return;
+
+	this->settings.erase(std::string{name});
+}
+
 void ScriptConfig::ResetEditableSettings(bool yet_to_start)
 {
 	if (this->info == nullptr) return ResetSettings();

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -130,6 +130,11 @@ public:
 	void ResetSettings();
 
 	/**
+	 * Reset a setting to its default value.
+	 */
+	void ResetSetting(std::string_view name);
+
+	/**
 	 * Reset only editable and visible settings to their default value.
 	 */
 	void ResetEditableSettings(bool yet_to_start);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
I noticed there is no button in the query string to reset an AI setting to its default, unlike in Game Options/Advanced
![image](https://github.com/user-attachments/assets/f03501a3-e4f3-4a85-a709-fb95e5f2ebd5)


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add Default button when changing the value of a setting.
![image](https://github.com/user-attachments/assets/f7c47a59-feb3-47f8-89cf-33cc0929df86)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
none
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
