### PR TITLE
Fix: Player-placed house protection for houses should override the callback

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -726,7 +726,7 @@
       </ul>
      </li>
      <li>m3 bit 6 : free</li>
-     <li>m3 bit 5 : The house is protected from the town upgrading it</li>
+     <li>m3 bit 5 : The house is protected by the player from the town upgrading it</li>
      <li>m3 bits 4..0 : triggers activated <a href="#newhouses">(newhouses)</a></li>
      <li>m4 : free</li>
      <li>m5 : see m3 bit 7</li>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -156,7 +156,7 @@ the array so you can quickly see what is used and what is not.
       <td class="caption">finished house</td>
       <td class="bits" rowspan=2><span class="used" title="House random bits">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="pool" title="Town index on pool">XXXX XXXX XXXX XXXX</span></td>
-      <td class="bits"><span class="used" title="House is complete/in construction (see m5)">1</span><span class="free">O</span><span class="used" title="The house is protected from the town upgrading it.">X</span><span class="usable" title="Activated triggers (bits 2..4 don't have a meaning)">X XX</span><span class="used" title="Activated triggers (bits 2..4 don't have a meaning)">XX</span></td>
+      <td class="bits"><span class="used" title="House is complete/in construction (see m5)">1</span><span class="free">O</span><span class="used" title="The house is protected by the player from the town upgrading it.">X</span><span class="usable" title="Activated triggers (bits 2..4 don't have a meaning)">X XX</span><span class="used" title="Activated triggers (bits 2..4 don't have a meaning)">XX</span></td>
       <td class="bits" rowspan=2><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Age in years, clamped at 255">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="abuse" title="Newhouses activated: periodic processing time remaining; if not, lift position for houses 04 and 05">XXXX XX</span><span class="used" title="Animated tile state">XX</span></td>
@@ -165,7 +165,7 @@ the array so you can quickly see what is used and what is not.
     </tr>
     <tr>
       <td class="caption">house under construction</td>
-      <td class="bits"><span class="used" title="House is complete/in construction (see m5)">O</span><span class="free">O</span><span class="used" title="The house is protected from the town upgrading it.">X</span><span class="usable" title="Activated triggers (bits 2..4 don't have a meaning)">X XX</span><span class="used" title="Activated triggers (bits 2..4 don't have a meaning)">XX</span></td>
+      <td class="bits"><span class="used" title="House is complete/in construction (see m5)">O</span><span class="free">O</span><span class="used" title="The house is protected by the player from the town upgrading it.">X</span><span class="usable" title="Activated triggers (bits 2..4 don't have a meaning)">X XX</span><span class="used" title="Activated triggers (bits 2..4 don't have a meaning)">XX</span></td>
       <td class="bits"><span class="free">OOO</span><span class="used" title="Construction stage">X X</span><span class="used" title="Construction counter">XXX</span></td>
     </tr>
     <tr>

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -595,12 +595,16 @@ bool CanDeleteHouse(TileIndex tile)
 		return true;
 	}
 
+	/* The house might be placed by a player or protected by the GRF house flag. */
+	if (IsHouseProtected(tile)) return false;
+
+	/* Check the callback result, if the house uses it. */
 	if (hs->callback_mask.Test(HouseCallbackMask::DenyDestruction)) {
 		uint16_t callback_res = GetHouseCallback(CBID_HOUSE_DENY_DESTRUCTION, 0, 0, GetHouseType(tile), Town::GetByTile(tile), tile);
 		return (callback_res == CALLBACK_FAILED || !ConvertBooleanCallback(hs->grf_prop.grffile, CBID_HOUSE_DENY_DESTRUCTION, callback_res));
-	} else {
-		return !IsHouseProtected(tile);
 	}
+
+	return true;
 }
 
 /**

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -614,11 +614,15 @@ bool CanDeleteHouse(TileIndex tile)
 		return true;
 	}
 
+	/* The house might be placed by a player. */
+	if (IsHousePlayerProtected(tile)) return false;
+
+	/* Houses can be protected by a NewGRF property or a callback. The callback overrides the property. */
 	if (hs->callback_mask.Test(HouseCallbackMask::DenyDestruction)) {
 		uint16_t callback_res = GetHouseCallback(CBID_HOUSE_DENY_DESTRUCTION, 0, 0, GetHouseType(tile), Town::GetByTile(tile), tile);
 		return (callback_res == CALLBACK_FAILED || !ConvertBooleanCallback(hs->grf_prop.grffile, CBID_HOUSE_DENY_DESTRUCTION, callback_res));
 	} else {
-		return !IsHouseProtected(tile);
+		return !hs->extra_flags.Test(HouseExtraFlag::BuildingIsProtected);
 	}
 }
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1559,16 +1559,6 @@ bool AfterLoadGame()
 		}
 	}
 
