### PR TITLE
Change: Make tile highlight red if the place operation would fail.

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -61,15 +61,21 @@ void CcBuildAirport(Commands, const CommandCost &result, TileIndex tile)
 
 /**
  * Place an airport.
+ * @param query Whether to only query the operation.
  * @param tile Position to put the new airport.
  */
-static void PlaceAirport(TileIndex tile)
+static void PlaceAirport(bool query, TileIndex tile)
 {
 	if (_selected_airport_index == -1) return;
 
 	uint8_t airport_type = AirportClass::Get(_selected_airport_class)->GetSpec(_selected_airport_index)->GetIndex();
 	uint8_t layout = _selected_airport_layout;
 	bool adjacent = _ctrl_pressed;
+
+	if (query) {
+		HandleSelectionQuery(STR_ERROR_CAN_T_BUILD_AIRPORT_HERE, Command<Commands::BuildAirport>::Query(tile, airport_type, layout, StationID::Invalid(), adjacent));
+		return;
+	}
 
 	auto proc = [=](bool test, StationID to_join) -> bool {
 		if (test) {
@@ -141,15 +147,15 @@ struct BuildAirToolbarWindow : Window {
 	}
 
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		switch (this->last_user_action) {
 			case WID_AT_AIRPORT:
-				PlaceAirport(tile);
+				PlaceAirport(query, tile);
 				break;
 
 			case WID_AT_DEMOLISH:
-				PlaceProc_DemolishArea(tile);
+				PlaceProc_DemolishArea(query, tile);
 				break;
 
 			default: NOT_REACHED();
@@ -166,10 +172,10 @@ struct BuildAirToolbarWindow : Window {
 		return AlignInitialConstructionToolbar(sm_width);
 	}
 
-	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
+	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile, bool query) override
 	{
 		if (pt.x != -1 && select_proc == DDSP_DEMOLISH_AREA) {
-			GUIPlaceProcDragXY(select_proc, start_tile, end_tile);
+			GUIPlaceProcDragXY(query, select_proc, start_tile, end_tile);
 		}
 	}
 

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -73,7 +73,7 @@ static void PlaceAirport(TileIndex tile)
 
 	auto proc = [=](bool test, StationID to_join) -> bool {
 		if (test) {
-			return Command<Commands::BuildAirport>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildAirport>()), tile, airport_type, layout, StationID::Invalid(), adjacent).Succeeded();
+			return Command<Commands::BuildAirport>::Query(tile, airport_type, layout, StationID::Invalid(), adjacent).Succeeded();
 		} else {
 			return Command<Commands::BuildAirport>::Post(STR_ERROR_CAN_T_BUILD_AIRPORT_HERE, CcBuildAirport, tile, airport_type, layout, to_join, adjacent);
 		}

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -378,7 +378,7 @@ void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transpo
 
 	/* only query bridge building possibility once, result is the same for all bridges!
 	 * returns CMD_ERROR on failure, and price on success */
-	CommandCost ret = Command<Commands::BuildBridge>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildBridge>()) | DoCommandFlag::QueryCost, end, start, transport_type, 0, road_rail_type);
+	CommandCost ret = Command<Commands::BuildBridge>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildBridge>()).Set(DoCommandFlag::QueryCost), end, start, transport_type, 0, road_rail_type);
 
 	GUIBridgeList bl;
 	if (!ret.Failed()) {

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -29,6 +29,7 @@ static const CommandCost CMD_ERROR = CommandCost(INVALID_STRING_ID);
 
 void NetworkSendCommand(Commands cmd, StringID err_message, CommandCallback *callback, CompanyID company, const CommandDataBuffer &cmd_data);
 bool IsNetworkRegisteredCallback(CommandCallback *callback);
+void HandleSelectionQuery(StringID err_message, CommandCost &&res);
 
 bool IsValidCommand(Commands cmd);
 CommandFlags GetCommandFlags(Commands cmd);
@@ -180,10 +181,52 @@ public:
 	 * @param args Parameters for the command.
 	 * @return cost of the command.
 	 */
-	static CommandCost Query(Targs... args)
+	static inline CommandCost Query(Targs... args)
 	{
-		Tret res = Do(CommandFlagsToDCFlags(GetCommandFlags<Tcmd>()), args...);
+		Tret res = Do(CommandFlagsToDCFlags(GetCommandFlags<Tcmd>()), std::forward<Targs>(args)...);
 		return ExtractCommandCost(res);
+	}
+
+	/**
+	 * Post or query a command.
+	 * @param query Whether to query (for selection) or post the command.
+	 * @param err_message Message prefix to show on error.
+	 * @param callback A callback function to call after the command is finished.
+	 * @param args Parameters for the command.
+	 * @return \c true if the command was posted and succeeded, else \c false.
+	 */
+	template <typename Tcallback>
+	static inline bool PostOrQuery(bool query, StringID err_message, Tcallback *callback, Targs... args)
+	{
+		if (query) {
+			HandleSelectionQuery(err_message, Query(std::forward<Targs>(args)...));
+			return false;
+		} else {
+			return Post(err_message, callback, std::forward<Targs>(args)...);
+		}
+	}
+
+	/**
+	 * Shortcut for the long PostOrQuery when not using a callback.
+	 * @param query Whether to query (for selection) or post the command.
+	 * @param err_message Message prefix to show on error.
+	 * @param args Parameters for the command.
+	 * @return \c true if the command was posted and succeeded, else \c false.
+	 */
+	static inline bool PostOrQuery(bool query, StringID err_message, Targs... args)
+	{
+		return PostOrQuery<CommandCallback>(query, err_message, nullptr, std::forward<Targs>(args)...);
+	}
+
+	/**
+	 * Shortcut for the long PostOrQuery when not using a callback or an error message.
+	 * @param query Whether to query (for selection) or post the command.
+	 * @param args Parameters for the command.
+	 * @return \c true if the command was posted and succeeded, else \c false.
+	 */
+	static inline bool PostOrQuery(bool query, Targs... args)
+	{
+		return PostOrQuery<CommandCallback>(query, static_cast<StringID>(0), nullptr, std::forward<Targs>(args)...);
 	}
 
 	/**

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -176,6 +176,17 @@ public:
 	}
 
 	/**
+	 * Shortcut to query a command with its flags to test if it will succeed.
+	 * @param args Parameters for the command.
+	 * @return cost of the command.
+	 */
+	static CommandCost Query(Targs... args)
+	{
+		Tret res = Do(CommandFlagsToDCFlags(GetCommandFlags<Tcmd>()), args...);
+		return ExtractCommandCost(res);
+	}
+
+	/**
 	 * Shortcut for the long Post when not using a callback.
 	 * @param err_message Message prefix to show on error
 	 * @param args Parameters for the command

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -2259,9 +2259,9 @@ struct CompanyWindow : Window
 		this->SetDirty();
 	}};
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
-		if (Command<Commands::BuildObject>::Post(STR_ERROR_CAN_T_BUILD_COMPANY_HEADQUARTERS, tile, OBJECT_HQ, 0) && !_shift_pressed) {
+		if (Command<Commands::BuildObject>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_COMPANY_HEADQUARTERS, tile, OBJECT_HQ, 0) && !_shift_pressed) {
 			ResetObjectToPlace();
 			this->RaiseButtons();
 		}

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -192,23 +192,23 @@ struct BuildDocksToolbarWindow : Window {
 		this->last_clicked_widget = widget;
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		switch (this->last_clicked_widget) {
 			case WID_DT_CANAL: // Build canal button
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_WATER);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_CREATE_WATER);
 				break;
 
 			case WID_DT_LOCK: // Build lock button
-				Command<Commands::BuildLock>::Post(STR_ERROR_CAN_T_BUILD_LOCKS, CcBuildDocks, tile);
+				Command<Commands::BuildLock>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_LOCKS, CcBuildDocks, tile);
 				break;
 
 			case WID_DT_DEMOLISH: // Demolish aka dynamite button
-				PlaceProc_DemolishArea(tile);
+				PlaceProc_DemolishArea(query, tile);
 				break;
 
 			case WID_DT_DEPOT: // Build depot button
-				Command<Commands::BuildShipDepot>::Post(STR_ERROR_CAN_T_BUILD_SHIP_DEPOT, CcBuildDocks, tile, _ship_depot_direction);
+				Command<Commands::BuildShipDepot>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_SHIP_DEPOT, CcBuildDocks, tile, _ship_depot_direction);
 				break;
 
 			case WID_DT_STATION: { // Build station button
@@ -217,6 +217,12 @@ struct BuildDocksToolbarWindow : Window {
 				TileIndex tile_to = (dir != INVALID_DIAGDIR ? TileAddByDiagDir(tile, ReverseDiagDir(dir)) : tile);
 
 				bool adjacent = _ctrl_pressed;
+
+				if (query) {
+					HandleSelectionQuery(STR_ERROR_CAN_T_BUILD_DOCK_HERE, Command<Commands::BuildDock>::Query(tile, StationID::Invalid(), adjacent));
+					break;
+				}
+
 				auto proc = [=](bool test, StationID to_join) -> bool {
 					if (test) {
 						return Command<Commands::BuildDock>::Query(tile, StationID::Invalid(), adjacent).Succeeded();
@@ -230,15 +236,15 @@ struct BuildDocksToolbarWindow : Window {
 			}
 
 			case WID_DT_BUOY: // Build buoy button
-				Command<Commands::BuildBuoy>::Post(STR_ERROR_CAN_T_POSITION_BUOY_HERE, CcBuildDocks, tile);
+				Command<Commands::BuildBuoy>::PostOrQuery(query, STR_ERROR_CAN_T_POSITION_BUOY_HERE, CcBuildDocks, tile);
 				break;
 
 			case WID_DT_RIVER: // Build river button (in scenario editor)
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_RIVER);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_CREATE_RIVER);
 				break;
 
 			case WID_DT_BUILD_AQUEDUCT: // Build aqueduct button
-				Command<Commands::BuildBridge>::Post(STR_ERROR_CAN_T_BUILD_AQUEDUCT_HERE, CcBuildBridge, tile, GetOtherAqueductEnd(tile), TRANSPORT_WATER, 0, 0);
+				Command<Commands::BuildBridge>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_AQUEDUCT_HERE, CcBuildBridge, tile, GetOtherAqueductEnd(tile), TRANSPORT_WATER, 0, 0);
 				break;
 
 			default: NOT_REACHED();
@@ -255,22 +261,22 @@ struct BuildDocksToolbarWindow : Window {
 		return AlignInitialConstructionToolbar(sm_width);
 	}
 
-	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
+	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile, bool query) override
 	{
 		if (pt.x != -1) {
 			switch (select_proc) {
 				case DDSP_DEMOLISH_AREA:
-					GUIPlaceProcDragXY(select_proc, start_tile, end_tile);
+					GUIPlaceProcDragXY(query, select_proc, start_tile, end_tile);
 					break;
 				case DDSP_CREATE_WATER:
 					if (_game_mode == GM_EDITOR) {
-						Command<Commands::BuildCanal>::Post(STR_ERROR_CAN_T_BUILD_CANALS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, _ctrl_pressed ? WaterClass::Sea : WaterClass::Canal, false);
+						Command<Commands::BuildCanal>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_CANALS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, _ctrl_pressed ? WaterClass::Sea : WaterClass::Canal, false);
 					} else {
-						Command<Commands::BuildCanal>::Post(STR_ERROR_CAN_T_BUILD_CANALS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, WaterClass::Canal, _ctrl_pressed);
+						Command<Commands::BuildCanal>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_CANALS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, WaterClass::Canal, _ctrl_pressed);
 					}
 					break;
 				case DDSP_CREATE_RIVER:
-					Command<Commands::BuildCanal>::Post(STR_ERROR_CAN_T_PLACE_RIVERS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, WaterClass::River, _ctrl_pressed);
+					Command<Commands::BuildCanal>::PostOrQuery(query, STR_ERROR_CAN_T_PLACE_RIVERS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, WaterClass::River, _ctrl_pressed);
 					break;
 
 				default: break;

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -219,7 +219,7 @@ struct BuildDocksToolbarWindow : Window {
 				bool adjacent = _ctrl_pressed;
 				auto proc = [=](bool test, StationID to_join) -> bool {
 					if (test) {
-						return Command<Commands::BuildDock>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildDock>()), tile, StationID::Invalid(), adjacent).Succeeded();
+						return Command<Commands::BuildDock>::Query(tile, StationID::Invalid(), adjacent).Succeeded();
 					} else {
 						return Command<Commands::BuildDock>::Post(STR_ERROR_CAN_T_BUILD_DOCK_HERE, CcBuildDocks, tile, to_join, adjacent);
 					}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -626,6 +626,39 @@ public:
 		MarkWholeScreenDirty();
 	}
 
+	/**
+	 * Get the bounds of an industry tile layout.
+	 * @param layout The industry tile layout.
+	 * @return The bounds.
+	 */
+	static Dimension GetIndustryLayoutSize(const IndustryTileLayout &layout)
+	{
+		int max_x = 0;
+		int max_y = 0;
+
+		/* Finds dimensions of largest variant of this industry */
+		for (const IndustryTileLayoutTile &it : layout) {
+			if (it.gfx == GFX_WATERTILE_SPECIALCHECK) continue; // watercheck tiles don't count for footprint size
+			if (it.ti.x > max_x) max_x = it.ti.x;
+			if (it.ti.y > max_y) max_y = it.ti.y;
+		}
+
+		return Dimension(max_x + 1, max_y + 1);
+	}
+
+	/**
+	 * Get the maximal bounds of the selected industry spec.
+	 * @return The maximal bounds.
+	 */
+	Dimension GetMaxIndustryLayoutSize() const
+	{
+		Dimension d{};
+		for (const auto &layout : GetIndustrySpec(this->selected_type)->layouts) {
+			d = maxdim(d, GetIndustryLayoutSize(layout));
+		}
+		return d;
+	}
+
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
@@ -668,6 +701,11 @@ public:
 
 					this->SetButtons();
 					if (this->enabled && click_count > 1) this->OnClick(pt, WID_DPI_FUND_WIDGET, 1);
+
+					if (_thd.GetCallbackWnd() == this) {
+						auto [x, y] = this->GetMaxIndustryLayoutSize();
+						SetTileSelectSize(x, y);
+					}
 				}
 				break;
 			}
