### PR TITLE
Codefix f220ed179d: GetUnicodeGlyph takes a unicode character.

### DIFF
--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -43,26 +43,26 @@ SpriteFontCache::SpriteFontCache(FontSize fs) : FontCache(fs)
 }
 
 /**
- * Get SpriteID associated with a GlyphID.
- * @param key Glyph to find.
- * @return SpriteID of glyph, or 0 if not present.
+ * Get SpriteID associated with a character.
+ * @param key Character to find.
+ * @return SpriteID for character, or 0 if not present.
  */
-SpriteID SpriteFontCache::GetUnicodeGlyph(GlyphID key)
+SpriteID SpriteFontCache::GetUnicodeGlyph(char32_t key)
 {
-	const auto found = this->glyph_to_spriteid_map.find(key & ~SPRITE_GLYPH);
-	if (found == std::end(this->glyph_to_spriteid_map)) return 0;
+	const auto found = this->char_map.find(key);
+	if (found == std::end(this->char_map)) return 0;
 	return found->second;
 }
 
 void SpriteFontCache::SetUnicodeGlyph(char32_t key, SpriteID sprite)
 {
-	this->glyph_to_spriteid_map[key] = sprite;
+	this->char_map[key] = sprite;
 }
 
 void SpriteFontCache::InitializeUnicodeGlyphMap()
 {
 	/* Clear out existing glyph map if it exists */
-	this->glyph_to_spriteid_map.clear();
+	this->char_map.clear();
 
 	SpriteID base;
 	switch (this->fs) {

--- a/src/fontcache/spritefontcache.h
+++ b/src/fontcache/spritefontcache.h
@@ -28,8 +28,8 @@ public:
 	bool IsBuiltInFont() override { return true; }
 
 private:
-	std::unordered_map<GlyphID, SpriteID> glyph_to_spriteid_map{}; ///< Mapping of glyphs to sprite IDs.
-	SpriteID GetUnicodeGlyph(GlyphID key);
+	std::unordered_map<char32_t, SpriteID> char_map{}; ///< Mapping of characters to sprite IDs.
+	SpriteID GetUnicodeGlyph(char32_t key);
 };
 
 #endif /* SPRITEFONTCACHE_H */


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`SpriteFontCache`'s `glyph_to_spriteid_map` and `GetUnicodeGlyph` use the wrong type for mapping unicode characters to sprite ids.

Previous change f220ed179d erroneously changed the type to `GlyphID`, based on naming. It should actually be `char32_t`.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Rename and use the correct type.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
