### PR TITLE
Codechange: Replace ScriptObject::[SG]etAllowDoCommand with ScriptObject::DisableDoCommandScope

### DIFF
--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -910,8 +910,7 @@ SQInteger ScriptList::Valuate(HSQUIRRELVM vm)
 
 	/* Don't allow docommand from a Valuator, as we can't resume in
 	 * mid C++-code. */
-	bool backup_allow = ScriptObject::GetAllowDoCommand();
-	ScriptObject::SetAllowDoCommand(false);
+	ScriptObject::DisableDoCommandScope disabler{};
 
 	/* Limit the total number of ops that can be consumed by a valuate operation */
 	SQOpsLimiter limiter(vm, MAX_VALUATE_OPS, "valuator function");
@@ -933,7 +932,6 @@ SQInteger ScriptList::Valuate(HSQUIRRELVM vm)
 
 		/* Call the function. Squirrel pops all parameters and pushes the return value. */
 		if (SQ_FAILED(sq_call(vm, nparam + 1, SQTrue, SQFalse))) {
-			ScriptObject::SetAllowDoCommand(backup_allow);
 			return SQ_ERROR;
 		}
 
@@ -956,7 +954,6 @@ SQInteger ScriptList::Valuate(HSQUIRRELVM vm)
 				/* See below for explanation. The extra pop is the return value. */
 				sq_pop(vm, nparam + 4);
 
-				ScriptObject::SetAllowDoCommand(backup_allow);
 				return sq_throwerror(vm, "return value of valuator is not valid (not integer/bool)");
 			}
 		}
@@ -966,7 +963,6 @@ SQInteger ScriptList::Valuate(HSQUIRRELVM vm)
 			/* See below for explanation. The extra pop is the return value. */
 			sq_pop(vm, nparam + 4);
 
-			ScriptObject::SetAllowDoCommand(backup_allow);
 			return sq_throwerror(vm, "modifying valuated list outside of valuator function");
 		}
 
@@ -984,6 +980,5 @@ SQInteger ScriptList::Valuate(HSQUIRRELVM vm)
 	 * 4. The ScriptList instance object. */
 	sq_pop(vm, nparam + 3);
 
-	ScriptObject::SetAllowDoCommand(backup_allow);
 	return 0;
 }

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -88,11 +88,9 @@ protected:
 			sq_push(vm, 2);
 		}
 
-		/* Don't allow docommand from a Valuator, as we can't resume in
+		/* Don't allow docommand from a filter, as we can't resume in
 		 * mid C++-code. */
-		bool backup_allow = ScriptObject::GetAllowDoCommand();
-		ScriptObject::SetAllowDoCommand(false);
-
+		ScriptObject::DisableDoCommandScope disabler{};
 
 		if (nparam < 1) {
 			ScriptList::FillList<T>(list, item_valid);
@@ -101,7 +99,7 @@ protected:
 			SQOpsLimiter limiter(vm, MAX_VALUATE_OPS, "list filter function");
 
 			ScriptList::FillList<T>(list, item_valid,
-				[vm, nparam, backup_allow](const T *item) {
+				[vm, nparam](const T *item) {
 					/* Push the root table as instance object, this is what squirrel does for meta-functions. */
 					sq_pushroottable(vm);
 					/* Push all arguments for the valuator function. */
@@ -112,7 +110,6 @@ protected:
 
 					/* Call the function. Squirrel pops all parameters and pushes the return value. */
 					if (SQ_FAILED(sq_call(vm, nparam + 1, SQTrue, SQFalse))) {
-						ScriptObject::SetAllowDoCommand(backup_allow);
 						throw static_cast<SQInteger>(SQ_ERROR);
 					}
 
@@ -125,7 +122,6 @@ protected:
 							break;
 
 						default:
-							ScriptObject::SetAllowDoCommand(backup_allow);
 							throw sq_throwerror(vm, "return value of filter is not valid (not bool)");
 					}
 
@@ -139,8 +135,6 @@ protected:
 			/* Pop the filter function */
 			sq_poptop(vm);
 		}
-
-		ScriptObject::SetAllowDoCommand(backup_allow);
 	}
 
 	template <typename T>

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -63,6 +63,10 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	ScriptObject::ActiveInstance::active = this->last_active;
 }
 
+ScriptObject::DisableDoCommandScope::DisableDoCommandScope()
+	: AutoRestoreBackup(GetStorage()->allow_do_command, false)
+{}
+
 /* static */ ScriptInstance &ScriptObject::GetActiveInstance()
 {
 	assert(ScriptObject::ActiveInstance::active != nullptr);
@@ -203,16 +207,6 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 /* static */ const CommandDataBuffer &ScriptObject::GetLastCommandResData()
 {
 	return GetStorage()->last_cmd_ret;
-}
-
-/* static */ void ScriptObject::SetAllowDoCommand(bool allow)
-{
-	GetStorage()->allow_do_command = allow;
-}
-
-/* static */ bool ScriptObject::GetAllowDoCommand()
-{
-	return GetStorage()->allow_do_command;
 }
 
 /* static */ void ScriptObject::SetCompany(::CompanyID company)

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -84,6 +84,11 @@ protected:
 		static ScriptInstance *active;  ///< The global current active instance.
 	};
 
+	class DisableDoCommandScope : private AutoRestoreBackup<bool> {
+	public:
+		DisableDoCommandScope();
+	};
+
 	/**
 	 * Save this object.
 	 * Must push 2 elements on the stack:
@@ -264,21 +269,6 @@ protected:
 	 * Get the extra return data from the last DoCommand.
 	 */
 	static const CommandDataBuffer &GetLastCommandResData();
-
-	/**
-	 * Store a allow_do_command per company.
-	 * @param allow The new allow.
-	 */
-	static void SetAllowDoCommand(bool allow);
-
-	/**
-	 * Get the internal value of allow_do_command. This can differ
-	 * from CanSuspend() if the reason we are not allowed
-	 * to execute a DoCommand is in squirrel and not the API.
-	 * In that case use this function to restore the previous value.
-	 * @return True iff DoCommands are allowed in the current scope.
-	 */
-	static bool GetAllowDoCommand();
 
 	/**
 	 * Set the current company to execute commands for or request


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Disabling `DoCommand` is typically temporary.
There's a `ScriptObject::SetAllowDoCommand(false)` call to disable `DoCommand`, and later a `ScriptObject::SetAllowDoCommand(backup_allow)` call to restore it.
The restoration has to be handled manually for every early returns.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Introduce `ScriptObject::AutoRestoreAllowDoCommand` using `AutoRestoreBackup` to automatically handle the restoration.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
