### PR TITLE
Replace ReferenceThroughBaseContainer with a type which only permits the correct index type

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -52,7 +52,7 @@ void UpdateObjectColours(const Company *c);
 
 CompanyID _local_company;   ///< Company controlled by the human player at this client. Can also be #COMPANY_SPECTATOR.
 CompanyID _current_company; ///< Company currently doing an action.
-ReferenceThroughBaseContainer<std::array<Colours, MAX_COMPANIES>> _company_colours; ///< NOSAVE: can be determined from company structs.
+TypedIndexContainer<std::array<Colours, MAX_COMPANIES>, CompanyID> _company_colours; ///< NOSAVE: can be determined from company structs.
 CompanyManagerFace _company_manager_face; ///< for company manager face storage in openttd.cfg
 uint _cur_company_tick_index;             ///< used to generate a name for one company that doesn't have a name yet per tick
 

--- a/src/company_func.h
+++ b/src/company_func.h
@@ -36,7 +36,7 @@ CommandCost CheckTileOwnership(TileIndex tile);
 extern CompanyID _local_company;
 extern CompanyID _current_company;
 
-extern ReferenceThroughBaseContainer<std::array<Colours, MAX_COMPANIES>> _company_colours;
+extern TypedIndexContainer<std::array<Colours, MAX_COMPANIES>, CompanyID> _company_colours;
 extern CompanyManagerFace _company_manager_face;
 PaletteID GetCompanyPalette(CompanyID company);
 

--- a/src/core/convertible_through_base.hpp
+++ b/src/core/convertible_through_base.hpp
@@ -30,26 +30,6 @@ template <typename T, typename TTo>
 concept ConvertibleThroughBaseOrTo = std::is_convertible_v<T, TTo> || ConvertibleThroughBase<T>;
 
 /**
- * A sort-of mixin that adds 'at(pos)' and 'operator[](pos)' implementations for 'ConvertibleThroughBase' types.
- * This to prevent having to call '.base()' for many container accesses.
- */
-template <typename Container>
-class ReferenceThroughBaseContainer : public Container {
-public:
-	Container::reference at(size_t pos) { return this->Container::at(pos); }
-	Container::reference at(const ConvertibleThroughBase auto &pos) { return this->Container::at(pos.base()); }
-
-	Container::const_reference at(size_t pos) const { return this->Container::at(pos); }
-	Container::const_reference at(const ConvertibleThroughBase auto &pos) const { return this->Container::at(pos.base()); }
-
-	Container::reference operator[](size_t pos) { return this->Container::operator[](pos); }
-	Container::reference operator[](const ConvertibleThroughBase auto &pos) { return this->Container::operator[](pos.base()); }
-
-	Container::const_reference operator[](size_t pos) const { return this->Container::operator[](pos); }
-	Container::const_reference operator[](const ConvertibleThroughBase auto &pos) const { return this->Container::operator[](pos.base()); }
-};
-
-/**
  * A sort-of mixin that implements 'at(pos)' and 'operator[](pos)' only for a specific type.
  * The type must have a suitable '.base()' method and therefore must inherently match 'ConvertibleThroughBase'.
  * This to prevent having to call '.base()' for many container accesses, whilst preventing accidental use of the wrong index type.

--- a/src/core/convertible_through_base.hpp
+++ b/src/core/convertible_through_base.hpp
@@ -49,4 +49,25 @@ public:
 	Container::const_reference operator[](const ConvertibleThroughBase auto &pos) const { return this->Container::operator[](pos.base()); }
 };
 
+/**
+ * A sort-of mixin that implements 'at(pos)' and 'operator[](pos)' only for a specific type.
+ * The type must have a suitable '.base()' method and therefore must inherently match 'ConvertibleThroughBase'.
+ * This to prevent having to call '.base()' for many container accesses, whilst preventing accidental use of the wrong index type.
+ */
+template <typename Container, typename Index>
+class TypedIndexContainer : public Container {
+public:
+	Container::reference at(size_t pos) { return this->Container::at(pos); }
+	Container::reference at(const Index &pos) { return this->Container::at(pos.base()); }
+
+	Container::const_reference at(size_t pos) const { return this->Container::at(pos); }
+	Container::const_reference at(const Index &pos) const { return this->Container::at(pos.base()); }
+
+	Container::reference operator[](size_t pos) { return this->Container::operator[](pos); }
+	Container::reference operator[](const Index &pos) { return this->Container::operator[](pos.base()); }
+
+	Container::const_reference operator[](size_t pos) const { return this->Container::operator[](pos); }
+	Container::const_reference operator[](const Index &pos) const { return this->Container::operator[](pos.base()); }
+};
+
 #endif /* CONVERTIBLE_THROUGH_BASE_HPP */

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -101,7 +101,7 @@ const ScoreInfo _score_info[] = {
 	{       0,   0}  // SCORE_TOTAL
 };
 
