### PR TITLE
Change: Always show station coverage area

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -261,8 +261,6 @@ public:
 
 		this->FinishInitNested(TRANSPORT_AIR);
 
-		this->SetWidgetLoweredState(WID_AP_BTN_DONTHILIGHT, !_settings_client.gui.station_show_coverage);
-		this->SetWidgetLoweredState(WID_AP_BTN_DOHILIGHT, _settings_client.gui.station_show_coverage);
 		this->OnInvalidateData();
 
 		/* Ensure airport class is valid (changing NewGRFs). */
@@ -485,7 +483,7 @@ public:
 			this->SetWidgetDisabledState(WID_AP_LAYOUT_INCREASE, _selected_airport_layout + 1U >= as->layouts.size());
 
 			int rad = _settings_game.station.modified_catchment ? as->catchment : (uint)CA_UNMODIFIED;
-			if (_settings_client.gui.station_show_coverage) SetTileSelectBigSize(-rad, -rad, 2 * rad, 2 * rad);
+			SetTileSelectBigSize(-rad, -rad, 2 * rad, 2 * rad);
 		}
 	}
 
@@ -503,16 +501,6 @@ public:
 				if (as->IsAvailable()) this->SelectOtherAirport(num_clicked);
 				break;
 			}
-
-			case WID_AP_BTN_DONTHILIGHT: case WID_AP_BTN_DOHILIGHT:
-				_settings_client.gui.station_show_coverage = (widget != WID_AP_BTN_DONTHILIGHT);
-				this->SetWidgetLoweredState(WID_AP_BTN_DONTHILIGHT, !_settings_client.gui.station_show_coverage);
-				this->SetWidgetLoweredState(WID_AP_BTN_DOHILIGHT, _settings_client.gui.station_show_coverage);
-				this->SetDirty();
-				SndClickBeep();
-				this->UpdateSelectSize();
-				SetViewportCatchmentStation(nullptr, true);
-				break;
 
 			case WID_AP_LAYOUT_DECREASE:
 				_selected_airport_layout--;
@@ -602,15 +590,6 @@ static constexpr NWidgetPart _nested_build_airport_widgets[] = {
 					NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_AP_LAYOUT_INCREASE), SetMinimalSize(12, 0), SetArrowWidgetTypeTip(AWV_INCREASE),
 				EndContainer(),
 				NWidget(WWT_EMPTY, INVALID_COLOUR, WID_AP_EXTRA_TEXT), SetFill(1, 0), SetMinimalSize(150, 0),
-				NWidget(WWT_LABEL, INVALID_COLOUR), SetStringTip(STR_STATION_BUILD_COVERAGE_AREA_TITLE), SetFill(1, 0),
-				NWidget(NWID_HORIZONTAL), SetPIP(14, 0, 14), SetPIPRatio(1, 0, 1),
-					NWidget(NWID_HORIZONTAL, NWidContainerFlag::EqualSize),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_AP_BTN_DONTHILIGHT), SetMinimalSize(60, 12), SetFill(1, 0),
-													SetStringTip(STR_STATION_BUILD_COVERAGE_OFF, STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_AP_BTN_DOHILIGHT), SetMinimalSize(60, 12), SetFill(1, 0),
-													SetStringTip(STR_STATION_BUILD_COVERAGE_ON, STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP),
-					EndContainer(),
-				EndContainer(),
 			EndContainer(),
 			NWidget(WWT_EMPTY, INVALID_COLOUR, WID_AP_ACCEPTANCE), SetResize(0, 1), SetFill(1, 0), SetMinimalTextLines(2, WidgetDimensions::unscaled.vsep_normal),
 		EndContainer(),

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -471,7 +471,7 @@ static constexpr NWidgetPart _nested_build_dock_station_widgets[] = {
 	EndContainer(),
 	NWidget(WWT_PANEL, COLOUR_DARK_GREEN, BDSW_BACKGROUND),
 		NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_normal, 0), SetPadding(WidgetDimensions::unscaled.picker),
