### PR TITLE
Change: separate ships travelling in opposite direction

### DIFF
--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -356,6 +356,23 @@ public:
 	}
 
 	/**
+	 * Whether the provided direction is a preferred direction for a given tile. This is used to separate ships travelling in opposite directions.
+	 * @param tile Tile of current node.
+	 * @param td Trackdir of current node.
+	 * @returns true if a preferred direction, false otherwise.
+	 */
+	inline static bool IsPreferredShipDirection(TileIndex tile, Trackdir td)
+	{
+		const bool odd_x = TileX(tile) & 1;
+		const bool odd_y = TileY(tile) & 1;
+		if (td == TRACKDIR_X_NE) return odd_y;
+		if (td == TRACKDIR_X_SW) return !odd_y;
+		if (td == TRACKDIR_Y_NW) return odd_x;
+		if (td == TRACKDIR_Y_SE) return !odd_x;
+		return (odd_x ^ odd_y) ^ HasBit(TRACKDIR_BIT_RIGHT_N | TRACKDIR_BIT_LEFT_S | TRACKDIR_BIT_UPPER_W | TRACKDIR_BIT_LOWER_E, td);
+	}
+
+	/**
 	 * Called by YAPF to calculate the cost from the origin to the given node.
 	 * Calculates only the cost of given node, adds it to the parent node cost
 	 * and stores the result into Node::cost member.
@@ -375,6 +392,9 @@ public:
 			});
 			c += count * 3 * YAPF_TILE_LENGTH;
 		}
+
+		/* Encourage separation between ships traveling in different directions. */
+		if (!IsPreferredShipDirection(n.GetTile(), n.GetTrackdir())) c += YAPF_TILE_LENGTH;
 
 		/* Skipped tile cost for aqueducts. */
 		c += YAPF_TILE_LENGTH * tf->tiles_skipped;


### PR DESCRIPTION
## Motivation / Problem

Ships going in opposite direction often go right through each other, which looks a bit silly.

## Description

Have the ship pathfinder prefer certain "lanes" (e.g. all tiles with an odd X coordinate) when the ship is traveling in a certain direction. This results in ships passing each other instead of going right through each other, at least most of the times.

Before:
![openttd_3uUFON36W0](https://github.com/user-attachments/assets/bb8735f2-0428-472c-9ca4-c0badbc659fb)

This PR:
![openttd_QaVN8ITpkI](https://github.com/user-attachments/assets/e3458813-ad06-472c-9afd-05beab97d989)

Shout out to @PeterN. He made a similar feature in an experimental branch, I re-used some of his code for my final implementation.

## Limitations

This is an uninformed mechanism that's based on the tile coordinate and ship direction alone. It doesn't take into acount left or right-handedness, in fact ships frequently change sides when going through narrow water parts. It doesn't take into account the position of any other ships, so faster ships still travel right through slower ships going in the same direction. It can also lead to slightly longer paths.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
