### PR TITLE
Add: [Script] Framework for cloning selected ScriptObject

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -828,6 +828,13 @@ function Regression::List()
 	print("  []:");
 	print("    4000 => " + list[4000]);
 
+	print("  clone:");
+	local list3 = clone list;
+	print("  Clone ListDump:");
+	foreach (idx, val in list3) {
+		print("    " + idx + " => " + val);
+	}
+
 	list.Clear();
 	print("  IsEmpty():     " + list.IsEmpty());
 
@@ -860,6 +867,12 @@ function Regression::List()
 		it = list.Next();
 		print("    " + it + " => " + list.GetValue(it));
 	}
+
+	print("  Clone ListDump:");
+	foreach (idx, val in list3) {
+		print("    " + idx + " => " + val);
+	}
+
 }
 
 function Regression::Map()

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -575,6 +575,13 @@
     4006 => 12
   []:
     4000 => 50
+  clone:
+  Clone ListDump:
+    1005 => 1005
+    4000 => 50
+    4001 => 8002
+    4002 => 8004
+    4006 => 12
   IsEmpty():     true
     0 => 5  (true)
 ERROR: Next() is invalid as Begin() is never called
@@ -584,6 +591,12 @@ ERROR: IsEnd() is invalid as Begin() is never called
     2 => 6  (true)
     3 => 6  (true)
     9 => 0  (false)
+  Clone ListDump:
+    1005 => 1005
+    4000 => 50
+    4001 => 8002
+    4002 => 8004
+    4006 => 12
 
 --Company--
   SetName():            true
@@ -9795,7 +9808,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
 constructor failed with: excessive CPU usage in list filter function
 Your script made an error: excessive CPU usage in valuator function
 
-*FUNCTION [Start()] regression/main.nut line [2120]
+*FUNCTION [Start()] regression/main.nut line [2133]
 
 [Infinite] CLOSURE
 [list] INSTANCE

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -34,6 +34,7 @@
  * \li AIWaypoint::GetWaypointID now returns the StationID of any type of waypoint
  * \li AIList instances can now be saved
  * \li AIVehicleList_Station accepts an optional AIVehicle::VehicleType parameter
+ * \li AIList instances can now be cloned
  *
  * \b 14.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -35,6 +35,7 @@
  * \li GSWaypoint::GetWaypointID now returns the StationID of any type of waypoint
  * \li GSList instances can now be saved
  * \li GSVehicleList_Station accepts an optional GSVehicle::VehicleType parameter
+ * \li GSList instances can now be cloned
  *
  * \b 14.0
  *

--- a/src/script/api/script_includes.hpp.in
+++ b/src/script/api/script_includes.hpp.in
@@ -11,22 +11,12 @@
 
 ${SQUIRREL_INCLUDES}
 
-static SQInteger ${APIUC}ObjectConstructor(HSQUIRRELVM vm)
-{
-	return sq_throwerror(vm, "This class is not instantiable");
-}
-
-static SQInteger ${APIUC}ObjectCloned(HSQUIRRELVM)
-{
-	throw Script_FatalError("This instance is not cloneable");
-}
-
 void SQ${APIUC}_RegisterAll(Squirrel &engine)
 {
 	DefSQClass<ScriptObject, ScriptType::${APIUC}> SQ${APIUC}Object("${APIUC}Object");
 	SQ${APIUC}Object.PreRegister(engine);
-	SQ${APIUC}Object.DefSQAdvancedStaticMethod(engine, &${APIUC}ObjectConstructor, "constructor");
-	SQ${APIUC}Object.DefSQAdvancedStaticMethod(engine, &${APIUC}ObjectCloned, "_cloned");
+	SQ${APIUC}Object.DefSQAdvancedStaticMethod(engine, &ScriptObject::Constructor, "constructor");
+	SQ${APIUC}Object.DefSQAdvancedStaticMethod(engine, &ScriptObject::_cloned, "_cloned");
 	SQ${APIUC}Object.PostRegister(engine);
 
 ${SQUIRREL_REGISTER}

--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -453,6 +453,20 @@ bool ScriptList::LoadObject(HSQUIRRELVM vm)
 	return true;
 }
 