-			NWidget(WWT_EMPTY, INVALID_COLOUR, BDSW_ACCEPTANCE), SetResize(0, 1), SetMinimalTextLines(2, WidgetDimensions::unscaled.vsep_normal),
+			NWidget(WWT_EMPTY, INVALID_COLOUR, BDSW_ACCEPTANCE), SetResize(0, 1), SetMinimalTextLines(2, WidgetDimensions::unscaled.vsep_normal), SetMinimalSize(150, 0),
 		EndContainer(),
 	EndContainer(),
 };

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -415,9 +415,6 @@ Window *ShowBuildDocksScenToolbar()
 /** Widget numbers of the build-dock GUI. */
 enum BuildDockStationWidgets {
 	BDSW_BACKGROUND, ///< Background panel.
-	BDSW_LT_OFF,     ///< 'Off' button of coverage high light.
-	BDSW_LT_ON,      ///< 'On' button of coverage high light.
-	BDSW_INFO,       ///< 'Coverage highlight' label.
 	BDSW_ACCEPTANCE, ///< Acceptance info.
 };
 
@@ -426,7 +423,6 @@ public:
 	BuildDocksStationWindow(WindowDesc &desc, Window *parent) : PickerWindowBase(desc, parent)
 	{
 		this->InitNested(TRANSPORT_WATER);
-		this->LowerWidget(_settings_client.gui.station_show_coverage + BDSW_LT_OFF);
 	}
 
 	void Close([[maybe_unused]] int data = 0) override
@@ -441,11 +437,7 @@ public:
 
 		this->DrawWidgets();
 
-		if (_settings_client.gui.station_show_coverage) {
-			SetTileSelectBigSize(-rad, -rad, 2 * rad, 2 * rad);
-		} else {
-			SetTileSelectSize(1, 1);
-		}
+		SetTileSelectBigSize(-rad, -rad, 2 * rad, 2 * rad);
 
 		/* strings such as 'Size' and 'Coverage Area' */
 		Rect r = this->GetWidget<NWidgetBase>(BDSW_ACCEPTANCE)->GetCurrentRect();
@@ -458,21 +450,6 @@ public:
 		 * (This is the case, if making the window bigger moves the mouse into the window.) */
 		if (r.top > bottom) {
 			ResizeWindow(this, 0, r.top - bottom, false);
-		}
-	}
-
-	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
-	{
-		switch (widget) {
-			case BDSW_LT_OFF:
-			case BDSW_LT_ON:
-				this->RaiseWidget(_settings_client.gui.station_show_coverage + BDSW_LT_OFF);
-				_settings_client.gui.station_show_coverage = (widget != BDSW_LT_OFF);
-				this->LowerWidget(_settings_client.gui.station_show_coverage + BDSW_LT_OFF);
-				SndClickBeep();
-				this->SetDirty();
-				SetViewportCatchmentStation(nullptr, true);
-				break;
 		}
 	}
 
@@ -494,13 +471,6 @@ static constexpr NWidgetPart _nested_build_dock_station_widgets[] = {
 	EndContainer(),
 	NWidget(WWT_PANEL, COLOUR_DARK_GREEN, BDSW_BACKGROUND),
 		NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_normal, 0), SetPadding(WidgetDimensions::unscaled.picker),
-			NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_picker, 0),
-				NWidget(WWT_LABEL, INVALID_COLOUR, BDSW_INFO), SetStringTip(STR_STATION_BUILD_COVERAGE_AREA_TITLE), SetFill(1, 0),
-				NWidget(NWID_HORIZONTAL, NWidContainerFlag::EqualSize), SetPIP(14, 0, 14),
-					NWidget(WWT_TEXTBTN, COLOUR_GREY, BDSW_LT_OFF), SetMinimalSize(60, 12), SetFill(1, 0), SetStringTip(STR_STATION_BUILD_COVERAGE_OFF, STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP),
-					NWidget(WWT_TEXTBTN, COLOUR_GREY, BDSW_LT_ON), SetMinimalSize(60, 12), SetFill(1, 0), SetStringTip(STR_STATION_BUILD_COVERAGE_ON, STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP),
-				EndContainer(),
-			EndContainer(),
 			NWidget(WWT_EMPTY, INVALID_COLOUR, BDSW_ACCEPTANCE), SetResize(0, 1), SetMinimalTextLines(2, WidgetDimensions::unscaled.vsep_normal),
 		EndContainer(),
 	EndContainer(),

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2757,11 +2757,6 @@ STR_LINKGRAPH_STATS_TOOLTIP_RETURN_EXTENSION                    :{}{CARGO_LONG} 
 STR_LINKGRAPH_STATS_TOOLTIP_TIME_EXTENSION                      :{}Average travel time: {UNITS_DAYS_OR_SECONDS}
 
 # Base for station construction window(s)
