### PR TITLE
Change: Don't measure group name widths in company livery window.

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -750,13 +750,6 @@ public:
 					d = maxdim(d, GetStringBoundingBox(STR_LIVERY_DEFAULT + scheme));
 				}
 
-				/* And group names */
-				for (const Group *g : Group::Iterate()) {
-					if (g->owner == this->window_number) {
-						d = maxdim(d, GetStringBoundingBox(GetString(STR_GROUP_NAME, g->index)));
-					}
-				}
-
 				size.width = std::max(size.width, 5 + d.width + padding.width);
 				break;
 			}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When opening the company livery window, the groups pool is iterated to find the maximum group name length for the current company.

Measuring the name width did not also take account of indentation levels so didn't prevent cropping, and the window can be resized anyway.

If there are a very large number of groups, finding the widths of them all some small time, as strings are formatted and layouted.

![image](https://github.com/user-attachments/assets/7e5eafe1-6498-4d2c-a75a-1c091bfcaabd)

Note that although the the peak value shown is only 2.5ms, the actual delay is about 1.25 seconds.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, simply don't measure the group name widths. The window is resizeable so it is not necessary.

This avoids the potential bottleneck due to layouting group names if there are a lot of groups present.

![image](https://github.com/user-attachments/assets/1c21f5ef-35ee-49ab-8a82-daa8200e4f6b)

No particular adverse impact from not measuring the widths:

![image](https://github.com/user-attachments/assets/414b8e34-396c-4de7-aa20-04f233139ab9)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
