### PR TITLE
Feature: Support for multi-railtype rail vehicles

### DIFF
--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -363,7 +363,7 @@ void AddArticulatedParts(Vehicle *first)
 
 				t->subtype = 0;
 				t->track = front->track;
-				t->railtype = front->railtype;
+				t->railtypes = front->railtypes;
 
 				t->spritenum = e_artic->u.rail.image_index;
 				if (e_artic->CanCarryCargo()) {

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -71,7 +71,7 @@ bool CheckAutoreplaceValidity(EngineID from, EngineID to, CompanyID company)
 	switch (type) {
 		case VEH_TRAIN: {
 			/* make sure the railtypes are compatible */
-			if (!GetRailTypeInfo(e_from->u.rail.railtype)->compatible_railtypes.Any(GetRailTypeInfo(e_to->u.rail.railtype)->compatible_railtypes)) return false;
+			if (!GetAllCompatibleRailTypes(e_from->u.rail.railtypes).Any(GetAllCompatibleRailTypes(e_to->u.rail.railtypes))) return false;
 
 			/* make sure we do not replace wagons with engines or vice versa */
 			if ((e_from->u.rail.railveh_type == RAILVEH_WAGON) != (e_to->u.rail.railveh_type == RAILVEH_WAGON)) return false;

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -111,7 +111,7 @@ class ReplaceVehicleWindow : public Window {
 
 		if (draw_left && this->sel_railtype != INVALID_RAILTYPE) {
 			/* Ensure that the railtype is specific to the selected one */
-			if (rvi->railtype != this->sel_railtype) return false;
+			if (!rvi->railtypes.Test(this->sel_railtype)) return false;
 		}
 		return true;
 	}

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -632,6 +632,19 @@ static int DrawRailEnginePurchaseInfo(int left, int right, int y, EngineID engin
 	}
 	y += GetCharacterHeight(FS_NORMAL);
 
+	/* Supported rail types */
+	std::string railtypes{};
+	std::string_view list_separator = GetListSeparator();
+
+	for (const auto &rt : _sorted_railtypes) {
+		if (!rvi->railtypes.Test(rt)) continue;
+
+		if (!railtypes.empty()) railtypes += list_separator;
+		AppendStringInPlace(railtypes, GetRailTypeInfo(rt)->strings.name);
+	}
+	DrawString(left, right, y, GetString(STR_PURCHASE_INFO_RAILTYPES, railtypes));
+	y += GetCharacterHeight(FS_NORMAL);
+
 	/* Max speed - Engine power */
 	DrawString(left, right, y, GetString(STR_PURCHASE_INFO_SPEED_POWER, PackVelocity(e->GetDisplayMaxSpeed(), e->type), e->GetPower()));
 	y += GetCharacterHeight(FS_NORMAL);

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -637,7 +637,7 @@ static int DrawRailEnginePurchaseInfo(int left, int right, int y, EngineID engin
 	y += GetCharacterHeight(FS_NORMAL);
 
 	/* Max tractive effort - not applicable if old acceleration or maglev */
-	if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL && GetRailTypeInfo(rvi->railtype)->acceleration_type != 2) {
+	if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL && GetRailTypeInfo(rvi->railtype)->acceleration_type != VehicleAccelerationModel::Maglev) {
 		DrawString(left, right, y, GetString(STR_PURCHASE_INFO_MAX_TE, e->GetDisplayMaxTractiveEffort()));
 		y += GetCharacterHeight(FS_NORMAL);
 	}

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -637,9 +637,15 @@ static int DrawRailEnginePurchaseInfo(int left, int right, int y, EngineID engin
 	y += GetCharacterHeight(FS_NORMAL);
 
 	/* Max tractive effort - not applicable if old acceleration or maglev */
-	if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL && GetRailTypeInfo(rvi->railtype)->acceleration_type != VehicleAccelerationModel::Maglev) {
-		DrawString(left, right, y, GetString(STR_PURCHASE_INFO_MAX_TE, e->GetDisplayMaxTractiveEffort()));
-		y += GetCharacterHeight(FS_NORMAL);
+	if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL) {
+		bool is_maglev = true;
+		for (RailType rt : rvi->railtypes) {
+			is_maglev &= GetRailTypeInfo(rt)->acceleration_type == VehicleAccelerationModel::Maglev;
+		}
+		if (!is_maglev) {
+			DrawString(left, right, y, GetString(STR_PURCHASE_INFO_MAX_TE, e->GetDisplayMaxTractiveEffort()));
+			y += GetCharacterHeight(FS_NORMAL);
+		}
 	}
 
 	/* Running cost */
@@ -1378,7 +1384,7 @@ struct BuildVehicleWindow : Window {
 			EngineID eid = e->index;
 			const RailVehicleInfo *rvi = &e->u.rail;
 
-			if (this->filter.railtype != INVALID_RAILTYPE && !HasPowerOnRail(rvi->railtype, this->filter.railtype)) continue;
+			if (this->filter.railtype != INVALID_RAILTYPE && !HasPowerOnRail(rvi->railtypes, this->filter.railtype)) continue;
 			if (!IsEngineBuildable(eid, VEH_TRAIN, _local_company)) continue;
 
 			/* Filter now! So num_engines and num_wagons is valid */

--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -580,15 +580,13 @@ void SettingsDisableElrail(int32_t new_value)
 
 void UpdateDisableElrailSettingState(bool disable, bool update_vehicles)
 {
-	/* pick appropriate railtype for elrail engines depending on setting */
-	const RailType new_railtype = disable ? RAILTYPE_RAIL : RAILTYPE_ELECTRIC;
-
 	/* walk through all train engines */
 	for (Engine *e : Engine::IterateType(VEH_TRAIN)) {
 		RailVehicleInfo *rv_info = &e->u.rail;
 		/* update railtype of engines intended to use elrail */
-		if (rv_info->intended_railtype == RAILTYPE_ELECTRIC) {
-			rv_info->railtype = new_railtype;
+		if (rv_info->intended_railtypes.Test(RAILTYPE_ELECTRIC)) {
+			rv_info->railtypes.Set(RAILTYPE_ELECTRIC, !disable);
+			rv_info->railtypes.Set(RAILTYPE_RAIL, disable);
 		}
 	}
 
@@ -596,11 +594,12 @@ void UpdateDisableElrailSettingState(bool disable, bool update_vehicles)
 	 *  normal rail too */
 	if (disable) {
 		for (Train *t : Train::Iterate()) {
-			if (t->railtype == RAILTYPE_ELECTRIC) {
+			if (t->railtypes.Test(RAILTYPE_ELECTRIC)) {
 				/* this railroad vehicle is now compatible only with elrail,
 				 *  so add there also normal rail compatibility */
 				t->compatible_railtypes.Set(RAILTYPE_RAIL);
-				t->railtype = RAILTYPE_RAIL;
+				t->railtypes.Reset(RAILTYPE_ELECTRIC);
+				t->railtypes.Set(RAILTYPE_RAIL);
 				t->flags.Set(VehicleRailFlag::AllowedOnNormalRail);
 			}
 		}

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1107,8 +1107,9 @@ static void NewVehicleAvailable(Engine *e)
 
 	if (e->type == VEH_TRAIN) {
 		/* maybe make another rail type available */
-		assert(e->u.rail.railtype < RAILTYPE_END);
-		for (Company *c : Company::Iterate()) c->avail_railtypes = AddDateIntroducedRailTypes(c->avail_railtypes | GetRailTypeInfo(e->u.rail.railtype)->introduces_railtypes, TimerGameCalendar::date);
+		assert(e->u.rail.railtypes != RailTypes{});
+		RailTypes introduced = GetAllIntroducesRailTypes(e->u.rail.railtypes);
+		for (Company *c : Company::Iterate()) c->avail_railtypes = AddDateIntroducedRailTypes(c->avail_railtypes | introduced, TimerGameCalendar::date);
 	} else if (e->type == VEH_ROAD) {
 		/* maybe make another road type available */
 		assert(e->u.road.roadtype < ROADTYPE_END);
@@ -1267,7 +1268,7 @@ bool IsEngineBuildable(EngineID engine, VehicleType type, CompanyID company)
 	if (type == VEH_TRAIN && company != OWNER_DEITY) {
 		/* Check if the rail type is available to this company */
 		const Company *c = Company::Get(company);
-		if (!GetRailTypeInfo(e->u.rail.railtype)->compatible_railtypes.Any(c->avail_railtypes)) return false;
+		if (!GetAllCompatibleRailTypes(e->u.rail.railtypes).Any(c->avail_railtypes)) return false;
 	}
 	if (type == VEH_ROAD && company != OWNER_DEITY) {
 		/* Check if the road type is available to this company */

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -181,7 +181,7 @@ static std::string GetTrainEngineInfoString(const Engine &e)
 	res << GetString(STR_ENGINE_PREVIEW_COST_WEIGHT, e.GetCost(), e.GetDisplayWeight());
 	res << '\n';
 
-	if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL && GetRailTypeInfo(e.u.rail.railtype)->acceleration_type != 2) {
+	if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL && GetRailTypeInfo(e.u.rail.railtype)->acceleration_type != VehicleAccelerationModel::Maglev) {
 		res << GetString(STR_ENGINE_PREVIEW_SPEED_POWER_MAX_TE, PackVelocity(e.GetDisplayMaxSpeed(), e.type), e.GetPower(), e.GetDisplayMaxTractiveEffort());
 		res << '\n';
 	} else {

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -182,6 +182,20 @@ static std::string GetTrainEngineInfoString(const Engine &e)
 	res << GetString(STR_ENGINE_PREVIEW_COST_WEIGHT, e.GetCost(), e.GetDisplayWeight());
 	res << '\n';
 
+	if (e.u.rail.railtypes.Count() > 1) {
+		std::string railtypes{};
+		std::string_view list_separator = GetListSeparator();
+
+		for (const auto &rt : _sorted_railtypes) {
+			if (!e.u.rail.railtypes.Test(rt)) continue;
+
+			if (!railtypes.empty()) railtypes += list_separator;
+			AppendStringInPlace(railtypes, GetRailTypeInfo(rt)->strings.name);
+		}
+		res << GetString(STR_ENGINE_PREVIEW_RAILTYPES, railtypes);
+		res << '\n';
+	}
+
 	bool is_maglev = true;
 	for (RailType rt : e.u.rail.railtypes) {
 		is_maglev &= GetRailTypeInfo(rt)->acceleration_type == VehicleAccelerationModel::Maglev;

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -47,7 +47,8 @@ StringID GetEngineCategoryName(EngineID engine)
 		case VEH_AIRCRAFT:          return STR_ENGINE_PREVIEW_AIRCRAFT;
 		case VEH_SHIP:              return STR_ENGINE_PREVIEW_SHIP;
 		case VEH_TRAIN:
-			return GetRailTypeInfo(e->u.rail.railtype)->strings.new_loco;
+			assert(e->u.rail.railtypes.Any());
+			return GetRailTypeInfo(e->u.rail.railtypes.GetNthSetBit(0).value())->strings.new_loco;
 	}
 }
 
@@ -181,7 +182,12 @@ static std::string GetTrainEngineInfoString(const Engine &e)
 	res << GetString(STR_ENGINE_PREVIEW_COST_WEIGHT, e.GetCost(), e.GetDisplayWeight());
 	res << '\n';
 
-	if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL && GetRailTypeInfo(e.u.rail.railtype)->acceleration_type != VehicleAccelerationModel::Maglev) {
+	bool is_maglev = true;
+	for (RailType rt : e.u.rail.railtypes) {
+		is_maglev &= GetRailTypeInfo(rt)->acceleration_type == VehicleAccelerationModel::Maglev;
+	}
+
+	if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL && !is_maglev) {
 		res << GetString(STR_ENGINE_PREVIEW_SPEED_POWER_MAX_TE, PackVelocity(e.GetDisplayMaxSpeed(), e.type), e.GetPower(), e.GetDisplayMaxTractiveEffort());
 		res << '\n';
 	} else {

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -43,6 +43,13 @@ enum EngineClass : uint8_t {
 	EC_MAGLEV,   ///< Maglev engine.
 };
 
+/** Acceleration model of a vehicle. */
+enum class VehicleAccelerationModel : uint8_t {
+	Normal,   ///< Default acceleration model.
+	Monorail, ///< Monorail acceleration model.
+	Maglev,   ///< Maglev acceleration model.
+};
+
 /** Information about a rail vehicle. */
 struct RailVehicleInfo {
 	uint8_t image_index = 0;

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -55,8 +55,8 @@ struct RailVehicleInfo {
 	uint8_t image_index = 0;
 	RailVehicleTypes railveh_type{};
 	uint8_t cost_factor = 0; ///< Purchase cost factor;      For multiheaded engines the sum of both engine prices.
-	RailType railtype{}; ///< Railtype, mangled if elrail is disabled.
-	RailType intended_railtype{}; ///< Intended railtype, regardless of elrail being enabled or disabled.
+	RailTypes railtypes{}; ///< Railtypes, mangled if elrail is disabled.
+	RailTypes intended_railtypes{}; ///< Intended railtypes, regardless of elrail being enabled or disabled.
 	uint8_t ai_passenger_only = 0; ///< Bit value to tell AI that this engine is for passenger use only
 	uint16_t max_speed = 0; ///< Maximum speed (1 unit = 1/1.6 mph = 1 km-ish/h)
 	uint16_t power = 0; ///< Power of engine (hp);      For multiheaded engines the sum of both engine powers.

--- a/src/ground_vehicle.cpp
+++ b/src/ground_vehicle.cpp
@@ -131,7 +131,7 @@ int GroundVehicle<T, Type>::GetAcceleration() const
 	 */
 	int64_t resistance = 0;
 
-	bool maglev = v->GetAccelerationType() == 2;
+	bool maglev = v->GetAccelerationType() == VehicleAccelerationModel::Maglev;
 
 	const int area = v->GetAirDragArea();
 	if (!maglev) {

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4183,6 +4183,7 @@ STR_PURCHASE_INFO_ALL_BUT                                       :All but {CARGO_
 STR_PURCHASE_INFO_MAX_TE                                        :{BLACK}Max. Tractive Effort: {GOLD}{FORCE}
 STR_PURCHASE_INFO_AIRCRAFT_RANGE                                :{BLACK}Range: {GOLD}{COMMA} tiles
 STR_PURCHASE_INFO_AIRCRAFT_TYPE                                 :{BLACK}Aircraft type: {GOLD}{STRING}
+STR_PURCHASE_INFO_RAILTYPES                                     :{BLACK}Rail types: {GOLD}{RAW_STRING}
 
 ###length 3
 STR_CARGO_TYPE_FILTER_ALL                                       :All cargo types
@@ -4366,6 +4367,7 @@ STR_ENGINE_PREVIEW_RUNCOST_YEAR                                 :Running Cost: {
 STR_ENGINE_PREVIEW_RUNCOST_PERIOD                               :Running Cost: {CURRENCY_LONG}/period
 STR_ENGINE_PREVIEW_CAPACITY                                     :Capacity: {CARGO_LONG}
 STR_ENGINE_PREVIEW_CAPACITY_2                                   :Capacity: {CARGO_LONG}, {CARGO_LONG}
+STR_ENGINE_PREVIEW_RAILTYPES                                    :Rail types: {RAW_STRING}
 
 # Autoreplace window
 STR_REPLACE_VEHICLES_WHITE                                      :{WHITE}Replace {STRING} - {STRING1}

--- a/src/newgrf/newgrf_act0_railtypes.cpp
+++ b/src/newgrf/newgrf_act0_railtypes.cpp
@@ -118,7 +118,7 @@ static ChangeInfoResult RailTypeChangeInfo(uint first, uint last, int prop, Byte
 				break;
 
 			case 0x15: // Acceleration model
-				rti->acceleration_type = Clamp(buf.ReadByte(), 0, 2);
+				rti->acceleration_type = static_cast<VehicleAccelerationModel>(Clamp(buf.ReadByte(), 0, 2));
 				break;
 
 			case 0x16: // Map colour

--- a/src/newgrf/newgrf_act0_trains.cpp
+++ b/src/newgrf/newgrf_act0_trains.cpp
@@ -328,6 +328,22 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 				e->badges = ReadBadgeList(buf, GSF_TRAINS);
 				break;
 
+			case 0x34: { // List of track types
+				uint8_t count = buf.ReadByte();
+
+				_gted[e->index].railtypelabels.clear();
+				while (count--) {
+					uint8_t tracktype = buf.ReadByte();
+
+					if (tracktype < _cur_gps.grffile->railtype_list.size()) {
+						_gted[e->index].railtypelabels.push_back(_cur_gps.grffile->railtype_list[tracktype]);
+					} else {
+						GrfMsg(1, "RailVehicleChangeInfo: Invalid track type {} specified, ignoring", tracktype);
+					}
+				}
+				break;
+			}
+
 			default:
 				ret = CommonVehicleChangeInfo(ei, prop, buf);
 				break;

--- a/src/newgrf/newgrf_act0_trains.cpp
+++ b/src/newgrf/newgrf_act0_trains.cpp
@@ -41,15 +41,16 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 			case 0x05: { // Track type
 				uint8_t tracktype = buf.ReadByte();
 
+				_gted[e->index].railtypelabels.clear();
 				if (tracktype < _cur_gps.grffile->railtype_list.size()) {
-					_gted[e->index].railtypelabel = _cur_gps.grffile->railtype_list[tracktype];
+					_gted[e->index].railtypelabels.push_back(_cur_gps.grffile->railtype_list[tracktype]);
 					break;
 				}
 
 				switch (tracktype) {
-					case 0: _gted[e->index].railtypelabel = rvi->engclass >= 2 ? RAILTYPE_LABEL_ELECTRIC : RAILTYPE_LABEL_RAIL; break;
-					case 1: _gted[e->index].railtypelabel = RAILTYPE_LABEL_MONO; break;
-					case 2: _gted[e->index].railtypelabel = RAILTYPE_LABEL_MAGLEV; break;
+					case 0: _gted[e->index].railtypelabels.push_back(rvi->engclass >= 2 ? RAILTYPE_LABEL_ELECTRIC : RAILTYPE_LABEL_RAIL); break;
+					case 1: _gted[e->index].railtypelabels.push_back(RAILTYPE_LABEL_MONO); break;
+					case 2: _gted[e->index].railtypelabels.push_back(RAILTYPE_LABEL_MAGLEV); break;
 					default:
 						GrfMsg(1, "RailVehicleChangeInfo: Invalid track type {} specified, ignoring", tracktype);
 						break;
@@ -179,11 +180,11 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 					break;
 				}
 
-				if (_cur_gps.grffile->railtype_list.empty()) {
+				if (_cur_gps.grffile->railtype_list.empty() && !_gted[e->index].railtypelabels.empty()) {
 					/* Use traction type to select between normal and electrified
 					 * rail only when no translation list is in place. */
-					if (_gted[e->index].railtypelabel == RAILTYPE_LABEL_RAIL     && engclass >= EC_ELECTRIC) _gted[e->index].railtypelabel = RAILTYPE_LABEL_ELECTRIC;
-					if (_gted[e->index].railtypelabel == RAILTYPE_LABEL_ELECTRIC && engclass  < EC_ELECTRIC) _gted[e->index].railtypelabel = RAILTYPE_LABEL_RAIL;
+					if (_gted[e->index].railtypelabels[0] == RAILTYPE_LABEL_RAIL && engclass >= EC_ELECTRIC) _gted[e->index].railtypelabels[0] = RAILTYPE_LABEL_ELECTRIC;
+					if (_gted[e->index].railtypelabels[0] == RAILTYPE_LABEL_ELECTRIC && engclass < EC_ELECTRIC) _gted[e->index].railtypelabels[0] = RAILTYPE_LABEL_RAIL;
 				}
 
 				rvi->engclass = engclass;

--- a/src/newgrf/newgrf_internal_vehicle.h
+++ b/src/newgrf/newgrf_internal_vehicle.h
@@ -27,7 +27,7 @@ struct GRFTempEngineData {
 	CargoClasses cargo_allowed;          ///< Bitmask of cargo classes that are allowed as a refit.
 	CargoClasses cargo_allowed_required; ///< Bitmask of cargo classes that are required to be all present to allow a cargo as a refit.
 	CargoClasses cargo_disallowed;       ///< Bitmask of cargo classes that are disallowed as a refit.
-	RailTypeLabel railtypelabel;
+	std::vector<RailTypeLabel> railtypelabels;
 	uint8_t roadtramtype;
 	const GRFFile *defaultcargo_grf; ///< GRF defining the cargo translation table to use if the default cargo is the 'first refittable'.
 	Refittability refittability;     ///< Did the newgrf set any refittability property? If not, default refittability will be applied.

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -565,7 +565,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 					RailType rt = GetTileRailType(v->tile);
 					const RailTypeInfo *rti = GetRailTypeInfo(rt);
 					return (rti->flags.Test(RailTypeFlag::Catenary) ? 0x200 : 0) |
-						(HasPowerOnRail(Train::From(v)->railtype, rt) ? 0x100 : 0) |
+						(HasPowerOnRail(Train::From(v)->railtypes, rt) ? 0x100 : 0) |
 						GetReverseRailTypeTranslation(rt, object->ro.grffile);
 				}
 
@@ -732,7 +732,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 				const Train *u = is_powered_wagon ? t->First() : t; // for powered wagons the engine defines the type of engine (i.e. railtype)
 				RailType railtype = GetRailType(v->tile);
 				bool powered = t->IsEngine() || is_powered_wagon;
-				bool has_power = HasPowerOnRail(u->railtype, railtype);
+				bool has_power = HasPowerOnRail(u->railtypes, railtype);
 
 				if (powered && has_power) SetBit(modflags, 5);
 				if (powered && !has_power) SetBit(modflags, 6);
@@ -915,7 +915,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 			Train *t = Train::From(v);
 			switch (variable - 0x80) {
 				case 0x62: return t->track;
-				case 0x66: return t->railtype;
+				case 0x66: return t->railtypes.GetNthSetBit(0).value_or(RailType::INVALID_RAILTYPE);
 				case 0x73: return 0x80 + VEHICLE_LENGTH - t->gcache.cached_veh_length;
 				case 0x74: return t->gcache.cached_power;
 				case 0x75: return GB(t->gcache.cached_power,  8, 24);

--- a/src/pathfinder/yapf/yapf_destrail.hpp
+++ b/src/pathfinder/yapf/yapf_destrail.hpp
@@ -22,7 +22,7 @@ public:
 	void SetDestination(const Train *v, bool override_rail_type = false)
 	{
 		this->compatible_railtypes = v->compatible_railtypes;
-		if (override_rail_type) this->compatible_railtypes.Set(GetRailTypeInfo(v->railtype)->compatible_railtypes);
+		if (override_rail_type) this->compatible_railtypes.Set(GetAllCompatibleRailTypes(v->railtypes));
 	}
 
 	bool IsCompatibleRailType(RailType rt)

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -296,7 +296,7 @@ PBSTileInfo FollowTrainReservation(const Train *v, Vehicle **train_on_res)
 	if (IsRailDepotTile(tile) && !GetDepotReservationTrackBits(tile)) return PBSTileInfo(tile, trackdir, false);
 
 	FindTrainOnTrackInfo ftoti;
-	ftoti.res = FollowReservation(v->owner, GetRailTypeInfo(v->railtype)->compatible_railtypes, tile, trackdir);
+	ftoti.res = FollowReservation(v->owner, GetAllCompatibleRailTypes(v->railtypes), tile, trackdir);
 	ftoti.res.okay = IsSafeWaitingPosition(v, ftoti.res.tile, ftoti.res.trackdir, true, _settings_game.pf.forbid_90_deg);
 	if (train_on_res != nullptr) {
 		CheckTrainsOnTrack(ftoti, ftoti.res.tile);
@@ -388,7 +388,7 @@ bool IsSafeWaitingPosition(const Train *v, TileIndex tile, Trackdir trackdir, bo
 	}
 
 	/* Check next tile. For performance reasons, we check for 90 degree turns ourself. */
-	CFollowTrackRail ft(v, GetRailTypeInfo(v->railtype)->compatible_railtypes);
+	CFollowTrackRail ft(v, GetAllCompatibleRailTypes(v->railtypes));
 
 	/* End of track? */
 	if (!ft.Follow(tile, trackdir)) {

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -132,11 +132,11 @@ RailTypes GetCompanyRailTypes(CompanyID company, bool introduces)
 			const RailVehicleInfo *rvi = &e->u.rail;
 
 			if (rvi->railveh_type != RAILVEH_WAGON) {
-				assert(rvi->railtype < RAILTYPE_END);
+				assert(rvi->railtypes.Any());
 				if (introduces) {
-					rts.Set(GetRailTypeInfo(rvi->railtype)->introduces_railtypes);
+					rts.Set(GetAllIntroducesRailTypes(rvi->railtypes));
 				} else {
-					rts.Set(rvi->railtype);
+					rts.Set(rvi->railtypes);
 				}
 			}
 		}
@@ -161,11 +161,11 @@ RailTypes GetRailTypes(bool introduces)
 
 		const RailVehicleInfo *rvi = &e->u.rail;
 		if (rvi->railveh_type != RAILVEH_WAGON) {
-			assert(rvi->railtype < RAILTYPE_END);
+			assert(rvi->railtypes.Any());
 			if (introduces) {
-				rts.Set(GetRailTypeInfo(rvi->railtype)->introduces_railtypes);
+				rts.Set(GetAllIntroducesRailTypes(rvi->railtypes));
 			} else {
-				rts.Set(rvi->railtype);
+				rts.Set(rvi->railtypes);
 			}
 		}
 	}

--- a/src/rail.h
+++ b/src/rail.h
@@ -211,7 +211,7 @@ public:
 	/**
 	 * Acceleration type of this rail type
 	 */
-	uint8_t acceleration_type;
+	VehicleAccelerationModel acceleration_type;
 
 	/**
 	 * Maximum speed for vehicles travelling on this rail type

--- a/src/rail.h
+++ b/src/rail.h
@@ -315,6 +315,42 @@ inline RailType GetRailTypeInfoIndex(const RailTypeInfo *rti)
 }
 
 /**
+ * Returns all compatible railtypes for a set of railtypes.
+ * @param railtypes Set of railtypes to get the compatible railtypes from.
+ * @return Union of all compatible railtypes.
+ */
+inline RailTypes GetAllCompatibleRailTypes(RailTypes railtypes)
+{
+	RailTypes compatible{};
+	for (RailType rt : railtypes) compatible.Set(GetRailTypeInfo(rt)->compatible_railtypes);
+	return compatible;
+}
+
+/**
+ * Returns all powered railtypes for a set of railtypes.
+ * @param railtypes Set of railtypes to get the powered railtypes from.
+ * @return Union of all powered railtypes.
+ */
+inline RailTypes GetAllPoweredRailTypes(RailTypes railtypes)
+{
+	RailTypes powered{};
+	for (RailType rt : railtypes) powered.Set(GetRailTypeInfo(rt)->powered_railtypes);
+	return powered;
+}
+
+/**
+ * Returns all introduced railtypes for a set of railtypes.
+ * @param railtypes Set of railtypes to get the introduced railtypes from.
+ * @return Union of all introduced railtypes.
+ */
+inline RailTypes GetAllIntroducesRailTypes(RailTypes railtypes)
+{
+	RailTypes introduces{};
+	for (RailType rt : railtypes) introduces.Set(GetRailTypeInfo(rt)->introduces_railtypes);
+	return introduces;
+}
+
+/**
  * Checks if an engine of the given RailType can drive on a tile with a given
  * RailType. This would normally just be an equality check, but for electric
  * rails (which also support non-electric engines).
@@ -328,6 +364,18 @@ inline bool IsCompatibleRail(RailType enginetype, RailType tiletype)
 }
 
 /**
+ * Checks if an engine of the given RailTypes can drive on a tile with a given
+ * RailType.
+ * @param  enginetype The RailTypes of the engine we are considering.
+ * @param  tiletype   The RailType of the tile we are considering.
+ * @return Whether the engine can drive on this tile.
+ */
+inline bool IsCompatibleRail(RailTypes enginetype, RailType tiletype)
+{
+	return GetAllCompatibleRailTypes(enginetype).Test(tiletype);
+}
+
+/**
  * Checks if an engine of the given RailType got power on a tile with a given
  * RailType. This would normally just be an equality check, but for electric
  * rails (which also support non-electric engines).
@@ -338,6 +386,18 @@ inline bool IsCompatibleRail(RailType enginetype, RailType tiletype)
 inline bool HasPowerOnRail(RailType enginetype, RailType tiletype)
 {
 	return GetRailTypeInfo(enginetype)->powered_railtypes.Test(tiletype);
+}
+
+/**
+ * Checks if an engine of the given RailTypes got power on a tile with a given
+ * RailType.
+ * @param  enginetype The RailTypes of the engine we are considering.
+ * @param  tiletype   The RailType of the tile we are considering.
+ * @return Whether the engine got power on this tile.
+ */
+inline bool HasPowerOnRail(RailTypes enginetype, RailType tiletype)
+{
+	return GetAllPoweredRailTypes(enginetype).Test(tiletype);
 }
 
 /**

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1605,7 +1605,7 @@ CommandCost CmdConvertRail(DoCommandFlags flags, TileIndex tile, TileIndex area_
 				Track     track;
 				while ((track = RemoveFirstTrack(&reserved)) != INVALID_TRACK) {
 					Train *v = GetTrainForReservation(tile, track);
-					if (v != nullptr && !HasPowerOnRail(v->railtype, totype)) {
+					if (v != nullptr && !HasPowerOnRail(v->railtypes, totype)) {
 						/* No power on new rail type, reroute. */
 						FreeTrainTrackReservation(v);
 						vehicles_affected.push_back(v);
@@ -1691,7 +1691,7 @@ CommandCost CmdConvertRail(DoCommandFlags flags, TileIndex tile, TileIndex area_
 					Track track = DiagDirToDiagTrack(GetTunnelBridgeDirection(tile));
 					if (HasTunnelBridgeReservation(tile)) {
 						Train *v = GetTrainForReservation(tile, track);
-						if (v != nullptr && !HasPowerOnRail(v->railtype, totype)) {
+						if (v != nullptr && !HasPowerOnRail(v->railtypes, totype)) {
 							/* No power on new rail type, reroute. */
 							FreeTrainTrackReservation(v);
 							vehicles_affected.push_back(v);

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -250,11 +250,11 @@ protected: // These functions should not be called outside acceleration code.
 
 	/**
 	 * Allows to know the acceleration type of a vehicle.
-	 * @return Zero, road vehicles always use a normal acceleration method.
+	 * @return \c VehicleAccelerationModel::Normal, road vehicles always use a normal acceleration method.
 	 */
-	inline int GetAccelerationType() const
+	inline VehicleAccelerationModel GetAccelerationType() const
 	{
-		return 0;
+		return VehicleAccelerationModel::Normal;
 	}
 
 	/**

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1333,10 +1333,10 @@ bool AfterLoadGame()
 		RailType min_rail = RAILTYPE_ELECTRIC;
 
 		for (Train *v : Train::Iterate()) {
-			RailType rt = RailVehInfo(v->engine_type)->railtype;
+			RailTypes rts = RailVehInfo(v->engine_type)->railtypes;
 
-			v->railtype = rt;
-			if (rt == RAILTYPE_ELECTRIC) min_rail = RAILTYPE_RAIL;
+			v->railtypes = rts;
+			if (rts.Test(RAILTYPE_ELECTRIC)) min_rail = RAILTYPE_RAIL;
 		}
 
 		/* .. so we convert the entire map from normal to elrail (so maintain "fairness") */

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1060,12 +1060,13 @@ static bool LoadOldCompany(LoadgameState &ls, int num)
 static uint32_t _old_order_ptr;
 static uint16_t _old_next_ptr;
 static typename VehicleID::BaseType _current_vehicle_id;
+static RailType _old_railtype;
 
 static const OldChunks vehicle_train_chunk[] = {
 	OCL_SVAR(  OC_UINT8, Train, track ),
 	OCL_SVAR(  OC_UINT8, Train, force_proceed ),
 	OCL_SVAR( OC_UINT16, Train, crash_anim_pos ),
-	OCL_SVAR(  OC_UINT8, Train, railtype ),
+	OCL_VAR (  OC_UINT8, 1, &_old_railtype),
 
 	OCL_NULL( 5 ), ///< Junk
 
@@ -1306,7 +1307,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 					if (v->spritenum / 2 >= lengthof(spriteset_rail)) return false;
 					v->spritenum = spriteset_rail[v->spritenum / 2]; // adjust railway sprite set offset
 					/* Should be the original values for monorail / rail, can't use RailType constants */
-					Train::From(v)->railtype = static_cast<RailType>(type == 0x25 ? 1 : 0);
+					Train::From(v)->railtypes = static_cast<RailType>(type == 0x25 ? 1 : 0);
 					break;
 				}
 
@@ -1366,6 +1367,10 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 			if (v->index != _current_vehicle_id) {
 				Debug(oldloader, 0, "Loading failed - vehicle-array is invalid");
 				return false;
+			}
+
+			if (v->type == VEH_TRAIN) {
+				Train::From(v)->railtypes = _old_railtype;
 			}
 		}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -411,6 +411,7 @@ enum SaveLoadVersion : uint16_t {
 
 	SLV_DOCKS_UNDER_BRIDGES,                ///< 360  PR#14594 Allow docks under bridges.
 	SLV_LOCKS_UNDER_BRIDGES,                ///< 361  PR#14595 Allow locks under bridges.
+	SLV_ENGINE_MULTI_RAILTYPE,              ///< 362  PR#14357 Train engines can have multiple railtypes.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -793,13 +793,16 @@ public:
 	}
 };
 
+static RailType _old_railtype;
+
 class SlVehicleTrain : public DefaultSaveLoadHandler<SlVehicleTrain, Vehicle> {
 public:
 	static inline const SaveLoad description[] = {
 		 SLEG_STRUCT("common", SlVehicleCommon),
 		     SLE_VAR(Train, crash_anim_pos,      SLE_UINT16),
 		     SLE_VAR(Train, force_proceed,       SLE_UINT8),
-		     SLE_VAR(Train, railtype,            SLE_UINT8),
+		SLEG_CONDVAR("railtype", _old_railtype,  SLE_UINT8, SL_MIN_VERSION, SLV_ENGINE_MULTI_RAILTYPE),
+			 SLE_VAR(Train, railtypes,           SLE_UINT64),
 		     SLE_VAR(Train, track,               SLE_UINT8),
 
 		 SLE_CONDVAR(Train, flags,               SLE_FILE_U8  | SLE_VAR_U16,   SLV_2,  SLV_100),
@@ -819,6 +822,10 @@ public:
 	{
 		if (v->type != VEH_TRAIN) return;
 		SlObject(v, this->GetLoadDescription());
+
+		if (IsSavegameVersionBefore(SLV_ENGINE_MULTI_RAILTYPE)) {
+			Train::From(v)->railtypes = _old_railtype;
+		}
 	}
 
 	void FixPointers(Vehicle *v) const override

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -29,6 +29,7 @@
  * \li AICargo::CC_NON_POTABLE
  * \li AIVehicleList_Waypoint
  * \li AIError::ERR_BRIDGE_TOO_LOW
+ * \li AIRail::GetAllRailTypes
  *
  * Other changes:
  * \li AIBridge::GetBridgeID renamed to AIBridge::GetBridgeType
@@ -36,6 +37,7 @@
  * \li AIList instances can now be saved
  * \li AIVehicleList_Station accepts an optional AIVehicle::VehicleType parameter
  * \li AIList instances can now be cloned
+ * \li AIRail::GetRailType will only return the first RailType of an engine, use AIRail::GetAllRailTypes instead
  *
  * \b 14.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -30,6 +30,7 @@
  * \li GSVehicleList_Waypoint
  * \li GSBaseStation::GetOwner
  * \li GSError:ERR_BRIDGE_TOO_LOW
+ * \li GSRail::GetAllRailTypes
  *
  * Other changes:
  * \li GSBridge::GetBridgeID renamed to GSBridge::GetBridgeType
@@ -37,6 +38,7 @@
  * \li GSList instances can now be saved
  * \li GSVehicleList_Station accepts an optional GSVehicle::VehicleType parameter
  * \li GSList instances can now be cloned
+ * \li GSRail::GetRailType will only return the first RailType of an engine, use GSRail::GetAllRailTypes instead
  *
  * \b 14.0
  *

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -245,6 +245,14 @@
 	return static_cast<ScriptRail::RailType>(::RailVehInfo(engine_id)->railtypes.GetNthSetBit(0).value_or(::RailType::INVALID_RAILTYPE));
 }
 
+/* static */ ScriptRail::RailTypes ScriptEngine::GetAllRailTypes(EngineID engine_id)
+{
+	if (!IsValidEngine(engine_id)) return ScriptRail::INVALID_RAILTYPES;
+	if (GetVehicleType(engine_id) != ScriptVehicle::VT_RAIL) return ScriptRail::INVALID_RAILTYPES;
+
+	return static_cast<ScriptRail::RailTypes>(::RailVehInfo(engine_id)->railtypes.base());
+}
+
 /* static */ bool ScriptEngine::IsArticulated(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return false;

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -203,7 +203,7 @@
 	if (GetVehicleType(engine_id) != ScriptVehicle::VT_RAIL) return false;
 	if (!ScriptRail::IsRailTypeAvailable(track_rail_type)) return false;
 
-	return ::IsCompatibleRail((::RailType)::RailVehInfo(engine_id)->railtype, (::RailType)track_rail_type);
+	return ::IsCompatibleRail(::RailVehInfo(engine_id)->railtypes, (::RailType)track_rail_type);
 }
 
 /* static */ bool ScriptEngine::HasPowerOnRail(EngineID engine_id, ScriptRail::RailType track_rail_type)
@@ -212,7 +212,7 @@
 	if (GetVehicleType(engine_id) != ScriptVehicle::VT_RAIL) return false;
 	if (!ScriptRail::IsRailTypeAvailable(track_rail_type)) return false;
 
-	return ::HasPowerOnRail((::RailType)::RailVehInfo(engine_id)->railtype, (::RailType)track_rail_type);
+	return ::HasPowerOnRail(::RailVehInfo(engine_id)->railtypes, (::RailType)track_rail_type);
 }
 
 /* static */ bool ScriptEngine::CanRunOnRoad(EngineID engine_id, ScriptRoad::RoadType road_type)
@@ -242,7 +242,7 @@
 	if (!IsValidEngine(engine_id)) return ScriptRail::RAILTYPE_INVALID;
 	if (GetVehicleType(engine_id) != ScriptVehicle::VT_RAIL) return ScriptRail::RAILTYPE_INVALID;
 
-	return (ScriptRail::RailType)(uint)::RailVehInfo(engine_id)->railtype;
+	return static_cast<ScriptRail::RailType>(::RailVehInfo(engine_id)->railtypes.GetNthSetBit(0).value_or(::RailType::INVALID_RAILTYPE));
 }
 
 /* static */ bool ScriptEngine::IsArticulated(EngineID engine_id)

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -249,12 +249,22 @@ public:
 
 	/**
 	 * Get the first RailType of the engine.
+	 * @note This will only return the first RailType of a multi-system engine. Use GetAllRailTypes to get all rail types of the engine.
 	 * @param engine_id The engine to get the RailType of.
 	 * @pre IsValidEngine(engine_id).
 	 * @pre GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL.
 	 * @return The first RailType the engine has.
 	 */
 	static ScriptRail::RailType GetRailType(EngineID engine_id);
+
+	/**
+	 * Get all RailType's of the engine.
+	 * @param engine_id The engine to get all RailTypes of.
+	 * @pre IsValidEngine(engine_id).
+	 * @pre GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL.
+	 * @return All rail types of the engine.
+	 */
+	static ScriptRail::RailTypes GetAllRailTypes(EngineID engine_id);
 
 	/**
 	 * Check if the engine is articulated.

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -248,11 +248,11 @@ public:
 	static ScriptRoad::RoadType GetRoadType(EngineID engine_id);
 
 	/**
-	 * Get the RailType of the engine.
+	 * Get the first RailType of the engine.
 	 * @param engine_id The engine to get the RailType of.
 	 * @pre IsValidEngine(engine_id).
 	 * @pre GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL.
-	 * @return The RailType the engine has.
+	 * @return The first RailType the engine has.
 	 */
 	static ScriptRail::RailType GetRailType(EngineID engine_id);
 

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -50,6 +50,14 @@ public:
 	};
 
 	/**
+	 * A bitmap with all possible rail types.
+	 */
+	enum RailTypes : int64_t {
+		/* Note: these values represent part of the in-game RailTypes enum */
+		INVALID_RAILTYPES = INT64_MAX, ///< Invalid RailTypes.
+	};
+
+	/**
 	 * A bitmap with all possible rail tracks on a tile.
 	 */
 	enum RailTrack {

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -270,7 +270,7 @@ void Squirrel::AddMethod(std::string_view method_name, SQFUNCTION proc, std::str
 	sq_newslot(this->vm, -3, SQFalse);
 }
 
-void Squirrel::AddConst(std::string_view var_name, int value)
+void Squirrel::AddConst(std::string_view var_name, SQInteger value)
 {
 	ScriptAllocatorScope alloc_scope(this);
 

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -104,15 +104,21 @@ public:
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
 	 */
-	void AddConst(std::string_view var_name, int value);
+	void AddConst(std::string_view var_name, SQInteger value);
 
 	/**
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
 	 */
-	void AddConst(std::string_view var_name, uint value) { this->AddConst(var_name, (int)value); }
+	void AddConst(std::string_view var_name, uint value) { this->AddConst(var_name, (SQInteger)value); }
 
-	void AddConst(std::string_view var_name, const ConvertibleThroughBase auto &value) { this->AddConst(var_name, static_cast<int>(value.base())); }
+	/**
+	 * Adds a const to the stack. Depending on the current state this means
+	 *  either a const to a class or to the global space.
+	 */
+	void AddConst(std::string_view var_name, int value) { this->AddConst(var_name, (SQInteger)value); }
+
+	void AddConst(std::string_view var_name, const ConvertibleThroughBase auto &value) { this->AddConst(var_name, static_cast<SQInteger>(value.base())); }
 
 	/**
 	 * Adds a const to the stack. Depending on the current state this means

--- a/src/table/railtypes.h
+++ b/src/table/railtypes.h
@@ -86,7 +86,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		8,
 
 		/* acceleration type */
-		0,
+		VehicleAccelerationModel::Normal,
 
 		/* max speed */
 		0,
@@ -188,7 +188,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		12,
 
 		/* acceleration type */
-		0,
+		VehicleAccelerationModel::Normal,
 
 		/* max speed */
 		0,
@@ -286,7 +286,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		16,
 
 		/* acceleration type */
-		1,
+		VehicleAccelerationModel::Monorail,
 
 		/* max speed */
 		0,
@@ -384,7 +384,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		24,
 
 		/* acceleration type */
-		2,
+		VehicleAccelerationModel::Maglev,
 
 		/* max speed */
 		0,

--- a/src/train.h
+++ b/src/train.h
@@ -302,7 +302,7 @@ protected: // These functions should not be called outside acceleration code.
 	 * Allows to know the acceleration type of a vehicle.
 	 * @return Acceleration type of the vehicle.
 	 */
-	inline int GetAccelerationType() const
+	inline VehicleAccelerationModel GetAccelerationType() const
 	{
 		return GetRailTypeInfo(this->railtype)->acceleration_type;
 	}

--- a/src/train.h
+++ b/src/train.h
@@ -99,7 +99,7 @@ struct Train final : public GroundVehicle<Train, VEH_TRAIN> {
 	Train *other_multiheaded_part = nullptr;
 
 	RailTypes compatible_railtypes{};
-	RailType railtype = INVALID_RAILTYPE;
+	RailTypes railtypes{};
 
 	TrackBits track{};
 	TrainForceProceeding force_proceed{};
@@ -180,6 +180,15 @@ struct Train final : public GroundVehicle<Train, VEH_TRAIN> {
 		return this->gcache.cached_veh_length / 2 + (this->Next() != nullptr ? this->Next()->gcache.cached_veh_length + 1 : 0) / 2;
 	}
 
+	/**
+	 * Allows to know the acceleration type of a vehicle.
+	 * @return Acceleration type of the vehicle.
+	 */
+	inline VehicleAccelerationModel GetAccelerationType() const
+	{
+		return GetRailTypeInfo(GetRailType(this->tile))->acceleration_type;
+	}
+
 protected: // These functions should not be called outside acceleration code.
 
 	/**
@@ -189,7 +198,7 @@ protected: // These functions should not be called outside acceleration code.
 	inline uint16_t GetPower() const
 	{
 		/* Power is not added for articulated parts */
-		if (!this->IsArticulatedPart() && HasPowerOnRail(this->railtype, GetRailType(this->tile))) {
+		if (!this->IsArticulatedPart() && HasPowerOnRail(this->railtypes, GetRailType(this->tile))) {
 			uint16_t power = GetVehicleProperty(this, PROP_TRAIN_POWER, RailVehInfo(this->engine_type)->power);
 			/* Halve power for multiheaded parts */
 			if (this->IsMultiheaded()) power /= 2;
@@ -206,7 +215,7 @@ protected: // These functions should not be called outside acceleration code.
 	inline uint16_t GetPoweredPartPower(const Train *head) const
 	{
 		/* For powered wagons the engine defines the type of engine (i.e. railtype) */
-		if (this->flags.Test(VehicleRailFlag::PoweredWagon) && HasPowerOnRail(head->railtype, GetRailType(this->tile))) {
+		if (this->flags.Test(VehicleRailFlag::PoweredWagon) && HasPowerOnRail(head->railtypes, GetRailType(this->tile))) {
 			return RailVehInfo(this->gcache.first_engine)->pow_wag_power;
 		}
 
@@ -296,15 +305,6 @@ protected: // These functions should not be called outside acceleration code.
 		 * The friction coefficient increases with speed in a way that
 		 * it doubles at 512 km/h, triples at 1024 km/h and so on. */
 		return 15 * (512 + this->GetCurrentSpeed()) / 512;
-	}
-
-	/**
-	 * Allows to know the acceleration type of a vehicle.
-	 * @return Acceleration type of the vehicle.
-	 */
-	inline VehicleAccelerationModel GetAccelerationType() const
-	{
-		return GetRailTypeInfo(this->railtype)->acceleration_type;
 	}
 
 	/**

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3074,7 +3074,7 @@ static inline void AffectSpeedByZChange(Train *v, int old_z)
 {
 	if (old_z == v->z_pos || _settings_game.vehicle.train_acceleration_model != AM_ORIGINAL) return;
 
-	const AccelerationSlowdownParams *asp = &_accel_slowdown[GetRailTypeInfo(v->railtype)->acceleration_type];
+	const AccelerationSlowdownParams *asp = &_accel_slowdown[static_cast<int>(GetRailTypeInfo(v->railtype)->acceleration_type)];
 
 	if (old_z < v->z_pos) {
 		v->cur_speed -= (v->cur_speed * asp->z_up >> 8);
@@ -3481,7 +3481,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 
 				if (chosen_dir != v->direction) {
 					if (prev == nullptr && _settings_game.vehicle.train_acceleration_model == AM_ORIGINAL) {
-						const AccelerationSlowdownParams *asp = &_accel_slowdown[GetRailTypeInfo(v->railtype)->acceleration_type];
+						const AccelerationSlowdownParams *asp = &_accel_slowdown[static_cast<int>(GetRailTypeInfo(v->railtype)->acceleration_type)];
 						DirDiff diff = DirDifference(v->direction, chosen_dir);
 						v->cur_speed -= (diff == DIRDIFF_45RIGHT || diff == DIRDIFF_45LEFT ? asp->small_turn : asp->large_turn) * v->cur_speed >> 8;
 					}

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2837,7 +2837,7 @@ void Vehicle::ShowVisualEffect() const
 				IsDepotTile(v->tile) ||
 				IsTunnelTile(v->tile) ||
 				(v->type == VEH_TRAIN &&
-				!HasPowerOnRail(Train::From(v)->railtype, GetTileRailType(v->tile)))) {
+				!HasPowerOnRail(Train::From(v)->railtypes, GetTileRailType(v->tile)))) {
 			continue;
 		}
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2598,7 +2598,7 @@ struct VehicleDetailsWindow : Window {
 						(v->type == VEH_ROAD && _settings_game.vehicle.roadveh_acceleration_model != AM_ORIGINAL)) {
 					const GroundVehicleCache *gcache = v->GetGroundVehicleCache();
 					if (v->type == VEH_TRAIN && (_settings_game.vehicle.train_acceleration_model == AM_ORIGINAL ||
-							GetRailTypeInfo(Train::From(v)->railtype)->acceleration_type == VehicleAccelerationModel::Maglev)) {
+							Train::From(v)->GetAccelerationType() == VehicleAccelerationModel::Maglev)) {
 						DrawString(tr, GetString(STR_VEHICLE_INFO_WEIGHT_POWER_MAX_SPEED, gcache->cached_weight, gcache->cached_power, max_speed));
 					} else {
 						DrawString(tr, GetString(STR_VEHICLE_INFO_WEIGHT_POWER_MAX_SPEED_MAX_TE, gcache->cached_weight, gcache->cached_power, max_speed, gcache->cached_max_te));

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2598,7 +2598,7 @@ struct VehicleDetailsWindow : Window {
 						(v->type == VEH_ROAD && _settings_game.vehicle.roadveh_acceleration_model != AM_ORIGINAL)) {
 					const GroundVehicleCache *gcache = v->GetGroundVehicleCache();
 					if (v->type == VEH_TRAIN && (_settings_game.vehicle.train_acceleration_model == AM_ORIGINAL ||
-							GetRailTypeInfo(Train::From(v)->railtype)->acceleration_type == 2)) {
+							GetRailTypeInfo(Train::From(v)->railtype)->acceleration_type == VehicleAccelerationModel::Maglev)) {
 						DrawString(tr, GetString(STR_VEHICLE_INFO_WEIGHT_POWER_MAX_SPEED, gcache->cached_weight, gcache->cached_power, max_speed));
 					} else {
 						DrawString(tr, GetString(STR_VEHICLE_INFO_WEIGHT_POWER_MAX_SPEED_MAX_TE, gcache->cached_weight, gcache->cached_power, max_speed, gcache->cached_max_te));


### PR DESCRIPTION
## Motivation / Problem

Rail vehicles that support multiple energy sources (like e.g. catenary and 3rd rail) or track types (train waggons with changeable gauge exist) are currently awkward to create. Due to the fact that a rail vehicle can have one railtype only, any such vehicle needs a corresponding mixed railtype to be defined.

Given the fact that IRL there are train locomotives that support up to 4 or more different electrification systems, any set that tries to recreate reality here quickly runs into a combinatorial explosion of types that can quickly use up the 64 rail types. Additionally, it is not very clear if such railtypes should be defined by vehicle NewGRFs or not.

## Description

Most of these problem can be avoided by allowing rail vehicles to belong to multiple railtypes.

This PR changes rail engines/vehicles to store not a single railtype but a bitmask of railtypes and uses set union wherever compatible or powered railtypes are queried. I though about using a vector to keep the railtype order, but the railtypes are currently part of an union.

A new property 34 is added to support  this on the NewGRF side. This and property 05 mutually overwrite each other. Legacy var E6 returns the numerically lowest railtype.


## Limitations and further Discussions

The build vehicle GUI and the engine preview/news item show the railtypes if more than one is defined, but the corresponding text uses a string from the railtype ("railway vehicle"/"electric railway vehicle"/...) that currently just uses the numerically lowest railtype. This is not ideal but might be good enough.

I would consider #9953 to be partly a requisite, as right now any powered engine basically overrides any waggon compatibility and thus e.g. a monorail/maglev engine will "magically" make any attached waggons or engines multi-railtype, too. Any change there has savegame compatibility effects though, thus needs more work.

~Additionally as described in #9953 railtype compatibility for path reservation purposes has problems which this PR probably exacerbates and thus sorting them is kind of a pre-requiste, too.~

Question: This could be done for road vehicles, too, either for symmetry or because of actual need.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
