### PR TITLE
Fix #14240: Remember previous GUI scale when toggling auto-detect

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -415,6 +415,7 @@ struct GameOptionsWindow : Window {
 	bool reload = false;
 	bool gui_scale_changed = false;
 	int gui_scale = 0;
+	static inline int previous_gui_scale = 0; ///< Previous GUI scale.
 	static inline WidgetID active_tab = WID_GO_TAB_GENERAL;
 
 	GameOptionsWindow(WindowDesc &desc) : Window(desc), filter_editbox(50)
@@ -1076,9 +1077,12 @@ struct GameOptionsWindow : Window {
 			case WID_GO_GUI_SCALE_AUTO:
 			{
 				if (_gui_scale_cfg == -1) {
-					_gui_scale_cfg = _gui_scale;
+					_gui_scale_cfg = this->previous_gui_scale; // Load the previous GUI scale
 					this->SetWidgetLoweredState(WID_GO_GUI_SCALE_AUTO, false);
+					if (AdjustGUIZoom(false)) ReInitAllWindows(true);
+					this->gui_scale = _gui_scale;
 				} else {
+					this->previous_gui_scale = _gui_scale; // Set the previous GUI scale value as the current one
 					_gui_scale_cfg = -1;
 					this->SetWidgetLoweredState(WID_GO_GUI_SCALE_AUTO, true);
 					if (AdjustGUIZoom(false)) ReInitAllWindows(true);


### PR DESCRIPTION
## Motivation / Problem

Fixes #14240 

When a user chooses a UI scale via the slider, then toggles Auto-detect size, the previously set UI scale is lost, which is unintuitive and forces the user to re-configure the setting.

## Description

This change stores the previously selected scale, so that it can be restored if Auto-detect is disabled. 
A static variable to store the selected scale. When Auto-detect is toggled off, the previously set scale is restored on the slider. The logic is contained within settings_gui.cpp.

## Limitations

- The scale will not be remembered if the user quits OpenTTD, as this would require saving the value.
