### PR TITLE
Codechange: Remove manual memory management of AIScannerInfo::info_dummy

### DIFF
--- a/src/ai/ai_info.cpp
+++ b/src/ai/ai_info.cpp
@@ -108,7 +108,7 @@ template <> SQInteger PushClassName<AIInfo, ScriptType::AI>(HSQUIRRELVM vm) { sq
 	/* Remove the link to the real instance, else it might get deleted by RegisterAI() */
 	sq_setinstanceup(vm, 2, nullptr);
 	/* Register the AI to the base system */
-	static_cast<AIScannerInfo *>(info->GetScanner())->SetDummyAI(info);
+	static_cast<AIScannerInfo *>(info->GetScanner())->SetDummyAI(std::unique_ptr<AIInfo>(info));
 	return 0;
 }
 

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -22,11 +22,8 @@
 #include "../safeguards.h"
 
 
-AIScannerInfo::AIScannerInfo() :
-	ScriptScanner(),
-	info_dummy(nullptr)
-{
-}
+AIScannerInfo::AIScannerInfo() = default;
+AIScannerInfo::~AIScannerInfo() = default;
 
 void AIScannerInfo::Initialize()
 {
@@ -39,14 +36,9 @@ void AIScannerInfo::Initialize()
 	Script_CreateDummyInfo(this->engine->GetVM(), "AI", "ai");
 }
 
-void AIScannerInfo::SetDummyAI(class AIInfo *info)
+void AIScannerInfo::SetDummyAI(std::unique_ptr<class AIInfo> &&info)
 {
-	this->info_dummy = info;
-}
-
-AIScannerInfo::~AIScannerInfo()
-{
-	delete this->info_dummy;
+	this->info_dummy = std::move(info);
 }
 
 std::string AIScannerInfo::GetScriptName(ScriptInfo &info)
@@ -63,7 +55,7 @@ AIInfo *AIScannerInfo::SelectRandomAI() const
 {
 	if (_game_mode == GM_MENU) {
 		Debug(script, 0, "The intro game should not use AI, loading 'dummy' AI.");
-		return this->info_dummy;
+		return this->info_dummy.get();
 	}
 
 	/* Filter for AIs suitable as Random AI. */
@@ -72,7 +64,7 @@ AIInfo *AIScannerInfo::SelectRandomAI() const
 	uint num_random_ais = std::ranges::distance(random_ais);
 	if (num_random_ais == 0) {
 		Debug(script, 0, "No suitable AI found, loading 'dummy' AI.");
-		return this->info_dummy;
+		return this->info_dummy.get();
 	}
 
 	/* Pick a random AI */

--- a/src/ai/ai_scanner.hpp
+++ b/src/ai/ai_scanner.hpp
@@ -37,7 +37,7 @@ public:
 	/**
 	 * Set the Dummy AI.
 	 */
-	void SetDummyAI(class AIInfo *info);
+	void SetDummyAI(std::unique_ptr<class AIInfo> &&info);
 
 protected:
 	std::string GetScriptName(ScriptInfo &info) override;
@@ -47,7 +47,7 @@ protected:
 	void RegisterAPI(class Squirrel &engine) override;
 
 private:
-	AIInfo *info_dummy; ///< The dummy AI.
+	std::unique_ptr<AIInfo> info_dummy; ///< The dummy AI.
 };
 
 class AIScannerLibrary : public ScriptScanner {


### PR DESCRIPTION
## Motivation / Problem

Memory management should be handled by classes whole sole purpose is to manage memory and object lifetime.

> I think these changes cause quite large changes to somewhat unrelated code, and should be handled as separate PRs.

_Originally posted by @PeterN in https://github.com/OpenTTD/OpenTTD/issues/14331#issuecomment-2949354860_

## Description

Replace use of new/delete in code with std::unique_ptr.

Split from [original PR](https://github.com/OpenTTD/OpenTTD/issues/14331).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