+ScriptObject *ScriptList::CloneObject()
+{
+	ScriptList *clone = new ScriptList();
+	clone->CopyList(this);
+	return clone;
+}
+
+void ScriptList::CopyList(const ScriptList *list)
+{
+	this->Sort(list->sorter_type, list->sort_ascending);
+	this->items = list->items;
+	this->buckets = list->buckets;
+}
+
 ScriptList::ScriptList()
 {
 	/* Default sorter */

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -145,6 +145,13 @@ protected:
 
 	virtual bool SaveObject(HSQUIRRELVM vm) override;
 	virtual bool LoadObject(HSQUIRRELVM vm) override;
+	virtual ScriptObject *CloneObject() override;
+
+	/**
+	 * Copy the content of a list.
+	 * @param list The list that will be copied.
+	 */
+	void CopyList(const ScriptList *list);
 
 public:
 	typedef std::set<SQInteger> ScriptItemList;                   ///< The list of items inside the bucket

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -105,6 +105,12 @@ protected:
 	 */
 	virtual bool LoadObject(HSQUIRRELVM) { return false; }
 
+	/**
+	 * Clone an object.
+	 * @return The clone if cloning this type is supported, nullptr otherwise.
+	 */
+	virtual ScriptObject *CloneObject() { return nullptr; }
+
 public:
 	/**
 	 * Store the latest result of a DoCommand per company.
@@ -135,6 +141,16 @@ public:
 	 * based on the current _random seed, but _random does not get changed.
 	 */
 	static void InitializeRandomizers();
+
+	/**
+	 * Used when trying to instanciate ScriptObject from squirrel.
+	 */
+	static SQInteger Constructor(HSQUIRRELVM);
+
+	/**
+	 * Used for 'clone' from squirrel.
+	 */
+	static SQInteger _cloned(HSQUIRRELVM);
 
 protected:
 	template <Commands TCmd, typename T> struct ScriptDoCommandHelper;

--- a/src/script/api/script_tilelist.cpp
+++ b/src/script/api/script_tilelist.cpp
@@ -23,6 +23,13 @@ bool ScriptTileList::SaveObject(HSQUIRRELVM vm)
 	return true;
 }
 
+ScriptObject *ScriptTileList::CloneObject()
+{
+	ScriptTileList *clone = new ScriptTileList();
+	clone->CopyList(this);
+	return clone;
+}
+
 void ScriptTileList::AddRectangle(TileIndex t1, TileIndex t2)
 {
 	if (!::IsValidTile(t1)) return;

--- a/src/script/api/script_tilelist.hpp
+++ b/src/script/api/script_tilelist.hpp
@@ -22,6 +22,7 @@
 class ScriptTileList : public ScriptList {
 protected:
 	virtual bool SaveObject(HSQUIRRELVM) override;
+	virtual ScriptObject *CloneObject() override;
 public:
 	/**
 	 * Adds the rectangle between tile_from and tile_to to the to-be-evaluated tiles.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
As mentioned in #13947, when using `clone` on a class instance the constructor is not invoked and initialisation must rely on `_cloned` metamethod.
And that's why it's not allowed to use `clone` on ScriptObject instances.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add a member method to clone a `ScriptObject`. This method will create a new instance, copy the data to the new instance and return it.

Implement a proper cloning in `_cloned` metamethod:
- Try to clone the source instance
- If the cloning step passed, set the real instance of the clone

And finally implement cloning for `ScriptList`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
The clone real instance doesn't necessarily match the squirrel instance type, but it should be compatible.
For instance cloning a `ScriptEngineList` will return a `ScriptList`, but since `ScriptEngineList` is a `ScriptList` with specialised constructor they have the same interface. So on squirrel side the clone will be a `[AI|GS]EngineList` with a `ScriptList` as real instance.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
