### PR TITLE
Fix: Industry accept/produce when not contiguous range from 0

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1761,17 +1761,25 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	auto &industries = Industry::industries[type];
 	industries.insert(i->index);
 
+	size_t produced_count = 0;
 	for (size_t index = 0; index < std::size(indspec->produced_cargo); ++index) {
-		if (!IsValidCargoType(indspec->produced_cargo[index])) break;
-
+		if (IsValidCargoType(indspec->produced_cargo[index])) {
+			produced_count = index + 1;
+		}
+	}
+	for (size_t index = 0; index < produced_count; ++index) {
 		Industry::ProducedCargo &p = i->produced.emplace_back();
 		p.cargo = indspec->produced_cargo[index];
 		p.rate = indspec->production_rate[index];
 	}
 
+	size_t accepted_count = 0;
 	for (size_t index = 0; index < std::size(indspec->accepts_cargo); ++index) {
-		if (!IsValidCargoType(indspec->accepts_cargo[index])) break;
-
+		if (IsValidCargoType(indspec->accepts_cargo[index])) {
+			accepted_count = index + 1;
+		}
+	}
+	for (size_t index = 0; index < accepted_count; ++index) {
 		Industry::AcceptedCargo &a = i->accepted.emplace_back();
 		a.cargo = indspec->accepts_cargo[index];
 	}


### PR DESCRIPTION
## Motivation / Problem

3de8853e2953b086e22c458c6ff625bb526e154c changes the storage of industry accept/produce lists from fixed size storage to a std::vector, however this assumes that the set of valid cargoes forms a contiguous range starting at 0.
The NewGRF spec does not require this, and industry sets such as ECS do use accept/produce lists which do not start at 0 (e.g. Brick Works and Cement Works in ECS Basics Vector II 1.2).
This results in empty or truncated accept/produced lists.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
