### PR TITLE
Fix: Disallow unsafe access to baseset version and parameters.

### DIFF
--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -130,6 +130,7 @@ struct GRFFile {
 	std::vector<std::unique_ptr<struct RoadStopSpec>> roadstops;
 
 	std::vector<uint32_t> param{};
+	std::vector<bool> unsafe_param{};
 
 	std::vector<GRFLabel> labels{}; ///< List of labels
 
@@ -164,10 +165,13 @@ struct GRFFile {
 	~GRFFile();
 
 	/** Get GRF Parameter with range checking */
-	uint32_t GetParam(uint number) const
+	uint32_t GetParam(uint number, bool allow_unsafe = false) const
 	{
 		/* Note: We implicitly test for number < this->param.size() and return 0 for invalid parameters.
 		 *       In fact this is the more important test, as param is zeroed anyway. */
+		if (!allow_unsafe) {
+			if (number < std::size(this->unsafe_param) && this->unsafe_param[number]) return 0;
+		}
 		return (number < std::size(this->param)) ? this->param[number] : 0;
 	}
 };

--- a/src/newgrf/newgrf_internal.h
+++ b/src/newgrf/newgrf_internal.h
@@ -199,7 +199,7 @@ GRFFile *GetFileByGRFID(uint32_t grfid);
 GRFError *DisableGrf(StringID message = {}, GRFConfig *config = nullptr);
 void DisableStaticNewGRFInfluencingNonStaticNewGRFs(GRFConfig &c);
 bool HandleChangeInfoResult(std::string_view caller, ChangeInfoResult cir, GrfSpecFeature feature, uint8_t property);
-uint32_t GetParamVal(uint8_t param, uint32_t *cond_val);
+uint32_t GetParamVal(uint8_t param, uint32_t *cond_val, bool *unsafe = nullptr);
 void GRFUnsafe(ByteReader &);
 
 void InitializePatchFlags();

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -64,9 +64,20 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
 
 		case 0x7D: return object.GetRegister(parameter);
 
-		case 0x7F:
+		case 0x7F: {
 			if (object.grffile == nullptr) return 0;
-			return object.grffile->GetParam(parameter);
+
+			/* Access to unsafe parameters is allowed when resolving for drawing graphics. */
+			bool allow_unsafe =
+				object.callback == CBID_NO_CALLBACK ||
+				object.callback == CBID_STATION_DRAW_TILE_LAYOUT ||
+				object.callback == CBID_INDTILE_DRAW_FOUNDATIONS ||
+				object.callback == CBID_CANALS_SPRITE_OFFSET ||
+				object.callback == CBID_HOUSE_DRAW_FOUNDATIONS ||
+				object.callback == CBID_AIRPTILE_DRAW_FOUNDATIONS;
+
+			return object.grffile->GetParam(parameter, allow_unsafe);
+		}
 
 		default:
 			/* First handle variables common with Action7/9/D */


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Alternative to #14304

> NewGRFs are able to read parameters of other NewGRFs.
> 
> Graphics basesets also contain a system NewGRFs, and https://github.com/OpenTTD/OpenTTD/pull/11347 added parameters to graphics basesets.
> 
> Therefore it may be possible for NewGRFs to read baseset parameters, which unlike non-system NewGRFs are not synchronised between clients.

Instead of preventing all access to baseset parameters, allow access but only when resolving sprites.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Track when a NewGRF accesses baseset parameters and mark them as unsafe.

Unsafe parameters are only allowed to be accessed for sprite resolving. For consistency this is applied in single-player and multi-player.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Completely untested, so may completely fail at its task.


<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
