### PR TITLE
Fix: Train path reservations on different railtypes could join leading to train crashes.

### DIFF
--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -331,7 +331,7 @@ protected:
 		}
 
 		/* rail transport is possible only on compatible rail types */
-		if (IsRailTT()) {
+		if (IsRailTT() && this->railtypes.Any()) {
 			RailType rail_type = GetTileRailType(this->new_tile);
 			if (!this->railtypes.Test(rail_type)) {
 				/* incompatible rail type */

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -436,8 +436,9 @@ bool IsWaitingPositionFree(const Train *v, TileIndex tile, Trackdir trackdir, bo
 	if (IsRailDepotTile(tile)) return true;
 	if (IsTileType(tile, MP_RAILWAY) && HasSignalOnTrackdir(tile, trackdir) && !IsPbsSignal(GetSignalType(tile, track))) return true;
 
-	/* Check the next tile, if it's a PBS signal, it has to be free as well. */
-	CFollowTrackRail ft(v, GetRailTypeInfo(v->railtype)->compatible_railtypes);
+	/* Check the next tile, it has to be free as well. Do not filter for compatible railtypes
+	 * to make sure we never accidentally join up reservations. */
+	CFollowTrackRail ft(v, RailTypes{});
 
 	if (!ft.Follow(tile, trackdir)) return true;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Trains can possibly crash into each other if railtypes with asymmetric compatibility are used. Path reservations can end at an end-of-line caused by a railtype that is not compatible with the current train. If the next tile of a different railtype is already reserved by another train and that train e.g. reverses, the second train can follow the reserved path of the first train in certain situations. This leads to train crashes without player intervention.

See [PR.9953.Example.1990-01-03.sav.zip](https://github.com/user-attachments/files/20745960/PR.9953.Example.1990-01-03.sav.zip) for an example.


## Description

To fix this, treat any safe waiting position as blocked if any reachable tracks on the next tile are reserved. This check ignores railtype compatibility to make sure a new reservation can never touch an old reservation at a railtype transition.


## Limitations

Was tested with the provided savegame and in artificial situations mixing e.g. rail and monorail, but I have not tried to construct arbitrarily complex layouts or made deliberately broken railtype GRFs to find any remaining flaws.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
