### PR TITLE
Fix: 'Map edges' GUI buttons shouldn't initialize with water on northeast edge

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -833,7 +833,11 @@ struct GenerateLandscapeWindow : public Window {
 				break;
 
 			case WID_GL_BORDERS_RANDOM:
-				_settings_newgame.game_creation.water_borders = (_settings_newgame.game_creation.water_borders == BorderFlag::Random) ? BorderFlag{} : BorderFlag::Random;
+				if (_settings_newgame.game_creation.water_borders == BorderFlag::Random) {
+					_settings_newgame.game_creation.water_borders.Reset();
+				} else {
+					_settings_newgame.game_creation.water_borders = BorderFlag::Random;
+				}
 				SndClickBeep();
 				this->InvalidateData();
 				break;


### PR DESCRIPTION
## Motivation / Problem

When selecting world generation settings, switching map edges to Manual always has the Northeast edge set to Water.

## Description

Toggling the map edges sets `_settings_newgame.game_creation.water_borders = BorderFlag{};`, but this doesn't work. Use `Reset()` instead.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
