### PR TITLE
Add: [Script] Auto-convert ObjectType bool to integer when setting values for items in lists via []

### DIFF
--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -844,18 +844,32 @@ SQInteger ScriptList::_get(HSQUIRRELVM vm)
 SQInteger ScriptList::_set(HSQUIRRELVM vm)
 {
 	if (sq_gettype(vm, 2) != OT_INTEGER) return SQ_ERROR;
-	if (sq_gettype(vm, 3) != OT_INTEGER && sq_gettype(vm, 3) != OT_NULL) {
-		return sq_throwerror(vm, "you can only assign integers to this list");
-	}
 
-	SQInteger idx, val;
+	SQInteger idx;
 	sq_getinteger(vm, 2, &idx);
-	if (sq_gettype(vm, 3) == OT_NULL) {
-		this->RemoveItem(idx);
-		return 0;
+
+	/* Retrieve the return value */
+	SQInteger val;
+	switch (sq_gettype(vm, 3)) {
+		case OT_NULL:
+			this->RemoveItem(idx);
+			return 0;
+
+		case OT_BOOL: {
+			SQBool v;
+			sq_getbool(vm, 3, &v);
+			val = v ? 1 : 0;
+			break;
+		}
+
+		case OT_INTEGER:
+			sq_getinteger(vm, 3, &val);
+			break;
+
+		default:
+			return sq_throwerror(vm, "you can only assign integers to this list");
 	}
 
-	sq_getinteger(vm, 3, &val);
 	if (!this->HasItem(idx)) {
 		this->AddItem(idx, val);
 		return 0;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
A bit of background story:
When dealing with a custom Valuate function in-squirrel to override OpenTTD's `ScriptList::Valuate`, I convert the result of valuator functions to integer, because ScriptList requires the values to be integer. The `valuator_function().tointeger()` moniker does the trick just fine, until I decided to test how much of an overhead `.tointeger()` conversion was. I found it to be rather expensive.

Trying to figure out how I could improve this without becoming such an intrusive addition, I decided to look on OpenTTD's native code, and found a good place where some auto-conversion could be done: The `ScriptList::_set` metamethod.



<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- Allow setting bool values to items in `ScriptList` via `[]` without requiring `.tointeger()` in squirrel side of code. The conversion is done in OpenTTD's side which makes this cost less squirrel opcodes.

Squirrel code example (before):
```
		local f = function(i) { return true; };
		local list = GSList();
		list[1] = f(i).tointeger();
		list[2] = 0;
```
Squirrel code example (after):
```
		local f = function(i) { return true; };
		local list = GSList();
		list[1] = f(i);
		list[2] = false;
```
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
None.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
