### PR TITLE
Feature: Gamepad viewport scrolling for Windows and Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,7 @@ if(WIN32)
         psapi
         winhttp
         bcrypt
+        xinput
     )
 endif()
 

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -75,6 +75,7 @@ void HandleTextInput(std::string_view str, bool marked = false,
 		std::optional<size_t> insert_location = std::nullopt, std::optional<size_t> replacement_end = std::nullopt);
 void HandleCtrlChanged();
 void HandleMouseEvents();
+void HandleGamepadScrolling(float stick_x, float stick_y, float max_axis_value);
 void UpdateWindows();
 void ChangeGameSpeed(bool enable_fast_forward);
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1720,6 +1720,25 @@ STR_CONFIG_SETTING_SCROLLWHEEL_ZOOM                             :Zoom map
 STR_CONFIG_SETTING_SCROLLWHEEL_SCROLL                           :Scroll map
 STR_CONFIG_SETTING_SCROLLWHEEL_OFF                              :Off
 
+STR_CONFIG_SETTING_GAMEPAD_STICK_SELECTION                      :Gamepad stick for scrolling: {STRING2}
+STR_CONFIG_SETTING_GAMEPAD_STICK_SELECTION_HELPTEXT             :Select which analog stick to use for map scrolling
+###length 3
+STR_CONFIG_SETTING_GAMEPAD_STICK_DISABLED                       :Disabled
+STR_CONFIG_SETTING_GAMEPAD_STICK_LEFT                           :Left stick
+STR_CONFIG_SETTING_GAMEPAD_STICK_RIGHT                          :Right stick
+
+STR_CONFIG_SETTING_GAMEPAD_DEADZONE                             :Gamepad deadzone: {STRING2}%
+STR_CONFIG_SETTING_GAMEPAD_DEADZONE_HELPTEXT                    :Minimum stick movement required before scrolling starts (0-100%)
+
+STR_CONFIG_SETTING_GAMEPAD_SENSITIVITY                          :Gamepad sensitivity: {STRING2}
+STR_CONFIG_SETTING_GAMEPAD_SENSITIVITY_HELPTEXT                 :Control the sensitivity of gamepad analog stick scrolling
+
+STR_CONFIG_SETTING_GAMEPAD_INVERT_X                             :Invert gamepad X-axis: {STRING2}
+STR_CONFIG_SETTING_GAMEPAD_INVERT_X_HELPTEXT                    :Invert the horizontal axis movement of the gamepad analog stick
+
+STR_CONFIG_SETTING_GAMEPAD_INVERT_Y                             :Invert gamepad Y-axis: {STRING2}
+STR_CONFIG_SETTING_GAMEPAD_INVERT_Y_HELPTEXT                    :Invert the vertical axis movement of the gamepad analog stick
+
 STR_CONFIG_SETTING_OSK_ACTIVATION                               :On screen keyboard: {STRING2}
 STR_CONFIG_SETTING_OSK_ACTIVATION_HELPTEXT                      :Select the method to open the on screen keyboard for entering text into editboxes only using the pointing device. This is meant for small devices without actual keyboard
 ###length 4

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1727,8 +1727,8 @@ STR_CONFIG_SETTING_GAMEPAD_STICK_DISABLED                       :Disabled
 STR_CONFIG_SETTING_GAMEPAD_STICK_LEFT                           :Left stick
 STR_CONFIG_SETTING_GAMEPAD_STICK_RIGHT                          :Right stick
 
-STR_CONFIG_SETTING_GAMEPAD_DEADZONE                             :Gamepad deadzone: {STRING2}%
-STR_CONFIG_SETTING_GAMEPAD_DEADZONE_HELPTEXT                    :Minimum stick movement required before scrolling starts (0-100%)
+STR_CONFIG_SETTING_GAMEPAD_DEADZONE                             :Gamepad deadzone: {STRING2}
+STR_CONFIG_SETTING_GAMEPAD_DEADZONE_HELPTEXT                    :Minimum stick movement required before scrolling starts
 
 STR_CONFIG_SETTING_GAMEPAD_SENSITIVITY                          :Gamepad sensitivity: {STRING2}
 STR_CONFIG_SETTING_GAMEPAD_SENSITIVITY_HELPTEXT                 :Control the sensitivity of gamepad analog stick scrolling

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -682,6 +682,11 @@ SettingsContainer &GetSettingsTree()
 				 *  Since it's also able to completely disable the scrollwheel will we display it on all platforms anyway */
 				viewports->Add(new SettingEntry("gui.scrollwheel_scrolling"));
 				viewports->Add(new SettingEntry("gui.scrollwheel_multiplier"));
