### PR TITLE
Codechange: [CI] Azure Code Signing has been rebranded 'Trusted Signing'

### DIFF
--- a/os/windows/sign_azure.ps1
+++ b/os/windows/sign_azure.ps1
@@ -24,7 +24,7 @@ if (!$Env:AZURE_CODESIGN_ENDPOINT -or !$Env:AZURE_CODESIGN_ACCOUNT_NAME -or !$En
 	exit
 }
 
-Install-Module -Name AzureCodeSigning -Scope CurrentUser -RequiredVersion 0.3.0 -Force -Repository PSGallery
+Install-Module -Name TrustedSigning -Scope CurrentUser -RequiredVersion 0.5.3 -Force -Repository PSGallery
 
 $params = @{}
 
@@ -37,4 +37,4 @@ $params["FileDigest"] = "SHA256"
 $params["TimestampRfc3161"] = "http://timestamp.acs.microsoft.com"
 $params["TimestampDigest"] = "SHA256"
 
-Invoke-AzureCodeSigning @params
+Invoke-TrustedSigning @params


### PR DESCRIPTION
As per the e-mail from Microsoft yesterday, Azure Code Signing has been renamed, and the PowerShell package has also been renamed. As of 28th July, the old package will not be supported - what that means in practice I don't know, but better that we're on the current version.

I've tested the updated build on my own fork and the signing was successful with the new package name.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
