### PR TITLE
Codechange: use default OnHotkey handler for focusing editboxes

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1131,11 +1131,6 @@ void GUIEngineListAddChildren(GUIEngineList &dst, const GUIEngineList &src, Engi
 	}
 }
 
-/** Enum referring to the Hotkeys in the build vehicle window */
-enum BuildVehicleHotkeys : int32_t {
-	BVHK_FOCUS_FILTER_BOX, ///< Focus the edit box for editing the filter string
-};
-
 /** GUI for building vehicles. */
 struct BuildVehicleWindow : Window {
 	VehicleType vehicle_type = VEH_INVALID; ///< Type of vehicles shown in the window.
@@ -1941,23 +1936,8 @@ struct BuildVehicleWindow : Window {
 		}
 	}
 
-	EventState OnHotkey(int hotkey) override
-	{
-		switch (hotkey) {
-			case BVHK_FOCUS_FILTER_BOX:
-				this->SetFocusedWidget(WID_BV_FILTER);
-				SetFocusedWindow(this); // The user has asked to give focus to the text box, so make sure this window is focused.
-				return ES_HANDLED;
-
-			default:
-				return ES_NOT_HANDLED;
-		}
-
-		return ES_HANDLED;
-	}
-
 	static inline HotkeyList hotkeys{"buildvehicle", {
-		Hotkey('F', "focus_filter_box", BVHK_FOCUS_FILTER_BOX),
+		Hotkey('F', "focus_filter_box", WID_BV_FILTER),
 	}};
 };
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1343,10 +1343,6 @@ static bool CargoFilter(const Industry * const *industry, const std::pair<CargoT
 
 static GUIIndustryList::FilterFunction * const _industry_filter_funcs[] = { &CargoFilter };
 
-/** Enum referring to the Hotkeys in the industry directory window */
-enum IndustryDirectoryHotkeys : int32_t {
-	IDHK_FOCUS_FILTER_BOX, ///< Focus the filter box
-};
 /**
  * The list of industries.
  */
@@ -1921,21 +1917,8 @@ public:
 		}
 	}
 
-	EventState OnHotkey(int hotkey) override
-	{
-		switch (hotkey) {
-			case IDHK_FOCUS_FILTER_BOX:
-				this->SetFocusedWidget(WID_ID_FILTER);
-				SetFocusedWindow(this); // The user has asked to give focus to the text box, so make sure this window is focused.
-				break;
-			default:
-				return ES_NOT_HANDLED;
-		}
-		return ES_HANDLED;
-	}
-
 	static inline HotkeyList hotkeys {"industrydirectory", {
-		Hotkey('F', "focus_filter_box", IDHK_FOCUS_FILTER_BOX),
+		Hotkey('F', "focus_filter_box", WID_ID_FILTER),
 	}};
 };
 

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -132,11 +132,6 @@ struct SignList {
 bool SignList::match_case = false;
 std::string SignList::default_name;
 
-/** Enum referring to the Hotkeys in the sign list window */
-enum SignListHotkeys : int32_t {
-	SLHK_FOCUS_FILTER_BOX, ///< Focus the edit box for editing the filter string
-};
-
 struct SignListWindow : Window, SignList {
 	QueryString filter_editbox; ///< Filter editbox;
 	int text_offset = 0; ///< Offset of the sign text relative to the left edge of the WID_SIL_LIST widget.
@@ -277,21 +272,6 @@ struct SignListWindow : Window, SignList {
 		}
 	}
 
-	EventState OnHotkey(int hotkey) override
-	{
-		switch (hotkey) {
-			case SLHK_FOCUS_FILTER_BOX:
-				this->SetFocusedWidget(WID_SIL_FILTER_TEXT);
-				SetFocusedWindow(this); // The user has asked to give focus to the text box, so make sure this window is focused.
-				break;
-
-			default:
-				return ES_NOT_HANDLED;
-		}
-
-		return ES_HANDLED;
-	}
-
 	void OnEditboxChanged(WidgetID widget) override
 	{
 		if (widget == WID_SIL_FILTER_TEXT) this->SetFilterString(this->filter_editbox.text.GetText());
@@ -345,7 +325,7 @@ struct SignListWindow : Window, SignList {
 	}
 
 	static inline HotkeyList hotkeys{"signlist", {
-		Hotkey('F', "focus_filter_box", SLHK_FOCUS_FILTER_BOX),
+		Hotkey('F', "focus_filter_box", WID_SIL_FILTER_TEXT),
 	}, SignListGlobalHotkeys};
 };
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -701,11 +701,6 @@ static constexpr NWidgetPart _nested_town_directory_widgets[] = {
 	EndContainer(),
 };
 
-/** Enum referring to the Hotkeys in the town directory window */
-enum TownDirectoryHotkeys : int32_t {
-	TDHK_FOCUS_FILTER_BOX, ///< Focus the filter box
-};
-
 /** Town directory window class. */
 struct TownDirectoryWindow : public Window {
 private:
@@ -1019,21 +1014,8 @@ public:
 		}
 	}
 
-	EventState OnHotkey(int hotkey) override
-	{
-		switch (hotkey) {
-			case TDHK_FOCUS_FILTER_BOX:
-				this->SetFocusedWidget(WID_TD_FILTER);
-				SetFocusedWindow(this); // The user has asked to give focus to the text box, so make sure this window is focused.
-				break;
-			default:
-				return ES_NOT_HANDLED;
-		}
-		return ES_HANDLED;
-	}
-
 	static inline HotkeyList hotkeys {"towndirectory", {
-		Hotkey('F', "focus_filter_box", TDHK_FOCUS_FILTER_BOX),
+		Hotkey('F', "focus_filter_box", WID_TD_FILTER),
 	}};
 };
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

1. General cleanup
2. Hotkey IDs are almost always Widget IDs, which is convenient for associating hotkeys with widgets, this commit removes a few unnecessary special cases.


## Description

The default OnHotkey handler will already focus editboxes for us:

```cpp
/**
 * A hotkey has been pressed.
 * @param hotkey  Hotkey index, by default a widget index of a button or editbox.
 * @return #ES_HANDLED if the key press has been handled, and the hotkey is not unavailable for some reason.
 */
EventState Window::OnHotkey(int hotkey)
{
	if (hotkey < 0) return ES_NOT_HANDLED;

	NWidgetCore *nw = this->GetWidget<NWidgetCore>(hotkey);
	if (nw == nullptr || nw->IsDisabled()) return ES_NOT_HANDLED;

	if (nw->type == WWT_EDITBOX) {
		if (this->IsShaded()) return ES_NOT_HANDLED;

		/* Focus editbox */
		this->SetFocusedWidget(hotkey);
		SetFocusedWindow(this);
	} else {
		/* Click button */
		this->OnClick(Point(), hotkey, 1);
	}
	return ES_HANDLED;
}
```



## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
