### PR TITLE
Fix: Prevent duplicate train reversal when already reversing

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1973,7 +1973,7 @@ static bool IsWholeTrainInsideDepot(const Train *v)
  */
 void ReverseTrainDirection(Train *v)
 {
-	DEBUG(driver, 1, "Reversing train %d on tile %d", v->index, v->tile);
+	//DEBUG(driver, 1, "Reversing train %d on tile %d", v->index, v->tile);
 
 	if (IsRailDepotTile(v->tile)) {
 		if (IsWholeTrainInsideDepot(v)) return;
@@ -3868,6 +3868,9 @@ static TileIndex TrainApproachingCrossingTile(const Train *v)
  */
 static bool TrainCheckIfLineEnds(Train *v, bool reverse)
 {
+
+	if (v->flags.Test(VehicleRailFlag::Reversing)) return false;
+	
 	/* First, handle broken down train */
 
 	int t = v->breakdown_ctr;
@@ -3915,6 +3918,7 @@ static bool TrainCheckIfLineEnds(Train *v, bool reverse)
 
 	return true;
 }
+
 
 
 static bool TrainLocoHandler(Train *v, bool mode)

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1973,6 +1973,8 @@ static bool IsWholeTrainInsideDepot(const Train *v)
  */
 void ReverseTrainDirection(Train *v)
 {
+	DEBUG(driver, 1, "Reversing train %d on tile %d", v->index, v->tile);
+
 	if (IsRailDepotTile(v->tile)) {
 		if (IsWholeTrainInsideDepot(v)) return;
 		InvalidateWindowData(WC_VEHICLE_DEPOT, v->tile);


### PR DESCRIPTION
## Motivation / Problem

Trains that already had the `Reversing` flag could still trigger automatic reversal again via `TrainCheckIfLineEnds()`.  
This caused inconsistent wagon order, redundant reversals, and potential logic issues during movement.

## Description

Added a guard clause at the beginning of `TrainCheckIfLineEnds()` to skip reversal logic when `VehicleRailFlag::Reversing` is already set.  
This ensures a train cannot reverse more than once while a prior reversal is still being processed.

## Limitations

This fix addresses only the specific case of duplicate reversal. Broader train movement or signal logic is not affected.

## Checklist for review

- [x] Fix relates to train movement behavior
- [x] `train_cmd.cpp` edited and tested
- [x] Closes issue #14024
