### PR TITLE
Change: Select snow line height by level instead of coverage

### DIFF
--- a/src/genworld.h
+++ b/src/genworld.h
@@ -47,6 +47,8 @@ static const uint CUSTOM_SEA_LEVEL_NUMBER_DIFFICULTY = 4; ///< Value for custom 
 static const uint CUSTOM_SEA_LEVEL_MIN_PERCENTAGE = 1;    ///< Minimum percentage a user can specify for custom sea level.
 static const uint CUSTOM_SEA_LEVEL_MAX_PERCENTAGE = 90;   ///< Maximum percentage a user can specify for custom sea level.
 
+static const uint CUSTOM_SNOW_LEVEL_NUMBER = 5; ///< Value for custom snow level in game creation settings.
+
 static constexpr uint MAP_HEIGHT_LIMIT_ORIGINAL = 15; ///< Original map height limit.
 
 static const uint MAP_HEIGHT_LIMIT_AUTO_MINIMUM = 30; ///< When map height limit is auto, make this the lowest possible map height limit.

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -126,7 +126,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_generate_landscape_w
 					/* Labels on the left side (global column 3). */
 					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
 						NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GL_CLIMATE_SEL_LABEL),
-							NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_SNOW_COVERAGE, STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT), SetFill(1, 1),
+							NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_SNOW_LINE_LEVEL, STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT), SetFill(1, 1),
 							NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_DESERT_COVERAGE, STR_CONFIG_SETTING_DESERT_COVERAGE_HELPTEXT), SetFill(1, 1),
 							NWidget(NWID_SPACER), SetFill(1, 1),
 						EndContainer(),
@@ -143,11 +143,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_generate_landscape_w
 					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
 						/* Climate selector. */
 						NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GL_CLIMATE_SEL_SELECTOR),
-							/* Snow coverage. */
+							/* Snow line level. */
 							NWidget(NWID_HORIZONTAL),
-								NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_COVERAGE_DOWN), SetSpriteTip(SPR_ARROW_DOWN, STR_MAPGEN_SNOW_COVERAGE_DOWN_TOOLTIP), SetFill(0, 1), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
-								NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_SNOW_COVERAGE_TEXT), SetToolTip(STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT), SetFill(1, 1),
-								NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_COVERAGE_UP), SetSpriteTip(SPR_ARROW_UP, STR_MAPGEN_SNOW_COVERAGE_UP_TOOLTIP), SetFill(0, 1), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
+								NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_SNOW_LINE_LEVEL_PULLDOWN), SetToolTip(STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT), SetFill(1, 1),
 							EndContainer(),
 							/* Desert coverage. */
 							NWidget(NWID_HORIZONTAL),
@@ -265,7 +263,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_heightmap_load_widge
 					/* Right half labels (global column 3) */
 					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
 						NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GL_CLIMATE_SEL_LABEL),
-							NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_SNOW_COVERAGE, STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT), SetFill(1, 1),
+							NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_SNOW_LINE_LEVEL, STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT), SetFill(1, 1),
 							NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_DESERT_COVERAGE, STR_CONFIG_SETTING_DESERT_COVERAGE_HELPTEXT), SetFill(1, 1),
 							NWidget(NWID_SPACER), SetFill(1, 1),
 						EndContainer(),
@@ -279,11 +277,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_heightmap_load_widge
 					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
 						/* Climate selector. */
 						NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GL_CLIMATE_SEL_SELECTOR),
-							/* Snow coverage. */
+							/* Snow line level. */
 							NWidget(NWID_HORIZONTAL),
-								NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_COVERAGE_DOWN), SetSpriteTip(SPR_ARROW_DOWN, STR_MAPGEN_SNOW_COVERAGE_DOWN_TOOLTIP), SetFill(0, 1), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
-								NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_SNOW_COVERAGE_TEXT), SetToolTip(STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT), SetFill(1, 1),
-								NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_COVERAGE_UP), SetSpriteTip(SPR_ARROW_UP, STR_MAPGEN_SNOW_COVERAGE_UP_TOOLTIP), SetFill(0, 1), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
+								NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_SNOW_LINE_LEVEL_PULLDOWN), SetToolTip(STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT), SetFill(1, 1),
 							EndContainer(),
 							/* Desert coverage. */
 							NWidget(NWID_HORIZONTAL),
