### PR TITLE
Fix ExploreSegment: Correct axis comparison for level crossings

### DIFF
--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -363,7 +363,10 @@ static SigFlags ExploreSegment(Owner owner)
 			case MP_ROAD:
 				if (!IsLevelCrossing(tile)) continue;
 				if (GetTileOwner(tile) != owner) continue;
-				if (DiagDirToAxis(enterdir) == GetCrossingRoadAxis(tile)) continue; // different axis
+				// Skip if the rail direction's axis is different from the road axis at the level crossing.
+				// The previous comparison used '==' while the comment stated 'different axis', causing the
+				// function to erroneously skip valid same-axis crossings and process different-axis ones.
+				if (DiagDirToAxis(enterdir) != GetCrossingRoadAxis(tile)) continue; // different axis
 
 				if (!flags.Test(SigFlag::Train) && HasVehicleOnTile(tile, IsTrainAndNotInDepot)) flags.Set(SigFlag::Train);
 				tile += TileOffsByDiagDir(exitdir);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

signal: fix inverted axis check at level crossings in ExploreSegment

The MP_ROAD (level crossing) handler compared axes with '==' while the
comment said "different axis", causing valid same‑axis crossings to be
skipped and different‑axis ones to be explored. Flip to '!=' and update
the comment. Prevents missed signal propagation across crossings.


signal: fix inverted axis check at level crossings in ExploreSegment

The MP_ROAD (level crossing) handler compared axes with '==' while the
comment said "different axis", causing valid same‑axis crossings to be
skipped and different‑axis ones to be explored. Flip to '!=' and update
the comment. Prevents missed signal propagation across crossings.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
