### PR TITLE
Fix c2d4098afa: Crash when accessing unconfigurable badge feature.

### DIFF
--- a/src/newgrf_badge_config.cpp
+++ b/src/newgrf_badge_config.cpp
@@ -118,14 +118,16 @@ void ResetBadgeClassConfiguration(GrfSpecFeature feature)
  */
 std::pair<const BadgeClassConfigItem &, int> GetBadgeClassConfigItem(GrfSpecFeature feature, std::string_view label)
 {
-	auto config = GetBadgeClassConfiguration(feature);
-	auto found = std::ranges::find(config, label, &BadgeClassConfigItem::label);
-	if (found == std::end(config)) {
-		return {BadgeClassConfig::EMPTY_CONFIG_ITEM, 0};
+	if (BadgeClassConfig::CONFIGURABLE_FEATURES.Test(feature)) {
+		auto config = GetBadgeClassConfiguration(feature);
+		auto found = std::ranges::find(config, label, &BadgeClassConfigItem::label);
+		if (found != std::end(config)) {
+			/* Sort order is simply the position in the configuration list. */
+			return {*found, static_cast<int>(std::distance(std::begin(config), found))};
+		}
 	}
 
-	/* Sort order is simply the position in the configuration list. */
-	return {*found, static_cast<int>(std::distance(std::begin(config), found))};
+	return {BadgeClassConfig::EMPTY_CONFIG_ITEM, 0};
 }
 
 /**


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Some features support badges but do not have a way to configure them. Accessing these features could crash the game. Some refactoring before merging meant this condition was missed.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Fixed by returning an empty badge class configuration when preparing the per-feature badge class list for an unconfigureable feature, instead of asserting.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
