### PR TITLE
Codechange: Remove output pointer from GetTileArea().

### DIFF
--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -130,11 +130,10 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 
 	/**
 	 * Get the tile area for a given station type.
-	 * @param ta tile area to fill.
 	 * @param type the type of the area
+	 * @return The tile area.
 	 */
-	virtual void GetTileArea(TileArea *ta, StationType type) const = 0;
-
+	virtual TileArea GetTileArea(StationType type) const = 0;
 
 	/**
 	 * Obtain the length of a platform

--- a/src/pathfinder/pathfinder_func.h
+++ b/src/pathfinder/pathfinder_func.h
@@ -25,8 +25,7 @@
 inline TileIndex CalcClosestStationTile(StationID station, TileIndex tile, StationType station_type)
 {
 	const BaseStation *st = BaseStation::Get(station);
-	TileArea ta;
-	st->GetTileArea(&ta, station_type);
+	TileArea ta = st->GetTileArea(station_type);
 
 	/* If the rail station is (temporarily) not present, use the station sign to drive near the station */
 	if (ta.tile == INVALID_TILE) return st->xy;

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -184,9 +184,7 @@ public:
 		if (v->current_order.IsType(OT_GOTO_STATION)) {
 			StationID station_id = v->current_order.GetDestination().ToStationID();
 			const BaseStation *station = BaseStation::Get(station_id);
-			TileArea tile_area;
-			station->GetTileArea(&tile_area, StationType::Dock);
-			for (const auto &tile : tile_area) {
+			for (const auto &tile : station->GetTileArea(StationType::Dock)) {
 				if (IsDockingTile(tile) && IsShipDestinationTile(tile, station_id)) {
 					pf.AddOrigin(GetWaterRegionPatchInfo(tile));
 				}

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -579,7 +579,7 @@ public:
 
 	uint32_t GetNewGRFVariable(const ResolverObject &object, uint8_t variable, uint8_t parameter, bool &available) const override;
 
-	void GetTileArea(TileArea *ta, StationType type) const override;
+	TileArea GetTileArea(StationType type) const override;
 };
 
 /** Iterator to iterate over all tiles belonging to an airport. */

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -411,30 +411,15 @@ static Station *GetClosestDeletedStation(TileIndex tile)
 }
 
 
-void Station::GetTileArea(TileArea *ta, StationType type) const
+TileArea Station::GetTileArea(StationType type) const
 {
 	switch (type) {
-		case StationType::Rail:
-			*ta = this->train_station;
-			return;
-
-		case StationType::Airport:
-			*ta = this->airport;
-			return;
-
-		case StationType::Truck:
-			*ta = this->truck_station;
-			return;
-
-		case StationType::Bus:
-			*ta = this->bus_station;
-			return;
-
+		case StationType::Rail: return this->train_station;
+		case StationType::Airport: return this->airport;
+		case StationType::Truck: return this->truck_station;
+		case StationType::Bus: return this->bus_station;
 		case StationType::Dock:
-		case StationType::Oilrig:
-			*ta = this->docking_station;
-			return;
-
+		case StationType::Oilrig: return this->docking_station;
 		default: NOT_REACHED();
 	}
 }

--- a/src/waypoint.cpp
+++ b/src/waypoint.cpp
@@ -32,23 +32,12 @@ void DrawWaypointSprite(int x, int y, StationClassID station_class, uint16_t sta
 	}
 }
 
-void Waypoint::GetTileArea(TileArea *ta, StationType type) const
+TileArea Waypoint::GetTileArea(StationType type) const
 {
 	switch (type) {
-		case StationType::RailWaypoint:
-			*ta = this->train_station;
-			return;
-
-		case StationType::RoadWaypoint:
-			*ta = this->road_waypoint_area;
-			return;
-
-		case StationType::Buoy:
-			ta->tile = this->xy;
-			ta->w    = 1;
-			ta->h    = 1;
-			break;
-
+		case StationType::RailWaypoint: return this->train_station;
+		case StationType::RoadWaypoint: return this->road_waypoint_area;
+		case StationType::Buoy: return {this->xy, 1, 1};
 		default: NOT_REACHED();
 	}
 }

--- a/src/waypoint_base.h
+++ b/src/waypoint_base.h
@@ -43,7 +43,7 @@ struct Waypoint final : SpecializedStation<Waypoint, true> {
 
 	uint32_t GetNewGRFVariable(const struct ResolverObject &object, uint8_t variable, uint8_t parameter, bool &available) const override;
 
-	void GetTileArea(TileArea *ta, StationType type) const override;
+	TileArea GetTileArea(StationType type) const override;
 
 	uint GetPlatformLength(TileIndex, DiagDirection) const override
 	{

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -60,9 +60,7 @@ private:
 			default:
 				NOT_REACHED();
 		}
-		TileArea ta;
-		this->wp->GetTileArea(&ta, type);
-		return ta.GetCenterTile();
+		return this->wp->GetTileArea(type).GetCenterTile();
 	}
 
 public:


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`BaseStation::GetTIleArea()` uses an output pointer as a location to store a `TileArea` instead of just returning it. This probably made sense at some point, but currently it just makes things more complicated, as the caller needs to create a `TileArea` to be filled.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove output pointer from `GetTileArea()`, and just use a regular return value instead.

This simplifies things and also removes undocumented type `ETileArea`

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
