### PR TITLE
Codefix: [macos] variable length array warnings with clang-17

### DIFF
--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -235,22 +235,22 @@ CoreTextParagraphLayout::CoreTextVisualRun::CoreTextVisualRun(CTRunRef run, Font
 	this->glyphs.resize(CTRunGetGlyphCount(run));
 
 	/* Query map of glyphs to source string index. */
-	CFIndex map[this->glyphs.size()];
-	CTRunGetStringIndices(run, CFRangeMake(0, 0), map);
+	auto map = std::make_unique<CFIndex[]>(this->glyphs.size());
+	CTRunGetStringIndices(run, CFRangeMake(0, 0), map.get());
 
 	this->glyph_to_char.resize(this->glyphs.size());
 	for (size_t i = 0; i < this->glyph_to_char.size(); i++) this->glyph_to_char[i] = (int)map[i];
 
-	CGPoint pts[this->glyphs.size()];
-	CTRunGetPositions(run, CFRangeMake(0, 0), pts);
-	CGSize advs[this->glyphs.size()];
-	CTRunGetAdvances(run, CFRangeMake(0, 0), advs);
+	auto pts = std::make_unique<CGPoint[]>(this->glyphs.size());
+	CTRunGetPositions(run, CFRangeMake(0, 0), pts.get());
+	auto advs = std::make_unique<CGSize[]>(this->glyphs.size());
+	CTRunGetAdvances(run, CFRangeMake(0, 0), advs.get());
 	this->positions.reserve(this->glyphs.size());
 
 	/* Convert glyph array to our data type. At the same time, substitute
 	 * the proper glyphs for our private sprite glyphs. */
-	CGGlyph gl[this->glyphs.size()];
-	CTRunGetGlyphs(run, CFRangeMake(0, 0), gl);
+	auto gl = std::make_unique<CGGlyph[]>(this->glyphs.size());
+	CTRunGetGlyphs(run, CFRangeMake(0, 0), gl.get());
 	for (size_t i = 0; i < this->glyphs.size(); i++) {
 		if (buff[this->glyph_to_char[i]] >= SCC_SPRITE_START && buff[this->glyph_to_char[i]] <= SCC_SPRITE_END && (gl[i] == 0 || gl[i] == 3)) {
 			/* A glyph of 0 indidicates not found, while apparently 3 is what char 0xFFFC maps to. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
With `macos-15` image, XCode is upgraded from 16.2 to 16.4 and clang from 16 to 17.
This triggers some `variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]` warnings.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Replace variable length arrays with std::unique_ptr.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Only tested compilation via CI, need somebody to check it still works as intended.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
