### PR TITLE
Change: Disable surveys for github previews

### DIFF
--- a/src/network/network_survey.h
+++ b/src/network/network_survey.h
@@ -36,7 +36,11 @@ public:
 
 	constexpr static bool IsSurveyPossible()
 	{
+#ifdef SURVEY_KEY
 		return true;
+#else
+		return false;
+#endif
 	}
 
 private:


### PR DESCRIPTION
## Motivation / Problem

GitHub previews ask if the user wants to participate in the survey. These previews function more like a sandbox to try things out and don't reflect real gameplay. That data shouldn't be recorded.

The popup can also be a bit annoying when you quickly want to test something out.

## Description

I've disabled surveys for ~emscripten builds~ any build that has no survey key

## Limitations

Preview statistics probably weren't contributing much to the survey data to begin with, but it doesn't hurt to excluse them.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