@@ -392,6 +388,7 @@ static const StringID _num_towns[]   = {STR_NUM_VERY_LOW, STR_NUM_LOW, STR_NUM_N
 static const StringID _num_inds[]    = {STR_FUNDING_ONLY, STR_MINIMAL, STR_NUM_VERY_LOW, STR_NUM_LOW, STR_NUM_NORMAL, STR_NUM_HIGH, STR_NUM_CUSTOM};
 static const StringID _variety[]     = {STR_VARIETY_NONE, STR_VARIETY_VERY_LOW, STR_VARIETY_LOW, STR_VARIETY_MEDIUM, STR_VARIETY_HIGH, STR_VARIETY_VERY_HIGH};
 static const StringID _average_height[] = {STR_CONFIG_SETTING_AVERAGE_HEIGHT_AUTO, STR_CONFIG_SETTING_AVERAGE_HEIGHT_LOWLANDS, STR_CONFIG_SETTING_AVERAGE_HEIGHT_NORMAL, STR_CONFIG_SETTING_AVERAGE_HEIGHT_PLATEAUS};
+static const StringID _snow_levels[] = {STR_SNOW_LINE_LEVEL_VERY_LOW, STR_SNOW_LINE_LEVEL_LOW, STR_SNOW_LINE_LEVEL_MEDIUM, STR_SNOW_LINE_LEVEL_HIGH, STR_SNOW_LINE_LEVEL_VERY_HIGH, STR_SNOW_LINE_LEVEL_CUSTOM};
 
 static_assert(std::size(_num_inds) == to_underlying(IndustryDensity::End));
 
@@ -434,7 +431,12 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_MAPSIZE_X_PULLDOWN:   return GetString(STR_JUST_INT, 1LL << _settings_newgame.game_creation.map_x);
 			case WID_GL_MAPSIZE_Y_PULLDOWN:   return GetString(STR_JUST_INT, 1LL << _settings_newgame.game_creation.map_y);
 			case WID_GL_HEIGHTMAP_HEIGHT_TEXT: return GetString(STR_JUST_INT, _settings_newgame.game_creation.heightmap_height);
-			case WID_GL_SNOW_COVERAGE_TEXT:   return GetString(STR_MAPGEN_SNOW_COVERAGE_TEXT, _settings_newgame.game_creation.snow_coverage);
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN:
+				if (_settings_newgame.game_creation.snow_line_level == CUSTOM_SNOW_LEVEL_NUMBER) {
+					return GetString(STR_SNOW_LINE_LEVEL_CUSTOM_NUMBER, _settings_newgame.game_creation.snow_line_height);
+				}
+				return GetString(_snow_levels[_settings_newgame.game_creation.snow_line_level]);
+
 			case WID_GL_DESERT_COVERAGE_TEXT: return GetString(STR_MAPGEN_DESERT_COVERAGE_TEXT, _settings_newgame.game_creation.desert_coverage);
 
 			case WID_GL_TOWN_PULLDOWN:
@@ -530,7 +532,7 @@ struct GenerateLandscapeWindow : public Window {
 		}
 
 		/* Disable snowline if not arctic */
-		this->SetWidgetDisabledState(WID_GL_SNOW_COVERAGE_TEXT, _settings_newgame.game_creation.landscape != LandscapeType::Arctic);
+		this->SetWidgetDisabledState(WID_GL_SNOW_LINE_LEVEL_PULLDOWN, _settings_newgame.game_creation.landscape != LandscapeType::Arctic);
 		/* Disable desert if not tropic */
 		this->SetWidgetDisabledState(WID_GL_DESERT_COVERAGE_TEXT, _settings_newgame.game_creation.landscape != LandscapeType::Tropic);
 
@@ -552,8 +554,6 @@ struct GenerateLandscapeWindow : public Window {
 		}
 		this->SetWidgetDisabledState(WID_GL_START_DATE_DOWN, _settings_newgame.game_creation.starting_year <= CalendarTime::MIN_YEAR);
 		this->SetWidgetDisabledState(WID_GL_START_DATE_UP,   _settings_newgame.game_creation.starting_year >= CalendarTime::MAX_YEAR);
-		this->SetWidgetDisabledState(WID_GL_SNOW_COVERAGE_DOWN, _settings_newgame.game_creation.snow_coverage <= 0 || _settings_newgame.game_creation.landscape != LandscapeType::Arctic);
-		this->SetWidgetDisabledState(WID_GL_SNOW_COVERAGE_UP,   _settings_newgame.game_creation.snow_coverage >= 100 || _settings_newgame.game_creation.landscape != LandscapeType::Arctic);
 		this->SetWidgetDisabledState(WID_GL_DESERT_COVERAGE_DOWN, _settings_newgame.game_creation.desert_coverage <= 0 || _settings_newgame.game_creation.landscape != LandscapeType::Tropic);
 		this->SetWidgetDisabledState(WID_GL_DESERT_COVERAGE_UP,   _settings_newgame.game_creation.desert_coverage >= 100 || _settings_newgame.game_creation.landscape != LandscapeType::Tropic);
 
@@ -593,8 +593,8 @@ struct GenerateLandscapeWindow : public Window {
 				d = GetStringBoundingBox(GetString(STR_JUST_INT, GetParamMaxValue(MAX_MAP_SIZE)));
 				break;
 
-			case WID_GL_SNOW_COVERAGE_TEXT:
-				d = GetStringBoundingBox(GetString(STR_MAPGEN_SNOW_COVERAGE_TEXT, GetParamMaxValue(MAX_TILE_HEIGHT)));
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN:
+				d = GetStringBoundingBox(GetString(STR_JUST_INT, GetParamMaxValue(MAX_SNOWLINE_HEIGHT)));
 				break;
 
 			case WID_GL_DESERT_COVERAGE_TEXT:
@@ -745,22 +745,8 @@ struct GenerateLandscapeWindow : public Window {
 				ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.starting_year), STR_MAPGEN_START_DATE_QUERY_CAPT, 8, this, CS_NUMERAL, QueryStringFlag::EnableDefault);
 				break;
 
-			case WID_GL_SNOW_COVERAGE_DOWN:
-			case WID_GL_SNOW_COVERAGE_UP: // Snow coverage buttons
-				/* Don't allow too fast scrolling */
-				if (!this->flags.Test(WindowFlag::Timeout) || this->timeout_timer <= 1) {
-					this->HandleButtonClick(widget);
-
-					_settings_newgame.game_creation.snow_coverage = Clamp(_settings_newgame.game_creation.snow_coverage + (widget - WID_GL_SNOW_COVERAGE_TEXT) * 10, 0, 100);
-					this->InvalidateData();
-				}
-				_left_button_clicked = false;
-				break;
-
-			case WID_GL_SNOW_COVERAGE_TEXT: // Snow coverage text
-				this->widget_id = WID_GL_SNOW_COVERAGE_TEXT;
-				ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.snow_coverage), STR_MAPGEN_SNOW_COVERAGE_QUERY_CAPT, 4, this, CS_NUMERAL, QueryStringFlag::EnableDefault);
-				SndClickBeep();
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN: // Snow line level
+				ShowDropDownMenu(this, _snow_levels, _settings_newgame.game_creation.snow_line_level, WID_GL_SNOW_LINE_LEVEL_PULLDOWN, 0, 0);
 				break;
 
 			case WID_GL_DESERT_COVERAGE_DOWN:
