### PR TITLE
Codechange: Add distinct type to hold pixel drawing colour.

### DIFF
--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -321,19 +321,19 @@ void Blitter_32bppAnim::DrawColourMappingRect(void *dst, int width, int height, 
 	Debug(misc, 0, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
 }
 
-void Blitter_32bppAnim::SetPixel(void *video, int x, int y, uint8_t colour)
+void Blitter_32bppAnim::SetPixel(void *video, int x, int y, PixelColour colour)
 {
-	*((Colour *)video + x + y * _screen.pitch) = LookupColourInPalette(colour);
+	*((Colour *)video + x + y * _screen.pitch) = LookupColourInPalette(colour.p);
 
 	/* Set the colour in the anim-buffer too, if we are rendering to the screen */
 	if (_screen_disable_anim) return;
 
-	this->anim_buf[this->ScreenToAnimOffset((uint32_t *)video) + x + y * this->anim_buf_pitch] = colour | (DEFAULT_BRIGHTNESS << 8);
+	this->anim_buf[this->ScreenToAnimOffset((uint32_t *)video) + x + y * this->anim_buf_pitch] = colour.p | (DEFAULT_BRIGHTNESS << 8);
 }
 
-void Blitter_32bppAnim::DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash)
+void Blitter_32bppAnim::DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, PixelColour colour, int width, int dash)
 {
-	const Colour c = LookupColourInPalette(colour);
+	const Colour c = LookupColourInPalette(colour.p);
 
 	if (_screen_disable_anim)  {
 		this->DrawLineGeneric(x, y, x2, y2, screen_width, screen_height, width, dash, [&](int x, int y) {
@@ -341,7 +341,7 @@ void Blitter_32bppAnim::DrawLine(void *video, int x, int y, int x2, int y2, int 
 		});
 	} else {
 		uint16_t * const offset_anim_buf = this->anim_buf + this->ScreenToAnimOffset((uint32_t *)video);
-		const uint16_t anim_colour = colour | (DEFAULT_BRIGHTNESS << 8);
+		const uint16_t anim_colour = colour.p | (DEFAULT_BRIGHTNESS << 8);
 		this->DrawLineGeneric(x, y, x2, y2, screen_width, screen_height, width, dash, [&](int x, int y) {
 			*((Colour *)video + x + y * _screen.pitch) = c;
 			offset_anim_buf[x + y * this->anim_buf_pitch] = anim_colour;
@@ -349,7 +349,7 @@ void Blitter_32bppAnim::DrawLine(void *video, int x, int y, int x2, int y2, int 
 	}
 }
 
-void Blitter_32bppAnim::DrawRect(void *video, int width, int height, uint8_t colour)
+void Blitter_32bppAnim::DrawRect(void *video, int width, int height, PixelColour colour)
 {
 	if (_screen_disable_anim) {
 		/* This means our output is not to the screen, so we can't be doing any animation stuff, so use our parent DrawRect() */
@@ -357,7 +357,7 @@ void Blitter_32bppAnim::DrawRect(void *video, int width, int height, uint8_t col
 		return;
 	}
 
-	Colour colour32 = LookupColourInPalette(colour);
+	Colour colour32 = LookupColourInPalette(colour.p);
 	uint16_t *anim_line = this->ScreenToAnimOffset((uint32_t *)video) + this->anim_buf;
 
 	do {
@@ -367,7 +367,7 @@ void Blitter_32bppAnim::DrawRect(void *video, int width, int height, uint8_t col
 		for (int i = width; i > 0; i--) {
 			*dst = colour32;
 			/* Set the colour in the anim-buffer too */
-			*anim = colour | (DEFAULT_BRIGHTNESS << 8);
+			*anim = colour.p | (DEFAULT_BRIGHTNESS << 8);
 			dst++;
 			anim++;
 		}

--- a/src/blitter/32bpp_anim.hpp
+++ b/src/blitter/32bpp_anim.hpp
@@ -34,9 +34,9 @@ public:
 
 	void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom) override;
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
-	void SetPixel(void *video, int x, int y, uint8_t colour) override;
-	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash) override;
-	void DrawRect(void *video, int width, int height, uint8_t colour) override;
+	void SetPixel(void *video, int x, int y, PixelColour colour) override;
+	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, PixelColour colour, int width, int dash) override;
+	void DrawRect(void *video, int width, int height, PixelColour colour) override;
 	void CopyFromBuffer(void *video, const void *src, int width, int height) override;
 	void CopyToBuffer(const void *video, void *dst, int width, int height) override;
 	void ScrollBuffer(void *video, int &left, int &top, int &width, int &height, int scroll_x, int scroll_y) override;

--- a/src/blitter/32bpp_base.cpp
+++ b/src/blitter/32bpp_base.cpp
@@ -18,22 +18,22 @@ void *Blitter_32bppBase::MoveTo(void *video, int x, int y)
 	return (uint32_t *)video + x + y * _screen.pitch;
 }
 
-void Blitter_32bppBase::SetPixel(void *video, int x, int y, uint8_t colour)
+void Blitter_32bppBase::SetPixel(void *video, int x, int y, PixelColour colour)
 {
-	*((Colour *)video + x + y * _screen.pitch) = LookupColourInPalette(colour);
+	*((Colour *)video + x + y * _screen.pitch) = LookupColourInPalette(colour.p);
 }
 
-void Blitter_32bppBase::DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash)
+void Blitter_32bppBase::DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, PixelColour colour, int width, int dash)
 {
-	const Colour c = LookupColourInPalette(colour);
+	const Colour c = LookupColourInPalette(colour.p);
 	this->DrawLineGeneric(x, y, x2, y2, screen_width, screen_height, width, dash, [=](int x, int y) {
 		*((Colour *)video + x + y * _screen.pitch) = c;
 	});
 }
 
-void Blitter_32bppBase::DrawRect(void *video, int width, int height, uint8_t colour)
+void Blitter_32bppBase::DrawRect(void *video, int width, int height, PixelColour colour)
 {
-	Colour colour32 = LookupColourInPalette(colour);
+	Colour colour32 = LookupColourInPalette(colour.p);
 
 	do {
 		Colour *dst = (Colour *)video;

--- a/src/blitter/32bpp_base.hpp
+++ b/src/blitter/32bpp_base.hpp
@@ -19,9 +19,9 @@ class Blitter_32bppBase : public Blitter {
 public:
 	uint8_t GetScreenDepth() override { return 32; }
 	void *MoveTo(void *video, int x, int y) override;
-	void SetPixel(void *video, int x, int y, uint8_t colour) override;
-	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash) override;
-	void DrawRect(void *video, int width, int height, uint8_t colour) override;
+	void SetPixel(void *video, int x, int y, PixelColour colour) override;
+	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, PixelColour colour, int width, int dash) override;
+	void DrawRect(void *video, int width, int height, PixelColour colour) override;
 	void CopyFromBuffer(void *video, const void *src, int width, int height) override;
 	void CopyToBuffer(const void *video, void *dst, int width, int height) override;
 	void CopyImageToBuffer(const void *video, void *dst, int width, int height, int dst_pitch) override;

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -27,7 +27,7 @@ static FBlitter_40bppAnim iFBlitter_40bppAnim;
 static const Colour _black_colour(0, 0, 0);
 
 
-void Blitter_40bppAnim::SetPixel(void *video, int x, int y, uint8_t colour)
+void Blitter_40bppAnim::SetPixel(void *video, int x, int y, PixelColour colour)
 {
 	if (_screen_disable_anim) {
 		Blitter_32bppOptimized::SetPixel(video, x, y, colour);
@@ -35,11 +35,11 @@ void Blitter_40bppAnim::SetPixel(void *video, int x, int y, uint8_t colour)
 		size_t y_offset = static_cast<size_t>(y) * _screen.pitch;
 		*((Colour *)video + x + y_offset) = _black_colour;
 
-		VideoDriver::GetInstance()->GetAnimBuffer()[((uint32_t *)video - (uint32_t *)_screen.dst_ptr) + x + y_offset] = colour;
+		VideoDriver::GetInstance()->GetAnimBuffer()[((uint32_t *)video - (uint32_t *)_screen.dst_ptr) + x + y_offset] = colour.p;
 	}
 }
 
-void Blitter_40bppAnim::DrawRect(void *video, int width, int height, uint8_t colour)
+void Blitter_40bppAnim::DrawRect(void *video, int width, int height, PixelColour colour)
 {
 	if (_screen_disable_anim) {
 		/* This means our output is not to the screen, so we can't be doing any animation stuff, so use our parent DrawRect() */
@@ -56,7 +56,7 @@ void Blitter_40bppAnim::DrawRect(void *video, int width, int height, uint8_t col
 
 		for (int i = width; i > 0; i--) {
 			*dst = _black_colour;
-			*anim = colour;
+			*anim = colour.p;
 			dst++;
 			anim++;
 		}
@@ -65,7 +65,7 @@ void Blitter_40bppAnim::DrawRect(void *video, int width, int height, uint8_t col
 	} while (--height);
 }
 
-void Blitter_40bppAnim::DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash)
+void Blitter_40bppAnim::DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, PixelColour colour, int width, int dash)
 {
 	if (_screen_disable_anim) {
 		/* This means our output is not to the screen, so we can't be doing any animation stuff, so use our parent DrawRect() */
@@ -78,7 +78,7 @@ void Blitter_40bppAnim::DrawLine(void *video, int x, int y, int x2, int y2, int 
 
 	this->DrawLineGeneric(x, y, x2, y2, screen_width, screen_height, width, dash, [=](int x, int y) {
 		*((Colour *)video + x + y * _screen.pitch) = _black_colour;
-		*(anim + x + y * _screen.pitch) = colour;
+		*(anim + x + y * _screen.pitch) = colour.p;
 	});
 }
 

--- a/src/blitter/40bpp_anim.hpp
+++ b/src/blitter/40bpp_anim.hpp
@@ -18,9 +18,9 @@
 class Blitter_40bppAnim : public Blitter_32bppOptimized {
 public:
 
-	void SetPixel(void *video, int x, int y, uint8_t colour) override;
-	void DrawRect(void *video, int width, int height, uint8_t colour) override;
-	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash) override;
+	void SetPixel(void *video, int x, int y, PixelColour colour) override;
+	void DrawRect(void *video, int width, int height, PixelColour colour) override;
+	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, PixelColour colour, int width, int dash) override;
 	void CopyFromBuffer(void *video, const void *src, int width, int height) override;
 	void CopyToBuffer(const void *video, void *dst, int width, int height) override;
 	void CopyImageToBuffer(const void *video, void *dst, int width, int height, int dst_pitch) override;

--- a/src/blitter/8bpp_base.cpp
+++ b/src/blitter/8bpp_base.cpp
@@ -29,23 +29,23 @@ void *Blitter_8bppBase::MoveTo(void *video, int x, int y)
 	return (uint8_t *)video + x + y * _screen.pitch;
 }
 
-void Blitter_8bppBase::SetPixel(void *video, int x, int y, uint8_t colour)
+void Blitter_8bppBase::SetPixel(void *video, int x, int y, PixelColour colour)
 {
-	*((uint8_t *)video + x + y * _screen.pitch) = colour;
+	*((uint8_t *)video + x + y * _screen.pitch) = colour.p;
 }
 
-void Blitter_8bppBase::DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash)
+void Blitter_8bppBase::DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, PixelColour colour, int width, int dash)
 {
 	this->DrawLineGeneric(x, y, x2, y2, screen_width, screen_height, width, dash, [=](int x, int y) {
-		*((uint8_t *)video + x + y * _screen.pitch) = colour;
+		*((uint8_t *)video + x + y * _screen.pitch) = colour.p;
 	});
 }
 
-void Blitter_8bppBase::DrawRect(void *video, int width, int height, uint8_t colour)
+void Blitter_8bppBase::DrawRect(void *video, int width, int height, PixelColour colour)
 {
 	std::byte *p = static_cast<std::byte *>(video);
 	do {
-		std::fill_n(p, width, static_cast<std::byte>(colour));
+		std::fill_n(p, width, static_cast<std::byte>(colour.p));
 		p += _screen.pitch;
 	} while (--height);
 }

--- a/src/blitter/8bpp_base.hpp
+++ b/src/blitter/8bpp_base.hpp
@@ -18,9 +18,9 @@ public:
 	uint8_t GetScreenDepth() override { return 8; }
 	void DrawColourMappingRect(void *dst, int width, int height, PaletteID pal) override;
 	void *MoveTo(void *video, int x, int y) override;
-	void SetPixel(void *video, int x, int y, uint8_t colour) override;
-	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash) override;
-	void DrawRect(void *video, int width, int height, uint8_t colour) override;
+	void SetPixel(void *video, int x, int y, PixelColour colour) override;
+	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, PixelColour colour, int width, int dash) override;
+	void DrawRect(void *video, int width, int height, PixelColour colour) override;
 	void CopyFromBuffer(void *video, const void *src, int width, int height) override;
 	void CopyToBuffer(const void *video, void *dst, int width, int height) override;
 	void CopyImageToBuffer(const void *video, void *dst, int width, int height, int dst_pitch) override;

