### PR TITLE
Fix: Include sort button width in content list header minimal size.

### DIFF
--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -583,17 +583,24 @@ public:
 	{
 		switch (widget) {
 			case WID_NCL_CHECKBOX:
-				size.width = this->checkbox_size.width + padding.width;
+				size.width = std::max<uint>(this->checkbox_size.width, Window::SortButtonWidth()) + padding.width;
 				break;
 
 			case WID_NCL_TYPE: {
+				/* Width must be enough for header label and sort buttons.*/
+				size.width += Window::SortButtonWidth() * 2;
+				/* And also enough for the width of each type of content. */
 				Dimension d = size;
 				for (int i = CONTENT_TYPE_BEGIN; i < CONTENT_TYPE_END; i++) {
 					d = maxdim(d, GetStringBoundingBox(STR_CONTENT_TYPE_BASE_GRAPHICS + i - CONTENT_TYPE_BASE_GRAPHICS));
 				}
-				size.width = d.width + padding.width;
+				size.width = std::max(size.width, d.width + padding.width);
 				break;
 			}
+
+			case WID_NCL_NAME:
+				size.width += Window::SortButtonWidth() * 2;
+				break;
 
 			case WID_NCL_MATRIX:
 				fill.height = resize.height = std::max(this->checkbox_size.height, (uint)GetCharacterHeight(FS_NORMAL)) + padding.height;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Header buttons on the Content window do not allow enough space for the sort buttons.

Depending on language and font settings, this can cause the sort button to over draw the text label:

![image](https://github.com/user-attachments/assets/da30a336-2e92-4485-b531-0c2d4c4c7e0e)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Include the width of the sort buttons when determining minimum size of the header buttons:

![image](https://github.com/user-attachments/assets/84884807-330b-4c78-a8d1-f0c07f93db09)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
