### PR TITLE
Codechange: Initialise/reset font cache with FontSizes bitset.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2369,7 +2369,7 @@ static bool ConFont(std::span<std::string_view> argv)
 		FontCacheSubSetting *setting = GetFontCacheSubSetting(fs);
 		/* Make sure all non sprite fonts are loaded. */
 		if (!setting->font.empty() && !fc->HasParent()) {
-			InitFontCache(fs == FS_MONO);
+			InitFontCache(fs);
 			fc = FontCache::Get(fs);
 		}
 		IConsolePrint(CC_DEFAULT, "{} font:", FontSizeToName(fs));

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -126,10 +126,10 @@ void SetFont(FontSize fontsize, const std::string &font, uint size)
 		CheckForMissingGlyphs();
 		_fcsettings = std::move(backup);
 	} else {
-		InitFontCache(true);
+		InitFontCache(fontsize);
 	}
 
-	LoadStringWidthTable(fontsize == FS_MONO);
+	LoadStringWidthTable(fontsize);
 	UpdateAllVirtCoords();
 	ReInitAllWindows(true);
 
@@ -213,15 +213,13 @@ std::string GetFontCacheFontName(FontSize fs)
 
 /**
  * (Re)initialize the font cache related things, i.e. load the non-sprite fonts.
- * @param monospace Whether to initialise the monospace or regular fonts.
+ * @param fontsizes Font sizes to be initialised.
  */
-void InitFontCache(bool monospace)
+void InitFontCache(FontSizes fontsizes)
 {
 	FontCache::InitializeFontCaches();
 
-	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
-		if (monospace != (fs == FS_MONO)) continue;
-
+	for (FontSize fs : fontsizes) {
 		FontCache *fc = FontCache::Get(fs);
 		if (fc->HasParent()) delete fc;
 

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -167,9 +167,9 @@ inline void InitializeUnicodeGlyphMap()
 	}
 }
 
-inline void ClearFontCache()
+inline void ClearFontCache(FontSizes fontsizes)
 {
-	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
+	for (FontSize fs : fontsizes) {
 		FontCache::Get(fs)->ClearFontCache();
 	}
 }
@@ -231,7 +231,7 @@ inline FontCacheSubSetting *GetFontCacheSubSetting(FontSize fs)
 
 uint GetFontCacheFontSize(FontSize fs);
 std::string GetFontCacheFontName(FontSize fs);
-void InitFontCache(bool monospace);
+void InitFontCache(FontSizes fontsizes);
 void UninitFontCache();
 
 bool GetFontAAState();

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -8,6 +8,7 @@
 /** @file gfx.cpp Handling of drawing text and other gfx related stuff. */
 
 #include "stdafx.h"
+#include "gfx_func.h"
 #include "gfx_layout.h"
 #include "progress.h"
 #include "zoom_func.h"
@@ -1240,14 +1241,14 @@ static void GfxMainBlitter(const Sprite *sprite, int x, int y, BlitterMode mode,
 }
 
 /**
- * Initialize _stringwidth_table cache
- * @param monospace Whether to load the monospace cache or the normal fonts.
+ * Initialize _stringwidth_table cache for the specified font sizes.
+ * @param fontsizes Font sizes to initialise.
  */
