### PR TITLE
Codechange: Add unit tests for tile creation

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_test_files(
     test_network_crypto.cpp
     test_script_admin.cpp
     test_window_desc.cpp
+    tile_creation.cpp
     tilearea.cpp
     utf8.cpp
 )

--- a/src/tests/tile_creation.cpp
+++ b/src/tests/tile_creation.cpp
@@ -1,0 +1,437 @@
+/**
+ * @file tile_creation.cpp
+ * Unit tests for tile creation functions Make{Clear,Field,RoadTunnel,...}.
+ */
+#include "../stdafx.h"
+
+#include "../3rdparty/catch2/catch.hpp"
+
+#include "../map_func.h"
+#include "../clear_map.h"
+#include "../object_map.h"
+#include "../rail_map.h"
+#include "../road_map.h"
+#include "../station_map.h"
+#include "../tile_map.h"
+#include "../town_map.h"
+#include "../tree_map.h"
+#include "../tunnel_map.h"
+#include "../water_map.h"
+#include "../industry_map.h"
+#include "../depot_map.h"
+
+#include "../safeguards.h"
+
+
+/**
+ * Helper function to create a tile in a map for testing.
+ * All fields are initialized to ones, so the tests can verify that the Make* functions cleanly initialize all fields.
+ */
+static Tile taintedMockTile()
+{
+	Map::Allocate(64, 64);
+	Tile t(TileXY(32, 32));
+	t.type() = 0xFF;
+	t.height() = 0xFF;
+	t.m1() = 0xFF;
+	t.m2() = 0xFFFF;
+	t.m3() = 0xFF;
+	t.m4() = 0xFF;
+	t.m5() = 0xFF;
+	t.m6() = 0xFF;
+	t.m7() = 0xFF;
+	t.m8() = 0xFFFF;
+	return t;
+}
+
+TEST_CASE("MakeTile - MakeClear")
+{
+	Tile t = taintedMockTile();
+
+	MakeClear(t, CLEAR_GRASS, 2);
+
+	CHECK(IsClearGround(t, CLEAR_GRASS));
+	CHECK_FALSE(IsClearGround(t, CLEAR_FIELDS));
+	CHECK(GetClearDensity(t) == 2);
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(GB(t.m1(), 5, 3) == 0);
+	REQUIRE(t.m2() == 0);
+	REQUIRE(GB(t.m3(), 0, 4) == 0);
+	REQUIRE(GB(t.m4(), 0, 2) == 0);
+	REQUIRE(GB(t.m6(), 0, 2) == 0);
+	REQUIRE(GB(t.m6(), 5, 3) == 0);
+	REQUIRE(t.m7() == 0);
+	REQUIRE(t.m8() == 0);
+}
+
+TEST_CASE("MakeTile - MakeField")
+{
+	Tile t = taintedMockTile();
+	MakeField(t, 1, IndustryID(1));
+
+	CHECK(IsClearGround(t, CLEAR_FIELDS));
+	CHECK(GetIndustryIndexOfField(t) == IndustryID(1));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(GB(t.m1(), 5, 3) == 0);
+	REQUIRE(GB(t.m4(), 0, 2) == 0);
+	//REQUIRE(GB(t.m6(), 0, 2) == 0); FIXME: not cleared.
+	//REQUIRE(GB(t.m6(), 5, 3) == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	REQUIRE(t.m8() == 0);
+}
+
+TEST_CASE("MakeTile - MakeRailNormal")
+{
+	Tile t = taintedMockTile();
+	MakeRailNormal(t, OWNER_NONE, TrackBits(0), RAILTYPE_MAGLEV);
+
+	CHECK(IsPlainRailTile(t));
+	CHECK(GetRailType(t) == RailType(RAILTYPE_MAGLEV));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	//REQUIRE(GB(t.m1(), 5, 2) == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m2(), 0, 8) == 0);
+	REQUIRE(GB(t.m2(), 12, 4) == 0);
+	REQUIRE(t.m3() == 0);
+	REQUIRE(GB(t.m4(), 4, 4) == 0);
+	REQUIRE(GB(t.m5(), 6, 2) == 0); // not free, but hard-coded to 0
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	REQUIRE(GB(t.m8(), 6, 10) == 0);
+}
+
+TEST_CASE("MakeTile - MakeRailDepot")
+{
+	Tile t = taintedMockTile();
+	MakeRailDepot(t, OWNER_NONE, DepotID(1), DIAGDIR_NE, RAILTYPE_RAIL);
+
+	CHECK(IsRailDepot(t));
+	CHECK(GetDepotIndex(t) == DepotID(1));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	//REQUIRE(GB(t.m1(), 5, 2) == 0); FIXME: not cleared.
+	REQUIRE(t.m3() == 0);
+	REQUIRE(GB(t.m4(), 4, 4) == 0);
+	REQUIRE(GB(t.m5(), 2, 2) == 0);
+	REQUIRE(GB(t.m5(), 5, 1) == 0);
+	REQUIRE(GB(t.m5(), 6, 2) == 3); // not free, but hard-coded to 1
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	REQUIRE(GB(t.m8(), 6, 10) == 0);
+}
+
+TEST_CASE("MakeTile - MakeRoadNormal")
+{
+	Tile t = taintedMockTile();
+	MakeRoadNormal(t, RoadBits(0), INVALID_ROADTYPE, INVALID_ROADTYPE, TownID(0), OWNER_NONE, OWNER_NONE);
+	SetRoadside(t, ROADSIDE_PAVED_ROAD_WORKS);
+
+	CHECK(IsNormalRoadTile(t));
+	CHECK(GetRoadTypeRoad(t) == INVALID_ROADTYPE);
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	//REQUIRE(GB(t.m1(), 5, 3) == 0); FIXME: not cleared.
+	//REQUIRE(GB(t.m4(), 6, 2) == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m5(), 6, 2) == 0); // not free, but hard-coded to 0
+	//REQUIRE(GB(t.m6(), 0, 3) == 0); FIXME: not cleared.
+	//REQUIRE(GB(t.m6(), 6, 2) == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m7(), 4, 1) == 0);
+	REQUIRE(GB(t.m7(), 6, 2) == 0);
+	//REQUIRE(GB(t.m8(), 0, 6) == 0); FIXME: not cleared.
+	//REQUIRE(GB(t.m8(), 12, 4) == 0); FIXME: not cleared.
+}
+
+TEST_CASE("MakeTile - MakeRoadDepot")
+{
+	Tile t = taintedMockTile();
+	MakeRoadDepot(t, OWNER_NONE, DepotID(1), DIAGDIR_NE, INVALID_ROADTYPE);
+
+	CHECK(IsRoadDepot(t));
+	CHECK(GetDepotIndex(t) == DepotID(1));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	//REQUIRE(GB(t.m1(), 5, 3) == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m3(), 0, 4) == 0);
+	REQUIRE(GB(t.m4(), 6, 2) == 0);
+	REQUIRE(GB(t.m5(), 2, 4) == 0);
+	REQUIRE(GB(t.m5(), 6, 2) == 2); // not free, but hard-coded to 10b
+	//REQUIRE(GB(t.m6(), 0, 3) == 0); FIXME: not cleared.
+	//REQUIRE(GB(t.m6(), 6, 2) == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m7(), 6, 2) == 0);
+	REQUIRE(GB(t.m8(), 0, 6) == 0);
+	REQUIRE(GB(t.m8(), 12, 4) == 0);
+}
+
+TEST_CASE("MakeTile - MakeHouseTile")
+{
+	Tile t = taintedMockTile();
+	MakeClear(t, CLEAR_GRASS, 2); // A house needs to be placed on a clear tile.
+	MakeHouseTile(t, TownID(8), 1, 1, HouseID(42), 0, false);
+
+	CHECK(IsTileType(t, MP_HOUSE));
+	CHECK(GetTownIndex(t) == TownID(8));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(GB(t.m3(), 6, 1) == 0);
+	REQUIRE(t.m4() == 0);
+	REQUIRE(GB(t.m8(), 12, 4) == 0);
+}
+
+TEST_CASE("MakeTile - MakeTree")
+{
+	Tile t = taintedMockTile();
+	MakeTree(t, TREE_TEMPERATE, 2, TreeGrowthStage::Grown, TREE_GROUND_GRASS, 1);
+
+	CHECK(IsTileType(t, MP_TREES));
+	CHECK(GetTreeType(t) == TREE_TEMPERATE);
+	CHECK(GetTreeCount(t) == 3);
+	CHECK(GetTreeGrowth(t) == TreeGrowthStage::Grown);
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	//REQUIRE(GB(t.m1(), 7, 1) == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m2(), 9, 7) == 0);
+	REQUIRE(GB(t.m4(), 0, 8) == 0);
+	REQUIRE(GB(t.m5(), 3, 3) == 0);
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	//REQUIRE(t.m8() == 0); FIXME: not cleared.
+}
+
+
+TEST_CASE("MakeTile - MakeStation")
+{
+	Tile t = taintedMockTile();
+	MakeStation(t, OWNER_NONE, StationID(1), StationType::Rail, 0);
+
+	CHECK(IsTileType(t, MP_STATION));
+	CHECK(GetStationType(t) == StationType::Rail);
+	CHECK(GetStationIndex(t) == StationID(1));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(GB(t.m1(), 7, 1) == 0);
+	REQUIRE(GB(t.m3(), 3, 1) == 0);
+	//REQUIRE(GB(t.m6(), 7, 1) == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m8(), 6, 6) == 0);
+}
+
+TEST_CASE("MakeTile - MakeAirport")
+{
+	Tile t = taintedMockTile();
+	MakeAirport(t, OWNER_NONE, StationID(1), 0, WATER_CLASS_SEA);
+
+	CHECK(IsTileType(t, MP_STATION));
+	CHECK(GetStationType(t) == StationType::Airport);
+	CHECK(GetStationIndex(t) == StationID(1));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(GB(t.m1(), 7, 1) == 0);
+	REQUIRE(GB(t.m3(), 0, 4) == 0);
+	REQUIRE(t.m4() == 0);
+	//REQUIRE(GB(t.m6(), 2, 1) == 0); FIXME: not cleared.
+	//REQUIRE(GB(t.m6(), 7, 1) == 0); FIXME: not cleared.
+	REQUIRE(t.m8() == 0);
+}
+
+TEST_CASE("MakeTile - MakeOilrig")
+{
+	Tile t = taintedMockTile();
+	MakeOilrig(t, StationID(1), WATER_CLASS_SEA);
+
+	CHECK(IsTileType(t, MP_STATION));
+	CHECK(GetStationType(t) == StationType::Oilrig);
+	CHECK(GetStationIndex(t) == StationID(1));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(GB(t.m1(), 7, 1) == 0);
+	REQUIRE(t.m3() == 0);
+	REQUIRE(t.m4() == 0);
+	//REQUIRE(GB(t.m6(), 2, 1) == 0); FIXME: not cleared.
+	//REQUIRE(GB(t.m6(), 7, 1) == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	REQUIRE(t.m8() == 0);
+}
+
+TEST_CASE("MakeTile - MakeWater")
+{
+	Tile t = taintedMockTile();
+	MakeWater(t, OWNER_NONE, WATER_CLASS_SEA, 0);
+
+	CHECK(IsWaterTile(t));
+	CHECK(GetWaterClass(t) == WATER_CLASS_SEA);
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(t.m2() == 0);
+	REQUIRE(GB(t.m3(), 1, 7) == 0);
+	REQUIRE(t.m4() == 0);
+	REQUIRE(GB(t.m5(), 0, 4) == 0);
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	//REQUIRE(t.m8() == 0); FIXME: not cleared.
+}
+
+TEST_CASE("MakeTile - MakeCanal")
+{
+	Tile t = taintedMockTile();
+	MakeCanal(t, OWNER_NONE, 0);
+
+	CHECK(IsCanal(t));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(t.m2() == 0);
+	REQUIRE(GB(t.m3(), 1, 7) == 0);
+	REQUIRE(t.m4() == 0);
+	REQUIRE(GB(t.m5(), 0, 4) == 0);
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	//REQUIRE(t.m8() == 0); FIXME: not cleared.
+}
+
+TEST_CASE("MakeTile - MakeShore")
+{
+	Tile t = taintedMockTile();
+	MakeShore(t);
+
+	CHECK(IsCoastTile(t));
+	CHECK(GetWaterClass(t) == WATER_CLASS_SEA);
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(t.m2() == 0);
+	REQUIRE(GB(t.m3(), 1, 7) == 0);
+	REQUIRE(t.m4() == 0);
+	REQUIRE(GB(t.m5(), 0, 4) == 0);
+	REQUIRE(GB(t.m5(), 4, 1) == 1); // hard-coded to 1
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	//REQUIRE(t.m8() == 0); FIXME: not cleared.
+}
+
+TEST_CASE("MakeTile - MakeLock")
+{
+	Tile t = taintedMockTile();
+	MakeLock(t, OWNER_NONE, DIAGDIR_NE, WATER_CLASS_CANAL, WATER_CLASS_CANAL, WATER_CLASS_CANAL);
+
+	CHECK(IsLock(t));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(t.m2() == 0);
+	REQUIRE(GB(t.m3(), 1, 7) == 0);
+	REQUIRE(t.m4() == 0);
+	REQUIRE(GB(t.m5(), 0, 4) == 0);
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	//REQUIRE(t.m8() == 0); FIXME: not cleared.
+}
+
+TEST_CASE("MakeTile - MakeShipDepot")
+{
+	Tile t = taintedMockTile();
+	MakeShipDepot(t, OWNER_NONE, DepotID(1), DEPOT_PART_SOUTH, AXIS_X, WATER_CLASS_SEA);
+
+	CHECK(IsShipDepot(t));
+	CHECK(GetDepotIndex(t) == DepotID(1));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(GB(t.m3(), 1, 7) == 0);
+	REQUIRE(t.m4() == 0);
+	REQUIRE(GB(t.m5(), 2, 2) == 0);
+	REQUIRE(GB(t.m5(), 4, 2) == 3); // hard-coded to 1
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(t.m7() == 0);
+	//REQUIRE(t.m8() == 0); FIXME: not cleared.
+}
+
+TEST_CASE("MakeTile - MakeIndustry")
+{
+	Tile t = taintedMockTile();
+	MakeIndustry(t, IndustryID(1), IndustryGfx(0), 0, WATER_CLASS_SEA);
+
+	CHECK(IsTileType(t, MP_INDUSTRY));
+	CHECK(GetIndustryIndex(t) == IndustryID(1));
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	REQUIRE(GB(t.m1(), 0, 5) == 0);
+	//REQUIRE(GB(t.m6(), 6, 2) == 0); FIXME: not cleared.
+	//REQUIRE(t.m8() == 0); FIXME: not cleared.
+}
+
+TEST_CASE("MakeTile - MakeRailTunnel")
+{
+	Tile t = taintedMockTile();
+
+	MakeRailTunnel(t, OWNER_NONE, DIAGDIR_NE, INVALID_RAILTYPE);
+
+	CHECK(IsTunnel(t));
+
+	// Check that unused bits according to docs/landscape_grid.html are cleared.
+	//REQUIRE(GB(t.m1(), 5, 2) == 0); FIXME: not cleared.
+	REQUIRE(t.m2() == 0);
+	REQUIRE(GB(t.m3(), 0, 4) == 0);
+	REQUIRE(GB(t.m4(), 6, 2) == 0);
+	REQUIRE(GB(t.m5(), 5, 2) == 0);
+	REQUIRE(GB(t.m5(), 7, 1) == 0); // hard-coded to 0
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m7(), 6, 2) == 0);
+	REQUIRE(GB(t.m8(), 12, 4) == 0);
+}
+
+
+TEST_CASE("MakeTile - MakeRoadTunnel")
+{
+	Tile t = taintedMockTile();
+
+	MakeRoadTunnel(t, OWNER_NONE, DIAGDIR_NE, INVALID_ROADTYPE, INVALID_ROADTYPE);
+
+	CHECK(IsTunnel(t));
+
+	// Check that unused bits according to docs/landscape_grid.html are cleared.
+	//REQUIRE(GB(t.m1(), 5, 2) == 0); FIXME: not cleared.
+	REQUIRE(t.m2() == 0);
+	REQUIRE(GB(t.m3(), 0, 4) == 0);
+	REQUIRE(GB(t.m4(), 6, 2) == 0);
+	REQUIRE(GB(t.m5(), 5, 2) == 0);
+	REQUIRE(GB(t.m5(), 7, 1) == 0); // hard-coded to 0
+	//REQUIRE(t.m6() == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m7(), 6, 2) == 0);
+	REQUIRE(GB(t.m8(), 12, 4) == 0);
+}
+
+TEST_CASE("MakeTile - MakeBridgeRamp")
+{
+	Tile t = taintedMockTile();
+
+	MakeBridgeRamp(t, OWNER_NONE, BridgeType(9), DIAGDIR_NE, TRANSPORT_ROAD);
+
+	CHECK(IsBridge(t));
+	CHECK(GetBridgeType(t) == 9);
+
+	// Check that unused bits according to docs/landscape_grid.html are cleared.
+	//REQUIRE(GB(t.m1(), 5, 2) == 0); FIXME: not cleared.
+	REQUIRE(t.m2() == 0);
+	REQUIRE(GB(t.m3(), 0, 4) == 0);
+	REQUIRE(GB(t.m4(), 6, 2) == 0);
+	REQUIRE(GB(t.m5(), 5, 2) == 0);
+	REQUIRE(GB(t.m5(), 7, 1) == 1); // hard-coded to 1
+	//REQUIRE(GB(t.m6(), 0, 2) == 0); FIXME: not cleared.
+	//REQUIRE(GB(t.m6(), 6, 2) == 0); FIXME: not cleared.
+	REQUIRE(GB(t.m7(), 6, 2) == 0);
+	REQUIRE(GB(t.m8(), 12, 4) == 0);
+}
+
+TEST_CASE("MakeTile - MakeObject")
+{
+	Tile t = taintedMockTile();
+
+	MakeObject(t, OWNER_NONE, ObjectID(1), WATER_CLASS_SEA, 0);
+
+	CHECK(IsTileType(t, MP_OBJECT)); // IsObjectTypeTile
+	CHECK(GetObjectIndex(t) == ObjectID(1));
+	CHECK(GetWaterClass(t) == WATER_CLASS_SEA);
+
+	// Check that unused bits are cleared according to docs/landscape_grid.html
+	//REQUIRE(GB(t.m1(), 7, 1) == 0); FIXME: not cleared.
+	REQUIRE(t.m4() == 0);
+	//REQUIRE(GB(t.m6(), 2, 6) == 0); FIXME: not cleared.
+	//REQUIRE(t.m8() == 0); FIXME: not cleared.
+}


