### PR TITLE
Fix #10222: Off by one drawing even-width horizontal/vertical lines

### DIFF
--- a/src/blitter/common.hpp
+++ b/src/blitter/common.hpp
@@ -78,11 +78,11 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 		int frac_low  = dy - frac_diff / 2;
 		int frac_high = dy + frac_diff / 2;
 
-		while (frac_low < -(dx / 2)) {
+		while (frac_low < -dx) {
 			frac_low += dx;
 			y_low -= stepy;
 		}
-		while (frac_high >= dx / 2) {
+		while (frac_high >= 0) {
 			frac_high -= dx;
 			y_high += stepy;
 		}
@@ -140,11 +140,11 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 		int frac_low  = dx - frac_diff / 2;
 		int frac_high = dx + frac_diff / 2;
 
-		while (frac_low < -(dy / 2)) {
+		while (frac_low < -dy) {
 			frac_low += dy;
 			x_low -= stepx;
 		}
-		while (frac_high >= dy / 2) {
+		while (frac_high >= 0) {
 			frac_high -= dy;
 			x_high += stepx;
 		}


### PR DESCRIPTION
## Motivation / Problem

#10222: Off by one drawing even-width horizontal/vertical lines

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