--- a/src/blitter/base.hpp
+++ b/src/blitter/base.hpp
@@ -95,18 +95,18 @@ public:
 	 * @param video The destination pointer (video-buffer).
 	 * @param x The x position within video-buffer.
 	 * @param y The y position within video-buffer.
-	 * @param colour A 8bpp mapping colour.
+	 * @param colour A pixel colour.
 	 */
-	virtual void SetPixel(void *video, int x, int y, uint8_t colour) = 0;
+	virtual void SetPixel(void *video, int x, int y, PixelColour colour) = 0;
 
 	/**
 	 * Make a single horizontal line in a single colour on the video-buffer.
 	 * @param video The destination pointer (video-buffer).
 	 * @param width The length of the line.
 	 * @param height The height of the line.
-	 * @param colour A 8bpp mapping colour.
+	 * @param colour A pixel colour.
 	 */
-	virtual void DrawRect(void *video, int width, int height, uint8_t colour) = 0;
+	virtual void DrawRect(void *video, int width, int height, PixelColour colour) = 0;
 
 	/**
 	 * Draw a line with a given colour.
@@ -117,11 +117,11 @@ public:
 	 * @param y2 The y coordinate to where the lines goes.
 	 * @param screen_width The width of the screen you are drawing in (to avoid buffer-overflows).
 	 * @param screen_height The height of the screen you are drawing in (to avoid buffer-overflows).
-	 * @param colour A 8bpp mapping colour.
+	 * @param colour A pixel colour.
 	 * @param width Line width.
 	 * @param dash Length of dashes for dashed lines. 0 means solid line.
 	 */
-	virtual void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8_t colour, int width, int dash = 0) = 0;
+	virtual void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, PixelColour colour, int width, int dash = 0) = 0;
 
 	/**
 	 * Copy from a buffer to the screen.

--- a/src/blitter/null.hpp
+++ b/src/blitter/null.hpp
@@ -20,9 +20,9 @@ public:
 	void DrawColourMappingRect(void *, int, int, PaletteID) override {};
 	Sprite *Encode(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator) override;
 	void *MoveTo(void *, int, int) override { return nullptr; };
-	void SetPixel(void *, int, int, uint8_t) override {};
-	void DrawRect(void *, int, int, uint8_t) override {};
-	void DrawLine(void *, int, int, int, int, int, int, uint8_t, int, int) override {};
+	void SetPixel(void *, int, int, PixelColour) override {};
+	void DrawRect(void *, int, int, PixelColour) override {};
+	void DrawLine(void *, int, int, int, int, int, int, PixelColour, int, int) override {};
 	void CopyFromBuffer(void *, const void *, int, int) override {};
 	void CopyToBuffer(const void *, void *, int, int) override {};
 	void CopyImageToBuffer(const void *, void *, int, int, int) override {};

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -60,8 +60,8 @@ public:
 
 	void DrawWidget(const Rect &r, WidgetID) const override
 	{
-		GfxFillRect(r.left, r.top, r.right, r.bottom, 4, FILLRECT_OPAQUE);
-		GfxFillRect(r.left, r.top, r.right, r.bottom, 0, FILLRECT_CHECKER);
+		GfxFillRect(r.left, r.top, r.right, r.bottom, PixelColour{4}, FILLRECT_OPAQUE);
+		GfxFillRect(r.left, r.top, r.right, r.bottom, PixelColour{0}, FILLRECT_CHECKER);
 	}
 };
 
@@ -385,10 +385,10 @@ bool HandleBootstrap()
 	/* Initialise the palette. The biggest step is 'faking' some recolour sprites.
 	 * This way the mauve and gray colours work and we can show the user interface. */
 	GfxInitPalettes();
