### PR TITLE
Codechange: Delete delete

### DIFF
--- a/src/ai/ai_info.cpp
+++ b/src/ai/ai_info.cpp
@@ -108,7 +108,7 @@ template <> SQInteger PushClassName<AIInfo, ScriptType::AI>(HSQUIRRELVM vm) { sq
 	/* Remove the link to the real instance, else it might get deleted by RegisterAI() */
 	sq_setinstanceup(vm, 2, nullptr);
 	/* Register the AI to the base system */
-	static_cast<AIScannerInfo *>(info->GetScanner())->SetDummyAI(info);
+	static_cast<AIScannerInfo *>(info->GetScanner())->SetDummyAI(std::unique_ptr<AIInfo>(info));
 	return 0;
 }
 

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -22,11 +22,8 @@
 #include "../safeguards.h"
 
 
-AIScannerInfo::AIScannerInfo() :
-	ScriptScanner(),
-	info_dummy(nullptr)
-{
-}
+AIScannerInfo::AIScannerInfo() = default;
+AIScannerInfo::~AIScannerInfo() = default;
 
 void AIScannerInfo::Initialize()
 {
@@ -39,14 +36,9 @@ void AIScannerInfo::Initialize()
 	Script_CreateDummyInfo(this->engine->GetVM(), "AI", "ai");
 }
 
-void AIScannerInfo::SetDummyAI(class AIInfo *info)
+void AIScannerInfo::SetDummyAI(std::unique_ptr<class AIInfo>&& info)
 {
-	this->info_dummy = info;
-}
-
-AIScannerInfo::~AIScannerInfo()
-{
-	delete this->info_dummy;
+	this->info_dummy = std::move(info);
 }
 
 std::string AIScannerInfo::GetScriptName(ScriptInfo &info)
@@ -63,7 +55,7 @@ AIInfo *AIScannerInfo::SelectRandomAI() const
 {
 	if (_game_mode == GM_MENU) {
 		Debug(script, 0, "The intro game should not use AI, loading 'dummy' AI.");
-		return this->info_dummy;
+		return this->info_dummy.get();
 	}
 
 	/* Filter for AIs suitable as Random AI. */
@@ -72,7 +64,7 @@ AIInfo *AIScannerInfo::SelectRandomAI() const
 	uint num_random_ais = std::ranges::distance(random_ais);
 	if (num_random_ais == 0) {
 		Debug(script, 0, "No suitable AI found, loading 'dummy' AI.");
-		return this->info_dummy;
+		return this->info_dummy.get();
 	}
 
 	/* Pick a random AI */

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -32,7 +32,7 @@ void AIScannerInfo::Initialize()
 {
 	ScriptScanner::Initialize("AIScanner");
 
-	ScriptAllocatorScope alloc_scope(this->engine);
+	ScriptAllocatorScope alloc_scope(this->engine.get());
 
 	/* Create the dummy AI */
 	this->main_script = "%_dummy";

--- a/src/ai/ai_scanner.hpp
+++ b/src/ai/ai_scanner.hpp
@@ -37,7 +37,7 @@ public:
 	/**
 	 * Set the Dummy AI.
 	 */
-	void SetDummyAI(class AIInfo *info);
+	void SetDummyAI(std::unique_ptr<class AIInfo>&& info);
 
 protected:
 	std::string GetScriptName(ScriptInfo &info) override;
@@ -47,7 +47,7 @@ protected:
 	void RegisterAPI(class Squirrel &engine) override;
 
 private:
-	AIInfo *info_dummy; ///< The dummy AI.
+	std::unique_ptr<AIInfo> info_dummy; ///< The dummy AI.
 };
 
 class AIScannerLibrary : public ScriptScanner {

--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -80,19 +80,17 @@ uint CountArticulatedParts(EngineID engine_type, bool purchase_window)
 	 * either, so it doesn't matter how many articulated parts there are. */
 	if (!Vehicle::CanAllocateItem()) return 0;
 
-	Vehicle *v = nullptr;
+	std::unique_ptr<Vehicle> v;
 	if (!purchase_window) {
-		v = new Vehicle();
+		v = std::make_unique<Vehicle>();
 		v->engine_type = engine_type;
 		v->owner = _current_company;
 	}
 
 	uint i;
 	for (i = 1; i < MAX_ARTICULATED_PARTS; i++) {
-		if (GetNextArticulatedPart(i, engine_type, v) == EngineID::Invalid()) break;
+		if (GetNextArticulatedPart(i, engine_type, v.get()) == EngineID::Invalid()) break;
 	}
-
-	delete v;
 
 	return i - 1;
 }

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -70,14 +70,6 @@ struct BaseSet {
 	uint found_files = 0; ///< Number of the files that could be found
 	uint valid_files = 0; ///< Number of the files that could be found and are valid
 
-	T *next = nullptr; ///< The next base set in this list
-
-	/** Free everything we allocated */
-	~BaseSet()
-	{
-		delete this->next;
-	}
-
 	/**
 	 * Get the number of missing files.
 	 * @return the number
@@ -170,8 +162,8 @@ struct BaseSet {
 template <class Tbase_set>
 class BaseMedia : FileScanner {
 protected:
-	static inline Tbase_set *available_sets = nullptr; ///< All available sets
-	static inline Tbase_set *duplicate_sets = nullptr; ///< All sets that aren't available, but needed for not downloading base sets when a newer version than the one on BaNaNaS is loaded.
+	static inline std::list<Tbase_set> available_sets; ///< All available sets
+	static inline std::list<Tbase_set> duplicate_sets; ///< All sets that aren't available, but needed for not downloading base sets when a newer version than the one on BaNaNaS is loaded.
 	static inline const Tbase_set *used_set = nullptr; ///< The currently used set
 
 	bool AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename) override;
@@ -198,7 +190,7 @@ public:
 		return num + fs.Scan(GetExtension(), BASESET_DIR, Tbase_set::SEARCH_IN_TARS);
 	}
 
-	static Tbase_set *GetAvailableSets();
+	static std::list<Tbase_set>& GetAvailableSets();
 
 	static bool SetSet(const Tbase_set *set);
 	static bool SetSetByName(const std::string &name);
@@ -226,6 +218,6 @@ public:
  * @return The filename of the first file of the base set, or \c std::nullopt if there is no match.
  */
 template <class Tbase_set>
-std::optional<std::string_view> TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, const Tbase_set *s);
+std::optional<std::string_view> TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, const std::list<Tbase_set>& sets);
 
 #endif /* BASE_MEDIA_BASE_H */