-	if (IsSavegameVersionBefore(SaveLoadVersion::ProtectPlacedHouses)) {
-		for (auto t : Map::Iterate()) {
-			if (IsTileType(t, TileType::House)) {
-				/* We now store house protection status in the map. Set this based on the house spec flags. */
-				const HouseSpec *hs = HouseSpec::Get(GetHouseType(t));
-				SetHouseProtected(t, hs->extra_flags.Test(HouseExtraFlag::BuildingIsProtected));
-			}
-		}
-	}
-
 	/* Check and update house and town values */
 	UpdateHousesAndTowns();
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -850,7 +850,11 @@ static void GetTileDesc_Town(TileIndex tile, TileDesc &td)
 	bool house_completed = IsHouseCompleted(tile);
 
 	td.str = hs->building_name;
-	td.town_can_upgrade = !IsHouseProtected(tile);
+
+	/* Show if a player has protected the house, or if the house property is set for protection.
+	 * Note that houses also have a callback which overrides their property (player choice is always respected),
+	 * but it's impossible to know the possible results of the callback in runtime so it's not evaluated here. */
+	td.town_can_upgrade = !IsHousePlayerProtected(tile) && !hs->extra_flags.Test(HouseExtraFlag::BuildingIsProtected);
 
 	std::array<int32_t, 1> regs100;
 	uint16_t callback_res = GetHouseCallback(CBID_HOUSE_CUSTOM_NAME, house_completed ? 1 : 0, 0, house, Town::GetByTile(tile), tile, regs100);
@@ -2505,7 +2509,7 @@ HouseZone GetTownRadiusGroup(const Town *t, TileIndex tile)
  * @param stage The current construction stage of the house.
  * @param type The type of house.
  * @param random_bits Random bits for newgrf houses to use.
- * @param is_protected Whether the house is protected from the town upgrading it.
+ * @param is_protected Whether a player has marked the house as protected from the town upgrading it.
  * @pre The house can be built here.
  */
 static inline void ClearMakeHouseTile(TileIndex tile, Town *t, uint8_t counter, uint8_t stage, HouseID type, uint8_t random_bits, bool is_protected)