-STR_STATION_BUILD_COVERAGE_AREA_TITLE                           :{BLACK}Coverage area highlight
-STR_STATION_BUILD_COVERAGE_OFF                                  :{BLACK}Off
-STR_STATION_BUILD_COVERAGE_ON                                   :{BLACK}On
-STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP                     :{BLACK}Don't highlight coverage area of proposed site
-STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP                      :{BLACK}Highlight coverage area of proposed site
 STR_STATION_BUILD_ACCEPTS_CARGO                                 :{BLACK}Accepts: {GOLD}{CARGO_LIST}
 STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Supplies: {GOLD}{CARGO_LIST}
 STR_STATION_BUILD_INFRASTRUCTURE_COST_YEAR                      :{BLACK}Maintenance cost: {GOLD}{CURRENCY_SHORT}/year

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1102,8 +1102,6 @@ public:
 			this->LowerWidget(WID_BRAS_PLATFORM_NUM_BEGIN + _settings_client.gui.station_numtracks);
 			this->LowerWidget(WID_BRAS_PLATFORM_LEN_BEGIN + _settings_client.gui.station_platlength);
 		}
-		this->SetWidgetLoweredState(WID_BRAS_HIGHLIGHT_OFF, !_settings_client.gui.station_show_coverage);
-		this->SetWidgetLoweredState(WID_BRAS_HIGHLIGHT_ON, _settings_client.gui.station_show_coverage);
 
 		this->PickerWindow::OnInit();
 	}
@@ -1141,7 +1139,7 @@ public:
 
 		int rad = (_settings_game.station.modified_catchment) ? CA_TRAIN : CA_UNMODIFIED;
 
-		if (_settings_client.gui.station_show_coverage) SetTileSelectBigSize(-rad, -rad, 2 * rad, 2 * rad);
+		SetTileSelectBigSize(-rad, -rad, 2 * rad, 2 * rad);
 
 		for (uint bits = 0; bits < 7; bits++) {
 			bool disable = bits >= _settings_game.station.station_spread;
@@ -1344,17 +1342,6 @@ public:
 				break;
 			}
 
-			case WID_BRAS_HIGHLIGHT_OFF:
-			case WID_BRAS_HIGHLIGHT_ON:
-				_settings_client.gui.station_show_coverage = (widget != WID_BRAS_HIGHLIGHT_OFF);
-
-				this->SetWidgetLoweredState(WID_BRAS_HIGHLIGHT_OFF, !_settings_client.gui.station_show_coverage);
-				this->SetWidgetLoweredState(WID_BRAS_HIGHLIGHT_ON, _settings_client.gui.station_show_coverage);
-				SndClickBeep();
-				this->SetDirty();
-				SetViewportCatchmentStation(nullptr, true);
-				break;
-
 			default:
 				this->PickerWindow::OnClick(pt, widget, click_count);
 				break;
@@ -1423,11 +1410,6 @@ static constexpr NWidgetPart _nested_station_builder_widgets[] = {
 					EndContainer(),
 					NWidget(NWID_HORIZONTAL), SetPIPRatio(1, 0, 1),
 						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BRAS_PLATFORM_DRAG_N_DROP), SetMinimalSize(75, 12), SetStringTip(STR_STATION_BUILD_DRAG_DROP, STR_STATION_BUILD_DRAG_DROP_TOOLTIP),
-					EndContainer(),
-					NWidget(WWT_LABEL, INVALID_COLOUR), SetStringTip(STR_STATION_BUILD_COVERAGE_AREA_TITLE), SetFill(1, 0),
-					NWidget(NWID_HORIZONTAL), SetPIPRatio(1, 0, 1),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BRAS_HIGHLIGHT_OFF), SetMinimalSize(60, 12), SetStringTip(STR_STATION_BUILD_COVERAGE_OFF, STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BRAS_HIGHLIGHT_ON), SetMinimalSize(60, 12), SetStringTip(STR_STATION_BUILD_COVERAGE_ON, STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP),
 					EndContainer(),
 					NWidget(WWT_EMPTY, INVALID_COLOUR, WID_BRAS_COVERAGE_TEXTS), SetFill(1, 1), SetResize(1, 0), SetMinimalTextLines(2, 0),
 				EndContainer(),

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1342,7 +1342,6 @@ public:
 		}
 
 		this->LowerWidget(WID_BROS_STATION_NE + _roadstop_gui.orientation);
