### PR TITLE
Fix: EngineImageType mismatch between sizing and drawing in preview window

### DIFF
--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -84,7 +84,7 @@ struct EnginePreviewWindow : Window {
 
 		/* Get size of engine sprite, on loan from depot_gui.cpp */
 		EngineID engine = static_cast<EngineID>(this->window_number);
-		EngineImageType image_type = EIT_PURCHASE;
+		EngineImageType image_type = EIT_PREVIEW;
 		uint x, y;
 		int x_offs, y_offs;
 


### PR DESCRIPTION
## Motivation / Problem

In the vehicle preview window, EIT_PURCHASE is used for window sizing calculations, but EIT_PREVIEW is actually drawn.
The two are not required to be the same size. For MU-type articulated vehicles in some GRFs, EIT_PREVIEW is noticeably longer.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
