### PR TITLE
Fix #14415: Update survey option text when changing setting

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -970,6 +970,7 @@ struct GameOptionsWindow : Window {
 
 				this->SetWidgetLoweredState(WID_GO_SURVEY_PARTICIPATE_BUTTON, _settings_client.network.participate_survey == PS_YES);
 				this->SetWidgetDirty(WID_GO_SURVEY_PARTICIPATE_BUTTON);
+				this->SetWidgetDirty(WID_GO_SURVEY_PARTICIPATE_TEXT);
 				break;
 
 			case WID_GO_SURVEY_LINK_BUTTON:


### PR DESCRIPTION
## Motivation / Problem

Per #14415:

> Turning on or off the "Participate in automated survey" setting does not immediately update the text to reflect the new state, resulting in the value in the slider not matching the value in the text.

<img width="408" height="390" alt="462876079-32b69a42-40b2-4737-8541-a451fa1419cc" src="https://github.com/user-attachments/assets/287e1d49-0e74-43e2-92ad-d33c4197c46a" />

## Description

Mark the text widget dirty when changing the setting, so that it gets redrawn immediately.

Closes #14415.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