-void LoadStringWidthTable(bool monospace)
+void LoadStringWidthTable(FontSizes fontsizes)
 {
-	ClearFontCache();
+	ClearFontCache(fontsizes);
 
-	for (FontSize fs = monospace ? FS_MONO : FS_BEGIN; fs < (monospace ? FS_END : FS_MONO); fs++) {
+	for (FontSize fs : fontsizes) {
 		for (uint i = 0; i != 224; i++) {
 			_stringwidth_table[fs][i] = GetGlyphWidth(fs, i + 32);
 		}
@@ -1812,7 +1813,7 @@ bool AdjustGUIZoom(bool automatic)
 	if (old_font_zoom != _font_zoom) {
 		GfxClearFontSpriteCache();
 	}
-	ClearFontCache();
+	ClearFontCache(FONTSIZES_ALL);
 	LoadStringWidthTable();
 
 	SetupWidgetDimensions();

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -149,7 +149,7 @@ int GetStringHeight(StringID str, int maxw);
 int GetStringLineCount(std::string_view str, int maxw);
 Dimension GetStringMultiLineBoundingBox(StringID str, const Dimension &suggestion);
 Dimension GetStringMultiLineBoundingBox(std::string_view str, const Dimension &suggestion, FontSize fontsize = FS_NORMAL);
-void LoadStringWidthTable(bool monospace = false);
+void LoadStringWidthTable(FontSizes fontsizes = FONTSIZES_REQUIRED);
 
 void DrawDirtyBlocks();
 void AddDirtyBlock(int left, int top, int right, int bottom);

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -258,6 +258,13 @@ enum FontSize : uint8_t {
 };
 DECLARE_INCREMENT_DECREMENT_OPERATORS(FontSize)
 
+using FontSizes = EnumBitSet<FontSize, uint8_t>;
+
+/** Mask of all possible font sizes. */
+constexpr FontSizes FONTSIZES_ALL{FS_NORMAL, FS_SMALL, FS_LARGE, FS_MONO};
+/** Mask of font sizes required to be present. */
+constexpr FontSizes FONTSIZES_REQUIRED{FS_NORMAL, FS_SMALL, FS_LARGE};
+
 inline std::string_view FontSizeToName(FontSize fs)
 {
 	static const std::string_view SIZE_TO_NAME[] = { "medium", "small", "large", "mono" };

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -245,7 +245,7 @@ static void RealChangeBlitter(std::string_view repl_blitter)
 
 	/* Clear caches that might have sprites for another blitter. */
 	VideoDriver::GetInstance()->ClearSystemSprites();
-	ClearFontCache();
+	ClearFontCache(FONTSIZES_ALL);
 	GfxClearSpriteCache();
 	ReInitAllWindows(false);
 }
@@ -326,7 +326,7 @@ void CheckBlitter()
 {
 	if (!SwitchNewGRFBlitter()) return;
 
-	ClearFontCache();
+	ClearFontCache(FONTSIZES_ALL);
 	GfxClearSpriteCache();
 	ReInitAllWindows(false);
 }
@@ -338,7 +338,7 @@ void GfxLoadSprites()
 
 	SwitchNewGRFBlitter();
 	VideoDriver::GetInstance()->ClearSystemSprites();
-	ClearFontCache();
+	ClearFontCache(FONTSIZES_ALL);
 	GfxInitSpriteMem();
 	LoadSpriteTables();
 	GfxInitPalettes();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -700,7 +700,7 @@ int openttd_main(std::span<std::string_view> arguments)
 	InitializeLanguagePacks();
 
 	/* Initialize the font cache */
-	InitFontCache(false);
+	InitFontCache(FONTSIZES_REQUIRED);
 
 	/* This must be done early, since functions use the SetWindowDirty* calls */
 	InitWindowSystem();

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -182,6 +182,6 @@ bool SetFallbackFont(FontCacheSettings *settings, const std::string &language_is
 	if (best_font == nullptr) return false;
 
 	callback->SetFontNames(settings, best_font, &best_index);
-	InitFontCache(callback->Monospace());
+	InitFontCache(callback->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
 	return true;
 }

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1036,9 +1036,8 @@ struct GameOptionsWindow : Window {
 				this->SetWidgetDisabledState(WID_GO_GUI_FONT_AA, _fcsettings.prefer_sprite);
 				this->SetDirty();
 
-				InitFontCache(false);
-				InitFontCache(true);
-				ClearFontCache();
+				InitFontCache(FONTSIZES_ALL);
+				ClearFontCache(FONTSIZES_ALL);
 				CheckForMissingGlyphs();
 				SetupWidgetDimensions();
 				UpdateAllVirtCoords();
@@ -1051,7 +1050,7 @@ struct GameOptionsWindow : Window {
 				this->SetWidgetLoweredState(WID_GO_GUI_FONT_AA, _fcsettings.global_aa);
 				MarkWholeScreenDirty();
 
-				ClearFontCache();
+				ClearFontCache(FONTSIZES_ALL);
 				break;
 #endif /* HAS_TRUETYPE_FONT */
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2278,7 +2278,7 @@ std::string_view GetCurrentLanguageIsoCode()
  */
 bool MissingGlyphSearcher::FindMissingGlyphs()
 {
-	InitFontCache(this->Monospace());
+	InitFontCache(this->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
 
 	this->Reset();
 	for (auto text = this->NextString(); text.has_value(); text = this->NextString()) {
@@ -2395,7 +2395,7 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 			/* Our fallback font does miss characters too, so keep the
 			 * user chosen font as that is more likely to be any good than
 			 * the wild guess we made */
-			InitFontCache(searcher->Monospace());
+			InitFontCache(searcher->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
 		}
 	}
 #endif
@@ -2412,12 +2412,12 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 		ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, std::move(err_str)), {}, WL_WARNING);
 
 		/* Reset the font width */
-		LoadStringWidthTable(searcher->Monospace());
+		LoadStringWidthTable(searcher->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
 		return;
 	}
 
 	/* Update the font with cache */
-	LoadStringWidthTable(searcher->Monospace());
+	LoadStringWidthTable(searcher->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
 
 #if !(defined(WITH_ICU_I18N) && defined(WITH_HARFBUZZ)) && !defined(WITH_UNISCRIBE) && !defined(WITH_COCOA)
 	/*


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When initialising, clearing or otherwise dealing with fonts, some places can only handle working on all font sizes. Other places can handle either required fonts (normal, small and large) or optional fonts (monospace).

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of choosing either "Normal/Small/Large" or "Monospace", use a `FontSizes` bitset to allow any combination to be processed instead.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

While this is a minor stepping-stone to more flexible fallback fonts, this does not address the issue of all fonts, including manually configured, being overridden when falling back to another font.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