@@ -862,9 +848,9 @@ struct GenerateLandscapeWindow : public Window {
 	void OnTimeout() override
 	{
 		if (mode == GLWM_HEIGHTMAP) {
-			this->RaiseWidgetsWhenLowered(WID_GL_HEIGHTMAP_HEIGHT_DOWN, WID_GL_HEIGHTMAP_HEIGHT_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
+			this->RaiseWidgetsWhenLowered(WID_GL_HEIGHTMAP_HEIGHT_DOWN, WID_GL_HEIGHTMAP_HEIGHT_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
 		} else {
-			this->RaiseWidgetsWhenLowered(WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
+			this->RaiseWidgetsWhenLowered(WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
 		}
 	}
 
@@ -879,6 +865,14 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_AVERAGE_HEIGHT_PULLDOWN: _settings_newgame.game_creation.average_height = static_cast<GenworldAverageHeight>(index); break;
 
 			case WID_GL_HEIGHTMAP_ROTATION_PULLDOWN: _settings_newgame.game_creation.heightmap_rotation = index; break;
+
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN: // Snow line level
+				if ((uint)index == CUSTOM_SNOW_LEVEL_NUMBER) {
+					this->widget_id = widget;
+					ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.snow_line_height), STR_MAPGEN_SNOW_LINE_LEVEL_QUERY_CAPT, 4, this, CS_NUMERAL, {});
+				}
+				_settings_newgame.game_creation.snow_line_level = index;
+				break;
 
 			case WID_GL_TOWN_PULLDOWN:
 				if ((uint)index == CUSTOM_TOWN_NUMBER_DIFFICULTY) {
@@ -958,7 +952,7 @@ struct GenerateLandscapeWindow : public Window {
 			switch (this->widget_id) {
 				case WID_GL_HEIGHTMAP_HEIGHT_TEXT: value = MAP_HEIGHT_LIMIT_AUTO_MINIMUM; break;
 				case WID_GL_START_DATE_TEXT: value = CalendarTime::DEF_START_YEAR.base(); break;
-				case WID_GL_SNOW_COVERAGE_TEXT: value = DEF_SNOW_COVERAGE; break;
+				case WID_GL_SNOW_LINE_LEVEL_PULLDOWN: value = DEF_SNOWLINE_HEIGHT; break;
 				case WID_GL_DESERT_COVERAGE_TEXT: value = DEF_DESERT_COVERAGE; break;
 				case WID_GL_TOWN_PULLDOWN: value = 1; break;
 				case WID_GL_INDUSTRY_PULLDOWN: value = 1; break;
@@ -979,9 +973,8 @@ struct GenerateLandscapeWindow : public Window {
 				_settings_newgame.game_creation.starting_year = Clamp(TimerGameCalendar::Year(value), CalendarTime::MIN_YEAR, CalendarTime::MAX_YEAR);
 				break;
 
-			case WID_GL_SNOW_COVERAGE_TEXT:
-				this->SetWidgetDirty(WID_GL_SNOW_COVERAGE_TEXT);
-				_settings_newgame.game_creation.snow_coverage = Clamp(value, 0, 100);
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN:
+				_settings_newgame.game_creation.snow_line_height = Clamp(value, MIN_SNOWLINE_HEIGHT, MAX_SNOWLINE_HEIGHT);
 				break;
 
 			case WID_GL_DESERT_COVERAGE_TEXT:

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -127,7 +127,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_generate_landscape_w
 					/* Labels on the left side (global column 3). */
 					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
 						NWidget(NWID_SELECTION, Colours::Invalid, WID_GL_CLIMATE_SEL_LABEL),
-							NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_SNOW_COVERAGE, STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT), SetFill(1, 1),
+							NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_SNOW_LINE_LEVEL, STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT), SetFill(1, 1),
 							NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_DESERT_COVERAGE, STR_CONFIG_SETTING_DESERT_COVERAGE_HELPTEXT), SetFill(1, 1),
 							NWidget(NWID_SPACER), SetFill(1, 1),
 						EndContainer(),
@@ -144,11 +144,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_generate_landscape_w
 					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
 						/* Climate selector. */
 						NWidget(NWID_SELECTION, Colours::Invalid, WID_GL_CLIMATE_SEL_SELECTOR),
-							/* Snow coverage. */
+							/* Snow line level. */
 							NWidget(NWID_HORIZONTAL),
-								NWidget(WWT_IMGBTN, Colours::Orange, WID_GL_SNOW_COVERAGE_DOWN), SetSpriteTip(SPR_ARROW_DOWN, STR_MAPGEN_SNOW_COVERAGE_DOWN_TOOLTIP), SetFill(0, 1), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
-								NWidget(WWT_TEXTBTN, Colours::Orange, WID_GL_SNOW_COVERAGE_TEXT), SetToolTip(STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT), SetFill(1, 1),
-								NWidget(WWT_IMGBTN, Colours::Orange, WID_GL_SNOW_COVERAGE_UP), SetSpriteTip(SPR_ARROW_UP, STR_MAPGEN_SNOW_COVERAGE_UP_TOOLTIP), SetFill(0, 1), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
+								NWidget(WWT_DROPDOWN, Colours::Orange, WID_GL_SNOW_LINE_LEVEL_PULLDOWN), SetToolTip(STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT), SetFill(1, 1),
 							EndContainer(),
 							/* Desert coverage. */
 							NWidget(NWID_HORIZONTAL),
@@ -268,7 +266,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_heightmap_load_widge
 					/* Right half labels (global column 3) */
 					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
 						NWidget(NWID_SELECTION, Colours::Invalid, WID_GL_CLIMATE_SEL_LABEL),
-							NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_SNOW_COVERAGE, STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT), SetFill(1, 1),
+							NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_SNOW_LINE_LEVEL, STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT), SetFill(1, 1),
 							NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_DESERT_COVERAGE, STR_CONFIG_SETTING_DESERT_COVERAGE_HELPTEXT), SetFill(1, 1),
 							NWidget(NWID_SPACER), SetFill(1, 1),
 						EndContainer(),
@@ -283,11 +281,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_heightmap_load_widge
 					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
 						/* Climate selector. */
 						NWidget(NWID_SELECTION, Colours::Invalid, WID_GL_CLIMATE_SEL_SELECTOR),
-							/* Snow coverage. */
+							/* Snow line level. */
 							NWidget(NWID_HORIZONTAL),
-								NWidget(WWT_IMGBTN, Colours::Orange, WID_GL_SNOW_COVERAGE_DOWN), SetSpriteTip(SPR_ARROW_DOWN, STR_MAPGEN_SNOW_COVERAGE_DOWN_TOOLTIP), SetFill(0, 1), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
-								NWidget(WWT_TEXTBTN, Colours::Orange, WID_GL_SNOW_COVERAGE_TEXT), SetToolTip(STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT), SetFill(1, 1),
-								NWidget(WWT_IMGBTN, Colours::Orange, WID_GL_SNOW_COVERAGE_UP), SetSpriteTip(SPR_ARROW_UP, STR_MAPGEN_SNOW_COVERAGE_UP_TOOLTIP), SetFill(0, 1), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
+								NWidget(WWT_DROPDOWN, Colours::Orange, WID_GL_SNOW_LINE_LEVEL_PULLDOWN), SetToolTip(STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT), SetFill(1, 1),
 							EndContainer(),
 							/* Desert coverage. */
 							NWidget(NWID_HORIZONTAL),
@@ -397,6 +393,7 @@ static const StringID _num_towns[]   = {STR_NUM_VERY_LOW, STR_NUM_LOW, STR_NUM_N
 static const StringID _num_inds[]    = {STR_FUNDING_ONLY, STR_MINIMAL, STR_NUM_VERY_LOW, STR_NUM_LOW, STR_NUM_NORMAL, STR_NUM_HIGH, STR_NUM_CUSTOM};
 static const StringID _variety[]     = {STR_VARIETY_NONE, STR_VARIETY_VERY_LOW, STR_VARIETY_LOW, STR_VARIETY_MEDIUM, STR_VARIETY_HIGH, STR_VARIETY_VERY_HIGH};
 static const StringID _average_height[] = {STR_CONFIG_SETTING_AVERAGE_HEIGHT_AUTO, STR_CONFIG_SETTING_AVERAGE_HEIGHT_LOWLANDS, STR_CONFIG_SETTING_AVERAGE_HEIGHT_NORMAL, STR_CONFIG_SETTING_AVERAGE_HEIGHT_PLATEAUS};
+static const StringID _snow_levels[] = {STR_SNOW_LINE_LEVEL_VERY_LOW, STR_SNOW_LINE_LEVEL_LOW, STR_SNOW_LINE_LEVEL_MEDIUM, STR_SNOW_LINE_LEVEL_HIGH, STR_SNOW_LINE_LEVEL_VERY_HIGH, STR_SNOW_LINE_LEVEL_CUSTOM};
 
 static_assert(std::size(_num_inds) == to_underlying(IndustryDensity::End));
 
@@ -439,7 +436,12 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_MAPSIZE_X_PULLDOWN:   return GetString(STR_JUST_INT, 1LL << _settings_newgame.game_creation.map_x);
 			case WID_GL_MAPSIZE_Y_PULLDOWN:   return GetString(STR_JUST_INT, 1LL << _settings_newgame.game_creation.map_y);
 			case WID_GL_HEIGHTMAP_HEIGHT_TEXT: return GetString(STR_JUST_INT, _settings_newgame.game_creation.heightmap_height);
-			case WID_GL_SNOW_COVERAGE_TEXT:   return GetString(STR_MAPGEN_SNOW_COVERAGE_TEXT, _settings_newgame.game_creation.snow_coverage);
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN:
+				if (_settings_newgame.game_creation.snow_line_level == CUSTOM_SNOW_LEVEL_NUMBER) {
+					return GetString(STR_SNOW_LINE_LEVEL_CUSTOM_NUMBER, _settings_newgame.game_creation.snow_line_height);
+				}
+				return GetString(_snow_levels[_settings_newgame.game_creation.snow_line_level]);
+
 			case WID_GL_DESERT_COVERAGE_TEXT: return GetString(STR_MAPGEN_DESERT_COVERAGE_TEXT, _settings_newgame.game_creation.desert_coverage);
 
 			case WID_GL_TOWN_PULLDOWN:
@@ -535,7 +537,7 @@ struct GenerateLandscapeWindow : public Window {
 		}
 
 		/* Disable snowline if not arctic */
-		this->SetWidgetDisabledState(WID_GL_SNOW_COVERAGE_TEXT, _settings_newgame.game_creation.landscape != LandscapeType::Arctic);
+		this->SetWidgetDisabledState(WID_GL_SNOW_LINE_LEVEL_PULLDOWN, _settings_newgame.game_creation.landscape != LandscapeType::Arctic);
 		/* Disable desert if not tropic */
 		this->SetWidgetDisabledState(WID_GL_DESERT_COVERAGE_TEXT, _settings_newgame.game_creation.landscape != LandscapeType::Tropic);
 
@@ -557,8 +559,6 @@ struct GenerateLandscapeWindow : public Window {
 		}
 		this->SetWidgetDisabledState(WID_GL_START_DATE_DOWN, _settings_newgame.game_creation.starting_year <= CalendarTime::MIN_YEAR);
 		this->SetWidgetDisabledState(WID_GL_START_DATE_UP,   _settings_newgame.game_creation.starting_year >= CalendarTime::MAX_YEAR);
-		this->SetWidgetDisabledState(WID_GL_SNOW_COVERAGE_DOWN, _settings_newgame.game_creation.snow_coverage <= 0 || _settings_newgame.game_creation.landscape != LandscapeType::Arctic);
-		this->SetWidgetDisabledState(WID_GL_SNOW_COVERAGE_UP,   _settings_newgame.game_creation.snow_coverage >= 100 || _settings_newgame.game_creation.landscape != LandscapeType::Arctic);
 		this->SetWidgetDisabledState(WID_GL_DESERT_COVERAGE_DOWN, _settings_newgame.game_creation.desert_coverage <= 0 || _settings_newgame.game_creation.landscape != LandscapeType::Tropic);
 		this->SetWidgetDisabledState(WID_GL_DESERT_COVERAGE_UP,   _settings_newgame.game_creation.desert_coverage >= 100 || _settings_newgame.game_creation.landscape != LandscapeType::Tropic);
 
@@ -598,8 +598,8 @@ struct GenerateLandscapeWindow : public Window {
 				d = GetStringBoundingBox(GetString(STR_JUST_INT, GetParamMaxValue(MAX_MAP_SIZE)));
 				break;
 
-			case WID_GL_SNOW_COVERAGE_TEXT:
-				d = GetStringBoundingBox(GetString(STR_MAPGEN_SNOW_COVERAGE_TEXT, GetParamMaxValue(MAX_TILE_HEIGHT)));
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN:
+				d = GetStringBoundingBox(GetString(STR_JUST_INT, GetParamMaxValue(MAX_SNOWLINE_HEIGHT)));
 				break;
 
 			case WID_GL_DESERT_COVERAGE_TEXT:
@@ -750,22 +750,8 @@ struct GenerateLandscapeWindow : public Window {
 				ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.starting_year), STR_MAPGEN_START_DATE_QUERY_CAPT, 8, this, CS_NUMERAL, QueryStringFlag::EnableDefault);
 				break;
 
-			case WID_GL_SNOW_COVERAGE_DOWN:
-			case WID_GL_SNOW_COVERAGE_UP: // Snow coverage buttons
-				/* Don't allow too fast scrolling */
-				if (!this->flags.Test(WindowFlag::Timeout) || this->timeout_timer <= 1) {
-					this->HandleButtonClick(widget);
-
-					_settings_newgame.game_creation.snow_coverage = Clamp(_settings_newgame.game_creation.snow_coverage + (widget - WID_GL_SNOW_COVERAGE_TEXT) * 10, 0, 100);
-					this->InvalidateData();
-				}
-				_left_button_clicked = false;
-				break;
-
-			case WID_GL_SNOW_COVERAGE_TEXT: // Snow coverage text
-				this->widget_id = WID_GL_SNOW_COVERAGE_TEXT;
-				ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.snow_coverage), STR_MAPGEN_SNOW_COVERAGE_QUERY_CAPT, 4, this, CS_NUMERAL, QueryStringFlag::EnableDefault);
-				SndClickBeep();
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN: // Snow line level
+				ShowDropDownMenu(this, _snow_levels, _settings_newgame.game_creation.snow_line_level, WID_GL_SNOW_LINE_LEVEL_PULLDOWN, 0, 0);
 				break;
 
 			case WID_GL_DESERT_COVERAGE_DOWN:
@@ -868,9 +854,9 @@ struct GenerateLandscapeWindow : public Window {
 	void OnTimeout() override
 	{
 		if (mode == GLWM_HEIGHTMAP) {
-			this->RaiseWidgetsWhenLowered(WID_GL_HEIGHTMAP_HEIGHT_DOWN, WID_GL_HEIGHTMAP_HEIGHT_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
+			this->RaiseWidgetsWhenLowered(WID_GL_HEIGHTMAP_HEIGHT_DOWN, WID_GL_HEIGHTMAP_HEIGHT_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
 		} else {
-			this->RaiseWidgetsWhenLowered(WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
+			this->RaiseWidgetsWhenLowered(WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN);
 		}
 	}
 
@@ -885,6 +871,14 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_AVERAGE_HEIGHT_PULLDOWN: _settings_newgame.game_creation.average_height = static_cast<GenworldAverageHeight>(index); break;
 
 			case WID_GL_HEIGHTMAP_ROTATION_PULLDOWN: _settings_newgame.game_creation.heightmap_rotation = index; break;
+
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN: // Snow line level
+				if ((uint)index == CUSTOM_SNOW_LEVEL_NUMBER) {
+					this->widget_id = widget;
+					ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.snow_line_height), STR_MAPGEN_SNOW_LINE_LEVEL_QUERY_CAPT, 4, this, CS_NUMERAL, {});
+				}
+				_settings_newgame.game_creation.snow_line_level = index;
+				break;
 
 			case WID_GL_TOWN_PULLDOWN:
 				if ((uint)index == CUSTOM_TOWN_NUMBER_DIFFICULTY) {
@@ -964,7 +958,7 @@ struct GenerateLandscapeWindow : public Window {
 			switch (this->widget_id) {
 				case WID_GL_HEIGHTMAP_HEIGHT_TEXT: value = MAP_HEIGHT_LIMIT_AUTO_MINIMUM; break;
 				case WID_GL_START_DATE_TEXT: value = CalendarTime::DEF_START_YEAR.base(); break;
-				case WID_GL_SNOW_COVERAGE_TEXT: value = DEF_SNOW_COVERAGE; break;
+				case WID_GL_SNOW_LINE_LEVEL_PULLDOWN: value = DEF_SNOWLINE_HEIGHT; break;
 				case WID_GL_DESERT_COVERAGE_TEXT: value = DEF_DESERT_COVERAGE; break;
 				case WID_GL_TOWN_PULLDOWN: value = 1; break;
 				case WID_GL_INDUSTRY_PULLDOWN: value = 1; break;
@@ -985,9 +979,8 @@ struct GenerateLandscapeWindow : public Window {
 				_settings_newgame.game_creation.starting_year = Clamp(TimerGameCalendar::Year(value), CalendarTime::MIN_YEAR, CalendarTime::MAX_YEAR);
 				break;
 
-			case WID_GL_SNOW_COVERAGE_TEXT:
-				this->SetWidgetDirty(WID_GL_SNOW_COVERAGE_TEXT);
-				_settings_newgame.game_creation.snow_coverage = Clamp(value, 0, 100);
+			case WID_GL_SNOW_LINE_LEVEL_PULLDOWN:
+				_settings_newgame.game_creation.snow_line_height = Clamp(value, MIN_SNOWLINE_HEIGHT, MAX_SNOWLINE_HEIGHT);
 				break;
 
 			case WID_GL_DESERT_COVERAGE_TEXT:

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1595,12 +1595,43 @@ static uint CalculateCoverageLine(uint coverage, uint edge_multiplier)
 }
 
 /**
+ * Get current maximum height of the map.
+ * @return The maximum height of the map.
+ */
+static uint GetMapMaxHeight()
+{
+	uint max_height = 0;
+
+	for (const auto tile : Map::Iterate()) {
+		uint h = TileHeight(tile);
+		if (h > max_height) {
+			max_height = h;
+		}
+	}
+
+	return max_height;
+}
+
+/**
  * Calculate the line from which snow begins.
  */
 static void CalculateSnowLine()
 {
-	/* We do not have snow sprites on coastal tiles, so never allow "1" as height. */
-	_settings_game.game_creation.snow_line_height = std::max<uint8_t>(CalculateCoverageLine(_settings_game.game_creation.snow_coverage, 0), 2u);
+	/* If snow_line_level is custom, then snow_line_height is already set
+	 * otherwise we have to calculate it. */
+	if (_settings_game.game_creation.snow_line_level != CUSTOM_SNOW_LEVEL_NUMBER) {
+		uint min_snow_line_height = 4;                              // Not too low to make room for farms.
+		uint max_snow_line_height = GetMapMaxHeight() - 2;          // Not too high to make room for forests.
+
+		uint max_height_diff = min_snow_line_height < max_snow_line_height
+			? max_snow_line_height - min_snow_line_height
+			: 0;
+
+		/* snow_line_level goes up to 4 so we divide by 5 to get a maximum ratio of 80%. */
+		uint height_diff = RoundDivSU(max_height_diff * _settings_game.game_creation.snow_line_level, 5);
+
+		_settings_game.game_creation.snow_line_height = min_snow_line_height + height_diff;
+	}
 }
 
 /**

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1234,6 +1234,15 @@ STR_TERRAIN_TYPE_ALPINIST                                       :Alpinist
 STR_TERRAIN_TYPE_CUSTOM                                         :Custom height
 STR_TERRAIN_TYPE_CUSTOM_VALUE                                   :Custom height ({NUM})
 
+###length 7
+STR_SNOW_LINE_LEVEL_VERY_LOW                                    :Very Low
+STR_SNOW_LINE_LEVEL_LOW                                         :Low
+STR_SNOW_LINE_LEVEL_MEDIUM                                      :Medium
+STR_SNOW_LINE_LEVEL_HIGH                                        :High
+STR_SNOW_LINE_LEVEL_VERY_HIGH                                   :Very high
+STR_SNOW_LINE_LEVEL_CUSTOM                                      :Custom
+STR_SNOW_LINE_LEVEL_CUSTOM_NUMBER                               :Custom ({NUM})
+
 ###length 4
 STR_CITY_APPROVAL_LENIENT                                       :Lenient
 STR_CITY_APPROVAL_TOLERANT                                      :Tolerant
@@ -1610,9 +1619,8 @@ STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Limit for how f
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT                              :Snow line height: {STRING2}
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT_HELPTEXT                     :Choose at what height snow starts in sub-arctic landscape. Snow also affects industry generation and town growth requirements. Can only be modified via Scenario Editor or is otherwise calculated via "snow coverage"
 
-STR_CONFIG_SETTING_SNOW_COVERAGE                                :Snow coverage: {STRING2}
-STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT                       :Choose the approximate amount of snow on the sub-arctic landscape. Snow also affects industry generation and town growth requirements. Only used during map generation. Sea level and coast tiles never have snow
-STR_CONFIG_SETTING_SNOW_COVERAGE_VALUE                          :{NUM}%
+STR_CONFIG_SETTING_SNOW_LINE_LEVEL                              :Snow line level: {STRING2}
+STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT                     :Choose the approximate height above which all tiles will be covered by snow in sub-arctic landscape. Snow also affects industry generation and town growth requirements.
 
 STR_CONFIG_SETTING_DESERT_COVERAGE                              :Desert coverage: {STRING2}
 STR_CONFIG_SETTING_DESERT_COVERAGE_HELPTEXT                     :Choose the approximate amount of desert on the tropical landscape. Desert also affects industry generation and town growth requirements. Only used during map generation
@@ -3386,10 +3394,7 @@ STR_MAPGEN_HEIGHTMAP_HEIGHT                                     :{BLACK}Highest 
 STR_MAPGEN_HEIGHTMAP_HEIGHT_TOOLTIP                             :{BLACK}Choose the highest peak that the game will attempt to create, measured in elevation above sea level
 STR_MAPGEN_HEIGHTMAP_HEIGHT_UP_TOOLTIP                          :{BLACK}Increase the maximum height of highest peak on the map by one
 STR_MAPGEN_HEIGHTMAP_HEIGHT_DOWN_TOOLTIP                        :{BLACK}Decrease the maximum height of highest peak on the map by one
-STR_MAPGEN_SNOW_COVERAGE                                        :{BLACK}Snow coverage:
-STR_MAPGEN_SNOW_COVERAGE_UP_TOOLTIP                             :{BLACK}Increase snow coverage by ten percent
-STR_MAPGEN_SNOW_COVERAGE_DOWN_TOOLTIP                           :{BLACK}Decrease snow coverage by ten percent
-STR_MAPGEN_SNOW_COVERAGE_TEXT                                   :{BLACK}{NUM}%
+STR_MAPGEN_SNOW_LINE_LEVEL                                      :{BLACK}Snow line level:
 STR_MAPGEN_DESERT_COVERAGE                                      :{BLACK}Desert coverage:
 STR_MAPGEN_DESERT_COVERAGE_UP_TOOLTIP                           :{BLACK}Increase desert coverage by ten percent
 STR_MAPGEN_DESERT_COVERAGE_DOWN_TOOLTIP                         :{BLACK}Decrease desert coverage by ten percent
@@ -3462,7 +3467,7 @@ STR_MAPGEN_HEIGHTMAP_SIZE                                       :{ORANGE}{NUM} x
 
 STR_MAPGEN_TERRAIN_TYPE_QUERY_CAPT                              :{WHITE}Target peak height
 STR_MAPGEN_HEIGHTMAP_HEIGHT_QUERY_CAPT                          :{WHITE}Highest peak
-STR_MAPGEN_SNOW_COVERAGE_QUERY_CAPT                             :{WHITE}Snow coverage (in %)
+STR_MAPGEN_SNOW_LINE_LEVEL_QUERY_CAPT                           :{WHITE}Snow line height
 STR_MAPGEN_DESERT_COVERAGE_QUERY_CAPT                           :{WHITE}Desert coverage (in %)
 STR_MAPGEN_START_DATE_QUERY_CAPT                                :{WHITE}Change starting year
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1236,6 +1236,15 @@ STR_TERRAIN_TYPE_ALPINIST                                       :Alpinist
 STR_TERRAIN_TYPE_CUSTOM                                         :Custom height
 STR_TERRAIN_TYPE_CUSTOM_VALUE                                   :Custom height ({NUM})
 
+###length 7
+STR_SNOW_LINE_LEVEL_VERY_LOW                                    :Very Low
+STR_SNOW_LINE_LEVEL_LOW                                         :Low
+STR_SNOW_LINE_LEVEL_MEDIUM                                      :Medium
+STR_SNOW_LINE_LEVEL_HIGH                                        :High
+STR_SNOW_LINE_LEVEL_VERY_HIGH                                   :Very high
+STR_SNOW_LINE_LEVEL_CUSTOM                                      :Custom
+STR_SNOW_LINE_LEVEL_CUSTOM_NUMBER                               :Custom ({NUM})
+
 ###length 4
 STR_CITY_APPROVAL_LENIENT                                       :Lenient
 STR_CITY_APPROVAL_TOLERANT                                      :Tolerant
@@ -1623,9 +1632,8 @@ STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Limit for how f
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT                              :Snow line height: {STRING2}
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT_HELPTEXT                     :Choose at what height snow starts in sub-arctic landscape. Snow also affects industry generation and town growth requirements. Can only be modified via Scenario Editor or is otherwise calculated via "snow coverage"
 
-STR_CONFIG_SETTING_SNOW_COVERAGE                                :Snow coverage: {STRING2}
-STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT                       :Choose the approximate amount of snow on the sub-arctic landscape. Snow also affects industry generation and town growth requirements. Only used during map generation. Sea level and coast tiles never have snow
-STR_CONFIG_SETTING_SNOW_COVERAGE_VALUE                          :{NUM}%
+STR_CONFIG_SETTING_SNOW_LINE_LEVEL                              :Snow line level: {STRING2}
+STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT                     :Choose the approximate height above which all tiles will be covered by snow in sub-arctic landscape. Snow also affects industry generation and town growth requirements.
 
 STR_CONFIG_SETTING_DESERT_COVERAGE                              :Desert coverage: {STRING2}
 STR_CONFIG_SETTING_DESERT_COVERAGE_HELPTEXT                     :Choose the approximate amount of desert on the tropical landscape. Desert also affects industry generation and town growth requirements. Only used during map generation
@@ -3424,10 +3432,7 @@ STR_MAPGEN_HEIGHTMAP_HEIGHT                                     :{BLACK}Highest 
 STR_MAPGEN_HEIGHTMAP_HEIGHT_TOOLTIP                             :{BLACK}Choose the highest peak that the game will attempt to create, measured in elevation above sea level
 STR_MAPGEN_HEIGHTMAP_HEIGHT_UP_TOOLTIP                          :{BLACK}Increase the maximum height of highest peak on the map by one
 STR_MAPGEN_HEIGHTMAP_HEIGHT_DOWN_TOOLTIP                        :{BLACK}Decrease the maximum height of highest peak on the map by one
-STR_MAPGEN_SNOW_COVERAGE                                        :{BLACK}Snow coverage:
-STR_MAPGEN_SNOW_COVERAGE_UP_TOOLTIP                             :{BLACK}Increase snow coverage by ten percent
-STR_MAPGEN_SNOW_COVERAGE_DOWN_TOOLTIP                           :{BLACK}Decrease snow coverage by ten percent
-STR_MAPGEN_SNOW_COVERAGE_TEXT                                   :{BLACK}{NUM}%
+STR_MAPGEN_SNOW_LINE_LEVEL                                      :{BLACK}Snow line level:
 STR_MAPGEN_DESERT_COVERAGE                                      :{BLACK}Desert coverage:
 STR_MAPGEN_DESERT_COVERAGE_UP_TOOLTIP                           :{BLACK}Increase desert coverage by ten percent
 STR_MAPGEN_DESERT_COVERAGE_DOWN_TOOLTIP                         :{BLACK}Decrease desert coverage by ten percent
@@ -3500,7 +3505,7 @@ STR_MAPGEN_HEIGHTMAP_SIZE                                       :{ORANGE}{NUM} x
 
 STR_MAPGEN_TERRAIN_TYPE_QUERY_CAPT                              :{WHITE}Target peak height
 STR_MAPGEN_HEIGHTMAP_HEIGHT_QUERY_CAPT                          :{WHITE}Highest peak
-STR_MAPGEN_SNOW_COVERAGE_QUERY_CAPT                             :{WHITE}Snow coverage (in %)
+STR_MAPGEN_SNOW_LINE_LEVEL_QUERY_CAPT                           :{WHITE}Snow line height
 STR_MAPGEN_DESERT_COVERAGE_QUERY_CAPT                           :{WHITE}Desert coverage (in %)
 STR_MAPGEN_START_DATE_QUERY_CAPT                                :{WHITE}Change starting year
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -66,6 +66,7 @@
 #include "../timer/timer_game_economy.h"
 #include "../timer/timer_game_tick.h"
 #include "../picker_func.h"
+#include "../genworld.h"
 
 #include "saveload_internal.h"
 
@@ -3406,6 +3407,11 @@ bool AfterLoadGame()
 		} else {
 			c->freegroups.UseID(g->number);
 		}
+	}
+
+	if (IsSavegameVersionBefore(SLV_SNOW_LINE_LEVEL)) {
+		/* The snow line level replaces the snow coverage but the two do not map very well. */
+		_settings_game.game_creation.snow_line_level = CUSTOM_SNOW_LEVEL_NUMBER;
 	}
 
 	AfterLoadLabelMaps();

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -66,6 +66,7 @@
 #include "../timer/timer_game_economy.h"
 #include "../timer/timer_game_tick.h"
 #include "../picker_func.h"
+#include "../genworld.h"
 
 #include "saveload_internal.h"
 
@@ -3433,6 +3434,11 @@ bool AfterLoadGame()
 		} else {
 			c->freegroups.UseID(g->number);
 		}
+	}
+
+	if (IsSavegameVersionBefore(SaveLoadVersion::SnowLineLevel)) {
+		/* The snow line level replaces the snow coverage but the two do not map very well. */
+		_settings_game.game_creation.snow_line_level = CUSTOM_SNOW_LEVEL_NUMBER;
 	}
 
 	AfterLoadLabelMaps();

--- a/src/saveload/compat/settings_sl_compat.h
+++ b/src/saveload/compat/settings_sl_compat.h
@@ -143,7 +143,7 @@ const SaveLoadCompat _settings_sl_compat[] = {
 	SLC_VAR("economy.fund_roads"),
 	SLC_VAR("economy.give_money"),
 	SLC_VAR("game_creation.snow_line_height"),
-	SLC_VAR("game_creation.snow_coverage"),
+	SLC_NULL(1, SLV_MAPGEN_SETTINGS_REVAMP, SLV_TABLE_CHUNKS),
 	SLC_VAR("game_creation.desert_coverage"),
 	SLC_NULL(4, SL_MIN_VERSION, SLV_144),
 	SLC_VAR("game_creation.starting_year"),

--- a/src/saveload/compat/settings_sl_compat.h
+++ b/src/saveload/compat/settings_sl_compat.h
@@ -143,7 +143,7 @@ const SaveLoadCompat _settings_sl_compat[] = {
 	SLC_VAR("economy.fund_roads"),
 	SLC_VAR("economy.give_money"),
 	SLC_VAR("game_creation.snow_line_height"),
-	SLC_VAR("game_creation.snow_coverage"),
+	SLC_NULL(1, SaveLoadVersion::MapgenSettingsRevamp, SaveLoadVersion::TableChunks),
 	SLC_VAR("game_creation.desert_coverage"),
 	SLC_NULL(4, SaveLoadVersion::MinVersion, SaveLoadVersion::ReorderUnmovableRemoveReserved),
 	SLC_VAR("game_creation.starting_year"),

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -415,6 +415,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_SIGN_TEXT_COLOURS,                  ///< 363  PR#14743 Configurable sign text colors in scenario editor.
 	SLV_BUOYS_AT_0_0,                       ///< 364  PR#14983 Allow to build buoys at (0x0).
 
+	SLV_SNOW_LINE_LEVEL,                    ///< 365  PR#14428 Replacement of snow coverage setting with snow line level setting.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -416,6 +416,7 @@ enum class SaveLoadVersion : uint16_t {
 	BuoysAt0_0, ///< Saveload version: 364, GitHub pull request: 14983\n Allow to build buoys at (0x0).
 
 	DriveBackwards, ///< Saveload version: 365, GitHub pull request: 15379\n Trains can drive backwards.
+	SnowLineLevel, ///< Saveload version: 366, GitHub pull request: 14428\n Replacement of snow coverage setting with snow line level setting.
 
 	MaxVersion, ///< Highest possible saveload version.
 };

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -844,7 +844,7 @@ SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("game_creation.average_height"));
 			genworld->Add(new SettingEntry("game_creation.tgen_smoothness"));
 			genworld->Add(new SettingEntry("game_creation.variety"));
-			genworld->Add(new SettingEntry("game_creation.snow_coverage"));
+			genworld->Add(new SettingEntry("game_creation.snow_line_level"));
 			genworld->Add(new SettingEntry("game_creation.snow_line_height"));
 			genworld->Add(new SettingEntry("game_creation.desert_coverage"));
 			genworld->Add(new SettingEntry("game_creation.amount_of_rivers"));

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -795,7 +795,7 @@ SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("game_creation.average_height"));
 			genworld->Add(new SettingEntry("game_creation.tgen_smoothness"));
 			genworld->Add(new SettingEntry("game_creation.variety"));
-			genworld->Add(new SettingEntry("game_creation.snow_coverage"));
+			genworld->Add(new SettingEntry("game_creation.snow_line_level"));
 			genworld->Add(new SettingEntry("game_creation.snow_line_height"));
 			genworld->Add(new SettingEntry("game_creation.desert_coverage"));
 			genworld->Add(new SettingEntry("game_creation.amount_of_rivers"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -408,8 +408,8 @@ struct GameCreationSettings {
 	uint8_t  map_y;                            ///< Y size of map
 	uint8_t land_generator;                   ///< the landscape generator
 	uint8_t oil_refinery_limit;               ///< distance oil refineries allowed from map edge
-	uint8_t snow_line_height;                 ///< the configured snow line height (deduced from "snow_coverage")
-	uint8_t snow_coverage;                    ///< the amount of snow coverage on the map
+	uint8_t snow_line_height;                 ///< the configured snow line height (deduced from "snow_line_level" unless it is set on "custom")
+	uint8_t snow_line_level;                  ///< the approximate snow line level on the map
 	uint8_t desert_coverage;                  ///< the amount of desert coverage on the map
 	uint8_t heightmap_height;                 ///< highest mountain for heightmap (towards what it scales)
 	uint8_t tgen_smoothness;                  ///< how rough is the terrain from 0-3

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -461,8 +461,8 @@ struct GameCreationSettings {
 	uint8_t map_y; ///< Y size of map
 	uint8_t land_generator; ///< the landscape generator
 	uint8_t oil_refinery_limit; ///< distance oil refineries allowed from map edge
-	uint8_t snow_line_height; ///< the configured snow line height (deduced from "snow_coverage")
-	uint8_t snow_coverage; ///< the amount of snow coverage on the map
+	uint8_t snow_line_height; ///< the configured snow line height (deduced from "snow_line_level" unless it is set on "custom")
+	uint8_t snow_line_level; ///< the approximate snow line level on the map
 	uint8_t desert_coverage; ///< the amount of desert coverage on the map
 	uint8_t heightmap_height; ///< highest mountain for heightmap (towards what it scales)
 	uint8_t tgen_smoothness; ///< how rough is the terrain from 0-3

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -97,17 +97,17 @@ strval   = STR_JUST_COMMA
 cat      = SC_BASIC
 
 [SDT_VAR]
-var      = game_creation.snow_coverage
+var      = game_creation.snow_line_level
 type     = SLE_UINT8
-from     = SLV_MAPGEN_SETTINGS_REVAMP
-flags    = SettingFlag::NewgameOnly
-def      = DEF_SNOW_COVERAGE
+from     = SLV_SNOW_LINE_LEVEL
+flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly
+def      = 1
 min      = 0
-max      = 100
-interval = 10
-str      = STR_CONFIG_SETTING_SNOW_COVERAGE
-strhelp  = STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT
-strval   = STR_CONFIG_SETTING_SNOW_COVERAGE_VALUE
+max      = 5
+interval = 1
+str      = STR_CONFIG_SETTING_SNOW_LINE_LEVEL
+strhelp  = STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT
+strval   = STR_SNOW_LINE_LEVEL_VERY_LOW
 cat      = SC_BASIC
 
 [SDT_VAR]

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -97,17 +97,17 @@ strval   = STR_JUST_COMMA
 cat      = SC_BASIC
 
 [SDT_VAR]
-var      = game_creation.snow_coverage
+var      = game_creation.snow_line_level
 type     = SLE_UINT8
-from     = SaveLoadVersion::MapgenSettingsRevamp
-flags    = SettingFlag::NewgameOnly
-def      = DEF_SNOW_COVERAGE
+from     = SaveLoadVersion::SnowLineLevel
+flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly
+def      = 1
 min      = 0
-max      = 100
-interval = 10
-str      = STR_CONFIG_SETTING_SNOW_COVERAGE
-strhelp  = STR_CONFIG_SETTING_SNOW_COVERAGE_HELPTEXT
-strval   = STR_CONFIG_SETTING_SNOW_COVERAGE_VALUE
+max      = 5
+interval = 1
+str      = STR_CONFIG_SETTING_SNOW_LINE_LEVEL
+strhelp  = STR_CONFIG_SETTING_SNOW_LINE_LEVEL_HELPTEXT
+strval   = STR_SNOW_LINE_LEVEL_VERY_LOW
 cat      = SC_BASIC
 
 [SDT_VAR]

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -33,7 +33,6 @@ static constexpr uint MIN_SNOWLINE_HEIGHT = 2;                     ///< Minimum 
 static constexpr uint DEF_SNOWLINE_HEIGHT = 10;                    ///< Default snowline height
 static constexpr uint MAX_SNOWLINE_HEIGHT = (MAX_TILE_HEIGHT - 2); ///< Maximum allowed snowline height
 
-static constexpr uint DEF_SNOW_COVERAGE = 40;                      ///< Default snow coverage.
 static constexpr uint DEF_DESERT_COVERAGE = 50;                    ///< Default desert coverage.
 
 

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -33,7 +33,6 @@ static constexpr uint MIN_SNOWLINE_HEIGHT = 2;                     ///< Minimum 
 static constexpr uint DEF_SNOWLINE_HEIGHT = 10;                    ///< Default snowline height
 static constexpr uint MAX_SNOWLINE_HEIGHT = (MAX_TILE_HEIGHT - 2); ///< Maximum allowed snowline height
 
-static constexpr uint DEF_SNOW_COVERAGE = 40;                      ///< Default snow coverage.
 static constexpr uint DEF_DESERT_COVERAGE = 50;                    ///< Default desert coverage.
 
 static constexpr size_t TILE_TYPE_BITS = 4; ///< How many bits in map array are dedicated for type of each tile.

--- a/src/widgets/genworld_widget.h
+++ b/src/widgets/genworld_widget.h
@@ -34,9 +34,7 @@ enum GenerateLandscapeWidgets : WidgetID {
 	WID_GL_START_DATE_TEXT,             ///< Start year.
 	WID_GL_START_DATE_UP,               ///< Increase start year.
 
-	WID_GL_SNOW_COVERAGE_DOWN,          ///< Decrease snow coverage.
-	WID_GL_SNOW_COVERAGE_TEXT,          ///< Snow coverage.
-	WID_GL_SNOW_COVERAGE_UP,            ///< Increase snow coverage.
+	WID_GL_SNOW_LINE_LEVEL_PULLDOWN,    ///< Snow line level.
 
 	WID_GL_DESERT_COVERAGE_DOWN,        ///< Decrease desert coverage.
 	WID_GL_DESERT_COVERAGE_TEXT,        ///< Desert coverage.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
As of now, the snow line height is automatically calculated based on the snow coverage parameter and the actual relief of the map, but this makes the snow height very random. Since the arctic climate is quite sensitive to the snow line height to generate a working map, this means that the user does not have much control on whether or not the map is playable. For the exact same set of settings, a map can have a snow height too low to allow for farms placement, or too high to allow for forest placement, as shown in the issue #14387. Even with an "Alpinist" terrain type on default sized maps, I still manage to have maps where no farm can be generated because the snow line height is too low.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

I propose to replace the "snow coverage" setting with a new "snow line level" in the game creation UI, similar to the "Sea level" setting. This settings determines the real snow line height depending on the height of the map, so it should scale upon a vast majority of settings. This should give more control on which snow line height we want in our maps, and also make the map generation more predictible, especially on default settings. There is also a "Custom" entry if the user wants to use a specific height.

<img width="961" height="582" alt="image" src="https://github.com/user-attachments/assets/c2ee8c91-3d55-4f8b-8f09-928d543aa9bc" />

<img width="506" height="259" alt="image" src="https://github.com/user-attachments/assets/0e555ef4-1676-4a62-be38-5aeb71b3e6b1" />

<img width="937" height="582" alt="image" src="https://github.com/user-attachments/assets/5948554e-9fe9-4adc-bf64-211fc57e64bc" />

<img width="823" height="807" alt="image" src="https://github.com/user-attachments/assets/956d8f6f-a2ab-4a15-8b54-fe51eeb8ef52" />


The formula is in `lanscape.cpp`, in function `CalculateSnowLine`.

Should fix #14387.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

~~This is not 100% finished as of now. Haven't really delved into the save/load part yet but I guess savegames will be impacted?~~ The savegame version has been increased.

On default sized maps with an "Alpinist" terrain and "very high" snow line level, I still managed to have some maps without any forest although it is quite rare. I guess this is an edge case though?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