@@ -2529,7 +2533,7 @@ static inline void ClearMakeHouseTile(TileIndex tile, Town *t, uint8_t counter, 
  * @param type The type of house.
  * @param stage The current construction stage.
  * @param random_bits Random bits for newgrf houses to use.
- * @param is_protected Whether the house is protected from the town upgrading it.
+ * @param is_protected Whether a player has marked the house as protected from the town upgrading it.
  * @pre The house can be built here.
  */
 static void MakeTownHouse(TileIndex tile, Town *t, uint8_t counter, uint8_t stage, HouseID type, uint8_t random_bits, bool is_protected)
@@ -2746,7 +2750,7 @@ static bool CheckTownBuild2x2House(TileIndex *tile, Town *t, int maxz, bool nosl
  * @param house The @a HouseID of the house.
  * @param random_bits The random data to be associated with the house.
  * @param house_completed Should the house be placed already complete, instead of under construction?
- * @param is_protected Whether the house is protected from the town upgrading it.
+ * @param is_protected Whether a player has marked the house as protected from the town upgrading it.
  */
 static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID house, uint8_t random_bits, bool house_completed, bool is_protected)
 {
@@ -2904,7 +2908,7 @@ static bool TryBuildTownHouse(Town *t, TileIndex tile, TownExpandModes modes)
 		/* Special houses that there can be only one of. */
 		t->flags.Set(oneof);
 
-		BuildTownHouse(t, tile, hs, house, random_bits, false, hs->extra_flags.Test(HouseExtraFlag::BuildingIsProtected));
+		BuildTownHouse(t, tile, hs, house, random_bits, false, false);
 
 		return true;
 	}
@@ -2917,7 +2921,7 @@ static bool TryBuildTownHouse(Town *t, TileIndex tile, TownExpandModes modes)
  * @param flags Type of operation.
  * @param tile Tile on which to place the house.
  * @param house The HouseID of the house spec.
- * @param is_protected Whether the house is protected from the town upgrading it.
+ * @param is_protected Whether a player has marked the house as protected from the town upgrading it.
  * @param replace Whether to automatically demolish an existing house on this tile, if present.
  * @return Empty cost or an error.
  */
@@ -2983,7 +2987,7 @@ CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, b
  * @param tile End tile of area dragging.
  * @param start_tile Start tile of area dragging.
  * @param house The HouseID of the house spec.
- * @param is_protected Whether the house is protected from the town upgrading it.
+ * @param is_protected Whether a player has marked the house as protected from the town upgrading it.
  * @param replace Whether we can replace existing houses.
  * @param diagonal Whether to use the Diagonal or Orthogonal tile iterator.
  * @return Empty cost or an error.

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1795,14 +1795,12 @@ struct BuildHouseWindow : public PickerWindow {
 			this->house_info = spec->enabled ? GetHouseInformation(spec) : "";
 		}
 
-		/* If house spec already has the protected flag, handle it automatically and disable the buttons. */
-		bool hasflag = spec->extra_flags.Test(HouseExtraFlag::BuildingIsProtected);
-		if (hasflag) BuildHouseWindow::house_protected = true;
-
+		/* The protection button only shows the player's choice.
+		 * Houses also have a property and a callback for protection, but these are not shown
+		 * since we cannot know the possible results of the callback in runtime. */
 		this->SetWidgetLoweredState(WID_BH_PROTECT_TOGGLE, BuildHouseWindow::house_protected);
-		this->SetWidgetLoweredState(WID_BH_REPLACE_TOGGLE, BuildHouseWindow::replace);
 
-		this->SetWidgetDisabledState(WID_BH_PROTECT_TOGGLE, hasflag);
+		this->SetWidgetLoweredState(WID_BH_REPLACE_TOGGLE, BuildHouseWindow::replace);
 	}
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -75,22 +75,22 @@ inline void SetHouseType(Tile t, HouseID house_id)
 }
 
 /**
- * Check if the house is protected from removal by towns.
+ * Check if a house is protected by a player from removal by towns.
  * @param t The tile.
  * @return If the house is protected from the town upgrading it.
  */
-inline bool IsHouseProtected(Tile t)
+inline bool IsHousePlayerProtected(Tile t)
 {
 	assert(IsTileType(t, TileType::House));
 	return HasBit(t.m3(), 5);
 }
 
 /**
- * Set a house as protected from removal by towns.
+ * Set a house as protected by a player from removal by towns.
  * @param t The tile.
  * @param house_protected Whether the house is protected from the town upgrading it.
  */
-inline void SetHouseProtected(Tile t, bool house_protected)
+inline void SetHousePlayerProtected(Tile t, bool house_protected)
 {
 	assert(IsTileType(t, TileType::House));
 	SB(t.m3(), 5, 1, house_protected ? 1 : 0);
@@ -383,7 +383,7 @@ inline void MakeHouseTile(Tile t, TownID tid, uint8_t counter, uint8_t stage, Ho
 	SetHouseType(t, type);
 	SetHouseCompleted(t, stage == TOWN_HOUSE_COMPLETED);
 	t.m5() = IsHouseCompleted(t) ? 0 : (stage << 3 | counter);
-	SetHouseProtected(t, house_protected);
+	SetHousePlayerProtected(t, house_protected);
 	SetAnimationFrame(t, 0);
 	SetHouseProcessingTime(t, HouseSpec::Get(type)->processing_time);
 	SB(t.m8(), 12, 4, 0);


### PR DESCRIPTION
## Motivation / Problem

In #13270 I added the ability to protect player-placed houses from the town upgrading them.

The callback was checked in the wrong order, and the player choice and NewGRF property erroneously combined. This resulted in the callback overriding the player's choice. My previous attempt to fix this (in this PR) [was incorrect](https://github.com/OpenTTD/OpenTTD/pull/14408#issuecomment-3444968481).

## Description

Check the player protection first before evaluating anything in GRF spec.

Revert the change to store the NewGRF property info in the same map bit as the player choice, to instead check the NewGRF property if the house doesn't implement the callback.

Edit a bunch of comments and docs to distinguish player-provided protection versus GRF spec.

## Limitations

Untested: it's really hard to test if a town doesn't perform a random action, especially when I don't know the callback logic. And this stuff is confusing.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
