### PR TITLE
Fix: Off-by-one in Blitter::DrawLineGeneric

### DIFF
--- a/src/blitter/common.hpp
+++ b/src/blitter/common.hpp
@@ -90,13 +90,14 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 		if (x1 < 0) {
 			dash_count = (-x1) % (dash + gap);
 			auto adjust_frac = [&](int64_t frac, int &y_bound) -> int {
-				frac -= ((int64_t) dy) * ((int64_t) x1);
+				frac -= ((int64_t) dy) * ((int64_t) (x1 + 1));
 				if (frac >= 0) {
 					int quotient = frac / dx;
 					int remainder = frac % dx;
 					y_bound += (1 + quotient) * stepy;
 					frac = remainder - dx;
 				}
+				frac += dy;
 				return frac;
 			};
 			frac_low = adjust_frac(frac_low, y_low);
@@ -152,13 +153,14 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 		if (y1 < 0) {
 			dash_count = (-y1) % (dash + gap);
 			auto adjust_frac = [&](int64_t frac, int &x_bound) -> int {
-				frac -= ((int64_t) dx) * ((int64_t) y1);
+				frac -= ((int64_t) dx) * ((int64_t) (y1 + 1));
 				if (frac >= 0) {
 					int quotient = frac / dy;
 					int remainder = frac % dy;
 					x_bound += (1 + quotient) * stepx;
 					frac = remainder - dy;
 				}
+				frac += dx;
 				return frac;
 			};
 			frac_low = adjust_frac(frac_low, x_low);


### PR DESCRIPTION
## Motivation / Problem

This fixes the line irregularities which occur when the start of the line begins before the clipping area.
In particular, this fixes the effect of moving window corners/edges past viewport lines (e.g. linkgraph lines).

<img width="110" height="65" alt="wobbly" src="https://github.com/user-attachments/assets/d4bd1fb0-5b7f-421b-8e3d-e21e0a58a87a" />

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
