### PR TITLE
Fix #14362, 4b677e8256: Don't crash old scripts doing silly instantiation

### DIFF
--- a/bin/ai/compat_14.nut
+++ b/bin/ai/compat_14.nut
@@ -36,3 +36,11 @@ AITown.FoundTown <- function(tile, size, city, layout, name) { return AITown.Fou
 
 AIVehicle.SetNameCompat14 <- AIVehicle.SetName;
 AIVehicle.SetName <- function(id, name) { return AIVehicle.SetNameCompat14(id, AICompat14.Text(name)); }
+
+AIObject.constructorCompat14 <- AIObject.constructor;
+foreach(name, object in CompatScriptRootTable) {
+	if (type(object) != "class") continue;
+	if (!object.rawin("constructor")) continue;
+	if (object.constructor != AIObject.constructorCompat14) continue;
+	object.constructor <- function() : (name) { AILog.Error("'" + name + "' is not instantiable"); }
+}

--- a/bin/game/compat_14.nut
+++ b/bin/game/compat_14.nut
@@ -81,3 +81,11 @@ GSTown.FoundTown <- function(tile, size, city, layout, name) { return GSTown.Fou
 
 GSVehicle.SetNameCompat14 <- GSVehicle.SetName;
 GSVehicle.SetName <- function(id, name) { return GSVehicle.SetNameCompat14(id, GSCompat14.Text(name)); }
+
+GSObject.constructorCompat14 <- GSObject.constructor;
+foreach(name, object in CompatScriptRootTable) {
+	if (type(object) != "class") continue;
+	if (!object.rawin("constructor")) continue;
+	if (object.constructor != GSObject.constructorCompat14) continue;
+	object.constructor <- function() : (name) { GSLog.Error("'" + name + "' is not instantiable"); }
+}

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -128,6 +128,13 @@ bool ScriptInstance::LoadCompatibilityScripts(Subdirectory dir, std::span<const 
 
 	ScriptLog::Info(fmt::format("Downgrading API to be compatible with version {}", this->api_version));
 
+	HSQUIRRELVM vm = this->engine->GetVM();
+	sq_pushroottable(vm);
+	sq_pushstring(vm, "CompatScriptRootTable");
+	sq_pushroottable(vm);
+	sq_newslot(vm, -3, SQFalse);
+	sq_pop(vm, 1);
+
 	/* Downgrade the API till we are the same version as the script. The last
 	 * entry in the list is always the current version, so skip that one. */
 	for (auto it = std::rbegin(api_versions) + 1; it != std::rend(api_versions); ++it) {
@@ -135,6 +142,11 @@ bool ScriptInstance::LoadCompatibilityScripts(Subdirectory dir, std::span<const 
 
 		if (*it == this->api_version) break;
 	}
+
+	sq_pushroottable(vm);
+	sq_pushstring(vm, "CompatScriptRootTable");
+	sq_deleteslot(vm, -2, SQFalse);
+	sq_pop(vm, 1);
 
 	return true;
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Some scripts (like NoNoCab v8) instantiate classes that should not be, and since 4b677e8256 it's no longer possible.
It's clearly a bug inside the AI, but things like https://github.com/Wormnest/nonocab/blob/master/advisors/VehiclesAdvisor.nut#L45-L49 used to work.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Allow scripts for older APIs to do their silly things.
The affected classes only have static members (else they would not use `[AI|GS]Object` dummy constructor) so creating an instance only on squirrel side is safe.

Needed to add a temporary access to root table for compat scripts (squirrel has `getroottable()` but we removed the export for scripts in OpenTTD).
Then compat scripts can replace the dummy constructor which triggers a crash with another dummy constructor reporting an error.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
