### PR TITLE
Codechange: Use unique_ptr instead of raw pointers in ScriptInstance.

### DIFF
--- a/src/ai/ai_instance.cpp
+++ b/src/ai/ai_instance.cpp
@@ -83,7 +83,7 @@ void AIInstance::Died()
 
 void AIInstance::LoadDummyScript()
 {
-	ScriptAllocatorScope alloc_scope(this->engine);
+	ScriptAllocatorScope alloc_scope(this->engine.get());
 	Script_CreateDummy(this->engine->GetVM(), STR_ERROR_AI_NO_AI_FOUND, "AI");
 }
 

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -53,7 +53,7 @@ static ScriptStorage &GetStorage()
 
 /* static */ ScriptInstance *ScriptObject::ActiveInstance::active = nullptr;
 
-ScriptObject::ActiveInstance::ActiveInstance(ScriptInstance &instance) : alc_scope(instance.engine)
+ScriptObject::ActiveInstance::ActiveInstance(ScriptInstance &instance) : alc_scope(instance.engine.get())
 {
 	this->last_active = ScriptObject::ActiveInstance::active;
 	ScriptObject::ActiveInstance::active = &instance;
@@ -230,8 +230,8 @@ ScriptObject::DisableDoCommandScope::DisableDoCommandScope()
 
 /* static */ bool ScriptObject::CanSuspend()
 {
-	Squirrel *squirrel = ScriptObject::GetActiveInstance().engine;
-	return GetStorage().allow_do_command && squirrel->CanSuspend();
+	Squirrel &squirrel = *ScriptObject::GetActiveInstance().engine;
+	return GetStorage().allow_do_command && squirrel.CanSuspend();
 }
 
 /* static */ ScriptEventQueue &ScriptObject::GetEventQueue()

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -50,8 +50,8 @@ static void PrintFunc(bool error_msg, std::string_view message)
 
 ScriptInstance::ScriptInstance(std::string_view api_name)
 {
-	this->storage = new ScriptStorage();
-	this->engine  = new Squirrel(api_name);
+	this->storage = std::make_unique<ScriptStorage>();
+	this->engine = std::make_unique<Squirrel>(api_name);
 	this->engine->SetPrintFunction(&PrintFunc);
 }
 
@@ -59,10 +59,10 @@ void ScriptInstance::Initialize(const std::string &main_script, const std::strin
 {
 	ScriptObject::ActiveInstance active(*this);
 
-	this->controller = new ScriptController(company);
+	this->controller = std::make_unique<ScriptController>(company);
 
 	/* Register the API functions and classes */
-	this->engine->SetGlobalPointer(this->engine);
+	this->engine->SetGlobalPointer(this->engine.get());
 	this->RegisterAPI();
 	if (this->IsDead()) {
 		/* Failed to register API; a message has already been logged. */
@@ -81,12 +81,11 @@ void ScriptInstance::Initialize(const std::string &main_script, const std::strin
 		}
 
 		/* Create the main-class */
-		this->instance = new SQObject();
-		if (!this->engine->CreateClassInstance(instance_name, this->controller, this->instance)) {
+		this->instance = std::make_unique<SQObject>();
+		if (!this->engine->CreateClassInstance(instance_name, this->controller.get(), this->instance.get())) {
 			/* If CreateClassInstance has returned false instance has not been
 			 * registered with squirrel, so avoid trying to Release it by clearing it now */
-			delete this->instance;
-			this->instance = nullptr;
+			this->instance.reset();
 			this->Died();
 			return;
 		}
@@ -146,11 +145,10 @@ ScriptInstance::~ScriptInstance()
 	ScriptObject::ActiveInstance active(*this);
 	this->in_shutdown = true;
 
-	if (instance != nullptr) this->engine->ReleaseObject(this->instance);
-	if (engine != nullptr) delete this->engine;
-	delete this->storage;
-	delete this->controller;
-	delete this->instance;
+	if (instance != nullptr) this->engine->ReleaseObject(this->instance.get());
+
+	/* Engine must be reset explicitly in scope of the active instance. */
+	this->engine.reset();
 }
 
 void ScriptInstance::Continue()
@@ -167,11 +165,9 @@ void ScriptInstance::Died()
 
 	this->last_allocated_memory = this->GetAllocatedMemory(); // Update cache
 
-	if (this->instance != nullptr) this->engine->ReleaseObject(this->instance);
-	delete this->instance;
-	delete this->engine;
-	this->instance = nullptr;
-	this->engine = nullptr;
+	if (this->instance != nullptr) this->engine->ReleaseObject(this->instance.get());
+	this->engine.reset();
+	this->instance.reset();
 }
 
 void ScriptInstance::GameLoop()

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -256,7 +256,7 @@ public:
 	void ReleaseSQObject(HSQOBJECT *obj);
 
 protected:
-	class Squirrel *engine = nullptr; ///< A wrapper around the squirrel vm.
+	std::unique_ptr<class Squirrel> engine; ///< A wrapper around the squirrel vm.
 	std::string api_version{}; ///< Current API used by this script.
 
 	/**
@@ -288,9 +288,9 @@ protected:
 	virtual void LoadDummyScript() = 0;
 
 private:
-	class ScriptController *controller = nullptr; ///< The script main class.
-	class ScriptStorage *storage = nullptr; ///< Some global information for each running script.
-	SQObject *instance = nullptr; ///< Squirrel-pointer to the script main class.
+	std::unique_ptr<class ScriptStorage> storage; ///< Some global information for each running script.
+	std::unique_ptr<class ScriptController> controller; ///< The script main class.
+	std::unique_ptr<SQObject> instance; ///< Squirrel-pointer to the script main class.
 
 	bool is_started = false; ///< Is the scripts constructor executed?
 	bool is_dead = false; ///< True if the script has been stopped.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Manual management of pointers owned by ScriptInstance.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace raw pointers in ScriptInstance with `std::unique_ptr` managed pointers.

This removes the need for manual memory management, with the caveat that `engine` must be destructed first.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The requirement for deconstruction to happen in a specific order ~~suggests that there is an ownership issue~~ is a bit awkward but necessary due to how scoping works.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
