### PR TITLE
Add: Setting to allow bridges over stations, and whether to check height

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1374,6 +1374,14 @@ STR_CONFIG_SETTING_AUTOSLOPE_HELPTEXT                           :Allow landscapi
 STR_CONFIG_SETTING_CATCHMENT                                    :Allow more realistically sized catchment areas: {STRING2}
 STR_CONFIG_SETTING_CATCHMENT_HELPTEXT                           :Have differently sized catchment areas for different types of stations and airports
 
+STR_CONFIG_SETTING_BRIDGES_OVER_STATIONS                        :Allow bridges over stations: {STRING2}
+STR_CONFIG_SETTING_BRIDGES_OVER_STATIONS_HELPTEXT               :Choose if bridges can be built over stations, and whether to enforce a minimum height requirement. Ignoring height allows using station NewGRFs which don't have height information, but can cause clipping
+
+###length 3
+STR_CONFIG_SETTING_BRIDGES_OVER_STATIONS_NONE                   :None
+STR_CONFIG_SETTING_BRIDGES_OVER_STATIONS_CHECK_HEIGHT           :Check height
+STR_CONFIG_SETTING_BRIDGES_OVER_STATIONS_IGNORE_HEIGHT          :Ignore height
+
 STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES                     :Company stations can serve industries with attached neutral stations: {STRING2}
 STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT            :When enabled, industries with attached stations (such as Oil Rigs) may also be served by company-owned stations built nearby. When disabled, these industries may only be served by their attached stations. Any nearby company stations won't be able to serve them, nor will the attached station serve anything else other than the industry
 
@@ -5346,6 +5354,7 @@ STR_ERROR_BRIDGE_TOO_LOW_FOR_BUOY                               :bridge is {HEIG
 STR_ERROR_BRIDGE_TOO_LOW_FOR_RAIL_WAYPOINT                      :bridge is {HEIGHT} too low for rail waypoint
 STR_ERROR_BRIDGE_TOO_LOW_FOR_ROAD_WAYPOINT                      :bridge is {HEIGHT} too low for road waypoint
 STR_ERROR_BRIDGE_TOO_LOW_FOR_LOCK                               :bridge is {HEIGHT} too low for lock
+STR_ERROR_BRIDGES_OVER_STATIONS_NOT_ALLOWED                     :bridges over stations are not allowed
 
 # Tunnel related errors
 STR_ERROR_CAN_T_BUILD_TUNNEL_HERE                               :Can't build tunnel here...

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -769,6 +769,7 @@ SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("station.station_spread"));
 			limitations->Add(new SettingEntry("station.distant_join_stations"));
 			limitations->Add(new SettingEntry("station.modified_catchment"));
+			limitations->Add(new SettingEntry("station.bridges_over_stations"));
 			limitations->Add(new SettingEntry("construction.road_stop_on_town_road"));
 			limitations->Add(new SettingEntry("construction.road_stop_on_competitor_road"));
 			limitations->Add(new SettingEntry("construction.crossing_with_competitor"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -137,6 +137,13 @@ enum class PlaceHouses : uint8_t {
 	AllowedConstructed,
 };
 
+/** Possible values for the "bridges_over_stations" setting. */
+enum class BridgesOverStations : uint8_t {
+	None = 0, ///< Bridges over stations are not allowed.
+	CheckHeight, ///< Allow if the height limit is met.
+	IgnoreHeight, ///< Always allow, regardless of height.
+};
+
 /** Possible values for "vehicle_breakdowns" setting. */
 enum class VehicleBreakdowns : uint8_t {
 	None = 0,
@@ -623,6 +630,7 @@ struct StationSettings {
 	bool modified_catchment; ///< different-size catchment areas
 	bool serve_neutral_industries; ///< company stations can serve industries with attached neutral stations
 	bool distant_join_stations; ///< allow to join non-adjacent stations
+	BridgesOverStations bridges_over_stations; ///< whether to allow bridges over stations, and whether to check height
 	bool never_expire_airports; ///< never expire airports
 	uint8_t station_spread; ///< amount a station may spread
 };

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -904,6 +904,9 @@ static StringID GetBridgeTooLowMessageForStationType(StationType type)
  */
 static CommandCost IsStationBridgeAboveOk(TileIndex tile, std::span<const BridgeableTileInfo> bridgeable_info, StationType type, StationGfx layout, int bridge_height, StringID disallowed_msg = INVALID_STRING_ID)
 {
+	if (_settings_game.station.bridges_over_stations == BridgesOverStations::IgnoreHeight) return CommandCost{};
+	if (_settings_game.station.bridges_over_stations == BridgesOverStations::None) return CommandCost(STR_ERROR_BRIDGES_OVER_STATIONS_NOT_ALLOWED);
+
 	int height = layout < std::size(bridgeable_info) ? bridgeable_info[layout].height : 0;
 
 	if (height == 0) {

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -10,6 +10,7 @@
 
 [pre-amble]
 static constexpr std::initializer_list<std::string_view> _roadsides{"left"sv, "right"sv};
+static constexpr std::initializer_list<std::string_view> _bridges_over_stations{"none"sv, "check height"sv, "ignore height"sv};
 
 static void StationSpreadChanged(int32_t new_value);
 static void UpdateConsists(int32_t new_value);
@@ -124,6 +125,19 @@ str      = STR_CONFIG_SETTING_CATCHMENT
 strhelp  = STR_CONFIG_SETTING_CATCHMENT_HELPTEXT
 post_cb  = StationCatchmentChanged
 cat      = SC_EXPERT
+
+[SDT_OMANY]
+var      = station.bridges_over_stations
+type     = SLE_UINT8
+flags    = SettingFlag::GuiDropdown
+def      = BridgesOverStations::CheckHeight
+min      = BridgesOverStations::None
+max      = BridgesOverStations::IgnoreHeight
+full     = _bridges_over_stations
+str      = STR_CONFIG_SETTING_BRIDGES_OVER_STATIONS
+strhelp  = STR_CONFIG_SETTING_BRIDGES_OVER_STATIONS_HELPTEXT
+strval   = STR_CONFIG_SETTING_BRIDGES_OVER_STATIONS_NONE
+cat      = SC_ADVANCED
 
 [SDT_BOOL]
 var      = station.serve_neutral_industries


### PR DESCRIPTION
## Motivation / Problem

#14477 adds bridges over stations (and stations under bridges), with height restrictions to avoid stations being too tall.

This height property must be set by the station NewGRF, so any station GRF which doesn't get updated won't have the info and no bridges will be allowed.

Also, some people have asked for a setting to disallow players from bridging over stations.

## Description

Add a setting to control bridges over stations (and stations under bridges).

By default, they are allowed if they meet the height requirement. There is also an option to prohibit all bridges over stations, and an option to ignore the height entirely.

## Limitations

Goes it add another setting.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
