### PR TITLE
Add: Buttons to change picker preview image height.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2833,6 +2833,11 @@ STR_PICKER_MODE_USED_TOOLTIP                                    :Toggle showing 
 STR_PICKER_MODE_SAVED                                           :Saved
 STR_PICKER_MODE_SAVED_TOOLTIP                                   :Toggle showing only saved items
 
+STR_PICKER_PREVIEW_SHRINK                                       :-
+STR_PICKER_PREVIEW_SHRINK_TOOLTIP                               :Reduce the height of preview images. Ctrl+Click to reduce to minimum
+STR_PICKER_PREVIEW_EXPAND                                       :+
+STR_PICKER_PREVIEW_EXPAND_TOOLTIP                               :Increase the height of preview images. Ctrl+Click to increase to maximum
+
 STR_PICKER_STATION_CLASS_TOOLTIP                                :Select a station class to display
 STR_PICKER_STATION_TYPE_TOOLTIP                                 :Select a station type to build. Ctrl+Click to add or remove in saved items
 STR_PICKER_WAYPOINT_CLASS_TOOLTIP                               :Select a waypoint class to display

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -181,6 +181,8 @@ void PickerWindow::ConstructWindow()
 	/* Test if pickers should be active.*/
 	bool is_active = this->callbacks.IsActive();
 
+	this->preview_height = std::max(this->callbacks.preview_height, PREVIEW_HEIGHT);
+
 	/* Functionality depends on widgets being present, not window class. */
 	this->has_class_picker = is_active && this->GetWidget<NWidgetBase>(WID_PW_CLASS_LIST) != nullptr && this->callbacks.HasClassChoice();
 	this->has_type_picker = is_active && this->GetWidget<NWidgetBase>(WID_PW_TYPE_MATRIX) != nullptr;
@@ -286,7 +288,7 @@ void PickerWindow::UpdateWidgetSize(WidgetID widget, Dimension &size, const Dime
 		/* Type picker */
 		case WID_PW_TYPE_ITEM:
 			size.width  = ScaleGUITrad(PREVIEW_WIDTH) + WidgetDimensions::scaled.fullbevel.Horizontal();
-			size.height = ScaleGUITrad(PREVIEW_HEIGHT) + WidgetDimensions::scaled.fullbevel.Vertical();
+			size.height = ScaleGUITrad(this->preview_height) + WidgetDimensions::scaled.fullbevel.Vertical();
 			break;
 
 		case WID_PW_CONFIGURE_BADGES:
@@ -332,7 +334,7 @@ void PickerWindow::DrawWidget(const Rect &r, WidgetID widget) const
 			if (FillDrawPixelInfo(&tmp_dpi, ir)) {
 				AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 				int x = (ir.Width()  - ScaleSpriteTrad(PREVIEW_WIDTH)) / 2 + ScaleSpriteTrad(PREVIEW_LEFT);
-				int y = (ir.Height() + ScaleSpriteTrad(PREVIEW_HEIGHT)) / 2 - ScaleSpriteTrad(PREVIEW_BOTTOM);
+				int y = (ir.Height() + ScaleSpriteTrad(this->preview_height)) / 2 - ScaleSpriteTrad(PREVIEW_BOTTOM);
 
 				this->callbacks.DrawType(x, y, item.class_index, item.index);
 
@@ -396,6 +398,18 @@ void PickerWindow::OnClick(Point pt, WidgetID widget, int)
 				SetBit(this->callbacks.mode, PFM_ALL);
 			}
 			this->InvalidateData({PickerInvalidation::Class, PickerInvalidation::Type, PickerInvalidation::Position});
+			break;
+
+		case WID_PW_SHRINK:
+			this->callbacks.preview_height = this->preview_height = _ctrl_pressed ? PREVIEW_HEIGHT : std::max(PREVIEW_HEIGHT, this->preview_height - STEP_PREVIEW_HEIGHT);
+			this->InvalidateData({});
+			this->ReInit();
+			break;
+
+		case WID_PW_EXPAND:
+			this->callbacks.preview_height = this->preview_height = _ctrl_pressed ? MAX_PREVIEW_HEIGHT : std::min(MAX_PREVIEW_HEIGHT, this->preview_height + STEP_PREVIEW_HEIGHT);
+			this->InvalidateData({});
+			this->ReInit();
 			break;
 
 		/* Type Picker */
@@ -490,6 +504,9 @@ void PickerWindow::OnInvalidateData(int data, bool gui_scope)
 		SetWidgetLoweredState(WID_PW_MODE_USED, HasBit(this->callbacks.mode, PFM_USED));
 		SetWidgetLoweredState(WID_PW_MODE_SAVED, HasBit(this->callbacks.mode, PFM_SAVED));
 	}
+
+	SetWidgetDisabledState(WID_PW_SHRINK, this->preview_height == PREVIEW_HEIGHT);
+	SetWidgetDisabledState(WID_PW_EXPAND, this->preview_height == MAX_PREVIEW_HEIGHT);
 }
 
 EventState PickerWindow::OnHotkey(int hotkey)
