### PR TITLE
Fix: Incorrect Company::freegroups handling on company merger

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -412,7 +412,7 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 	if (new_owner == INVALID_OWNER) {
 		RemoveAllGroupsForCompany(old_owner);
 	} else {
-		Company *c = Company::Get(old_owner);
+		Company *c = Company::Get(new_owner);
 		for (Group *g : Group::Iterate()) {
 			if (g->owner == old_owner) {
 				g->owner = new_owner;


### PR DESCRIPTION
## Motivation / Problem

The wrong company is used in `Company::freegroups` handling on company merger.

See attached save for problem reproducer.
[PR 14534 Ltd, 1990-01-15.sav.zip](https://github.com/user-attachments/files/21956751/PR.14534.Ltd.1990-01-15.sav.zip)

Result:
```
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140737275330496) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140737275330496) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140737275330496, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007ffff6f8b476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff6f717f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007ffff6f7171b in __assert_fail_base
    (fmt=0x7ffff7126130 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x5555561cb138 "index / BITMAP_SIZE < this->used_bitmap.size()", file=0x5555561cae50 "/home/jgr/openttd/trunk/src/vehicle.cpp", line=1867, function=<optimised out>) at ./assert/assert.c:94
#6  0x00007ffff6f82e96 in __GI___assert_fail
    (assertion=0x5555561cb138 "index / BITMAP_SIZE < this->used_bitmap.size()", file=0x5555561cae50 "/home/jgr/openttd/trunk/src/vehicle.cpp", line=1867, function=0x5555561cb108 "void FreeUnitIDGenerator::ReleaseID(UnitID)")
    at ./assert/assert.c:103
#7  0x0000555556054f26 in FreeUnitIDGenerator::ReleaseID(unsigned short) (this=0x7ffff71284b8, index=<optimised out>) at /home/jgr/openttd/trunk/src/vehicle.cpp:1867
#8  FreeUnitIDGenerator::ReleaseID(unsigned short) (this=this@entry=0x7fff6dafd508, index=<optimised out>) at /home/jgr/openttd/trunk/src/vehicle.cpp:1861
#9  0x0000555555dcd758 in CmdDeleteGroup(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>) (flags=flags@entry=..., group_id=...)
    at /home/jgr/openttd/trunk/src/group_cmd.cpp:409
#10 0x0000555555dd56a3 in std::__invoke_impl<CommandCost, CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535> >(std::__invoke_other, CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>&&, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>&&)
    (__f=<optimised out>) at /usr/include/c++/12/bits/invoke.h:60
#11 std::__invoke<CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535> >(CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>&&, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>&&) (__fn=<optimised out>) at /usr/include/c++/12/bits/invoke.h:97
#12 std::__apply_impl<CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), std::tuple<EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535> >, 0ul, 1ul>(CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), std::tuple<EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535> >&&, std::integer_sequence<unsigned long, 0ul, 1ul>) (__t=..., __f=<optimised out>) at /usr/include/c++/12/tuple:1853
#13 std::apply<CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), std::tuple<EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535> > >(CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), std::tuple<EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535> >&&) (__t=..., __f=<optimised out>)
    at /usr/include/c++/12/tuple:1865
#14 CommandHelper<(Commands)123, CommandCost (*)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), true>::Execute(unsigned int, void (*)(Commands, CommandCost const&, StrongType::Typedef<unsigned int, TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int>, StrongType::Compatible<long> >), bool, bool, bool, StrongType::Typedef<unsigned int, TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int>, StrongType::Compatible<long> >, std::tuple<PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535> >)
    (args=std::tuple containing = {...}, tile=..., network_command=false, estimate_only=<optimised out>, callback=0x0, err_message=4137) at /home/jgr/openttd/trunk/src/command_func.h:398
#15 CommandHelper<(Commands)123, CommandCost (*)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), true>::InternalPost<void (Commands, CommandCost const&, StrongType::Typedef<unsigned int, TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int>, StrongType::Compatible<long> >)>(unsigned int, void (*)(Commands, CommandCost const&, StrongType::Typedef<unsigned int, TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int>, StrongType::Compatible<long> >), bool, bool, StrongType::Typedef<unsigned int, TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int>, StrongType::Compatible<long> >, std::tuple<PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535> >)
    (args=std::tuple containing = {...}, tile=..., network_command=false, my_cmd=true, callback=0x0, err_message=4137) at /home/jgr/openttd/trunk/src/command_func.h:294
#16 CommandHelper<(Commands)123, CommandCost (*)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), true>::InternalPost<void (Commands, CommandCost const&, StrongType::Typedef<unsigned int, TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int>, StrongType::Compatible<long> >)>(unsigned int, void (*)(Commands, CommandCost const&, StrongType::Typedef<unsigned int, TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int>, StrongType::Compatible<long> >), bool, bool, std::tuple<PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535> >)
    (args=std::tuple containing = {...}, network_command=false, my_cmd=true, callback=0x0, err_message=4137) at /home/jgr/openttd/trunk/src/command_func.h:279
#17 CommandHelper<(Commands)123, CommandCost (*)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), true>::Post<void (Commands, CommandCost const&, StrongType::Typedef<unsigned int, TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int>, StrongType::Compatible<long> >)>(unsigned int, void (*)(Commands, CommandCost const&, StrongType::Typedef<unsigned int, TileIndexTag, StrongType::Compare, StrongType::Integer, StrongType::Compatible<int>, StrongType::Compatible<long> >), PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>)
     (args#0=..., callback=0x0, err_message=4137) at /home/jgr/openttd/trunk/src/command_func.h:199
#18 CommandHelper<(Commands)123, CommandCost (*)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>), true>::Post(unsigned int, PoolID<unsigned short, GroupIDTag, (unsigned short)64000, (unsigned short)65535>) (args#0=..., err_message=4137) at /home/jgr/openttd/trunk/src/command_func.h:172
#19 VehicleGroupWindow::DeleteGroupCallback(Window*, bool) (confirmed=true, win=<optimised out>) at /home/jgr/openttd/trunk/src/group_gui.cpp:682
#20 VehicleGroupWindow::DeleteGroupCallback(Window*, bool) (win=<optimised out>, confirmed=<optimised out>) at /home/jgr/openttd/trunk/src/group_gui.cpp:677
#21 0x00005555560af49a in DispatchLeftClickEvent (click_count=1, y=<optimised out>, x=<optimised out>, w=0x555557826920) at /home/jgr/openttd/trunk/src/window.cpp:749
#22 MouseLoop (mousewheel=<optimised out>, click=<optimised out>) at /home/jgr/openttd/trunk/src/window.cpp:2915
#23 HandleMouseEvents() () at /home/jgr/openttd/trunk/src/window.cpp:3001
#24 0x0000555555ca0a85 in VideoDriver_SDL_Base::PollEvent() (this=0x555556712fc0) at /home/jgr/openttd/trunk/src/video/sdl2_v.cpp:444
--Type <RET> for more, q to quit, c to continue without paging--
#25 0x0000555555ca52b5 in VideoDriver::Tick() (this=this@entry=0x555556712fc0) at /home/jgr/openttd/trunk/src/video/video_driver.cpp:137
#26 0x0000555555c9fe8e in VideoDriver_SDL_Base::LoopOnce() (this=0x555556712fc0) at /home/jgr/openttd/trunk/src/video/sdl2_v.cpp:661
#27 VideoDriver_SDL_Base::LoopOnce() (this=0x555556712fc0) at /home/jgr/openttd/trunk/src/video/sdl2_v.cpp:634
#28 VideoDriver_SDL_Base::MainLoop() (this=0x555556712fc0) at /home/jgr/openttd/trunk/src/video/sdl2_v.cpp:679
#29 0x0000555555ec0559 in openttd_main(std::span<std::basic_string_view<char, std::char_traits<char> >, 18446744073709551615ul>)Python Exception <class 'gdb.error'>: No symbol "static_cast" in current context.
 (arguments=...) at /home/jgr/openttd/trunk/src/openttd.cpp:811
#30 0x0000555555817528 in main(int, char**) (argc=<optimised out>, argv=<optimised out>) at /usr/include/c++/12/span:90
```

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