-ReferenceThroughBaseContainer<std::array<std::array<int64_t, SCORE_END>, MAX_COMPANIES>> _score_part;
+TypedIndexContainer<std::array<std::array<int64_t, SCORE_END>, MAX_COMPANIES>, CompanyID> _score_part;
 Economy _economy;
 Prices _price;
 static PriceMultipliers _price_base_multiplier;

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -23,7 +23,7 @@ void ResetPriceBaseMultipliers();
 void SetPriceBaseMultiplier(Price price, int factor);
 
 extern const ScoreInfo _score_info[];
-extern ReferenceThroughBaseContainer<std::array<std::array<int64_t, SCORE_END>, MAX_COMPANIES>> _score_part;
+extern TypedIndexContainer<std::array<std::array<int64_t, SCORE_END>, MAX_COMPANIES>, CompanyID> _score_part;
 extern Economy _economy;
 /* Prices and also the fractional part. */
 extern Prices _price;

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -39,7 +39,7 @@ void ReconsiderGameScriptLanguage();
 /** Container for the raw (unencoded) language strings of a language. */
 struct LanguageStrings {
 	std::string language; ///< Name of the language (base filename). Empty string if invalid.
-	ReferenceThroughBaseContainer<StringList> lines; ///< The lines of the file to pass into the parser/encoder.
+	TypedIndexContainer<StringList, StringIndexInTab> lines; ///< The lines of the file to pass into the parser/encoder.
 
 	LanguageStrings() {}
 	LanguageStrings(const std::string &lang) : language(lang) {}
@@ -56,8 +56,8 @@ struct GameStrings {
 
 	std::vector<LanguageStrings> raw_strings;      ///< The raw strings per language, first must be English/the master language!.
 	std::vector<LanguageStrings> compiled_strings; ///< The compiled strings per language, first must be English/the master language!.
-	ReferenceThroughBaseContainer<StringList> string_names; ///< The names of the compiled strings.
-	ReferenceThroughBaseContainer<StringParamsList> string_params; ///< The parameters for the strings.
+	TypedIndexContainer<StringList, StringIndexInTab> string_names; ///< The names of the compiled strings.
+	TypedIndexContainer<StringParamsList, StringIndexInTab> string_params; ///< The parameters for the strings.
 
 	void Compile();
 

--- a/src/linkgraph/mcf.cpp
+++ b/src/linkgraph/mcf.cpp
@@ -134,7 +134,7 @@ private:
 	LinkGraphJob &job; ///< Link graph job we're working with.
 
 	/** Lookup table for getting NodeIDs from StationIDs. */
-	ReferenceThroughBaseContainer<std::vector<NodeID>> station_to_node;
+	TypedIndexContainer<std::vector<NodeID>, StationID> station_to_node;
 
 	/** Current iterator in the shares map. */
 	FlowStat::SharesMap::const_iterator it;

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -45,7 +45,7 @@ void NetworkDisconnect(bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
 std::string_view ParseFullConnectionString(std::string_view connection_string, uint16_t &port, CompanyID *company_id = nullptr);
-using NetworkCompanyStatsArray = ReferenceThroughBaseContainer<std::array<NetworkCompanyStats, MAX_COMPANIES>>;
+using NetworkCompanyStatsArray = TypedIndexContainer<std::array<NetworkCompanyStats, MAX_COMPANIES>, CompanyID>;
 NetworkCompanyStatsArray NetworkGetCompanyStats();
 
 void NetworkUpdateClientInfo(ClientID client_id);

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -74,7 +74,7 @@ GRFLoadedFeatures _loaded_newgrf_features;
 
 GrfProcessingState _cur_gps;
 
-ReferenceThroughBaseContainer<std::vector<GRFTempEngineData>> _gted;  ///< Temporary engine data used during NewGRF loading
+TypedIndexContainer<std::vector<GRFTempEngineData>, EngineID> _gted;  ///< Temporary engine data used during NewGRF loading
 
 /**
  * Debug() function dedicated to newGRF debugging messages

--- a/src/newgrf/newgrf_internal_vehicle.h
+++ b/src/newgrf/newgrf_internal_vehicle.h
@@ -49,7 +49,7 @@ struct GRFTempEngineData {
 	}
 };
 
-extern ReferenceThroughBaseContainer<std::vector<GRFTempEngineData>> _gted;  ///< Temporary engine data used during NewGRF loading
+extern TypedIndexContainer<std::vector<GRFTempEngineData>, EngineID> _gted;  ///< Temporary engine data used during NewGRF loading
 
 Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id, bool static_access = false);
 void ConvertTTDBasePrice(uint32_t base_pointer, std::string_view error_location, Price *index);

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -74,7 +74,7 @@ struct GRFTextEntry {
 };
 
 
-static ReferenceThroughBaseContainer<std::vector<GRFTextEntry>> _grf_text;
+static TypedIndexContainer<std::vector<GRFTextEntry>, StringIndexInTab> _grf_text;
 static uint8_t _current_lang_id = GRFLX_ENGLISH;  ///< by default, english is used.
 
 /**

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -222,8 +222,8 @@ public:
 	}
 };
 
-ReferenceThroughBaseContainer<std::vector<WaterRegionData>> _water_region_data;
-ReferenceThroughBaseContainer<std::vector<bool>> _is_water_region_valid;
+TypedIndexContainer<std::vector<WaterRegionData>, WaterRegionIndex> _water_region_data;
+TypedIndexContainer<std::vector<bool>, WaterRegionIndex> _is_water_region_valid;
 
 static TileIndex GetTileIndexFromLocalCoordinate(int region_x, int region_y, int local_x, int local_y)
 {

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -41,7 +41,7 @@ static const SaveLoad _engine_desc[] = {
 	SLE_CONDSSTR(Engine, name,                SLE_STR,                    SLV_84, SL_MAX_VERSION),
 };
 
-static ReferenceThroughBaseContainer<std::vector<Engine>> _temp_engine;
+static TypedIndexContainer<std::vector<Engine>, EngineID> _temp_engine;
 
 Engine *GetTempDataEngine(EngineID index)
 {
@@ -134,7 +134,7 @@ struct ENGSChunkHandler : ChunkHandler {
 	{
 		/* Load old separate String ID list into a temporary array. This
 		 * was always 256 entries. */
-		ReferenceThroughBaseContainer<std::array<StringID, 256>> names{};
+		TypedIndexContainer<std::array<StringID, 256>, EngineID> names{};
 
 		SlCopy(names.data(), std::size(names), SLE_STRINGID);
 

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -347,7 +347,7 @@ private:
 	static std::tuple<bool, bool, bool, bool> DoCommandPrep();
 	static bool DoCommandProcessResult(const CommandCost &res, Script_SuspendCallbackProc *callback, bool estimate_only, bool asynchronous);
 	static CommandCallbackData *GetDoCommandCallback();
-	using RandomizerArray = ReferenceThroughBaseContainer<std::array<Randomizer, OWNER_END.base()>>;
+	using RandomizerArray = TypedIndexContainer<std::array<Randomizer, OWNER_END.base()>, Owner>;
 	static RandomizerArray random_states; ///< Random states for each of the scripts (game script uses OWNER_DEITY)
 };
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -598,7 +598,7 @@ struct CompanySettings {
 /** Container for AI and Game script configuration. */
 struct ScriptConfigSettings
 {
-	ReferenceThroughBaseContainer<std::array<std::unique_ptr<class AIConfig>, MAX_COMPANIES>> ai; ///< settings per company
+	TypedIndexContainer<std::array<std::unique_ptr<class AIConfig>, MAX_COMPANIES>, CompanyID> ai; ///< settings per company
 	std::unique_ptr<class GameConfig> game; ///< settings for gamescript
 
 	ScriptConfigSettings();

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -181,7 +181,7 @@ static IndustryType _smallmap_industry_highlight = IT_INVALID;
 /** State of highlight blinking */
 static bool _smallmap_industry_highlight_state;
 /** For connecting company ID to position in owner list (small map legend) */
-static ReferenceThroughBaseContainer<std::array<uint32_t, MAX_COMPANIES>> _company_to_list_pos;
+static TypedIndexContainer<std::array<uint32_t, MAX_COMPANIES>, CompanyID> _company_to_list_pos;
 
 /**
  * Fills an array for the industries legends.

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4431,8 +4431,8 @@ uint MoveGoodsToStation(CargoType cargo, uint amount, Source source, const Stati
 		return UpdateStationWaiting(first_station, cargo, amount, source);
 	}
 
-	ReferenceThroughBaseContainer<std::array<uint32_t, OWNER_END.base()>> company_best = {};  // best rating for each company, including OWNER_NONE
-	ReferenceThroughBaseContainer<std::array<uint32_t, OWNER_END.base()>> company_sum = {};   // sum of ratings for each company
+	TypedIndexContainer<std::array<uint32_t, OWNER_END.base()>, Owner> company_best = {};  // best rating for each company, including OWNER_NONE
+	TypedIndexContainer<std::array<uint32_t, OWNER_END.base()>, Owner> company_sum = {};   // sum of ratings for each company
 	uint best_rating = 0;
 	uint best_sum = 0;  // sum of best ratings for each company
 

--- a/src/town.h
+++ b/src/town.h
@@ -69,10 +69,10 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	/* Company ratings. */
 	CompanyMask have_ratings{}; ///< which companies have a rating
-	ReferenceThroughBaseContainer<std::array<uint8_t, MAX_COMPANIES>> unwanted{}; ///< how many months companies aren't wanted by towns (bribe)
+	TypedIndexContainer<std::array<uint8_t, MAX_COMPANIES>, CompanyID> unwanted{}; ///< how many months companies aren't wanted by towns (bribe)
 	CompanyID exclusivity = CompanyID::Invalid(); ///< which company has exclusivity
 	uint8_t exclusive_counter = 0; ///< months till the exclusivity expires
-	ReferenceThroughBaseContainer<std::array<int16_t, MAX_COMPANIES>> ratings{};  ///< ratings of each company for this town
+	TypedIndexContainer<std::array<int16_t, MAX_COMPANIES>, CompanyID> ratings{};  ///< ratings of each company for this town
 
 	std::array<TransportedCargoStat<uint32_t>, NUM_CARGO> supplied{}; ///< Cargo statistics about supplied cargo.
 	std::array<TransportedCargoStat<uint16_t>, NUM_TAE> received{}; ///< Cargo statistics about received cargotypes.


### PR DESCRIPTION
## Motivation / Problem

ReferenceThroughBaseContainer is a wrapper which allows any type matching ConvertibleThroughBase to be used as the index type for a wrapped container.
This is non-ideal because it does not enforce that the given type is actually the correct one for the container, so somewhat defeats the purpose of use strong/wrapper types.
The correct index type is not stated anywhere in the container definition, which obfuscates what it actually is.

## Description

Replace ReferenceThroughBaseContainer with a TypedIndexContainer type which takes the correct index type as the second template parameter. This clarifies what the correct index type actually is and prevents accidental use of incorrect types.

## Limitations

This PR does not (currently) remove the size_t accessors, so doesn't completely prevent accidentally using an index of the wrong logical type via an integer type.
In particular this would need many changes for accesses to Town::ratings.
A future PR could do this or add a policy parameter or whatever to conditionally enable them, if this is of interest.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