-	static const int offsets[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80, 0, 0, 0, 0x04, 0x08 };
+	static const uint8_t offsets[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80, 0, 0, 0, 0x04, 0x08 };
 	for (Colours i = COLOUR_BEGIN; i != COLOUR_END; i++) {
 		for (ColourShade j = SHADE_BEGIN; j < SHADE_END; j++) {
-			SetColourGradient(i, j, offsets[i] + j);
+			SetColourGradient(i, j, PixelColour(offsets[i] + j));
 		}
 	}
 

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -956,7 +956,7 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 	int sprite_right = GetVehicleImageCellSize(type, EIT_PURCHASE).extend_right;
 	int sprite_width = sprite_left + sprite_right;
 	int circle_width = std::max(GetScaledSpriteSize(SPR_CIRCLE_FOLDED).width, GetScaledSpriteSize(SPR_CIRCLE_UNFOLDED).width);
-	int linecolour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
+	PixelColour linecolour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
 
 	auto badge_column_widths = badge_classes.GetColumnWidths();
 

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -74,8 +74,8 @@ static const uint TOWN_PRODUCTION_DIVISOR = 256;
 struct CargoSpec {
 	CargoLabel label;                ///< Unique label of the cargo type.
 	uint8_t bitnum = INVALID_CARGO_BITNUM; ///< Cargo bit number, is #INVALID_CARGO_BITNUM for a non-used spec.
-	uint8_t legend_colour;
-	uint8_t rating_colour;
+	PixelColour legend_colour;
+	PixelColour rating_colour;
 	uint8_t weight;                    ///< Weight of a single unit of this cargo type in 1/16 ton (62.5 kg).
 	uint16_t multiplier = 0x100; ///< Capacity multiplier for vehicles. (8 fractional bits)
 	CargoClasses classes; ///< Classes of this cargo type. @see CargoClass

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -150,8 +150,8 @@ void SetLocalCompany(CompanyID new_company)
  */
 TextColour GetDrawStringCompanyColour(CompanyID company)
 {
-	if (!Company::IsValidID(company)) return (TextColour)GetColourGradient(COLOUR_WHITE, SHADE_NORMAL) | TC_IS_PALETTE_COLOUR;
-	return (TextColour)GetColourGradient(_company_colours[company], SHADE_NORMAL) | TC_IS_PALETTE_COLOUR;
+	if (!Company::IsValidID(company)) return GetColourGradient(COLOUR_WHITE, SHADE_NORMAL).ToTextColour();
+	return GetColourGradient(_company_colours[company], SHADE_NORMAL).ToTextColour();
 }
 
 /**

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -544,7 +544,7 @@ bool IsValidConsoleColour(TextColour c)
 	 * colour gradient, so it must be one of those. */
 	c &= ~TC_IS_PALETTE_COLOUR;
 	for (Colours i = COLOUR_BEGIN; i < COLOUR_END; i++) {
-		if (GetColourGradient(i, SHADE_NORMAL) == c) return true;
+		if (GetColourGradient(i, SHADE_NORMAL).p == c) return true;
 	}
 
 	return false;

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -413,7 +413,7 @@ struct DepotWindow : Window {
 		 */
 		if (this->type == VEH_TRAIN && _consistent_train_width != 0) {
 			int w = ScaleSpriteTrad(2 * _consistent_train_width);
-			int col = GetColourGradient(wid->colour, SHADE_NORMAL);
+			PixelColour col = GetColourGradient(wid->colour, SHADE_NORMAL);
 			Rect image = ir.Indent(this->header_width, rtl).Indent(this->count_width, !rtl);
 			int first_line = w + (-this->hscroll->GetPosition()) % w;
 			if (rtl) {

--- a/src/dropdown_common_type.h
+++ b/src/dropdown_common_type.h
@@ -37,8 +37,8 @@ public:
 
 	void Draw(const Rect &full, const Rect &, bool, int, Colours bg_colour) const override
 	{
-		uint8_t c1 = GetColourGradient(bg_colour, SHADE_DARK);
-		uint8_t c2 = GetColourGradient(bg_colour, SHADE_LIGHTEST);
+		PixelColour c1 = GetColourGradient(bg_colour, SHADE_DARK);
+		PixelColour c2 = GetColourGradient(bg_colour, SHADE_LIGHTEST);
 
 		int mid = CentreBounds(full.top, full.bottom, 0);
 		GfxFillRect(full.left, mid - WidgetDimensions::scaled.bevel.bottom, full.right, mid - 1, c1);

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -867,9 +867,9 @@ struct FrametimeGraphWindow : Window {
 			const int x_max = r.right;
 			const int y_zero = r.top + (int)this->graph_size.height;
 			const int y_max = r.top;
-			const int c_grid = PC_DARK_GREY;
-			const int c_lines = PC_BLACK;
-			const int c_peak = PC_DARK_RED;
+			const PixelColour c_grid = PC_DARK_GREY;
+			const PixelColour c_lines = PC_BLACK;
+			const PixelColour c_peak = PC_DARK_RED;
 
 			const TimingMeasurement draw_horz_scale = (TimingMeasurement)this->horizontal_scale * TIMESTAMP_PRECISION / 2;
 			const TimingMeasurement draw_vert_scale = (TimingMeasurement)this->vertical_scale;
@@ -959,7 +959,7 @@ struct FrametimeGraphWindow : Window {
 
 			/* If the peak value is significantly larger than the average, mark and label it */
 			if (points_drawn > 0 && peak_value > TIMESTAMP_PRECISION / 100 && 2 * peak_value > 3 * value_sum / points_drawn) {
-				TextColour tc_peak = (TextColour)(TC_IS_PALETTE_COLOUR | c_peak);
+				TextColour tc_peak = c_peak.ToTextColour();
 				GfxFillRect(peak_point.x - 1, peak_point.y - 1, peak_point.x + 1, peak_point.y + 1, c_peak);
 				uint64_t value = peak_value * 1000 / TIMESTAMP_PRECISION;
 				int label_y = std::max(y_max, peak_point.y - GetCharacterHeight(FS_SMALL));

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -103,11 +103,11 @@ bool DrawStringMultiLineWithClipping(int left, int right, int top, int bottom, s
 
 void DrawCharCentered(char32_t c, const Rect &r, TextColour colour);
 
-void GfxFillRect(int left, int top, int right, int bottom, int colour, FillRectMode mode = FILLRECT_OPAQUE);
-void GfxFillPolygon(std::span<const Point> shape, int colour, FillRectMode mode = FILLRECT_OPAQUE);
-void GfxDrawLine(int left, int top, int right, int bottom, int colour, int width = 1, int dash = 0);
+void GfxFillRect(int left, int top, int right, int bottom, const std::variant<PixelColour, PaletteID> &colour, FillRectMode mode = FILLRECT_OPAQUE);
+void GfxFillPolygon(std::span<const Point> shape, const std::variant<PixelColour, PaletteID> &colour, FillRectMode mode = FILLRECT_OPAQUE);
+void GfxDrawLine(int left, int top, int right, int bottom, PixelColour colour, int width = 1, int dash = 0);
 void DrawBox(int x, int y, int dx1, int dy1, int dx2, int dy2, int dx3, int dy3);
-void DrawRectOutline(const Rect &r, int colour, int width = 1, int dash = 0);
+void DrawRectOutline(const Rect &r, PixelColour colour, int width = 1, int dash = 0);
 
 /* Versions of DrawString/DrawStringMultiLine that accept a Rect instead of separate left, right, top and bottom parameters. */
 inline int DrawString(const Rect &r, std::string_view str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL)
@@ -135,7 +135,7 @@ inline bool DrawStringMultiLineWithClipping(const Rect &r, std::string_view str,
 	return DrawStringMultiLineWithClipping(r.left, r.right, r.top, r.bottom, str, colour, align, underline, fontsize);
 }
 
-inline void GfxFillRect(const Rect &r, int colour, FillRectMode mode = FILLRECT_OPAQUE)
+inline void GfxFillRect(const Rect &r, const std::variant<PixelColour, PaletteID> &colour, FillRectMode mode = FILLRECT_OPAQUE)
 {
 	GfxFillRect(r.left, r.top, r.right, r.bottom, colour, mode);
 }

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -245,7 +245,6 @@ using Colour = std::conditional_t<std::endian::native == std::endian::little, Co
 
 static_assert(sizeof(Colour) == sizeof(uint32_t));
 
-
 /** Available font sizes */
 enum FontSize : uint8_t {
 	FS_NORMAL, ///< Index of the normal font in the font tables.
@@ -402,5 +401,15 @@ enum StringAlignment : uint8_t {
 	SA_FORCE       = 1 << 4, ///< Force the alignment, i.e. don't swap for RTL languages.
 };
 DECLARE_ENUM_AS_BIT_SET(StringAlignment)
+
+/** Colour for pixel/line drawing. */
+struct PixelColour {
+	uint8_t p; ///< Palette index.
+
+	constexpr PixelColour() : p(0) {}
+	explicit constexpr PixelColour(uint8_t p) : p(p) {}
+
+	constexpr inline TextColour ToTextColour() const { return static_cast<TextColour>(this->p) | TC_IS_PALETTE_COLOUR; }
+};
 
 #endif /* GFX_TYPE_H */

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -165,11 +165,11 @@ struct ValuesInterval {
 struct BaseGraphWindow : Window {
 protected:
 	static const int GRAPH_MAX_DATASETS     =  64;
-	static const int GRAPH_BASE_COLOUR      =  GREY_SCALE(2);
-	static const int GRAPH_GRID_COLOUR      =  GREY_SCALE(3);
-	static const int GRAPH_AXIS_LINE_COLOUR =  GREY_SCALE(1);
-	static const int GRAPH_ZERO_LINE_COLOUR =  GREY_SCALE(8);
-	static const int GRAPH_YEAR_LINE_COLOUR =  GREY_SCALE(5);
+	static constexpr PixelColour GRAPH_BASE_COLOUR      =  GREY_SCALE(2);
+	static constexpr PixelColour GRAPH_GRID_COLOUR      =  GREY_SCALE(3);
+	static constexpr PixelColour GRAPH_AXIS_LINE_COLOUR =  GREY_SCALE(1);
+	static constexpr PixelColour GRAPH_ZERO_LINE_COLOUR =  GREY_SCALE(8);
+	static constexpr PixelColour GRAPH_YEAR_LINE_COLOUR =  GREY_SCALE(5);
 	static const int GRAPH_NUM_MONTHS       =  24; ///< Number of months displayed in the graph.
 	static const int GRAPH_PAYMENT_RATE_STEPS = 20; ///< Number of steps on Payment rate graph.
 	static const int PAYMENT_GRAPH_X_STEP_DAYS    = 10; ///< X-axis step label for cargo payment rates "Days in transit".
@@ -203,7 +203,7 @@ protected:
 
 	struct DataSet {
 		std::array<OverflowSafeInt64, GRAPH_NUM_MONTHS> values;
-		uint8_t colour;
+		PixelColour colour;
 		uint8_t exclude_bit;
 		uint8_t range_bit;
 		uint8_t dash;
@@ -390,7 +390,7 @@ protected:
 
 		/* Draw the grid lines. */
 		int gridline_width = WidgetDimensions::scaled.bevel.top;
-		int grid_colour = GRAPH_GRID_COLOUR;
+		PixelColour grid_colour = GRAPH_GRID_COLOUR;
 
 		/* Don't draw the first line, as that's where the axis will be. */
 		if (rtl) {
@@ -516,7 +516,7 @@ protected:
 		uint pointoffs1 = pointwidth / 2;
 		uint pointoffs2 = pointwidth - pointoffs1;
 
-		auto draw_dataset = [&](const DataSet &dataset, uint8_t colour) {
+		auto draw_dataset = [&](const DataSet &dataset, PixelColour colour) {
 			if (HasBit(this->excluded_data, dataset.exclude_bit)) return;
 			if (HasBit(this->excluded_range, dataset.range_bit)) return;
 
@@ -1208,7 +1208,7 @@ struct BaseCargoGraphWindow : BaseGraphWindow {
 			/* Cargo-colour box with outline */
 			const Rect cargo = text.WithWidth(this->legend_width, rtl);
 			GfxFillRect(cargo, PC_BLACK);
-			uint8_t pc = cs->legend_colour;
+			PixelColour pc = cs->legend_colour;
 			if (this->highlight_data == cs->Index()) pc = this->highlight_state ? PC_WHITE : PC_BLACK;
 			GfxFillRect(cargo.Shrink(WidgetDimensions::scaled.bevel), pc);
 
@@ -1485,8 +1485,8 @@ struct PerformanceRatingDetailWindow : Window {
 		ScoreID score_type = (ScoreID)(widget - WID_PRD_SCORE_FIRST);
 
 		/* The colours used to show how the progress is going */
-		int colour_done = GetColourGradient(COLOUR_GREEN, SHADE_NORMAL);
-		int colour_notdone = GetColourGradient(COLOUR_RED, SHADE_NORMAL);
+		PixelColour colour_done = GetColourGradient(COLOUR_GREEN, SHADE_NORMAL);
+		PixelColour colour_notdone = GetColourGradient(COLOUR_RED, SHADE_NORMAL);
 
 		/* Draw all the score parts */
 		int64_t val    = _score_part[company][score_type];

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -305,7 +305,7 @@ private:
 
 		const int offset = (rtl ? -(int)this->column_size[VGC_FOLD].width : (int)this->column_size[VGC_FOLD].width) / 2;
 		const int level_width = rtl ? -WidgetDimensions::scaled.hsep_indent : WidgetDimensions::scaled.hsep_indent;
-		const int linecolour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
+		const PixelColour linecolour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
 
 		if (indent > 0) {
 			/* Draw tree continuation lines. */

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2005,8 +2005,8 @@ struct CargoesField {
 	static Dimension cargo_space;
 	static Dimension cargo_stub;
 
-	static const int INDUSTRY_LINE_COLOUR;
-	static const int CARGO_LINE_COLOUR;
+	static const PixelColour INDUSTRY_LINE_COLOUR;
+	static const PixelColour CARGO_LINE_COLOUR;
 
 	static int small_height, normal_height;
 	static int cargo_field_width;
@@ -2414,8 +2414,8 @@ int CargoesField::vert_inter_industry_space; ///< Amount of space between two in
 
 int CargoesField::blob_distance; ///< Distance of the industry legend colour from the edge of the industry box.
 
-const int CargoesField::INDUSTRY_LINE_COLOUR = PC_YELLOW; ///< Line colour of the industry type box.
-const int CargoesField::CARGO_LINE_COLOUR    = PC_YELLOW; ///< Line colour around the cargo.
+const PixelColour CargoesField::INDUSTRY_LINE_COLOUR = PC_YELLOW; ///< Line colour of the industry type box.
+const PixelColour CargoesField::CARGO_LINE_COLOUR    = PC_YELLOW; ///< Line colour around the cargo.
 
 /** A single row of #CargoesField. */
 struct CargoesRow {

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -119,7 +119,7 @@ struct IndustrySpec {
 	IndustryLifeTypes life_type;                 ///< This is also known as Industry production flag, in newgrf specs
 	LandscapeTypes climate_availability; ///< Bitmask, giving landscape enums as bit position
 	IndustryBehaviours behaviour;                ///< How this industry will behave, and how others entities can use it
-	uint8_t map_colour;                            ///< colour used for the small map
+	PixelColour map_colour; ///< colour used for the small map
 	StringID name;                              ///< Displayed name of the industry
 	StringID new_industry_text;                 ///< Message appearing when the industry is built
 	StringID closure_text;                      ///< Message appearing when the industry closes

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -30,26 +30,26 @@
  * Colours for the various "load" states of links. Ordered from "unused" to
  * "overloaded".
  */
-const uint8_t LinkGraphOverlay::LINK_COLOURS[][12] = {
+const PixelColour LinkGraphOverlay::LINK_COLOURS[][12] = {
 {
-	0x0f, 0xd1, 0xd0, 0x57,
-	0x55, 0x53, 0xbf, 0xbd,
-	0xba, 0xb9, 0xb7, 0xb5
+	PixelColour{0x0f}, PixelColour{0xd1}, PixelColour{0xd0}, PixelColour{0x57},
+	PixelColour{0x55}, PixelColour{0x53}, PixelColour{0xbf}, PixelColour{0xbd},
+	PixelColour{0xba}, PixelColour{0xb9}, PixelColour{0xb7}, PixelColour{0xb5}
 },
 {
-	0x0f, 0xd1, 0xd0, 0x57,
-	0x55, 0x53, 0x96, 0x95,
-	0x94, 0x93, 0x92, 0x91
+	PixelColour{0x0f}, PixelColour{0xd1}, PixelColour{0xd0}, PixelColour{0x57},
+	PixelColour{0x55}, PixelColour{0x53}, PixelColour{0x96}, PixelColour{0x95},
+	PixelColour{0x94}, PixelColour{0x93}, PixelColour{0x92}, PixelColour{0x91}
 },
 {
-	0x0f, 0x0b, 0x09, 0x07,
-	0x05, 0x03, 0xbf, 0xbd,
-	0xba, 0xb9, 0xb7, 0xb5
+	PixelColour{0x0f}, PixelColour{0x0b}, PixelColour{0x09}, PixelColour{0x07},
+	PixelColour{0x05}, PixelColour{0x03}, PixelColour{0xbf}, PixelColour{0xbd},
+	PixelColour{0xba}, PixelColour{0xb9}, PixelColour{0xb7}, PixelColour{0xb5}
 },
 {
-	0x0f, 0x0b, 0x0a, 0x09,
-	0x08, 0x07, 0x06, 0x05,
-	0x04, 0x03, 0x02, 0x01
+	PixelColour{0x0f}, PixelColour{0x0b}, PixelColour{0x0a}, PixelColour{0x09},
+	PixelColour{0x08}, PixelColour{0x07}, PixelColour{0x06}, PixelColour{0x05},
+	PixelColour{0x04}, PixelColour{0x03}, PixelColour{0x02}, PixelColour{0x01}
 }
 };
 
@@ -297,7 +297,7 @@ void LinkGraphOverlay::DrawLinks(const DrawPixelInfo *dpi) const
 void LinkGraphOverlay::DrawContent(Point pta, Point ptb, const LinkProperties &cargo) const
 {
 	uint usage_or_plan = std::min(cargo.capacity * 2 + 1, cargo.Usage());
-	int colour = LinkGraphOverlay::LINK_COLOURS[_settings_client.gui.linkgraph_colours][usage_or_plan * lengthof(LinkGraphOverlay::LINK_COLOURS[0]) / (cargo.capacity * 2 + 2)];
+	PixelColour colour = LinkGraphOverlay::LINK_COLOURS[_settings_client.gui.linkgraph_colours][usage_or_plan * lengthof(LinkGraphOverlay::LINK_COLOURS[0]) / (cargo.capacity * 2 + 2)];
 	int width = ScaleGUITrad(this->scale);
 	int dash = cargo.shared ? width * 4 : 0;
 
@@ -345,7 +345,7 @@ void LinkGraphOverlay::DrawStationDots(const DrawPixelInfo *dpi) const
  * @param colour Colour with which the vertex will be filled.
  * @param border_colour Colour for the border of the vertex.
  */
-/* static */ void LinkGraphOverlay::DrawVertex(int x, int y, int size, int colour, int border_colour)
+/* static */ void LinkGraphOverlay::DrawVertex(int x, int y, int size, PixelColour colour, PixelColour border_colour)
 {
 	size--;
 	int w1 = size / 2;
@@ -607,7 +607,7 @@ void LinkGraphLegendWindow::DrawWidget(const Rect &r, WidgetID widget) const
 		DrawCompanyIcon(cid, CentreBounds(br.left, br.right, sprite_size.width), CentreBounds(br.top, br.bottom, sprite_size.height));
 	}
 	if (IsInsideMM(widget, WID_LGL_SATURATION_FIRST, WID_LGL_SATURATION_LAST + 1)) {
-		uint8_t colour = LinkGraphOverlay::LINK_COLOURS[_settings_client.gui.linkgraph_colours][widget - WID_LGL_SATURATION_FIRST];
+		PixelColour colour = LinkGraphOverlay::LINK_COLOURS[_settings_client.gui.linkgraph_colours][widget - WID_LGL_SATURATION_FIRST];
 		GfxFillRect(br, colour);
 		StringID str = STR_NULL;
 		if (widget == WID_LGL_SATURATION_FIRST) {

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -44,7 +44,7 @@ public:
 	typedef std::map<StationID, StationLinkMap> LinkMap;
 	typedef std::vector<std::pair<StationID, uint> > StationSupplyList;
 
-	static const uint8_t LINK_COLOURS[][12];
+	static const PixelColour LINK_COLOURS[][12];
 
 	/**
 	 * Create a link graph overlay for the specified window.
@@ -95,7 +95,7 @@ protected:
 	void RebuildCache();
 
 	static void AddStats(CargoType new_cargo, uint new_cap, uint new_usg, uint new_flow, uint32_t time, bool new_shared, LinkProperties &cargo);
-	static void DrawVertex(int x, int y, int size, int colour, int border_colour);
+	static void DrawVertex(int x, int y, int size, PixelColour colour, PixelColour border_colour);
 };
 
 void ShowLinkGraphLegend();

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -556,7 +556,7 @@ void SetupColoursAndInitialWindow()
 		const uint8_t *b = GetNonSprite(GetColourPalette(i), SpriteType::Recolour) + 1;
 		assert(b != nullptr);
 		for (ColourShade j = SHADE_BEGIN; j < SHADE_END; j++) {
-			SetColourGradient(i, j, b[0xC6 + j]);
+			SetColourGradient(i, j, PixelColour{b[0xC6 + j]});
 		}
 	}
 

--- a/src/newgrf/newgrf_act0_cargo.cpp
+++ b/src/newgrf/newgrf_act0_cargo.cpp
@@ -97,11 +97,11 @@ static ChangeInfoResult CargoReserveInfo(uint first, uint last, int prop, ByteRe
 				break;
 
 			case 0x13: // Colour for station rating bars
-				cs->rating_colour = buf.ReadByte();
+				cs->rating_colour = PixelColour{buf.ReadByte()};
 				break;
 
 			case 0x14: // Colour for cargo graph
-				cs->legend_colour = buf.ReadByte();
+				cs->legend_colour = PixelColour{buf.ReadByte()};
 				break;
 
 			case 0x15: // Freight status

--- a/src/newgrf/newgrf_act0_industries.cpp
+++ b/src/newgrf/newgrf_act0_industries.cpp
@@ -565,7 +565,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 				break;
 
 			case 0x19: // Map colour
-				indsp->map_colour = buf.ReadByte();
+				indsp->map_colour = PixelColour{buf.ReadByte()};
 				break;
 
 			case 0x1A: // Special industry flags to define special behavior

--- a/src/newgrf/newgrf_act0_railtypes.cpp
+++ b/src/newgrf/newgrf_act0_railtypes.cpp
@@ -121,7 +121,7 @@ static ChangeInfoResult RailTypeChangeInfo(uint first, uint last, int prop, Byte
 				break;
 
 			case 0x16: // Map colour
-				rti->map_colour = buf.ReadByte();
+				rti->map_colour = PixelColour{buf.ReadByte()};
 				break;
 
 			case 0x17: // Introduction date

--- a/src/newgrf/newgrf_act0_roadtypes.cpp
+++ b/src/newgrf/newgrf_act0_roadtypes.cpp
@@ -109,7 +109,7 @@ static ChangeInfoResult RoadTypeChangeInfo(uint first, uint last, int prop, Byte
 				break;
 
 			case 0x16: // Map colour
-				rti->map_colour = buf.ReadByte();
+				rti->map_colour = PixelColour{buf.ReadByte()};
 				break;
 
 			case 0x17: // Introduction date

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -358,9 +358,9 @@ void DoPaletteAnimations()
  * @param threshold Background colour brightness threshold below which the background is considered dark and TC_WHITE is returned, range: 0 - 255, default 128.
  * @return TC_BLACK or TC_WHITE depending on what gives a better contrast.
  */
-TextColour GetContrastColour(uint8_t background, uint8_t threshold)
+TextColour GetContrastColour(PixelColour background, uint8_t threshold)
 {
-	Colour c = _cur_palette.palette[background];
+	Colour c = _cur_palette.palette[background.p];
 	/* Compute brightness according to http://www.w3.org/TR/AERT#color-contrast.
 	 * The following formula computes 1000 * brightness^2, with brightness being in range 0 to 255. */
 	uint sq1000_brightness = c.r * c.r * 299 + c.g * c.g * 587 + c.b * c.b * 114;
@@ -374,7 +374,7 @@ TextColour GetContrastColour(uint8_t background, uint8_t threshold)
  */
 struct ColourGradients
 {
-	using ColourGradient = std::array<uint8_t, SHADE_END>;
+	using ColourGradient = std::array<PixelColour, SHADE_END>;
 
 	static inline std::array<ColourGradient, COLOUR_END> gradient{};
 };
@@ -385,7 +385,7 @@ struct ColourGradients
  * @param shade Shade level from 1 to 7.
  * @returns palette index of colour.
  */
-uint8_t GetColourGradient(Colours colour, ColourShade shade)
+PixelColour GetColourGradient(Colours colour, ColourShade shade)
 {
 	return ColourGradients::gradient[colour % COLOUR_END][shade % SHADE_END];
 }
@@ -396,7 +396,7 @@ uint8_t GetColourGradient(Colours colour, ColourShade shade)
  * @param shade Shade level from 1 to 7.
  * @param palette_index Palette index to set.
  */
-void SetColourGradient(Colours colour, ColourShade shade, uint8_t palette_index)
+void SetColourGradient(Colours colour, ColourShade shade, PixelColour palette_index)
 {
 	assert(colour < COLOUR_END);
 	assert(shade < SHADE_END);

--- a/src/palette_func.h
+++ b/src/palette_func.h
@@ -67,7 +67,7 @@ inline bool IsValidColours(Colours colours)
 	return colours < COLOUR_END;
 }
 
-TextColour GetContrastColour(uint8_t background, uint8_t threshold = 128);
+TextColour GetContrastColour(PixelColour background, uint8_t threshold = 128);
 
 enum ColourShade : uint8_t {
 	SHADE_BEGIN = 0,
@@ -83,45 +83,45 @@ enum ColourShade : uint8_t {
 };
 DECLARE_INCREMENT_DECREMENT_OPERATORS(ColourShade)
 
-uint8_t GetColourGradient(Colours colour, ColourShade shade);
-void SetColourGradient(Colours colour, ColourShade shade, uint8_t palette_colour);
+PixelColour GetColourGradient(Colours colour, ColourShade shade);
+void SetColourGradient(Colours colour, ColourShade shade, PixelColour palette_colour);
 
 /**
  * Return the colour for a particular greyscale level.
  * @param level Intensity, 0 = black, 15 = white
  * @return colour
  */
-constexpr uint8_t GREY_SCALE(uint8_t level) { return level; }
+inline constexpr PixelColour GREY_SCALE(uint8_t level) { return PixelColour{level}; }
 
-static const uint8_t PC_BLACK              = GREY_SCALE(1);  ///< Black palette colour.
-static const uint8_t PC_DARK_GREY          = GREY_SCALE(6);  ///< Dark grey palette colour.
-static const uint8_t PC_GREY               = GREY_SCALE(10); ///< Grey palette colour.
-static const uint8_t PC_WHITE              = GREY_SCALE(15); ///< White palette colour.
+static constexpr PixelColour PC_BLACK              {GREY_SCALE(1)};  ///< Black palette colour.
+static constexpr PixelColour PC_DARK_GREY          {GREY_SCALE(6)};  ///< Dark grey palette colour.
+static constexpr PixelColour PC_GREY               {GREY_SCALE(10)}; ///< Grey palette colour.
+static constexpr PixelColour PC_WHITE              {GREY_SCALE(15)}; ///< White palette colour.
 
-static const uint8_t PC_VERY_DARK_RED      = 0xB2;           ///< Almost-black red palette colour.
-static const uint8_t PC_DARK_RED           = 0xB4;           ///< Dark red palette colour.
-static const uint8_t PC_RED                = 0xB8;           ///< Red palette colour.
+static constexpr PixelColour PC_VERY_DARK_RED      {0xB2};           ///< Almost-black red palette colour.
+static constexpr PixelColour PC_DARK_RED           {0xB4};           ///< Dark red palette colour.
+static constexpr PixelColour PC_RED                {0xB8};           ///< Red palette colour.
 
-static const uint8_t PC_VERY_DARK_BROWN    = 0x56;           ///< Almost-black brown palette colour.
+static constexpr PixelColour PC_VERY_DARK_BROWN    {0x56};           ///< Almost-black brown palette colour.
 
-static const uint8_t PC_ORANGE             = 0xC2;           ///< Orange palette colour.
+static constexpr PixelColour PC_ORANGE             {0xC2};           ///< Orange palette colour.
 
-static const uint8_t PC_YELLOW             = 0xBF;           ///< Yellow palette colour.
-static const uint8_t PC_LIGHT_YELLOW       = 0x44;           ///< Light yellow palette colour.
-static const uint8_t PC_VERY_LIGHT_YELLOW  = 0x45;           ///< Almost-white yellow palette colour.
+static constexpr PixelColour PC_YELLOW             {0xBF};           ///< Yellow palette colour.
+static constexpr PixelColour PC_LIGHT_YELLOW       {0x44};           ///< Light yellow palette colour.
+static constexpr PixelColour PC_VERY_LIGHT_YELLOW  {0x45};           ///< Almost-white yellow palette colour.
 
-static const uint8_t PC_GREEN              = 0xD0;           ///< Green palette colour.
+static constexpr PixelColour PC_GREEN              {0xD0};           ///< Green palette colour.
 
-static const uint8_t PC_VERY_DARK_BLUE     = 0x9A;           ///< Almost-black blue palette colour.
-static const uint8_t PC_DARK_BLUE          = 0x9D;           ///< Dark blue palette colour.
-static const uint8_t PC_LIGHT_BLUE         = 0x98;           ///< Light blue palette colour.
+static constexpr PixelColour PC_VERY_DARK_BLUE     {0x9A};           ///< Almost-black blue palette colour.
+static constexpr PixelColour PC_DARK_BLUE          {0x9D};           ///< Dark blue palette colour.
+static constexpr PixelColour PC_LIGHT_BLUE         {0x98};           ///< Light blue palette colour.
 
-static const uint8_t PC_ROUGH_LAND         = 0x52;           ///< Dark green palette colour for rough land.
-static const uint8_t PC_GRASS_LAND         = 0x54;           ///< Dark green palette colour for grass land.
-static const uint8_t PC_BARE_LAND          = 0x37;           ///< Brown palette colour for bare land.
-static const uint8_t PC_RAINFOREST         = 0x5C;           ///< Pale green palette colour for rainforest.
-static const uint8_t PC_FIELDS             = 0x25;           ///< Light brown palette colour for fields.
-static const uint8_t PC_TREES              = 0x57;           ///< Green palette colour for trees.
-static const uint8_t PC_WATER              = 0xC9;           ///< Dark blue palette colour for water.
+static constexpr PixelColour PC_ROUGH_LAND         {0x52};           ///< Dark green palette colour for rough land.
+static constexpr PixelColour PC_GRASS_LAND         {0x54};           ///< Dark green palette colour for grass land.
+static constexpr PixelColour PC_BARE_LAND          {0x37};           ///< Brown palette colour for bare land.
+static constexpr PixelColour PC_RAINFOREST         {0x5C};           ///< Pale green palette colour for rainforest.
+static constexpr PixelColour PC_FIELDS             {0x25};           ///< Light brown palette colour for fields.
+static constexpr PixelColour PC_TREES              {0x57};           ///< Green palette colour for trees.
+static constexpr PixelColour PC_WATER              {0xC9};           ///< Dark blue palette colour for water.
 
 #endif /* PALETTE_FUNC_H */

--- a/src/rail.h
+++ b/src/rail.h
@@ -234,7 +234,7 @@ public:
 	/**
 	 * Colour on mini-map
 	 */
-	uint8_t map_colour;
+	PixelColour map_colour;
 
 	/**
 	 * Introduction date.

--- a/src/road.h
+++ b/src/road.h
@@ -145,7 +145,7 @@ public:
 	/**
 	 * Colour on mini-map
 	 */
-	uint8_t map_colour;
+	PixelColour map_colour;
 
 	/**
 	 * Introduction date.

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -99,7 +99,7 @@ uint BaseSettingEntry::Draw(GameSettings *settings_ptr, int left, int right, int
 
 	int x = rtl ? right : left;
 	if (cur_row >= first_row) {
-		int colour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
+		PixelColour colour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
 		y += (cur_row - first_row) * SETTING_HEIGHT; // Compute correct y start position
 
 		/* Draw vertical for parent nesting levels */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1849,7 +1849,7 @@ void ShowGameOptions()
  */
 void DrawArrowButtons(int x, int y, Colours button_colour, uint8_t state, bool clickable_left, bool clickable_right)
 {
-	int colour = GetColourGradient(button_colour, SHADE_DARKER);
+	PixelColour colour = GetColourGradient(button_colour, SHADE_DARKER);
 	Dimension dim = NWidgetScrollbar::GetHorizontalDimension();
 
 	Rect lr = {x,                  y, x + (int)dim.width     - 1, y + (int)dim.height - 1};
@@ -1881,7 +1881,7 @@ void DrawArrowButtons(int x, int y, Colours button_colour, uint8_t state, bool c
  */
 void DrawUpDownButtons(int x, int y, Colours button_colour, uint8_t state, bool clickable_up, bool clickable_down)
 {
-	int colour = GetColourGradient(button_colour, SHADE_DARKER);
+	PixelColour colour = GetColourGradient(button_colour, SHADE_DARKER);
 
 	Rect r = {x, y, x + SETTING_BUTTON_WIDTH - 1, y + SETTING_BUTTON_HEIGHT - 1};
 	Rect ur = r.WithWidth(SETTING_BUTTON_WIDTH / 2, (_current_text_dir == TD_RTL));
@@ -1907,7 +1907,7 @@ void DrawUpDownButtons(int x, int y, Colours button_colour, uint8_t state, bool 
  */
 void DrawDropDownButton(int x, int y, Colours button_colour, bool state, bool clickable)
 {
-	int colour = GetColourGradient(button_colour, SHADE_DARKER);
+	PixelColour colour = GetColourGradient(button_colour, SHADE_DARKER);
 
 	Rect r = {x, y, x + SETTING_BUTTON_WIDTH - 1, y + SETTING_BUTTON_HEIGHT - 1};
 

--- a/src/slider.cpp
+++ b/src/slider.cpp
@@ -45,9 +45,9 @@ void DrawSliderWidget(Rect r, Colours wedge_colour, Colours handle_colour, TextC
 	int wx1 = r.left  + sw / 2;
 	int wx2 = r.right - sw / 2;
 	if (_current_text_dir == TD_RTL) std::swap(wx1, wx2);
-	const uint shadow = GetColourGradient(wedge_colour, SHADE_DARK);
-	const uint fill = GetColourGradient(wedge_colour, SHADE_LIGHTER);
-	const uint light = GetColourGradient(wedge_colour, SHADE_LIGHTEST);
+	const PixelColour shadow = GetColourGradient(wedge_colour, SHADE_DARK);
+	const PixelColour fill = GetColourGradient(wedge_colour, SHADE_LIGHTER);
+	const PixelColour light = GetColourGradient(wedge_colour, SHADE_LIGHTEST);
 	const std::array<Point, 3> wedge{ Point{wx1, r.bottom - ha}, Point{wx2, r.top + ha}, Point{wx2, r.bottom - ha} };
 	GfxFillPolygon(wedge, fill);
 	GfxDrawLine(wedge[0].x, wedge[0].y, wedge[2].x, wedge[2].y, light, t);

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -225,7 +225,7 @@ static void StationsWndShowStationRating(int left, int right, int y, CargoType c
 
 	int padding = ScaleGUITrad(1);
 	int width = right - left;
-	int colour = cs->rating_colour;
+	PixelColour colour = cs->rating_colour;
 	TextColour tc = GetContrastColour(colour);
 	uint w = std::min(amount + 5, units_full) * width / units_full;
 

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -1134,7 +1134,7 @@ enum IndustryTypes : uint8_t {
 		{r1, r2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, m, \
 		{INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO, INVALID_CARGO}, \
 		{{im1, 0}, {im2, 0}, {im3, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}}, \
-		pr, clim, bev, col, in, intx, s1, s2, s3, STR_UNDEFINED, {ai1, ai2, ai3, ai4}, {ag1, ag2, ag3, ag4}, \
+		pr, clim, bev, PixelColour{col}, in, intx, s1, s2, s3, STR_UNDEFINED, {ai1, ai2, ai3, ai4}, {ag1, ag2, ag3, ag4}, \
 		IndustryCallbackMasks{}, true, SubstituteGRFFileProps(IT_INVALID), snd, {}, \
 		{{p1, p2}}, {{a1, a2, a3}}}
 	/* Format:

--- a/src/table/cargo_const.h
+++ b/src/table/cargo_const.h
@@ -49,7 +49,7 @@
  * @param classes      Classes of this cargo type. @see CargoClass
  */
 #define MK(bt, label, colour, weight, mult, ip, td1, td2, freight, tae, str_plural, str_singular, str_volume, classes) \
-		{label, bt, colour, colour, weight, mult, classes, ip, {td1, td2}, freight, tae, INVALID_TPE, TOWN_PRODUCTION_DIVISOR, CargoCallbackMasks{}, \
+		{label, bt, PixelColour{colour}, PixelColour{colour}, weight, mult, classes, ip, {td1, td2}, freight, tae, INVALID_TPE, TOWN_PRODUCTION_DIVISOR, CargoCallbackMasks{}, \
 		MK_STR_CARGO_PLURAL(str_plural), MK_STR_CARGO_SINGULAR(str_singular), str_volume, MK_STR_QUANTITY(str_plural), MK_STR_ABBREV(str_plural), \
 		MK_SPRITE(str_plural), nullptr, nullptr, 0}
 

--- a/src/table/railtypes.h
+++ b/src/table/railtypes.h
@@ -98,7 +98,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		RailTypeLabelList(),
 
 		/* map colour */
-		0x0A,
+		PC_GREY,
 
 		/* introduction date */
 		CalendarTime::INVALID_DATE,
@@ -200,7 +200,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		RailTypeLabelList(),
 
 		/* map colour */
-		0x0A,
+		PC_GREY,
 
 		/* introduction date */
 		CalendarTime::INVALID_DATE,
@@ -298,7 +298,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		RailTypeLabelList(),
 
 		/* map colour */
-		0x0A,
+		PC_GREY,
 
 		/* introduction date */
 		CalendarTime::INVALID_DATE,
@@ -396,7 +396,7 @@ static const RailTypeInfo _original_railtypes[] = {
 		RailTypeLabelList(),
 
 		/* map colour */
-		0x0A,
+		PC_GREY,
 
 		/* introduction date */
 		CalendarTime::INVALID_DATE,

--- a/src/table/roadtypes.h
+++ b/src/table/roadtypes.h
@@ -81,7 +81,7 @@ static const RoadTypeInfo _original_roadtypes[] = {
 		RoadTypeLabelList(),
 
 		/* map colour */
-		0x01,
+		PC_BLACK,
 
 		/* introduction date */
 		CalendarTime::MIN_DATE,
@@ -162,7 +162,7 @@ static const RoadTypeInfo _original_roadtypes[] = {
 		RoadTypeLabelList(),
 
 		/* map colour */
-		0x01,
+		PC_BLACK,
 
 		/* introduction date */
 		CalendarTime::INVALID_DATE,

--- a/src/table/string_colours.h
+++ b/src/table/string_colours.h
@@ -8,22 +8,22 @@
 /** @file string_colours.h The colour translation of GRF's strings. */
 
 /** Colour mapping for #TextColour. */
-static const uint8_t _string_colourmap[17] = {
-	150, // TC_BLUE
-	 12, // TC_SILVER
-	189, // TC_GOLD
-	184, // TC_RED
-	174, // TC_PURPLE
-	 30, // TC_LIGHT_BROWN
-	195, // TC_ORANGE
-	209, // TC_GREEN
-	 68, // TC_YELLOW
-	 95, // TC_DARK_GREEN
-	 79, // TC_CREAM
-	116, // TC_BROWN
-	 15, // TC_WHITE
-	152, // TC_LIGHT_BLUE
-	  6, // TC_GREY
-	133, // TC_DARK_BLUE
-	  1, // TC_BLACK
+static constexpr PixelColour _string_colourmap[17] = {
+	PixelColour{150}, // TC_BLUE
+	PixelColour{ 12}, // TC_SILVER
+	PixelColour{189}, // TC_GOLD
+	PixelColour{184}, // TC_RED
+	PixelColour{174}, // TC_PURPLE
+	PixelColour{ 30}, // TC_LIGHT_BROWN
+	PixelColour{195}, // TC_ORANGE
+	PixelColour{209}, // TC_GREEN
+	PixelColour{ 68}, // TC_YELLOW
+	PixelColour{ 95}, // TC_DARK_GREEN
+	PixelColour{ 79}, // TC_CREAM
+	PixelColour{116}, // TC_BROWN
+	PixelColour{ 15}, // TC_WHITE
+	PixelColour{152}, // TC_LIGHT_BLUE
+	PixelColour{  6}, // TC_GREY
+	PixelColour{133}, // TC_DARK_BLUE
+	PixelColour{  1}, // TC_BLACK
 };

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -697,7 +697,7 @@ static void DrawVehicleRefitWindow(const RefitOptions &refits, const RefitOption
 	bool rtl = _current_text_dir == TD_RTL;
 	uint iconwidth = std::max(GetSpriteSize(SPR_CIRCLE_FOLDED).width, GetSpriteSize(SPR_CIRCLE_UNFOLDED).width);
 	uint iconheight = GetSpriteSize(SPR_CIRCLE_FOLDED).height;
-	int linecolour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
+	PixelColour linecolour = GetColourGradient(COLOUR_ORANGE, SHADE_NORMAL);
 
 	int iconleft   = rtl ? ir.right - iconwidth     : ir.left;
 	int iconcenter = rtl ? ir.right - iconwidth / 2 : ir.left + iconwidth / 2;

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1732,13 +1732,13 @@ static void ViewportDrawDirtyBlocks()
 	int right =  UnScaleByZoom(dpi->width,  dpi->zoom);
 	int bottom = UnScaleByZoom(dpi->height, dpi->zoom);
 
-	int colour = _string_colourmap[_dirty_block_colour & 0xF];
+	PixelColour colour = _string_colourmap[_dirty_block_colour & 0xF];
 
 	dst = dpi->dst_ptr;
 
 	uint8_t bo = UnScaleByZoom(dpi->left + dpi->top, dpi->zoom) & 1;
 	do {
-		for (int i = (bo ^= 1); i < right; i += 2) blitter->SetPixel(dst, i, 0, (uint8_t)colour);
+		for (int i = (bo ^= 1); i < right; i += 2) blitter->SetPixel(dst, i, 0, colour);
 		dst = blitter->MoveTo(dst, 0, 1);
 	} while (--bottom > 0);
 }
@@ -1761,7 +1761,7 @@ static void ViewportDrawStrings(ZoomLevel zoom, const StringSpriteToDrawVector *
 		}
 
 		if (ss.flags.Test(ViewportStringFlag::TextColour)) {
-			if (ss.colour != INVALID_COLOUR) colour = static_cast<TextColour>(GetColourGradient(ss.colour, SHADE_LIGHTER) | TC_IS_PALETTE_COLOUR);
+			if (ss.colour != INVALID_COLOUR) colour = GetColourGradient(ss.colour, SHADE_LIGHTER).ToTextColour();
 		}
 
 		int left = x + WidgetDimensions::scaled.fullbevel.left;

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -302,11 +302,11 @@ void DrawFrameRect(int left, int top, int right, int bottom, Colours colour, Fra
 	} else {
 		assert(colour < COLOUR_END);
 
-		const uint dark         = GetColourGradient(colour, SHADE_DARK);
-		const uint medium_dark  = GetColourGradient(colour, SHADE_LIGHT);
-		const uint medium_light = GetColourGradient(colour, SHADE_LIGHTER);
-		const uint light        = GetColourGradient(colour, SHADE_LIGHTEST);
-		uint interior;
+		const PixelColour dark         = GetColourGradient(colour, SHADE_DARK);
+		const PixelColour medium_dark  = GetColourGradient(colour, SHADE_LIGHT);
+		const PixelColour medium_light = GetColourGradient(colour, SHADE_LIGHTER);
+		const PixelColour light        = GetColourGradient(colour, SHADE_LIGHTEST);
+		PixelColour interior;
 
 		Rect outer = {left, top, right, bottom};                   // Outside rectangle
 		Rect inner = outer.Shrink(WidgetDimensions::scaled.bevel); // Inside rectangle
@@ -469,7 +469,7 @@ static inline void DrawMatrix(const Rect &r, Colours colour, bool clicked, uint3
 		row_height = r.Height() / num_rows;
 	}
 
-	int col = GetColourGradient(colour, SHADE_LIGHTER);
+	PixelColour col = GetColourGradient(colour, SHADE_LIGHTER);
 
 	int x = r.left;
 	for (int ctr = num_columns; ctr > 1; ctr--) {
@@ -515,8 +515,8 @@ static inline void DrawVerticalScrollbar(const Rect &r, Colours colour, bool up_
 	DrawImageButtons(r.WithHeight(height, false),  NWID_VSCROLLBAR, colour, up_clicked,   SPR_ARROW_UP,   SA_CENTER);
 	DrawImageButtons(r.WithHeight(height, true),   NWID_VSCROLLBAR, colour, down_clicked, SPR_ARROW_DOWN, SA_CENTER);
 
-	int c1 = GetColourGradient(colour, SHADE_DARK);
-	int c2 = GetColourGradient(colour, SHADE_LIGHTEST);
+	PixelColour c1 = GetColourGradient(colour, SHADE_DARK);
+	PixelColour c2 = GetColourGradient(colour, SHADE_LIGHTEST);
 
 	/* draw "shaded" background */
 	GfxFillRect(r.left, r.top + height, r.right, r.bottom - height, c2);
@@ -554,8 +554,8 @@ static inline void DrawHorizontalScrollbar(const Rect &r, Colours colour, bool l
 	DrawImageButtons(r.WithWidth(width, false), NWID_HSCROLLBAR, colour, left_clicked,  SPR_ARROW_LEFT,  SA_CENTER);
 	DrawImageButtons(r.WithWidth(width, true),  NWID_HSCROLLBAR, colour, right_clicked, SPR_ARROW_RIGHT, SA_CENTER);
 
-	int c1 = GetColourGradient(colour, SHADE_DARK);
-	int c2 = GetColourGradient(colour, SHADE_LIGHTEST);
+	PixelColour c1 = GetColourGradient(colour, SHADE_DARK);
+	PixelColour c2 = GetColourGradient(colour, SHADE_LIGHTEST);
 
 	/* draw "shaded" background */
 	GfxFillRect(r.left + width, r.top, r.right - width, r.bottom, c2);
@@ -593,8 +593,8 @@ static inline void DrawFrame(const Rect &r, Colours colour, TextColour text_colo
 
 	if (!str.empty()) x2 = DrawString(r.left + WidgetDimensions::scaled.frametext.left, r.right - WidgetDimensions::scaled.frametext.right, r.top, str, text_colour, align, false, fs);
 
-	int c1 = GetColourGradient(colour, SHADE_DARK);
-	int c2 = GetColourGradient(colour, SHADE_LIGHTEST);
+	PixelColour c1 = GetColourGradient(colour, SHADE_DARK);
+	PixelColour c2 = GetColourGradient(colour, SHADE_LIGHTEST);
 
 	/* If the frame has text, adjust the top bar to fit half-way through */
 	Rect inner = r.Shrink(ScaleGUITrad(1));
@@ -791,7 +791,7 @@ void Window::DrawWidgets() const
 			Rect outer = widget->GetCurrentRect();
 			Rect inner = outer.Shrink(WidgetDimensions::scaled.bevel).Expand(1);
 
-			int colour = _string_colourmap[_window_highlight_colour ? widget->GetHighlightColour() : TC_WHITE];
+			PixelColour colour = _string_colourmap[_window_highlight_colour ? widget->GetHighlightColour() : TC_WHITE];
 
 			GfxFillRect(outer.left,     outer.top,    inner.left,      inner.bottom, colour);
 			GfxFillRect(inner.left + 1, outer.top,    inner.right - 1, inner.top,    colour);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When drawing pixels, lines and rectangles, a raw palette index is passed around. This is stored and passed either in a `uint8_t` or a `int` depending on... nothing really. It can easily be confused with other types.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Introduce a new type `PixelColour` to store these colours, named because it's used for pixel-based drawing instead of text, palette remapping, or sprite rendering.

This is used for individual pixels as well as line and rectangle drawing. Mini-map colours are also `PixelColour`s.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

YACT - Yet Another Colour Type.

We currently have a few different colour types and this seems to add yet another one, although really I'm just rationalising the one that's hidden by `int colour` or `uint8_t colour`.

`p` is a bit short for a member name. `palette_index` is quite long. But maybe it should be done for clarity.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
