### PR TITLE
Fix #14081: Check if removed item is a savegame

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -543,8 +543,12 @@ static bool ConRemove(std::span<std::string_view> argv)
 	_console_file_list_savegame.ValidateFileList();
 	const FiosItem *item = _console_file_list_savegame.FindItem(file);
 	if (item != nullptr) {
-		if (!FioRemove(item->name)) {
-			IConsolePrint(CC_ERROR, "Failed to delete '{}'.", item->name);
+		if (item->type.abstract == FT_SAVEGAME) {
+			if (!FioRemove(item->name)) {
+				IConsolePrint(CC_ERROR, "Failed to delete '{}'.", item->name);
+			}
+		} else {
+			IConsolePrint(CC_ERROR, "'{}' is not a savegame.", file);
 		}
 	} else {
 		IConsolePrint(CC_ERROR, "'{}' could not be found.", file);


### PR DESCRIPTION

## Motivation / Problem
Fixes the problem described in #14081. When selecting the folders, the command did nothing. When selecting a drive letter, it crashed the whole game.

## Description

Implemented checks that are done while loading the savegame from the console. If the user tries to delete something else than a savegame, he will receive the message `... is not a savegame.`

## Limitations

Maybe rm should also handle the directories in some special way? Right now and before the fix players could not remove the directories with `rm` command

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
