### PR TITLE
Fix #14375: When loading config, validate timekeeping mode and minutes per year

### DIFF
--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -667,6 +667,15 @@ static void ChangeMinutesPerYear(int32_t new_value)
 	}
 }
 
+/* Get the valid range of the "minutes per calendar year" setting. */
+static std::tuple<int32_t, uint32_t> GetMinutesPerYearRange(const IntSettingDesc &)
+{
+	/* Allow a non-default value only if using Wallclock timekeeping units. */
+	if (_settings_newgame.economy.timekeeping_units == TKU_WALLCLOCK) return { CalendarTime::FROZEN_MINUTES_PER_YEAR, CalendarTime::MAX_MINUTES_PER_YEAR };
+
+	return { CalendarTime::DEF_MINUTES_PER_YEAR, CalendarTime::DEF_MINUTES_PER_YEAR };
+}
+
 /**
  * Pre-callback check when trying to change the timetable mode. This is locked to Seconds when using wallclock units.
  * @param Unused.

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -11,6 +11,7 @@
 static void TownFoundingChanged(int32_t new_value);
 static void ChangeTimekeepingUnits(int32_t new_value);
 static void ChangeMinutesPerYear(int32_t new_value);
+static std::tuple<int32_t, uint32_t> GetMinutesPerYearRange(const IntSettingDesc &sd);
 
 static constexpr std::initializer_list<std::string_view> _place_houses{"forbidden"sv, "allowed"sv, "fully constructed"sv};
 
@@ -332,6 +333,7 @@ strhelp  = STR_CONFIG_SETTING_MINUTES_PER_YEAR_HELPTEXT
 strval   = STR_CONFIG_SETTING_MINUTES_PER_YEAR_VALUE
 pre_cb   = [](auto) { return _game_mode == GM_MENU || _settings_game.economy.timekeeping_units == 1; }
 post_cb  = ChangeMinutesPerYear
+range_cb = GetMinutesPerYearRange
 cat      = SC_BASIC
 
 [SDT_VAR]


### PR DESCRIPTION
## Motivation / Problem

Per #14375, it is possible to use an invalid combination of Calendar Timekeeping Mode and a non-default Minutes Per Year setting, by editing the config file manually.

## Description

Implement a range callback for "minutes per calendar year" to clamp it to a valid range. This follows the same behavior as when timekeeping mode is changed in the menu (`ChangeTimekeepingUnits()` callback). This is simpler than the callback for when Minutes Per Year is changed.

Closes #14375.

## Limitations

~~It is still possible to set an invalid Minutes Per Year (negative number, etc.) but that is possible for all settings. I don't think we need to validate everything, just when these two settings depend on each other -- which is not necessarily obvious, as we see in #14374.~~

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
