### PR TITLE
Codechange: Remove manual memory management from CountArticulatedParts

### DIFF
--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -80,19 +80,17 @@ uint CountArticulatedParts(EngineID engine_type, bool purchase_window)
 	 * either, so it doesn't matter how many articulated parts there are. */
 	if (!Vehicle::CanAllocateItem()) return 0;
 
-	Vehicle *v = nullptr;
+	std::unique_ptr<Vehicle> v;
 	if (!purchase_window) {
-		v = new Vehicle();
+		v = std::make_unique<Vehicle>();
 		v->engine_type = engine_type;
 		v->owner = _current_company;
 	}
 
 	uint i;
 	for (i = 1; i < MAX_ARTICULATED_PARTS; i++) {
-		if (GetNextArticulatedPart(i, engine_type, v) == EngineID::Invalid()) break;
+		if (GetNextArticulatedPart(i, engine_type, v.get()) == EngineID::Invalid()) break;
 	}
-
-	delete v;
 
 	return i - 1;
 }


### PR DESCRIPTION

## Motivation / Problem

Memory management should be handled by classes whole sole purpose is to manage memory and object lifetime.

> I think these changes cause quite large changes to somewhat unrelated code, and should be handled as separate PRs.

_Originally posted by @PeterN in https://github.com/OpenTTD/OpenTTD/issues/14331#issuecomment-2949354860_

## Description

Replace use of new/delete in code with std::unique_ptr.

Split from [original PR](https://github.com/OpenTTD/OpenTTD/issues/14331).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
