### PR TITLE
Fix #14277: Aircraft can land when Zeppeliner in the runway

### DIFF
--- a/src/airport.h
+++ b/src/airport.h
@@ -127,6 +127,7 @@ enum class AirportBlock : uint8_t {
 	/* end of new blocks */
 
 	Nothing          = 30,
+	Zeppeliner       = 62, ///< Block for the zeppeliner disaster vehicle.
 	AirportClosed    = 63, ///< Dummy block for indicating a closed airport.
 };
 using AirportBlocks = EnumBitSet<AirportBlock, uint64_t>;

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -215,7 +215,7 @@ void DisasterVehicle::UpdatePosition(int x, int y, int z)
 
 /**
  * Zeppeliner handling, v->state states:
- * 0: Zeppeliner initialization has found a small airport, go there and crash
+ * 0: Zeppeliner initialization has found an airport, go there and crash
  * 1: Create crash and animate falling down for extra dramatic effect
  * 2: Create more smoke and leave debris on ground
  * 2: Clear the runway after some time and remove crashed zeppeliner
@@ -263,7 +263,7 @@ static bool DisasterTick_Zeppeliner(DisasterVehicle *v)
 
 		if (IsValidTile(v->tile) && IsAirportTile(v->tile)) {
 			Station *st = Station::GetByTile(v->tile);
-			st->airport.blocks.Reset(AirportBlock::RunwayIn);
+			st->airport.blocks.Reset({AirportBlock::Zeppeliner, AirportBlock::RunwayIn});
 			AI::NewEvent(GetTileOwner(v->tile), new ScriptEventDisasterZeppelinerCleared(st->index));
 		}
 
@@ -300,7 +300,7 @@ static bool DisasterTick_Zeppeliner(DisasterVehicle *v)
 	}
 
 	if (IsValidTile(v->tile) && IsAirportTile(v->tile)) {
-		Station::GetByTile(v->tile)->airport.blocks.Set(AirportBlock::RunwayIn);
+		Station::GetByTile(v->tile)->airport.blocks.Reset({AirportBlock::Zeppeliner, AirportBlock::RunwayIn});
 	}
 
 	return true;
@@ -722,14 +722,14 @@ typedef void DisasterInitProc();
 
 
 /**
- * Zeppeliner which crashes on a small airport if one found,
+ * Zeppeliner which crashes on an airport if one found,
  * otherwise crashes on a random tile
  */
 static void Disaster_Zeppeliner_Init()
 {
 	if (!Vehicle::CanAllocateItem(2)) return;
 
-	/* Pick a random place, unless we find a small airport */
+	/* Pick a random place, unless we find an airport */
 	int x = TileX(RandomTile()) * TILE_SIZE + TILE_SIZE / 2;
 
 	for (const Station *st : Station::Iterate()) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Fix #14277: Aircraft can land with a crashed Zeppelin in the runway

It is possible for aircrafts to lend when Zeppelin is in the runway. This does not happen all the time but only when an aircraft block runway at the time of the crash.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

To resolve this issue, create new Zeppeliner AirportBlock. When this block is set, aircraft that currently hold the runway block will not clear its blocks when it moves to the next location, ultimately preventing other planes from landing/taking off.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

~~Currently an aircraft that is landing will still land even if the Zeppeliner is in the way.~~
In new patch version, approaching aircraft will abort landing if Zeppeliner crashes

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
