### PR TITLE
Change: Make truncation ellipsis translatable.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -267,6 +267,7 @@ STR_UNITS_YEARS                                                 :{NUM}{NBSP}year
 STR_UNITS_PERIODS                                               :{NUM}{NBSP}period{P "" s}
 
 STR_LIST_SEPARATOR                                              :,{SPACE}
+STR_TRUNCATION_ELLIPSIS                                         :...
 
 # Common window strings
 STR_LIST_FILTER_TITLE                                           :{BLACK}Filter:

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -286,6 +286,7 @@ struct LoadedLanguagePack {
 	std::array<uint, TEXT_TAB_END> langtab_start; ///< Offset into langpack offs
 
 	std::string list_separator; ///< Current list separator string.
+	std::string ellipsis; ///< Current ellipsis string.
 };
 
 static LoadedLanguagePack _langpack;
@@ -299,6 +300,15 @@ static bool _scan_for_gender_data = false;  ///< Are we scanning for the gender 
 std::string_view GetListSeparator()
 {
 	return _langpack.list_separator;
+}
+
+/**
+ * Get the ellipsis string for the current language.
+ * @returns string containing ellipsis to use.
+ */
+std::string_view GetEllipsis()
+{
+	return _langpack.ellipsis;
 }
 
 std::string_view GetStringPtr(StringID string)
@@ -2063,6 +2073,7 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 	_config_language_file = FS2OTTD(_current_language->file.filename().native());
 	SetCurrentGrfLangID(_current_language->newgrflangid);
 	_langpack.list_separator = GetString(STR_LIST_SEPARATOR);
+	_langpack.ellipsis = GetString(STR_TRUNCATION_ELLIPSIS);
 
 #ifdef _WIN32
 	extern void Win32SetCurrentLocaleName(std::string iso_code);

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -98,6 +98,7 @@ extern TextDirection _current_text_dir; ///< Text direction of the currently sel
 void InitializeLanguagePacks();
 std::string_view GetCurrentLanguageIsoCode();
 std::string_view GetListSeparator();
+std::string_view GetEllipsis();
 
 /**
  * Helper to create the StringParameters with its own buffer with the given


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When truncating text, the ellipsis is hardcoded to be 3 `.` characters. Some languages might prefer something different, e.g. a single `…` character.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a string containing just the ellipsis, and use when truncating text. This invokes the layouter to layout the ellipsis, so that the same code that draws the main text can also draw the ellipsis.

The default ellipsis is left as 3 periods, (`...`) as some fonts that players use may not include a `…` character, though the default fonts do include it.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
