### PR TITLE
Fix: Prevent NewGRFs from reading parameters of graphics baseset.

### DIFF
--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -153,6 +153,7 @@ static std::unique_ptr<GRFConfig> GetDefaultExtraGRFConfig()
 	gc->palette |= GRFP_GRF_DOS;
 	FillGRFDetails(*gc, false, BASESET_DIR);
 	gc->flags.Reset(GRFConfigFlag::InitOnly);
+	gc->flags.Set(GRFConfigFlag::System);
 	return gc;
 }
 
@@ -165,6 +166,7 @@ static std::unique_ptr<GRFConfig> GetBasesetExtraGRFConfig()
 	auto gc = std::make_unique<GRFConfig>(BaseGraphics::GetUsedSet()->GetOrCreateExtraConfig());
 	if (gc->param.empty()) gc->SetParameterDefaults();
 	gc->flags.Reset(GRFConfigFlag::InitOnly);
+	gc->flags.Set(GRFConfigFlag::System);
 	return gc;
 }
 

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -319,7 +319,7 @@ static void ParamSet(ByteReader &buf)
 				/* Disable the read GRF if it is a static NewGRF. */
 				DisableStaticNewGRFInfluencingNonStaticNewGRFs(*c);
 				src1 = 0;
-			} else if (file == nullptr || c == nullptr || c->status == GCS_DISABLED) {
+			} else if (file == nullptr || c == nullptr || c->status == GCS_DISABLED || c->flags.Test(GRFConfigFlag::System)) {
 				src1 = 0;
 			} else if (src1 == 0xFE) {
 				src1 = c->version;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

NewGRFs are able to read parameters of other NewGRFs.

Graphics basesets also contain a system NewGRFs, and #11347 added parameters to graphics basesets.

Therefore it may be possible for NewGRFs to read baseset parameters, which unlike non-system NewGRFs are not synchronised between clients.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Forcibly mark baseset NewGRFs as System outside the test for GRFID starting with 0xFF.

Prevent reading parameters from System NewGRFs.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Spacebars.

Also, not tested because I don't have any example...

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
