### PR TITLE
Codechange: Removed T prefix from water region related types.

### DIFF
--- a/src/pathfinder/water_regions.h
+++ b/src/pathfinder/water_regions.h
@@ -14,12 +14,12 @@
 #include "../tile_type.h"
 #include "../map_func.h"
 
-using TWaterRegionIndex = StrongType::Typedef<uint, struct TWaterRegionIndexTag, StrongType::Compare>;
-using TWaterRegionPatchLabel = StrongType::Typedef<uint8_t, struct TWaterRegionPatchLabelTag, StrongType::Compare, StrongType::Integer>;
+using WaterRegionIndex = StrongType::Typedef<uint, struct TWaterRegionIndexTag, StrongType::Compare>;
+using WaterRegionPatchLabel = StrongType::Typedef<uint8_t, struct TWaterRegionPatchLabelTag, StrongType::Compare, StrongType::Integer>;
 
 constexpr int WATER_REGION_EDGE_LENGTH = 16;
 constexpr int WATER_REGION_NUMBER_OF_TILES = WATER_REGION_EDGE_LENGTH * WATER_REGION_EDGE_LENGTH;
-constexpr TWaterRegionPatchLabel INVALID_WATER_REGION_PATCH{0};
+constexpr WaterRegionPatchLabel INVALID_WATER_REGION_PATCH{0};
 
 /**
  * Describes a single interconnected patch of water within a particular water region.
@@ -28,7 +28,7 @@ struct WaterRegionPatchDesc
 {
 	int x; ///< The X coordinate of the water region, i.e. X=2 is the 3rd water region along the X-axis
 	int y; ///< The Y coordinate of the water region, i.e. Y=2 is the 3rd water region along the Y-axis
-	TWaterRegionPatchLabel label; ///< Unique label identifying the patch within the region
+	WaterRegionPatchLabel label; ///< Unique label identifying the patch within the region
 
 	bool operator==(const WaterRegionPatchDesc &other) const { return x == other.x && y == other.y && label == other.label; }
 };
@@ -57,8 +57,8 @@ WaterRegionPatchDesc GetWaterRegionPatchInfo(TileIndex tile);
 
 void InvalidateWaterRegion(TileIndex tile);
 
-using TVisitWaterRegionPatchCallBack = std::function<void(const WaterRegionPatchDesc &)>;
-void VisitWaterRegionPatchNeighbours(const WaterRegionPatchDesc &water_region_patch, TVisitWaterRegionPatchCallBack &callback);
+using VisitWaterRegionPatchCallback = std::function<void(const WaterRegionPatchDesc &)>;
+void VisitWaterRegionPatchNeighbours(const WaterRegionPatchDesc &water_region_patch, VisitWaterRegionPatchCallback &callback);
 
 void AllocateWaterRegions();
 

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -164,7 +164,7 @@ protected:
 public:
 	inline void PfFollowNode(Node &old_node)
 	{
-		TVisitWaterRegionPatchCallBack visit_func = [&](const WaterRegionPatchDesc &water_region_patch)
+		VisitWaterRegionPatchCallback visit_func = [&](const WaterRegionPatchDesc &water_region_patch)
 		{
 			Node &node = Yapf().CreateNewNode();
 			node.Set(&old_node, water_region_patch);

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -168,7 +168,7 @@ static const Depot *FindClosestShipDepot(const Vehicle *v, uint max_distance)
 		patches_to_search.pop_front();
 
 		/* Add neighbours of the current patch to the search queue. */
-		TVisitWaterRegionPatchCallBack visit_func = [&](const WaterRegionPatchDesc &water_region_patch) {
+		VisitWaterRegionPatchCallback visit_func = [&](const WaterRegionPatchDesc &water_region_patch) {
 			/* Note that we check the max distance per axis, not the total distance. */
 			if (std::abs(water_region_patch.x - start_patch.x) > max_region_distance ||
 					std::abs(water_region_patch.y - start_patch.y) > max_region_distance) return;


### PR DESCRIPTION
## Motivation / Problem

A few water region related types were prefixed with a T, e.g. `TWaterRegionIndex`. The T prefix is meant to be used for templates only.

## Description

Removed T prefix

## Limitations

Is based on #14289 so that needs merging first.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