-		this->LowerWidget(WID_BROS_LT_OFF + _settings_client.gui.station_show_coverage);
 
 		this->window_class = (rs == RoadStopType::Bus) ? WC_BUS_STATION : WC_TRUCK_STATION;
 	}
@@ -1369,11 +1368,7 @@ public:
 		this->DrawWidgets();
 
 		int rad = _settings_game.station.modified_catchment ? ((this->window_class == WC_BUS_STATION) ? CA_BUS : CA_TRUCK) : CA_UNMODIFIED;
-		if (_settings_client.gui.station_show_coverage) {
-			SetTileSelectBigSize(-rad, -rad, 2 * rad, 2 * rad);
-		} else {
-			SetTileSelectSize(1, 1);
-		}
+		SetTileSelectBigSize(-rad, -rad, 2 * rad, 2 * rad);
 
 		if (this->IsShaded()) return;
 
@@ -1482,16 +1477,6 @@ public:
 				CloseWindowById(WC_SELECT_STATION, 0);
 				break;
 
-			case WID_BROS_LT_OFF:
-			case WID_BROS_LT_ON:
-				this->RaiseWidget(_settings_client.gui.station_show_coverage + WID_BROS_LT_OFF);
-				_settings_client.gui.station_show_coverage = (widget != WID_BROS_LT_OFF);
-				this->LowerWidget(_settings_client.gui.station_show_coverage + WID_BROS_LT_OFF);
-				SndClickBeep();
-				this->SetDirty();
-				SetViewportCatchmentStation(nullptr, true);
-				break;
-
 			default:
 				this->PickerWindow::OnClick(pt, widget, click_count);
 				break;
@@ -1551,13 +1536,6 @@ static constexpr NWidgetPart _nested_road_station_picker_widgets[] = {
 							EndContainer(),
 						EndContainer(),
 					EndContainer(),
-					NWidget(WWT_LABEL, INVALID_COLOUR), SetStringTip(STR_STATION_BUILD_COVERAGE_AREA_TITLE), SetFill(1, 0),
-					NWidget(NWID_HORIZONTAL), SetPIPRatio(1, 0, 1),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BROS_LT_OFF), SetMinimalSize(60, 12),
-								SetStringTip(STR_STATION_BUILD_COVERAGE_OFF, STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BROS_LT_ON), SetMinimalSize(60, 12),
-								SetStringTip(STR_STATION_BUILD_COVERAGE_ON, STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP),
-					EndContainer(),
 					NWidget(WWT_EMPTY, INVALID_COLOUR, WID_BROS_ACCEPTANCE), SetFill(1, 1), SetResize(1, 0), SetMinimalTextLines(2, 0),
 				EndContainer(),
 			EndContainer(),
