### PR TITLE
Fix #12900: Join station window will be shown for stations with existing stations in tile gaps

### DIFF
--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2222,18 +2222,13 @@ static void AddNearbyStation(TileIndex tile, TileArea *ctx)
  * @tparam T the station filter type, for stations to look for
  */
 template <class T>
-static const BaseStation *FindStationsNearby(TileArea ta, bool distant_join)
+static void FindStationsNearby(TileArea ta, bool distant_join)
 {
 	TileArea ctx = ta;
 
 	_stations_nearby_list.clear();
 	_stations_nearby_list.push_back(NEW_STATION);
 	_deleted_stations_nearby.clear();
-
-	/* Check the inside, to return, if we sit on another station */
-	for (TileIndex t : ta) {
-		if (t < Map::Size() && IsTileType(t, MP_STATION) && T::IsValidID(GetStationIndex(t))) return BaseStation::GetByTile(t);
-	}
 
 	/* Look for deleted stations */
 	for (const BaseStation *st : BaseStation::Iterate()) {
@@ -2251,17 +2246,20 @@ static const BaseStation *FindStationsNearby(TileArea ta, bool distant_join)
 		}
 	}
 
+	/* Add stations that are within station tile area. Stations do not have to occupy all tiles */
+	for (auto t : ta) {
+		AddNearbyStation<T>(t, &ctx);
+	}
+
 	/* Only search tiles where we have a chance to stay within the station spread.
 	 * The complete check needs to be done in the callback as we don't know the
 	 * extent of the found station, yet. */
-	if (distant_join && std::min(ta.w, ta.h) >= _settings_game.station.station_spread) return nullptr;
+	if (distant_join && std::min(ta.w, ta.h) >= _settings_game.station.station_spread) return;
 	uint max_dist = distant_join ? _settings_game.station.station_spread - std::min(ta.w, ta.h) : 1;
 
 	for (auto tile : SpiralTileSequence(TileAddByDir(ctx.tile, DIR_N), max_dist, ta.w, ta.h)) {
 		AddNearbyStation<T>(tile, &ctx);
 	}
-
-	return nullptr;
 }
 
 static constexpr NWidgetPart _nested_select_station_widgets[] = {
@@ -2421,7 +2419,7 @@ static WindowDesc _select_station_desc(
  * @return whether we need to show the station selection window.
  */
 template <class T>
-static bool StationJoinerNeeded(TileArea ta, const StationPickerCmdProc &proc)
+static bool StationJoinerNeeded(const StationPickerCmdProc &proc)
 {
 	/* Only show selection if distant join is enabled in the settings */
 	if (!_settings_game.station.distant_join_stations) return false;
@@ -2439,9 +2437,7 @@ static bool StationJoinerNeeded(TileArea ta, const StationPickerCmdProc &proc)
 	if (!_ctrl_pressed) return false;
 
 	/* Now check if we could build there */
-	if (!proc(true, StationID::Invalid())) return false;
-
-	return FindStationsNearby<T>(ta, false) == nullptr;
+	return proc(true, StationID::Invalid());
 }
 
 /**
@@ -2453,7 +2449,7 @@ static bool StationJoinerNeeded(TileArea ta, const StationPickerCmdProc &proc)
 template <class T>
 void ShowSelectBaseStationIfNeeded(TileArea ta, StationPickerCmdProc&& proc)
 {
-	if (StationJoinerNeeded<T>(ta, proc)) {
+	if (StationJoinerNeeded<T>(proc)) {
 		if (!_settings_client.gui.persistent_buildingtools) ResetObjectToPlace();
 		new SelectStationWindow<T>(_select_station_desc, ta, std::move(proc));
 	} else {


### PR DESCRIPTION
## Motivation / Problem

Fixes the problem described in #12900. Building a station (airport in this case) with Ctrl pressed when the existing station was present in the tile gap did not open the station selection window. Instead of this stations were joined.


## Description

`FindStationsNearby` was improved. The logic to find stations in tile gaps was put in place. FindStationsNearby does not need to return any value after the removal of the setting for adjacent stations in #12862. Checking if we sit on another station is not necessary as `StationJoinerNeeded` checks if station can be built.

Closes #12900.

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
