### PR TITLE
Fix: Missing button beeps

### DIFF
--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -19,6 +19,7 @@
 #include "depot_base.h"
 #include "spritecache.h"
 #include "strings_func.h"
+#include "sound_func.h"
 #include "vehicle_func.h"
 #include "company_func.h"
 #include "tilehighlight_func.h"
@@ -815,6 +816,7 @@ struct DepotWindow : Window {
 				} else {
 					ResetObjectToPlace();
 				}
+				SndClickBeep();
 				break;
 
 			case WID_D_LOCATION:

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -11,6 +11,7 @@
 #include "dropdown_type.h"
 #include "dropdown_func.h"
 #include "strings_func.h"
+#include "sound_func.h"
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 #include "window_gui.h"
@@ -413,6 +414,9 @@ void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID b
  */
 void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, uint width, bool instant_close, bool persist)
 {
+	/* Handle the beep of the player's click. */
+	SndClickBeep();
+
 	/* Our parent's button widget is used to determine where to place the drop
 	 * down list window. */
 	NWidgetCore *nwi = w->GetWidget<NWidgetCore>(button);

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -654,6 +654,7 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_TROPICAL:
 			case WID_GL_TOYLAND:
 				SetNewLandscapeType(LandscapeType(widget - WID_GL_TEMPERATE));
+				SndClickBeep();
 				break;
 
 			case WID_GL_MAPSIZE_X_PULLDOWN: // Mapsize X
@@ -718,6 +719,7 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_HEIGHTMAP_HEIGHT_TEXT: // Height level text
 				this->widget_id = WID_GL_HEIGHTMAP_HEIGHT_TEXT;
 				ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.heightmap_height), STR_MAPGEN_HEIGHTMAP_HEIGHT_QUERY_CAPT, 4, this, CS_NUMERAL, QueryStringFlag::EnableDefault);
+				SndClickBeep();
 				break;
 
 
@@ -753,6 +755,7 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_SNOW_COVERAGE_TEXT: // Snow coverage text
 				this->widget_id = WID_GL_SNOW_COVERAGE_TEXT;
 				ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.snow_coverage), STR_MAPGEN_SNOW_COVERAGE_QUERY_CAPT, 4, this, CS_NUMERAL, QueryStringFlag::EnableDefault);
+				SndClickBeep();
 				break;
 
 			case WID_GL_DESERT_COVERAGE_DOWN:
@@ -770,6 +773,7 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_DESERT_COVERAGE_TEXT: // Desert line text
 				this->widget_id = WID_GL_DESERT_COVERAGE_TEXT;
 				ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.desert_coverage), STR_MAPGEN_DESERT_COVERAGE_QUERY_CAPT, 4, this, CS_NUMERAL, QueryStringFlag::EnableDefault);
+				SndClickBeep();
 				break;
 
 			case WID_GL_HEIGHTMAP_ROTATION_PULLDOWN: // Heightmap rotation
