### PR TITLE
Feature: House placer mode to replace existing houses

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2880,10 +2880,8 @@ STR_HOUSE_PICKER_CLASS_ZONE3                                    :Outer Suburbs
 STR_HOUSE_PICKER_CLASS_ZONE4                                    :Inner Suburbs
 STR_HOUSE_PICKER_CLASS_ZONE5                                    :Town centre
 
-STR_HOUSE_PICKER_PROTECT_TITLE                                  :Prevent upgrades
+STR_HOUSE_PICKER_PROTECT                                        :Prevent upgrades
 STR_HOUSE_PICKER_PROTECT_TOOLTIP                                :Choose whether this house will be protected from replacement as the town grows
-STR_HOUSE_PICKER_PROTECT_OFF                                    :Off
-STR_HOUSE_PICKER_PROTECT_ON                                     :On
 
 STR_HOUSE_PICKER_REPLACE                                        :Replace existing
 STR_HOUSE_PICKER_REPLACE_TOOLTIP                                :Choose whether to automatically remove an existing house on the tile where this house is placed

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2885,6 +2885,9 @@ STR_HOUSE_PICKER_PROTECT_TOOLTIP                                :Choose whether 
 STR_HOUSE_PICKER_PROTECT_OFF                                    :Off
 STR_HOUSE_PICKER_PROTECT_ON                                     :On
 
+STR_HOUSE_PICKER_REPLACE                                        :Replace existing
+STR_HOUSE_PICKER_REPLACE_TOOLTIP                                :Choose whether to automatically remove an existing house on the tile where this house is placed
+
 STR_STATION_CLASS_DFLT                                          :Default
 STR_STATION_CLASS_DFLT_STATION                                  :Default station
 STR_STATION_CLASS_DFLT_ROADSTOP                                 :Default road stop

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2932,9 +2932,10 @@ static bool TryBuildTownHouse(Town *t, TileIndex tile, TownExpandModes modes)
  * @param tile Tile on which to place the house.
  * @param HouseID The HouseID of the house spec.
  * @param is_protected Whether the house is protected from the town upgrading it.
+ * @param replace Whether to automatically demolish an existing house on this tile, if present.
  * @return Empty cost or an error.
  */
-CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, bool is_protected)
+CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, bool is_protected, bool replace)
 {
 	if (_game_mode != GM_EDITOR && _settings_game.economy.place_houses == PH_FORBIDDEN) return CMD_ERROR;
 
@@ -2944,39 +2945,45 @@ CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, b
 	const HouseSpec *hs = HouseSpec::Get(house);
 	if (!hs->enabled) return CMD_ERROR;
 
-	Town *t = ClosestTownFromTile(tile, UINT_MAX);
-
-	/* cannot build on these slopes... */
-	Slope slope = GetTileSlope(tile);
-	if (IsSteepSlope(slope)) return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
-
-	/* building under a bridge? */
-	if (IsBridgeAbove(tile)) return CommandCost(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
-
-	/* can we clear the land? */
-	CommandCost cost = Command<CMD_LANDSCAPE_CLEAR>::Do({DoCommandFlag::Auto, DoCommandFlag::NoWater}, tile);
-	if (!cost.Succeeded()) return cost;
-
 	int maxz = GetTileMaxZ(tile);
 
-	/* Make sure there is no slope? */
-	bool noslope = hs->building_flags.Test(BuildingFlag::NotSloped);
-	if (noslope && slope != SLOPE_FLAT) return CommandCost(STR_ERROR_FLAT_LAND_REQUIRED);
-
-	TileArea ta = tile;
+	/* Check each tile of a multi-tile house. */
+	TileArea ta(tile, 1, 1);
 	if (hs->building_flags.Test(BuildingFlag::Size2x2)) ta.Add(TileAddXY(tile, 1, 1));
 	if (hs->building_flags.Test(BuildingFlag::Size2x1)) ta.Add(TileAddByDiagDir(tile, DIAGDIR_SW));
 	if (hs->building_flags.Test(BuildingFlag::Size1x2)) ta.Add(TileAddByDiagDir(tile, DIAGDIR_SE));
 
-	/* Check additional tiles covered by this house. */
-	for (const TileIndex &subtile : ta) {
-		cost = Command<CMD_LANDSCAPE_CLEAR>::Do({DoCommandFlag::Auto, DoCommandFlag::NoWater}, subtile);
-		if (!cost.Succeeded()) return cost;
+	for (const TileIndex subtile : ta) {
+		/* Houses cannot be built on steep slopes. */
+		Slope slope = GetTileSlope(subtile);
+		if (IsSteepSlope(slope)) return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
 
-		if (!CheckBuildHouseSameZ(subtile, maxz, noslope)) return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
+		/* Houses cannot be built under bridges. */
+		if (IsBridgeAbove(subtile)) return CommandCost(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
+
+		/* Make sure there is no slope? */
+		bool noslope = hs->building_flags.Test(BuildingFlag::NotSloped);
+		if (noslope && slope != SLOPE_FLAT) return CommandCost(STR_ERROR_FLAT_LAND_REQUIRED);
+
+		/* All tiles of a multi-tile house must have the same z-level. */
+		if (GetTileMaxZ(subtile) != maxz) return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
+
+		/* We might be replacing an existing house, otherwise check if we can clear land. */
+		if (!(replace && GetTileType(subtile) == MP_HOUSE)) {
+			CommandCost cost = Command<CMD_LANDSCAPE_CLEAR>::Do({DoCommandFlag::Auto, DoCommandFlag::NoWater}, subtile);
+			if (!cost.Succeeded()) return cost;
+		}
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {
+		/* If replacing, clear any existing houses first. */
+		if (replace) {
+			for (const TileIndex &subtile : ta) {
+				if (GetTileType(subtile) == MP_HOUSE) ClearTownHouse(Town::GetByTile(subtile), subtile);
+			}
+		}
+
+		Town *t = ClosestTownFromTile(tile, UINT_MAX);
 		bool house_completed = _settings_game.economy.place_houses == PH_ALLOWED_CONSTRUCTED;
 		BuildTownHouse(t, tile, hs, house, Random(), house_completed, is_protected);
 	}

--- a/src/town_cmd.h
+++ b/src/town_cmd.h
@@ -27,7 +27,7 @@ CommandCost CmdTownCargoGoal(DoCommandFlags flags, TownID town_id, TownAcceptanc
 CommandCost CmdTownSetText(DoCommandFlags flags, TownID town_id, const EncodedString &text);
 CommandCost CmdExpandTown(DoCommandFlags flags, TownID town_id, uint32_t grow_amount, TownExpandModes modes);
 CommandCost CmdDeleteTown(DoCommandFlags flags, TownID town_id);
-CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, bool house_protected);
+CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, bool house_protected, bool replace);
 
 DEF_CMD_TRAIT(CMD_FOUND_TOWN,       CmdFoundTown,      CommandFlags({CommandFlag::Deity, CommandFlag::NoTest}),  CommandType::LandscapeConstruction) // founding random town can fail only in exec run
 DEF_CMD_TRAIT(CMD_RENAME_TOWN,      CmdRenameTown,     CommandFlags({CommandFlag::Deity, CommandFlag::Server}),  CommandType::OtherManagement)

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1645,6 +1645,7 @@ static CargoTypes GetProducedCargoOfHouse(const HouseSpec *hs)
 struct BuildHouseWindow : public PickerWindow {
 	std::string house_info{};
 	static inline bool house_protected;
+	static inline bool replace;
 
 	BuildHouseWindow(WindowDesc &desc, Window *parent) : PickerWindow(desc, parent, 0, HousePickerCallbacks::instance)
 	{
@@ -1759,6 +1760,14 @@ struct BuildHouseWindow : public PickerWindow {
 				this->SetDirty();
 				break;
 
+			case WID_BH_REPLACE_TOGGLE:
+				BuildHouseWindow::replace = !BuildHouseWindow::replace;
+				this->SetWidgetLoweredState(WID_BH_REPLACE_TOGGLE, BuildHouseWindow::replace);
+
+				SndClickBeep();
+				this->SetDirty();
+				break;
+
 			default:
 				this->PickerWindow::OnClick(pt, widget, click_count);
 				break;
@@ -1784,6 +1793,8 @@ struct BuildHouseWindow : public PickerWindow {
 
 		this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !BuildHouseWindow::house_protected);
 		this->SetWidgetLoweredState(WID_BH_PROTECT_ON, BuildHouseWindow::house_protected);
+		this->SetWidgetLoweredState(WID_BH_REPLACE_TOGGLE, BuildHouseWindow::replace);
+
 
 		this->SetWidgetDisabledState(WID_BH_PROTECT_OFF, hasflag);
 		this->SetWidgetDisabledState(WID_BH_PROTECT_ON, hasflag);
@@ -1792,7 +1803,7 @@ struct BuildHouseWindow : public PickerWindow {
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
 	{
 		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
-		Command<CMD_PLACE_HOUSE>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), BuildHouseWindow::house_protected);
+		Command<CMD_PLACE_HOUSE>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), BuildHouseWindow::house_protected, BuildHouseWindow::replace);
 	}
 
 	const IntervalTimer<TimerWindow> view_refresh_interval = {std::chrono::milliseconds(2500), [this](auto) {
@@ -1827,9 +1838,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_house_widgets 
 						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BH_PROTECT_OFF), SetMinimalSize(60, 12), SetStringTip(STR_HOUSE_PICKER_PROTECT_OFF, STR_HOUSE_PICKER_PROTECT_TOOLTIP),
 						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BH_PROTECT_ON), SetMinimalSize(60, 12), SetStringTip(STR_HOUSE_PICKER_PROTECT_ON, STR_HOUSE_PICKER_PROTECT_TOOLTIP),
 					EndContainer(),
+					NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BH_REPLACE_TOGGLE), SetMinimalSize(60, 12), SetStringTip(STR_HOUSE_PICKER_REPLACE, STR_HOUSE_PICKER_REPLACE_TOOLTIP),
 				EndContainer(),
 			EndContainer(),
-
 		EndContainer(),
 		NWidgetFunction(MakePickerTypeWidgets),
 	EndContainer(),

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1750,11 +1750,9 @@ struct BuildHouseWindow : public PickerWindow {
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
 		switch (widget) {
-			case WID_BH_PROTECT_OFF:
-			case WID_BH_PROTECT_ON:
-				BuildHouseWindow::house_protected = (widget == WID_BH_PROTECT_ON);
-				this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !BuildHouseWindow::house_protected);
-				this->SetWidgetLoweredState(WID_BH_PROTECT_ON, BuildHouseWindow::house_protected);
+			case WID_BH_PROTECT_TOGGLE:
+				BuildHouseWindow::house_protected = !BuildHouseWindow::house_protected;
+				this->SetWidgetLoweredState(WID_BH_PROTECT_TOGGLE, BuildHouseWindow::house_protected);
 
 				SndClickBeep();
 				this->SetDirty();
@@ -1791,13 +1789,10 @@ struct BuildHouseWindow : public PickerWindow {
 		bool hasflag = spec->extra_flags.Test(HouseExtraFlag::BuildingIsProtected);
 		if (hasflag) BuildHouseWindow::house_protected = true;
 
-		this->SetWidgetLoweredState(WID_BH_PROTECT_OFF, !BuildHouseWindow::house_protected);
-		this->SetWidgetLoweredState(WID_BH_PROTECT_ON, BuildHouseWindow::house_protected);
+		this->SetWidgetLoweredState(WID_BH_PROTECT_TOGGLE, BuildHouseWindow::house_protected);
 		this->SetWidgetLoweredState(WID_BH_REPLACE_TOGGLE, BuildHouseWindow::replace);
 
-
-		this->SetWidgetDisabledState(WID_BH_PROTECT_OFF, hasflag);
-		this->SetWidgetDisabledState(WID_BH_PROTECT_ON, hasflag);
+		this->SetWidgetDisabledState(WID_BH_PROTECT_TOGGLE, hasflag);
 	}
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
@@ -1833,11 +1828,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_house_widgets 
 			NWidget(WWT_PANEL, COLOUR_DARK_GREEN),
 				NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_picker, 0), SetPadding(WidgetDimensions::unscaled.picker),
 					NWidget(WWT_EMPTY, INVALID_COLOUR, WID_BH_INFO), SetFill(1, 1), SetMinimalTextLines(10, 0),
-					NWidget(WWT_LABEL, INVALID_COLOUR), SetStringTip(STR_HOUSE_PICKER_PROTECT_TITLE, STR_NULL), SetFill(1, 0),
-					NWidget(NWID_HORIZONTAL), SetPIPRatio(1, 0, 1),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BH_PROTECT_OFF), SetMinimalSize(60, 12), SetStringTip(STR_HOUSE_PICKER_PROTECT_OFF, STR_HOUSE_PICKER_PROTECT_TOOLTIP),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BH_PROTECT_ON), SetMinimalSize(60, 12), SetStringTip(STR_HOUSE_PICKER_PROTECT_ON, STR_HOUSE_PICKER_PROTECT_TOOLTIP),
-					EndContainer(),
+					NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BH_PROTECT_TOGGLE), SetMinimalSize(60, 12), SetStringTip(STR_HOUSE_PICKER_PROTECT, STR_HOUSE_PICKER_PROTECT_TOOLTIP),
 					NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BH_REPLACE_TOGGLE), SetMinimalSize(60, 12), SetStringTip(STR_HOUSE_PICKER_REPLACE, STR_HOUSE_PICKER_REPLACE_TOOLTIP),
 				EndContainer(),
 			EndContainer(),

