### PR TITLE
Update townname.h add "Vannes"

### DIFF
--- a/src/table/townname.h
+++ b/src/table/townname.h
@@ -776,6 +776,7 @@ static const std::string_view _name_french_real[] = {
 	"Chamonix",
 	"Angoul\u00e8me",
 	"Alen\u00e7on",
+	"Vannes",
 };
 
 static const std::string_view _name_silly_1[] = {


### PR DESCRIPTION
Added the French city "Vannes" to the town name list

Hello OpenTTD team,

I’ve added "Vannes", a French city, to the list of available town names in the game, and I’d like to submit this small contribution.

Vannes is a beautiful city located in Brittany, in the Morbihan department of France. It has a rich historical heritage, including medieval ramparts, a lovely pleasure port, cobblestone streets, and the warm, welcoming atmosphere typical of the region. It’s the city where I grew up, and it holds a special place in my heart.

It would mean a lot to me to see this city included in OpenTTD. While it’s just a small addition, it’s very symbolic to me. I’d be truly honored if you accepted this contribution. I have already test there are not bug with this

Thank you so much for all the incredible work you do keeping Transport Tycoon alive through this amazing project!

Kind regards,
Ruizaki

Thank You