+				viewports->Add(new SettingEntry("gui.gamepad_stick_selection"));
+				viewports->Add(new SettingEntry("gui.gamepad_deadzone"));
+				viewports->Add(new SettingEntry("gui.gamepad_sensitivity"));
+				viewports->Add(new SettingEntry("gui.gamepad_invert_x"));
+				viewports->Add(new SettingEntry("gui.gamepad_invert_y"));
 #ifdef __APPLE__
 				/* We might need to emulate a right mouse button on mac */
 				viewports->Add(new SettingEntry("gui.right_mouse_btn_emulation"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -159,6 +159,13 @@ enum ScrollWheelScrollingSetting : uint8_t {
 	SWS_OFF = 2             ///< Scroll wheel has no effect.
 };
 
+/** Settings related to gamepad stick selection. */
+enum class GamepadStickSelection : uint8_t {
+	DISABLED, ///< Gamepad scrolling disabled.
+	LEFT_STICK, ///< Use left analog stick for scrolling.
+	RIGHT_STICK, ///< Use right analog stick for scrolling.
+};
+
 /** Settings related to the GUI and other stuff that is not saved in the savegame. */
 struct GUISettings {
 	bool   sg_full_load_any;                 ///< new full load calculation, any cargo must be full read from pre v93 savegames
@@ -202,6 +209,11 @@ struct GUISettings {
 	uint8_t  right_mouse_btn_emulation;        ///< should we emulate right mouse clicking?
 	uint8_t  scrollwheel_scrolling;            ///< scrolling using the scroll wheel?
 	uint8_t  scrollwheel_multiplier;           ///< how much 'wheel' per incoming event from the OS?
+	uint8_t  gamepad_deadzone;                 ///< deadzone for gamepad analog sticks (0-100)
+	uint8_t  gamepad_sensitivity;              ///< sensitivity multiplier for gamepad scrolling
+	bool     gamepad_invert_x;                 ///< invert X axis for gamepad scrolling?
+	bool     gamepad_invert_y;                 ///< invert Y axis for gamepad scrolling?
+	GamepadStickSelection gamepad_stick_selection; ///< which stick to use for scrolling (left/right/disabled)
 	bool   timetable_arrival_departure;      ///< show arrivals and departures in vehicle timetables
 	RightClickClose  right_click_wnd_close;  ///< close window with right click
 	bool   toolbar_dropdown_autoselect;      ///< should toolbar dropdown buttons autoselect when releasing the mouse button

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -930,7 +930,7 @@ max      = 100
 interval = 5
 str      = STR_CONFIG_SETTING_GAMEPAD_DEADZONE
 strhelp  = STR_CONFIG_SETTING_GAMEPAD_DEADZONE_HELPTEXT
-strval   = STR_JUST_COMMA
+strval   = STR_CONFIG_SETTING_PERCENTAGE
 cat      = SC_BASIC
 startup  = true
 
@@ -944,7 +944,7 @@ max      = 100
 interval = 5
 str      = STR_CONFIG_SETTING_GAMEPAD_SENSITIVITY
 strhelp  = STR_CONFIG_SETTING_GAMEPAD_SENSITIVITY_HELPTEXT
-strval   = STR_JUST_COMMA
+strval   = STR_CONFIG_SETTING_PERCENTAGE
 cat      = SC_BASIC
 startup  = true
 

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -920,3 +920,62 @@ post_cb  = [](auto) { SetupWidgetDimensions(); ReInitAllWindows(true); }
 cat      = SC_BASIC
 startup  = true
 
+[SDTC_VAR]
+var      = gui.gamepad_deadzone
+type     = SLE_UINT8
+flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
+def      = 10
+min      = 0
+max      = 100
+interval = 5
+str      = STR_CONFIG_SETTING_GAMEPAD_DEADZONE
+strhelp  = STR_CONFIG_SETTING_GAMEPAD_DEADZONE_HELPTEXT
+strval   = STR_JUST_COMMA
+cat      = SC_BASIC
+startup  = true
+
+[SDTC_VAR]
+var      = gui.gamepad_sensitivity
+type     = SLE_UINT8
+flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
+def      = 10
+min      = 1
+max      = 100
+interval = 5
+str      = STR_CONFIG_SETTING_GAMEPAD_SENSITIVITY
+strhelp  = STR_CONFIG_SETTING_GAMEPAD_SENSITIVITY_HELPTEXT
+strval   = STR_JUST_COMMA
+cat      = SC_BASIC
+startup  = true
+
+[SDTC_BOOL]
+var      = gui.gamepad_invert_x
+flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
+def      = false
+str      = STR_CONFIG_SETTING_GAMEPAD_INVERT_X
+strhelp  = STR_CONFIG_SETTING_GAMEPAD_INVERT_X_HELPTEXT
+cat      = SC_BASIC
+startup  = true
+
+[SDTC_BOOL]
+var      = gui.gamepad_invert_y
+flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
+def      = false
+str      = STR_CONFIG_SETTING_GAMEPAD_INVERT_Y
+strhelp  = STR_CONFIG_SETTING_GAMEPAD_INVERT_Y_HELPTEXT
+cat      = SC_BASIC
+startup  = true
+
+[SDTC_VAR]
+var      = gui.gamepad_stick_selection
+type     = SLE_UINT8
+flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
+def      = to_underlying(GamepadStickSelection::LEFT_STICK)
+min      = to_underlying(GamepadStickSelection::DISABLED)
+max      = to_underlying(GamepadStickSelection::RIGHT_STICK)
+str      = STR_CONFIG_SETTING_GAMEPAD_STICK_SELECTION
+strhelp  = STR_CONFIG_SETTING_GAMEPAD_STICK_SELECTION_HELPTEXT
+strval   = STR_CONFIG_SETTING_GAMEPAD_STICK_DISABLED
+cat      = SC_BASIC
+startup  = true
+

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -521,6 +521,10 @@ bool VideoDriver_SDL_Base::PollEvent()
 				/* mouse left the window, undraw cursor */
 				UndrawMouseCursor();
 				_cursor.in_window = false;
+			} else if (ev.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) {
+				this->window_has_focus = true;
+			} else if (ev.window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
+				this->window_has_focus = false;
 			}
 			break;
 		}
@@ -662,8 +666,8 @@ void VideoDriver_SDL_Base::InputLoop()
 
 	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
 
-	/* Process gamepad input for scrolling */
-	this->ProcessGamepadInput();
+	/* Process gamepad input for scrolling only when focused */
+	if (this->window_has_focus) this->ProcessGamepadInput();
 }
 
 void VideoDriver_SDL_Base::LoopOnce()

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -11,6 +11,7 @@
 #define VIDEO_SDL_H
 
 #include <condition_variable>
+#include <SDL.h>
 
 #include "video_driver.hpp"
 
@@ -57,6 +58,10 @@ protected:
 	void CheckPaletteAnim() override;
 	bool PollEvent() override;
 
+	bool OpenGamepad() override;
+	void CloseGamepad() override;
+	void ProcessGamepadInput() override;
+
 	/** Indicate to the driver the client-side might have changed. */
 	void ClientSizeChanged(int w, int h, bool force);
 
@@ -86,6 +91,8 @@ private:
 	bool edit_box_focused = false;
 
 	int startup_display = 0;
+
+	SDL_GameController *gamepad = nullptr; ///< Currently opened gamepad.
 };
 
 #endif /* VIDEO_SDL_H */

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -90,6 +90,9 @@ private:
 	 */
 	bool edit_box_focused = false;
 
