### PR TITLE
Codechange: Use StationID as StationIDStack Titem type

### DIFF
--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -410,7 +410,7 @@ void VehicleCargoList::AgeCargo()
 		return (accepted && cp->first_station != current_station) ? MTA_DELIVER : MTA_KEEP;
 	} else if (cargo_next == current_station) {
 		return MTA_DELIVER;
-	} else if (next_station.Contains(cargo_next.base())) {
+	} else if (next_station.Contains(cargo_next)) {
 		return MTA_KEEP;
 	} else {
 		return MTA_TRANSFER;
@@ -470,7 +470,7 @@ bool VehicleCargoList::Stage(bool accepted, StationID current_station, StationID
 				new_shares.ChangeShare(current_station, INT_MIN);
 				StationIDStack excluded = next_station;
 				while (!excluded.IsEmpty() && !new_shares.GetShares()->empty()) {
-					new_shares.ChangeShare(StationID{excluded.Pop()}, INT_MIN);
+					new_shares.ChangeShare(excluded.Pop(), INT_MIN);
 				}
 				if (new_shares.GetShares()->empty()) {
 					cargo_next = StationID::Invalid();
@@ -743,7 +743,7 @@ uint StationCargoList::ShiftCargo(Taction action, StationIDStack next, bool incl
 {
 	uint max_move = action.MaxMove();
 	while (!next.IsEmpty()) {
-		this->ShiftCargo(action, StationID{next.Pop()});
+		this->ShiftCargo(action, next.Pop());
 		if (action.MaxMove() == 0) break;
 	}
 	if (include_invalid && action.MaxMove() > 0) {
@@ -853,7 +853,7 @@ uint StationCargoList::Load(uint max_move, VehicleCargoList *dest, StationIDStac
  */
 uint StationCargoList::Reroute(uint max_move, StationCargoList *dest, StationID avoid, StationID avoid2, const GoodsEntry *ge)
 {
-	return this->ShiftCargo(StationCargoReroute(this, dest, max_move, avoid, avoid2, ge), avoid.base(), false);
+	return this->ShiftCargo(StationCargoReroute(this, dest, max_move, avoid, avoid2, ge), avoid, false);
 }
 
 /*

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -555,7 +555,7 @@ public:
 	inline bool HasCargoFor(StationIDStack next) const
 	{
 		while (!next.IsEmpty()) {
-			if (this->packets.find(StationID{next.Pop()}) != this->packets.end()) return true;
+			if (this->packets.find(next.Pop()) != this->packets.end()) return true;
 		}
 		/* Packets for StationID::Invalid() can go anywhere. */
 		return this->packets.find(StationID::Invalid()) != this->packets.end();

--- a/src/core/smallstack_type.hpp
+++ b/src/core/smallstack_type.hpp
@@ -113,13 +113,14 @@ struct SmallStackItem {
  *    index types of the same length.
  * @tparam Titem Value type to be used.
  * @tparam Tindex Index type to use for the pool.
- * @tparam Tinvalid Invalid item to keep at the bottom of each stack.
+ * @tparam Tinvalid_value Value to construct invalid item to keep at the bottom of each stack.
  * @tparam Tgrowth_step Growth step for pool.
  * @tparam Tmax_size Maximum size for pool.
  */
-template <typename Titem, typename Tindex, Titem Tinvalid, Tindex Tgrowth_step, Tindex Tmax_size>
+template <typename Titem, typename Tindex, auto Tinvalid_value, Tindex Tgrowth_step, Tindex Tmax_size>
 class SmallStack : public SmallStackItem<Titem, Tindex> {
 public:
+	static constexpr Titem Tinvalid{Tinvalid_value};
 
 	typedef SmallStackItem<Titem, Tindex> Item;
 

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -136,7 +136,7 @@ LinkGraphJob::~LinkGraphJob()
 				/* Delete old flows for source stations which have been deleted
 				 * from the new flows. This avoids flow cycles between old and
 				 * new flows. */
-				while (!erased.IsEmpty()) geflows.erase(StationID{erased.Pop()});
+				while (!erased.IsEmpty()) geflows.erase(erased.Pop());
 			} else if ((*lg)[node_id][dest_id].last_unrestricted_update == EconomyTime::INVALID_DATE) {
 				/* Edge is fully restricted. */
 				flows.RestrictFlows(to);

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -368,7 +368,7 @@ StationIDStack OrderList::GetNextStoppingStation(const Vehicle *v, VehicleOrderI
 		next = v->cur_implicit_order_index;
 		if (next >= this->GetNumOrders()) {
 			next = this->GetFirstOrder();
-			if (next == INVALID_VEH_ORDER_ID) return StationID::Invalid().base();
+			if (next == INVALID_VEH_ORDER_ID) return StationID::Invalid();
 		} else {
 			/* GetNext never returns INVALID_VEH_ORDER_ID if there is a valid station in the list.
 			 * As the given "next" is already valid and a station in the list, we
@@ -404,11 +404,11 @@ StationIDStack OrderList::GetNextStoppingStation(const Vehicle *v, VehicleOrderI
 		if (next == INVALID_VEH_ORDER_ID || ((orders[next].IsType(OT_GOTO_STATION) || orders[next].IsType(OT_IMPLICIT)) &&
 				orders[next].GetDestination() == v->last_station_visited &&
 				(orders[next].GetUnloadType() & (OUFB_TRANSFER | OUFB_UNLOAD)) != 0)) {
-			return StationID::Invalid().base();
+			return StationID::Invalid();
 		}
 	} while (orders[next].IsType(OT_GOTO_DEPOT) || orders[next].GetDestination() == v->last_station_visited);
 
-	return orders[next].GetDestination().ToStationID().base();
+	return orders[next].GetDestination().ToStationID();
 }
 
 /**

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -5079,7 +5079,7 @@ StationIDStack FlowStatMap::DeleteFlows(StationID via)
 		FlowStat &s_flows = f_it->second;
 		s_flows.ChangeShare(via, INT_MIN);
 		if (s_flows.GetShares()->empty()) {
-			ret.Push(f_it->first.base());
+			ret.Push(f_it->first);
 			this->erase(f_it++);
 		} else {
 			++f_it;

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -26,7 +26,7 @@ struct RoadStop;
 struct StationSpec;
 struct Waypoint;
 
-using StationIDStack = SmallStack<StationID::BaseType, StationID::BaseType, StationID::Invalid().base(), 8, StationID::End().base()>;
+using StationIDStack = SmallStack<StationID, StationID::BaseType, StationID::Invalid().base(), 8, StationID::End().base()>;
 
 /** Station types */
 enum class StationType : uint8_t {

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -741,7 +741,7 @@ public:
 	 */
 	inline StationIDStack GetNextStoppingStation() const
 	{
-		return (this->orders == nullptr) ? StationID::Invalid().base() : this->orders->GetNextStoppingStation(this);
+		return (this->orders == nullptr) ? StationID::Invalid() : this->orders->GetNextStoppingStation(this);
 	}
 
 	void ResetRefitCaps();


### PR DESCRIPTION
## Motivation / Problem

StationIDStack uses StationID::BaseType as the item type, this results in many casts/calls to base().

## Description

Use StationID as the item type, so that these casts/calls to base() can be removed.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
