### PR TITLE
Fix #14295, 0455627d16: v->cur_implicit_order_index is never INVALID_VEH_ORDER_ID

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -366,8 +366,8 @@ StationIDStack OrderList::GetNextStoppingStation(const Vehicle *v, VehicleOrderI
 	VehicleOrderID next = first;
 	if (first == INVALID_VEH_ORDER_ID) {
 		next = v->cur_implicit_order_index;
-		if (next == INVALID_VEH_ORDER_ID) {
-			next = v->orders->GetFirstOrder();
+		if (next >= this->GetNumOrders()) {
+			next = this->GetFirstOrder();
 			if (next == INVALID_VEH_ORDER_ID) return StationID::Invalid().base();
 		} else {
 			/* GetNext never returns INVALID_VEH_ORDER_ID if there is a valid station in the list.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
#13948 changed type of `next` in `OrderList::GetNextStoppingStation()` from `Order *` to `VehicleOrderID`.
Getting order at `v->cur_implicit_order_index` used to return `nullptr` for out of range/invalid index.
Check against `nullptr` were replaced with checks against `INVALID_VEH_ORDER_ID`, but `v->cur_implicit_order_index` is never `INVALID_VEH_ORDER_ID`.
This ends up in wrong branch taken in `if/else`.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Use the correct test to detect "invalid" `v->cur_implicit_order_index`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
