### PR TITLE
Fix: [Linkgraph] Incorrect NodeID to StationID conversion for EraseFlows

### DIFF
--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -42,13 +42,13 @@ LinkGraphJob::LinkGraphJob(const LinkGraph &orig) :
 }
 
 /**
- * Erase all flows originating at a specific node.
- * @param from Node to erase flows for.
+ * Erase all flows originating at a specific station.
+ * @param from StationID to erase flows for.
  */
-void LinkGraphJob::EraseFlows(NodeID from)
+void LinkGraphJob::EraseFlows(StationID from)
 {
 	for (NodeID node_id = 0; node_id < this->Size(); ++node_id) {
-		(*this)[node_id].flows.erase(StationID{from});
+		(*this)[node_id].flows.erase(from);
 	}
 }
 
@@ -106,7 +106,7 @@ LinkGraphJob::~LinkGraphJob()
 		/* The station can have been deleted. Remove all flows originating from it then. */
 		Station *st = Station::GetIfValid(from.base.station);
 		if (st == nullptr) {
-			this->EraseFlows(node_id);
+			this->EraseFlows(from.base.station);
 			continue;
 		}
 
@@ -114,7 +114,7 @@ LinkGraphJob::~LinkGraphJob()
 		 * sure that everything is still consistent or ignore it otherwise. */
 		GoodsEntry &ge = st->goods[this->Cargo()];
 		if (ge.link_graph != this->link_graph.index || ge.node != node_id) {
-			this->EraseFlows(node_id);
+			this->EraseFlows(from.base.station);
 			continue;
 		}
 

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -167,7 +167,7 @@ protected:
 	std::atomic<bool> job_completed = false; ///< Is the job still running. This is accessed by multiple threads and reads may be stale.
 	std::atomic<bool> job_aborted = false; ///< Has the job been aborted. This is accessed by multiple threads and reads may be stale.
 
-	void EraseFlows(NodeID from);
+	void EraseFlows(StationID from);
 	void JoinThread();
 	void SpawnThread();
 


### PR DESCRIPTION
## Motivation / Problem

LinkGraphJob::EraseFlows incorrectly used a NodeID as a StationID.
59df0ff49 added a cast to silence this, which highlighted the issue.

## Description

Change LinkGraphJob::EraseFlows to take a StationID, adjust the call sites to pass the associated station ID.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