--- a/src/widgets/town_widget.h
+++ b/src/widgets/town_widget.h
@@ -80,6 +80,7 @@ enum BuildHouseWidgets : WidgetID {
 	WID_BH_INFO, ///< Information panel of selected house.
 	WID_BH_PROTECT_OFF, ///< Button to protect the next house built.
 	WID_BH_PROTECT_ON, ///< Button to not protect the next house built.
+	WID_BH_REPLACE_TOGGLE, ///< Button to toggle replacing existing houses.
 };
 
 #endif /* WIDGETS_TOWN_WIDGET_H */

--- a/src/widgets/town_widget.h
+++ b/src/widgets/town_widget.h
@@ -78,8 +78,7 @@ enum TownFoundingWidgets : WidgetID {
 /** Widgets of the #BuildHouseWindow class. */
 enum BuildHouseWidgets : WidgetID {
 	WID_BH_INFO, ///< Information panel of selected house.
-	WID_BH_PROTECT_OFF, ///< Button to protect the next house built.
-	WID_BH_PROTECT_ON, ///< Button to not protect the next house built.
+	WID_BH_PROTECT_TOGGLE, ///< Button to toggle protecting the next house built.
 	WID_BH_REPLACE_TOGGLE, ///< Button to toggle replacing existing houses.
 };
 


### PR DESCRIPTION
## Motivation / Problem

When placing houses, I'd like to be able to replace existing houses without having to demolish them separately. Objects behave this way and it's very convenient.

This is also requested in #14443.

## Description

Add a toggle button to the house placer to toggle replacing existing houses. The existing On/Off buttons for preventing town upgrades were clunky, so I also changed them to a single toggle button.

<img width="607" height="485" alt="house-placer" src="https://github.com/user-attachments/assets/dfb40425-2ecb-4911-be54-518063c1dbf2" />

Replacing works for houses of all sizes, and I did some refactoring while I was there to avoid multiple checks for the same thing.

## Limitations

If you're reading carefully, you'll notice that I replaced a call to `CheckBuildHouseSameZ()` with some of its contents, sans the `CanBuildHouseHere()` call. `CanBuildHouseHere()` duplicates the checks for slopes, bridges above, etc., but returns a bool instead of an error message. I left this alone in this PR rather than de-duplicate anything. This codechange happens to fix #14479, but I can open a separate PR for the refactoring/fix if desired.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
