### PR TITLE
Codefix: Move provider instances to static members.

### DIFF
--- a/src/screenshot_bmp.cpp
+++ b/src/screenshot_bmp.cpp
@@ -145,6 +145,9 @@ public:
 
 		return true;
 	}
+
+private:
+	static ScreenshotProvider_Bmp instance;
 };
 
-static ScreenshotProvider_Bmp s_screenshot_provider_bmp;
+/* static */ ScreenshotProvider_Bmp ScreenshotProvider_Bmp::instance{};

--- a/src/screenshot_pcx.cpp
+++ b/src/screenshot_pcx.cpp
@@ -149,6 +149,9 @@ public:
 
 		return success;
 	}
+
+private:
+	static ScreenshotProvider_Pcx instance;
 };
 
-static const ScreenshotProvider_Pcx s_screenshot_provider_pcx;
+/* static */ ScreenshotProvider_Pcx ScreenshotProvider_Pcx::instance{};

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -177,6 +177,9 @@ private:
 	{
 		Debug(misc, 1, "[libpng] warning: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
 	}
+
+private:
+	static ScreenshotProvider_Png instance;
 };
 
-static ScreenshotProvider_Png s_screenshot_provider_png;
+/* static */ ScreenshotProvider_Png ScreenshotProvider_Png::instance{};

--- a/src/soundloader_opus.cpp
+++ b/src/soundloader_opus.cpp
@@ -83,6 +83,9 @@ public:
 
 		return true;
 	}
+
+private:
+	static SoundLoader_Opus instance;
 };
 
-static SoundLoader_Opus s_sound_loader_opus;
+/* static */ SoundLoader_Opus SoundLoader_Opus::instance{};

--- a/src/soundloader_raw.cpp
+++ b/src/soundloader_raw.cpp
@@ -47,6 +47,9 @@ public:
 
 		return true;
 	}
+
+private:
+	static SoundLoader_Raw instance;
 };
 
-static SoundLoader_Raw s_sound_loader_raw;
+/* static */ SoundLoader_Raw SoundLoader_Raw::instance{};

--- a/src/soundloader_wav.cpp
+++ b/src/soundloader_wav.cpp
@@ -96,6 +96,9 @@ public:
 
 		return false;
 	}
+
+private:
+	static SoundLoader_Wav instance;
 };
 
-static SoundLoader_Wav s_sound_loader_wav;
+/* static */ SoundLoader_Wav SoundLoader_Wav::instance{};


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

> @[rubidium42](https://github.com/rubidium42) rubidium42 [Aug 6, 2025](https://github.com/OpenTTD/OpenTTD/pull/14450#discussion_r2257916674)

> I'm only noticing this now, and did not with the sound loader and screenshot provider... but these shouldn't have the `s` prefix. I > know that the blitter and drivers do use `s`, but those are local static variables. These are global variables.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Move instance of existing provider implementations to a static member variable of the implementation itself.

This avoids naming issues and keeps things self-contained.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