@@ -683,6 +721,8 @@ public:
 						this->HandleButtonClick(WID_DPI_FUND_WIDGET);
 					} else {
 						HandlePlacePushButton(this, WID_DPI_FUND_WIDGET, SPR_CURSOR_INDUSTRY, HT_RECT);
+						auto [x, y] = this->GetMaxIndustryLayoutSize();
+						SetTileSelectSize(x, y);
 					}
 				}
 				break;
@@ -696,7 +736,7 @@ public:
 		this->vscroll->SetCapacityFromWidget(this, WID_DPI_MATRIX_WIDGET);
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		bool success = true;
 		/* We do not need to protect ourselves against "Random Many Industries" in this mode */
@@ -706,7 +746,7 @@ public:
 
 		if (_game_mode == GM_EDITOR) {
 			/* Show error if no town exists at all */
-			if (Town::GetNumItems() == 0) {
+			if (!query && Town::GetNumItems() == 0) {
 				ShowErrorMessage(GetEncodedString(STR_ERROR_CAN_T_BUILD_HERE, indsp->name),
 					GetEncodedString(STR_ERROR_MUST_FOUND_TOWN_FIRST), WL_INFO, pt.x, pt.y);
 				return;
@@ -716,9 +756,9 @@ public:
 			AutoRestoreBackup backup_generating_world(_generating_world, true);
 			AutoRestoreBackup backup_ignore_industry_restritions(_ignore_industry_restrictions, true);
 
-			Command<Commands::BuildIndustry>::Post(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, tile, this->selected_type, layout_index, false, seed);
+			Command<Commands::BuildIndustry>::PostOrQuery(query, STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, tile, this->selected_type, layout_index, false, seed);
 		} else {
-			success = Command<Commands::BuildIndustry>::Post(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, tile, this->selected_type, layout_index, false, seed);
+			success = Command<Commands::BuildIndustry>::PostOrQuery(query, STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, tile, this->selected_type, layout_index, false, seed);
 		}
 
 		/* If an industry has been built, just reset the cursor and the system */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5083,6 +5083,7 @@ STR_ERROR_SCREENSHOT_FAILED                                     :Screenshot fail
 # Error message titles
 STR_ERROR_MESSAGE_CAPTION                                       :{YELLOW}Message
 STR_ERROR_MESSAGE_CAPTION_OTHER_COMPANY                         :{YELLOW}Message from {COMPANY}
+STR_ERROR_MESSAGE_OVERLAY                                       :{STRING} {RAW_STRING}
 
 # Generic construction errors
 STR_ERROR_OFF_EDGE_OF_MAP                                       :off edge of map

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -980,7 +980,7 @@ struct QueryStringWindow : public Window
 		}
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, [[maybe_unused]] bool query) override
 	{
 		switch (this->last_user_action) {
 			case WID_QS_MOVE: // Move name button

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -330,14 +330,14 @@ public:
 		}
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		const ObjectSpec *spec = ObjectClass::Get(_object_gui.sel_class)->GetSpec(_object_gui.sel_type);
 
 		if (spec->size == OBJECT_SIZE_1X1) {
-			VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_BUILD_OBJECT);
+			VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_BUILD_OBJECT);
 		} else {
-			Command<Commands::BuildObject>::Post(STR_ERROR_CAN_T_BUILD_OBJECT, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), _object_gui.sel_view);
+			Command<Commands::BuildObject>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_OBJECT, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), _object_gui.sel_view);
 		}
 	}
 
@@ -346,15 +346,16 @@ public:
 		VpSelectTilesWithMethod(pt.x, pt.y, select_method);
 	}
 