@@ -748,6 +765,8 @@ std::unique_ptr<NWidgetBase> MakePickerTypeWidgets()
 					NWidget(WWT_TEXTBTN, COLOUR_DARK_GREEN, WID_PW_MODE_ALL), SetFill(1, 0), SetResize(1, 0), SetStringTip(STR_PICKER_MODE_ALL, STR_PICKER_MODE_ALL_TOOLTIP),
 					NWidget(WWT_TEXTBTN, COLOUR_DARK_GREEN, WID_PW_MODE_USED), SetFill(1, 0), SetResize(1, 0), SetStringTip(STR_PICKER_MODE_USED, STR_PICKER_MODE_USED_TOOLTIP),
 					NWidget(WWT_TEXTBTN, COLOUR_DARK_GREEN, WID_PW_MODE_SAVED), SetFill(1, 0), SetResize(1, 0), SetStringTip(STR_PICKER_MODE_SAVED, STR_PICKER_MODE_SAVED_TOOLTIP),
+					NWidget(WWT_PUSHTXTBTN, COLOUR_DARK_GREEN, WID_PW_SHRINK), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON), SetStringTip(STR_PICKER_PREVIEW_SHRINK, STR_PICKER_PREVIEW_SHRINK_TOOLTIP),
+					NWidget(WWT_PUSHTXTBTN, COLOUR_DARK_GREEN, WID_PW_EXPAND), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON), SetStringTip(STR_PICKER_PREVIEW_EXPAND, STR_PICKER_PREVIEW_EXPAND_TOOLTIP),
 				EndContainer(),
 				NWidget(NWID_HORIZONTAL),
 					NWidget(WWT_PANEL, COLOUR_DARK_GREEN), SetScrollbar(WID_PW_TYPE_SCROLL),

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -96,6 +96,8 @@ public:
 	const std::string ini_group; ///< Ini Group for saving favourites.
 	uint8_t mode = 0; ///< Bitmask of \c PickerFilterModes.
 
+	int preview_height = 0; ///< Previously adjusted height.
+
 	std::set<PickerItem> used; ///< Set of items used in the current game by the current company.
 	std::set<PickerItem> saved; ///< Set of saved favourite items.
 };
@@ -170,15 +172,19 @@ public:
 
 	static constexpr PickerInvalidations PICKER_INVALIDATION_ALL{PickerInvalidation::Class, PickerInvalidation::Type, PickerInvalidation::Position, PickerInvalidation::Validate};
 
-	static const int PREVIEW_WIDTH = 64; ///< Width of each preview button.
-	static const int PREVIEW_HEIGHT = 48; ///< Height of each preview button.
-	static const int PREVIEW_LEFT = 31; ///< Offset from left edge to draw preview.
-	static const int PREVIEW_BOTTOM = 31; ///< Offset from bottom edge to draw preview.
+	static constexpr int PREVIEW_WIDTH = 64; ///< Width of each preview button.
+	static constexpr int PREVIEW_HEIGHT = 48; ///< Height of each preview button.
+	static constexpr int PREVIEW_LEFT = 31; ///< Offset from left edge to draw preview.
+	static constexpr int PREVIEW_BOTTOM = 31; ///< Offset from bottom edge to draw preview.
 
-	static const uint EDITBOX_MAX_SIZE = 16; ///< The maximum number of characters for the filter edit box.
+	static constexpr int STEP_PREVIEW_HEIGHT = 16; ///< Step for decreasing or increase preivew button height.
+	static constexpr int MAX_PREVIEW_HEIGHT = PREVIEW_HEIGHT * 3; ///< Maximum height of each preview button.
+
+	static constexpr uint EDITBOX_MAX_SIZE = 16; ///< The maximum number of characters for the filter edit box.
 
 	bool has_class_picker = false; ///< Set if this window has a class picker 'component'.
 	bool has_type_picker = false; ///< Set if this window has a type picker 'component'.
+	int preview_height = 0; ///< Height of preview images.
 
 	PickerWindow(WindowDesc &desc, Window *parent, int window_number, PickerCallbacks &callbacks);
 	void OnInit() override;

--- a/src/widgets/picker_widget.h
+++ b/src/widgets/picker_widget.h
@@ -24,6 +24,8 @@ enum PickerClassWindowWidgets : WidgetID {
 	WID_PW_MODE_ALL, ///< Toggle "Show all" filter mode.
 	WID_PW_MODE_USED, ///< Toggle showing only used types.
 	WID_PW_MODE_SAVED, ///< Toggle showing only saved types.
+	WID_PW_SHRINK, ///< Button to reduce preview image height.
+	WID_PW_EXPAND, ///< Button to increase preview image height.
 	WID_PW_TYPE_MATRIX, ///< Matrix with items.
 	WID_PW_TYPE_ITEM, ///< A single item.
 	WID_PW_TYPE_SCROLL, ///< Scrollbar for the matrix.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When I introduced the unified picker window, we removed the logic that expanded preview windows to fit content, as it resulted in an explosion of window sizes with some content loaded.

The preview height was deliberately limited something similar to the original station picker previews, providing consistency.

For objects, and the advent of the house placer, this may be a bit awkward to use, especially when there are multiple similar items that vary by height.

![image](https://github.com/user-attachments/assets/32e84aac-9e04-4000-843c-ea580f35f231)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

As a compromise, allow the picker preview images to be changed. The difference between this and the original system is that the height is controlled by the player.

Increasing the height is a compromise: it allows more of the item to be visible, but it also means the window must be larger and needs to be scrolled more.

![image](https://github.com/user-attachments/assets/d1b9806b-067c-425b-8c25-f59b45599bc4)

Add buttons to change picker preview image height. This is changed per-type (station, house, object, etc) The adjusted height is remembered per picker type while OpenTTD is running, but not saved.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Not sure if this is a problem that actually needs solving...

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