@@ -806,26 +810,31 @@ struct GenerateLandscapeWindow : public Window {
 			/* Freetype map borders */
 			case WID_GL_WATER_NW:
 				_settings_newgame.game_creation.water_borders.Flip(BorderFlag::NorthWest);
+				SndClickBeep();
 				this->InvalidateData();
 				break;
 
 			case WID_GL_WATER_NE:
 				_settings_newgame.game_creation.water_borders.Flip(BorderFlag::NorthEast);
+				SndClickBeep();
 				this->InvalidateData();
 				break;
 
 			case WID_GL_WATER_SE:
 				_settings_newgame.game_creation.water_borders.Flip(BorderFlag::SouthEast);
+				SndClickBeep();
 				this->InvalidateData();
 				break;
 
 			case WID_GL_WATER_SW:
 				_settings_newgame.game_creation.water_borders.Flip(BorderFlag::SouthWest);
+				SndClickBeep();
 				this->InvalidateData();
 				break;
 
 			case WID_GL_BORDERS_RANDOM:
 				_settings_newgame.game_creation.water_borders = (_settings_newgame.game_creation.water_borders == BorderFlag::Random) ? BorderFlag{} : BorderFlag::Random;
+				SndClickBeep();
 				this->InvalidateData();
 				break;
 

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -18,6 +18,7 @@
 #include "cargotype.h"
 #include "strings_func.h"
 #include "window_func.h"
+#include "sound_func.h"
 #include "gfx_func.h"
 #include "core/geometry_func.hpp"
 #include "currency.h"
@@ -92,6 +93,8 @@ struct GraphLegendWindow : Window {
 		InvalidateWindowData(WC_DELIVERED_CARGO, 0);
 		InvalidateWindowData(WC_PERFORMANCE_HISTORY, 0);
 		InvalidateWindowData(WC_COMPANY_VALUE, 0);
+
+		SndClickBeep();
 	}
 
 	/**
@@ -767,6 +770,7 @@ public:
 
 				if (HasBit(this->masked_range, row)) break;
 				ToggleBit(this->excluded_range, row);
+				SndClickBeep();
 				this->SetDirty();
 				break;
 			}
@@ -1315,6 +1319,8 @@ struct BaseCargoGraphWindow : BaseGraphWindow {
 			case WID_GRAPH_MATRIX: {
 				int row = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_GRAPH_MATRIX);
 				if (row >= this->vscroll->GetCount()) return;
+
+				SndClickBeep();
 
 				for (const CargoSpec *cs : _sorted_cargo_specs) {
 					if (!HasBit(this->cargo_types, cs->Index())) continue;

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -398,6 +398,7 @@ void PickerWindow::OnClick(Point pt, WidgetID widget, int)
 				SetBit(this->callbacks.mode, PFM_ALL);
 			}
 			this->InvalidateData({PickerInvalidation::Class, PickerInvalidation::Type, PickerInvalidation::Position});
+			SndClickBeep();
 			break;
 
 		case WID_PW_SHRINK:

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1580,10 +1580,12 @@ public:
 					if (w != nullptr) ToggleRailButton_Remove(w);
 				}
 
+				SndClickBeep();
 				break;
 
 			case WID_BS_CONVERT:
 				_convert_signal_button = !_convert_signal_button;
+				SndClickBeep();
 				break;
 
 			case WID_BS_DRAG_SIGNALS_DENSITY_DECREASE:

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -953,6 +953,7 @@ struct GameOptionsWindow : Window {
 			case WID_GO_TAB_SOUND:
 			case WID_GO_TAB_ADVANCED:
 			case WID_GO_TAB_SOCIAL:
+				SndClickBeep();
 				this->SetTab(widget);
 				break;
 

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1735,7 +1735,6 @@ public:
 			case WID_SM_CENTERMAP: // Center the smallmap again
 				this->SmallMapCenterOnCurrentPos();
 				this->HandleButtonClick(WID_SM_CENTERMAP);
-				SndClickBeep();
 				break;
 
 			case WID_SM_TOGGLETOWNNAME: // Toggle town names

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -621,7 +621,6 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 				if (!IsInsideMM(size, 1, 8 + 1)) return;
 				_terraform_size = size;
 
-				SndClickBeep();
 				this->SetDirty();
 				break;
 			}

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -857,7 +857,6 @@ static CallBackFunction ToolbarZoomInClick(Window *w)
 {
 	if (DoZoomInOutWindow(ZOOM_IN, GetMainWindow())) {
 		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (WidgetID)WID_TE_ZOOM_IN : (WidgetID)WID_TN_ZOOM_IN);
-		SndClickBeep();
 	}
 	return CBF_NONE;
 }
@@ -868,7 +867,6 @@ static CallBackFunction ToolbarZoomOutClick(Window *w)
 {
 	if (DoZoomInOutWindow(ZOOM_OUT, GetMainWindow())) {
 		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (WidgetID)WID_TE_ZOOM_OUT : (WidgetID)WID_TN_ZOOM_OUT);
-		SndClickBeep();
 	}
 	return CBF_NONE;
 }
@@ -1232,7 +1230,6 @@ static CallBackFunction ToolbarScenDateForward(Window *w)
 static CallBackFunction ToolbarScenGenLand(Window *w)
 {
 	w->HandleButtonClick(WID_TE_LAND_GENERATE);
-	SndClickBeep();
 
 	ShowEditorTerraformToolbar();
 	return CBF_NONE;
@@ -1256,7 +1253,6 @@ static CallBackFunction ToolbarScenGenTown(int index)
 static CallBackFunction ToolbarScenGenIndustry(Window *w)
 {
 	w->HandleButtonClick(WID_TE_INDUSTRY);
-	SndClickBeep();
 	ShowBuildIndustryWindow();
 	return CBF_NONE;
 }
@@ -1304,7 +1300,6 @@ static CallBackFunction ToolbarScenBuildTram(int index)
 static CallBackFunction ToolbarScenBuildDocks(Window *w)
 {
 	w->HandleButtonClick(WID_TE_WATER);
-	SndClickBeep();
 	ShowBuildDocksScenToolbar();
 	return CBF_NONE;
 }
@@ -1312,7 +1307,6 @@ static CallBackFunction ToolbarScenBuildDocks(Window *w)
 static CallBackFunction ToolbarScenPlantTrees(Window *w)
 {
 	w->HandleButtonClick(WID_TE_TREES);
-	SndClickBeep();
 	ShowBuildTreesToolbar();
 	return CBF_NONE;
 }
@@ -1320,7 +1314,6 @@ static CallBackFunction ToolbarScenPlantTrees(Window *w)
 static CallBackFunction ToolbarScenPlaceSign(Window *w)
 {
 	w->HandleButtonClick(WID_TE_SIGNS);
-	SndClickBeep();
 	return SelectSignTool();
 }
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -289,6 +289,7 @@ public:
 
 				this->town->show_zone = new_show_state;
 				this->SetWidgetLoweredState(widget, new_show_state);
+				SndClickBeep();
 				MarkWholeScreenDirty();
 				break;
 			}

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -36,6 +36,7 @@
 #include "framerate_type.h"
 #include "network/network_func.h"
 #include "news_func.h"
+#include "sound_func.h"
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 
@@ -596,6 +597,7 @@ void Window::HandleButtonClick(WidgetID widget)
 	this->LowerWidget(widget);
 	this->SetTimeout();
 	this->SetWidgetDirty(widget);
+	SndClickBeep();
 }
 
 static void StartWindowDrag(Window *w);


### PR DESCRIPTION
## Motivation / Problem

Many buttons don't go beep when you click them.

## Description

Make buttons go beep.

For most buttons, `Window::HandleButtonClick()` can do it, simply based on the type of widget. The same goes for dropdown menus, albeit in a messier way since the wrapper has many more parameters. There's probably a nicer way to do this in C++ that I don't know of. 🙂 

Graphs get beeps added manually to the selectors.

Some buttons just get the beep added manually to their `OnClick()` override.

I plan to squash when merging, separate commits are just for ease of review.

Thanks to Peter for sending me down this sidequest rabbit-hole. 😛 

## Limitations

* Handling beeps automatically based on the widget type is very nice. I wish it worked for more things. Maybe it could. But if not, if we change the type of widgets for any buttons in the future, it could be changed to a doubly-loud beep by firing twice.
* Some Scenario Editor toolbar items are doubly-loud beeps (trees, for one) because the sound fires twice. Not sure if it's because it's both a button and a main toolbar dropdown...?
* I have probably missed some things that could go beep.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
