### PR TITLE
Fix #14385: [Strgen] Don't count parameters more than one time

### DIFF
--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -639,6 +639,8 @@ static size_t TranslateArgumentIdx(size_t argidx, size_t offset)
 	for (size_t i = 0; i < argidx; i++) {
 		cs = _cur_pcs.consuming_commands[i];
 
+		if (cs == nullptr && sum > i) continue;
+
 		sum += (cs != nullptr) ? cs->consumes : 1;
 	}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
#13685 replaced
* `STR_INDUSTRY_VIEW_ACCEPT_CARGO                                  :{YELLOW}{0:STRING}{BLACK}{3:RAW_STRING}`
* `STR_INDUSTRY_VIEW_ACCEPT_CARGO_AMOUNT                           :{YELLOW}{STRING}{BLACK}: {CARGO_SHORT} waiting{RAW_STRING}`

with
* `STR_INDUSTRY_VIEW_ACCEPT_CARGO_SUFFIX                           :{YELLOW}{0:STRING}{BLACK}{3:RAW_STRING}`
* `STR_INDUSTRY_VIEW_ACCEPT_CARGO_AMOUNT_SUFFIX                    :{YELLOW}{0:STRING}{BLACK}: {1:CARGO_SHORT} waiting{3:RAW_STRING}`
* `STR_INDUSTRY_VIEW_ACCEPT_CARGO_NOSUFFIX                         :{YELLOW}{0:STRING}`
* `STR_INDUSTRY_VIEW_ACCEPT_CARGO_AMOUNT_NOSUFFIX                  :{YELLOW}{0:STRING}{BLACK}: {1:CARGO_SHORT} waiting`

`strgen` incorrectly determine the real offset for `{3:RAW_STRING}` in `STR_INDUSTRY_VIEW_ACCEPT_CARGO_AMOUNT_SUFFIX` (it uses `4` while `3` is expected).
But it correctly uses `3` for `{3:RAW_STRING}` in `STR_INDUSTRY_VIEW_ACCEPT_CARGO_SUFFIX`.

The issue is how `TranslateArgumentIdx()` does the math. When looping over `_cur_pcs.consuming_commands` it adds the consumed parameters if it's a real command, or 1 for placeholders.
In `STR_INDUSTRY_VIEW_ACCEPT_CARGO_SUFFIX` case the array contains `STRING, nullptr, nullptr, RAW_STRING` so the math to get real index of param 3 (RAW_STRING)  is 1 (STRING) + 1 (nullptr) + 1 (nullptr) => 3.
In `STR_INDUSTRY_VIEW_ACCEPT_CARGO_AMOUNT_SUFFIX` case the array contains `STRING, CARGO_SHORT, nullptr, RAW_STRING` so the math to get real index of param 3 (RAW_STRING)  is 1 (STRING) + 2 (CARGO_SHORT) + 1 (nullptr) => 4.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I see two possible fixes:
* use `{2:RAW_STRING}` in `STR_INDUSTRY_VIEW_ACCEPT_CARGO_AMOUNT_SUFFIX` but that feels un-intuitive when `STR_INDUSTRY_VIEW_ACCEPT_CARGO_SUFFIX` still requires `{3:RAW_STRING}`
* change the math to ignore `nullptr` if it's already counted via a real command consuming more than 1 parameters.

I decided to change the math.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
