### PR TITLE
Fix: Drag drop line position when dragging NewGRF from file to active panel

### DIFF
--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -863,7 +863,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 							/* Get index of current selection. */
 							int active_sel_pos = this->GetCurrentActivePosition();
 							if (active_sel_pos != this->active_over) {
-								uint top = this->active_over < active_sel_pos ? tr.top + 1 : tr.top + step_height - 2;
+								uint top = (active_sel_pos < 0 || this->active_over < active_sel_pos) ? tr.top + 1 : tr.top + step_height - 2;
 								GfxFillRect(tr.left, top - 1, tr.right, top + 1, PC_GREY);
 							}
 						}


### PR DESCRIPTION
## Motivation / Problem

The drag-drop line in the NewGRF window active panel was drawn below instead of above the target item, when dragging from the file panel. On completion of the drag drop from the file panel the new item is inserted above the target item.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
