### PR TITLE
Change: Use new game setting for disable_elrails when loading very old save

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1333,18 +1333,23 @@ bool AfterLoadGame()
 		}
 	}
 
-	/* Elrails got added in rev 24 */
+	/* Elrails got added in rev 24 but can be disabled since version 38. */
 	if (IsSavegameVersionBefore(SaveLoadVersion::Elrail)) {
-		RailType min_rail = RAILTYPE_ELECTRIC;
+		RailType min_rail = static_cast<RailType>(1); // Monorail was 1 before elrails were introduced.
 
-		for (Train *v : Train::Iterate()) {
-			RailTypes rts = RailVehInfo(v->engine_type)->railtypes;
+		if (!_settings_game.vehicle.disable_elrails) {
+			for (Train *v : Train::Iterate()) {
+				RailTypes rts = RailVehInfo(v->engine_type)->railtypes;
 
-			v->railtypes = rts;
-			if (rts.Test(RAILTYPE_ELECTRIC)) min_rail = RAILTYPE_RAIL;
+				if (rts.Test(RAILTYPE_ELECTRIC)) {
+					min_rail = RAILTYPE_RAIL;
+					break;
+				}
+			}
 		}
 
-		/* .. so we convert the entire map from normal to elrail (so maintain "fairness") */
+		/* We update the entire map to keep monorail and maglev in place. */
+		/* If min_rail == RAILTYPE_RAIL, this will also upgrade normal rail to electric rail. */
 		for (const auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case TileType::Railway:
@@ -1373,7 +1378,14 @@ bool AfterLoadGame()
 					break;
 			}
 		}
+	} else if (IsSavegameVersionBefore(SaveLoadVersion::DisableElrailSetting)) {
+		/* Since we cannot know the preference of a user, let elrails enabled; it
+		 * can be disabled manually. */
+		_settings_game.vehicle.disable_elrails = false;
 	}
+	/* Do the same as when elrails were enabled/disabled manually just now. */
+	UpdateDisableElrailSettingState(_settings_game.vehicle.disable_elrails, false);
+	InitializeSignalGui();
 
 	/* In version 16.1 of the savegame a company can decide if trains, which get
 	 * replaced, shall keep their old length. In all prior versions, just default
@@ -1504,13 +1516,6 @@ bool AfterLoadGame()
 			v->current_order.SetRefit(CARGO_NO_REFIT);
 		}
 	}
-
-	/* from version 38 we have optional elrails, since we cannot know the
-	 * preference of a user, let elrails enabled; it can be disabled manually */
-	if (IsSavegameVersionBefore(SaveLoadVersion::DisableElrailSetting)) _settings_game.vehicle.disable_elrails = false;
-	/* do the same as when elrails were enabled/disabled manually just now */
-	UpdateDisableElrailSettingState(_settings_game.vehicle.disable_elrails, false);
-	InitializeSignalGui();
 
 	/* From version 53, the map array was changed for house tiles to allow
 	 * space for newhouses grf features. A new byte, m7, was also added. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

Electric railways were added in OpenTTD 0.5, and when a savegame from older versions than 0.5 is loaded, the railways are automatically updated to electric railway if there is any electric locomotive (to maintain "fairness" as written in the comments).


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

In that case, I propose to use the "Disable electric rail" option instead of electrifying all the rail automatically. My current understanding is that it was meant to mimic the behavior before OpenTTD 0.5 so it feels like a natural fit. Players could then choose to enable the electric railways in the settings if they want.

Not sure if this is the correct way to do that though as the commit seems a bit messy.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
I did not test it extensively, hopefully there is no regression.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