+	/* Tracks whether the SDL window currently has focus to gate gamepad input. */
+	bool window_has_focus = true;
+
 	int startup_display = 0;
 
 	SDL_GameController *gamepad = nullptr; ///< Currently opened gamepad.

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -273,6 +273,16 @@ protected:
 	 */
 	virtual bool PollEvent() { return false; };
 
+	/** Gamepad support */
+
+	/**
+	* Open the gamepad for input.
+	* @return True if the gamepad is available and open. False if no gamepad is available.
+	*/
+	virtual bool OpenGamepad() { return false; }
+	virtual void CloseGamepad() {}
+	virtual void ProcessGamepadInput() {}
+
 	/**
 	 * Start the loop for game-tick.
 	 */

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -993,8 +993,8 @@ void VideoDriver_Win32Base::InputLoop()
 
 	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
 
-	/* Process gamepad input for scrolling */
-	this->ProcessGamepadInput();
+	/* Process gamepad input for scrolling only while focused */
+	if (this->has_focus) this->ProcessGamepadInput();
 }
 
 bool VideoDriver_Win32Base::PollEvent()

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <windows.h>
+#include <xinput.h>
 
 /** Base class for Windows video drivers. */
 class VideoDriver_Win32Base : public VideoDriver {
@@ -55,6 +56,10 @@ protected:
 	void CheckPaletteAnim() override;
 	bool PollEvent() override;
 
+	bool OpenGamepad() override;
+	void CloseGamepad() override;
+	void ProcessGamepadInput() override;
+
 	void Initialize();
 	bool MakeWindow(bool full_screen, bool resize = true);
 	void ClientSizeChanged(int w, int h, bool force = false);
@@ -72,6 +77,9 @@ protected:
 
 private:
 	friend LRESULT CALLBACK WndProcGdi(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+	DWORD gamepad_user_index = XUSER_MAX_COUNT; ///< Index of currently opened gamepad (XUSER_MAX_COUNT = no gamepad).
+	uint32_t gamepad_reconnect_timer = 0;       ///< Timer for retrying gamepad connection after disconnect.
 };
 /** The GDI video driver for windows. */
 class VideoDriver_Win32GDI : public VideoDriver_Win32Base {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3665,8 +3665,13 @@ void HandleGamepadScrolling(float stick_x, float stick_y, float max_axis_value)
 
 		/* Apply scrolling to the target viewport */
 		if (target_window != nullptr && target_window->viewport != nullptr) {
-			/* Cancel vehicle following when gamepad scrolling */
-			target_window->viewport->CancelFollow(*target_window);
+			/* Check if the viewport is following a vehicle (similar to mouse scroll behavior) */
+			if (target_window == GetMainWindow() && target_window->viewport->follow_vehicle != VehicleID::Invalid()) {
+				/* If following a vehicle, center on it and stop following (like mouse scroll) */
+				const Vehicle *veh = Vehicle::Get(target_window->viewport->follow_vehicle);
+				ScrollMainWindowTo(veh->x_pos, veh->y_pos, veh->z_pos, true); // This also resets follow_vehicle
+				return; // Don't apply gamepad scroll, just like mouse scroll returns ES_NOT_HANDLED
+			}
 
 			/* Apply the scroll using the same method as keyboard scrolling */
 			target_window->viewport->dest_scrollpos_x += ScaleByZoom(delta_x, target_window->viewport->zoom);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3654,7 +3654,10 @@ void HandleGamepadScrolling(float stick_x, float stick_y, float max_axis_value)
 			    pt.x < w->viewport->left - w->left + w->viewport->width &&
 			    pt.y >= w->viewport->top - w->top &&
 			    pt.y < w->viewport->top - w->top + w->viewport->height) {
-				target_window = w;
+				/* Respect the same lock as RMB-drag scrolling: some viewports disable scrolling entirely. */
+				if (!w->flags.Test(WindowFlag::DisableVpScroll)) {
+					target_window = w;
+				}
 			}
 		}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

My primary motivation is improved steam deck support.

## Description

There is a popular (only?) community mapping which already maps left stick to a makeshift scroller by automatically right-clicking the mouse button and using the stick as mouse. This works to some extent, where if the cursor is not over a window, this will actually drag the map. If the cursor is over a window, however, the right-click would get consumed by such window and result in an unreliable experience for the user.

The defaults I've used differ in that they are not inverted (so they do not 'drag' the map as mouse would have, but instead push the view in the direction of the stick). This is user-configurable.

The configuration includes:
- which stick to use: [left, right, disabled]
- deadzone
- sensitivity
- X and Y axis inversion (independent)

![image](https://github.com/user-attachments/assets/cf5885a2-6e3a-4364-8af4-4582bbdec366)

My testing included gamepad hotswap, but only ever with single device.

## Limitations

I have added support to SDL2 and Win32 drivers.

While I did test a version for Allegro, it seems this version is less used (certainly the steam build only reports `sdl-opengl`, `sdl`, `dedicated`, `null`) and there are significant caveats to how well it could be supported due to the nature of game controllers - each device has an ever so slightly different mapping. This is already solved in SDL by a higher level API (`SDL_GameController`) which consumes the lower level API (`SDL_Joystick`) events and parses them through [internal mapping](https://github.com/libsdl-org/SDL/blob/f5d1402c287963bf71f7a4cf14f16bbedffae143/src/joystick/SDL_gamepad_db.h#L31-L915). XInput handles this on system level as well. Allegro has no such functionality and in my testing it results in a bad experience, where gamepad's trigger can be considered as _one_ of the stick axis and makes the view scroll all the way to the left without any user interaction. Allegro is also different from other systems in that [axes values are -128..128](https://liballeg.org/stabledocs/en/alleg007.html) rather than more common [-32768..32767](https://wiki.libsdl.org/SDL2/SDL_GameControllerGetAxis).

I have no access to macOS to implement it for this driver.

While in the opening statement I mentioned my motivation is steam deck support, I have only tested in on a Ubuntu and Windows systems.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