### PR DESCRIPTION
Create unit tests for the `MakeXXX(Tile t, ...` functions.

Also test that the bits which are free according to the documentation are initialized to zero.

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

I was trying some vibe coding with GitHub Copilot. Unfortunately, the LLMs I used (GPT 4.1 and Sonnet 3.5) did not get very far. In fact, they got really easily confused about the Tile layout, trying to change the bit meanings (which would break old savegames) or are hallucinating that a tile can be all types at once, ...
This forced me to think myself and I thought I'm putting this thinking into a nice set of unit tests.

The code here was mostly written by hand. LLMs helped with test stubs, but I figured I need to write the bit tests by hand, since I will have to validate them anyway manually.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

Just some unit tests.

### Copilot AI Pre-Review

I tried a few more Copilot LLMs and Gemini 2.5 Pro looked like it can parse the table in docs/landscape_grid.html and extract the free bits. It created a plausible-looking summary for me and I asked it to cross-check this summary against my unit tests. It concluded that they match.
While this commit is NOT vibe coded and NOT written by AI, I'm very happy that an LLM could check that I did not mis-type some of the bits.

### Tested

```sh
$ /usr/bin/ctest -j4 -C Debug -T test --output-on-failure -R "^Make"
Test project /home/vscode/git/OpenTTD/build
      Start  88: MakeTile - MakeClear
      Start  89: MakeTile - MakeField
      Start  90: MakeTile - MakeRailNormal
      Start  91: MakeTile - MakeRailDepot
 1/21 Test  #88: MakeTile - MakeClear .............   Passed    0.13 sec
      Start  92: MakeTile - MakeRoadNormal
 2/21 Test  #89: MakeTile - MakeField .............   Passed    0.13 sec
      Start  93: MakeTile - MakeRoadDepot
 3/21 Test  #90: MakeTile - MakeRailNormal ........   Passed    0.13 sec
      Start  94: MakeTile - MakeHouseTile
 4/21 Test  #91: MakeTile - MakeRailDepot .........   Passed    0.12 sec
      Start  95: MakeTile - MakeTree
 5/21 Test  #93: MakeTile - MakeRoadDepot .........   Passed    0.08 sec
      Start  96: MakeTile - MakeStation
 6/21 Test  #92: MakeTile - MakeRoadNormal ........   Passed    0.10 sec
      Start  97: MakeTile - MakeAirport
 7/21 Test  #95: MakeTile - MakeTree ..............   Passed    0.06 sec
      Start  98: MakeTile - MakeOilrig
 8/21 Test  #94: MakeTile - MakeHouseTile .........   Passed    0.13 sec
      Start  99: MakeTile - MakeWater
 9/21 Test  #96: MakeTile - MakeStation ...........   Passed    0.09 sec
      Start 100: MakeTile - MakeCanal
10/21 Test  #98: MakeTile - MakeOilrig ............   Passed    0.07 sec
      Start 101: MakeTile - MakeShore
11/21 Test  #97: MakeTile - MakeAirport ...........   Passed    0.10 sec
      Start 102: MakeTile - MakeLock
12/21 Test  #99: MakeTile - MakeWater .............   Passed    0.08 sec
      Start 103: MakeTile - MakeShipDepot
13/21 Test #103: MakeTile - MakeShipDepot .........   Passed    0.05 sec
      Start 104: MakeTile - MakeIndustry
14/21 Test #100: MakeTile - MakeCanal .............   Passed    0.10 sec
      Start 105: MakeTile - MakeRailTunnel
15/21 Test #101: MakeTile - MakeShore .............   Passed    0.10 sec
      Start 106: MakeTile - MakeRoadTunnel
16/21 Test #102: MakeTile - MakeLock ..............   Passed    0.14 sec
      Start 107: MakeTile - MakeBridgeRamp
17/21 Test #105: MakeTile - MakeRailTunnel ........   Passed    0.06 sec
      Start 108: MakeTile - MakeObject
18/21 Test #104: MakeTile - MakeIndustry ..........   Passed    0.08 sec
19/21 Test #106: MakeTile - MakeRoadTunnel ........   Passed    0.10 sec
20/21 Test #107: MakeTile - MakeBridgeRamp ........   Passed    0.08 sec
21/21 Test #108: MakeTile - MakeObject ............   Passed    0.08 sec

100% tests passed, 0 tests failed out of 21

Total Test time (real) =   0.59 sec
```

(timings on an old i5-6300U with disabled turbo boost)


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

There is no formal process in place to make sure docs/landscape_grid.html and src/tests/tile_creation.cpp remain in sync.

Also, the tests reveal that several of the free bits are not actually set to 0. I marked them with `FIXME`.

I think all the bits which are documented to be free should be explicitly set to 0 on tile creation. Otherwise, an author who wants to add a new feature and needs a free bit may assume that the bits are not 0 for legacy savegames, which could cause issues. But this is probably a future PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
