### PR TITLE
Change: Company manager face definitions and dynamic UI.

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -28,6 +28,7 @@
 #include "sound_func.h"
 #include "rail.h"
 #include "core/pool_func.hpp"
+#include "core/string_consumer.hpp"
 #include "settings_func.h"
 #include "vehicle_base.h"
 #include "vehicle_func.h"
@@ -44,6 +45,7 @@
 #include "widgets/statusbar_widget.h"
 
 #include "table/strings.h"
+#include "table/company_face.h"
 
 #include "safeguards.h"
 
@@ -53,7 +55,7 @@ void UpdateObjectColours(const Company *c);
 CompanyID _local_company;   ///< Company controlled by the human player at this client. Can also be #COMPANY_SPECTATOR.
 CompanyID _current_company; ///< Company currently doing an action.
 TypedIndexContainer<std::array<Colours, MAX_COMPANIES>, CompanyID> _company_colours; ///< NOSAVE: can be determined from company structs.
-CompanyManagerFace _company_manager_face; ///< for company manager face storage in openttd.cfg
+std::string _company_manager_face; ///< for company manager face storage in openttd.cfg
 uint _cur_company_tick_index;             ///< used to generate a name for one company that doesn't have a name yet per tick
 
 CompanyPool _company_pool("Company"); ///< Pool of companies.
