### PR TITLE
Fix: GL error typo

### DIFF
--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -118,7 +118,7 @@ std::optional<std::string_view> VideoDriver_SDL_OpenGL::AllocateContext()
 	}
 
 	this->gl_context = SDL_GL_CreateContext(this->sdl_window);
-	if (this->gl_context == nullptr) return "SDL2: Can't active GL context";
+	if (this->gl_context == nullptr) return "SDL2: Can't activate GL context";
 
 	ToggleVsync(_video_vsync);
 

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1507,7 +1507,7 @@ std::optional<std::string_view> VideoDriver_Win32OpenGL::AllocateContext()
 		rc = wglCreateContext(this->dc);
 		if (rc == nullptr) return "Can't create OpenGL context";
 	}
-	if (!wglMakeCurrent(this->dc, rc)) return "Can't active GL context";
+	if (!wglMakeCurrent(this->dc, rc)) return "Can't activate GL context";
 
 	this->ToggleVsync(_video_vsync);
 


### PR DESCRIPTION
## Motivation / Problem

There is a typo in an error message when the GL context can't be activated.


## Description

Fix the typo's.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