@@ -1590,13 +1568,6 @@ static constexpr NWidgetPart _nested_tram_station_picker_widgets[] = {
 					NWidget(NWID_HORIZONTAL_LTR), SetPIP(0, WidgetDimensions::unscaled.hsep_normal, 0), SetPIPRatio(1, 0, 1),
 						NWidget(WWT_PANEL, COLOUR_GREY, WID_BROS_STATION_X), SetFill(0, 0), EndContainer(),
 						NWidget(WWT_PANEL, COLOUR_GREY, WID_BROS_STATION_Y), SetFill(0, 0), EndContainer(),
-					EndContainer(),
-					NWidget(WWT_LABEL, INVALID_COLOUR), SetStringTip(STR_STATION_BUILD_COVERAGE_AREA_TITLE), SetFill(1, 0),
-					NWidget(NWID_HORIZONTAL), SetPIPRatio(1, 0, 1),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BROS_LT_OFF), SetMinimalSize(60, 12),
-								SetStringTip(STR_STATION_BUILD_COVERAGE_OFF, STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP),
-						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_BROS_LT_ON), SetMinimalSize(60, 12),
-								SetStringTip(STR_STATION_BUILD_COVERAGE_ON, STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP),
 					EndContainer(),
 					NWidget(WWT_EMPTY, INVALID_COLOUR, WID_BROS_ACCEPTANCE), SetFill(1, 1), SetResize(1, 0), SetMinimalTextLines(2, 0),
 				EndContainer(),

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -201,7 +201,6 @@ struct GUISettings {
 	uint8_t station_numtracks;                ///< the number of platforms to default on for rail stations
 	uint8_t station_platlength;               ///< the platform length, in tiles, for rail stations
 	bool   station_dragdrop;                 ///< whether drag and drop is enabled for stations
-	bool   station_show_coverage;            ///< whether to highlight coverage area
 	bool   persistent_buildingtools;         ///< keep the building tools active after usage
 	bool   expenses_layout;                  ///< layout of expenses window
 	uint32_t last_newgrf_count;                ///< the numbers of NewGRFs we found during the last scan

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -168,7 +168,7 @@ void CheckRedrawStationCoverage(const Window *w)
 		_thd.dirty &= ~1;
 		w->SetDirty();
 
-		if (_settings_client.gui.station_show_coverage && _thd.drawstyle == HT_RECT) {
+		if (_thd.drawstyle == HT_RECT) {
 			FindStationsAroundSelection<StationTypeFilter>();
 		}
 	}

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -692,12 +692,6 @@ def      = true
 cat      = SC_BASIC
 
 [SDTC_BOOL]
-var      = gui.station_show_coverage
-flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
-def      = false
-cat      = SC_BASIC
-
-[SDTC_BOOL]
 var      = gui.persistent_buildingtools
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = true

--- a/src/widgets/airport_widget.h
+++ b/src/widgets/airport_widget.h
@@ -28,9 +28,6 @@ enum AirportPickerWidgets : WidgetID {
 	WID_AP_LAYOUT_INCREASE, ///< Increase the layout number.
 	WID_AP_AIRPORT_SPRITE,  ///< A visual display of the airport currently selected.
 	WID_AP_EXTRA_TEXT,      ///< Additional text about the airport.
-	WID_AP_COVERAGE_LABEL,  ///< Label if you want to see the coverage.
-	WID_AP_BTN_DONTHILIGHT, ///< Don't show the coverage button.
-	WID_AP_BTN_DOHILIGHT,   ///< Show the coverage button.
 	WID_AP_ACCEPTANCE,      ///< Acceptance info.
 };
 

--- a/src/widgets/rail_widget.h
+++ b/src/widgets/rail_widget.h
@@ -56,8 +56,6 @@ enum BuildRailStationWidgets : WidgetID {
 
 	WID_BRAS_PLATFORM_DRAG_N_DROP, ///< Button to enable drag and drop type station placement.
 
-	WID_BRAS_HIGHLIGHT_OFF,        ///< Button for turning coverage highlighting off.
-	WID_BRAS_HIGHLIGHT_ON,         ///< Button for turning coverage highlighting on.
 	WID_BRAS_COVERAGE_TEXTS,       ///< Empty space for the coverage texts.
 
 	WID_BRAS_PLATFORM_NUM_BEGIN = WID_BRAS_PLATFORM_NUM_1 - 1, ///< Helper for determining the chosen platform width.


### PR DESCRIPTION
## Motivation / Problem

The windows for building stations/roadstops/docks/airports each have buttons allowing the player to show or hide the coverage of the station.

The setting is off by default, but [82.8% of players](https://survey.openttd.org/summaries/2025/q2/14#game.settings.gui.station_show_coverage) have turned it on. To me, this reads as overwhelming support: the next-closest non-default settings are "smooth scrolling" with 36.2% disabled, "signal GUI mode" with 30.8% showing all signal types, and "pause on new game" with 24.5% enabled.

In our evergreen quest to streamline OpenTTD's user interface, I think this is an easy candidate for removal.

<img width="303" height="389" alt="buttons2" src="https://github.com/user-attachments/assets/fe2bc900-aeff-43bd-8118-ef2b19179e8f" />

## Description

Eliminate the buttons and always show station coverage. 

<img width="299" height="339" alt="nobuttons2" src="https://github.com/user-attachments/assets/1375a1c1-ef89-4925-bf31-3b3d39ffe50a" />

## Limitations

Workflow.png.

The dock menu no longer has any buttons, just a list of accepted cargo, so it looks funny (but still works fine).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