--- a/src/base_media_graphics.h
+++ b/src/base_media_graphics.h
@@ -47,6 +47,8 @@ public:
 
 	GraphicsSet();
 	~GraphicsSet();
+	GraphicsSet(GraphicsSet&&);
+	GraphicsSet& operator =(GraphicsSet&&);
 
 	bool FillSetDetails(const IniFile &ini, const std::string &path, const std::string &full_filename);
 	GRFConfig *GetExtraConfig() const { return this->extra_cfg.get(); }

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -352,6 +352,10 @@ GraphicsSet::GraphicsSet() = default;
 /* instantiate here, because unique_ptr needs a complete type */
 GraphicsSet::~GraphicsSet() = default;
 
+GraphicsSet::GraphicsSet(GraphicsSet&&) = default;
+GraphicsSet& GraphicsSet::operator =(GraphicsSet&&) = default;
+
+
 bool GraphicsSet::FillSetDetails(const IniFile &ini, const std::string &path, const std::string &full_filename)
 {
 	if (!this->BaseSet<GraphicsSet>::FillSetDetails(ini, path, full_filename, false)) return false;
@@ -480,26 +484,26 @@ template <>
 
 	const GraphicsSet *best = nullptr;
 
-	auto IsBetter = [&best] (const auto *current) {
+	auto IsBetter = [&best] (const auto& current) {
 		/* Nothing chosen yet. */
 		if (best == nullptr) return true;
 		/* Not being a fallback is better. */
-		if (best->fallback && !current->fallback) return true;
+		if (best->fallback && !current.fallback) return true;
 		/* Having more valid files is better. */
-		if (best->valid_files < current->valid_files) return true;
+		if (best->valid_files < current.valid_files) return true;
 		/* Having (essentially) fewer valid files is worse. */
-		if (best->valid_files != current->valid_files) return false;
+		if (best->valid_files != current.valid_files) return false;
 		/* Having a later version of the same base set is better. */
-		if (best->shortname == current->shortname && best->version < current->version) return true;
+		if (best->shortname == current.shortname && best->version < current.version) return true;
 		/* The DOS palette is the better palette. */
-		return best->palette != PAL_DOS && current->palette == PAL_DOS;
+		return best->palette != PAL_DOS && current.palette == PAL_DOS;
 	};
 
-	for (const GraphicsSet *c = BaseMedia<GraphicsSet>::available_sets; c != nullptr; c = c->next) {
+	for (const GraphicsSet& gs : BaseMedia<GraphicsSet>::available_sets) {
 		/* Skip unusable sets */
-		if (c->GetNumMissing() != 0) continue;
+		if (gs.GetNumMissing() != 0) continue;
 
-		if (IsBetter(c)) best = c;
+		if (IsBetter(gs)) best = &gs;
 	}
 
 	BaseMedia<GraphicsSet>::used_set = best;

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -95,15 +95,15 @@ template <>
 	if (BaseMedia<MusicSet>::used_set != nullptr) return true;
 
 	const MusicSet *best = nullptr;
-	for (const MusicSet *c = BaseMedia<MusicSet>::available_sets; c != nullptr; c = c->next) {
-		if (c->GetNumMissing() != 0) continue;
+	for (const MusicSet& c : BaseMedia<MusicSet>::available_sets) {
+		if (c.GetNumMissing() != 0) continue;
 
 		if (best == nullptr ||
-				(best->fallback && !c->fallback) ||
-				best->valid_files < c->valid_files ||
-				(best->valid_files == c->valid_files &&
-					(best->shortname == c->shortname && best->version < c->version))) {
-			best = c;
+				(best->fallback && !c.fallback) ||
+				best->valid_files < c.valid_files ||
+				(best->valid_files == c.valid_files &&
+					(best->shortname == c.shortname && best->version < c.version))) {
+			best = &c;
 		}
 	}
 

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -58,7 +58,7 @@ void ScriptScanner::ResetEngine()
 
 void ScriptScanner::Initialize(std::string_view name)
 {
-	this->engine = new Squirrel(name);
+	this->engine = std::make_unique<Squirrel>(name);
 
 	this->RescanDir();
 
@@ -68,8 +68,6 @@ void ScriptScanner::Initialize(std::string_view name)
 ScriptScanner::~ScriptScanner()
 {
 	this->Reset();
-
-	delete this->engine;
 }
 
 void ScriptScanner::RescanDir()

--- a/src/script/script_scanner.hpp
+++ b/src/script/script_scanner.hpp
@@ -26,7 +26,7 @@ public:
 	/**
 	 * Get the engine of the main squirrel handler (it indexes all available scripts).
 	 */
-	class Squirrel *GetEngine() { return this->engine; }
+	class Squirrel *GetEngine() { return this->engine.get(); }
 
 	/**
 	 * Get the current main script the ScanDir is currently tracking.
@@ -84,7 +84,7 @@ public:
 	void RescanDir();
 
 protected:
-	class Squirrel *engine;  ///< The engine we're scanning with.
+	std::unique_ptr<class Squirrel> engine;  ///< The engine we're scanning with.
 	std::string main_script; ///< The full path of the script.
 	std::string tar_file;    ///< If, which tar file the script was in.
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -268,16 +268,16 @@ template <>
 	if (BaseMedia<SoundsSet>::used_set != nullptr) return true;
 
 	const SoundsSet *best = nullptr;
-	for (const SoundsSet *c = BaseMedia<SoundsSet>::available_sets; c != nullptr; c = c->next) {
+	for (const SoundsSet& c : BaseMedia<SoundsSet>::available_sets) {
 		/* Skip unusable sets */
-		if (c->GetNumMissing() != 0) continue;
+		if (c.GetNumMissing() != 0) continue;
 
 		if (best == nullptr ||
-				(best->fallback && !c->fallback) ||
-				best->valid_files < c->valid_files ||
-				(best->valid_files == c->valid_files &&
-					(best->shortname == c->shortname && best->version < c->version))) {
-			best = c;
+				(best->fallback && !c.fallback) ||
+				best->valid_files < c.valid_files ||
+				(best->valid_files == c.valid_files &&
+					(best->shortname == c.shortname && best->version < c.version))) {
+			best = &c;
 		}
 	}
 


### PR DESCRIPTION
This is a series of commits aiming to remove as much manual memory management as possible.

## Motivation / Problem

Memory management should be handled by classes whole sole purpose is to manage memory and object lifetieme.
There is still some low-hanging instances of new/delete where ownership semantics are obvious and can be easily delegated to std::unique_ptr or a container. 

## Description

See each commit for details of how new/delete was removed

## Limitations

1. Some classes do `delete this;`. While self ownership is legal, it's not considered good practice. Untangling that will take a while and ought to wait for another commit series.
2. `PoolType` should probably be replace with `std::hive`, but that requires C++26.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
