### PR TITLE
Change: Set endgame background to match original graphics borders

### DIFF
--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -49,6 +49,9 @@ struct EndGameHighScoreBaseWindow : Window {
 
 		this->DrawWidgets();
 
+		/* Fill with the appropriate background colour instead of leaving default window colour */
+		GfxFillRect(Rect{0, 0, this->width, this->height}, PixelColour{105}, FILLRECT_OPAQUE);
+
 		/* Standard background slices are 50 pixels high, but it's designed
 		 * for 480 pixels total. 96% of 500 is 480. */
 		Dimension dim = GetSpriteSize(this->background_img);


### PR DESCRIPTION
## Motivation / Problem

The background colour around the endgame magazine/newspaper/high score table graphics was not set. The full screen display is a window in disguise, so the background colour is just the default beige colour of eg. the main menu window.

In TTD this wasn't an issue, as the 640x480 graphics filled the full screen. Now it just looks a little ugly.

## Description

Changed to fill the entire window with `0x69`, the dark brown which is found in the border around the magazine and newspaper designs in the original graphics.

<img width="1777" height="1197" alt="image" src="https://github.com/user-attachments/assets/2d829492-8e73-434a-a7f4-550a428334f0" />


Plus, I think a dark colour looks nicer and focuses attention on the graphics.

## Limitations

This is designed to match the original TTD graphics, and other base sets may not match. OGFX1 is (arguably) depreciated, and I can easily update OGFX2 to use this background colour.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
