### PR TITLE
Codefix 4f9c10d35f: Symbol consistency in landscape_grid.html

### DIFF
--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -246,7 +246,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits" rowspan=4><span class="free">OOOO OOOO OOOO OOOO</span></td>
       <td class="bits" rowspan=5><span class="free">OOOO OOO</span><span class="used" title="Non-flooding state">X</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">0000</span> <span class="free">OOO0</span></td>
+      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">0000</span> <span class="free">OOOO</span></td>
       <td class="bits" rowspan=5><span class="free">OOOO OOOO</span></td>
       <td class="bits" rowspan=5><span class="free">OOOO OOOO</span></td>
       <td class="bits" rowspan=5><span class="free">OOOO OOOO OOOO OOOO</span></td>


### PR DESCRIPTION
The table in landscape_grid.html uses both the letter `O` as well as the digit `0` (zero) to denote bits.

Doing a quick count via
```
grep -o '<span[^>]*>[^<]*</span>' docs/landscape_grid.html | grep -o 'O' | wc -l && grep -o '<span[^>]*>[^<]*</span>' docs/land
scape_grid.html | grep -o '0' | wc -l
```

I see over 600 uses of the letter `O` and only 41 uses of the digit `0`. Most of the digit `0` uses are actually inside a <span> title comment and perfectly valid. But in some places, there is a `0` instead of a `O`.

I don't know why `O` is preferred over `0`. But it is clearly the preferred choice. This change adds consistency by replacing all `0` with `O`.

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

I was trying to code a bit in OpenTTD for fun and I noticed the AI was stumbling over this document and constantly failed to understand this table.


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

I did a manual search&replace and replaced all `0` with `O`, but only in the visible table part, not in documentation strings.

Preview: https://htmlpreview.github.io/?https://github.com/diekmann/OpenTTD/blob/03ee22a54fe47a084e3cf1952a056c80ca84cb2e/docs/landscape_grid.html


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

The table still uses the letter `O` instead of the digit `0`. Using the digit `0` would probably be clearer and avoid future inconsitencies.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
  * _No backport, minor nit_
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
  * _No language touched_
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