-	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, [[maybe_unused]] ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
+	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, [[maybe_unused]] ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile, bool query) override
 	{
 		if (pt.x == -1) return;
 
 		assert(select_proc == DDSP_BUILD_OBJECT);
 
 		const ObjectSpec *spec = ObjectClass::Get(_object_gui.sel_class)->GetSpec(_object_gui.sel_type);
-		Command<Commands::BuildObjectArea>::Post(STR_ERROR_CAN_T_BUILD_OBJECT, CcPlaySound_CONSTRUCTION_OTHER,
-			end_tile, start_tile, spec->Index(), _object_gui.sel_view, _ctrl_pressed);
+
+		Command<Commands::BuildObjectArea>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_OBJECT, CcPlaySound_CONSTRUCTION_OTHER,
+				end_tile, start_tile, spec->Index(), _object_gui.sel_view, _ctrl_pressed);
 	}
 
 	void OnPlaceObjectAbort() override

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1442,8 +1442,10 @@ public:
 		return ES_HANDLED;
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
+		if (query) return;
+
 		if (this->goto_type == OPOS_GOTO) {
 			const Order cmd = GetOrderCmdFromTile(this->vehicle, tile);
 			if (cmd.IsType(OT_NOTHING)) return;

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -75,7 +75,7 @@ struct StationPickerSelection {
 static StationPickerSelection _station_gui; ///< Settings of the station picker.
 
 
-static void HandleStationPlacement(TileIndex start, TileIndex end);
+static void HandleStationPlacement(bool query, TileIndex start, TileIndex end);
 static void ShowBuildTrainDepotPicker(Window *parent);
 static void ShowBuildWaypointPicker(Window *parent);
 static Window *ShowStationBuilder(Window *parent);
@@ -101,13 +101,19 @@ void CcPlaySound_CONSTRUCTION_RAIL(Commands, const CommandCost &result, TileInde
 	if (result.Succeeded() && _settings_client.sound.confirm) SndPlayTileFx(SND_20_CONSTRUCTION_RAIL, tile);
 }
 
-static void GenericPlaceRail(TileIndex tile, Track track)
+/**
+ * Place or remove rail on a tile.
+ * @param query Whether to only query the operation.
+ * @param tile The tile to operate on.
+ * @param track The track piece.
+ */
+static void GenericPlaceRail(bool query, TileIndex tile, Track track)
 {
 	if (_remove_button_clicked) {
-		Command<Commands::RemoveRail>::Post(STR_ERROR_CAN_T_REMOVE_RAILROAD_TRACK, CcPlaySound_CONSTRUCTION_RAIL,
+		Command<Commands::RemoveRail>::PostOrQuery(query, STR_ERROR_CAN_T_REMOVE_RAILROAD_TRACK, CcPlaySound_CONSTRUCTION_RAIL,
 				tile, track);
 	} else {
-		Command<Commands::BuildRail>::Post(STR_ERROR_CAN_T_BUILD_RAILROAD_TRACK, CcPlaySound_CONSTRUCTION_RAIL,
+		Command<Commands::BuildRail>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_RAILROAD_TRACK, CcPlaySound_CONSTRUCTION_RAIL,
 				tile, _cur_railtype, track, _settings_client.gui.auto_remove_signals);
 	}
 }
@@ -165,24 +171,25 @@ void CcRailDepot(Commands, const CommandCost &result, TileIndex tile, RailType, 
 
 /**
  * Place a rail waypoint.
+ * @param query Whether to only query the operation.
  * @param tile Position to start dragging a waypoint.
  */
-static void PlaceRail_Waypoint(TileIndex tile)
+static void PlaceRail_Waypoint(bool query, TileIndex tile)
 {
 	if (_remove_button_clicked) {
-		VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_REMOVE_STATION);
+		VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_REMOVE_STATION);
 		return;
 	}
 
 	Axis axis = GetAxisForNewRailWaypoint(tile);
 	if (IsValidAxis(axis)) {
 		/* Valid tile for waypoints */
-		VpStartPlaceSizing(tile, axis == AXIS_X ? VPM_X_LIMITED : VPM_Y_LIMITED, DDSP_BUILD_STATION);
+		VpStartPlaceSizing(query, tile, axis == AXIS_X ? VPM_X_LIMITED : VPM_Y_LIMITED, DDSP_BUILD_STATION);
 		VpSetPlaceSizingLimit(_settings_game.station.station_spread);
 	} else {
 		/* Tile where we can't build rail waypoints. This is always going to fail,
 		 * but provides the user with a proper error message. */
-		Command<Commands::BuildRailWaypoint>::Post(STR_ERROR_CAN_T_BUILD_RAIL_WAYPOINT , tile, AXIS_X, 1, 1, STAT_CLASS_WAYP, 0, StationID::Invalid(), false);
+		Command<Commands::BuildRailWaypoint>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_RAIL_WAYPOINT , tile, AXIS_X, 1, 1, STAT_CLASS_WAYP, 0, StationID::Invalid(), false);
 	}
 }
 
@@ -197,15 +204,16 @@ void CcStation(Commands, const CommandCost &result, TileIndex tile)
 
 /**
  * Place a rail station.
+ * @param query Whether to only query the operation.
  * @param tile Position to place or start dragging a station.
  */
-static void PlaceRail_Station(TileIndex tile)
+static void PlaceRail_Station(bool query, TileIndex tile)
 {
 	if (_remove_button_clicked) {
-		VpStartPlaceSizing(tile, VPM_X_AND_Y_LIMITED, DDSP_REMOVE_STATION);
+		VpStartPlaceSizing(query, tile, VPM_X_AND_Y_LIMITED, DDSP_REMOVE_STATION);
 		VpSetPlaceSizingLimit(-1);
 	} else if (_settings_client.gui.station_dragdrop) {
-		VpStartPlaceSizing(tile, VPM_X_AND_Y_LIMITED, DDSP_BUILD_STATION);
+		VpStartPlaceSizing(query, tile, VPM_X_AND_Y_LIMITED, DDSP_BUILD_STATION);
 		VpSetPlaceSizingLimit(_settings_game.station.station_spread);
 	} else {
 		int w = _settings_client.gui.station_numtracks;
@@ -217,6 +225,11 @@ static void PlaceRail_Station(TileIndex tile)
 		uint8_t numtracks = _settings_client.gui.station_numtracks;
 		uint8_t platlength = _settings_client.gui.station_platlength;
 		bool adjacent = _ctrl_pressed;
+
+		if (query) {
+			HandleSelectionQuery(STR_ERROR_CAN_T_BUILD_RAILROAD_STATION, Command<Commands::BuildRailStation>::Query(tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, StationID::Invalid(), adjacent));
+			return;
+		}
 
 		auto proc = [=](bool test, StationID to_join) -> bool {
 			if (test) {
@@ -232,10 +245,10 @@ static void PlaceRail_Station(TileIndex tile)
 
 /**
  * Build a new signal or edit/remove a present signal, use CmdBuildSingleSignal() or CmdRemoveSingleSignal() in rail_cmd.cpp
- *
+ * @param query Whether to only query the operation.
  * @param tile The tile where the signal will build or edit
  */
-static void GenericPlaceSignals(TileIndex tile)
+static void GenericPlaceSignals(bool query, TileIndex tile)
 {
 	TrackBits trackbits = TrackStatusToTrackBits(GetTileTrackStatus(tile, TRANSPORT_RAIL, 0));
 
@@ -250,7 +263,7 @@ static void GenericPlaceSignals(TileIndex tile)
 	Track track = FindFirstTrack(trackbits);
 
 	if (_remove_button_clicked) {
-		Command<Commands::RemoveSignal>::Post(STR_ERROR_CAN_T_REMOVE_SIGNALS_FROM, CcPlaySound_CONSTRUCTION_RAIL, tile, track);
+		Command<Commands::RemoveSignal>::PostOrQuery(query, STR_ERROR_CAN_T_REMOVE_SIGNALS_FROM, CcPlaySound_CONSTRUCTION_RAIL, tile, track);
 	} else {
 		/* Which signals should we cycle through? */
 		bool tile_has_signal = IsPlainRailTile(tile) && IsValidTrack(track) && HasSignalOnTrack(tile, track);
@@ -277,11 +290,11 @@ static void GenericPlaceSignals(TileIndex tile)
 
 		if (FindWindowById(WC_BUILD_SIGNAL, 0) != nullptr) {
 			/* signal GUI is used */
-			Command<Commands::BuildSignal>::Post(_convert_signal_button ? STR_ERROR_SIGNAL_CAN_T_CONVERT_SIGNALS_HERE : STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
+			Command<Commands::BuildSignal>::PostOrQuery(query, _convert_signal_button ? STR_ERROR_SIGNAL_CAN_T_CONVERT_SIGNALS_HERE : STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
 				tile, track, _cur_signal_type, _cur_signal_variant, _convert_signal_button, false, _ctrl_pressed, cycle_start, cycle_end, 0, 0);
 		} else {
 			SignalVariant sigvar = TimerGameCalendar::year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC;
-			Command<Commands::BuildSignal>::Post(STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
+			Command<Commands::BuildSignal>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
 				tile, track, _settings_client.gui.default_signal_type, sigvar, false, false, _ctrl_pressed, cycle_start, cycle_end, 0, 0);
 
 		}
@@ -290,17 +303,18 @@ static void GenericPlaceSignals(TileIndex tile)
 
 /**
  * Start placing a rail bridge.
+ * @param query Whether to only query the operation.
  * @param tile Position of the first tile of the bridge.
  * @param w    Rail toolbar window.
  */
-static void PlaceRail_Bridge(TileIndex tile, Window *w)
+static void PlaceRail_Bridge(bool query, TileIndex tile, Window *w)
 {
 	if (IsBridgeTile(tile)) {
 		TileIndex other_tile = GetOtherTunnelBridgeEnd(tile);
 		Point pt = {0, 0};
-		w->OnPlaceMouseUp(VPM_X_OR_Y, DDSP_BUILD_BRIDGE, pt, other_tile, tile);
+		if (!query) w->OnPlaceMouseUp(VPM_X_OR_Y, DDSP_BUILD_BRIDGE, pt, other_tile, tile, query);
 	} else {
-		VpStartPlaceSizing(tile, VPM_X_OR_Y, DDSP_BUILD_BRIDGE);
+		VpStartPlaceSizing(query, tile, VPM_X_OR_Y, DDSP_BUILD_BRIDGE);
 	}
 }
 
@@ -387,27 +401,36 @@ static void BuildRailClick_Remove(Window *w)
 	}
 }
 
-static void DoRailroadTrack(Track track)
+/**
+ * Build or remove rail track.
+ * @param query Whether to only query the operation.
+ * @param track Track to build or remove.
+ */
+static void DoRailroadTrack(bool query, Track track)
 {
 	if (_remove_button_clicked) {
-		Command<Commands::RemoveRailLong>::Post(STR_ERROR_CAN_T_REMOVE_RAILROAD_TRACK, CcPlaySound_CONSTRUCTION_RAIL,
+		Command<Commands::RemoveRailLong>::PostOrQuery(query, STR_ERROR_CAN_T_REMOVE_RAILROAD_TRACK, CcPlaySound_CONSTRUCTION_RAIL,
 				TileVirtXY(_thd.selend.x, _thd.selend.y), TileVirtXY(_thd.selstart.x, _thd.selstart.y), track);
 	} else {
-		Command<Commands::BuildRailLong>::Post(STR_ERROR_CAN_T_BUILD_RAILROAD_TRACK, CcPlaySound_CONSTRUCTION_RAIL,
+		Command<Commands::BuildRailLong>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_RAILROAD_TRACK, CcPlaySound_CONSTRUCTION_RAIL,
 				TileVirtXY(_thd.selend.x, _thd.selend.y), TileVirtXY(_thd.selstart.x, _thd.selstart.y),  _cur_railtype, track, _settings_client.gui.auto_remove_signals, false);
 	}
 }
 
-static void HandleAutodirPlacement()
+/**
+ * Handle drag-and-drop rail operations.
+ * @param query Whether to only query the operation.
+ */
+static void HandleAutodirPlacement(bool query)
 {
 	Track trackstat = static_cast<Track>( _thd.drawstyle & HT_DIR_MASK); // 0..5
 
 	if (_thd.drawstyle & HT_RAIL) { // one tile case
-		GenericPlaceRail(TileVirtXY(_thd.selend.x, _thd.selend.y), trackstat);
+		GenericPlaceRail(query, TileVirtXY(_thd.selend.x, _thd.selend.y), trackstat);
 		return;
 	}
 
-	DoRailroadTrack(trackstat);
+	DoRailroadTrack(query, trackstat);
 }
 
 /**
@@ -415,26 +438,27 @@ static void HandleAutodirPlacement()
  *
  * If one tile marked abort and use GenericPlaceSignals()
  * else use CmdBuildSingleSignal() or CmdRemoveSingleSignal() in rail_cmd.cpp to build many signals
+ * @param query Whether to only query the operation.
  */
-static void HandleAutoSignalPlacement()
+static void HandleAutoSignalPlacement(bool query)
 {
 	Track track = (Track)GB(_thd.drawstyle, 0, 3); // 0..5
 
 	if ((_thd.drawstyle & HT_DRAG_MASK) == HT_RECT) { // one tile case
-		GenericPlaceSignals(TileVirtXY(_thd.selend.x, _thd.selend.y));
+		GenericPlaceSignals(query, TileVirtXY(_thd.selend.x, _thd.selend.y));
 		return;
 	}
 
 	/* _settings_client.gui.drag_signals_density is given as a parameter such that each user
 	 * in a network game can specify their own signal density */
 	if (_remove_button_clicked) {
-		Command<Commands::RemoveSignalLong>::Post(STR_ERROR_CAN_T_REMOVE_SIGNALS_FROM, CcPlaySound_CONSTRUCTION_RAIL,
+		Command<Commands::RemoveSignalLong>::PostOrQuery(query, STR_ERROR_CAN_T_REMOVE_SIGNALS_FROM, CcPlaySound_CONSTRUCTION_RAIL,
 				TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y), track, _ctrl_pressed);
 	} else {
 		bool sig_gui = FindWindowById(WC_BUILD_SIGNAL, 0) != nullptr;
 		SignalType sigtype = sig_gui ? _cur_signal_type : _settings_client.gui.default_signal_type;
 		SignalVariant sigvar = sig_gui ? _cur_signal_variant : (TimerGameCalendar::year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC);
-		Command<Commands::BuildSignalLong>::Post(STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
+		Command<Commands::BuildSignalLong>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
 				TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y), track, sigtype, sigvar, false, _ctrl_pressed, !_settings_client.gui.drag_signals_fixed_distance, _settings_client.gui.drag_signals_density);
 	}
 }
@@ -674,59 +698,59 @@ struct BuildRailToolbarWindow : Window {
 		return Window::OnHotkey(hotkey);
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		switch (this->last_user_action) {
 			case WID_RAT_BUILD_NS:
-				VpStartPlaceSizing(tile, VPM_FIX_VERTICAL | VPM_RAILDIRS, DDSP_PLACE_RAIL);
+				VpStartPlaceSizing(query, tile, VPM_FIX_VERTICAL | VPM_RAILDIRS, DDSP_PLACE_RAIL);
 				break;
 
 			case WID_RAT_BUILD_X:
-				VpStartPlaceSizing(tile, VPM_FIX_Y | VPM_RAILDIRS, DDSP_PLACE_RAIL);
+				VpStartPlaceSizing(query, tile, VPM_FIX_Y | VPM_RAILDIRS, DDSP_PLACE_RAIL);
 				break;
 
 			case WID_RAT_BUILD_EW:
-				VpStartPlaceSizing(tile, VPM_FIX_HORIZONTAL | VPM_RAILDIRS, DDSP_PLACE_RAIL);
+				VpStartPlaceSizing(query, tile, VPM_FIX_HORIZONTAL | VPM_RAILDIRS, DDSP_PLACE_RAIL);
 				break;
 
 			case WID_RAT_BUILD_Y:
-				VpStartPlaceSizing(tile, VPM_FIX_X | VPM_RAILDIRS, DDSP_PLACE_RAIL);
+				VpStartPlaceSizing(query, tile, VPM_FIX_X | VPM_RAILDIRS, DDSP_PLACE_RAIL);
 				break;
 
 			case WID_RAT_AUTORAIL:
-				VpStartPlaceSizing(tile, VPM_RAILDIRS, DDSP_PLACE_RAIL);
+				VpStartPlaceSizing(query, tile, VPM_RAILDIRS, DDSP_PLACE_RAIL);
 				break;
 
 			case WID_RAT_DEMOLISH:
-				PlaceProc_DemolishArea(tile);
+				PlaceProc_DemolishArea(query, tile);
 				break;
 
 			case WID_RAT_BUILD_DEPOT:
-				Command<Commands::BuildRailDepot>::Post(STR_ERROR_CAN_T_BUILD_TRAIN_DEPOT, CcRailDepot, tile, _cur_railtype, _build_depot_direction);
+				Command<Commands::BuildRailDepot>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_TRAIN_DEPOT, CcRailDepot, tile, _cur_railtype, _build_depot_direction);
 				break;
 
 			case WID_RAT_BUILD_WAYPOINT:
-				PlaceRail_Waypoint(tile);
+				PlaceRail_Waypoint(query, tile);
 				break;
 
 			case WID_RAT_BUILD_STATION:
-				PlaceRail_Station(tile);
+				PlaceRail_Station(query, tile);
 				break;
 
 			case WID_RAT_BUILD_SIGNALS:
-				VpStartPlaceSizing(tile, VPM_SIGNALDIRS, DDSP_BUILD_SIGNALS);
+				VpStartPlaceSizing(query, tile, VPM_SIGNALDIRS, DDSP_BUILD_SIGNALS);
 				break;
 
 			case WID_RAT_BUILD_BRIDGE:
-				PlaceRail_Bridge(tile, this);
+				PlaceRail_Bridge(query, tile, this);
 				break;
 
 			case WID_RAT_BUILD_TUNNEL:
-				Command<Commands::BuildTunnel>::Post(STR_ERROR_CAN_T_BUILD_TUNNEL_HERE, CcBuildRailTunnel, tile, TRANSPORT_RAIL, _cur_railtype);
+				Command<Commands::BuildTunnel>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_TUNNEL_HERE, CcBuildRailTunnel, tile, TRANSPORT_RAIL, _cur_railtype);
 				break;
 
 			case WID_RAT_CONVERT_RAIL:
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CONVERT_RAIL);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_CONVERT_RAIL);
 				break;
 
 			default: NOT_REACHED();
@@ -746,30 +770,31 @@ struct BuildRailToolbarWindow : Window {
 		return AlignInitialConstructionToolbar(sm_width);
 	}
 
-	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
+	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile, bool query) override
 	{
 		if (pt.x != -1) {
 			switch (select_proc) {
 				default: NOT_REACHED();
 				case DDSP_BUILD_BRIDGE:
+					if (query) return;
 					if (!_settings_client.gui.persistent_buildingtools) ResetObjectToPlace();
 					ShowBuildBridgeWindow(start_tile, end_tile, TRANSPORT_RAIL, _cur_railtype);
 					break;
 
 				case DDSP_PLACE_RAIL:
-					HandleAutodirPlacement();
+					HandleAutodirPlacement(query);
 					break;
 
 				case DDSP_BUILD_SIGNALS:
-					HandleAutoSignalPlacement();
+					HandleAutoSignalPlacement(query);
 					break;
 
 				case DDSP_DEMOLISH_AREA:
-					GUIPlaceProcDragXY(select_proc, start_tile, end_tile);
+					GUIPlaceProcDragXY(query, select_proc, start_tile, end_tile);
 					break;
 
 				case DDSP_CONVERT_RAIL:
-					Command<Commands::ConvertRail>::Post(STR_ERROR_CAN_T_CONVERT_RAIL, CcPlaySound_CONSTRUCTION_RAIL, end_tile, start_tile, _cur_railtype, _ctrl_pressed);
+					Command<Commands::ConvertRail>::PostOrQuery(query, STR_ERROR_CAN_T_CONVERT_RAIL, CcPlaySound_CONSTRUCTION_RAIL, end_tile, start_tile, _cur_railtype, _ctrl_pressed);
 					break;
 
 				case DDSP_REMOVE_STATION:
@@ -778,19 +803,24 @@ struct BuildRailToolbarWindow : Window {
 						/* Station */
 						if (_remove_button_clicked) {
 							bool keep_rail = !_ctrl_pressed;
-							Command<Commands::RemoveFromRailStation>::Post(STR_ERROR_CAN_T_REMOVE_PART_OF_STATION, CcPlaySound_CONSTRUCTION_RAIL, end_tile, start_tile, keep_rail);
+							Command<Commands::RemoveFromRailStation>::PostOrQuery(query, STR_ERROR_CAN_T_REMOVE_PART_OF_STATION, CcPlaySound_CONSTRUCTION_RAIL, end_tile, start_tile, keep_rail);
 						} else {
-							HandleStationPlacement(start_tile, end_tile);
+							HandleStationPlacement(query, start_tile, end_tile);
 						}
 					} else {
 						/* Waypoint */
 						if (_remove_button_clicked) {
 							bool keep_rail = !_ctrl_pressed;
-							Command<Commands::RemoveFromRailWaypoint>::Post(STR_ERROR_CAN_T_REMOVE_RAIL_WAYPOINT , CcPlaySound_CONSTRUCTION_RAIL, end_tile, start_tile, keep_rail);
+							Command<Commands::RemoveFromRailWaypoint>::PostOrQuery(query, STR_ERROR_CAN_T_REMOVE_RAIL_WAYPOINT , CcPlaySound_CONSTRUCTION_RAIL, end_tile, start_tile, keep_rail);
 						} else {
 							TileArea ta(start_tile, end_tile);
 							Axis axis = select_method == VPM_X_LIMITED ? AXIS_X : AXIS_Y;
 							bool adjacent = _ctrl_pressed;
+
+							if (query) {
+								HandleSelectionQuery(STR_ERROR_CAN_T_BUILD_RAIL_WAYPOINT, Command<Commands::BuildRailWaypoint>::Query(ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, StationID::Invalid(), adjacent));
+								return;
+							}
 
 							auto proc = [=](bool test, StationID to_join) -> bool {
 								if (test) {
@@ -970,10 +1000,13 @@ Window *ShowBuildRailToolbar(RailType railtype)
 	return new BuildRailToolbarWindow(_build_rail_desc, railtype);
 }
 
-/* TODO: For custom stations, respect their allowed platforms/lengths bitmasks!
- * --pasky */
-
-static void HandleStationPlacement(TileIndex start, TileIndex end)
+/**
+ * Handle station placement operation.
+ * @param query Whether to only query the operation.
+ * @param start First tile of operation.
+ * @param end Last tile of operation.
+ */
+static void HandleStationPlacement(bool query, TileIndex start, TileIndex end)
 {
 	TileArea ta(start, end);
 	uint numtracks = ta.w;
@@ -984,6 +1017,11 @@ static void HandleStationPlacement(TileIndex start, TileIndex end)
 	StationPickerSelection params = _station_gui;
 	RailType rt = _cur_railtype;
 	bool adjacent = _ctrl_pressed;
+
+	if (query) {
+		HandleSelectionQuery(STR_ERROR_CAN_T_BUILD_RAILROAD_STATION, Command<Commands::BuildRailStation>::Query(ta.tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, StationID::Invalid(), adjacent));
+		return;
+	}
 
 	auto proc = [=](bool test, StationID to_join) -> bool {
 		if (test) {

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -220,7 +220,7 @@ static void PlaceRail_Station(TileIndex tile)
 
 		auto proc = [=](bool test, StationID to_join) -> bool {
 			if (test) {
-				return Command<Commands::BuildRailStation>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildRailStation>()), tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, StationID::Invalid(), adjacent).Succeeded();
+				return Command<Commands::BuildRailStation>::Query(tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, StationID::Invalid(), adjacent).Succeeded();
 			} else {
 				return Command<Commands::BuildRailStation>::Post(STR_ERROR_CAN_T_BUILD_RAILROAD_STATION, CcStation, tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, to_join, adjacent);
 			}
@@ -794,7 +794,7 @@ struct BuildRailToolbarWindow : Window {
 
 							auto proc = [=](bool test, StationID to_join) -> bool {
 								if (test) {
-									return Command<Commands::BuildRailWaypoint>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildRailWaypoint>()), ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, StationID::Invalid(), adjacent).Succeeded();
+									return Command<Commands::BuildRailWaypoint>::Query(ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, StationID::Invalid(), adjacent).Succeeded();
 								} else {
 									return Command<Commands::BuildRailWaypoint>::Post(STR_ERROR_CAN_T_BUILD_RAIL_WAYPOINT , CcPlaySound_CONSTRUCTION_RAIL, ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, to_join, adjacent);
 								}
@@ -987,7 +987,7 @@ static void HandleStationPlacement(TileIndex start, TileIndex end)
 
 	auto proc = [=](bool test, StationID to_join) -> bool {
 		if (test) {
-			return Command<Commands::BuildRailStation>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildRailStation>()), ta.tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, StationID::Invalid(), adjacent).Succeeded();
+			return Command<Commands::BuildRailStation>::Query(ta.tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, StationID::Invalid(), adjacent).Succeeded();
 		} else {
 			return Command<Commands::BuildRailStation>::Post(STR_ERROR_CAN_T_BUILD_RAILROAD_STATION, CcStation, ta.tile, rt, params.axis, numtracks, platlength, params.sel_class, params.sel_type, to_join, adjacent);
 		}

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -122,17 +122,18 @@ void CcPlaySound_CONSTRUCTION_OTHER(Commands, const CommandCost &result, TileInd
 
 /**
  * Callback to start placing a bridge.
+ * @param query Whether to only query the operation.
  * @param tile Start tile of the bridge.
  * @param w The window to call back to when overbuilding a bridge.
  */
-static void PlaceRoad_Bridge(TileIndex tile, Window *w)
+static void PlaceRoad_Bridge(bool query, TileIndex tile, Window *w)
 {
 	if (IsBridgeTile(tile)) {
 		TileIndex other_tile = GetOtherTunnelBridgeEnd(tile);
 		Point pt = {0, 0};
-		w->OnPlaceMouseUp(VPM_X_OR_Y, DDSP_BUILD_BRIDGE, pt, other_tile, tile);
+		if (!query) w->OnPlaceMouseUp(VPM_X_OR_Y, DDSP_BUILD_BRIDGE, pt, other_tile, tile, query);
 	} else {
-		VpStartPlaceSizing(tile, VPM_X_OR_Y, DDSP_BUILD_BRIDGE);
+		VpStartPlaceSizing(query, tile, VPM_X_OR_Y, DDSP_BUILD_BRIDGE);
 	}
 }
 
@@ -222,6 +223,7 @@ void CcRoadStop(Commands, const CommandCost &result, TileIndex tile, uint8_t wid
 
 /**
  * Place a new road stop.
+ * @param query Whether to only query the operation.
  * @param start_tile First tile of the area.
  * @param end_tile Last tile of the area.
  * @param stop_type Type of stop (bus/truck).
@@ -230,7 +232,7 @@ void CcRoadStop(Commands, const CommandCost &result, TileIndex tile, uint8_t wid
  * @param err_msg Error message to show.
  * @see CcRoadStop()
  */
-static void PlaceRoadStop(TileIndex start_tile, TileIndex end_tile, RoadStopType stop_type, bool adjacent, RoadType rt, StringID err_msg)
+static void PlaceRoadStop(bool query, TileIndex start_tile, TileIndex end_tile, RoadStopType stop_type, bool adjacent, RoadType rt, StringID err_msg)
 {
 	TileArea ta(start_tile, end_tile);
 	DiagDirection ddir = _roadstop_gui.orientation;
@@ -238,6 +240,12 @@ static void PlaceRoadStop(TileIndex start_tile, TileIndex end_tile, RoadStopType
 	if (drive_through) ddir = static_cast<DiagDirection>(ddir - DIAGDIR_END); // Adjust picker result to actual direction.
 	RoadStopClassID spec_class = _roadstop_gui.sel_class;
 	uint16_t spec_index = _roadstop_gui.sel_type;
+
+	if (query) {
+		HandleSelectionQuery(err_msg, Command<Commands::BuildRoadStop>::Query(ta.tile, ta.w, ta.h, stop_type, drive_through,
+				ddir, rt, spec_class, spec_index, StationID::Invalid(), adjacent));
+		return;
+	}
 
 	auto proc = [=](bool test, StationID to_join) -> bool {
 		if (test) {
@@ -254,40 +262,42 @@ static void PlaceRoadStop(TileIndex start_tile, TileIndex end_tile, RoadStopType
 
 /**
  * Place a road waypoint.
+ * @param query Whether to only query the operation.
  * @param tile Position to start dragging a waypoint.
  */
-static void PlaceRoad_Waypoint(TileIndex tile)
+static void PlaceRoad_Waypoint(bool query, TileIndex tile)
 {
 	if (_remove_button_clicked) {
-		VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_REMOVE_ROAD_WAYPOINT);
+		VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_REMOVE_ROAD_WAYPOINT);
 		return;
 	}
 
 	Axis axis = GetAxisForNewRoadWaypoint(tile);
 	if (IsValidAxis(axis)) {
 		/* Valid tile for waypoints */
-		VpStartPlaceSizing(tile, axis == AXIS_X ? VPM_X_LIMITED : VPM_Y_LIMITED, DDSP_BUILD_ROAD_WAYPOINT);
+		VpStartPlaceSizing(query, tile, axis == AXIS_X ? VPM_X_LIMITED : VPM_Y_LIMITED, DDSP_BUILD_ROAD_WAYPOINT);
 		VpSetPlaceSizingLimit(_settings_game.station.station_spread);
 	} else {
 		/* Tile where we can't build road waypoints. This is always going to fail,
 		 * but provides the user with a proper error message. */
-		Command<Commands::BuildRoadWaypoint>::Post(STR_ERROR_CAN_T_BUILD_ROAD_WAYPOINT, tile, AXIS_X, 1, 1, ROADSTOP_CLASS_WAYP, 0, StationID::Invalid(), false);
+		Command<Commands::BuildRoadWaypoint>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_ROAD_WAYPOINT, tile, AXIS_X, 1, 1, ROADSTOP_CLASS_WAYP, 0, StationID::Invalid(), false);
 	}
 }
 
 /**
  * Callback for placing a bus station.
+ * @param query Whether to only query the operation.
  * @param tile Position to place the station.
  */
-static void PlaceRoad_BusStation(TileIndex tile)
+static void PlaceRoad_BusStation(bool query, TileIndex tile)
 {
 	if (_remove_button_clicked) {
-		VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_REMOVE_BUSSTOP);
+		VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_REMOVE_BUSSTOP);
 	} else {
 		if (_roadstop_gui.orientation < DIAGDIR_END) { // Not a drive-through stop.
-			VpStartPlaceSizing(tile, (DiagDirToAxis(_roadstop_gui.orientation) == AXIS_X) ? VPM_X_LIMITED : VPM_Y_LIMITED, DDSP_BUILD_BUSSTOP);
+			VpStartPlaceSizing(query, tile, (DiagDirToAxis(_roadstop_gui.orientation) == AXIS_X) ? VPM_X_LIMITED : VPM_Y_LIMITED, DDSP_BUILD_BUSSTOP);
 		} else {
-			VpStartPlaceSizing(tile, VPM_X_AND_Y_LIMITED, DDSP_BUILD_BUSSTOP);
+			VpStartPlaceSizing(query, tile, VPM_X_AND_Y_LIMITED, DDSP_BUILD_BUSSTOP);
 		}
 		VpSetPlaceSizingLimit(_settings_game.station.station_spread);
 	}
@@ -295,17 +305,18 @@ static void PlaceRoad_BusStation(TileIndex tile)
 
 /**
  * Callback for placing a truck station.
+ * @param query Whether to only query the operation.
  * @param tile Position to place the station.
  */
-static void PlaceRoad_TruckStation(TileIndex tile)
+static void PlaceRoad_TruckStation(bool query, TileIndex tile)
 {
 	if (_remove_button_clicked) {
-		VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_REMOVE_TRUCKSTOP);
+		VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_REMOVE_TRUCKSTOP);
 	} else {
 		if (_roadstop_gui.orientation < DIAGDIR_END) { // Not a drive-through stop.
-			VpStartPlaceSizing(tile, (DiagDirToAxis(_roadstop_gui.orientation) == AXIS_X) ? VPM_X_LIMITED : VPM_Y_LIMITED, DDSP_BUILD_TRUCKSTOP);
+			VpStartPlaceSizing(query, tile, (DiagDirToAxis(_roadstop_gui.orientation) == AXIS_X) ? VPM_X_LIMITED : VPM_Y_LIMITED, DDSP_BUILD_TRUCKSTOP);
 		} else {
-			VpStartPlaceSizing(tile, VPM_X_AND_Y_LIMITED, DDSP_BUILD_TRUCKSTOP);
+			VpStartPlaceSizing(query, tile, VPM_X_AND_Y_LIMITED, DDSP_BUILD_TRUCKSTOP);
 		}
 		VpSetPlaceSizingLimit(_settings_game.station.station_spread);
 	}
@@ -646,7 +657,7 @@ struct BuildRoadToolbarWindow : Window {
 		return Window::OnHotkey(hotkey);
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		_remove_button_clicked = this->IsWidgetLowered(WID_ROT_REMOVE);
 		_one_way_button_clicked = RoadTypeIsRoad(this->roadtype) ? this->IsWidgetLowered(WID_ROT_ONE_WAY) : false;
@@ -654,54 +665,54 @@ struct BuildRoadToolbarWindow : Window {
 			case WID_ROT_ROAD_X:
 				_place_road_dir = AXIS_X;
 				_place_road_start_half_x = _tile_fract_coords.x >= 8;
-				VpStartPlaceSizing(tile, VPM_FIX_Y, DDSP_PLACE_ROAD_X_DIR);
+				VpStartPlaceSizing(query, tile, VPM_FIX_Y, DDSP_PLACE_ROAD_X_DIR);
 				break;
 
 			case WID_ROT_ROAD_Y:
 				_place_road_dir = AXIS_Y;
 				_place_road_start_half_y = _tile_fract_coords.y >= 8;
-				VpStartPlaceSizing(tile, VPM_FIX_X, DDSP_PLACE_ROAD_Y_DIR);
+				VpStartPlaceSizing(query, tile, VPM_FIX_X, DDSP_PLACE_ROAD_Y_DIR);
 				break;
 
 			case WID_ROT_AUTOROAD:
 				_place_road_dir = INVALID_AXIS;
 				_place_road_start_half_x = _tile_fract_coords.x >= 8;
 				_place_road_start_half_y = _tile_fract_coords.y >= 8;
-				VpStartPlaceSizing(tile, VPM_X_OR_Y, DDSP_PLACE_AUTOROAD);
+				VpStartPlaceSizing(query, tile, VPM_X_OR_Y, DDSP_PLACE_AUTOROAD);
 				break;
 
 			case WID_ROT_DEMOLISH:
-				PlaceProc_DemolishArea(tile);
+				PlaceProc_DemolishArea(query, tile);
 				break;
 
 			case WID_ROT_DEPOT:
-				Command<Commands::BuildRoadDepot>::Post(GetRoadTypeInfo(this->roadtype)->strings.err_depot, CcRoadDepot,
+				Command<Commands::BuildRoadDepot>::PostOrQuery(query, GetRoadTypeInfo(this->roadtype)->strings.err_depot, CcRoadDepot,
 						tile, _cur_roadtype, _road_depot_orientation);
 				break;
 
 			case WID_ROT_BUILD_WAYPOINT:
-				PlaceRoad_Waypoint(tile);
+				PlaceRoad_Waypoint(query, tile);
 				break;
 
 			case WID_ROT_BUS_STATION:
-				PlaceRoad_BusStation(tile);
+				PlaceRoad_BusStation(query, tile);
 				break;
 
 			case WID_ROT_TRUCK_STATION:
-				PlaceRoad_TruckStation(tile);
+				PlaceRoad_TruckStation(query, tile);
 				break;
 
 			case WID_ROT_BUILD_BRIDGE:
-				PlaceRoad_Bridge(tile, this);
+				PlaceRoad_Bridge(query, tile, this);
 				break;
 
 			case WID_ROT_BUILD_TUNNEL:
-				Command<Commands::BuildTunnel>::Post(STR_ERROR_CAN_T_BUILD_TUNNEL_HERE, CcBuildRoadTunnel,
+				Command<Commands::BuildTunnel>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_TUNNEL_HERE, CcBuildRoadTunnel,
 						tile, TRANSPORT_ROAD, _cur_roadtype);
 				break;
 
 			case WID_ROT_CONVERT_ROAD:
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CONVERT_ROAD);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_CONVERT_ROAD);
 				break;
 
 			default: NOT_REACHED();
@@ -729,12 +740,15 @@ struct BuildRoadToolbarWindow : Window {
 		CloseWindowByClass(WC_BUILD_BRIDGE);
 	}
 
-	void OnPlaceDrag(ViewportPlaceMethod select_method, [[maybe_unused]] ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt) override
+	/**
+	 * Update flags for road placement actions.
+	 * @param select_proc What should be created.
+	 * @param pt The exact point on the map where the mouse was released.
+	 */
+	static void UpdateEndTileFlags(ViewportDragDropSelectionProcess select_proc, Point pt)
 	{
-		/* Here we update the end tile flags
-		 * of the road placement actions.
-		 * At first we reset the end halfroad
-		 * bits and if needed we set them again. */
+		/* Here we update the end tile flags of the road placement actions.
+		 * At first we reset the end halfroad bits and if needed we set them again. */
 		switch (select_proc) {
 			case DDSP_PLACE_ROAD_X_DIR:
 				_place_road_end_half = pt.x & 8;
@@ -764,6 +778,11 @@ struct BuildRoadToolbarWindow : Window {
 			default:
 				break;
 		}
+	}
+
+	void OnPlaceDrag(ViewportPlaceMethod select_method, [[maybe_unused]] ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt) override
+	{
+		this->UpdateEndTileFlags(select_proc, pt);
 
 		VpSelectTilesWithMethod(pt.x, pt.y, select_method);
 	}
@@ -773,30 +792,32 @@ struct BuildRoadToolbarWindow : Window {
 		return AlignInitialConstructionToolbar(sm_width);
 	}
 
-	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
+	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile, bool query) override
 	{
 		if (pt.x != -1) {
 			switch (select_proc) {
 				default: NOT_REACHED();
 				case DDSP_BUILD_BRIDGE:
+					if (query) break;
 					if (!_settings_client.gui.persistent_buildingtools) ResetObjectToPlace();
 					ShowBuildBridgeWindow(start_tile, end_tile, TRANSPORT_ROAD, _cur_roadtype);
 					break;
 
 				case DDSP_DEMOLISH_AREA:
-					GUIPlaceProcDragXY(select_proc, start_tile, end_tile);
+					GUIPlaceProcDragXY(query, select_proc, start_tile, end_tile);
 					break;
 
 				case DDSP_PLACE_ROAD_X_DIR:
 				case DDSP_PLACE_ROAD_Y_DIR:
 				case DDSP_PLACE_AUTOROAD: {
+					if (query) this->UpdateEndTileFlags(select_proc, pt);
 					bool start_half = _place_road_dir == AXIS_Y ? _place_road_start_half_y : _place_road_start_half_x;
 
 					if (_remove_button_clicked) {
-						Command<Commands::RemoveRoadLong>::Post(GetRoadTypeInfo(this->roadtype)->strings.err_remove_road, CcPlaySound_CONSTRUCTION_OTHER,
+						Command<Commands::RemoveRoadLong>::PostOrQuery(query, GetRoadTypeInfo(this->roadtype)->strings.err_remove_road, CcPlaySound_CONSTRUCTION_OTHER,
 								end_tile, start_tile, _cur_roadtype, _place_road_dir, start_half, _place_road_end_half);
 					} else {
-						Command<Commands::BuildRoadLong>::Post(GetRoadTypeInfo(this->roadtype)->strings.err_build_road, CcPlaySound_CONSTRUCTION_OTHER,
+						Command<Commands::BuildRoadLong>::PostOrQuery(query, GetRoadTypeInfo(this->roadtype)->strings.err_build_road, CcPlaySound_CONSTRUCTION_OTHER,
 								end_tile, start_tile, _cur_roadtype, _place_road_dir, _one_way_button_clicked ? DRD_NORTHBOUND : DRD_NONE, start_half, _place_road_end_half, false);
 					}
 					break;
@@ -806,11 +827,16 @@ struct BuildRoadToolbarWindow : Window {
 				case DDSP_REMOVE_ROAD_WAYPOINT:
 					if (this->IsWidgetLowered(WID_ROT_BUILD_WAYPOINT)) {
 						if (_remove_button_clicked) {
-							Command<Commands::RemoveFromRoadWaypoint>::Post(STR_ERROR_CAN_T_REMOVE_ROAD_WAYPOINT, CcPlaySound_CONSTRUCTION_OTHER, end_tile, start_tile);
+							Command<Commands::RemoveFromRoadWaypoint>::PostOrQuery(query, STR_ERROR_CAN_T_REMOVE_ROAD_WAYPOINT, CcPlaySound_CONSTRUCTION_OTHER, end_tile, start_tile);
 						} else {
 							TileArea ta(start_tile, end_tile);
 							Axis axis = select_method == VPM_X_LIMITED ? AXIS_X : AXIS_Y;
 							bool adjacent = _ctrl_pressed;
+
+							if (query) {
+								HandleSelectionQuery(STR_ERROR_CAN_T_BUILD_ROAD_WAYPOINT, Command<Commands::BuildRoadWaypoint>::Query(ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, StationID::Invalid(), adjacent));
+								return;
+							}
 
 							auto proc = [=](bool test, StationID to_join) -> bool {
 								if (test) {
@@ -831,10 +857,10 @@ struct BuildRoadToolbarWindow : Window {
 						if (_remove_button_clicked) {
 							TileArea ta(start_tile, end_tile);
 							StringID str = GetRoadTypeInfo(this->roadtype)->strings.err_remove_station[to_underlying(RoadStopType::Bus)];
-							Command<Commands::RemoveRoadStop>::Post(str, CcPlaySound_CONSTRUCTION_OTHER, ta.tile, ta.w, ta.h, RoadStopType::Bus, _ctrl_pressed);
+							Command<Commands::RemoveRoadStop>::PostOrQuery(query, str, CcPlaySound_CONSTRUCTION_OTHER, ta.tile, ta.w, ta.h, RoadStopType::Bus, _ctrl_pressed);
 						} else {
 							StringID str = GetRoadTypeInfo(this->roadtype)->strings.err_build_station[to_underlying(RoadStopType::Bus)];
-							PlaceRoadStop(start_tile, end_tile, RoadStopType::Bus, _ctrl_pressed, _cur_roadtype, str);
+							PlaceRoadStop(query, start_tile, end_tile, RoadStopType::Bus, _ctrl_pressed, _cur_roadtype, str);
 						}
 					}
 					break;
@@ -845,16 +871,16 @@ struct BuildRoadToolbarWindow : Window {
 						if (_remove_button_clicked) {
 							TileArea ta(start_tile, end_tile);
 							StringID str = GetRoadTypeInfo(this->roadtype)->strings.err_remove_station[to_underlying(RoadStopType::Truck)];
-							Command<Commands::RemoveRoadStop>::Post(str, CcPlaySound_CONSTRUCTION_OTHER, ta.tile, ta.w, ta.h, RoadStopType::Truck, _ctrl_pressed);
+							Command<Commands::RemoveRoadStop>::PostOrQuery(query, str, CcPlaySound_CONSTRUCTION_OTHER, ta.tile, ta.w, ta.h, RoadStopType::Truck, _ctrl_pressed);
 						} else {
 							StringID str = GetRoadTypeInfo(this->roadtype)->strings.err_build_station[to_underlying(RoadStopType::Truck)];
-							PlaceRoadStop(start_tile, end_tile, RoadStopType::Truck, _ctrl_pressed, _cur_roadtype, str);
+							PlaceRoadStop(query, start_tile, end_tile, RoadStopType::Truck, _ctrl_pressed, _cur_roadtype, str);
 						}
 					}
 					break;
 
 				case DDSP_CONVERT_ROAD:
-					Command<Commands::ConvertRoad>::Post(GetRoadTypeInfo(this->roadtype)->strings.err_convert_road, CcPlaySound_CONSTRUCTION_OTHER, end_tile, start_tile, _cur_roadtype, _ctrl_pressed);
+					Command<Commands::ConvertRoad>::PostOrQuery(query, GetRoadTypeInfo(this->roadtype)->strings.err_convert_road, CcPlaySound_CONSTRUCTION_OTHER, end_tile, start_tile, _cur_roadtype, _ctrl_pressed);
 					break;
 			}
 		}

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -241,7 +241,7 @@ static void PlaceRoadStop(TileIndex start_tile, TileIndex end_tile, RoadStopType
 
 	auto proc = [=](bool test, StationID to_join) -> bool {
 		if (test) {
-			return Command<Commands::BuildRoadStop>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildRoadStop>()), ta.tile, ta.w, ta.h, stop_type, drive_through,
+			return Command<Commands::BuildRoadStop>::Query(ta.tile, ta.w, ta.h, stop_type, drive_through,
 					ddir, rt, spec_class, spec_index, StationID::Invalid(), adjacent).Succeeded();
 		} else {
 			return Command<Commands::BuildRoadStop>::Post(err_msg, CcRoadStop, ta.tile, ta.w, ta.h, stop_type, drive_through,
@@ -814,7 +814,7 @@ struct BuildRoadToolbarWindow : Window {
 
 							auto proc = [=](bool test, StationID to_join) -> bool {
 								if (test) {
-									return Command<Commands::BuildRoadWaypoint>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildRoadWaypoint>()), ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, StationID::Invalid(), adjacent).Succeeded();
+									return Command<Commands::BuildRoadWaypoint>::Query(ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, StationID::Invalid(), adjacent).Succeeded();
 								} else {
 									return Command<Commands::BuildRoadWaypoint>::Post(STR_ERROR_CAN_T_BUILD_ROAD_WAYPOINT, CcPlaySound_CONSTRUCTION_OTHER, ta.tile, axis, ta.w, ta.h, _waypoint_gui.sel_class, _waypoint_gui.sel_type, to_join, adjacent);
 								}

--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -144,9 +144,11 @@ void CcPlaceSign(Commands, const CommandCost &result, SignID new_sign)
  *
  * PlaceProc function, called when someone pressed the button if the
  *  sign-tool is selected
+ * @param query Whether to only query the operation.
  * @param tile on which to place the sign
  */
-void PlaceProc_Sign(TileIndex tile)
+void PlaceProc_Sign(bool query, TileIndex tile)
 {
+	if (query) return;
 	Command<Commands::PlaceSign>::Post(STR_ERROR_CAN_T_PLACE_SIGN_HERE, CcPlaceSign, tile, {});
 }

--- a/src/signs_func.h
+++ b/src/signs_func.h
@@ -16,7 +16,7 @@
 struct Window;
 
 void UpdateAllSignVirtCoords();
-void PlaceProc_Sign(TileIndex tile);
+void PlaceProc_Sign(bool query, TileIndex tile);
 bool CompanyCanEditSign(const Sign *si);
 
 /* signs_gui.cpp */

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -565,7 +565,7 @@ struct SignWindow : Window, SignList {
 		}
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, [[maybe_unused]] bool query) override
 	{
 		switch (this->last_user_action) {
 			case WID_QES_MOVE: // Place sign button

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -891,8 +891,10 @@ public:
 		this->SetWidgetDirty(WID_SB_PAGE_PANEL);
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
+		if (query) return;
+
 		const StoryPageElement *const pe = StoryPageElement::GetIfValid(this->active_button_id);
 		if (pe == nullptr || pe->type != SPET_BUTTON_TILE) {
 			ResetObjectToPlace();

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -110,6 +110,7 @@ static void GenerateRockyArea(TileIndex end, TileIndex start)
 
 /**
  * A central place to handle all X_AND_Y dragged GUI functions.
+ * @param query Whether to only query the operation.
  * @param proc       Procedure related to the dragging
  * @param start_tile Begin of the dragging
  * @param end_tile   End of the dragging
@@ -117,7 +118,7 @@ static void GenerateRockyArea(TileIndex end, TileIndex start)
  * allows for additional implements that are more local. For example X_Y drag
  * of convertrail which belongs in rail_gui.cpp and not terraform_gui.cpp
  */
-bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_tile, TileIndex end_tile)
+bool GUIPlaceProcDragXY(bool query, ViewportDragDropSelectionProcess proc, TileIndex start_tile, TileIndex end_tile)
 {
 	if (!_settings_game.construction.freeform_edges) {
 		/* When end_tile is TileType::Void, the error tile will not be visible to the
@@ -128,22 +129,22 @@ bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_t
 
 	switch (proc) {
 		case DDSP_DEMOLISH_AREA:
-			Command<Commands::ClearArea>::Post(STR_ERROR_CAN_T_CLEAR_THIS_AREA, CcPlaySound_EXPLOSION, end_tile, start_tile, _ctrl_pressed);
+			Command<Commands::ClearArea>::PostOrQuery(query, STR_ERROR_CAN_T_CLEAR_THIS_AREA, CcPlaySound_EXPLOSION, end_tile, start_tile, _ctrl_pressed);
 			break;
 		case DDSP_RAISE_AND_LEVEL_AREA:
-			Command<Commands::LevelLand>::Post(STR_ERROR_CAN_T_RAISE_LAND_HERE, CcTerraform, end_tile, start_tile, _ctrl_pressed, LM_RAISE);
+			Command<Commands::LevelLand>::PostOrQuery(query, STR_ERROR_CAN_T_RAISE_LAND_HERE, CcTerraform, end_tile, start_tile, _ctrl_pressed, LM_RAISE);
 			break;
 		case DDSP_LOWER_AND_LEVEL_AREA:
-			Command<Commands::LevelLand>::Post(STR_ERROR_CAN_T_LOWER_LAND_HERE, CcTerraform, end_tile, start_tile, _ctrl_pressed, LM_LOWER);
+			Command<Commands::LevelLand>::PostOrQuery(query, STR_ERROR_CAN_T_LOWER_LAND_HERE, CcTerraform, end_tile, start_tile, _ctrl_pressed, LM_LOWER);
 			break;
 		case DDSP_LEVEL_AREA:
-			Command<Commands::LevelLand>::Post(STR_ERROR_CAN_T_LEVEL_LAND_HERE, CcTerraform, end_tile, start_tile, _ctrl_pressed, LM_LEVEL);
+			Command<Commands::LevelLand>::PostOrQuery(query, STR_ERROR_CAN_T_LEVEL_LAND_HERE, CcTerraform, end_tile, start_tile, _ctrl_pressed, LM_LEVEL);
 			break;
 		case DDSP_CREATE_ROCKS:
-			GenerateRockyArea(end_tile, start_tile);
+			if (!query) GenerateRockyArea(end_tile, start_tile);
 			break;
 		case DDSP_CREATE_DESERT:
-			GenerateDesertArea(end_tile, start_tile);
+			if (!query) GenerateDesertArea(end_tile, start_tile);
 			break;
 		default:
 			return false;
@@ -154,11 +155,12 @@ bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_t
 
 /**
  * Start a drag for demolishing an area.
+ * @param query Whether to only query the operation.
  * @param tile Position of one corner.
  */
-void PlaceProc_DemolishArea(TileIndex tile)
+void PlaceProc_DemolishArea(bool query, TileIndex tile)
 {
-	VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_DEMOLISH_AREA);
+	VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_DEMOLISH_AREA);
 }
 
 /** Terra form toolbar managing class. */
@@ -226,31 +228,31 @@ struct TerraformToolbarWindow : Window {
 		}
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		switch (this->last_user_action) {
 			case WID_TT_LOWER_LAND: // Lower land button
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_LOWER_AND_LEVEL_AREA);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_LOWER_AND_LEVEL_AREA);
 				break;
 
 			case WID_TT_RAISE_LAND: // Raise land button
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_RAISE_AND_LEVEL_AREA);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_RAISE_AND_LEVEL_AREA);
 				break;
 
 			case WID_TT_LEVEL_LAND: // Level land button
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_LEVEL_AREA);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_LEVEL_AREA);
 				break;
 
 			case WID_TT_DEMOLISH: // Demolish aka dynamite button
-				PlaceProc_DemolishArea(tile);
+				PlaceProc_DemolishArea(query, tile);
 				break;
 
 			case WID_TT_BUY_LAND: // Buy land button
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_BUILD_OBJECT);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_BUILD_OBJECT);
 				break;
 
 			case WID_TT_PLACE_SIGN: // Place sign button
-				PlaceProc_Sign(tile);
+				PlaceProc_Sign(query, tile);
 				break;
 
 			default: NOT_REACHED();
@@ -270,7 +272,7 @@ struct TerraformToolbarWindow : Window {
 		return pt;
 	}
 
-	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
+	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile, bool query) override
 	{
 		if (pt.x != -1) {
 			switch (select_proc) {
@@ -279,7 +281,7 @@ struct TerraformToolbarWindow : Window {
 				case DDSP_RAISE_AND_LEVEL_AREA:
 				case DDSP_LOWER_AND_LEVEL_AREA:
 				case DDSP_LEVEL_AREA:
-					GUIPlaceProcDragXY(select_proc, start_tile, end_tile);
+					GUIPlaceProcDragXY(query, select_proc, start_tile, end_tile);
 					break;
 				case DDSP_BUILD_OBJECT:
 					if (!_settings_game.construction.freeform_edges) {
@@ -288,8 +290,8 @@ struct TerraformToolbarWindow : Window {
 						if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
 						if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
 					}
-					Command<Commands::BuildObjectArea>::Post(STR_ERROR_CAN_T_PURCHASE_THIS_LAND, CcPlaySound_CONSTRUCTION_RAIL,
-						end_tile, start_tile, OBJECT_OWNED_LAND, 0, _ctrl_pressed);
+					Command<Commands::BuildObjectArea>::PostOrQuery(query, STR_ERROR_CAN_T_PURCHASE_THIS_LAND, CcPlaySound_CONSTRUCTION_RAIL,
+							end_tile, start_tile, OBJECT_OWNED_LAND, 0, _ctrl_pressed);
 					break;
 			}
 		}
@@ -652,31 +654,31 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 		}
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		switch (this->last_user_action) {
 			case WID_ETT_DEMOLISH: // Demolish aka dynamite button
-				PlaceProc_DemolishArea(tile);
+				PlaceProc_DemolishArea(query, tile);
 				break;
 
 			case WID_ETT_LOWER_LAND: // Lower land button
-				CommonRaiseLowerBigLand(tile, false);
+				if (!query) CommonRaiseLowerBigLand(tile, false);
 				break;
 
 			case WID_ETT_RAISE_LAND: // Raise land button
-				CommonRaiseLowerBigLand(tile, true);
+				if (!query) CommonRaiseLowerBigLand(tile, true);
 				break;
 
 			case WID_ETT_LEVEL_LAND: // Level land button
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_LEVEL_AREA);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_LEVEL_AREA);
 				break;
 
 			case WID_ETT_PLACE_ROCKS: // Place rocks button
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_ROCKS);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_CREATE_ROCKS);
 				break;
 
 			case WID_ETT_PLACE_DESERT: // Place desert button (in tropical climate)
-				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_DESERT);
+				VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_CREATE_DESERT);
 				break;
 
 			default: NOT_REACHED();
@@ -688,7 +690,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 		VpSelectTilesWithMethod(pt.x, pt.y, select_method);
 	}
 
-	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
+	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile, bool query) override
 	{
 		if (pt.x != -1) {
 			switch (select_proc) {
@@ -699,7 +701,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 				case DDSP_LOWER_AND_LEVEL_AREA:
 				case DDSP_LEVEL_AREA:
 				case DDSP_DEMOLISH_AREA:
-					GUIPlaceProcDragXY(select_proc, start_tile, end_tile);
+					GUIPlaceProcDragXY(query, select_proc, start_tile, end_tile);
 					break;
 			}
 		}

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -126,8 +126,8 @@ void DrawTextEffects(DrawPixelInfo *dpi)
 	for (const TextEffect &te : _text_effects) {
 		if (!te.IsValid()) continue;
 
-		if (te.mode == TE_RISING || _settings_client.gui.loading_indicators) {
-			std::string *str = ViewportAddString(dpi, &te, flags, INVALID_COLOUR);
+		if (te.mode == TE_RISING || te.mode == TE_ERROR || _settings_client.gui.loading_indicators) {
+			std::string *str = ViewportAddString(dpi, &te, te.mode == TE_ERROR ? flags | ViewportStringFlag::TextColour | ViewportStringFlag::TransparentRect : flags, te.mode == TE_ERROR ? COLOUR_RED : INVALID_COLOUR);
 			if (str == nullptr) continue;
 
 			*str = te.msg.GetDecodedString();

--- a/src/texteff.hpp
+++ b/src/texteff.hpp
@@ -21,6 +21,7 @@ enum TextEffectMode : uint8_t {
 	TE_INVALID, ///< Text effect is invalid.
 	TE_RISING, ///< Make the text effect slowly go upwards
 	TE_STATIC, ///< Keep the text effect static
+	TE_ERROR, ///< Error text effect.
 };
 
 using TextEffectID = uint16_t;

--- a/src/tilehighlight_func.h
+++ b/src/tilehighlight_func.h
@@ -13,8 +13,8 @@
 #include "gfx_type.h"
 #include "tilehighlight_type.h"
 
-void PlaceProc_DemolishArea(TileIndex tile);
-bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_tile, TileIndex end_tile);
+void PlaceProc_DemolishArea(bool query, TileIndex tile);
+bool GUIPlaceProcDragXY(bool query, ViewportDragDropSelectionProcess proc, TileIndex start_tile, TileIndex end_tile);
 
 bool HandlePlacePushButton(Window *w, WidgetID widget, CursorID cursor, HighLightStyle mode);
 void SetObjectToPlaceWnd(CursorID icon, PaletteID pal, HighLightStyle mode, Window *w);
@@ -23,7 +23,7 @@ void ResetObjectToPlace();
 
 void VpSelectTilesWithMethod(int x, int y, ViewportPlaceMethod method);
 void VpStartDragging(ViewportDragDropSelectionProcess process);
-void VpStartPlaceSizing(TileIndex tile, ViewportPlaceMethod method, ViewportDragDropSelectionProcess process);
+void VpStartPlaceSizing(bool query, TileIndex tile, ViewportPlaceMethod method, ViewportDragDropSelectionProcess process);
 void VpSetPresizeRange(TileIndex from, TileIndex to);
 void VpSetPlaceSizingLimit(int limit);
 

--- a/src/tilehighlight_type.h
+++ b/src/tilehighlight_type.h
@@ -11,6 +11,7 @@
 #define TILEHIGHLIGHT_TYPE_H
 
 #include "core/geometry_type.hpp"
+#include "texteff.hpp"
 #include "window_type.h"
 #include "tile_type.h"
 #include "viewport_type.h"
@@ -69,10 +70,13 @@ struct TileHighlightData {
 	WindowNumber window_number;    ///< The \c WindowNumber of the window that is responsible for the selection mode.
 
 	bool make_square_red;          ///< Whether to give a tile a red selection.
+	bool make_square_pulsate_red; ///< Whether to give a tile a pulsating red selection.
 	TileIndex redsq;               ///< The tile that has to get a red selection.
 
 	ViewportPlaceMethod select_method;            ///< The method which governs how tiles are selected.
 	ViewportDragDropSelectionProcess select_proc; ///< The procedure that has to be called when the selection is done.
+
+	TextEffectID error = INVALID_TE_ID; ///< TextEffectID of command error.
 
 	void Reset();
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2075,15 +2075,15 @@ struct MainToolbarWindow : Window {
 		return ES_HANDLED;
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		switch (_last_started_action) {
 			case CBF_PLACE_SIGN:
-				PlaceProc_Sign(tile);
+				PlaceProc_Sign(query, tile);
 				break;
 
 			case CBF_PLACE_LANDINFO:
-				ShowLandInfo(tile);
+				if (!query) ShowLandInfo(tile);
 				break;
 
 			default: NOT_REACHED();
@@ -2426,15 +2426,15 @@ struct ScenarioEditorToolbarWindow : Window {
 		return ES_HANDLED;
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		switch (_last_started_action) {
 			case CBF_PLACE_SIGN:
-				PlaceProc_Sign(tile);
+				PlaceProc_Sign(query, tile);
 				break;
 
 			case CBF_PLACE_LANDINFO:
-				ShowLandInfo(tile);
+				if (!query) ShowLandInfo(tile);
 				break;
 
 			default: NOT_REACHED();

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1352,7 +1352,7 @@ static bool GrowTownWithBridge(const Town *t, const TileIndex tile, const DiagDi
 
 		/* Can we actually build the bridge? */
 		RoadType rt = GetTownRoadType();
-		if (Command<Commands::BuildBridge>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildBridge>()), tile, bridge_tile, TRANSPORT_ROAD, bridge_type, rt).Succeeded()) {
+		if (Command<Commands::BuildBridge>::Query(tile, bridge_tile, TRANSPORT_ROAD, bridge_type, rt).Succeeded()) {
 			Command<Commands::BuildBridge>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildBridge>()).Set(DoCommandFlag::Execute), tile, bridge_tile, TRANSPORT_ROAD, bridge_type, rt);
 			return true;
 		}
@@ -1422,7 +1422,7 @@ static bool GrowTownWithTunnel(const Town *t, const TileIndex tile, const DiagDi
 
 	/* Attempt to build the tunnel. Return false if it fails to let the town build a road instead. */
 	RoadType rt = GetTownRoadType();
-	if (Command<Commands::BuildTunnel>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildTunnel>()), tile, TRANSPORT_ROAD, rt).Succeeded()) {
+	if (Command<Commands::BuildTunnel>::Query(tile, TRANSPORT_ROAD, rt).Succeeded()) {
 		Command<Commands::BuildTunnel>::Do(CommandFlagsToDCFlags(GetCommandFlags<Commands::BuildTunnel>()).Set(DoCommandFlag::Execute), tile, TRANSPORT_ROAD, rt);
 		return true;
 	}

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1219,8 +1219,16 @@ public:
 		this->SetDirty();
 	}
 
+	/**
+	 * Issue a FoundTown command.
+	 * @param tile Tile for town.
+	 * @param random Use random location.
+	 * @param query Whether to only query the operation.
+	 * @param errstr Error string to use for the operation.
+	 * @param cc Callback to execute.
+	 */
 	template <typename Tcallback>
-	void ExecuteFoundTownCommand(TileIndex tile, bool random, StringID errstr, Tcallback cc)
+	void ExecuteFoundTownCommand(TileIndex tile, bool random, bool query, StringID errstr, Tcallback cc)
 	{
 		std::string name;
 
@@ -1232,7 +1240,7 @@ public:
 			if (original_name != this->townname_editbox.text.GetText()) name = this->townname_editbox.text.GetText();
 		}
 
-		bool success = Command<Commands::FoundTown>::Post(errstr, cc,
+		bool success = Command<Commands::FoundTown>::PostOrQuery(query, errstr, cc,
 				tile, this->town_size, this->city, this->town_layout, random, townnameparts, name);
 
 		/* Rerandomise name, if success and no cost-estimation. */
@@ -1247,7 +1255,7 @@ public:
 				break;
 
 			case WID_TF_RANDOM_TOWN:
-				this->ExecuteFoundTownCommand(TileIndex{}, true, STR_ERROR_CAN_T_GENERATE_TOWN, CcFoundRandomTown);
+				this->ExecuteFoundTownCommand(TileIndex{}, true, false, STR_ERROR_CAN_T_GENERATE_TOWN, CcFoundRandomTown);
 				break;
 
 			case WID_TF_TOWN_NAME_RANDOM:
@@ -1321,9 +1329,9 @@ public:
 		old_generating_world.Restore();
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
-		this->ExecuteFoundTownCommand(tile, false, STR_ERROR_CAN_T_FOUND_TOWN_HERE, CcFoundTown);
+		this->ExecuteFoundTownCommand(tile, false, query, STR_ERROR_CAN_T_FOUND_TOWN_HERE, CcFoundTown);
 	}
 
 	void OnPlaceObjectAbort() override
@@ -1804,14 +1812,13 @@ struct BuildHouseWindow : public PickerWindow {
 		this->SetWidgetDisabledState(WID_BH_PROTECT_TOGGLE, hasflag);
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
-
 		if (spec->building_flags.Test(BuildingFlag::Size1x1)) {
-			VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_PLACE_HOUSE);
+			VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_PLACE_HOUSE);
 		} else {
-			Command<Commands::PlaceHouse>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), BuildHouseWindow::house_protected, BuildHouseWindow::replace);
+			Command<Commands::PlaceHouse>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), BuildHouseWindow::house_protected, BuildHouseWindow::replace);
 		}
 	}
 
@@ -1820,14 +1827,14 @@ struct BuildHouseWindow : public PickerWindow {
 		VpSelectTilesWithMethod(pt.x, pt.y, select_method);
 	}
 
-	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, [[maybe_unused]] ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
+	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, [[maybe_unused]] ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile, bool query) override
 	{
 		if (pt.x == -1) return;
 
 		assert(select_proc == DDSP_PLACE_HOUSE);
 
 		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
-		Command<Commands::PlaceHouseArea>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER,
+		Command<Commands::PlaceHouseArea>::PostOrQuery(query, STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER,
 			end_tile, start_tile, spec->Index(), BuildHouseWindow::house_protected, BuildHouseWindow::replace, _ctrl_pressed);
 	}
 

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -20,6 +20,7 @@
 #include "zoom_func.h"
 #include "tree_map.h"
 #include "tree_cmd.h"
+#include "viewport_func.h"
 
 #include "widgets/tree_widget.h"
 
@@ -212,11 +213,11 @@ public:
 		}
 	}
 
-	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
+	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile, bool query) override
 	{
 		if (_game_mode != GM_EDITOR && this->mode == PM_NORMAL) {
-			VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_PLANT_TREES);
-		} else {
+			VpStartPlaceSizing(query, tile, VPM_X_AND_Y, DDSP_PLANT_TREES);
+		} else if (!query) {
 			VpStartDragging(DDSP_PLANT_TREES);
 		}
 	}
@@ -236,10 +237,10 @@ public:
 		}
 	}
 
-	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
+	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile, bool query) override
 	{
 		if (_game_mode != GM_EDITOR && this->mode == PM_NORMAL && pt.x != -1 && select_proc == DDSP_PLANT_TREES) {
-			Command<Commands::PlantTree>::Post(STR_ERROR_CAN_T_PLANT_TREE_HERE, end_tile, start_tile, this->tree_to_plant, _ctrl_pressed);
+			Command<Commands::PlantTree>::PostOrQuery(query, STR_ERROR_CAN_T_PLANT_TREE_HERE, end_tile, start_tile, this->tree_to_plant, _ctrl_pressed);
 		}
 	}
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1110,6 +1110,18 @@ static void HighlightTownLocalAuthorityTiles(const TileInfo *ti)
 }
 
 /**
+ * Get the palette to use for a tile highlight.
+ * @param thd Tile highlight data.
+ * @return Palette for tile highlight.
+ */
+static PaletteID GetHighlightPalette(const TileHighlightData &thd)
+{
+	if (thd.make_square_pulsate_red) return PALETTE_TILE_RED_PULSATING;
+	if (thd.make_square_red) return PALETTE_SEL_TILE_RED;
+	return PAL_NONE;
+}
+
+/**
  * Checks if the specified tile is selected and if so draws selection using correct selectionstyle.
  * @param *ti TileInfo Tile that is being drawn
  */
@@ -1138,7 +1150,7 @@ static void DrawTileSelection(const TileInfo *ti)
 			IsInsideBS(ti->y, _thd.pos.y, _thd.size.y)) {
 draw_inner:
 		if (_thd.drawstyle & HT_RECT) {
-			if (!is_redsq) DrawTileSelectionRect(ti, _thd.make_square_red ? PALETTE_SEL_TILE_RED : PAL_NONE);
+			if (!is_redsq) DrawTileSelectionRect(ti, GetHighlightPalette(_thd));
 		} else if (_thd.drawstyle & HT_POINT) {
 			/* Figure out the Z coordinate for the single dot. */
 			int z = 0;
@@ -1155,7 +1167,7 @@ draw_inner:
 					if (IsSteepSlope(ti->tileh)) z -= TILE_HEIGHT;
 				}
 			}
-			DrawSelectionSprite(SPR_DOT, PAL_NONE, ti, z, foundation_part);
+			DrawSelectionSprite(SPR_DOT, GetHighlightPalette(_thd), ti, z, foundation_part);
 		} else if (_thd.drawstyle & HT_RAIL) {
 			/* autorail highlight piece under cursor */
 			HighLightStyle type = _thd.drawstyle & HT_DIR_MASK;
@@ -1789,7 +1801,7 @@ static void ViewportDrawStrings(ZoomLevel zoom, const StringSpriteToDrawVector *
 		}
 
 		if (ss.flags.Test(ViewportStringFlag::TextColour)) {
-			if (ss.colour != INVALID_COLOUR) colour = GetColourGradient(ss.colour, SHADE_LIGHTER).ToTextColour();
+			if (ss.colour != INVALID_COLOUR) colour = GetColourGradient(ss.colour, SHADE_LIGHTER).ToTextColour() | TC_FORCED;
 		}
 
 		int left = x + WidgetDimensions::scaled.fullbevel.left;
@@ -2254,8 +2266,43 @@ static void SetSelectionTilesDirty()
 
 void SetSelectionRed(bool b)
 {
+	if (_thd.make_square_red == b) return;
 	_thd.make_square_red = b;
 	SetSelectionTilesDirty();
+}
+
+/**
+ * Set or reset the tile highlight selecion to pulsate.
+ * @param b Whether to set or reset the pulsate state.
+ */
+void SetSelectionPulsateRed(bool b)
+{
+	if (_thd.make_square_pulsate_red == b) return;
+	_thd.make_square_pulsate_red = b;
+	SetSelectionTilesDirty();
+}
+
+/**
+ * Update tile highlight selection to reflect the command cost.
+ * @param err_message Primary error message for operation.
+ * @param cost CommandCost.
+ */
+void HandleSelectionQuery(StringID err_message, CommandCost &&cost)
+{
+	SetSelectionPulsateRed(cost.Failed());
+	if (_thd.error != INVALID_TE_ID) RemoveTextEffect(_thd.error);
+
+	if (cost.Failed()) {
+		Point pt = RemapCoords(_thd.new_pos.x, _thd.new_pos.y, GetTilePixelZ(TileXY(_thd.new_pos.x / TILE_SIZE, _thd.new_pos.y / TILE_SIZE)));
+
+		EncodedString error = std::move(cost.GetEncodedMessage());
+		if (error.empty()) error = GetEncodedStringIfValid(cost.GetErrorMessage());
+		if (err_message != STR_NULL) error = GetEncodedString(STR_ERROR_MESSAGE_OVERLAY, err_message, error.GetDecodedString());
+
+		_thd.error = AddTextEffect(std::move(error), pt.x, pt.y, 0, TextEffectMode::TE_ERROR);
+	} else {
+		_thd.error = INVALID_TE_ID;
+	}
 }
 
 /**
@@ -2470,7 +2517,11 @@ static bool CheckClickOnLandscape(const Viewport &vp, int x, int y)
 	return true;
 }
 
-static void PlaceObject()
+/**
+ * Dispatch an ONPlaceObject window event.
+ * @param query Whether to only query the operation.
+ */
+static void PlaceObject(bool query)
 {
 	Point pt;
 	Window *w;
@@ -2487,23 +2538,41 @@ static void PlaceObject()
 	_tile_fract_coords.y = pt.y & TILE_UNIT_MASK;
 
 	w = _thd.GetCallbackWnd();
-	if (w != nullptr) w->OnPlaceObject(pt, TileVirtXY(pt.x, pt.y));
+	if (w != nullptr) {
+		TileIndex tile = TileVirtXY(pt.x, pt.y);
+		if (query) {
+			/* Query only if moved to a new tile. */
+			static TileIndex last_tile = INVALID_TILE;
+			if (tile == last_tile) return;
+			last_tile = tile;
+		}
+		w->OnPlaceObject(pt, tile, query);
+	}
 }
 
-
-bool HandleViewportClicked(const Viewport &vp, int x, int y)
+/**
+ * Handle viewport click event.
+ * @param vp Viewport of event.
+ * @param x Horizontal coordinate from left of screen.
+ * @param y Vertical coordinate from top of screen.
+ * @param query Whether to only query the operation.
+ * @return true iff the event was handled.
+ */
+bool HandleViewportClicked(const Viewport &vp, int x, int y, bool query)
 {
 	const Vehicle *v = CheckClickOnVehicle(vp, x, y);
 
 	if (_thd.place_mode & HT_VEHICLE) {
-		if (v != nullptr && VehicleClicked(v)) return true;
+		if (!query && v != nullptr && VehicleClicked(v)) return true;
 	}
 
 	/* Vehicle placement mode already handled above. */
 	if ((_thd.place_mode & HT_DRAG_MASK) != HT_NONE) {
-		PlaceObject();
+		PlaceObject(query);
 		return true;
 	}
+
+	if (query) return false;
 
 	if (CheckClickOnViewportSign(vp, x, y)) return true;
 	bool result = CheckClickOnLandscape(vp, x, y);
@@ -2646,6 +2715,9 @@ void TileHighlightData::Reset()
 	this->pos.y = 0;
 	this->new_pos.x = 0;
 	this->new_pos.y = 0;
+
+	if (this->error != INVALID_TE_ID) RemoveTextEffect(this->error);
+	this->error = INVALID_TE_ID;
 }
 
 /**
@@ -2794,8 +2866,10 @@ static void HideMeasurementTooltips()
 }
 
 /** highlighting tiles while only going over them with the mouse */
-void VpStartPlaceSizing(TileIndex tile, ViewportPlaceMethod method, ViewportDragDropSelectionProcess process)
+void VpStartPlaceSizing(bool query, TileIndex tile, ViewportPlaceMethod method, ViewportDragDropSelectionProcess process)
 {
+	if (_thd.select_method != method || _thd.select_proc != process) SetSelectionPulsateRed(false);
+
 	_thd.select_method = method;
 	_thd.select_proc   = process;
 	_thd.selend.x = TileX(tile) * TILE_SIZE;
@@ -2812,6 +2886,8 @@ void VpStartPlaceSizing(TileIndex tile, ViewportPlaceMethod method, ViewportDrag
 		_thd.selstart.x += TILE_SIZE / 2;
 		_thd.selstart.y += TILE_SIZE / 2;
 	}
+
+	if (query) return;
 
 	HighLightStyle others = _thd.place_mode & ~(HT_DRAG_MASK | HT_DIR_MASK);
 	if ((_thd.place_mode & HT_DRAG_MASK) == HT_RECT) {
@@ -3457,6 +3533,20 @@ calc_heightdiff_single_direction:;
  */
 EventState VpHandlePlaceSizingDrag()
 {
+	if (_thd.window_class != WC_INVALID && _thd.select_proc != DDSP_NONE) {
+		static TileIndex last_start, last_end;
+		Point selend = _special_mouse_mode == WSM_NONE ? _thd.new_pos : _thd.selend;
+		TileIndex start = TileVirtXY(_thd.new_pos.x, _thd.new_pos.y);
+		TileIndex end = TileVirtXY(selend.x, selend.y);
+		if (start != last_start || end != last_end) {
+			last_start = start;
+			last_end = end;
+			if (Window *w = _thd.GetCallbackWnd(); w != nullptr) {
+				w->OnPlaceMouseUp(_thd.select_method, _thd.select_proc, selend, start, end, true);
+			}
+		}
+	}
+
 	if (_special_mouse_mode != WSM_SIZING && _special_mouse_mode != WSM_DRAGGING) return ES_NOT_HANDLED;
 
 	/* stop drag mode if the window has been closed */
@@ -3497,7 +3587,7 @@ EventState VpHandlePlaceSizingDrag()
 	SetTileSelectSize(1, 1);
 
 	HideMeasurementTooltips();
-	w->OnPlaceMouseUp(_thd.select_method, _thd.select_proc, _thd.selend, TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y));
+	w->OnPlaceMouseUp(_thd.select_method, _thd.select_proc, _thd.selend, TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y), false);
 
 	return ES_HANDLED;
 }
@@ -3547,6 +3637,7 @@ void SetObjectToPlace(CursorID icon, PaletteID pal, HighLightStyle mode, WindowC
 	SetTileSelectSize(1, 1);
 
 	_thd.make_square_red = false;
+	_thd.make_square_pulsate_red = false;
 
 	if (mode == HT_DRAG) { // HT_DRAG is for dragdropping trains in the depot window
 		mode = HT_NONE;
@@ -3555,9 +3646,13 @@ void SetObjectToPlace(CursorID icon, PaletteID pal, HighLightStyle mode, WindowC
 		_special_mouse_mode = WSM_NONE;
 	}
 
+	_thd.select_proc = DDSP_NONE;
 	_thd.place_mode = mode;
 	_thd.window_class = window_class;
 	_thd.window_number = window_num;
+
+	if (_thd.error != INVALID_TE_ID) RemoveTextEffect(_thd.error);
+	_thd.error = INVALID_TE_ID;
 
 	if ((mode & HT_DRAG_MASK) == HT_SPECIAL) { // special tools, like tunnels or docks start with presizing mode
 		VpStartPreSizing();

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -21,6 +21,7 @@
 static const int TILE_HEIGHT_STEP = 50; ///< One Z unit tile height difference is displayed as 50m.
 
 void SetSelectionRed(bool);
+void SetSelectionPulsateRed(bool);
 
 void InitializeWindowViewport(Window *w, int x, int y, int width, int height, std::variant<TileIndex, VehicleID> focus, ZoomLevel zoom);
 Viewport *IsPtInWindowViewport(const Window *w, int x, int y);
@@ -64,7 +65,7 @@ inline void AddSortableSpriteToDraw(SpriteID image, PaletteID pal, const Coord3D
 void StartSpriteCombine();
 void EndSpriteCombine();
 
-bool HandleViewportClicked(const Viewport &vp, int x, int y);
+bool HandleViewportClicked(const Viewport &vp, int x, int y, bool query);
 void SetRedErrorSquare(TileIndex tile);
 void SetTileSelectSize(int w, int h);
 void SetTileSelectBigSize(int ox, int oy, int sx, int sy);

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -117,6 +117,8 @@ DECLARE_ENUM_AS_BIT_SET(ViewportPlaceMethod)
  * you've selected it.
  */
 enum ViewportDragDropSelectionProcess : uint8_t {
+	DDSP_NONE, ///< No process.
+
 	DDSP_DEMOLISH_AREA,        ///< Clear area
 	DDSP_RAISE_AND_LEVEL_AREA, ///< Raise / level area
 	DDSP_LOWER_AND_LEVEL_AREA, ///< Lower / level area

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2891,14 +2891,14 @@ static void MouseLoop(MouseClick click, int mousewheel)
 	HandleMouseOver();
 
 	bool scrollwheel_scrolling = _settings_client.gui.scrollwheel_scrolling == ScrollWheelScrolling::ScrollMap && _cursor.wheel_moved;
-	if (click == MC_NONE && mousewheel == 0 && !scrollwheel_scrolling) return;
+	if (click == MC_NONE && mousewheel == 0 && !scrollwheel_scrolling && (_thd.drawstyle & HT_DRAG_MASK) == HT_NONE) return;
 
 	int x = _cursor.pos.x;
 	int y = _cursor.pos.y;
 	Window *w = FindWindowFromPt(x, y);
 	if (w == nullptr) return;
 
-	if (click != MC_HOVER && !MaybeBringWindowToFront(w)) return;
+	if (click != MC_NONE && click != MC_HOVER && !MaybeBringWindowToFront(w)) return;
 	Viewport *vp = IsPtInWindowViewport(w, x, y);
 
 	/* Don't allow any action in a viewport if either in menu or when having a modal progress window */
@@ -2926,7 +2926,7 @@ static void MouseLoop(MouseClick click, int mousewheel)
 		switch (click) {
 			case MC_DOUBLE_LEFT:
 			case MC_LEFT:
-				if (HandleViewportClicked(*vp, x, y)) return;
+				if (HandleViewportClicked(*vp, x, y, false)) return;
 				if (!w->flags.Test(WindowFlag::DisableVpScroll) &&
 						_settings_client.gui.scroll_mode == ViewportScrollMode::MapLMB) {
 					_scrolling_viewport = true;
@@ -2947,6 +2947,7 @@ static void MouseLoop(MouseClick click, int mousewheel)
 				break;
 
 			default:
+				HandleViewportClicked(*vp, x, y, true);
 				break;
 		}
 	}

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -803,8 +803,9 @@ public:
 	 * has been set.
 	 * @param pt   the exact point on the map that has been clicked.
 	 * @param tile the tile on the map that has been clicked.
+	 * @param query set if the tile was not actually clicked.
 	 */
-	virtual void OnPlaceObject([[maybe_unused]] Point pt, [[maybe_unused]] TileIndex tile) {}
+	virtual void OnPlaceObject([[maybe_unused]] Point pt, [[maybe_unused]] TileIndex tile, [[maybe_unused]] bool query) {}
 
 	/**
 	 * The user clicked on a vehicle while HT_VEHICLE has been set.
@@ -846,8 +847,9 @@ public:
 	 * @param pt            the exact point on the map where the mouse was released.
 	 * @param start_tile    the begin tile of the drag.
 	 * @param end_tile      the end tile of the drag.
+	 * @param query Whether to only query the operation.
 	 */
-	virtual void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, [[maybe_unused]] ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, [[maybe_unused]] TileIndex start_tile, [[maybe_unused]] TileIndex end_tile) {}
+	virtual void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, [[maybe_unused]] ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, [[maybe_unused]] TileIndex start_tile, [[maybe_unused]] TileIndex end_tile, [[maybe_unused]] bool query) {}
 
 	/**
 	 * The user moves over the map when a tile highlight mode has been set


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Funding industries, especially water-based industries with placement restrictions, can be frustrating as it's difficult to know where it will succeed.

The game knows, so can we tell the player in advance?

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Scope-creep: if we do this for industry funding, why not any type of building / removal?

Adds an tile highlight area for industry funding, the size of which is the maximum of all layouts for the industry. This will usually be larger than actually required, but probably gives a better indication than just a single tile.

Make the tile highlight system query the operation and mark the highlight red if it would be unsuccessful. This extends the `OnPlaceObject` and `OnPlaceMouseUp` to have `query` parameter, so they can do the same operation as actually building, but in test mode.

Conflict: red tile highlight is already used by the bulldozer tools to indicate that the selection will be removed instead of built.

Part of the error message is displayed as an overlay (actually a TextEffect), though this overlay probably wants revising). Red text on even a darked area seems quite difficult to read.

This means you can immediately see if a build or remove operation will be successful without having to (shift-)click everywhere.

![image](https://github.com/user-attachments/assets/fd1c7dbf-fc66-4a22-aebd-b059f6ee6d7b)
![image](https://github.com/user-attachments/assets/19d0d585-756b-4b8a-b0c6-ed4509ac54e4)
![image](https://github.com/user-attachments/assets/cd5148c5-150d-48b5-ac4f-a3a9b170db84)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
