### PR TITLE
Codechange: Don't pre-fill font metrics when loading fonts.

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -22,9 +22,10 @@
 
 #include "safeguards.h"
 
-/** Default heights for the different sizes of fonts. */
-static const int _default_font_height[FS_END]   = {10, 6, 18, 10};
-static const int _default_font_ascender[FS_END] = { 8, 5, 15,  8};
+/** Default unscaled heights for the different sizes of fonts. */
+/* static */ const int FontCache::DEFAULT_FONT_HEIGHT[FS_END] = {10, 6, 18, 10};
+/** Default unscaled ascenders for the different sizes of fonts. */
+/* static */ const int FontCache::DEFAULT_FONT_ASCENDER[FS_END] = {8, 5, 15, 8};
 
 FontCacheSettings _fcsettings;
 
@@ -32,8 +33,7 @@ FontCacheSettings _fcsettings;
  * Create a new font cache.
  * @param fs The size of the font.
  */
-FontCache::FontCache(FontSize fs) : parent(FontCache::Get(fs)), fs(fs), height(_default_font_height[fs]),
-		ascender(_default_font_ascender[fs]), descender(_default_font_ascender[fs] - _default_font_height[fs])
+FontCache::FontCache(FontSize fs) : parent(FontCache::Get(fs)), fs(fs)
 {
 	assert(this->parent == nullptr || this->fs == this->parent->fs);
 	FontCache::caches[this->fs] = this;
@@ -50,7 +50,7 @@ FontCache::~FontCache()
 
 int FontCache::GetDefaultFontHeight(FontSize fs)
 {
-	return _default_font_height[fs];
+	return FontCache::DEFAULT_FONT_HEIGHT[fs];
 }
 
 /**

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -23,15 +23,20 @@ protected:
 	static FontCache *caches[FS_END]; ///< All the font caches.
 	FontCache *parent;                ///< The parent of this font cache.
 	const FontSize fs;                ///< The size of the font.
-	int height;                       ///< The height of the font.
-	int ascender;                     ///< The ascender value of the font.
-	int descender;                    ///< The descender value of the font.
+	int height = 0; ///< The height of the font.
+	int ascender = 0; ///< The ascender value of the font.
+	int descender = 0; ///< The descender value of the font.
 
 public:
 	FontCache(FontSize fs);
 	virtual ~FontCache();
 
 	static void InitializeFontCaches();
+
+	/** Default unscaled font heights. */
+	static const int DEFAULT_FONT_HEIGHT[FS_END];
+	/** Default unscaled font ascenders. */
+	static const int DEFAULT_FONT_ASCENDER[FS_END];
 
 	static int GetDefaultFontHeight(FontSize fs);
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Each font cache implementation sets its own metrics based on the loaded font, so there is no need to pre-fill with (unscaled, invalid) default metrics.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove from `FontCache`'s member initializer list.

Additionally make the two arrays static members of `FontCache` instead of underscore-prefixed static globals.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

In fact, default ascenders is no longer used, but I have further branches that make use if it.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