@@ -181,24 +183,12 @@ void DrawCompanyIcon(CompanyID c, int x, int y)
  */
 static bool IsValidCompanyManagerFace(CompanyManagerFace cmf)
 {
-	if (!AreCompanyManagerFaceBitsValid(cmf, CMFV_GEN_ETHN, GE_WM)) return false;
+	if (cmf.style >= GetNumCompanyManagerFaceStyles()) return false;
 
-	GenderEthnicity ge   = (GenderEthnicity)GetCompanyManagerFaceBits(cmf, CMFV_GEN_ETHN, GE_WM);
-	bool has_moustache   = !HasBit(ge, GENDER_FEMALE) && GetCompanyManagerFaceBits(cmf, CMFV_HAS_MOUSTACHE,   ge) != 0;
-	bool has_tie_earring = !HasBit(ge, GENDER_FEMALE) || GetCompanyManagerFaceBits(cmf, CMFV_HAS_TIE_EARRING, ge) != 0;
-	bool has_glasses     = GetCompanyManagerFaceBits(cmf, CMFV_HAS_GLASSES, ge) != 0;
-
-	if (!AreCompanyManagerFaceBitsValid(cmf, CMFV_EYE_COLOUR, ge)) return false;
-	for (CompanyManagerFaceVariable cmfv = CMFV_CHEEKS; cmfv < CMFV_END; cmfv++) {
-		switch (cmfv) {
-			case CMFV_MOUSTACHE:   if (!has_moustache)   continue; break;
-			case CMFV_LIPS:
-			case CMFV_NOSE:        if (has_moustache)    continue; break;
-			case CMFV_TIE_EARRING: if (!has_tie_earring) continue; break;
-			case CMFV_GLASSES:     if (!has_glasses)     continue; break;
-			default: break;
-		}
-		if (!AreCompanyManagerFaceBitsValid(cmf, cmfv, ge)) return false;
+	/* Test if each enabled part is valid. */
+	FaceVars vars = GetCompanyManagerFaceVars(cmf.style);
+	for (uint var : SetBitIterator(GetActiveFaceVars(cmf, vars))) {
+		if (!vars[var].IsValid(cmf)) return false;
 	}
 
 	return true;
@@ -633,11 +623,15 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid(
 
 	/* If starting a player company in singleplayer and a favorite company manager face is selected, choose it. Otherwise, use a random face.
 	 * In a network game, we'll choose the favorite face later in CmdCompanyCtrl to sync it to all clients. */
-	if (_company_manager_face != 0 && !is_ai && !_networking) {
-		c->face = _company_manager_face;
-	} else {
-		RandomCompanyManagerFaceBits(c->face, (GenderEthnicity)Random(), false, _random);
+	bool randomise_face = true;
+	if (!_company_manager_face.empty() && !is_ai && !_networking) {
+		auto cmf = ParseCompanyManagerFaceCode(_company_manager_face);
+		if (cmf.has_value()) {
+			randomise_face = false;
+			c->face = std::move(*cmf);
+		}
 	}
+	if (randomise_face) RandomiseCompanyManagerFace(c->face, _random);
 
 	SetDefaultCompanySettings(c->index);
 	ClearEnginesHiddenFlagOfCompany(c->index);
@@ -926,7 +920,12 @@ CommandCost CmdCompanyCtrl(DoCommandFlags flags, CompanyCtrlAction cca, CompanyI
 				 * its configuration and we are currently in the execution of a command, we have
 				 * to circumvent the normal ::Post logic for commands and just send the command.
 				 */
-				if (_company_manager_face != 0) Command<CMD_SET_COMPANY_MANAGER_FACE>::SendNet(STR_NULL, c->index, _company_manager_face);
+				if (!_company_manager_face.empty()) {
+					auto cmf = ParseCompanyManagerFaceCode(_company_manager_face);
+					if (cmf.has_value()) {
+						Command<CMD_SET_COMPANY_MANAGER_FACE>::SendNet(STR_NULL, c->index, cmf->bits, cmf->style);
+					}
+				}
 
 				/* Now that we have a new company, broadcast our company settings to
 				 * all clients so everything is in sync */
@@ -1049,15 +1048,20 @@ CommandCost CmdCompanyAllowListCtrl(DoCommandFlags flags, CompanyAllowListCtrlAc
 /**
  * Change the company manager's face.
  * @param flags operation to perform
- * @param cmf face bitmasked
+ * @param bits The bits of company manager face.
+ * @param style The style of the company manager face.
  * @return the cost of this operation or an error
  */
-CommandCost CmdSetCompanyManagerFace(DoCommandFlags flags, CompanyManagerFace cmf)
+CommandCost CmdSetCompanyManagerFace(DoCommandFlags flags, uint32_t bits, uint style)
 {
-	if (!IsValidCompanyManagerFace(cmf)) return CMD_ERROR;
+	CompanyManagerFace tmp_face{style, bits, {}};
+	if (!IsValidCompanyManagerFace(tmp_face)) return CMD_ERROR;
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Company::Get(_current_company)->face = cmf;
+		CompanyManagerFace &cmf = Company::Get(_current_company)->face;
+		SetCompanyManagerFaceStyle(cmf, style);
+		cmf.bits = tmp_face.bits;
+
 		MarkWholeScreenDirty();
 	}
 	return CommandCost();
@@ -1374,4 +1378,158 @@ CompanyID GetFirstPlayableCompanyID()
 	}
 
 	return CompanyID::Begin();
+}
+
+static std::vector<FaceSpec> _faces; ///< All company manager face styles.
+
+/**
+ * Reset company manager face styles to default.
+ */
+void ResetFaces()
+{
+	_faces.clear();
+	_faces.assign(std::begin(_original_faces), std::end(_original_faces));
+}
+
+/**
+ * Get the number of company manager face styles.
+ * @return Number of face styles.
+ */
+uint GetNumCompanyManagerFaceStyles()
+{
+	return static_cast<uint>(std::size(_faces));
+}
+
+/**
+ * Get the definition of a company manager face style.
+ * @param style_index Face style to get.
+ * @return Definition of face style.
+ */
+const FaceSpec *GetCompanyManagerFaceSpec(uint style_index)
+{
+	if (style_index < GetNumCompanyManagerFaceStyles()) return &_faces[style_index];
+	return nullptr;
+}
+
+/**
+ * Find a company manager face style by label.
+ * @param label Label to find.
+ * @return Index of face style if label is found, otherwise std::nullopt.
+ */
+std::optional<uint> FindCompanyManagerFaceLabel(std::string_view label)
+{
+	auto it = std::ranges::find(_faces, label, &FaceSpec::label);
+	if (it == std::end(_faces)) return std::nullopt;
+
+	return static_cast<uint>(std::distance(std::begin(_faces), it));
+}
+
+/**
+ * Get the face variables for a face style.
+ * @param style_index Face style to get variables for.
+ * @return Variables for the face style.
+ */
+FaceVars GetCompanyManagerFaceVars(uint style)
+{
+	const FaceSpec *spec = GetCompanyManagerFaceSpec(style);
+	if (spec == nullptr) return {};
+	return spec->GetFaceVars();
+}
+
+/**
+ * Set a company face style.
+ * Changes both the style index and the label.
+ * @param cmf The CompanyManagerFace to change.
+ * @param style The style to set.
+ */
+void SetCompanyManagerFaceStyle(CompanyManagerFace &cmf, uint style)
+{
+	const FaceSpec *spec = GetCompanyManagerFaceSpec(style);
+	assert(spec != nullptr);
+
+	cmf.style = style;
+	cmf.style_label = spec->label;
+}
+
+/**
+ * Completely randomise a company manager face, including style.
+ * @note randomizer should passed be appropriate for server-side or client-side usage.
+ * @param cmf The CompanyManagerFace to randomise.
+ * @param randomizer The randomizer to use.
+ */
+void RandomiseCompanyManagerFace(CompanyManagerFace &cmf, Randomizer &randomizer)
+{
+	SetCompanyManagerFaceStyle(cmf, randomizer.Next(GetNumCompanyManagerFaceStyles()));
+	RandomiseCompanyManagerFaceBits(cmf, GetCompanyManagerFaceVars(cmf.style), randomizer);
+}
+
+/**
+ * Mask company manager face bits to ensure they are all within range.
+ * @note Does not update the CompanyManagerFace itself. Unused bits are cleared.
+ * @param cmf The CompanyManagerFace.
+ * @param style The face variables.
+ * @return The masked face bits.
+ */
+uint32_t MaskCompanyManagerFaceBits(const CompanyManagerFace &cmf, FaceVars vars)
+{
+	CompanyManagerFace face{};
+
+	for (auto var : SetBitIterator(GetActiveFaceVars(cmf, vars))) {
+		vars[var].SetBits(face, vars[var].GetBits(cmf));
+	}
+
+	return face.bits;
+}
+
+/**
+ * Get a face code representation of a company manager face.
+ * @param cmf The company manager face.
+ * @return String containing face code.
+ */
+std::string FormatCompanyManagerFaceCode(const CompanyManagerFace &cmf)
+{
+	uint32_t masked_face_bits = MaskCompanyManagerFaceBits(cmf, GetCompanyManagerFaceVars(cmf.style));
+	return fmt::format("{}:{}", cmf.style_label, masked_face_bits);
+}
+
+/**
+ * Parse a face code into a company manager face.
+ * @param str Face code to parse.
+ * @return Company manager face, or std::nullopt if it could not be parsed.
+ */
+std::optional<CompanyManagerFace> ParseCompanyManagerFaceCode(std::string_view str)
+{
+	if (str.empty()) return std::nullopt;
+
+	CompanyManagerFace cmf;
+	StringConsumer consumer{str};
+	if (consumer.FindChar(':') != StringConsumer::npos) {
+		auto label = consumer.ReadUntilChar(':', StringConsumer::SKIP_ONE_SEPARATOR);
+
+		/* Read numeric part and ensure it's valid. */
+		auto bits = consumer.TryReadIntegerBase<uint32_t>(10, true);
+		if (!bits.has_value() || consumer.AnyBytesLeft()) return std::nullopt;
+
+		/* Ensure style laberl is valid. */
+		auto style = FindCompanyManagerFaceLabel(label);
+		if (!style.has_value()) return std::nullopt;
+
+		SetCompanyManagerFaceStyle(cmf, *style);
+		cmf.bits = *bits;
+	} else {
+		/* No ':' included, treat as numeric-only. This allows old-style codes to be entered. */
+		auto bits = ParseInteger(str, 10, true);
+		if (!bits.has_value()) return std::nullopt;
+
+		/* Old codes use bits 0..1 to represent face style. These map directly to the default face styles. */
+		SetCompanyManagerFaceStyle(cmf, GB(*bits, 0, 2));
+		cmf.bits = *bits;
+	}
+
+	/* Force the face bits to be valid. */
+	FaceVars vars = GetCompanyManagerFaceVars(cmf.style);
+	ScaleAllCompanyManagerFaceBits(cmf, vars);
+	cmf.bits = MaskCompanyManagerFaceBits(cmf, vars);
+
+	return cmf;
 }

--- a/src/company_cmd.h
+++ b/src/company_cmd.h
@@ -22,7 +22,7 @@ CommandCost CmdCompanyAllowListCtrl(DoCommandFlags flags, CompanyAllowListCtrlAc
 CommandCost CmdGiveMoney(DoCommandFlags flags, Money money, CompanyID dest_company);
 CommandCost CmdRenameCompany(DoCommandFlags flags, const std::string &text);
 CommandCost CmdRenamePresident(DoCommandFlags flags, const std::string &text);
-CommandCost CmdSetCompanyManagerFace(DoCommandFlags flags, CompanyManagerFace cmf);
+CommandCost CmdSetCompanyManagerFace(DoCommandFlags flags, uint style, uint32_t bits);
 CommandCost CmdSetCompanyColour(DoCommandFlags flags, LiveryScheme scheme, bool primary, Colours colour);
 
 DEF_CMD_TRAIT(CMD_COMPANY_CTRL,             CmdCompanyCtrl,           CommandFlags({CommandFlag::Spectator, CommandFlag::ClientID, CommandFlag::NoEst}), CMDT_SERVER_SETTING)

--- a/src/company_func.h
+++ b/src/company_func.h
@@ -37,7 +37,7 @@ extern CompanyID _local_company;
 extern CompanyID _current_company;
 
 extern TypedIndexContainer<std::array<Colours, MAX_COMPANIES>, CompanyID> _company_colours;
-extern CompanyManagerFace _company_manager_face;
+extern std::string _company_manager_face;
 PaletteID GetCompanyPalette(CompanyID company);
 
 /**

--- a/src/company_manager_face.h
+++ b/src/company_manager_face.h
@@ -12,158 +12,142 @@
 
 #include "core/random_func.hpp"
 #include "core/bitmath_func.hpp"
-#include "table/sprites.h"
+#include "strings_type.h"
 #include "company_type.h"
+#include "gfx_type.h"
 
-/** The gender/race combinations that we have faces for */
-enum GenderEthnicity : uint8_t {
-	GENDER_FEMALE    = 0, ///< This bit set means a female, otherwise male
-	ETHNICITY_BLACK  = 1, ///< This bit set means black, otherwise white
+#include "table/strings.h"
 
-	GE_WM = 0,                                         ///< A male of Caucasian origin (white)
-	GE_WF = 1 << GENDER_FEMALE,                        ///< A female of Caucasian origin (white)
-	GE_BM = 1 << ETHNICITY_BLACK,                      ///< A male of African origin (black)
-	GE_BF = 1 << ETHNICITY_BLACK | 1 << GENDER_FEMALE, ///< A female of African origin (black)
-	GE_END,
+enum class FaceVarType : uint8_t {
+	Sprite,
+	Palette,
+	Toggle,
 };
-DECLARE_ENUM_AS_BIT_SET(GenderEthnicity) ///< See GenderRace as a bitset
-
-/** Bitgroups of the CompanyManagerFace variable */
-enum CompanyManagerFaceVariable : uint8_t {
-	CMFV_GENDER,
-	CMFV_ETHNICITY,
-	CMFV_GEN_ETHN,
-	CMFV_HAS_MOUSTACHE,
-	CMFV_HAS_TIE_EARRING,
-	CMFV_HAS_GLASSES,
-	CMFV_EYE_COLOUR,
-	CMFV_CHEEKS,
-	CMFV_CHIN,
-	CMFV_EYEBROWS,
-	CMFV_MOUSTACHE,
-	CMFV_LIPS,
-	CMFV_NOSE,
-	CMFV_HAIR,
-	CMFV_COLLAR,
-	CMFV_JACKET,
-	CMFV_TIE_EARRING,
-	CMFV_GLASSES,
-	CMFV_END,
-};
-DECLARE_INCREMENT_DECREMENT_OPERATORS(CompanyManagerFaceVariable)
 
 /** Information about the valid values of CompanyManagerFace bitgroups as well as the sprites to draw */
-struct CompanyManagerFaceBitsInfo {
-	uint8_t     offset;               ///< Offset in bits into the CompanyManagerFace
-	uint8_t     length;               ///< Number of bits used in the CompanyManagerFace
-	uint8_t     valid_values[GE_END]; ///< The number of valid values per gender/ethnicity
-	SpriteID first_sprite[GE_END]; ///< The first sprite per gender/ethnicity
-};
+struct FaceVar {
+	FaceVarType type;
+	uint8_t position; ///< Position in UI.
+	uint8_t offset; ///< Offset in bits into the CompanyManagerFace
+	uint8_t length; ///< Number of bits used in the CompanyManagerFace
+	uint8_t valid_values; ///< The number of valid values
+	std::variant<SpriteID, uint64_t, std::pair<uint64_t, uint64_t>> data; ///< The first sprite
+	StringID name = STR_NULL;
 
-/** Lookup table for indices into the CompanyManagerFace, valid ranges and sprites */
-static const CompanyManagerFaceBitsInfo _cmf_info[] = {
-	/* Index                   off len   WM  WF  BM  BF         WM     WF     BM     BF
-	 * CMFV_GENDER          */ {  0, 1, {  2,  2,  2,  2 }, {     0,     0,     0,     0 } }, ///< 0 = male, 1 = female
-	/* CMFV_ETHNICITY       */ {  1, 2, {  2,  2,  2,  2 }, {     0,     0,     0,     0 } }, ///< 0 = (Western-)Caucasian, 1 = African(-American)/Black
-	/* CMFV_GEN_ETHN        */ {  0, 3, {  4,  4,  4,  4 }, {     0,     0,     0,     0 } }, ///< Shortcut to get/set gender _and_ ethnicity
-	/* CMFV_HAS_MOUSTACHE   */ {  3, 1, {  2,  0,  2,  0 }, {     0,     0,     0,     0 } }, ///< Females do not have a moustache
-	/* CMFV_HAS_TIE_EARRING */ {  3, 1, {  0,  2,  0,  2 }, {     0,     0,     0,     0 } }, ///< Draw the earring for females or not. For males the tie is always drawn.
-	/* CMFV_HAS_GLASSES     */ {  4, 1, {  2,  2,  2,  2 }, {     0,     0,     0,     0 } }, ///< Whether to draw glasses or not
-	/* CMFV_EYE_COLOUR      */ {  5, 2, {  3,  3,  1,  1 }, {     0,     0,     0,     0 } }, ///< Palette modification
-	/* CMFV_CHEEKS          */ {  0, 0, {  1,  1,  1,  1 }, { 0x325, 0x326, 0x390, 0x3B0 } }, ///< Cheeks are only indexed by their gender/ethnicity
-	/* CMFV_CHIN            */ {  7, 2, {  4,  1,  2,  2 }, { 0x327, 0x327, 0x391, 0x3B1 } },
-	/* CMFV_EYEBROWS        */ {  9, 4, { 12, 16, 11, 16 }, { 0x32B, 0x337, 0x39A, 0x3B8 } },
-	/* CMFV_MOUSTACHE       */ { 13, 2, {  3,  0,  3,  0 }, { 0x367,     0, 0x397,     0 } }, ///< Depends on CMFV_HAS_MOUSTACHE
-	/* CMFV_LIPS            */ { 13, 4, { 12, 10,  9,  9 }, { 0x35B, 0x351, 0x3A5, 0x3C8 } }, ///< Depends on !CMFV_HAS_MOUSTACHE
-	/* CMFV_NOSE            */ { 17, 3, {  8,  4,  4,  5 }, { 0x349, 0x34C, 0x393, 0x3B3 } }, ///< Depends on !CMFV_HAS_MOUSTACHE
-	/* CMFV_HAIR            */ { 20, 4, {  9,  5,  5,  5 }, { 0x382, 0x38B, 0x3D4, 0x3D9 } },
-	/* CMFV_COLLAR          */ { 26, 2, {  4,  4,  4,  4 }, { 0x36E, 0x37B, 0x36E, 0x37B } },
-	/* CMFV_JACKET          */ { 24, 2, {  3,  3,  3,  3 }, { 0x36B, 0x378, 0x36B, 0x378 } },
-	/* CMFV_TIE_EARRING     */ { 28, 3, {  6,  3,  6,  3 }, { 0x372, 0x37F, 0x372, 0x3D1 } }, ///< Depends on CMFV_HAS_TIE_EARRING
-	/* CMFV_GLASSES         */ { 31, 1, {  2,  2,  2,  2 }, { 0x347, 0x347, 0x3AE, 0x3AE } }  ///< Depends on CMFV_HAS_GLASSES
-};
-/** Make sure the table's size is right. */
-static_assert(lengthof(_cmf_info) == CMFV_END);
-
-/**
- * Gets the company manager's face bits for the given company manager's face variable
- * @param cmf  the face to extract the bits from
- * @param cmfv the face variable to get the data of
- * @param ge   the gender and ethnicity of the face
- * @pre _cmf_info[cmfv].valid_values[ge] != 0
- * @return the requested bits
- */
-inline uint GetCompanyManagerFaceBits(CompanyManagerFace cmf, CompanyManagerFaceVariable cmfv, [[maybe_unused]] GenderEthnicity ge)
-{
-	assert(_cmf_info[cmfv].valid_values[ge] != 0);
-
-	return GB(cmf, _cmf_info[cmfv].offset, _cmf_info[cmfv].length);
-}
-
-/**
- * Sets the company manager's face bits for the given company manager's face variable
- * @param cmf  the face to write the bits to
- * @param cmfv the face variable to write the data of
- * @param ge   the gender and ethnicity of the face
- * @param val  the new value
- * @pre val < _cmf_info[cmfv].valid_values[ge]
- */
-inline void SetCompanyManagerFaceBits(CompanyManagerFace &cmf, CompanyManagerFaceVariable cmfv, [[maybe_unused]] GenderEthnicity ge, uint val)
-{
-	assert(val < _cmf_info[cmfv].valid_values[ge]);
-
-	SB(cmf, _cmf_info[cmfv].offset, _cmf_info[cmfv].length, val);
-}
-
-/**
- * Increase/Decrease the company manager's face variable by the given amount.
- * The value wraps around to stay in the valid range.
- *
- * @param cmf    the company manager face to write the bits to
- * @param cmfv   the company manager face variable to write the data of
- * @param ge     the gender and ethnicity of the company manager's face
- * @param amount the amount which change the value
- *
- * @pre 0 <= val < _cmf_info[cmfv].valid_values[ge]
- */
-inline void IncreaseCompanyManagerFaceBits(CompanyManagerFace &cmf, CompanyManagerFaceVariable cmfv, GenderEthnicity ge, int8_t amount)
-{
-	int8_t val = GetCompanyManagerFaceBits(cmf, cmfv, ge) + amount; // the new value for the cmfv
-
-	/* scales the new value to the correct scope */
-	while (val < 0) {
-		val += _cmf_info[cmfv].valid_values[ge];
+	/**
+	 * Gets the company manager's face bits.
+	 * @param cmf The face to extract the bits from.
+	 * @return the requested bits
+	 */
+	inline uint GetBits(const CompanyManagerFace &cmf) const
+	{
+		return GB(cmf.bits, this->offset, this->length);
 	}
-	val %= _cmf_info[cmfv].valid_values[ge];
 
-	SetCompanyManagerFaceBits(cmf, cmfv, ge, val); // save the new value
-}
+	/**
+	 * Sets the company manager's face bits.
+	 * @param cmf The face to write the bits to.
+	 * @param val The new value.
+	 */
+	inline void SetBits(CompanyManagerFace &cmf, uint val) const
+	{
+		SB(cmf.bits, this->offset, this->length, val);
+	}
+
+	/**
+	 * Increase/Decrease the company manager's face variable by the given amount.
+	 * The value wraps around to stay in the valid range.
+	 * @param cmf The face to write the bits to.
+	 * @param amount the amount to change the value
+	 */
+	inline void ChangeBits(CompanyManagerFace &cmf, int8_t amount) const
+	{
+		int8_t val = this->GetBits(cmf) + amount; // the new value for the cmfv
+
+		/* scales the new value to the correct scope */
+		while (val < 0) {
+			val += this->valid_values;
+		}
+		val %= this->valid_values;
+
+		this->SetBits(cmf, val); // save the new value
+	}
+
+	/**
+	 * Checks whether the company manager's face bits have a valid range
+	 * @param cmf The face to check.
+	 * @return true if and only if the bits are valid
+	 */
+	inline bool IsValid(const CompanyManagerFace &cmf) const
+	{
+		return GB(cmf.bits, this->offset, this->length) < this->valid_values;
+	}
+
+	/**
+	 * Scales a company manager's face bits variable to the correct scope
+	 * @param vars The face variables of the face style.
+	 * @pre val < (1U << length), i.e. val has a value of 0..2^(bits used for this variable)-1
+	 * @return the scaled value
+	 */
+	inline uint ScaleBits(uint val) const
+	{
+		assert(val < (1U << this->length));
+		return (val * this->valid_values) >> this->length;
+	}
+
+	/**
+	 * Gets the sprite to draw.
+	 * @param cmf The face to extract the data from
+	 * @pre vars[var].type == FaceVarType::Sprite.
+	 * @return sprite to draw
+	 */
+	inline SpriteID GetSprite(const CompanyManagerFace &cmf) const
+	{
+		assert(this->type == FaceVarType::Sprite);
+		return std::get<SpriteID>(this->data) + this->GetBits(cmf);
+	}
+};
+
+using FaceVars = std::span<const FaceVar>;
+
+struct FaceSpec {
+	std::string label;
+	std::variant<FaceVars, std::vector<FaceVar>> face_vars;
+
+	inline FaceVars GetFaceVars() const
+	{
+		struct visitor {
+			FaceVars operator()(FaceVars vars) const { return vars; }
+			FaceVars operator()(const std::vector<FaceVar> &vars) const { return vars; }
+		};
+		return std::visit(visitor{}, this->face_vars);
+	}
+};
+
+void ResetFaces();
+uint GetNumCompanyManagerFaceStyles();
+std::optional<uint> FindCompanyManagerFaceLabel(std::string_view label);
+const FaceSpec *GetCompanyManagerFaceSpec(uint style_index);
+FaceVars GetCompanyManagerFaceVars(uint style_index);
 
 /**
- * Checks whether the company manager's face bits have a valid range
- * @param cmf  the face to extract the bits from
- * @param cmfv the face variable to get the data of
- * @param ge   the gender and ethnicity of the face
- * @return true if and only if the bits are valid
+ * Get a bitmask of currently active face variables.
+ * Face variables can be inactive due to toggles in the face variables.
+ * @param cmf The company manager face.
+ * @param vars The face variables of the face.
+ * @return Currently active face variables for the face.
  */
-inline bool AreCompanyManagerFaceBitsValid(CompanyManagerFace cmf, CompanyManagerFaceVariable cmfv, GenderEthnicity ge)
+inline uint64_t GetActiveFaceVars(const CompanyManagerFace &cmf, FaceVars vars)
 {
-	return GB(cmf, _cmf_info[cmfv].offset, _cmf_info[cmfv].length) < _cmf_info[cmfv].valid_values[ge];
-}
+	uint64_t active_vars = (1ULL << std::size(vars)) - 1ULL;
 
-/**
- * Scales a company manager's face bits variable to the correct scope
- * @param cmfv the face variable to write the data of
- * @param ge  the gender and ethnicity of the face
- * @param val the to value to scale
- * @pre val < (1U << _cmf_info[cmfv].length), i.e. val has a value of 0..2^(bits used for this variable)-1
- * @return the scaled value
- */
-inline uint ScaleCompanyManagerFaceValue(CompanyManagerFaceVariable cmfv, GenderEthnicity ge, uint val)
-{
-	assert(val < (1U << _cmf_info[cmfv].length));
+	for (const auto &info : vars) {
+		if (info.type != FaceVarType::Toggle) continue;
+		const auto &[off, on] = std::get<std::pair<uint64_t, uint64_t>>(info.data);
+		active_vars &= ~(HasBit(cmf.bits, info.offset) ? on : off);
+	}
 
-	return (val * _cmf_info[cmfv].valid_values[ge]) >> _cmf_info[cmfv].length;
+	return active_vars;
 }
 
 /**
@@ -171,69 +155,31 @@ inline uint ScaleCompanyManagerFaceValue(CompanyManagerFaceVariable cmfv, Gender
  *
  * @param cmf the company manager's face to write the bits to
  */
-inline void ScaleAllCompanyManagerFaceBits(CompanyManagerFace &cmf)
+inline void ScaleAllCompanyManagerFaceBits(CompanyManagerFace &cmf, FaceVars vars)
 {
-	IncreaseCompanyManagerFaceBits(cmf, CMFV_ETHNICITY, GE_WM, 0); // scales the ethnicity
-
-	GenderEthnicity ge = (GenderEthnicity)GB(cmf, _cmf_info[CMFV_GEN_ETHN].offset, _cmf_info[CMFV_GEN_ETHN].length); // gender & ethnicity of the face
-
-	/* Is a male face with moustache. Need to reduce CPU load in the loop. */
-	bool is_moust_male = !HasBit(ge, GENDER_FEMALE) && GetCompanyManagerFaceBits(cmf, CMFV_HAS_MOUSTACHE, ge) != 0;
-
-	for (CompanyManagerFaceVariable cmfv = CMFV_EYE_COLOUR; cmfv < CMFV_END; cmfv++) { // scales all other variables
-
-		/* The moustache variable will be scaled only if it is a male face with has a moustache */
-		if (cmfv != CMFV_MOUSTACHE || is_moust_male) {
-			IncreaseCompanyManagerFaceBits(cmf, cmfv, ge, 0);
-		}
+	for (auto var : SetBitIterator(GetActiveFaceVars(cmf, vars))) {
+		vars[var].ChangeBits(cmf, 0);
 	}
 }
 
 /**
- * Make a random new face.
- * If it is for the advanced company manager's face window then the new face have the same gender
- * and ethnicity as the old one, else the gender is equal and the ethnicity is random.
- *
- * @param cmf the company manager's face to write the bits to
- * @param ge  the gender and ethnicity of the old company manager's face
- * @param adv if it for the advanced company manager's face window
- * @param randomizer the source of random to use for creating the manager face
- *
- * @pre scale 'ge' to a valid gender/ethnicity combination
+ * Make a random new face without changing the face style.
+ * @param cmf The company manager's face to write the bits to
+ * @param vars The face variables.
+ * @param randomizer The source of random to use for creating the manager face
  */
-inline void RandomCompanyManagerFaceBits(CompanyManagerFace &cmf, GenderEthnicity ge, bool adv, Randomizer &randomizer)
+inline void RandomiseCompanyManagerFaceBits(CompanyManagerFace &cmf, FaceVars vars, Randomizer &randomizer)
 {
-	cmf = randomizer.Next(); // random all company manager's face bits
-
-	/* scale ge: 0 == GE_WM, 1 == GE_WF, 2 == GE_BM, 3 == GE_BF (and maybe in future: ...) */
-	ge = (GenderEthnicity)((uint)ge % GE_END);
-
-	/* set the gender (and ethnicity) for the new company manager's face */
-	if (adv) {
-		SetCompanyManagerFaceBits(cmf, CMFV_GEN_ETHN, ge, ge);
-	} else {
-		SetCompanyManagerFaceBits(cmf, CMFV_GENDER, ge, HasBit(ge, GENDER_FEMALE));
-	}
-
-	/* scales all company manager's face bits to the correct scope */
-	ScaleAllCompanyManagerFaceBits(cmf);
+	cmf.bits = randomizer.Next();
+	ScaleAllCompanyManagerFaceBits(cmf, vars);
 }
 
-/**
- * Gets the sprite to draw for the given company manager's face variable
- * @param cmf  the face to extract the data from
- * @param cmfv the face variable to get the sprite of
- * @param ge   the gender and ethnicity of the face
- * @pre _cmf_info[cmfv].valid_values[ge] != 0
- * @return sprite to draw
- */
-inline SpriteID GetCompanyManagerFaceSprite(CompanyManagerFace cmf, CompanyManagerFaceVariable cmfv, GenderEthnicity ge)
-{
-	assert(_cmf_info[cmfv].valid_values[ge] != 0);
+void SetCompanyManagerFaceStyle(CompanyManagerFace &cmf, uint style);
+void RandomiseCompanyManagerFace(CompanyManagerFace &cmf, Randomizer &randomizer);
+uint32_t MaskCompanyManagerFaceBits(const CompanyManagerFace &cmf, FaceVars vars);
+std::string FormatCompanyManagerFaceCode(const CompanyManagerFace &cmf);
+std::optional<CompanyManagerFace> ParseCompanyManagerFaceCode(std::string_view str);
 
-	return _cmf_info[cmfv].first_sprite[ge] + GB(cmf, _cmf_info[cmfv].offset, _cmf_info[cmfv].length);
-}
-
-void DrawCompanyManagerFace(CompanyManagerFace face, Colours colour, const Rect &r);
+void DrawCompanyManagerFace(const CompanyManagerFace &cmf, Colours colour, const Rect &r);
 
 #endif /* COMPANY_MANAGER_FACE_H */

--- a/src/company_type.h
+++ b/src/company_type.h
@@ -49,7 +49,12 @@ public:
 };
 
 struct Company;
-typedef uint32_t CompanyManagerFace; ///< Company manager face bits, info see in company_manager_face.h
+
+struct CompanyManagerFace {
+	uint style = 0; ///< Company manager face style.
+	uint32_t bits = 0; ///< Company manager face bits, meaning is dependent on style.
+	std::string style_label; ///< Face style label.
+};
 
 /** The reason why the company was removed. */
 enum CompanyRemoveReason : uint8_t {

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -28,6 +28,7 @@
 
 #include "widgets/error_widget.h"
 
+#include "table/sprites.h"
 #include "table/strings.h"
 
 #include "safeguards.h"

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2320,12 +2320,7 @@ STR_LIVERY_FREIGHT_TRAM                                         :Freight Tram
 STR_FACE_CAPTION                                                :{WHITE}Face Selection
 STR_FACE_CANCEL_TOOLTIP                                         :{BLACK}Cancel new face selection
 STR_FACE_OK_TOOLTIP                                             :{BLACK}Accept new face selection
-STR_FACE_RANDOM                                                 :{BLACK}Randomise
 
-STR_FACE_MALE_BUTTON                                            :{BLACK}Male
-STR_FACE_MALE_TOOLTIP                                           :{BLACK}Select male faces
-STR_FACE_FEMALE_BUTTON                                          :{BLACK}Female
-STR_FACE_FEMALE_TOOLTIP                                         :{BLACK}Select female faces
 STR_FACE_NEW_FACE_BUTTON                                        :{BLACK}New Face
 STR_FACE_NEW_FACE_TOOLTIP                                       :{BLACK}Generate random new face
 STR_FACE_ADVANCED                                               :{BLACK}Advanced
@@ -2335,44 +2330,31 @@ STR_FACE_SIMPLE_TOOLTIP                                         :{BLACK}Simple f
 STR_FACE_LOAD                                                   :{BLACK}Load
 STR_FACE_LOAD_TOOLTIP                                           :{BLACK}Load favourite face
 STR_FACE_LOAD_DONE                                              :{WHITE}Your favourite face has been loaded from the OpenTTD configuration file
-STR_FACE_FACECODE                                               :{BLACK}Player face no.
-STR_FACE_FACECODE_TOOLTIP                                       :{BLACK}View and/or set face number of the company president
-STR_FACE_FACECODE_CAPTION                                       :{WHITE}View and/or set president face number
-STR_FACE_FACECODE_SET                                           :{WHITE}New face number code has been set
-STR_FACE_FACECODE_ERR                                           :{WHITE}Couldn't set president face number - must be a number between 0 and 4,294,967,295!
+STR_FACE_FACECODE                                               :{BLACK}Player face code
+STR_FACE_FACECODE_TOOLTIP                                       :{BLACK}View and/or set face code of the company president
+STR_FACE_FACECODE_CAPTION                                       :{WHITE}View and/or set president face code
+STR_FACE_FACECODE_SET                                           :{WHITE}New president face has been set
+STR_FACE_FACECODE_ERR                                           :{WHITE}Couldn't set president face code - must be a valid label and number
 STR_FACE_SAVE                                                   :{BLACK}Save
 STR_FACE_SAVE_TOOLTIP                                           :{BLACK}Save favourite face
 STR_FACE_SAVE_DONE                                              :{WHITE}This face will be saved as your favourite in the OpenTTD configuration file
-STR_FACE_EUROPEAN                                               :{BLACK}European
-STR_FACE_EUROPEAN_TOOLTIP                                       :{BLACK}Select European faces
-STR_FACE_AFRICAN                                                :{BLACK}African
-STR_FACE_AFRICAN_TOOLTIP                                        :{BLACK}Select African faces
+STR_FACE_SETTING_TOGGLE                                         :{STRING} {ORANGE}{STRING}
+STR_FACE_SETTING_NUMERIC                                        :{STRING} {ORANGE}{NUM} / {NUM}
 STR_FACE_YES                                                    :Yes
 STR_FACE_NO                                                     :No
-STR_FACE_MOUSTACHE_EARRING_TOOLTIP                              :{BLACK}Enable moustache or earring
+STR_FACE_STYLE                                                  :Style:
 STR_FACE_HAIR                                                   :Hair:
-STR_FACE_HAIR_TOOLTIP                                           :{BLACK}Change hair
 STR_FACE_EYEBROWS                                               :Eyebrows:
-STR_FACE_EYEBROWS_TOOLTIP                                       :{BLACK}Change eyebrows
 STR_FACE_EYECOLOUR                                              :Eye colour:
-STR_FACE_EYECOLOUR_TOOLTIP                                      :{BLACK}Change eye colour
 STR_FACE_GLASSES                                                :Glasses:
-STR_FACE_GLASSES_TOOLTIP                                        :{BLACK}Enable glasses
-STR_FACE_GLASSES_TOOLTIP_2                                      :{BLACK}Change glasses
 STR_FACE_NOSE                                                   :Nose:
-STR_FACE_NOSE_TOOLTIP                                           :{BLACK}Change nose
 STR_FACE_LIPS                                                   :Lips:
 STR_FACE_MOUSTACHE                                              :Moustache:
-STR_FACE_LIPS_MOUSTACHE_TOOLTIP                                 :{BLACK}Change lips or moustache
 STR_FACE_CHIN                                                   :Chin:
-STR_FACE_CHIN_TOOLTIP                                           :{BLACK}Change chin
 STR_FACE_JACKET                                                 :Jacket:
-STR_FACE_JACKET_TOOLTIP                                         :{BLACK}Change jacket
 STR_FACE_COLLAR                                                 :Collar:
-STR_FACE_COLLAR_TOOLTIP                                         :{BLACK}Change collar
 STR_FACE_TIE                                                    :Tie:
 STR_FACE_EARRING                                                :Earring:
-STR_FACE_TIE_EARRING_TOOLTIP                                    :{BLACK}Change tie or earring
 
 # Matches ServerGameType
 ###length 3

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "core/backup_type.hpp"
 #include "core/container_func.hpp"
+#include "company_manager_face.h"
 #include "debug.h"
 #include "fileio_func.h"
 #include "engine_func.h"
@@ -462,6 +463,8 @@ void ResetNewGRFData()
 
 	/* Reset canal sprite groups and flags */
 	_water_feature.fill({});
+
+	ResetFaces();
 
 	/* Reset the snowline table. */
 	ClearSnowLine();

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -11,6 +11,7 @@
 #define NEWS_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "company_type.h"
 #include "engine_type.h"
 #include "industry_type.h"
 #include "gfx_type.h"
@@ -164,7 +165,7 @@ struct CompanyNewsInformation : NewsAllocatedData {
 	std::string other_company_name; ///< The name of the company taking over this one
 
 	StringID title;
-	uint32_t face; ///< The face of the president
+	CompanyManagerFace face; ///< The face of the president
 	Colours colour; ///< The colour related to the company
 
 	CompanyNewsInformation(StringID title, const struct Company *c, const struct Company *other = nullptr);

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -939,7 +939,7 @@ static bool LoadOldCompanyEconomy(LoadgameState &ls, int)
 static const OldChunks _company_chunk[] = {
 	OCL_VAR ( OC_UINT16,   1, &_old_string_id ),
 	OCL_SVAR( OC_UINT32, Company, name_2 ),
-	OCL_SVAR( OC_UINT32, Company, face ),
+	OCL_SVAR( OC_UINT32, Company, face.bits ),
 	OCL_VAR ( OC_UINT16,   1, &_old_string_id_2 ),
 	OCL_SVAR( OC_UINT32, Company, president_name_2 ),
 
@@ -992,9 +992,9 @@ static bool LoadOldCompany(LoadgameState &ls, int num)
 
 	if (_savegame_type == SGT_TTO) {
 		/* adjust manager's face */
-		if (HasBit(c->face, 27) && GB(c->face, 26, 1) == GB(c->face, 19, 1)) {
+		if (HasBit(c->face.bits, 27) && GB(c->face.bits, 26, 1) == GB(c->face.bits, 19, 1)) {
 			/* if face would be black in TTD, adjust tie colour and thereby face colour */
-			ClrBit(c->face, 27);
+			ClrBit(c->face.bits, 27);
 		}
 
 		/* Company name */

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -403,6 +403,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_FIX_SCC_ENCODED_NEGATIVE,           ///< 353  PR#14049 Fix encoding of negative parameters.
 	SLV_ORDERS_OWNED_BY_ORDERLIST,          ///< 354  PR#13948 Orders stored in OrderList, pool removed.
 
+	SLV_FACE_STYLES,                        ///< 355  PR#14319 Addition of face styles, replacing gender and ethnicity.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/table/CMakeLists.txt
+++ b/src/table/CMakeLists.txt
@@ -11,6 +11,7 @@ add_files(
     build_industry.h
     cargo_const.h
     clear_land.h
+    company_face.h
     control_codes.h
     elrail_data.h
     engines.h

--- a/src/table/company_face.h
+++ b/src/table/company_face.h
@@ -1,0 +1,98 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file table/company_face.h
+ * This file contains all definitions for default company faces.
+ */
+
+#ifndef TABLE_COMPANY_FACE_H
+#define TABLE_COMPANY_FACE_H
+
+#include "../company_manager_face.h"
+
+/* Definitions for default face variables.
+ * Faces are drawn in the listed order, so sprite layers must be ordered
+ * according to how the face should be rendered. */
+
+/** Variables of first masculine face. */
+static constexpr FaceVar _face_style_1[] = {
+	{FaceVarType::Toggle, 3, 3, 1, 2, std::pair{1ULL << 6, 1ULL << 7 | 1ULL << 8}, STR_FACE_MOUSTACHE},
+	{FaceVarType::Toggle, 11, 4, 1, 2, std::pair{1ULL << 13, 0ULL}, STR_FACE_GLASSES},
+	{FaceVarType::Palette, 2, 5, 2, 3, uint64_t{1ULL << 5}, STR_FACE_EYECOLOUR},
+	{FaceVarType::Sprite, 0, 0, 0, 1, SpriteID{0x325}},
+	{FaceVarType::Sprite, 7, 7, 2, 4, SpriteID{0x327}, STR_FACE_CHIN},
+	{FaceVarType::Sprite, 1, 9, 4, 12, SpriteID{0x32B}, STR_FACE_EYEBROWS},
+	{FaceVarType::Sprite, 4, 13, 2, 3, SpriteID{0x367}, STR_FACE_MOUSTACHE},
+	{FaceVarType::Sprite, 6, 13, 4, 12, SpriteID{0x35B}, STR_FACE_LIPS},
+	{FaceVarType::Sprite, 5, 17, 3, 8, SpriteID{0x349}, STR_FACE_NOSE},
+	{FaceVarType::Sprite, 0, 20, 4, 9, SpriteID{0x382}, STR_FACE_HAIR},
+	{FaceVarType::Sprite, 9, 26, 2, 4, SpriteID{0x36E}, STR_FACE_COLLAR},
+	{FaceVarType::Sprite, 8, 24, 2, 3, SpriteID{0x36B}, STR_FACE_JACKET},
+	{FaceVarType::Sprite, 10, 28, 3, 6, SpriteID{0x372}, STR_FACE_TIE},
+	{FaceVarType::Sprite, 12, 31, 1, 2, SpriteID{0x347}, STR_FACE_GLASSES},
+};
+
+/** Variables of first feminine face. */
+static constexpr FaceVar _face_style_2[] = {
+	{FaceVarType::Toggle, 9, 3, 1, 2, std::pair{1ULL << 11, 0}, STR_FACE_EARRING},
+	{FaceVarType::Toggle, 7, 4, 1, 2, std::pair{1ULL << 12, 0}, STR_FACE_GLASSES},
+	{FaceVarType::Palette, 2, 5, 2, 3, uint64_t{1ULL << 5}, STR_FACE_EYECOLOUR},
+	{FaceVarType::Sprite, 0, 0, 0, 1, SpriteID{0x326}},
+	{FaceVarType::Sprite, 0, 0, 0, 1, SpriteID{0x327}},
+	{FaceVarType::Sprite, 1, 9, 4, 16, SpriteID{0x337}, STR_FACE_EYEBROWS},
+	{FaceVarType::Sprite, 4, 13, 4, 10, SpriteID{0x351}, STR_FACE_LIPS},
+	{FaceVarType::Sprite, 3, 17, 3, 4, SpriteID{0x34C}, STR_FACE_NOSE},
+	{FaceVarType::Sprite, 0, 20, 4, 5, SpriteID{0x38B}, STR_FACE_HAIR},
+	{FaceVarType::Sprite, 6, 26, 2, 4, SpriteID{0x37B}, STR_FACE_COLLAR},
+	{FaceVarType::Sprite, 5, 24, 2, 3, SpriteID{0x378}, STR_FACE_JACKET},
+	{FaceVarType::Sprite, 10, 28, 3, 3, SpriteID{0x37F}, STR_FACE_EARRING},
+	{FaceVarType::Sprite, 8, 31, 1, 2, SpriteID{0x347}, STR_FACE_GLASSES},
+};
+
+/** Variables of second masculine face. */
+static constexpr FaceVar _face_style_3[] = {
+	{FaceVarType::Toggle, 2, 3, 1, 2, std::pair{1ULL << 5, 1ULL << 6 | 1ULL << 7}, STR_FACE_MOUSTACHE},
+	{FaceVarType::Toggle, 10, 4, 1, 2, std::pair{1ULL << 12, 0ULL}, STR_FACE_GLASSES},
+	{FaceVarType::Sprite, 0, 0, 0, 1, SpriteID{0x390}},
+	{FaceVarType::Sprite, 6, 7, 2, 2, SpriteID{0x391}, STR_FACE_CHIN},
+	{FaceVarType::Sprite, 1, 9, 4, 11, SpriteID{0x39A}, STR_FACE_EYEBROWS},
+	{FaceVarType::Sprite, 3, 13, 2, 3, SpriteID{0x397}, STR_FACE_MOUSTACHE},
+	{FaceVarType::Sprite, 5, 13, 4, 9, SpriteID{0x3A5}, STR_FACE_LIPS},
+	{FaceVarType::Sprite, 4, 17, 3, 4, SpriteID{0x393}, STR_FACE_NOSE},
+	{FaceVarType::Sprite, 0, 20, 4, 5, SpriteID{0x3D4}, STR_FACE_HAIR},
+	{FaceVarType::Sprite, 8, 26, 2, 4, SpriteID{0x36E}, STR_FACE_COLLAR},
+	{FaceVarType::Sprite, 7, 24, 2, 3, SpriteID{0x36B}, STR_FACE_JACKET},
+	{FaceVarType::Sprite, 9, 28, 3, 6, SpriteID{0x372}, STR_FACE_TIE},
+	{FaceVarType::Sprite, 11, 31, 1, 2, SpriteID{0x3AE}, STR_FACE_GLASSES},
+};
+
+/** Variables of second feminine face. */
+static constexpr FaceVar _face_style_4[] = {
+	{FaceVarType::Toggle, 9, 3, 1, 2, std::pair{1ULL << 10, 0ULL}, STR_FACE_EARRING},
+	{FaceVarType::Toggle, 7, 4, 1, 2, std::pair{1ULL << 11, 0ULL}, STR_FACE_GLASSES},
+	{FaceVarType::Sprite, 0, 0, 0, 1, SpriteID{0x3B0}},
+	{FaceVarType::Sprite, 4, 7, 2, 2, SpriteID{0x3B1}, STR_FACE_CHIN},
+	{FaceVarType::Sprite, 1, 9, 4, 16, SpriteID{0x3B8}, STR_FACE_EYEBROWS},
+	{FaceVarType::Sprite, 3, 13, 4, 9, SpriteID{0x3C8}, STR_FACE_LIPS},
+	{FaceVarType::Sprite, 2, 17, 3, 5, SpriteID{0x3B3}, STR_FACE_NOSE},
+	{FaceVarType::Sprite, 0, 20, 4, 5, SpriteID{0x3D9}, STR_FACE_HAIR},
+	{FaceVarType::Sprite, 6, 26, 2, 4, SpriteID{0x37B}, STR_FACE_COLLAR},
+	{FaceVarType::Sprite, 5, 24, 2, 3, SpriteID{0x378}, STR_FACE_JACKET},
+	{FaceVarType::Sprite, 10, 28, 3, 3, SpriteID{0x3D1}, STR_FACE_EARRING},
+	{FaceVarType::Sprite, 8, 31, 1, 2, SpriteID{0x3AE}, STR_FACE_GLASSES},
+};
+
+/** Original face styles. */
+static FaceSpec _original_faces[] = {
+	{"default/face1", _face_style_1},
+	{"default/face2", _face_style_2},
+	{"default/face3", _face_style_3},
+	{"default/face4", _face_style_4},
+};
+
+#endif /* TABLE_COMPANY_FACE_H */

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -268,13 +268,11 @@ min      = 1
 max      = 512
 cat      = SC_EXPERT
 
-[SDTG_VAR]
+[SDTG_SSTR]
 name     = ""player_face""
-type     = SLE_UINT32
+type     = SLE_STR
 var      = _company_manager_face
-def      = 0
-min      = 0
-max      = 0xFFFFFFFF
+def      = """"
 cat      = SC_BASIC
 
 [SDTG_VAR]

--- a/src/widgets/company_widget.h
+++ b/src/widgets/company_widget.h
@@ -97,8 +97,6 @@ enum SelectCompanyLiveryWidgets : WidgetID {
 
 /**
  * Widgets of the #SelectCompanyManagerFaceWindow class.
- * Do not change the order of the widgets from WID_SCMF_HAS_MOUSTACHE_EARRING to WID_SCMF_GLASSES_R,
- * this order is needed for the WE_CLICK event of DrawFaceStringLabel().
  */
 enum SelectCompanyManagerFaceWidgets : WidgetID {
 	WID_SCMF_CAPTION,                    ///< Caption of window.
@@ -106,65 +104,18 @@ enum SelectCompanyManagerFaceWidgets : WidgetID {
 	WID_SCMF_SELECT_FACE,                ///< Select face.
 	WID_SCMF_CANCEL,                     ///< Cancel.
 	WID_SCMF_ACCEPT,                     ///< Accept.
-	WID_SCMF_MALE,                       ///< Male button in the simple view.
-	WID_SCMF_FEMALE,                     ///< Female button in the simple view.
-	WID_SCMF_MALE2,                      ///< Male button in the advanced view.
-	WID_SCMF_FEMALE2,                    ///< Female button in the advanced view.
 	WID_SCMF_SEL_LOADSAVE,               ///< Selection to display the load/save/number buttons in the advanced view.
-	WID_SCMF_SEL_MALEFEMALE,             ///< Selection to display the male/female buttons in the simple view.
-	WID_SCMF_SEL_PARTS,                  ///< Selection to display the buttons for setting each part of the face in the advanced view.
+	WID_SCMF_SEL_PARTS, ///< Selection to display the buttons for setting each part of the face in the advanced view.
+	WID_SCMF_SEL_RESIZE, ///< Selection to display the resize button.
 	WID_SCMF_RANDOM_NEW_FACE,            ///< Create random new face.
 	WID_SCMF_TOGGLE_LARGE_SMALL_BUTTON,  ///< Toggle for large or small.
 	WID_SCMF_FACE,                       ///< Current face.
 	WID_SCMF_LOAD,                       ///< Load face.
 	WID_SCMF_FACECODE,                   ///< Get the face code.
 	WID_SCMF_SAVE,                       ///< Save face.
-	WID_SCMF_HAS_MOUSTACHE_EARRING_TEXT, ///< Text about moustache and earring.
-	WID_SCMF_TIE_EARRING_TEXT,           ///< Text about tie and earring.
-	WID_SCMF_LIPS_MOUSTACHE_TEXT,        ///< Text about lips and moustache.
-	WID_SCMF_HAS_GLASSES_TEXT,           ///< Text about glasses.
-	WID_SCMF_HAIR_TEXT,                  ///< Text about hair.
-	WID_SCMF_EYEBROWS_TEXT,              ///< Text about eyebrows.
-	WID_SCMF_EYECOLOUR_TEXT,             ///< Text about eyecolour.
-	WID_SCMF_GLASSES_TEXT,               ///< Text about glasses.
-	WID_SCMF_NOSE_TEXT,                  ///< Text about nose.
-	WID_SCMF_CHIN_TEXT,                  ///< Text about chin.
-	WID_SCMF_JACKET_TEXT,                ///< Text about jacket.
-	WID_SCMF_COLLAR_TEXT,                ///< Text about collar.
-	WID_SCMF_ETHNICITY_EUR,              ///< Text about ethnicity european.
-	WID_SCMF_ETHNICITY_AFR,              ///< Text about ethnicity african.
-	WID_SCMF_HAS_MOUSTACHE_EARRING,      ///< Has moustache or earring.
-	WID_SCMF_HAS_GLASSES,                ///< Has glasses.
-	WID_SCMF_EYECOLOUR_L,                ///< Eyecolour left.
-	WID_SCMF_EYECOLOUR,                  ///< Eyecolour.
-	WID_SCMF_EYECOLOUR_R,                ///< Eyecolour right.
-	WID_SCMF_CHIN_L,                     ///< Chin left.
-	WID_SCMF_CHIN,                       ///< Chin.
-	WID_SCMF_CHIN_R,                     ///< Chin right.
-	WID_SCMF_EYEBROWS_L,                 ///< Eyebrows left.
-	WID_SCMF_EYEBROWS,                   ///< Eyebrows.
-	WID_SCMF_EYEBROWS_R,                 ///< Eyebrows right.
-	WID_SCMF_LIPS_MOUSTACHE_L,           ///< Lips / Moustache left.
-	WID_SCMF_LIPS_MOUSTACHE,             ///< Lips / Moustache.
-	WID_SCMF_LIPS_MOUSTACHE_R,           ///< Lips / Moustache right.
-	WID_SCMF_NOSE_L,                     ///< Nose left.
-	WID_SCMF_NOSE,                       ///< Nose.
-	WID_SCMF_NOSE_R,                     ///< Nose right.
-	WID_SCMF_HAIR_L,                     ///< Hair left.
-	WID_SCMF_HAIR,                       ///< Hair.
-	WID_SCMF_HAIR_R,                     ///< Hair right.
-	WID_SCMF_JACKET_L,                   ///< Jacket left.
-	WID_SCMF_JACKET,                     ///< Jacket.
-	WID_SCMF_JACKET_R,                   ///< Jacket right.
-	WID_SCMF_COLLAR_L,                   ///< Collar left.
-	WID_SCMF_COLLAR,                     ///< Collar.
-	WID_SCMF_COLLAR_R,                   ///< Collar right.
-	WID_SCMF_TIE_EARRING_L,              ///< Tie / Earring left.
-	WID_SCMF_TIE_EARRING,                ///< Tie / Earring.
-	WID_SCMF_TIE_EARRING_R,              ///< Tie / Earring right.
-	WID_SCMF_GLASSES_L,                  ///< Glasses left.
-	WID_SCMF_GLASSES,                    ///< Glasses.
-	WID_SCMF_GLASSES_R,                  ///< Glasses right.
+	WID_SCMF_STYLE, ///< Style selector widget.
+	WID_SCMF_PARTS, ///< Face configuration parts widget.
+	WID_SCMF_PARTS_SCROLLBAR, ///< Scrollbar for configuration parts widget.
 };
 
 /** Widgets of the #CompanyInfrastructureWindow class. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Company manager faces are brittle and have no room for extension. The language used can also be problematic, e.g. "European" and "African".

Bitstuffed values are used to control sprite selections, with lots of special casing to handle differences between male and female faces. Validation of company face bits does not always take account of all cases, which can allow invalid faces to be used in some cases.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Adds a face definition system. This definition is similar to the old CompanyManagerFaceBitsInfo data, but instead of trying to describe all 4 faces in one definition, splits the default faces into 4 separate styles

Each face style can have a variable number of layers, and this is even used by the default faces, removing the special cases used before. Variables can also include toggles and palette selections which affect other variables, used for things like glasses, earrings, moustache, and eye colour.

The user interface is now dynamic and only shows the layers relevant to the current style and toggleable options. This is drawn in a matrix widget, in a style similar to other settings windows.

For future-proofing, each face style is given a string label, so that the numerical index of the style is not important. There is no NewGRF support in this PR, but that could be developed later.

Bumps the savegame version as face style is stored separately.

Simple face selection window now has only a "New Face" button to change the face. This randomises all variables AND the style:
![image](https://github.com/user-attachments/assets/6acdbaea-5bfe-413e-b1fb-2e2ddf5d4b1d)

Advanced face selection, with dynamic rendering of face options.
![image](https://github.com/user-attachments/assets/38ebc574-ac93-4c3a-8316-6f42b96ee248)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The AI/GS script API includes functions to get and set the company president gender. The switch from 2 gender and 2 ethnicity options to a 4 separate face styles consciously removes the distinction of gender and ethnicity, so the API functions fake this based on the index.

Savegame changes might want to store face style by label instead of index, if NewGRF faces are introduced.

Some code parts are a bit TOO far along the line of adding NewGRF support, and can be toned back a bit.

Lacking doxygen.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
