### PR TITLE
Codefix: Spelling error in name of GetGRFStringTextStackParameters

### DIFF
--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -476,7 +476,7 @@ CommandCost GetErrorMessageFromLocationCallbackResult(uint16_t cb_res, std::span
 		/* If this error isn't for the local player then it won't be seen, so don't bother encoding anything. */
 		if (IsLocalCompany()) {
 			StringID stringid = GetGRFStringID(grffile->grfid, text_id);
-			auto params = GetGRFSringTextStackParameters(grffile, stringid, textstack);
+			auto params = GetGRFStringTextStackParameters(grffile, stringid, textstack);
 			res.SetEncodedMessage(GetEncodedStringWithArgs(stringid, params));
 		}
 

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -973,7 +973,7 @@ static void HandleNewGRFStringControlCodes(std::string_view str, TextRefStack &s
  * @param textstack Text parameter stack.
  * @returns Parameters for GRF string.
  */
-std::vector<StringParameter> GetGRFSringTextStackParameters(const GRFFile *grffile, StringID stringid, std::span<const int32_t> textstack)
+std::vector<StringParameter> GetGRFStringTextStackParameters(const GRFFile *grffile, StringID stringid, std::span<const int32_t> textstack)
 {
 	if (stringid == INVALID_STRING_ID) return {};
 
@@ -998,6 +998,6 @@ std::vector<StringParameter> GetGRFSringTextStackParameters(const GRFFile *grffi
 std::string GetGRFStringWithTextStack(const struct GRFFile *grffile, GRFStringID grfstringid, std::span<const int32_t> textstack)
 {
 	StringID stringid = GetGRFStringID(grffile->grfid, grfstringid);
-	auto params = GetGRFSringTextStackParameters(grffile, stringid, textstack);
+	auto params = GetGRFStringTextStackParameters(grffile, stringid, textstack);
 	return GetStringWithArgs(stringid, params);
 }

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -28,7 +28,7 @@ void AddGRFTextToList(GRFTextWrapper &list, std::string_view text_to_add);
 
 bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version);
 
-std::vector<StringParameter> GetGRFSringTextStackParameters(const struct GRFFile *grffile, StringID stringid, std::span<const int32_t> textstack);
+std::vector<StringParameter> GetGRFStringTextStackParameters(const struct GRFFile *grffile, StringID stringid, std::span<const int32_t> textstack);
 std::string GetGRFStringWithTextStack(const struct GRFFile *grffile, GRFStringID grfstringid, std::span<const int32_t> textstack);
 
 #endif /* NEWGRF_TEXT_H */


### PR DESCRIPTION
## Motivation / Problem

Spelling error in the name of the `GetGRFSringTextStackParameters` function introduced in #13642.

## Description

Rename to `GetGRFStringTextStackParameters`.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
