### PR TITLE
Fix: Restore the behaviour when entering numbers in query windows: clamp integers out of range to the maximum valid value.

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -608,7 +608,7 @@ struct CheatWindow : Window {
 
 			int32_t value;
 			if (!str->empty()) {
-				auto llvalue = ParseInteger<int64_t>(*str);
+				auto llvalue = ParseInteger<int64_t>(*str, 10, true);
 				if (!llvalue.has_value()) return;
 
 				/* Save the correct currency-translated value */
@@ -623,7 +623,7 @@ struct CheatWindow : Window {
 		} else {
 			const CheatEntry *ce = &_cheats_ui[clicked_cheat];
 			int oldvalue = static_cast<int32_t>(ReadValue(ce->variable, ce->type));
-			auto value = ParseInteger<int32_t>(*str);
+			auto value = ParseInteger<int32_t>(*str, 10, true);
 			if (!value.has_value()) return;
 			*ce->been_used = true;
 			value = ce->proc(*value, *value - oldvalue);

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1693,7 +1693,7 @@ public:
 		if (!str.has_value()) return;
 		/* Set a new company manager face number */
 		if (!str->empty()) {
-			auto val = ParseInteger(*str);
+			auto val = ParseInteger(*str, 10, true);
 			if (!val.has_value()) return;
 			this->face = *val;
 			ScaleAllCompanyManagerFaceBits(this->face);
@@ -2458,7 +2458,7 @@ struct CompanyWindow : Window
 			default: NOT_REACHED();
 
 			case WID_C_GIVE_MONEY: {
-				auto value = ParseInteger<uint64_t>(*str);
+				auto value = ParseInteger<uint64_t>(*str, 10, true);
 				if (!value.has_value()) return;
 				Money money = *value / GetCurrency().rate;
 				Command<CMD_GIVE_MONEY>::Post(STR_ERROR_CAN_T_GIVE_MONEY, money, this->window_number);

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -348,7 +348,7 @@ struct GSConfigWindow : public Window {
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
 		if (!str.has_value()) return;
-		auto value = ParseInteger<int32_t>(*str);
+		auto value = ParseInteger<int32_t>(*str, 10, true);
 		if (!value.has_value()) return;
 		SetValue(*value);
 	}

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -914,7 +914,7 @@ struct GenerateLandscapeWindow : public Window {
 
 		int32_t value;
 		if (!str->empty()) {
-			auto val = ParseInteger<int32_t>(*str);
+			auto val = ParseInteger<int32_t>(*str, 10, true);
 			if (!val.has_value()) return;
 			value = *val;
 		} else {
@@ -1203,7 +1203,7 @@ struct CreateScenarioWindow : public Window
 	{
 		if (!str.has_value()) return;
 
-		auto value = ParseInteger<int32_t>(*str);
+		auto value = ParseInteger<int32_t>(*str, 10, true);
 		if (!value.has_value()) return;
 
 		switch (this->widget_id) {

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1165,7 +1165,7 @@ public:
 		if (!str.has_value() || str->empty()) return;
 
 		Industry *i = Industry::Get(this->window_number);
-		auto value = ParseInteger(*str);
+		auto value = ParseInteger(*str, 10, true);
 		if (!value.has_value()) return;
 		switch (this->editbox_line) {
 			case IL_NONE: NOT_REACHED();

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1116,7 +1116,7 @@ struct NetworkStartServerWindow : public Window {
 		if (this->widget_id == WID_NSS_SETPWD) {
 			_settings_client.network.server_password = std::move(*str);
 		} else {
-			auto value = ParseInteger<int32_t>(*str);
+			auto value = ParseInteger<int32_t>(*str, 10, true);
 			if (!value.has_value()) return;
 			this->SetWidgetDirty(this->widget_id);
 			switch (this->widget_id) {

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -594,7 +594,7 @@ struct NewGRFInspectWindow : Window {
 	{
 		if (!str.has_value()) return;
 
-		auto val = ParseInteger<int32_t>(*str);
+		auto val = ParseInteger<int32_t>(*str, 10, true);
 		if (!val.has_value()) return;
 		NewGRFInspectWindow::var60params[GetFeatureNum(this->window_number)][this->current_edit_param - 0x60] = *val;
 		this->SetDirty();
@@ -1066,7 +1066,7 @@ struct SpriteAlignerWindow : Window {
 	{
 		if (!str.has_value()) return;
 
-		auto value = ParseInteger(*str);
+		auto value = ParseInteger(*str, 10, true);
 		if (!value.has_value()) return;
 		this->current_sprite = *value;
 		if (this->current_sprite >= GetMaxSpriteID()) this->current_sprite = 0;

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -435,7 +435,7 @@ struct NewGRFParametersWindow : public Window {
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
 		if (!str.has_value() || str->empty()) return;
-		auto value = ParseInteger<int32_t>(*str);
+		auto value = ParseInteger<int32_t>(*str, 10, true);
 		if (!value.has_value()) return;
 		GRFParameterInfo &par_info = this->GetParameterInfo(this->clicked_row);
 		this->grf_config.SetValue(par_info, *value);

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1363,7 +1363,7 @@ public:
 		if (!str.has_value() || str->empty()) return;
 
 		VehicleOrderID sel = this->OrderGetSel();
-		auto value = ParseInteger(*str);
+		auto value = ParseInteger(*str, 10, true);
 		if (!value.has_value()) return;
 
 		switch (this->vehicle->GetOrder(sel)->GetConditionVariable()) {

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -486,7 +486,7 @@ struct ScriptSettingsWindow : public Window {
 	void OnQueryTextFinished(std::optional<std::string> str) override
 	{
 		if (!str.has_value()) return;
-		auto value = ParseInteger<int32_t>(*str);
+		auto value = ParseInteger<int32_t>(*str, 10, true);
 		if (!value.has_value()) return;
 		SetValue(*value);
 	}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1371,7 +1371,7 @@ struct GameOptionsWindow : Window {
 
 		int32_t value;
 		if (!str->empty()) {
-			auto llvalue = ParseInteger<int64_t>(*str);
+			auto llvalue = ParseInteger<int64_t>(*str, 10, true);
 			if (!llvalue.has_value()) return;
 
 			/* Save the correct currency-translated value */
@@ -2067,7 +2067,7 @@ struct CustomCurrencyWindow : Window {
 
 		switch (this->query_widget) {
 			case WID_CC_RATE: {
-				auto val = ParseInteger(*str);
+				auto val = ParseInteger(*str, 10, true);
 				if (!val.has_value()) return;
 				GetCustomCurrency().rate = Clamp(*val, 1, UINT16_MAX);
 				break;
@@ -2088,7 +2088,7 @@ struct CustomCurrencyWindow : Window {
 			case WID_CC_YEAR: { // Year to switch to euro
 				TimerGameCalendar::Year year = CF_NOEURO;
 				if (!str->empty()) {
-					auto val = ParseInteger(*str);
+					auto val = ParseInteger(*str, 10, true);
 					if (!val.has_value()) return;
 					year = Clamp(static_cast<TimerGameCalendar::Year>(*val), MIN_EURO_YEAR, CalendarTime::MAX_YEAR);
 				}

--- a/src/tests/string_consumer.cpp
+++ b/src/tests/string_consumer.cpp
@@ -321,6 +321,8 @@ TEST_CASE("StringConsumer - parse int")
 	CHECK(consumer.ReadUtf8() == ' ');
 	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(8, 0xffffffff));
 	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16, true) == std::pair<StringConsumer::size_type, uint32_t>(8, 0xffffffff));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16, true) == std::pair<StringConsumer::size_type, int32_t>(8, 0x7fffffff));
 	CHECK(consumer.TryReadIntegerBase<int32_t>(16) == std::nullopt);
 	CHECK(consumer.ReadIntegerBase<int32_t>(16) == 0);
 	CHECK(consumer.ReadUtf8() == ' ');
@@ -328,6 +330,8 @@ TEST_CASE("StringConsumer - parse int")
 	CHECK(consumer.ReadUtf8() == ' ');
 	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(9, -0x1aaaaaaa));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16, true) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16, true) == std::pair<StringConsumer::size_type, int32_t>(9, -0x1aaaaaaa));
 	CHECK(consumer.TryReadIntegerBase<uint32_t>(16) == std::nullopt);
 	CHECK(consumer.ReadIntegerBase<uint32_t>(16) == 0);
 	CHECK(consumer.ReadUtf8() == ' ');
@@ -350,6 +354,10 @@ TEST_CASE("StringConsumer - parse int")
 	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<uint64_t>(10) == std::pair<StringConsumer::size_type, uint64_t>(13, 1234567890123));
 	CHECK(consumer.PeekIntegerBase<int64_t>(10) == std::pair<StringConsumer::size_type, int64_t>(13, 1234567890123));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10, true) == std::pair<StringConsumer::size_type, uint32_t>(13, 0xffffffff));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10, true) == std::pair<StringConsumer::size_type, int32_t>(13, 0x7fffffff));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(10, true) == std::pair<StringConsumer::size_type, uint64_t>(13, 1234567890123));
+	CHECK(consumer.PeekIntegerBase<int64_t>(10, true) == std::pair<StringConsumer::size_type, int64_t>(13, 1234567890123));
 	CHECK(consumer.TryReadIntegerBase<uint32_t>(10) == std::nullopt);
 	CHECK(consumer.ReadIntegerBase<uint32_t>(10) == 0);
 	CHECK(consumer.ReadUtf8() == ' ');
@@ -370,6 +378,10 @@ TEST_CASE("StringConsumer - parse int")
 	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<uint64_t>(16) == std::pair<StringConsumer::size_type, uint64_t>(16, 0xffffffff'fffffffe));
 	CHECK(consumer.PeekIntegerBase<int64_t>(16) == std::pair<StringConsumer::size_type, int64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16, true) == std::pair<StringConsumer::size_type, uint32_t>(16, 0xffffffff));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16, true) == std::pair<StringConsumer::size_type, int32_t>(16, 0x7fffffff));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(16, true) == std::pair<StringConsumer::size_type, uint64_t>(16, 0xffffffff'fffffffe));
+	CHECK(consumer.PeekIntegerBase<int64_t>(16, true) == std::pair<StringConsumer::size_type, int64_t>(16, 0x7fffffff'ffffffff));
 	CHECK(consumer.ReadIntegerBase<uint32_t>(16) == 0);
 	CHECK(consumer.ReadUtf8() == ' ');
 	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
@@ -500,9 +512,11 @@ TEST_CASE("StringConsumer - invalid int")
 
 TEST_CASE("StringConsumer - most negative")
 {
-	StringConsumer consumer("-80000000 -0x80000000 -2147483648"sv);
+	StringConsumer consumer("-80000000 -0x80000000 -2147483648 -9223372036854775808"sv);
 	CHECK(consumer.PeekIntegerBase<uint32_t>(16) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(16) == std::pair<StringConsumer::size_type, int32_t>(9, 0x80000000));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(16, true) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(16, true) == std::pair<StringConsumer::size_type, int32_t>(9, 0x80000000));
 	consumer.SkipIntegerBase(16);
 	CHECK(consumer.ReadUtf8() == ' ');
 	CHECK(consumer.PeekIntegerBase<uint32_t>(0) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
@@ -511,4 +525,14 @@ TEST_CASE("StringConsumer - most negative")
 	CHECK(consumer.ReadUtf8() == ' ');
 	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
 	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(11, 0x80000000));
+	consumer.SkipIntegerBase(0);
+	CHECK(consumer.ReadUtf8() == ' ');
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10) == std::pair<StringConsumer::size_type, int32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(10) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(10) == std::pair<StringConsumer::size_type, int64_t>(20, 0x80000000'00000000));
+	CHECK(consumer.PeekIntegerBase<uint32_t>(10, true) == std::pair<StringConsumer::size_type, uint32_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int32_t>(10, true) == std::pair<StringConsumer::size_type, int32_t>(20, 0x80000000));
+	CHECK(consumer.PeekIntegerBase<uint64_t>(10, true) == std::pair<StringConsumer::size_type, uint64_t>(0, 0));
+	CHECK(consumer.PeekIntegerBase<int64_t>(10, true) == std::pair<StringConsumer::size_type, int64_t>(20, 0x80000000'00000000));
 }

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -748,7 +748,7 @@ struct TimetableWindow : Window {
 		if (!str.has_value()) return;
 
 		const Vehicle *v = this->vehicle;
-		uint64_t val = ParseInteger<uint64_t>(*str).value_or(0);
+		uint64_t val = ParseInteger<uint64_t>(*str, 10, true).value_or(0);
 		auto [order_id, mtf] = PackTimetableArgs(v, this->sel_index, query_widget == WID_VT_CHANGE_SPEED);
 
 		switch (query_widget) {

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2501,7 +2501,7 @@ struct ScenarioEditorToolbarWindow : Window {
 
 		TimerGameCalendar::Year value;
 		if (!str->empty()) {
-			auto val = ParseInteger(*str);
+			auto val = ParseInteger(*str, 10, true);
 			if (!val.has_value()) return;
 			value = static_cast<TimerGameCalendar::Year>(*val);
 		} else {

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1275,7 +1275,7 @@ public:
 		/* Was 'cancel' pressed? */
 		if (!str.has_value()) return;
 
-		auto value = ParseInteger(*str);
+		auto value = ParseInteger(*str, 10, true);
 		if (!value.has_value()) return;
 
 		Backup<bool> old_generating_world(_generating_world, true);


### PR DESCRIPTION
## Motivation / Problem

When entering numbers in query windows, the behavior changed recently:
* `strtol` would return `INT_MAX`, if the entered value is larger.
* `ParseInteger` would reject those values as invalid.

While only baboons enter extreme values, interpreting "999...999" as the maximum valid value is still better, than doing nothing.

Closes #14266.

## Description

* Extend `ParseInteger` with an option for how to treat out of range values.
* Enable clamping parsing for all QueryWindows.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
