### PR TITLE
Fix #14377: Make house picker window remember house protection state when closed

### DIFF
--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1628,7 +1628,7 @@ static CargoTypes GetProducedCargoOfHouse(const HouseSpec *hs)
 
 struct BuildHouseWindow : public PickerWindow {
 	std::string house_info{};
-	bool house_protected = false;
+	static inline bool house_protected;
 
 	BuildHouseWindow(WindowDesc &desc, Window *parent) : PickerWindow(desc, parent, 0, HousePickerCallbacks::instance)
 	{
@@ -1735,9 +1735,9 @@ struct BuildHouseWindow : public PickerWindow {
 		switch (widget) {
 			case WID_BH_PROTECT_OFF:
 			case WID_BH_PROTECT_ON:
-				this->house_protected = (widget == WID_BH_PROTECT_ON);
-				this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !this->house_protected);
-				this->SetWidgetLoweredState(WID_BH_PROTECT_ON, this->house_protected);
+				BuildHouseWindow::house_protected = (widget == WID_BH_PROTECT_ON);
+				this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !BuildHouseWindow::house_protected);
+				this->SetWidgetLoweredState(WID_BH_PROTECT_ON, BuildHouseWindow::house_protected);
 
 				if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 				this->SetDirty();
@@ -1764,10 +1764,10 @@ struct BuildHouseWindow : public PickerWindow {
 
 		/* If house spec already has the protected flag, handle it automatically and disable the buttons. */
 		bool hasflag = spec->extra_flags.Test(HouseExtraFlag::BuildingIsProtected);
-		if (hasflag) this->house_protected = true;
+		if (hasflag) BuildHouseWindow::house_protected = true;
 
-		this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !this->house_protected);
-		this->SetWidgetLoweredState(WID_BH_PROTECT_ON, this->house_protected);
+		this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !BuildHouseWindow::house_protected);
+		this->SetWidgetLoweredState(WID_BH_PROTECT_ON, BuildHouseWindow::house_protected);
 
 		this->SetWidgetDisabledState(WID_BH_PROTECT_OFF, hasflag);
 		this->SetWidgetDisabledState(WID_BH_PROTECT_ON, hasflag);
@@ -1776,7 +1776,7 @@ struct BuildHouseWindow : public PickerWindow {
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
 	{
 		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
-		Command<CMD_PLACE_HOUSE>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), this->house_protected);
+		Command<CMD_PLACE_HOUSE>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), BuildHouseWindow::house_protected);
 	}
 
 	const IntervalTimer<TimerWindow> view_refresh_interval = {std::chrono::milliseconds(2500), [this](auto) {


### PR DESCRIPTION
## Motivation / Problem

On the house picker, the player can choose whether the next house will be protected from the town rebuilding it when growing.

It would be nice if their choice was remembered while OpenTTD is running, instead of being reset each time the window is closed and re-opened.

## Description

Remember the state instead of discarding it when the window is closed.

Closes #14377.

## Limitations

~~More code than simply changing the existing storage to `static inline bool house_protected`, but I like having it kept with other window state. I'm happy to change it if requested.~~ Changed to the simple version. 🙂 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
