### PR TITLE
Fix: Off-by-one when drawing diagonal lines

### DIFF
--- a/src/blitter/common.hpp
+++ b/src/blitter/common.hpp
@@ -82,7 +82,7 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 			frac_low += dx;
 			y_low -= stepy;
 		}
-		while (frac_high >= 0) {
+		while (frac_high >= dy) {
 			frac_high -= dx;
 			y_high += stepy;
 		}
@@ -145,7 +145,7 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 			frac_low += dy;
 			x_low -= stepx;
 		}
-		while (frac_high >= 0) {
+		while (frac_high >= dx) {
 			frac_high -= dy;
 			x_high += stepx;
 		}


### PR DESCRIPTION
## Motivation / Problem

The diagonal case in the cross https://github.com/OpenTTD/OpenTTD/pull/10499#issuecomment-1445059401 still isn't right.

## Description

This should resolve that, by more closely matching the subsequent loop.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
