### PR TITLE
Codechange: Decouple glyph map from SpriteFontCache instances.

### DIFF
--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -70,16 +70,6 @@ public:
 	 */
 	virtual int GetFontSize() const { return this->height; }
 
-	/**
-	 * Map a SpriteID to the key
-	 * @param key The key to map to.
-	 * @param sprite The sprite that is being mapped.
-	 */
-	virtual void SetUnicodeGlyph(char32_t key, SpriteID sprite) = 0;
-
-	/** Initialize the glyph map */
-	virtual void InitializeUnicodeGlyphMap() = 0;
-
 	/** Clear the font cache. */
 	virtual void ClearFontCache() = 0;
 
@@ -153,20 +143,6 @@ public:
 	virtual bool IsBuiltInFont() = 0;
 };
 
-/** Map a SpriteID to the font size and key */
-inline void SetUnicodeGlyph(FontSize size, char32_t key, SpriteID sprite)
-{
-	FontCache::Get(size)->SetUnicodeGlyph(key, sprite);
-}
-
-/** Initialize the glyph map */
-inline void InitializeUnicodeGlyphMap()
-{
-	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
-		FontCache::Get(fs)->InitializeUnicodeGlyphMap();
-	}
-}
-
 inline void ClearFontCache(FontSizes fontsizes)
 {
 	for (FontSize fs : fontsizes) {
@@ -236,5 +212,9 @@ void UninitFontCache();
 
 bool GetFontAAState();
 void SetFont(FontSize fontsize, const std::string &font, uint size);
+
+/* Implemented in spritefontcache.cpp */
+void InitializeUnicodeGlyphMap();
+void SetUnicodeGlyph(FontSize size, char32_t key, SpriteID sprite);
 
 #endif /* FONTCACHE_H */

--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -10,6 +10,7 @@
 #include "../stdafx.h"
 #include "../fontcache.h"
 #include "../gfx_layout.h"
+#include "../string_func.h"
 #include "../zoom_func.h"
 #include "spritefontcache.h"
 
@@ -31,41 +32,43 @@ static int ScaleFontTrad(int value)
 	return UnScaleByZoom(value * ZOOM_BASE, _font_zoom);
 }
 
-/**
- * Create a new sprite font cache.
- * @param fs The font size to create the cache for.
- */
-SpriteFontCache::SpriteFontCache(FontSize fs) : FontCache(fs)
-{
-	this->InitializeUnicodeGlyphMap();
-	this->height = ScaleGUITrad(FontCache::GetDefaultFontHeight(this->fs));
-	this->ascender = (this->height - ScaleFontTrad(FontCache::GetDefaultFontHeight(this->fs))) / 2;
-}
+static std::array<std::unordered_map<char32_t, SpriteID>, FS_END> _char_maps{}; ///< Glyph map for each font size.
 
 /**
  * Get SpriteID associated with a character.
  * @param key Character to find.
  * @return SpriteID for character, or 0 if not present.
  */
-SpriteID SpriteFontCache::GetUnicodeGlyph(char32_t key)
+static SpriteID GetUnicodeGlyph(FontSize fs, char32_t key)
 {
-	const auto found = this->char_map.find(key);
-	if (found == std::end(this->char_map)) return 0;
-	return found->second;
+	auto found = _char_maps[fs].find(key);
+	if (found != std::end(_char_maps[fs])) return found->second;
+	return 0;
 }
 
-void SpriteFontCache::SetUnicodeGlyph(char32_t key, SpriteID sprite)
+/**
+ * Set the SpriteID for a unicode character.
+ * @param fs Font size to set.
+ * @param key Unicode character to set.
+ * @param sprite SpriteID of character.
+ */
+void SetUnicodeGlyph(FontSize fs, char32_t key, SpriteID sprite)
 {
-	this->char_map[key] = sprite;
+	_char_maps[fs][key] = sprite;
 }
 
-void SpriteFontCache::InitializeUnicodeGlyphMap()
+/**
+ * Initialize the glyph map for a font size.
+ * This populates the glyph map with the baseset font sprites.
+ * @param fs Font size to initialize.
+ */
+void InitializeUnicodeGlyphMap(FontSize fs)
 {
 	/* Clear out existing glyph map if it exists */
-	this->char_map.clear();
+	_char_maps[fs].clear();
 
 	SpriteID base;
-	switch (this->fs) {
+	switch (fs) {
 		default: NOT_REACHED();
 		case FS_MONO:   // Use normal as default for mono spaced font
 		case FS_NORMAL: base = SPR_ASCII_SPACE;       break;
@@ -76,22 +79,43 @@ void SpriteFontCache::InitializeUnicodeGlyphMap()
 	for (uint i = ASCII_LETTERSTART; i < 256; i++) {
 		SpriteID sprite = base + i - ASCII_LETTERSTART;
 		if (!SpriteExists(sprite)) continue;
-		this->SetUnicodeGlyph(i, sprite);
-		this->SetUnicodeGlyph(i + SCC_SPRITE_START, sprite);
+		SetUnicodeGlyph(fs, i, sprite);
+		SetUnicodeGlyph(fs, i + SCC_SPRITE_START, sprite);
 	}
 
+	/* Modify map to move non-standard glyphs to a better unicode codepoint. */
 	for (const auto &unicode_map : _default_unicode_map) {
 		uint8_t key = unicode_map.key;
 		if (key == CLRA) {
 			/* Clear the glyph. This happens if the glyph at this code point
 			 * is non-standard and should be accessed by an SCC_xxx enum
 			 * entry only. */
-			this->SetUnicodeGlyph(unicode_map.code, 0);
+			SetUnicodeGlyph(fs, unicode_map.code, 0);
 		} else {
 			SpriteID sprite = base + key - ASCII_LETTERSTART;
-			this->SetUnicodeGlyph(unicode_map.code, sprite);
+			SetUnicodeGlyph(fs, unicode_map.code, sprite);
 		}
 	}
+}
+
+/**
+ * Initialize the glyph map.
+ */
+void InitializeUnicodeGlyphMap()
+{
+	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
+		InitializeUnicodeGlyphMap(fs);
+	}
+}
+
+/**
+ * Create a new sprite font cache.
+ * @param fs The font size to create the cache for.
+ */
+SpriteFontCache::SpriteFontCache(FontSize fs) : FontCache(fs)
+{
+	this->height = ScaleGUITrad(FontCache::GetDefaultFontHeight(this->fs));
+	this->ascender = (this->height - ScaleFontTrad(FontCache::GetDefaultFontHeight(this->fs))) / 2;
 }
 
 void SpriteFontCache::ClearFontCache()
@@ -104,21 +128,21 @@ void SpriteFontCache::ClearFontCache()
 const Sprite *SpriteFontCache::GetGlyph(GlyphID key)
 {
 	SpriteID sprite = static_cast<SpriteID>(key & ~SPRITE_GLYPH);
-	if (sprite == 0) sprite = this->GetUnicodeGlyph('?');
+	if (sprite == 0) sprite = GetUnicodeGlyph(this->fs, '?');
 	return GetSprite(sprite, SpriteType::Font);
 }
 
 uint SpriteFontCache::GetGlyphWidth(GlyphID key)
 {
 	SpriteID sprite = static_cast<SpriteID>(key & ~SPRITE_GLYPH);
-	if (sprite == 0) sprite = this->GetUnicodeGlyph('?');
+	if (sprite == 0) sprite = GetUnicodeGlyph(this->fs, '?');
 	return SpriteExists(sprite) ? GetSprite(sprite, SpriteType::Font)->width + ScaleFontTrad(this->fs != FS_NORMAL ? 1 : 0) : 0;
 }
 
 GlyphID SpriteFontCache::MapCharToGlyph(char32_t key, [[maybe_unused]] bool allow_fallback)
 {
 	assert(IsPrintable(key));
-	SpriteID sprite = this->GetUnicodeGlyph(key);
+	SpriteID sprite = GetUnicodeGlyph(this->fs, key);
 	if (sprite == 0) return 0;
 	return SPRITE_GLYPH | sprite;
 }

--- a/src/fontcache/spritefontcache.h
+++ b/src/fontcache/spritefontcache.h
@@ -10,15 +10,12 @@
 #ifndef SPRITEFONTCACHE_H
 #define SPRITEFONTCACHE_H
 
-#include "../string_func.h"
 #include "../fontcache.h"
 
 /** Font cache for fonts that are based on a freetype font. */
 class SpriteFontCache : public FontCache {
 public:
 	SpriteFontCache(FontSize fs);
-	void SetUnicodeGlyph(char32_t key, SpriteID sprite) override;
-	void InitializeUnicodeGlyphMap() override;
 	void ClearFontCache() override;
 	const Sprite *GetGlyph(GlyphID key) override;
 	uint GetGlyphWidth(GlyphID key) override;
@@ -26,10 +23,6 @@ public:
 	GlyphID MapCharToGlyph(char32_t key, bool allow_fallback = true) override;
 	std::string GetFontName() override { return "sprite"; }
 	bool IsBuiltInFont() override { return true; }
-
-private:
-	std::unordered_map<char32_t, SpriteID> char_map{}; ///< Mapping of characters to sprite IDs.
-	SpriteID GetUnicodeGlyph(char32_t key);
 };
 
 #endif /* SPRITEFONTCACHE_H */

--- a/src/fontcache/truetypefontcache.h
+++ b/src/fontcache/truetypefontcache.h
@@ -46,8 +46,6 @@ public:
 	TrueTypeFontCache(FontSize fs, int pixels);
 	virtual ~TrueTypeFontCache();
 	int GetFontSize() const override { return this->used_size; }
-	void SetUnicodeGlyph(char32_t key, SpriteID sprite) override { this->parent->SetUnicodeGlyph(key, sprite); }
-	void InitializeUnicodeGlyphMap() override { this->parent->InitializeUnicodeGlyphMap(); }
 	const Sprite *GetGlyph(GlyphID key) override;
 	void ClearFontCache() override;
 	uint GetGlyphWidth(GlyphID key) override;

--- a/src/tests/mock_fontcache.h
+++ b/src/tests/mock_fontcache.h
@@ -21,8 +21,6 @@ public:
 		this->height = FontCache::GetDefaultFontHeight(this->fs);
 	}
 
-	void SetUnicodeGlyph(char32_t, SpriteID) override {}
-	void InitializeUnicodeGlyphMap() override {}
 	void ClearFontCache() override {}
 	const Sprite *GetGlyph(GlyphID) override { return nullptr; }
 	uint GetGlyphWidth(GlyphID) override { return this->height / 2; }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Each `SpriteFontCache` currently holds a character to glyph map. Setting up in the map requires going through the FontCache parents for each size and it complicates the FontCache interface.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Move the character glyph map out of SpriteFontCache. TrueType font caches no longer have to care about it.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This doesn't really do much different right now. It becomes more useful with my other font changes as it allows the SpriteFontCache to be re-instantiated without losing the character glyph map.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
