### PR TITLE
Codechange: [Script] Don't report multiple errors on valuator/filter failure

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -2112,6 +2112,11 @@ function Regression::Start()
 	local list = AIList();
 	list.AddItem(0, 0);
 	local Infinite = function(id) { while(true); }
+	try {
+		list = AIIndustryList(Infinite);
+	} catch (e) {
+		print("constructor failed with: " + e);
+	}
 	list.Valuate(Infinite);
 }
 

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -9792,20 +9792,10 @@ ERROR: IsEnd() is invalid as Begin() is never called
   -2147483648 >  2147483647:   false
    13725      > -2147483648:   true
 --Valuate() with excessive CPU usage--
+constructor failed with: excessive CPU usage in list filter function
 Your script made an error: excessive CPU usage in valuator function
 
-*FUNCTION [unknown()] regression/main.nut line [2114]
-*FUNCTION [Valuate()] NATIVE line [-1]
-*FUNCTION [Start()] regression/main.nut line [2115]
-
-[id] 0
-[this] TABLE
-[Infinite] CLOSURE
-[list] INSTANCE
-[this] INSTANCE
-Your script made an error: excessive CPU usage in valuator function
-
-*FUNCTION [Start()] regression/main.nut line [2115]
+*FUNCTION [Start()] regression/main.nut line [2120]
 
 [Infinite] CLOSURE
 [list] INSTANCE

--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -932,7 +932,7 @@ SQInteger ScriptList::Valuate(HSQUIRRELVM vm)
 		}
 
 		/* Call the function. Squirrel pops all parameters and pushes the return value. */
-		if (SQ_FAILED(sq_call(vm, nparam + 1, SQTrue, SQTrue))) {
+		if (SQ_FAILED(sq_call(vm, nparam + 1, SQTrue, SQFalse))) {
 			ScriptObject::SetAllowDoCommand(backup_allow);
 			return SQ_ERROR;
 		}

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -111,9 +111,9 @@ protected:
 					}
 
 					/* Call the function. Squirrel pops all parameters and pushes the return value. */
-					if (SQ_FAILED(sq_call(vm, nparam + 1, SQTrue, SQTrue))) {
+					if (SQ_FAILED(sq_call(vm, nparam + 1, SQTrue, SQFalse))) {
 						ScriptObject::SetAllowDoCommand(backup_allow);
-						throw sq_throwerror(vm, "failed to run filter");
+						throw static_cast<SQInteger>(SQ_ERROR);
 					}
 
 					SQBool add = SQFalse;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
When the function used as valuator/filter fails, the output is quite verbose, as it shows two errors.

In filter case it shows error from running the filter function, then another error because `constructor` call failed:
```
 Your script made an error: excessive CPU usage in list filter function

 *FUNCTION [unknown()] regression\main.nut line [2112]
 *FUNCTION [constructor()] NATIVE line [-1]
 *FUNCTION [Start()] regression\main.nut line [2113]

 [id] 0
 [this] TABLE
 [Infinite] CLOSURE
 [this] INSTANCE
 Your script made an error: failed to run filter

 *FUNCTION [Start()] regression\main.nut line [2113]

 [Infinite] CLOSURE
 [this] INSTANCE
```

In valuator case it shows error from running the valuator function, then it shows it again because `Valuate` call failed (without setting its own error):
```
 Your script made an error: excessive CPU usage in valuator function

 *FUNCTION [unknown()] regression\main.nut line [2114]
 *FUNCTION [Valuate()] NATIVE line [-1]
 *FUNCTION [Start()] regression\main.nut line [2115]

 [id] 0
 [this] TABLE
 [Infinite] CLOSURE
 [list] INSTANCE
 [this] INSTANCE
 Your script made an error: excessive CPU usage in valuator function

 *FUNCTION [Start()] regression\main.nut line [2115]

 [Infinite] CLOSURE
 [list] INSTANCE
 [this] INSTANCE
```

It's possible to enclose `constructor` or `Valuate` calls in `try/catch` (to then do things in a different way), but the first error will still be shown while the script might continue to run unaffected.

Output when running regression from this PR in master:
```
Your script made an error: excessive CPU usage in list filter function

*FUNCTION [unknown()] regression/main.nut line [2114]
*FUNCTION [constructor()] NATIVE line [-1]
*FUNCTION [Start()] regression/main.nut line [2116]

[id] 0
[this] TABLE
[Infinite] CLOSURE
[list] INSTANCE
[this] INSTANCE
constructor failed with: failed to run filter
Your script made an error: excessive CPU usage in valuator function

*FUNCTION [unknown()] regression/main.nut line [2114]
*FUNCTION [Valuate()] NATIVE line [-1]
*FUNCTION [Start()] regression/main.nut line [2115]
*FUNCTION [Start()] regression/main.nut line [2120]

[id] 0
[this] TABLE
[Infinite] CLOSURE
[list] INSTANCE
[this] INSTANCE
Your script made an error: excessive CPU usage in valuator function

*FUNCTION [Start()] regression/main.nut line [2115]
*FUNCTION [Start()] regression/main.nut line [2120]

[Infinite] CLOSURE
[list] INSTANCE
[this] INSTANCE
```
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Don't report error when running valuator/filter, but transfer it to the caller, so it is shown unless the script catches it with `try/catch`.

Filter case:
```
 Your script made an error: excessive CPU usage in list filter function

 *FUNCTION [Start()] regression\main.nut line [2113]

 [Infinite] CLOSURE
 [this] INSTANCE
```

Valuator case:
```
 Your script made an error: excessive CPU usage in valuator function

 *FUNCTION [Start()] regression\main.nut line [2115]

 [Infinite] CLOSURE
 [list] INSTANCE
 [this] INSTANCE
```
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Output now misses some details like exact location of error inside valuator/filter function.
But this output can be enabled using `notifyallexceptions(true)` inside the script, or by setting script debug level above 5.

![image](https://github.com/user-attachments/assets/26856252-0413-4c80-af6a-f7584f32e74c)

![image](https://github.com/user-attachments/assets/c3bcfd10-1459-4187-947e-9af3a2b7de49)

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
