### PR TITLE
Codefix: several typos

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1674,7 +1674,7 @@ static void AircraftEventHandler_Flying(Aircraft *v, const AirportFTAClass *apc)
 			if (current->heading == landingtype) {
 				/* save speed before, since if AirportHasBlock is false, it resets them to 0
 				 * we don't want that for plane in air
-				 * hack for speed thingie */
+				 * hack for speed thingy */
 				uint16_t tcur_speed = v->cur_speed;
 				uint16_t tsubspeed = v->subspeed;
 				if (!AirportHasBlock(v, current, apc)) {

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -435,7 +435,7 @@ static CommandCost CopyHeadSpecificThings(Vehicle *old_head, Vehicle *new_head, 
 
 	/* Last do those things which do never fail (resp. we do not care about), but which are not undo-able */
 	if (cost.Succeeded() && old_head != new_head && flags.Test(DoCommandFlag::Execute)) {
-		/* Copy other things which cannot be copied by a command and which shall not stay resetted from the build vehicle command */
+		/* Copy other things which cannot be copied by a command and which shall not stay reset from the build vehicle command */
 		new_head->CopyVehicleConfigAndStatistics(old_head);
 		GroupStatistics::AddProfitLastYear(new_head);
 

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -562,8 +562,8 @@ public:
 					this->HandleButtonClick(WID_RV_START_REPLACE);
 					ReplaceClick_StartReplace(false);
 				} else {
-					bool replacment_when_old = EngineHasReplacementWhenOldForCompany(Company::Get(_local_company), this->sel_engine[0], this->sel_group);
-					ShowDropDownMenu(this, _start_replace_dropdown, replacment_when_old ? 1 : 0, WID_RV_START_REPLACE, !this->replace_engines ? 1 << 1 : 0, 0);
+					bool replacement_when_old = EngineHasReplacementWhenOldForCompany(Company::Get(_local_company), this->sel_engine[0], this->sel_group);
+					ShowDropDownMenu(this, _start_replace_dropdown, replacement_when_old ? 1 : 0, WID_RV_START_REPLACE, !this->replace_engines ? 1 << 1 : 0, 0);
 				}
 				break;
 			}

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -243,7 +243,7 @@ struct SpecializedStation : public BaseStation {
 
 	/**
 	 * Gets station with given index
-	 * @return pointer to station with given index casted to T *
+	 * @return pointer to station with given index cast to T *
 	 */
 	static inline T *Get(auto index)
 	{

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -571,7 +571,7 @@ public:
 	}
 
 	/**
-	 * Returns sum of cargo still available for loading at the sation.
+	 * Returns sum of cargo still available for loading at the station.
 	 * (i.e. not counting cargo which is already reserved for loading)
 	 * @return Cargo on board the vehicle.
 	 */

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -24,7 +24,7 @@ struct GRFFile;
 class CommandCost {
 	Money cost;                                 ///< The cost of this action
 	StringID message;                           ///< Warning message for when success is unset
-	ExpensesType expense_type;                  ///< the type of expence as shown on the finances view
+	ExpensesType expense_type;                  ///< the type of expense as shown on the finances view
 	bool success;                               ///< Whether the command went fine up to this moment
 	Owner owner = CompanyID::Invalid(); ///< Originator owner of error.
 	StringID extra_message = INVALID_STRING_ID; ///< Additional warning message for when success is unset

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -196,7 +196,7 @@ static bool IsValidCompanyManagerFace(CompanyManagerFace cmf)
 	return true;
 }
 
-static CompanyMask _dirty_company_finances{}; ///< Bitmask of compamy finances that should be marked dirty.
+static CompanyMask _dirty_company_finances{}; ///< Bitmask of company finances that should be marked dirty.
 
 /**
  * Mark all finance windows owned by a company as needing a refresh.
@@ -1512,7 +1512,7 @@ std::optional<CompanyManagerFace> ParseCompanyManagerFaceCode(std::string_view s
 		auto bits = consumer.TryReadIntegerBase<uint32_t>(10, true);
 		if (!bits.has_value() || consumer.AnyBytesLeft()) return std::nullopt;
 
-		/* Ensure style laberl is valid. */
+		/* Ensure style label is valid. */
 		auto style = FindCompanyManagerFaceLabel(label);
 		if (!style.has_value()) return std::nullopt;
 

--- a/src/core/string_consumer.hpp
+++ b/src/core/string_consumer.hpp
@@ -74,7 +74,7 @@ public:
 	[[nodiscard]] size_type GetBytesLeft() const noexcept { return this->src.size() - this->position; }
 
 	/**
-	 * Check wheter any bytes were already read.
+	 * Check whether any bytes were already read.
 	 */
 	[[nodiscard]] bool AnyBytesRead() const noexcept { return this->position > 0; }
 	/**
@@ -543,12 +543,12 @@ public:
 	void Skip(size_type len);
 
 	/**
-	 * Find first occurence of 'str'.
+	 * Find first occurrence of 'str'.
 	 * @return Offset from current reader position. 'npos' if no match found.
 	 */
 	[[nodiscard]] size_type Find(std::string_view str) const;
 	/**
-	 * Find first occurence of 8-bit char 'c'.
+	 * Find first occurrence of 8-bit char 'c'.
 	 * @return Offset from current reader position. 'npos' if no match found.
 	 */
 	[[nodiscard]] size_type FindChar(char c) const
@@ -556,18 +556,18 @@ public:
 		return this->Find({&c, 1});
 	}
 	/**
-	 * Find first occurence of UTF-8 char 'c'.
+	 * Find first occurrence of UTF-8 char 'c'.
 	 * @return Offset from current reader position. 'npos' if no match found.
 	 */
 	[[nodiscard]] size_type FindUtf8(char32_t c) const;
 
 	/**
-	 * Find first occurence of any 8-bit char in 'chars'.
+	 * Find first occurrence of any 8-bit char in 'chars'.
 	 * @return Offset from current reader position. 'npos' if no match found.
 	 */
 	[[nodiscard]] size_type FindCharIn(std::string_view chars) const;
 	/**
-	 * Find first occurence of any 8-bit char not in 'chars'.
+	 * Find first occurrence of any 8-bit char not in 'chars'.
 	 * @return Offset from current reader position. 'npos' if no match found.
 	 */
 	[[nodiscard]] size_type FindCharNotIn(std::string_view chars) const;

--- a/src/currency.h
+++ b/src/currency.h
@@ -44,7 +44,7 @@ enum Currencies : uint8_t {
 	CURRENCY_NLG,       ///< Dutch Gulden
 	CURRENCY_NOK,       ///< Norwegian Krone
 	CURRENCY_PLN,       ///< Polish Zloty
-	CURRENCY_RON,       ///< Romenian Leu
+	CURRENCY_RON,       ///< Romanian Leu
 	CURRENCY_RUR,       ///< Russian Rouble
 	CURRENCY_SIT,       ///< Slovenian Tolar
 	CURRENCY_SEK,       ///< Swedish Krona

--- a/src/effectvehicle_func.h
+++ b/src/effectvehicle_func.h
@@ -17,7 +17,7 @@ enum EffectVehicleType : uint8_t {
 	EV_CHIMNEY_SMOKE            =  0, ///< Smoke of power plant (industry).
 	EV_STEAM_SMOKE              =  1, ///< Smoke of steam engines.
 	EV_DIESEL_SMOKE             =  2, ///< Smoke of diesel engines.
-	EV_ELECTRIC_SPARK           =  3, ///< Sparcs of electric engines.
+	EV_ELECTRIC_SPARK           =  3, ///< Sparks of electric engines.
 	EV_CRASH_SMOKE              =  4, ///< Smoke of disasters.
 	EV_EXPLOSION_LARGE          =  5, ///< Various explosions.
 	EV_BREAKDOWN_SMOKE          =  6, ///< Smoke of broken vehicles except aircraft.

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -524,7 +524,7 @@ void EngineOverrideManager::ResetToDefaultMapping()
  * @param grf_local_id The local id in the newgrf
  * @param grfid The GrfID that defines the scope of grf_local_id.
  *              If a newgrf overrides the engines of another newgrf, the "scope grfid" is the ID of the overridden newgrf.
- *              If dynnamic_engines is disabled, all newgrf share the same ID scope identified by INVALID_GRFID.
+ *              If dynamic_engines is disabled, all newgrf share the same ID scope identified by INVALID_GRFID.
  * @return The engine ID if present, or EngineID::Invalid() if not.
  */
 EngineID EngineOverrideManager::GetID(VehicleType type, uint16_t grf_local_id, uint32_t grfid)
@@ -542,7 +542,7 @@ EngineID EngineOverrideManager::GetID(VehicleType type, uint16_t grf_local_id, u
  * @param grf_local_id The local id in the newgrf
  * @param grfid The GrfID that defines the scope of grf_local_id.
  *              If a newgrf overrides the engines of another newgrf, the "scope grfid" is the ID of the overridden newgrf.
- *              If dynnamic_engines is disabled, all newgrf share the same ID scope identified by INVALID_GRFID.
+ *              If dynamic_engines is disabled, all newgrf share the same ID scope identified by INVALID_GRFID.
  * @param static_access Whether to actually reserve the EngineID.
  * @return The engine ID if present and now reserved, or EngineID::Invalid() if not.
  */

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -212,7 +212,7 @@ struct EngineIDMappingKeyProjection {
 
 /**
  * Stores the mapping of EngineID to the internal id of newgrfs.
- * Note: This is not part of Engine, as the data in the EngineOverrideManager and the engine pool get resetted in different cases.
+ * Note: This is not part of Engine, as the data in the EngineOverrideManager and the engine pool get reset in different cases.
  */
 struct EngineOverrideManager {
 	std::array<std::vector<EngineIDMapping>, VEH_COMPANY_END> mappings;

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -455,7 +455,7 @@ void LoadTownData()
 			default: NOT_REACHED();
 		}
 
-		TownID town_id; // The TownID of the town in OpenTTD. Not imported, but set during the founding proceess and stored here for convenience.
+		TownID town_id; // The TownID of the town in OpenTTD. Not imported, but set during the founding process and stored here for convenience.
 		/* Try founding on the target tile, and if that doesn't work, find the nearest suitable tile up to 16 tiles away.
 		 * The target might be on water, blocked somehow, or on a steep slope that can't be terraformed by the founding command. */
 		for (auto tile : SpiralTileSequence(target_tile, 16, 0, 0)) {

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -850,7 +850,7 @@ int DrawStringMultiLine(int left, int right, int top, int bottom, StringID str, 
 /**
  * Draw a multiline string, possibly over multiple lines, if the region is within the current display clipping area.
  * @note With clipping, it is not possible to determine how tall the rendered text will be, as it's not layouted.
- *       Regulard DrawStringMultiLine must be used if the height needs to be known.
+ *       Regular DrawStringMultiLine must be used if the height needs to be known.
  *
  * @param left   The left most position to draw on.
  * @param right  The right most position to draw on.

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1602,7 +1602,7 @@ struct PerformanceRatingDetailWindow : Window {
 		/* Draw it */
 		DrawString(this->bar_left, this->bar_right, text_top, GetString(STR_PERFORMANCE_DETAIL_PERCENT, Clamp<int64_t>(val, 0, needed) * 100 / needed), TC_FROMSTRING, SA_HOR_CENTER);
 
-		/* SCORE_LOAN is inversed */
+		/* SCORE_LOAN is inverted */
 		if (score_type == SCORE_LOAN) val = needed - val;
 
 		/* Draw the amount we have against what is needed

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -96,7 +96,7 @@ uint16_t GroupStatistics::GetNumEngines(EngineID engine) const
 }
 
 /**
- * Returns the GroupStatistic for the ALL_GROUPO of a vehicle type.
+ * Returns the GroupStatistic for the ALL_GROUP of a vehicle type.
  * @param v Vehicle.
  * @return GroupStatistics for the ALL_GROUP of the vehicle type.
  */

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -58,10 +58,10 @@ static inline bool IsValidHeightmapDimension(size_t width, size_t height)
 }
 
 /**
- * Convert RGB colours to Grayscale using 29.9% Red, 58.7% Green, 11.4% Blue
+ * Convert RGB colours to Greyscale using 29.9% Red, 58.7% Green, 11.4% Blue
  *  (average luminosity formula, NTSC Colour Space)
  */
-static inline uint8_t RGBToGrayscale(uint8_t red, uint8_t green, uint8_t blue)
+static inline uint8_t RGBToGreyscale(uint8_t red, uint8_t green, uint8_t blue)
 {
 	/* To avoid doubles and stuff, multiply it with a total of 65536 (16bits), then
 	 *  divide by it to normalize the value to a byte again. */
@@ -84,7 +84,7 @@ static void ReadHeightmapPNGImageData(std::span<uint8_t> map, png_structp png_pt
 	bool has_palette = png_get_color_type(png_ptr, info_ptr) == PNG_COLOR_TYPE_PALETTE;
 	uint channels = png_get_channels(png_ptr, info_ptr);
 
-	/* Get palette and convert it to grayscale */
+	/* Get palette and convert it to greyscale */
 	if (has_palette) {
 		int i;
 		int palette_size;
@@ -94,7 +94,7 @@ static void ReadHeightmapPNGImageData(std::span<uint8_t> map, png_structp png_pt
 		png_get_PLTE(png_ptr, info_ptr, &palette, &palette_size);
 		for (i = 0; i < palette_size && (palette_size != 16 || all_gray); i++) {
 			all_gray &= palette[i].red == palette[i].green && palette[i].red == palette[i].blue;
-			gray_palette[i] = RGBToGrayscale(palette[i].red, palette[i].green, palette[i].blue);
+			gray_palette[i] = RGBToGreyscale(palette[i].red, palette[i].green, palette[i].blue);
 		}
 
 		/**
@@ -112,7 +112,7 @@ static void ReadHeightmapPNGImageData(std::span<uint8_t> map, png_structp png_pt
 
 	row_pointers = png_get_rows(png_ptr, info_ptr);
 
-	/* Read the raw image data and convert in 8-bit grayscale */
+	/* Read the raw image data and convert in 8-bit greyscale */
 	for (x = 0; x < png_get_image_width(png_ptr, info_ptr); x++) {
 		for (y = 0; y < png_get_image_height(png_ptr, info_ptr); y++) {
 			uint8_t *pixel = &map[y * png_get_image_width(png_ptr, info_ptr) + x];
@@ -121,7 +121,7 @@ static void ReadHeightmapPNGImageData(std::span<uint8_t> map, png_structp png_pt
 			if (has_palette) {
 				*pixel = gray_palette[row_pointers[y][x_offset]];
 			} else if (channels == 3) {
-				*pixel = RGBToGrayscale(row_pointers[y][x_offset + 0],
+				*pixel = RGBToGreyscale(row_pointers[y][x_offset + 0],
 						row_pointers[y][x_offset + 1], row_pointers[y][x_offset + 2]);
 			} else {
 				*pixel = row_pointers[y][x_offset];
@@ -133,7 +133,7 @@ static void ReadHeightmapPNGImageData(std::span<uint8_t> map, png_structp png_pt
 /**
  * Reads the heightmap and/or size of the heightmap from a PNG file.
  * If map == nullptr only the size of the PNG is read, otherwise a map
- * with grayscale pixels is allocated and assigned to *map.
+ * with greyscale pixels is allocated and assigned to *map.
  */
 static bool ReadHeightmapPNG(std::string_view filename, uint *x, uint *y, std::vector<uint8_t> *map)
 {
@@ -162,7 +162,7 @@ static bool ReadHeightmapPNG(std::string_view filename, uint *x, uint *y, std::v
 	png_init_io(png_ptr, *fp);
 
 	/* Allocate memory and read image, without alpha or 16-bit samples
-	 * (result is either 8-bit indexed/grayscale or 24-bit RGB) */
+	 * (result is either 8-bit indexed/greyscale or 24-bit RGB) */
 	png_set_packing(png_ptr);
 	png_read_png(png_ptr, info_ptr, PNG_TRANSFORM_PACKING | PNG_TRANSFORM_STRIP_ALPHA | PNG_TRANSFORM_STRIP_16, nullptr);
 
@@ -211,7 +211,7 @@ static void ReadHeightmapBMPImageData(std::span<uint8_t> map, const BmpInfo &inf
 		if (info.palette_size != 2) {
 			for (uint i = 0; i < info.palette_size && (info.palette_size != 16 || all_gray); i++) {
 				all_gray &= data.palette[i].r == data.palette[i].g && data.palette[i].r == data.palette[i].b;
-				gray_palette[i] = RGBToGrayscale(data.palette[i].r, data.palette[i].g, data.palette[i].b);
+				gray_palette[i] = RGBToGreyscale(data.palette[i].r, data.palette[i].g, data.palette[i].b);
 			}
 
 			/**
@@ -235,7 +235,7 @@ static void ReadHeightmapBMPImageData(std::span<uint8_t> map, const BmpInfo &inf
 		}
 	}
 
-	/* Read the raw image data and convert in 8-bit grayscale */
+	/* Read the raw image data and convert in 8-bit greyscale */
 	for (uint y = 0; y < info.height; y++) {
 		uint8_t *pixel = &map[y * static_cast<size_t>(info.width)];
 		const uint8_t *bitmap = &data.bitmap[y * static_cast<size_t>(info.width) * (info.bpp == 24 ? 3 : 1)];
@@ -244,7 +244,7 @@ static void ReadHeightmapBMPImageData(std::span<uint8_t> map, const BmpInfo &inf
 			if (info.bpp != 24) {
 				*pixel++ = gray_palette[*bitmap++];
 			} else {
-				*pixel++ = RGBToGrayscale(*bitmap, *(bitmap + 1), *(bitmap + 2));
+				*pixel++ = RGBToGreyscale(*bitmap, *(bitmap + 1), *(bitmap + 2));
 				bitmap += 3;
 			}
 		}
@@ -254,7 +254,7 @@ static void ReadHeightmapBMPImageData(std::span<uint8_t> map, const BmpInfo &inf
 /**
  * Reads the heightmap and/or size of the heightmap from a BMP file.
  * If map == nullptr only the size of the BMP is read, otherwise a map
- * with grayscale pixels is allocated and assigned to *map.
+ * with greyscale pixels is allocated and assigned to *map.
  */
 static bool ReadHeightmapBMP(std::string_view filename, uint *x, uint *y, std::vector<uint8_t> *map)
 {
@@ -295,13 +295,13 @@ static bool ReadHeightmapBMP(std::string_view filename, uint *x, uint *y, std::v
 }
 
 /**
- * Converts a given grayscale map to something that fits in OTTD map system
+ * Converts a given greyscale map to something that fits in OTTD map system
  * and create a map of that data.
  * @param img_width  the with of the image in pixels/tiles
  * @param img_height the height of the image in pixels/tiles
  * @param map        the input map
  */
-static void GrayscaleToMapHeights(uint img_width, uint img_height, std::span<const uint8_t> map)
+static void GreyscaleToMapHeights(uint img_width, uint img_height, std::span<const uint8_t> map)
 {
 	/* Defines the detail of the aspect ratio (to avoid doubles) */
 	const uint num_div = 16384;
@@ -520,7 +520,7 @@ bool LoadHeightmap(DetailedFileType dft, std::string_view filename)
 		return false;
 	}
 
-	GrayscaleToMapHeights(x, y, map);
+	GreyscaleToMapHeights(x, y, map);
 
 	FixSlopes();
 	MarkWholeScreenDirty();

--- a/src/highscore.h
+++ b/src/highscore.h
@@ -15,7 +15,7 @@
 #include "settings_type.h"
 
 struct HighScore {
-	std::string name; ///< The name of the companyy and president.
+	std::string name; ///< The name of the company and president.
 	StringID title = INVALID_STRING_ID; ///< NOSAVE, has troubles with changing string-numbers.
 	uint16_t score = 0; ///< The score for this high score. Do NOT change type, will break hs.dat
 };

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -701,7 +701,7 @@ static void AnimateTile_Industry(TileIndex tile)
 		if ((TimerGameTick::counter & 1) == 0) AnimateSugarSieve(tile);
 		break;
 
-	case GFX_TOFFEE_QUARY:
+	case GFX_TOFFEE_QUARRY:
 		if ((TimerGameTick::counter & 3) == 0) AnimateToffeeQuarry(tile);
 		break;
 
@@ -793,7 +793,7 @@ static void MakeIndustryTileBigger(TileIndex tile)
 
 	case GFX_TOY_FACTORY:
 	case GFX_BUBBLE_CATCHER:
-	case GFX_TOFFEE_QUARY:
+	case GFX_TOFFEE_QUARRY:
 		SetAnimationFrame(tile, 0);
 		SetIndustryAnimationLoop(tile, 0);
 		break;
@@ -938,7 +938,7 @@ static void TileLoop_Industry(TileIndex tile)
 		TileLoopIndustry_BubbleGenerator(tile);
 		break;
 
-	case GFX_TOFFEE_QUARY:
+	case GFX_TOFFEE_QUARRY:
 		AddAnimatedTile(tile);
 		break;
 

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -49,7 +49,7 @@ enum IndustryGraphics : uint8_t {
 	GFX_PLASTIC_FOUNTAIN_ANIMATED_8    = 155,
 	GFX_BUBBLE_GENERATOR               = 161,
 	GFX_BUBBLE_CATCHER                 = 162,
-	GFX_TOFFEE_QUARY                   = 165,
+	GFX_TOFFEE_QUARRY                  = 165,
 	GFX_SUGAR_MINE_SIEVE               = 174,
 	GFX_WATERTILE_SPECIALCHECK         = 255,  ///< not really a tile, but rather a very special check
 };

--- a/src/lang/afrikaans.txt
+++ b/src/lang/afrikaans.txt
@@ -2330,10 +2330,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Verskaf:
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Sluit by stasie aan
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Bou 'n aparte stasie
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Bou 'n aparte stasie
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Verbind roetebaken
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Bou 'n aparte roetebaken
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Bou 'n aparte roetebaken
 
 # Generic toolbar
 
@@ -4274,7 +4274,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Bestuurd
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maksimum toegelaate lening groote is {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Kan nie meer geld leen nie...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... geen lening om terug te betaal
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... geen lening om terug te betaal
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} vereis
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kan nie lening terugbetaal nie...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Kan nie geld wat van die bank geleen is weggee nie...

--- a/src/lang/arabic_egypt.txt
+++ b/src/lang/arabic_egypt.txt
@@ -2222,10 +2222,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{GOLD}{CARGO_LI
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}اربط المحطات
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW} بناء محطة مفصلة
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW} بناء محطة مفصلة
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}اربط نقطة العبور
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW} ابني نقطة عبور مستقلة
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW} ابني نقطة عبور مستقلة
 
 # Generic toolbar
 
@@ -4145,7 +4145,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}لا ي�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... اعلى دين مسموح به : {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}بلغت الحد الاقصى للقرض
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... لا يوجد دين للسداد
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... لا يوجد دين للسداد
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}...{CURRENCY_LONG} مطلوب
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}لا يمكن تسديد الدين
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}لا يمكن التخلي عن النقود المعطاة من البنك على سبيل الاعارة ...

--- a/src/lang/basque.txt
+++ b/src/lang/basque.txt
@@ -2210,10 +2210,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Hornidur
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Geltokia batu
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Geltoki bereizitua eraiki
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Geltoki bereizitua eraiki
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Bidepuntua lotu
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Ibilbide puntu bereizitua eraiki
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Ibilbide puntu bereizitua eraiki
 
 # Generic toolbar
 
@@ -4034,7 +4034,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Ezin da 
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... geheienzko milegua {CURRENCY_LONG} da
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Ezin da diru gehiago eskatu...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... ez dago mailegurik ordaintzeko
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... ez dago mailegurik ordaintzeko
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} beharrezkoa
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Ezin da mailegua ordaindu...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Ezin da mailegatutako dirua eman...

--- a/src/lang/belarusian.txt
+++ b/src/lang/belarusian.txt
@@ -3046,10 +3046,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Утры
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Аб'яднаць станцыі
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Пабудаваць асобную станцыю
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Пабудаваць асобную станцыю
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Аб'яднаць маршрутныя пункты
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Пабудаваць асобны маршрутны пункт
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Пабудаваць асобны маршрутны пункт
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Адключана, бо няма прыдатных транспартных сродкаў для гэтай інфраструктуры
@@ -5245,7 +5245,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Нема
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... больш за {CURRENCY_LONG} пазыкі Вам не дадуць.
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Немагчыма заняць больш грошай...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... пазыка цалкам пагашана
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... пазыка цалкам пагашана
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... патрабуецца {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Немагчыма пагасіць пазыку...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Немагчыма аддаць пазычаныя банкам грошы...

--- a/src/lang/brazilian_portuguese.txt
+++ b/src/lang/brazilian_portuguese.txt
@@ -2786,10 +2786,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Custo de
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Unir estação
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construir uma estação separada
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Construir uma estação separada
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Unir ponto de controle
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Construir um ponto de controle separado
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Construir um ponto de controle separado
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Desativado porque atualmente não existem veículos disponíveis para esta infraestrutura
@@ -5057,7 +5057,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Não é 
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... o valor máximo de empréstimo permitido é {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Não é possível pedir mais dinheiro emprestado...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... não existe empréstimo para pagar
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... não existe empréstimo para pagar
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... é necessário {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Não é possível pagar empréstimo...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Não é possível doar dinheiro proveniente de empréstimo bancário...

--- a/src/lang/bulgarian.txt
+++ b/src/lang/bulgarian.txt
@@ -2745,10 +2745,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Разх
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Присъедини станцията
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Направи отделна станция
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Направи отделна станция
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Съедини междинен пункт
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Построй отделен междинен пункт
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Построй отделен междинен пункт
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Деактивирано, тъй като в момента няма налични превозни средства за тази инфраструктура
@@ -4967,7 +4967,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Не м�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... максимално разрешеният размер на заема е {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Не може да изтеглите повече пари...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... няма заем за изплащане
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... няма заем за изплащане
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} са необходими
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Не може да изплатите заема...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Не може да се харчат пари които са заети от банка...

--- a/src/lang/catalan.txt
+++ b/src/lang/catalan.txt
@@ -2786,10 +2786,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Cost de 
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Ajunta la nova estació a...
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construeix una estació separada
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Construeix una estació separada
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Uneix punt de pas
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Construeix un punt de pas separat
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Construeix un punt de pas separat
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}S'ha desactivat ja que actualment no disposeu de vehicles per usar aquesta infraestructura.
@@ -5057,7 +5057,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}No es po
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... el màxim import permès del préstec és {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}No pots demanar més diners...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... No queda préstec per amortitzar
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... No queda préstec per amortitzar
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} necessaris
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}No es pot amortitzar préstec...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}No es poden regalar els diners deixats pel banc...

--- a/src/lang/croatian.txt
+++ b/src/lang/croatian.txt
@@ -2473,10 +2473,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Zalihe: 
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Spoji postaju
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Izgradi odvojenu postaju
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Izgradi odvojenu postaju
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Spoji čvorište
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Izgradi zasebno čvorište
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Izgradi zasebno čvorište
 
 # Generic toolbar
 
@@ -4460,7 +4460,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Nije mog
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... najveći dopušteni zajam iznosi {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nije moguće posuditi još više novaca...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... nema zajma za otplatu
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... nema zajma za otplatu
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}...{CURRENCY_LONG} potrebno
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Nije moguće otplatiti zajam...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Nije moguće dati novac koji je pozajmljen od banke...

--- a/src/lang/czech.txt
+++ b/src/lang/czech.txt
@@ -2833,10 +2833,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Náklady
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Spojování stanic
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Postavit samostatnou stanici
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Postavit samostatnou stanici
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Spojování směrování
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Postavit samostatné směrování
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Postavit samostatné směrování
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Zakázáno, protože pro tento typ infrastruktury aktuálně nejsou dostupná žádná vozidla
@@ -5080,7 +5080,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Nelze p�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... nejvyšší možná výše půjčky je {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nelze půjčit více peněz...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... žádný dluh ke splacení
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... žádný dluh ke splacení
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... je potřeba {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Nelze splatit dluh...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Nelze darovat peníze půjčené z banky...

--- a/src/lang/danish.txt
+++ b/src/lang/danish.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Vedligeh
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Sammenkæd station
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Byg en separat station
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Byg en separat station
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Forbind rutepunkt
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Byg et separat rutepunkt
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Byg et separat rutepunkt
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Deaktiveret da der aktuelt ikke er nogen fartøjer tilgængelige for denne infrastruktur
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Kan ikke
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maksimale størrelse af lån er {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Kan ikke låne flere penge...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... ingen lån at tilbagebetale
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... ingen lån at tilbagebetale
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} krævet
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kan ikke tilbagebetale lån...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Du kan ikke forære penge væk, som du har lånt i banken...

--- a/src/lang/dutch.txt
+++ b/src/lang/dutch.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Onderhou
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Station samenvoegen
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Een losstaand station bouwen
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Een losstaand station bouwen
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Routepunt samenvoegen
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Los routepunt bouwen
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Los routepunt bouwen
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Momenteel uitgeschakeld omdat er geen voertuigen zijn voor deze infrastructuur
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Kan dire
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maximaal toegestane lening bedraagt {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Kan geen geld meer lenen...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... geen lening om af te betalen
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... geen lening om af te betalen
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} benodigd
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kan de lening niet afbetalen..
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Kan geen geld weggeven dat van de bank geleend is...

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Maintena
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Join station
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Build a separate station
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Build a separate station
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Join waypoint
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Build a separate waypoint
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Build a separate waypoint
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Disabled as currently no vehicles are available for this infrastructure
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Can't ch
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maximum permitted loan size is {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Can't borrow any more money...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... no loan to repay
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... no loan to repay
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} required
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Can't repay loan...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Can't give away money that is loaned from the bank...

--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Maintena
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Join station
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Build a separate station
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Build a separate station
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Join waypoint
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Build a separate waypoint
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Build a separate waypoint
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Disabled as currently no vehicles are available for this infrastructure
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Can't ch
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maximum permitted loan size is {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Can't borrow any more money...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... no loan to repay
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... no loan to repay
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} required
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Can't repay loan...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Can't give away money that is loaned from the bank...

--- a/src/lang/english_US.txt
+++ b/src/lang/english_US.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Maintena
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Join station
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Build a separate station
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Build a separate station
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Join waypoint
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Build a separate waypoint
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Build a separate waypoint
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Disabled as currently no vehicles are available for this infrastructure
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Can't ch
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maximum permitted loan size is {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Can't borrow any more money...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... no loan to repay
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... no loan to repay
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} required
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Can't repay loan...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Can't give away money that is loaned from the bank...

--- a/src/lang/esperanto.txt
+++ b/src/lang/esperanto.txt
@@ -2685,10 +2685,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Provizoj
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Ligi stacion
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Konstrui apartan stacion
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Konstrui apartan stacion
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Ligi vojpunkton
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Krei apartan vojpunkton
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Krei apartan vojpunkton
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Malaktiva ĉar ĉi-momente ne haveblas veturiloj por tia ĉi infrastrukturo
@@ -4782,7 +4782,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Ne povas
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maksimuma permesata prunto estas {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Ne povas prunti pli da mono...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... ne estas repagebla prunto
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... ne estas repagebla prunto
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} necesas
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Ne povas repagi prunton...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Ne povas donaci monon pruntitan de la banko...

--- a/src/lang/estonian.txt
+++ b/src/lang/estonian.txt
@@ -2783,10 +2783,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Hooldusk
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Liida jaamale
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Ehita eraldi jaam
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Ehita eraldi jaam
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Liida teemärgis
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Ehita eraldi teemärgis
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Ehita eraldi teemärgis
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Välja lülitatud, sest ükski saadaval sõiduk ei sobi selle infrastruktuuriga
@@ -4974,7 +4974,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Ei saa p
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... suurim lubatud laen on {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Rohkem raha ei saa laenata...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... pole laenu, mida tagasi maksta
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... pole laenu, mida tagasi maksta
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... vajad {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Ei saa laenu tagasi maksta...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Ei saa anda raha, mis on laenatud pangast.

--- a/src/lang/faroese.txt
+++ b/src/lang/faroese.txt
@@ -2120,10 +2120,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Veitur: 
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Bind støð saman
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Bygg serstaka støð
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Bygg serstaka støð
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Bind waypoint saman
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Bygg eitt serstakt waypoint
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Bygg eitt serstakt waypoint
 
 # Generic toolbar
 
@@ -3700,7 +3700,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Kann ikk
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... hægst loyvda lán er {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Kann ikki lána meira pening...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... einki lán at gjalda aftur
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... einki lán at gjalda aftur
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} neyðugar
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kann ikki gjalda lán aftur...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Kann ikki geva pening burtur ið er lándur frá bankanum...

--- a/src/lang/finnish.txt
+++ b/src/lang/finnish.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Ylläpit
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Liitä asema
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Rakenna erillinen asema
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Rakenna erillinen asema
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Liitä reittipiste
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Rakenna erillinen reittipiste
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Rakenna erillinen reittipiste
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Ei käytössä, koska tälle infrastruktuurille ei ole kulkuneuvoja tällä hetkellä
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Pääjoh
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... suurin sallittu lainan suuruus on {CURRENCY_LONG}.
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Lisälainan otto ei onnistu...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... ei lainaa maksettavana.
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... ei lainaa maksettavana.
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... tarvitaan {CURRENCY_LONG}.
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Lainaa ei voi lyhentää...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Pankista lainattua rahaa ei voi antaa pois...

--- a/src/lang/french.txt
+++ b/src/lang/french.txt
@@ -2786,10 +2786,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Coût d'
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Joindre une station
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construire une station séparée
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Construire une station séparée
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Joindre un point de contrôle
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Construire un point de contrôle séparé
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Construire un point de contrôle séparé
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Désactivé car aucun véhicule n'est actuellement disponible pour cette infrastructure
@@ -5057,7 +5057,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Impossib
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... le prêt maximum est de {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Impossible d'emprunter plus...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... emprunt déjà remboursé
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... emprunt déjà remboursé
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} nécessaires
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Impossible de rembourser...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Impossible de distribuer de l'argent emprunté à la banque...

--- a/src/lang/frisian.txt
+++ b/src/lang/frisian.txt
@@ -2212,10 +2212,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Levert: 
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Stasjon gearfoegje
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}In apart stasjon bouwe
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}In apart stasjon bouwe
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Kontrôlepost gearfoegje
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}In apart kontrôlepost bouwe
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}In apart kontrôlepost bouwe
 
 # Generic toolbar
 
@@ -3874,7 +3874,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Kin namm
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maksmaal tasteane liening is {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Kin net mear jild liene
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... gjin liening werom te betelje
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... gjin liening werom te betelje
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}...{CURRENCY_LONG} nedich
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kin liening net werombetelje...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Kin gjin jild dat fan de bank lient is weijaan...

--- a/src/lang/gaelic.txt
+++ b/src/lang/gaelic.txt
@@ -2500,10 +2500,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Solairea
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Co-aonaich an stèisean
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Tog stèisean fa leth
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Tog stèisean fa leth
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Co-aonaich a' phuing-thurais
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Tog puing-thurais fa leth
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Tog puing-thurais fa leth
 
 # Generic toolbar
 
@@ -4418,7 +4418,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Chan urr
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... is {CURRENCY_LONG} an t-iasad as motha a tha ceadaichte dhut
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Chan urrainn dhut barrachd airgid fhaighinn air iasad...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... chan eil iasad ri pàigheadh ann
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... chan eil iasad ri pàigheadh ann
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... feum air {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Cha ghabh an t-iasad pàigheadh air ais...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Chan urrainn dhut airgead a thoirt seachad a chaidh a thoirt dhut mar iasad leis a’ bhanca...

--- a/src/lang/galician.txt
+++ b/src/lang/galician.txt
@@ -2784,10 +2784,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Custo de
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Unir estación
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construír unha estación separada
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Construír unha estación separada
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Unir punto de ruta
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Constrúe un un punto de ruta separado
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Constrúe un un punto de ruta separado
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Deshabilitada xa que non hai vehículos dispoñibles actualmente para esta infraestrutura.
@@ -5055,7 +5055,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Non se p
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... o préstamo máximo permitido é de {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Non se pode solicitar máis diñeiro...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... non queda préstamo a devolver
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... non queda préstamo a devolver
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... precisas {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Non se pode devolve-lo préstamo...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Non podes da-lo diñeiro prestado polo banco...

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -2784,10 +2784,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Wartungs
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Verbinde mit Station
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Errichte eine getrennte Station
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Errichte eine getrennte Station
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Verbinde mit Wegpunkt
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Errichte einen getrennten Wegpunkt
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Errichte einen getrennten Wegpunkt
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :Deaktiviert, da aktuell keine Fahrzeuge für diese Infrastruktur verfügbar sind.
@@ -5055,7 +5055,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Managern
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maximale Kredithöhe beträgt {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Weitere Kreditaufnahme nicht möglich ...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... Kredit bereits getilgt
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... Kredit bereits getilgt
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... erfordert {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kredit kann nicht getilgt werden ...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Von der Bank geliehenes Geld kann nicht abgegeben werden ...

--- a/src/lang/greek.txt
+++ b/src/lang/greek.txt
@@ -2878,10 +2878,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Κόστ
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Συνένωση σταθμού
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Κατασκευάστε ένα ξεχωριστό σταθμό
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Κατασκευάστε ένα ξεχωριστό σταθμό
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Συνένωση σημείου καθοδήγησης
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Κατασκευή ενός ξεχωριστού σημείου καθοδήγησης
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Κατασκευή ενός ξεχωριστού σημείου καθοδήγησης
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Απενεργοποιημένο διότι δεν υπάρχουν διαθέσιμα οχήματα για αυτή την υποδομή
@@ -5157,7 +5157,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Δεν �
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... το μέγιστο επιτρεπόμενο δάνειο είναι {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Δεν μπορείτε να δανειστείτε περισσότερα χρήματα...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... δεν υπάρχει δάνειο προς αποπληρωμή
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... δεν υπάρχει δάνειο προς αποπληρωμή
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... απαιτούνται {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Αδύνατη η αποπληρωμή του δανείου...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Δεν είναι δυνατό να δοθούν χρήματα που είναι δανεισμένα από τη τράπεζα...

--- a/src/lang/hebrew.txt
+++ b/src/lang/hebrew.txt
@@ -2489,10 +2489,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}עלות
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}חבר לתחנה קיימת
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}בנה תחנה נפרדת
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}בנה תחנה נפרדת
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}חבר נקודות ציון
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}בנה נקודת ציון נפרדת
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}בנה נקודת ציון נפרדת
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}כרגע מבוטל מכייוון שאין רכבים זמינים לתשתית הזאת
@@ -4509,7 +4509,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}לא נ�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... גודל ההלוואה המירבי הוא {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}לא ניתן לקבל הלוואה נוספת
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... אין הלוואה להחזיר
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... אין הלוואה להחזיר
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... דרושים {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}לא ניתן להחזיר את ההלוואה...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}לא ניתן למסור כסף שנלווה מהבנק...

--- a/src/lang/hungarian.txt
+++ b/src/lang/hungarian.txt
@@ -2849,10 +2849,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Üzemelt
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Állomás egyesítése
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Különálló állomás építése
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Különálló állomás építése
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Ellenőrző pont egyesítése
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Különálló ellenőrző pont építése
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Különálló ellenőrző pont építése
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Kikapcsolva, mivel semmilyen jármű sem tudná használni
@@ -5120,7 +5120,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Nem vál
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}...{CURRENCY_LONG} a megengedett legnagyobb kölcsön.
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nem kölcsönözhetsz több pénzt...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... nincs visszafizetendő kölcsönöd
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... nincs visszafizetendő kölcsönöd
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} kellene hozzá
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Nem törleszthetsz a kölcsönből...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Nem tudod a banktól kölcsönkapott pénzt továbbadni...

--- a/src/lang/icelandic.txt
+++ b/src/lang/icelandic.txt
@@ -2161,10 +2161,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Birgðir
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Tengja stöðvar
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Reisa aðra stöð
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Reisa aðra stöð
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Tengja millistöð
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Reisa aðra millistöð
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Reisa aðra millistöð
 
 # Generic toolbar
 
@@ -3926,7 +3926,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Get ekki
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... hámarksleyfi á láni er {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Ekki hægt að fá meiri pening lánaðan...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... ekkert lán til að borga
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... ekkert lán til að borga
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} vantar
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Getur ekki borgað lán...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Það er ekki hægt að gefa peninga sem teknir eru að láni frá bankanum...

--- a/src/lang/indonesian.txt
+++ b/src/lang/indonesian.txt
@@ -2663,10 +2663,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Suplai: 
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Gabung stasiun
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Pisahkan stasiun
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Pisahkan stasiun
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Gabungkan waypoint
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Pisahkan waypoint
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Pisahkan waypoint
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Dinonaktifkan karena saat ini tidak ada kendaraan yang tersedia untuk infrastruktur ini
@@ -4782,7 +4782,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Tidak da
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... besar pinjaman maksimal yang diizinkan adalah {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Tidak dapat meminjam uang lagi...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... tidak ada hutang yang harus dibayar
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... tidak ada hutang yang harus dibayar
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... dibutuhkan {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Tidak dapat membayar hutang...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Tidak dapat memberikan uang yang berasal dari pinjaman bank...

--- a/src/lang/irish.txt
+++ b/src/lang/irish.txt
@@ -2484,10 +2484,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Solátha
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Ceangail stáisiún
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Tóg stáisiún ar leithligh
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Tóg stáisiún ar leithligh
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Ceangail pointe bealaigh
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Tóg pointe bealaigh ar leithligh
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Tóg pointe bealaigh ar leithligh
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Díchumasaithe toisc nach bhfuil aon fheithicil ar fáil faoi láthair don bhonneagar seo
@@ -4509,7 +4509,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Ní féi
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... is é uasmhéid na hiasachta a cheadaítear ná {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Ní féidir a thuilleadh airgid a fháil ar iasacht...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... níl aon iasacht le haisíoc
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... níl aon iasacht le haisíoc
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} ag teastáil
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Ní féidir an iasacht a aisíoc...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Ní féidir airgead a thabhairt uait atá ar iasacht ón mbanc...

--- a/src/lang/italian.txt
+++ b/src/lang/italian.txt
@@ -2778,10 +2778,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Costo di
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Unisci stazione
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Costruisci stazione separata
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Costruisci stazione separata
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Unisci waypoint
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Costruisci waypoint separato
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Costruisci waypoint separato
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Disabilitato perché non ci sono veicoli disponibili per questa infrastruttura
@@ -4987,7 +4987,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Impossib
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... il prestito massimo concesso è di {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Impossibile chiedere in prestito altro denaro...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... debito già estinto
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... debito già estinto
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} richiesti
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Impossibile ripagare il prestito...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Impossibile trasferire denaro prestato dalla banca...

--- a/src/lang/japanese.txt
+++ b/src/lang/japanese.txt
@@ -2602,10 +2602,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}供給�
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}停留施設を統合
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}統合せずに建設
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}統合せずに建設
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}通過点を統合
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}統合せずに建設
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}統合せずに建設
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}現在このインフラで運用できる車両がないため無効化されています
@@ -4698,7 +4698,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}社長�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}最高借入金は{CURRENCY_LONG}です
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}これ以上は借入できません
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}全額返済済みです
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}全額返済済みです
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}{CURRENCY_LONG}が必要です
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}借入金を返済できません
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}借入金を送金することはできません

--- a/src/lang/korean.txt
+++ b/src/lang/korean.txt
@@ -2786,10 +2786,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}유지�
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}같은 이름으로 정거장 만들기
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}분리된 역을 새로 만들기
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}분리된 역을 새로 만들기
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}연결할 경유지
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}분리된 경유지를 새로 만들기
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}분리된 경유지를 새로 만들기
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}현재 이 기반시설에서 사용할 수 있는 차량이 없어 비활성화되었습니다
@@ -5057,7 +5057,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}사장�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... 최대로 빌릴 수 있는 대출금은 {CURRENCY_LONG} 입니다
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}돈을 더 빌릴 수 없습니다...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... 값아야 할 대출금이 없습니다
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... 값아야 할 대출금이 없습니다
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} 만큼의 돈이 필요합니다
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}대출금을 갚을 수 없습니다...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}은행에서 빌린 돈은 송금할 수 없습니다...

--- a/src/lang/latin.txt
+++ b/src/lang/latin.txt
@@ -2513,10 +2513,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Produntu
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Iungere stationem
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Struere discretam stationem
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Struere discretam stationem
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Iungere interlocum
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Struere discretum interlocum
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Struere discretum interlocum
 
 # Generic toolbar
 
@@ -4409,7 +4409,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Non lice
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... creditum maximum est {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Non licet plurem pecuniae mutuari...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... non est creditum solvendum
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... non est creditum solvendum
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} poscitur
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Non licet creditum reddere...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Non licet pecuniam mutuam largiri...

--- a/src/lang/latvian.txt
+++ b/src/lang/latvian.txt
@@ -2764,10 +2764,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Uzturē�
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Pievienot staciju
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Būvēt atdalītu staciju
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Būvēt atdalītu staciju
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Pievienot pieturas punktu
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Uzbūvēt jaunu maršruta punktu
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Uzbūvēt jaunu maršruta punktu
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Atspējots, jo pašlaik šai infrastruktūrai nav pieejami transportlīdzekļi
@@ -5033,7 +5033,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Vadītā
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maksimāli pieļaujamais aizdevuma apjoms ir {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nevar aizņemties vairāk naudas...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... nav atmaksājamu aizdevumu
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... nav atmaksājamu aizdevumu
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}...{CURRENCY_LONG} nepieciešams
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Nevar atmaksāt aizdevumu...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Bankas aizdoto naudu nevar dot projām...

--- a/src/lang/lithuanian.txt
+++ b/src/lang/lithuanian.txt
@@ -2879,10 +2879,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Prieži�
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Sujungti stoteles
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Statyti atskirą stotelę
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Statyti atskirą stotelę
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Sujungti kontrolės punktus
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Statyti atskirą kontrolės punktą
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Statyti atskirą kontrolės punktą
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Išjungta, nes nėra jokių šiai infrastruktūrai prieinamų transporto priemonių
@@ -5073,7 +5073,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Direktor
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... daugiausia pasiskolinti galima {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Daugiau skolintis negalima...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... visa paskola gražinta
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... visa paskola gražinta
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}...reikia turėti {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Skolos grąžinti negalima...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Negalima dovanoti iš banko pasiskolintų pinigų...

--- a/src/lang/luxembourgish.txt
+++ b/src/lang/luxembourgish.txt
@@ -2753,10 +2753,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Ennerhal
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Statioun verbannen
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Eng separat Statioun bauen
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Eng separat Statioun bauen
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Weepunkt verbannen
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Separate Weepunkt bauen
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Separate Weepunkt bauen
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Ausgeschalt, well et grad keng Gefierer fir dës Infrastruktur gëtt
@@ -5005,7 +5005,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Kann den
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maximale Kredit ass {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Kann net méi Geld léinen...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... keen Kredit zeréckzebezuelen
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... keen Kredit zeréckzebezuelen
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... et ginn {CURRENCY_LONG} gebraucht
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kann de Kredit net zeréckbezuelen...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Kann keng Suen ginn déi vun der Bank geléint sinn...

--- a/src/lang/malay.txt
+++ b/src/lang/malay.txt
@@ -2057,10 +2057,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Bekalan-
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Gabungkan stesen
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Bina stesen asingan
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Bina stesen asingan
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Sambungkan tandatuju
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Bina tandatuju yang berasingan
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Bina tandatuju yang berasingan
 
 # Generic toolbar
 
@@ -3835,7 +3835,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Nama pen
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... saiz pinjaman maksimum yang dibenarkan ialah {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Tidak boleh meminjam wang lagi...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... tiada pinjaman untuk dibayar semula
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... tiada pinjaman untuk dibayar semula
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} diperlukan
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Tidak boleh membayar semula pinjaman...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Tidak boleh memberi wang yang dipinjamkan oleh bank...

--- a/src/lang/maori.txt
+++ b/src/lang/maori.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Utu taut
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Honoa te teihana
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Hangaia he teihana motuhake
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Hangaia he teihana motuhake
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Honoa te aratohu
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Hangaia he aratohu motuhake
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Hangaia he aratohu motuhake
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Tē āhei ināianei i te mea kāore he waka i te wātea mō tēnei tūāhanga
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Tē taea
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... ko te {CURRENCY_LONG} te mōrahi o te moni taurewa ka tukuna
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Tē taea te mino atu i te moni...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... kāore he moni taurewa hei whakaea
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... kāore he moni taurewa hei whakaea
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} e hiahiatia ana
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Tē taea te whakaea te moni taurewa...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Tē taea te hoatu te moni kua minoa mai i te pēke...

--- a/src/lang/norwegian_bokmal.txt
+++ b/src/lang/norwegian_bokmal.txt
@@ -2787,10 +2787,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Vedlikeh
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Slå sammen stasjoner
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Bygg separat stasjon
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Bygg separat stasjon
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Slå sammen veipunkter
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Bygg et separat veipunkt
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Bygg et separat veipunkt
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Deaktivert da det ikke er noen kjøretøy tilgjengelig for denne infrastrukturen
@@ -5058,7 +5058,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Kan ikke
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... største tillatte lån er {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Kan ikke låne mer penger...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... ingen lån å tilbakebetale
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... ingen lån å tilbakebetale
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... du trenger {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kan ikke betale tilbake lån...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Kan ikke gi bort penger som er lånt fra banken...

--- a/src/lang/norwegian_nynorsk.txt
+++ b/src/lang/norwegian_nynorsk.txt
@@ -2233,10 +2233,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Forsynin
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Spleisa stasjonen
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Bygg ein seperat stasjon
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Bygg ein seperat stasjon
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Spleis kontrollpunkt
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Bygg eit seperat kontrollpunkt
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Bygg eit seperat kontrollpunkt
 
 # Generic toolbar
 
@@ -4084,7 +4084,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Kan ikkj
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maks. lån er {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Kan ikkje låne meir pengar...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... lånet er allereie betalt attende
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... lånet er allereie betalt attende
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... du treng {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kan ikkje betale lånet attende...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Kan ikkje gje vekk pengar som er lånt frå banken...

--- a/src/lang/persian.txt
+++ b/src/lang/persian.txt
@@ -2236,10 +2236,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}تدار
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}پیوستن ایستگاه
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}ساخت یک ایستگاه جداگانه
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}ساخت یک ایستگاه جداگانه
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}پیوستن نقطه مسیر
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}ساخت یک نقطه مسیر جداگانه
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}ساخت یک نقطه مسیر جداگانه
 
 # Generic toolbar
 

--- a/src/lang/polish.txt
+++ b/src/lang/polish.txt
@@ -3165,10 +3165,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Koszt ut
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Połącz stację
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Zbuduj oddzielną stację
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Zbuduj oddzielną stację
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Połącz posterunki
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Zbuduj oddzielny posterunek
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Zbuduj oddzielny posterunek
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Nieaktywne, ponieważ nie są dostępne pojazdy korzystające z takiej infrastruktury
@@ -5442,7 +5442,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Nie moż
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maksymalna dozwolona pożyczka wynosi {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nie można pożyczyć więcej pieniędzy...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... pożyczka już jest spłacona
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... pożyczka już jest spłacona
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}...{CURRENCY_LONG} wymagane
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Nie można zwrócić pożyczki...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Nie możesz wydać pieniędzy, które są pożyczone z banku...

--- a/src/lang/portuguese.txt
+++ b/src/lang/portuguese.txt
@@ -2786,10 +2786,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Custo de
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Juntar estação
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construir uma estação separada
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Construir uma estação separada
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Juntar ponto de controlo
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Construir um ponto de controlo separado
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Construir um ponto de controlo separado
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Desativado pois não existem atualmente veículos disponíveis para esta infraestrutura
@@ -5057,7 +5057,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Não é 
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... o empréstimo máximo permitido é de {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Não é possível pedir mais dinheiro emprestado...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... não há empréstimo para pagar
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... não há empréstimo para pagar
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... é necessário {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Não é possível pagar empréstimo...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Não é possível ceder capital proveniente de empréstimo bancário...

--- a/src/lang/romanian.txt
+++ b/src/lang/romanian.txt
@@ -2747,10 +2747,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Cost de 
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Unește stația
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construiește o stație separată
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Construiește o stație separată
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Unește punctul de tranzit
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Construiește un punct de tranzit separat
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Construiește un punct de tranzit separat
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Dezactivat, deoarece momentan nu sunt vehicule disponibile pentru acest tip de infrastructură
@@ -4984,7 +4984,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Nu se po
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... creditul maxim permis este de {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nu mai poți împrumuta bani...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... nu ai nici un credit de plătit
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... nu ai nici un credit de plătit
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... ai nevoie de {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Nu poți plăti creditul...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Nu poți dona din banii împrumutați de la bancă...

--- a/src/lang/russian.txt
+++ b/src/lang/russian.txt
@@ -2948,10 +2948,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Соде
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Объединить станции
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Построить отдельную станцию
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Построить отдельную станцию
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Объединить маршрутные точки
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Поставить отдельную маршрутную точку
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Поставить отдельную маршрутную точку
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Отключено, так как нет подходящих транспортных средств для этой инфраструктуры
@@ -5243,7 +5243,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Нево
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... максимально допустимая сумма кредита - {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Невозможно занять больше денег...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... кредит полностью погашен.
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... кредит полностью погашен.
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... требуется {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Невозможно выплатить сумму...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Невозможно отдать занятые у банка деньги...

--- a/src/lang/serbian.txt
+++ b/src/lang/serbian.txt
@@ -2858,10 +2858,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Snabdeva
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Pridruži stanicu
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Izgradi zasebnu stanicu
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Izgradi zasebnu stanicu
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Spoji putanje
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Napravi zasebnu putanju
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Napravi zasebnu putanju
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Isključeno jer trenutno ne postoje dostupna vozila za ovu infrastrukturu
@@ -5001,7 +5001,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Vlasnik 
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maksimalan dozvoljen zajam iznosi: {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nije moguće pozajmiti još novca...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... nema duga
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... nema duga
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... potrebno {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Nije moguće vratiti deo zajma...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Nemoguće je dati novac koji je pozajmljen od banke...

--- a/src/lang/simplified_chinese.txt
+++ b/src/lang/simplified_chinese.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}维护�
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}合并车站
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}建造分体车站
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}建造分体车站
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}合并路点
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}建造分体路点
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}建造分体路点
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}由于没有可使用此类设施的载具，已禁用此设施
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}不能�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}……最大贷款额度是{CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}无法借更多钱……
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}……没有要偿还的贷款
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}……没有要偿还的贷款
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}……需要{CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}不能偿还贷款……
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}不能给予银行贷款……

--- a/src/lang/slovak.txt
+++ b/src/lang/slovak.txt
@@ -2790,10 +2790,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Výdavky
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Spojiť stanicu
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Postaviť stanicu oddelene
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Postaviť stanicu oddelene
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Spojiť smerový bod
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Postaviť smerový bod oddelene
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Postaviť smerový bod oddelene
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Vypnuté, pretože v súčasnosti nie sú dostuné žiadne vozidlá pre tento typ infraštruktúry
@@ -4975,7 +4975,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Meno pre
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... úverovy limit je {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Nemôžete si požičať viac peňazí...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... úver už bol splatený
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... úver už bol splatený
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... Potrebuješ {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Úver sa nedá splatiť...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Nie je možné presunúť peniaze, ktoré sú požičané z banky...

--- a/src/lang/slovenian.txt
+++ b/src/lang/slovenian.txt
@@ -2456,10 +2456,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Dobavlja
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Združi postaje
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Izgradnja ločene postaje
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Izgradnja ločene postaje
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Združi točke poti
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Zgradi ločeno točko poti
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Zgradi ločeno točko poti
 
 # Generic toolbar
 
@@ -4304,7 +4304,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Ni mogo�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... najvišje dovoljeno posojilo je {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Ni mogoča izposoja več denarja...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... ni posojila za odplačati
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... ni posojila za odplačati
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... potrebuješ {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Ni mogoče odplačati posojila...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Ni mogoča oddaja denarja, ki je izposojen od banke...

--- a/src/lang/spanish.txt
+++ b/src/lang/spanish.txt
@@ -2761,10 +2761,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Coste de
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Unir estación
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construir una estación separada
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Construir una estación separada
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Unir punto de ruta
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Construir un punto de ruta separado
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Construir un punto de ruta separado
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Desactivado porque actualmente no hay vehículos disponibles para esta infraestructura
@@ -5023,7 +5023,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}No se pu
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... máxima cantidad de préstamo permitida es {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}No se puede incrementar el préstamo...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... no hay préstamo que pagar
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... no hay préstamo que pagar
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} requerido
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}No es posible pagar préstamo...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}No se puede dar dinero que ha sido prestado de un banco...

--- a/src/lang/spanish_MX.txt
+++ b/src/lang/spanish_MX.txt
@@ -2781,10 +2781,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Costo de
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Ampliar estación
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Construir aparte
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Construir aparte
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Unir puntos de ruta
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Construir aparte
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Construir aparte
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Deshabilitado al no haber vehículos disponibles para esta infraestructura
@@ -5050,7 +5050,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}No se pu
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... el máximo préstamo permitido es de {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}No se puede pedir más préstamo...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... no hay préstamo que pagar
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... no hay préstamo que pagar
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... se requieren {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}No se puede pagar préstamo...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}No se puede regalar dinero que fue prestado de un banco...

--- a/src/lang/swedish.txt
+++ b/src/lang/swedish.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Underhå
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Slå ihop stationer
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Bygg en separat station
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Bygg en separat station
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Slå ihop riktmärken
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Bygg ett separat riktmärke
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Bygg ett separat riktmärke
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Inaktiverad eftersom det ej finns några tillgängliga fordon till denna infrastruktur
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Kan inte
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... maximal storlek på lånet är {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Kan inte låna mer pengar...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... lånet är redan återbetalt
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... lånet är redan återbetalt
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} krävs
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kan inte återbetala lånet...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Kan inte ge bort pengar som är lånade från banken...

--- a/src/lang/tamil.txt
+++ b/src/lang/tamil.txt
@@ -2491,10 +2491,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}பர�
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}நிலையத்தினை இணை
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}தனியாக ஒரு நிலையத்தினை கட்டு
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}தனியாக ஒரு நிலையத்தினை கட்டு
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}பாதைப்புள்ளியினை இணை
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}தனியொரு பாதைப்புள்ளிடினை கட்டு
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}தனியொரு பாதைப்புள்ளிடினை கட்டு
 
 # Generic toolbar
 
@@ -4499,7 +4499,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}மே�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... அதிகபட்ச கடன் அளவு {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}மேலும் கடன் வாங்க இயலாது...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... திரும்பிச் செலுத்த எந்தக் கடனும் இல்லை
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... திரும்பிச் செலுத்த எந்தக் கடனும் இல்லை
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} தேவைப்படுகிறது
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}கடனினைத் திருப்பி கட்ட இயலாது...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}வங்கியிலிருந்து கடனாக பெறப்பட்டத் தொகையினை தங்களால் கொடுக்க இயலாது...

--- a/src/lang/thai.txt
+++ b/src/lang/thai.txt
@@ -2346,10 +2346,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}สิ�
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}รวมสถานี
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}สร้างสถานีแยกต่างหาก
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}สร้างสถานีแยกต่างหาก
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}รวมจุดตรวจ
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}สร้างจุดตรวจแยกต่างหาก
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}สร้างจุดตรวจแยกต่างหาก
 
 # Generic toolbar
 
@@ -4261,7 +4261,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}ไม�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... ปริมาณเงินสูงสุดที่สามารถกู้ได้ {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}ไม่สามารถกู้เงินเพิ่มได้จากนี้แล้ว...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... ไม่มีหนี้ที่ค้างชำระแล้ว
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... ไม่มีหนี้ที่ค้างชำระแล้ว
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} ต้องการ
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}ไม่สามารถใช้หนี้ได้...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}ไม่สามารถส่งเงินได้ นี่คือเงินกู้ที่มาจากธนาคาร...

--- a/src/lang/traditional_chinese.txt
+++ b/src/lang/traditional_chinese.txt
@@ -2785,10 +2785,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}維護�
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}合併車站
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}建造獨立車站
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}建造獨立車站
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}合併中途站
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}建立個別中途站
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}建立個別中途站
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}此設施已被禁用，因為沒有任何此設施可用的載具
@@ -5056,7 +5056,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}無法�
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... 貸款額度上限是 {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}無法再借更多錢...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... 不需償還貸款
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... 不需償還貸款
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... 需要 {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}無法償還貸款...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}無法把貸款的錢流通出去...

--- a/src/lang/turkish.txt
+++ b/src/lang/turkish.txt
@@ -2724,10 +2724,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Bakım m
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}İstasyonu birleştir
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Ayrı bir istasyon inşa et
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Ayrı bir istasyon inşa et
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Yerimini birleştir
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Ayrı bir yerimi yap
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Ayrı bir yerimi yap
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Şu anda bu altyapı için hiçbir araç bulunmadığından devre dışı bırakıldı
@@ -4938,7 +4938,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Yönetic
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... izin verilen azami borç {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Daha fazla kredi alınamaz...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... ödenecek borç yok
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... ödenecek borç yok
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... {CURRENCY_LONG} gerekli
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Kredi ödenemiyor...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Bankadan borç alınan para verilemez...

--- a/src/lang/ukrainian.txt
+++ b/src/lang/ukrainian.txt
@@ -2900,10 +2900,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Варт
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Об'єднати станцію
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Побудувати окрему станцію
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Побудувати окрему станцію
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}З'єднати точку маршруту
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Створити окрему точку маршруту
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Створити окрему точку маршруту
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Відключено через поточну відсутність транспорту для цієї інфраструктури
@@ -5164,7 +5164,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Немо
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... найбільший дозволений розмір позики {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Неможливо взяти ще позику...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... позика вже повернута
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... позика вже повернута
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... потрібно {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Неможливо повернути позику...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Неможливо передати гроші, позичені у банку...

--- a/src/lang/urdu.txt
+++ b/src/lang/urdu.txt
@@ -1932,10 +1932,10 @@ STR_STATION_BUILD_SUPPLIES_CARGO                                :{GOLD}{CARGO_LI
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}اسٹیشن ملائیں
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}الگ اسٹیشن تعمیر کریں
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}الگ اسٹیشن تعمیر کریں
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}گزرگاہ ملائیں
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}الگ سے گزرگاہ تعمیر کریں
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}الگ سے گزرگاہ تعمیر کریں
 
 # Generic toolbar
 

--- a/src/lang/vietnamese.txt
+++ b/src/lang/vietnamese.txt
@@ -2773,10 +2773,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Chi phí
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Nối ga, bến
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Tạo một ga, bến riêng rẽ
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Tạo một ga, bến riêng rẽ
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Nối điểm mốc
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Tạo một điểm mốc riêng rẽ
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Tạo một điểm mốc riêng rẽ
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Đã bị tắt bởi chưa có phương tiện nào có sẵn cho hạ tầng này
@@ -5042,7 +5042,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Không t
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... hạn mức vay tối đa là {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Không thể vay thêm được tiền...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... không vay đâu cần trả
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... không vay đâu cần trả
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... cần {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Không thể trả nợ...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Không thể đem tặng tiền mà bạn vay từ ngân hàng...

--- a/src/lang/welsh.txt
+++ b/src/lang/welsh.txt
@@ -2773,10 +2773,10 @@ STR_STATION_BUILD_INFRASTRUCTURE_COST_PERIOD                    :{BLACK}Cost cyn
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Uno gorsaf
-STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Adeiladu gorsaf ar wahân
+STR_JOIN_STATION_CREATE_SPLIT_STATION                           :{YELLOW}Adeiladu gorsaf ar wahân
 
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Uno pwynt llwybro
-STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Adeiladu pwynt llwybro annibynnol
+STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT                         :{YELLOW}Adeiladu pwynt llwybro annibynnol
 
 # Generic toolbar
 STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Analluogwyd gan nad oes cerbydau ar gael i'r tanadeiledd yma ar hyn o bryd
@@ -5042,7 +5042,7 @@ STR_ERROR_CAN_T_CHANGE_PRESIDENT                                :{WHITE}Does dim
 
 STR_ERROR_MAXIMUM_PERMITTED_LOAN                                :{WHITE}... mae'r uchafswm benthyciad posib yn {CURRENCY_LONG}
 STR_ERROR_CAN_T_BORROW_ANY_MORE_MONEY                           :{WHITE}Does dim modd i chi fenthyg rhagor o arian...
-STR_ERROR_LOAN_ALREADY_REPAYED                                  :{WHITE}... nid oes benthyciad i'w ad-dalu
+STR_ERROR_LOAN_ALREADY_REPAID                                   :{WHITE}... nid oes benthyciad i'w ad-dalu
 STR_ERROR_CURRENCY_REQUIRED                                     :{WHITE}... angen {CURRENCY_LONG}
 STR_ERROR_CAN_T_REPAY_LOAN                                      :{WHITE}Does dim modd ad-dalu benthyciad...
 STR_ERROR_INSUFFICIENT_FUNDS                                    :{WHITE}Does dim modd rhoi arian sydd wedi ei fenthyg gan y banc i ffwrdd...

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -28,7 +28,7 @@ INSTANTIATE_POOL_METHODS(LinkGraphJob)
 
 /**
  * Create a link graph job from a link graph. The link graph will be copied so
- * that the calculations don't interfer with the normal operations on the
+ * that the calculations don't interfere with the normal operations on the
  * original. The job is immediately started.
  * @param orig Original LinkGraph to be copied.
  */

--- a/src/linkgraph/linkgraphschedule.cpp
+++ b/src/linkgraph/linkgraphschedule.cpp
@@ -75,7 +75,7 @@ void LinkGraphSchedule::JoinNext()
 	delete next; // implicitly joins the thread
 	if (LinkGraph::IsValidID(id)) {
 		LinkGraph *lg = LinkGraph::Get(id);
-		this->Unqueue(lg); // Unqueue to avoid double-queueing recycled IDs.
+		this->Dequeue(lg); // Dequeue to avoid double-queueing recycled IDs.
 		this->Queue(lg);
 	}
 }

--- a/src/linkgraph/linkgraphschedule.h
+++ b/src/linkgraph/linkgraphschedule.h
@@ -74,7 +74,7 @@ public:
 	 * Remove a link graph from the execution queue.
 	 * @param lg Link graph to be removed.
 	 */
-	void Unqueue(LinkGraph *lg) { this->schedule.remove(lg); }
+	void Dequeue(LinkGraph *lg) { this->schedule.remove(lg); }
 };
 
 void StateGameLoop_LinkGraphPauseControl();

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -201,7 +201,7 @@ enum GlobalHotKeys : int32_t {
 	GHK_TOGGLE_TRANSPARENCY,
 	GHK_TOGGLE_INVISIBILITY = GHK_TOGGLE_TRANSPARENCY + 9,
 	GHK_TRANSPARENCY_TOOLBAR = GHK_TOGGLE_INVISIBILITY + 8,
-	GHK_TRANSPARANCY,
+	GHK_TRANSPARENCY,
 	GHK_CHAT,
 	GHK_CHAT_ALL,
 	GHK_CHAT_COMPANY,
@@ -382,7 +382,7 @@ struct MainWindow : Window
 				ShowTransparencyToolbar();
 				break;
 
-			case GHK_TRANSPARANCY:
+			case GHK_TRANSPARENCY:
 				ResetRestoreAllTransparency();
 				break;
 
@@ -515,7 +515,7 @@ struct MainWindow : Window
 		Hotkey('7' | WKC_CTRL | WKC_SHIFT, "invisibility_structures", GHK_TOGGLE_INVISIBILITY + 6),
 		Hotkey('8' | WKC_CTRL | WKC_SHIFT, "invisibility_catenary", GHK_TOGGLE_INVISIBILITY + 7),
 		Hotkey('X' | WKC_CTRL, "transparency_toolbar", GHK_TRANSPARENCY_TOOLBAR),
-		Hotkey('X', "toggle_transparency", GHK_TRANSPARANCY),
+		Hotkey('X', "toggle_transparency", GHK_TRANSPARENCY),
 		Hotkey({WKC_RETURN, 'T'}, "chat", GHK_CHAT),
 		Hotkey({WKC_SHIFT | WKC_RETURN, WKC_SHIFT | 'T'}, "chat_all", GHK_CHAT_ALL),
 		Hotkey({WKC_CTRL | WKC_RETURN, WKC_CTRL | 'T'}, "chat_company", GHK_CHAT_COMPANY),

--- a/src/misc_cmd.cpp
+++ b/src/misc_cmd.cpp
@@ -86,7 +86,7 @@ CommandCost CmdDecreaseLoan(DoCommandFlags flags, LoanCommand cmd, Money amount)
 {
 	Company *c = Company::Get(_current_company);
 
-	if (c->current_loan == 0) return CommandCost(STR_ERROR_LOAN_ALREADY_REPAYED);
+	if (c->current_loan == 0) return CommandCost(STR_ERROR_LOAN_ALREADY_REPAID);
 
 	Money loan;
 	switch (cmd) {

--- a/src/music/midi.h
+++ b/src/music/midi.h
@@ -10,7 +10,7 @@
 #ifndef MUSIC_MIDI_H
 #define MUSIC_MIDI_H
 
-/** Header of a Stanard MIDI File */
+/** Header of a Standard MIDI File */
 struct SMFHeader {
 	uint16_t format;
 	uint16_t tracks;
@@ -73,7 +73,7 @@ enum MidiController : uint8_t {
 	MIDICT_GENERAL4          =  19,
 	/* Offset from MSB to LSB of continuous controllers */
 	MIDICTOFS_HIGHRES        =  32,
-	/* Stanard continuous controllers (LSB control) */
+	/* Standard continuous controllers (LSB control) */
 	MIDICT_BANKSELECT_LO     = MIDICTOFS_HIGHRES + MIDICT_BANKSELECT,
 	MIDICT_MODWHEEL_LO       = MIDICTOFS_HIGHRES + MIDICT_MODWHEEL,
 	MIDICT_BREATH_LO         = MIDICTOFS_HIGHRES + MIDICT_BREATH,

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -262,7 +262,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 			std::copy_n(reinterpret_cast<const std::byte *>(runp->ai_addr), runp->ai_addrlen, reinterpret_cast<std::byte *>(&this->address));
 #ifdef __EMSCRIPTEN__
 			/* Emscripten doesn't zero sin_zero, but as we compare addresses
-			 * to see if they are the same address, we need them to be zero'd.
+			 * to see if they are the same address, we need them to be zeroed.
 			 * Emscripten is, as far as we know, the only OS not doing this.
 			 *
 			 * https://github.com/emscripten-core/emscripten/issues/12998

--- a/src/network/core/http_winhttp.cpp
+++ b/src/network/core/http_winhttp.cpp
@@ -159,7 +159,7 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 			DWORD size = *(DWORD *)info;
 
 			/* Next step: read the data in a temporary allocated buffer.
-			 * The buffer will be free'd by OnReceiveData() in the next step. */
+			 * The buffer will be freed by OnReceiveData() in the next step. */
 			char *buffer = size == 0 ? nullptr : new char[size];
 			WinHttpReadData(this->request, buffer, size, 0);
 		} break;
@@ -278,7 +278,7 @@ bool NetworkHTTPRequest::Receive()
 /**
  * Destructor of the HTTP request.
  *
- * Makes sure all handlers are closed, and all memory is free'd.
+ * Makes sure all handlers are closed, and all memory is freed.
  */
 NetworkHTTPRequest::~NetworkHTTPRequest()
 {

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -42,7 +42,7 @@ NetworkServerGameInfo _network_game_info; ///< Information about our game.
 
 /**
  * Get the network version string used by this build.
- * The returned string is guaranteed to be at most NETWORK_REVISON_LENGTH bytes including '\0' terminator.
+ * The returned string is guaranteed to be at most NETWORK_REVISION_LENGTH bytes including '\0' terminator.
  */
 std::string_view GetNetworkRevisionString()
 {

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -109,7 +109,7 @@ ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
 }
 
 /**
- * Handle the acception of a connection.
+ * Handle the acceptance of a connection.
  * @param s The socket of the new connection.
  * @param address The address of the peer.
  */

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1117,7 +1117,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MOVE(Packet &p)
 	ClientID client_id   = (ClientID)p.Recv_uint32();
 	CompanyID company_id = (CompanyID)p.Recv_uint8();
 
-	Debug(net, 9, "Client::Receive_SERVER_MOVE(): client_id={}, comapny_id={}", client_id, company_id);
+	Debug(net, 9, "Client::Receive_SERVER_MOVE(): client_id={}, company_id={}", client_id, company_id);
 
 	if (client_id == 0) {
 		/* definitely an invalid client id, debug message and do nothing. */

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -656,7 +656,7 @@ void ClientNetworkCoordinatorSocketHandler::CloseTurnHandler(std::string_view to
 	turn_it->second->CloseSocket();
 
 	/* We don't remove turn_handler here, as we can be called from within that
-	 * turn_handler instance, so our object cannot be free'd yet. Instead, we
+	 * turn_handler instance, so our object cannot be freed yet. Instead, we
 	 * check later if the connection is closed, and free the object then. */
 }
 

--- a/src/network/network_crypto.cpp
+++ b/src/network/network_crypto.cpp
@@ -92,7 +92,7 @@ bool X25519DerivedKeys::Exchange(const X25519PublicKey &peer_public_key, X25519K
 }
 
 /**
- * Encryption handler implementation for monocypther encryption after a X25519 key exchange.
+ * Encryption handler implementation for monocypher encryption after a X25519 key exchange.
  */
 class X25519EncryptionHandler : public NetworkEncryptionHandler {
 private:

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1428,7 +1428,7 @@ private:
 	}
 
 	/**
-	 * Crete new company button is clicked.
+	 * Create new company button is clicked.
 	 * @param w The instance of this window.
 	 * @param pt The point where this button was clicked.
 	 */
@@ -1621,7 +1621,7 @@ public:
 	{
 		this->RebuildList();
 
-		/* Currently server information is not sync'd to clients, so we cannot show it on clients. */
+		/* Currently server information is not synced to clients, so we cannot show it on clients. */
 		this->GetWidget<NWidgetStacked>(WID_CL_SERVER_SELECTOR)->SetDisplayedPlane(_network_server ? 0 : SZSP_HORIZONTAL);
 		this->SetWidgetDisabledState(WID_CL_SERVER_NAME_EDIT, !_network_server);
 	}
@@ -2065,7 +2065,7 @@ struct NetworkJoinStatusWindow : Window {
 						}
 						[[fallthrough]];
 
-					default: // Waiting is 15%, so the resting receivement of map is maximum 70%
+					default: // Waiting is 15%, so the remaining downloading of the map is maximum 70%
 						progress = 15 + _network_join_bytes * (100 - 15) / _network_join_bytes_total;
 						break;
 				}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1444,7 +1444,7 @@ static void ActivateOldShore()
 }
 
 /**
- * Replocate the old tram depot sprites to the new position, if no new ones were loaded.
+ * Relocate the old tram depot sprites to the new position, if no new ones were loaded.
  */
 static void ActivateOldTramDepot()
 {

--- a/src/newgrf/newgrf_act0_cargo.cpp
+++ b/src/newgrf/newgrf_act0_cargo.cpp
@@ -142,7 +142,7 @@ static ChangeInfoResult CargoReserveInfo(uint first, uint last, int prop, ByteRe
 				cs->callback_mask = static_cast<CargoCallbackMasks>(buf.ReadByte());
 				break;
 
-			case 0x1D: // Vehicle capacity muliplier
+			case 0x1D: // Vehicle capacity multiplier
 				cs->multiplier = std::max<uint16_t>(1u, buf.ReadWord());
 				break;
 

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -472,7 +472,7 @@ bool GetGlobalVariable(uint8_t param, uint32_t *value, const GRFFile *grffile)
 				/* skip elrail multiplier - disabled */
 				SB(*value, 8, 8, GetRailTypeInfo(RAILTYPE_MONO)->cost_multiplier); // monorail
 			} else {
-				SB(*value, 8, 8, GetRailTypeInfo(RAILTYPE_ELECTRIC)->cost_multiplier); // electified railway
+				SB(*value, 8, 8, GetRailTypeInfo(RAILTYPE_ELECTRIC)->cost_multiplier); // electrified railway
 				/* Skip monorail multiplier - no space in result */
 			}
 			SB(*value, 16, 8, GetRailTypeInfo(RAILTYPE_MAGLEV)->cost_multiplier); // maglev

--- a/src/newgrf/newgrf_act0_industries.cpp
+++ b/src/newgrf/newgrf_act0_industries.cpp
@@ -418,7 +418,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 
 						IndustryTileLayoutTile &it = layout.emplace_back();
 
-						it.ti.x = buf.ReadByte(); // Offsets from northermost tile
+						it.ti.x = buf.ReadByte(); // Offsets from northernmost tile
 						++bytes_read;
 
 						if (it.ti.x == 0xFE && k == 0) {

--- a/src/newgrf/newgrf_act7_9.cpp
+++ b/src/newgrf/newgrf_act7_9.cpp
@@ -44,7 +44,7 @@ void InitializePatchFlags()
 	                   |                                                       (1U << 0x09)  // trainrefit
 	                   |                                                       (0U << 0x0B)  // subsidiaries
 	                   |         ((_settings_game.order.gradual_loading ? 1U : 0U) << 0x0C)  // gradualloading
-	                   |                                                       (1U << 0x12)  // unifiedmaglevmode - set bit 0 mode. Not revelant to OTTD
+	                   |                                                       (1U << 0x12)  // unifiedmaglevmode - set bit 0 mode. Not relevant to OTTD
 	                   |                                                       (1U << 0x13)  // unifiedmaglevmode - set bit 1 mode
 	                   |                                                       (1U << 0x14)  // bridgespeedlimits
 	                   |                                                       (1U << 0x16)  // eternalgame
@@ -55,7 +55,7 @@ void InitializePatchFlags()
 	                   | ((_settings_game.construction.train_signal_side == 1 ? 1U : 0U) << 0x1B)  // signalsontrafficside
 	                   |       ((_settings_game.vehicle.disable_elrails ? 0U : 1U) << 0x1C); // electrifiedrailway
 
-	_ttdpatch_flags[2] =                                                       (1U << 0x01)  // loadallgraphics - obsolote
+	_ttdpatch_flags[2] =                                                       (1U << 0x01)  // loadallgraphics - obsolete
 	                   |                                                       (1U << 0x03)  // semaphores
 	                   |                                                       (1U << 0x0A)  // newobjects
 	                   |                                                       (0U << 0x0B)  // enhancedgui

--- a/src/newgrf_act5.h
+++ b/src/newgrf_act5.h
@@ -15,7 +15,7 @@
 /** The type of action 5 type. */
 enum Action5BlockType : uint8_t {
 	A5BLOCK_FIXED,                ///< Only allow replacing a whole block of sprites. (TTDP compatible)
-	A5BLOCK_ALLOW_OFFSET,         ///< Allow replacing any subset by specifiing an offset.
+	A5BLOCK_ALLOW_OFFSET,         ///< Allow replacing any subset by specifying an offset.
 	A5BLOCK_INVALID,              ///< unknown/not-implemented type
 };
 

--- a/src/newgrf_badge_gui.cpp
+++ b/src/newgrf_badge_gui.cpp
@@ -363,7 +363,7 @@ DropDownList BuildBadgeClassConfigurationList(const GUIBadgeClasses &gui_classes
  * Toggle badge class visibility.
  * @param feature Feature being used.
  * @param class_badge Class badge.
- * @param click Dropdown click reuslt.
+ * @param click Dropdown click result.
  */
 static void BadgeClassToggleVisibility(GrfSpecFeature feature, Badge &class_badge, int click_result, BadgeFilterChoices &choices)
 {
@@ -570,7 +570,7 @@ void ResetBadgeFilter(BadgeFilterChoices &choices, BadgeClassID badge_class_inde
 
 /**
  * Set badge filter choice for a class.
- * @param choides Badge filter choides.
+ * @param choices Badge filter choices.
  * @param badge_index Badge to set. The badge class is inferred from the badge.
  * @note if the badge_index is invalid, the filter will be reset instead.
  */

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -6,7 +6,7 @@
  */
 
 /**
- * @file newgrf_commons.h This file simplyfies and embeds a common mechanism of
+ * @file newgrf_commons.h This file simplifies and embeds a common mechanism of
  * loading/saving and mapping of grf entities.
  */
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -246,7 +246,7 @@ enum TTDPAircraftMovementActions : uint8_t {
 	AMA_TTDP_PAD1_TO_TAKEOFF,
 	AMA_TTDP_PAD2_TO_TAKEOFF,
 	AMA_TTDP_PAD3_TO_TAKEOFF,
-	AMA_TTDP_HANGAR_TO_TAKOFF,
+	AMA_TTDP_HANGAR_TO_TAKEOFF,
 	AMA_TTDP_LANDING_TO_HANGAR,
 	AMA_TTDP_IN_FLIGHT,
 };
@@ -1243,7 +1243,7 @@ int GetEngineProperty(EngineID engine, PropertyID property, int orig_value, cons
 }
 
 /**
- * Test for vehicle build probablity type.
+ * Test for vehicle build probability type.
  * @param v Vehicle whose build probability to test.
  * @param type Build probability type to test for.
  * @returns True or false depending on the probability result, or std::nullopt if the callback failed.

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1771,7 +1771,7 @@ void ShowOrdersWindow(const Vehicle *v)
 	/* Using a different WindowDescs for _local_company causes problems.
 	 * Due to this we have to close order windows in ChangeWindowOwner/CloseCompanyWindows,
 	 * because we cannot change switch the WindowDescs and keeping the old WindowDesc results
-	 * in crashed due to missing widges.
+	 * in crashed due to missing widget.
 	 * TODO Rewrite the order GUI to not use different WindowDescs.
 	 */
 	if (v->owner != _local_company) {

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -170,8 +170,8 @@ static const CTRunDelegateCallbacks _sprite_font_callback = {
 	CFAutoRelease<CFStringRef> base(CFStringCreateWithCharactersNoCopy(kCFAllocatorDefault, buff, length, kCFAllocatorNull));
 	CFAttributedStringReplaceString(str.get(), CFRangeMake(0, 0), base.get());
 
-	const UniChar replacment_char = 0xFFFC;
-	CFAutoRelease<CFStringRef> replacment_str(CFStringCreateWithCharacters(kCFAllocatorDefault, &replacment_char, 1));
+	const UniChar replacement_char = 0xFFFC;
+	CFAutoRelease<CFStringRef> replacement_str(CFStringCreateWithCharacters(kCFAllocatorDefault, &replacement_char, 1));
 
 	/* Apply font and colour ranges to our string. This is important to make sure
 	 * that we get proper glyph boundaries on style changes. */
@@ -199,7 +199,7 @@ static const CTRunDelegateCallbacks _sprite_font_callback = {
 			if (buff[c] >= SCC_SPRITE_START && buff[c] <= SCC_SPRITE_END && font->fc->MapCharToGlyph(buff[c], false) == 0) {
 				CFAutoRelease<CTRunDelegateRef> del(CTRunDelegateCreate(&_sprite_font_callback, (void *)(size_t)(buff[c] | (font->fc->GetSize() << 24))));
 				/* According to the official documentation, if a run delegate is used, the char should always be 0xFFFC. */
-				CFAttributedStringReplaceString(str.get(), CFRangeMake(c, 1), replacment_str.get());
+				CFAttributedStringReplaceString(str.get(), CFRangeMake(c, 1), replacement_str.get());
 				CFAttributedStringSetAttribute(str.get(), CFRangeMake(c, 1), kCTRunDelegateAttributeName, del.get());
 			}
 		}
@@ -253,7 +253,7 @@ CoreTextParagraphLayout::CoreTextVisualRun::CoreTextVisualRun(CTRunRef run, Font
 	CTRunGetGlyphs(run, CFRangeMake(0, 0), gl.get());
 	for (size_t i = 0; i < this->glyphs.size(); i++) {
 		if (buff[this->glyph_to_char[i]] >= SCC_SPRITE_START && buff[this->glyph_to_char[i]] <= SCC_SPRITE_END && (gl[i] == 0 || gl[i] == 3)) {
-			/* A glyph of 0 indidicates not found, while apparently 3 is what char 0xFFFC maps to. */
+			/* A glyph of 0 indicates not found, while apparently 3 is what char 0xFFFC maps to. */
 			this->glyphs[i] = font->fc->MapCharToGlyph(buff[this->glyph_to_char[i]]);
 			this->positions.emplace_back(pts[i].x, pts[i].x + advs[i].width - 1, (font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(font->fc->GetSize()))) / 2); // Align sprite font to centre
 		} else {

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -29,7 +29,7 @@ static std::recursive_mutex _palette_mutex; ///< To coordinate access to _cur_pa
  * PALETTE_BITS reduces the bits-per-channel of 32bpp graphics data to allow faster palette lookups from
  * a smaller lookup table.
  *
- * 6 bpc is chosen as this results in a palette lookup table of 256KiB with adequate fidelty.
+ * 6 bpc is chosen as this results in a palette lookup table of 256KiB with adequate fidelity.
  * In contrast, a 5 bpc lookup table would be 32KiB, and 7 bpc would be 2MiB.
  *
  * Values in the table are filled as they are first encountered -- larger lookup table means more colour

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -404,7 +404,7 @@ public:
 					TileArea non_cached_area = v->IsBus() ? st->bus_station : st->truck_station;
 					non_cached_area.Expand(YAPF_ROADVEH_PATH_CACHE_DESTINATION_LIMIT);
 
-					/* Find the first tile not contained by the non-cachable area, and remove from the cache. */
+					/* Find the first tile not contained by the non-cacheable area, and remove from the cache. */
 					auto it = std::find_if(std::begin(path_cache), std::end(path_cache), [&non_cached_area](const auto &pc) { return !non_cached_area.Contains(pc.tile); });
 					path_cache.erase(std::begin(path_cache), it);
 				}

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -178,7 +178,7 @@ public:
 	static constexpr int PREVIEW_LEFT = 31; ///< Offset from left edge to draw preview.
 	static constexpr int PREVIEW_BOTTOM = 31; ///< Offset from bottom edge to draw preview.
 
-	static constexpr int STEP_PREVIEW_HEIGHT = 16; ///< Step for decreasing or increase preivew button height.
+	static constexpr int STEP_PREVIEW_HEIGHT = 16; ///< Step for decreasing or increase preview button height.
 	static constexpr int MAX_PREVIEW_HEIGHT = PREVIEW_HEIGHT * 3; ///< Maximum height of each preview button.
 
 	static constexpr uint EDITBOX_MAX_SIZE = 16; ///< The maximum number of characters for the filter edit box.

--- a/src/random_access_file_type.h
+++ b/src/random_access_file_type.h
@@ -24,7 +24,7 @@ class RandomAccessFile {
 	static constexpr int BUFFER_SIZE = 512;
 
 	std::string filename;            ///< Full name of the file; relative path to subdir plus the extension of the file.
-	std::string simplified_filename; ///< Simplified lowecase name of the file; only the name, no path or extension.
+	std::string simplified_filename; ///< Simplified lowercase name of the file; only the name, no path or extension.
 
 	std::optional<FileHandle> file_handle; ///< File handle of the open file.
 	size_t pos;                      ///< Position in the file of the end of the read buffer.

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -794,7 +794,7 @@ CommandCost CmdBuildRoad(DoCommandFlags flags, TileIndex tile, RoadBits pieces, 
 
 		case MP_TUNNELBRIDGE: {
 			if (GetTunnelBridgeTransportType(tile) != TRANSPORT_ROAD) goto do_clear;
-			/* Only allow building the outern roadbit, so building long roads stops at existing bridges */
+			/* Only allow building the outer roadbit, so building long roads stops at existing bridges */
 			if (MirrorRoadBits(DiagDirToRoadBits(GetTunnelBridgeDirection(tile))) != pieces) goto do_clear;
 			if (HasTileRoadType(tile, rtt)) return CommandCost(STR_ERROR_ALREADY_BUILT);
 			/* Don't allow adding roadtype to the bridge/tunnel when vehicles are already driving on it */

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1712,7 +1712,7 @@ static void CheckIfRoadVehNeedsService(RoadVehicle *v)
 	SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);
 }
 
-/** Calandar day handler */
+/** Calander day handler */
 void RoadVehicle::OnNewCalendarDay()
 {
 	if (!this->IsFrontEngine()) return;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3035,7 +3035,7 @@ bool AfterLoadGame()
 		/* Fix articulated road vehicles.
 		 * Some curves were shorter than other curves.
 		 * Now they have the same length, but that means that trailing articulated parts will
-		 * take longer to go through the curve than the parts in front which already left the courve.
+		 * take longer to go through the curve than the parts in front which already left the curve.
 		 * So, make articulated parts catch up. */
 		bool roadside = _settings_game.vehicle.road_side == 1;
 		std::vector<uint> skip_frames;

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -932,7 +932,7 @@ static bool LoadOldCompanyEconomy(LoadgameState &ls, int)
 
 	if (!LoadChunk(ls, &c->cur_economy, _company_economy_chunk)) return false;
 
-	/* Don't ask, but the number in TTD(Patch) are inversed to OpenTTD */
+	/* Don't ask, but the number in TTD(Patch) are inverted to OpenTTD */
 	c->cur_economy.income   = -c->cur_economy.income;
 	c->cur_economy.expenses = -c->cur_economy.expenses;
 

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -285,7 +285,7 @@ static bool MakeLargeWorldScreenshot(ScreenshotType t, uint32_t width = 0, uint3
 }
 
 /**
- * Callback for generating a heightmap. Supports 8bpp grayscale only.
+ * Callback for generating a heightmap. Supports 8bpp greyscale only.
  * @param buffer   Destination buffer.
  * @param y        Line number of the first line to write.
  * @param n        Number of lines to write.

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -354,7 +354,7 @@ ScriptObject::DisableDoCommandScope::DisableDoCommandScope()
 
 /* static */ SQInteger ScriptObject::Constructor(HSQUIRRELVM)
 {
-	throw Script_FatalError("This class is not instantiable");
+	throw Script_FatalError("This class is not instantiatable");
 }
 
 /* static */ SQInteger ScriptObject::_cloned(HSQUIRRELVM vm)

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -55,7 +55,7 @@ private:
 };
 
 /**
- * Uper-parent object of all API classes. You should never use this class in
+ * Upper-parent object of all API classes. You should never use this class in
  *   your script, as it doesn't publish any public functions. It is used
  *   internally to have a common place to handle general things, like internal
  *   command processing, and command-validation checks.
@@ -143,7 +143,7 @@ public:
 	static void InitializeRandomizers();
 
 	/**
-	 * Used when trying to instanciate ScriptObject from squirrel.
+	 * Used when trying to instantiate ScriptObject from squirrel.
 	 */
 	static SQInteger Constructor(HSQUIRRELVM);
 

--- a/src/script/api/script_order.hpp
+++ b/src/script/api/script_order.hpp
@@ -93,7 +93,7 @@ public:
 		OC_RELIABILITY         = ::OCV_RELIABILITY,        ///< Skip based on the reliability, value is percent (0..100).
 		OC_MAX_RELIABILITY     = ::OCV_MAX_RELIABILITY,    ///< Skip based on the maximum reliability.  Value in percent
 		OC_MAX_SPEED           = ::OCV_MAX_SPEED,          ///< Skip based on the maximum speed, value is in OpenTTD's internal speed unit, see ScriptEngine::GetMaxSpeed.
-		OC_AGE                 = ::OCV_AGE,                ///< Skip based on the age, value is in calender-years. @see \ref ScriptCalendarTime
+		OC_AGE                 = ::OCV_AGE,                ///< Skip based on the age, value is in calendar-years. @see \ref ScriptCalendarTime
 		OC_REQUIRES_SERVICE    = ::OCV_REQUIRES_SERVICE,   ///< Skip when the vehicle requires service, no value.
 		OC_UNCONDITIONALLY     = ::OCV_UNCONDITIONALLY,    ///< Always skip, no compare function, no value.
 		OC_REMAINING_LIFETIME  = ::OCV_REMAINING_LIFETIME, ///< Skip based on the remaining lifetime in calendar-years. @see \ref ScriptCalendarTime

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -282,7 +282,7 @@ public:
 	/**
 	 * Opens the Story Book if not yet open and selects the given page.
 	 * @param story_page_id The story page to update. If it is a global page, clients of all
-	 * companies are affecetd. Otherwise only the clients of the company which the page belongs
+	 * companies are affected. Otherwise only the clients of the company which the page belongs
 	 * to are affected.
 	 * @return True if the action succeeded.
 	 * @pre ScriptCompanyMode::IsDeity().

--- a/src/script/api/script_subsidy.hpp
+++ b/src/script/api/script_subsidy.hpp
@@ -50,7 +50,7 @@ public:
 
 	/**
 	 * Create a new subsidy.
-	 * @param cargo_type The type of cargo to cary for the subsidy.
+	 * @param cargo_type The type of cargo to carry for the subsidy.
 	 * @param from_type The type of the subsidy on the 'from' side.
 	 * @param from_id The ID of the 'from' side.
 	 * @param to_type The type of the subsidy on the 'to' side.

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -415,7 +415,7 @@ public:
 	 * Raise the given corners of the tile. The corners can be combined,
 	 *  for example: SLOPE_N | SLOPE_W (= SLOPE_NW) will raise the west and the north corner.
 	 * @note The corners will be modified in the order west (first), south, east, north (last).
-	 *       Changing one corner might cause another corner to be changed too. So modifiing
+	 *       Changing one corner might cause another corner to be changed too. So modifying
 	 *       multiple corners may result in changing some corners by multiple steps.
 	 * @param tile The tile to raise.
 	 * @param slope Corners to raise (SLOPE_xxx).
@@ -432,7 +432,7 @@ public:
 	 * Lower the given corners of the tile. The corners can be combined,
 	 *  for example: SLOPE_N | SLOPE_W (= SLOPE_NW) will lower the west and the north corner.
 	 * @note The corners will be modified in the order west (first), south, east, north (last).
-	 *       Changing one corner might cause another corner to be changed too. So modifiing
+	 *       Changing one corner might cause another corner to be changed too. So modifying
 	 *       multiple corners may result in changing some corners by multiple steps.
 	 * @param tile The tile to lower.
 	 * @param slope Corners to lower (SLOPE_xxx).

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -370,7 +370,7 @@ public:
 	 *   is owned by you.
 	 * @pre ScriptEngine::IsBuildable(engine_id).
 	 * @pre ScriptCargo::IsValidCargo(cargo).
-	 * @return The capacity the vehicle will have when refited.
+	 * @return The capacity the vehicle will have when refitted.
 	 */
 	static SQInteger GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoType cargo);
 
@@ -431,7 +431,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo).
 	 * @pre You must own the vehicle.
 	 * @pre The vehicle must be stopped in the depot.
-	 * @return The capacity the vehicle will have when refited.
+	 * @return The capacity the vehicle will have when refitted.
 	 */
 	static SQInteger GetRefitCapacity(VehicleID vehicle_id, CargoType cargo);
 

--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -167,7 +167,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 		CoUninitialize();
 
 		Debug(driver, 0, "xaudio2_s: XAudio2Create failed ({:08x})", (uint)hr);
-		return "Failed to inititialise the XAudio2 engine";
+		return "Failed to initialise the XAudio2 engine";
 	}
 
 	/* Create a mastering voice */

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -115,7 +115,7 @@ Station::~Station()
 		}
 		lg->RemoveNode(this->goods[cargo].node);
 		if (lg->Size() == 0) {
-			LinkGraphSchedule::instance.Unqueue(lg);
+			LinkGraphSchedule::instance.Dequeue(lg);
 			delete lg;
 		}
 	}

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4246,11 +4246,11 @@ void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint
 		if (ge1.link_graph != ge2.link_graph) {
 			LinkGraph *lg2 = LinkGraph::Get(ge2.link_graph);
 			if (lg->Size() < lg2->Size()) {
-				LinkGraphSchedule::instance.Unqueue(lg);
+				LinkGraphSchedule::instance.Dequeue(lg);
 				lg2->Merge(lg); // Updates GoodsEntries of lg
 				lg = lg2;
 			} else {
-				LinkGraphSchedule::instance.Unqueue(lg2);
+				LinkGraphSchedule::instance.Dequeue(lg2);
 				lg->Merge(lg2); // Updates GoodsEntries of lg2
 			}
 		}

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -888,7 +888,7 @@ typedef std::set<std::unique_ptr<CargoDataEntry>, CargoSorter> CargoDataSet;
 /**
  * A cargo data entry representing one possible row in the station view window's
  * top part. Cargo data entries form a tree where each entry can have several
- * children. Parents keep track of the sums of their childrens' cargo counts.
+ * children. Parents keep track of the sums of their children's cargo counts.
  */
 class CargoDataEntry {
 public:

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2321,7 +2321,7 @@ struct SelectStationWindow : Window {
 		if (widget != WID_JS_PANEL) return;
 
 		/* Determine the widest string */
-		Dimension d = GetStringBoundingBox(T::IsWaypoint() ? STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT : STR_JOIN_STATION_CREATE_SPLITTED_STATION);
+		Dimension d = GetStringBoundingBox(T::IsWaypoint() ? STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT : STR_JOIN_STATION_CREATE_SPLIT_STATION);
 		for (const auto &station : _stations_nearby_list) {
 			if (station == NEW_STATION) continue;
 			const BaseStation *st = BaseStation::Get(station);
@@ -2345,7 +2345,7 @@ struct SelectStationWindow : Window {
 		auto [first, last] = this->vscroll->GetVisibleRangeIterators(_stations_nearby_list);
 		for (auto it = first; it != last; ++it, tr.top += this->resize.step_height) {
 			if (*it == NEW_STATION) {
-				DrawString(tr, T::IsWaypoint() ? STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT : STR_JOIN_STATION_CREATE_SPLITTED_STATION);
+				DrawString(tr, T::IsWaypoint() ? STR_JOIN_WAYPOINT_CREATE_SPLIT_WAYPOINT : STR_JOIN_STATION_CREATE_SPLIT_STATION);
 			} else {
 				const BaseStation *st = BaseStation::Get(*it);
 				DrawString(tr, T::IsWaypoint()

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -5,7 +5,7 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file strings_interal.h Types and functions related to the internal workings of formatting OpenTTD's strings. */
+/** @file strings_internal.h Types and functions related to the internal workings of formatting OpenTTD's strings. */
 
 #ifndef STRINGS_INTERNAL_H
 #define STRINGS_INTERNAL_H

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -56,6 +56,6 @@ static const uint SUBSIDY_PAX_MIN_POPULATION   = 400; ///< Min. population of to
 static const uint SUBSIDY_CARGO_MIN_POPULATION = 900; ///< Min. population of destination town for cargo route
 static const uint SUBSIDY_MAX_PCT_TRANSPORTED  =  42; ///< Subsidy will be created only for towns/industries with less % transported
 static const uint SUBSIDY_MAX_DISTANCE         =  70; ///< Max. length of subsidised route (DistanceManhattan)
-static const uint SUBSIDY_TOWN_CARGO_RADIUS    =   6; ///< Extent of a tile area around town center when scanning for town cargo acceptance and production (6 ~= min catchmement + min station / 2)
+static const uint SUBSIDY_TOWN_CARGO_RADIUS    =   6; ///< Extent of a tile area around town center when scanning for town cargo acceptance and production (6 ~= min catchment + min station / 2)
 
 #endif /* SUBSIDY_BASE_H */

--- a/src/table/airport_defaults.h
+++ b/src/table/airport_defaults.h
@@ -114,7 +114,7 @@ static const std::initializer_list<AirportTileLayout> _tile_table_city = {
 	{ _tile_table_city_0, DIR_N },
 };
 
-/** Tiles for Metropolitain Airport (large) - 2 runways */
+/** Tiles for Metropolitan Airport (large) - 2 runways */
 static const std::initializer_list<AirportTileTable> _tile_table_metropolitan_0 = {
 	MK(0, 0, APT_BUILDING_1),
 	MK(1, 0, APT_APRON_FENCE_NW),

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -5,7 +5,7 @@
 ;
 
 ; Locale settings as stored in the main configuration file ("openttd.cfg") and
-; in the savegame PATS chunk. These settings are not sync'd over the network.
+; in the savegame PATS chunk. These settings are not synced over the network.
 
 [pre-amble]
 static std::pair<StringParameter, StringParameter> SettingsValueVelocityUnit(const IntSettingDesc &sd, int32_t value);

--- a/src/table/sprites.h
+++ b/src/table/sprites.h
@@ -153,7 +153,7 @@ static const SpriteID SPR_GROUP_LIVERY_SHIP          = SPR_OPENTTD_BASE + 177;
 static const SpriteID SPR_GROUP_LIVERY_AIRCRAFT      = SPR_OPENTTD_BASE + 178;
 
 static const SpriteID SPR_TOWN_RATING_NA             = SPR_OPENTTD_BASE + 162;
-static const SpriteID SPR_TOWN_RATING_APALLING       = SPR_OPENTTD_BASE + 163;
+static const SpriteID SPR_TOWN_RATING_APPALLING      = SPR_OPENTTD_BASE + 163;
 static const SpriteID SPR_TOWN_RATING_MEDIOCRE       = SPR_OPENTTD_BASE + 164;
 static const SpriteID SPR_TOWN_RATING_GOOD           = SPR_OPENTTD_BASE + 165;
 

--- a/src/tests/test_script_admin.cpp
+++ b/src/tests/test_script_admin.cpp
@@ -52,7 +52,7 @@ extern bool ScriptAdminMakeJSON(nlohmann::json &json, HSQUIRRELVM vm, SQInteger 
 static std::optional<std::string> TestScriptAdminMakeJSON(std::string_view squirrel)
 {
 	auto vm = sq_open(1024);
-	/* sq_compile creates a closure with our snipper, which is a table.
+	/* sq_compile creates a closure with our snippet, which is a table.
 	 * Add "return " to get the table on the stack. */
 	std::string buffer = fmt::format("return {}", squirrel);
 

--- a/src/tilearea_type.h
+++ b/src/tilearea_type.h
@@ -77,7 +77,7 @@ struct DiagonalTileArea {
 	 * Construct this tile area with some set values.
 	 * @param tile The base tile.
 	 * @param a The "x" extent.
-	 * @param b The "y" estent.
+	 * @param b The "y" extent.
 	 */
 	DiagonalTileArea(TileIndex tile = INVALID_TILE, int16_t a = 0, int16_t b = 0) : tile(tile), a(a), b(b)
 	{

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -81,7 +81,7 @@ RailType _last_built_railtype;
 RoadType _last_built_roadtype;
 RoadType _last_built_tramtype;
 
-/** Toobar modes */
+/** Toolbar modes */
 enum ToolbarMode : uint8_t {
 	TB_NORMAL,
 	TB_UPPER,
@@ -1117,7 +1117,7 @@ void ToggleDirtyBlocks()
 }
 
 /**
- * Toggle drawing of widget outlihes.
+ * Toggle drawing of widget outlines.
  * @note has only an effect when newgrf_developer_tools are active.
  */
 void ToggleWidgetOutlines()
@@ -1426,8 +1426,8 @@ public:
 		this->current_y = given_height;
 
 		/* Figure out what are the visible buttons */
-		uint arrangable_count, button_count, spacer_count;
-		const WidgetID *arrangement = GetButtonArrangement(given_width, arrangable_count, button_count, spacer_count);
+		uint arrangeable_count, button_count, spacer_count;
+		const WidgetID *arrangement = GetButtonArrangement(given_width, arrangeable_count, button_count, spacer_count);
 
 		/* Create us ourselves a quick lookup table from WidgetID to slot. */
 		std::map<WidgetID, uint> lookup;
@@ -1448,8 +1448,8 @@ public:
 		uint button_i = 0;
 
 		/* Index into the arrangement indices. */
-		const WidgetID *slotp = rtl ? &arrangement[arrangable_count - 1] : arrangement;
-		for (uint i = 0; i < arrangable_count; i++) {
+		const WidgetID *slotp = rtl ? &arrangement[arrangeable_count - 1] : arrangement;
+		for (uint i = 0; i < arrangeable_count; i++) {
 			uint slot = lookup[*slotp];
 			auto &child_wid = this->children[slot];
 			/* If we have space to give to the spacers, do that. */
@@ -1495,24 +1495,24 @@ public:
 	/**
 	 * Get the arrangement of the buttons for the toolbar.
 	 * @param width the new width of the toolbar.
-	 * @param arrangable_count output of the number of visible items.
+	 * @param arrangeable_count output of the number of visible items.
 	 * @param button_count output of the number of visible buttons.
 	 * @param spacer_count output of the number of spacers.
 	 * @return the button configuration.
 	 */
-	virtual const WidgetID *GetButtonArrangement(uint &width, uint &arrangable_count, uint &button_count, uint &spacer_count) const = 0;
+	virtual const WidgetID *GetButtonArrangement(uint &width, uint &arrangeable_count, uint &button_count, uint &spacer_count) const = 0;
 };
 
 /** Container for the 'normal' main toolbar */
 class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
-	const WidgetID *GetButtonArrangement(uint &width, uint &arrangable_count, uint &button_count, uint &spacer_count) const override
+	const WidgetID *GetButtonArrangement(uint &width, uint &arrangeable_count, uint &button_count, uint &spacer_count) const override
 	{
 		static const uint SMALLEST_ARRANGEMENT = 14;
 		static const uint BIGGEST_ARRANGEMENT  = 20;
 
 		/* The number of buttons of each row of the toolbar should match the number of items which we want to be visible.
-		 * The total number of buttons should be equal to arrangable_count * 2.
-		 * No bad things happen, but we could see strange behaviours if we have buttons < (arrangable_count * 2) like a
+		 * The total number of buttons should be equal to arrangeable_count * 2.
+		 * No bad things happen, but we could see strange behaviours if we have buttons < (arrangeable_count * 2) like a
 		 * pause button appearing on the right of the lower toolbar and weird resizing of the widgets even if there is
 		 * enough space.
 		 */
@@ -1811,7 +1811,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 		/* If at least BIGGEST_ARRANGEMENT fit, just spread all the buttons nicely */
 		uint full_buttons = std::max(CeilDiv(width, this->smallest_x), SMALLEST_ARRANGEMENT);
 		if (full_buttons > BIGGEST_ARRANGEMENT) {
-			button_count = arrangable_count = lengthof(arrange_all);
+			button_count = arrangeable_count = lengthof(arrange_all);
 			spacer_count = this->spacers;
 			return arrange_all;
 		}
@@ -1819,7 +1819,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 		/* Introduce the split toolbar */
 		static const WidgetID * const arrangements[] = { arrange14, arrange15, arrange16, arrange17, arrange18, arrange19, arrange20 };
 
-		button_count = arrangable_count = full_buttons;
+		button_count = arrangeable_count = full_buttons;
 		spacer_count = this->spacers;
 		return arrangements[full_buttons - SMALLEST_ARRANGEMENT] + ((_toolbar_mode == TB_LOWER) ? full_buttons : 0);
 	}
@@ -1845,7 +1845,7 @@ class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
 		}
 	}
 
-	const WidgetID *GetButtonArrangement(uint &width, uint &arrangable_count, uint &button_count, uint &spacer_count) const override
+	const WidgetID *GetButtonArrangement(uint &width, uint &arrangeable_count, uint &button_count, uint &spacer_count) const override
 	{
 		static const WidgetID arrange_all[] = {
 			WID_TE_PAUSE,
@@ -1918,8 +1918,8 @@ class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
 		size_t min_full_width = (lengthof(arrange_all) - std::size(this->panel_widths)) * this->smallest_x + this->panel_widths[0] + this->panel_widths[1];
 		if (width >= min_full_width) {
 			width -= this->panel_widths[0] + this->panel_widths[1];
-			arrangable_count = lengthof(arrange_all);
-			button_count = arrangable_count - 2;
+			arrangeable_count = lengthof(arrange_all);
+			button_count = arrangeable_count - 2;
 			spacer_count = this->spacers;
 			return arrange_all;
 		}
@@ -1928,18 +1928,18 @@ class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
 		size_t min_small_width = (lengthof(arrange_switch) - std::size(this->panel_widths)) * this->smallest_x / 2 + this->panel_widths[1];
 		if (width > min_small_width) {
 			width -= this->panel_widths[1];
-			arrangable_count = lengthof(arrange_nopanel);
-			button_count = arrangable_count - 1;
+			arrangeable_count = lengthof(arrange_nopanel);
+			button_count = arrangeable_count - 1;
 			spacer_count = this->spacers - 1;
 			return arrange_nopanel;
 		}
 
 		/* Split toolbar */
 		width -= this->panel_widths[1];
-		arrangable_count = lengthof(arrange_switch) / 2;
-		button_count = arrangable_count - 1;
+		arrangeable_count = lengthof(arrange_switch) / 2;
+		button_count = arrangeable_count - 1;
 		spacer_count = 0;
-		return arrange_switch + ((_toolbar_mode == TB_LOWER) ? arrangable_count : 0);
+		return arrange_switch + ((_toolbar_mode == TB_LOWER) ? arrangeable_count : 0);
 	}
 };
 

--- a/src/town.h
+++ b/src/town.h
@@ -213,7 +213,7 @@ enum TownCouncilAttitudes {
  */
 enum TownRatingCheckType {
 	ROAD_REMOVE         = 0,      ///< Removal of a road owned by the town.
-	TUNNELBRIDGE_REMOVE = 1,      ///< Removal of a tunnel or bridge owned by the towb.
+	TUNNELBRIDGE_REMOVE = 1,      ///< Removal of a tunnel or bridge owned by the town.
 	TOWN_RATING_CHECK_TYPE_COUNT, ///< Number of town checking action types.
 };
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1427,7 +1427,7 @@ static bool GrowTownWithTunnel(const Town *t, const TileIndex tile, const DiagDi
 			slope_tile += delta;
 		}
 
-		/* More population means longer tunnels, but make sure we can at least cover the smallest mountain which neccesitates tunneling. */
+		/* More population means longer tunnels, but make sure we can at least cover the smallest mountain which necessitates tunneling. */
 		max_tunnel_length = (t->cache.population / 1000) + 7;
 	} else {
 		/* When tunneling under an obstruction, the length limit is 5, enough to tunnel under a four-track railway. */
@@ -1435,7 +1435,7 @@ static bool GrowTownWithTunnel(const Town *t, const TileIndex tile, const DiagDi
 	}
 
 	uint8_t tunnel_length = 0;
-	TileIndex tunnel_tile = tile; // Iteratator to store the other end tile of the tunnel.
+	TileIndex tunnel_tile = tile; // Iterator to store the other end tile of the tunnel.
 
 	/* Find the end tile of the tunnel for length and continuation checks. */
 	do {
@@ -1636,7 +1636,7 @@ static TownGrowthResult GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, Dia
 		if (cur_rb & target_rb) {
 			/* If it's a road turn possibly build a house in a corner.
 			 * Use intersection with straight road as an indicator
-			 * that we randomed corner house position.
+			 * that we randomised corner house position.
 			 * A turn (and we check for that later) always has only
 			 * one common bit with a straight road so it has the same
 			 * chance to be chosen as the house on the side of a road.

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -870,7 +870,7 @@ public:
 					if (_game_mode == GM_EDITOR || !t->have_ratings.Test(_local_company)) {
 						DrawSprite(SPR_TOWN_RATING_NA, PAL_NONE, icon_x, tr.top + (this->resize.step_height - icon_size.height) / 2);
 					} else {
-						SpriteID icon = SPR_TOWN_RATING_APALLING;
+						SpriteID icon = SPR_TOWN_RATING_APPALLING;
 						if (t->ratings[_local_company] > RATING_VERYPOOR) icon = SPR_TOWN_RATING_MEDIOCRE;
 						if (t->ratings[_local_company] > RATING_GOOD)     icon = SPR_TOWN_RATING_GOOD;
 						DrawSprite(icon, PAL_NONE, icon_x, tr.top + (this->resize.step_height - icon_size.height) / 2);

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -267,7 +267,7 @@ static Money TunnelBridgeClearCost(TileIndex tile, Price base_price)
 		} break;
 
 		case TRANSPORT_RAIL: base_cost += RailClearCost(GetRailType(tile)); break;
-		/* Aquaducts have their own clear price. */
+		/* Aqueducts have their own clear price. */
 		case TRANSPORT_WATER: base_cost = _price[PR_CLEAR_AQUEDUCT]; break;
 		default: break;
 	}

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -746,7 +746,7 @@ public:
 	/**
 	 * Copy certain configurations and statistics of a vehicle after successful autoreplace/renew
 	 * The function shall copy everything that cannot be copied by a command (like orders / group etc),
-	 * and that shall not be resetted for the new vehicle.
+	 * and that shall not be reset for the new vehicle.
 	 * @param src The old vehicle
 	 */
 	inline void CopyVehicleConfigAndStatistics(Vehicle *src)
@@ -1129,7 +1129,7 @@ struct SpecializedVehicle : public Vehicle {
 
 	/**
 	 * Gets vehicle with given index
-	 * @return pointer to vehicle with given index casted to T *
+	 * @return pointer to vehicle with given index cast to T *
 	 */
 	static inline T *Get(auto index)
 	{

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -357,7 +357,7 @@ struct RefitResult {
  * @param new_subtype  Cargo subtype to refit to. 0xFF means to try keeping the same subtype according to GetBestFittingSubType().
  * @param flags        Command flags
  * @param auto_refit   Refitting is done as automatic refitting outside a depot.
- * @return Refit cost + refittet capacity + mail capacity (aircraft).
+ * @return Refit cost + refitted capacity + mail capacity (aircraft).
  */
 static std::tuple<CommandCost, uint, uint16_t, CargoArray> RefitVehicle(Vehicle *v, bool only_this, uint8_t num_vehicles, CargoType new_cargo_type, uint8_t new_subtype, DoCommandFlags flags, bool auto_refit)
 {

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2939,7 +2939,7 @@ void StartStopVehicle(const Vehicle *v, bool texteffect)
 }
 
 /** Checks whether the vehicle may be refitted at the moment.*/
-static bool IsVehicleRefitable(const Vehicle *v)
+static bool IsVehicleRefittable(const Vehicle *v)
 {
 	if (!v->IsStoppedInDepot()) return false;
 
@@ -3079,11 +3079,11 @@ public:
 	{
 		const Vehicle *v = Vehicle::Get(this->window_number);
 		bool is_localcompany = v->owner == _local_company;
-		bool refitable_and_stopped_in_depot = IsVehicleRefitable(v);
+		bool refittable_and_stopped_in_depot = IsVehicleRefittable(v);
 
 		this->SetWidgetDisabledState(WID_VV_RENAME, !is_localcompany);
 		this->SetWidgetDisabledState(WID_VV_GOTO_DEPOT, !is_localcompany);
-		this->SetWidgetDisabledState(WID_VV_REFIT, !refitable_and_stopped_in_depot || !is_localcompany);
+		this->SetWidgetDisabledState(WID_VV_REFIT, !refittable_and_stopped_in_depot || !is_localcompany);
 		this->SetWidgetDisabledState(WID_VV_CLONE, !is_localcompany);
 
 		if (v->type == VEH_TRAIN) {

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -141,7 +141,7 @@ std::optional<std::string_view> VideoDriver_Cocoa::Initialize()
 /**
  * Set dirty a rectangle managed by a cocoa video subdriver.
  * @param left Left x cooordinate of the dirty rectangle.
- * @param top Uppder y coordinate of the dirty rectangle.
+ * @param top Upper y coordinate of the dirty rectangle.
  * @param width Width of the dirty rectangle.
  * @param height Height of the dirty rectangle.
  */

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1065,7 +1065,7 @@ static void DrawTileHighlightType(const TileInfo *ti, TileHighlightType tht)
 }
 
 /**
- * Highlights tiles insede local authority of selected towns.
+ * Highlights tiles inside local authority of selected towns.
  * @param *ti TileInfo Tile that is being drawn
  */
 static void HighlightTownLocalAuthorityTiles(const TileInfo *ti)
@@ -1104,7 +1104,7 @@ static void HighlightTownLocalAuthorityTiles(const TileInfo *ti)
  */
 static void DrawTileSelection(const TileInfo *ti)
 {
-	/* Highlight tiles insede local authority of selected towns. */
+	/* Highlight tiles inside local authority of selected towns. */
 	HighlightTownLocalAuthorityTiles(ti);
 
 	/* Draw a red error square? */
@@ -1590,7 +1590,7 @@ static void ViewportSortParentSprites(ParentSpriteToSortVector *psdv)
 	 * adding extra fields to ParentSpriteToDraw structure.
 	 */
 	const uint32_t ORDER_COMPARED = UINT32_MAX; // Sprite was compared but we still need to compare the ones preceding it
-	const uint32_t ORDER_RETURNED = UINT32_MAX - 1; // Makr sorted sprite in case there are other occurrences of it in the stack
+	const uint32_t ORDER_RETURNED = UINT32_MAX - 1; // Mark sorted sprite in case there are other occurrences of it in the stack
 	std::stack<ParentSpriteToDraw *> sprite_order;
 	uint32_t next_order = 0;
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1169,7 +1169,7 @@ void NWidgetCore::SetString(StringID string)
 
 /**
  * Set string and tool tip of the nested widget.
- * @param stringThe new string.
+ * @param string The new string.
  * @param tool_tip The new tool_tip.
  */
 void NWidgetCore::SetStringTip(StringID string, StringID tool_tip)
@@ -3397,7 +3397,7 @@ std::unique_ptr<NWidgetBase> MakeNWidgets(std::span<const NWidgetPart> nwid_part
  * between the title bar and the window body if the first widget in the parts array looks like a title bar (it is a horizontal
  * container with a caption widget) and has a shade box widget.
  * @param nwid_parts Span of nested widget parts.
- * @param[out] shade_select Pointer to the inserted shade selection widget (\c nullptr if not unserted).
+ * @param[out] shade_select Pointer to the inserted shade selection widget (\c nullptr if not inserted).
  * @return Root of the nested widget tree, a vertical container containing the entire GUI.
  * @ingroup NestedWidgetParts
  */

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -541,7 +541,7 @@ public:
 
 	void AdjustPaddingForZoom() override;
 	void SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip_post);
-	void SetPIPRatio(uint8_t pip_ratio_pre, uint8_t pip_ratio_inter, uint8_t pip_rato_post);
+	void SetPIPRatio(uint8_t pip_ratio_pre, uint8_t pip_ratio_inter, uint8_t pip_ratio_post);
 
 protected:
 	NWidContainerFlags flags{}; ///< Flags of the container.

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -706,7 +706,7 @@ static void DispatchLeftClickEvent(Window *w, int x, int y, int click_count)
 				int dx = (w->resize.step_width  == 0) ? 0 : def_width  - w->width;
 				int dy = (w->resize.step_height == 0) ? 0 : def_height - w->height;
 				/* dx and dy has to go by step.. calculate it.
-				 * The cast to int is necessary else dx/dy are implicitly casted to unsigned int, which won't work. */
+				 * The cast to int is necessary else dx/dy are implicitly cast to unsigned int, which won't work. */
 				if (w->resize.step_width  > 1) dx -= dx % (int)w->resize.step_width;
 				if (w->resize.step_height > 1) dy -= dy % (int)w->resize.step_height;
 				ResizeWindow(w, dx, dy, false);
@@ -996,7 +996,7 @@ void Window::ReInit(int rx, int ry, bool reposition)
 	int dx = (this->resize.step_width  == 0) ? 0 : window_width  - this->width;
 	int dy = (this->resize.step_height == 0) ? 0 : window_height - this->height;
 	/* dx and dy has to go by step.. calculate it.
-	 * The cast to int is necessary else dx/dy are implicitly casted to unsigned int, which won't work. */
+	 * The cast to int is necessary else dx/dy are implicitly cast to unsigned int, which won't work. */
 	if (this->resize.step_width  > 1) dx -= dx % (int)this->resize.step_width;
 	if (this->resize.step_height > 1) dy -= dy % (int)this->resize.step_height;
 
@@ -1490,7 +1490,7 @@ void Window::FindWindowPlacementAndResize(int def_width, int def_height, bool al
 			int enlarge_y = std::max(std::min(def_height - this->height, free_height   - this->height), 0);
 
 			/* X and Y has to go by step.. calculate it.
-			 * The cast to int is necessary else x/y are implicitly casted to
+			 * The cast to int is necessary else x/y are implicitly cast to
 			 * unsigned int, which won't work. */
 			if (this->resize.step_width  > 1) enlarge_x -= enlarge_x % (int)this->resize.step_width;
 			if (this->resize.step_height > 1) enlarge_y -= enlarge_y % (int)this->resize.step_height;
@@ -2066,7 +2066,7 @@ static void EnsureVisibleCaption(Window *w, int nx, int ny)
  * Resize the window.
  * Update all the widgets of a window based on their resize flags
  * Both the areas of the old window and the new sized window are set dirty
- * ensuring proper redrawal.
+ * ensuring proper redrawing.
  * @param w       Window to resize
  * @param delta_x Delta x-size of changed window (positive if larger, etc.)
  * @param delta_y Delta y-size of changed window
@@ -2266,7 +2266,7 @@ static EventState HandleWindowDragging()
 			}
 
 			/* X and Y has to go by step.. calculate it.
-			 * The cast to int is necessary else x/y are implicitly casted to
+			 * The cast to int is necessary else x/y are implicitly cast to
 			 * unsigned int, which won't work. */
 			if (w->resize.step_width  > 1) x -= x % (int)w->resize.step_width;
 			if (w->resize.step_height > 1) y -= y % (int)w->resize.step_height;
@@ -2293,7 +2293,7 @@ static EventState HandleWindowDragging()
 				_drag_delta.x += x;
 			}
 
-			/* ResizeWindow sets both pre- and after-size to dirty for redrawal */
+			/* ResizeWindow sets both pre- and after-size to dirty for redrawing */
 			ResizeWindow(w, x, y);
 			return ES_HANDLED;
 		}
@@ -2377,7 +2377,7 @@ static void HandleScrollbarScrolling(Window *w)
 }
 
 /**
- * Handle active widget (mouse draggin on widget) with the mouse.
+ * Handle active widget (mouse dragging on widget) with the mouse.
  * @return State of handling the event.
  */
 static EventState HandleActiveWidget()


### PR DESCRIPTION
## Motivation / Problem

Well, typos/spelling mistakes like 'compamy' or 'sation` in the code.


## Description

One commit for typos in string names.
One commit for typos in function/variable/constant names.
One commit for typos in comments and strings.


## Limitations

Could break some external applications, if check for specific strings. Specifically: "This class is not instantiatable", "Failed to inititialise the XAudio2 engine" or "Client::Receive_SERVER_MOVE(): client_id={}, comapny_id={}".

Left a lot of US vs UK spelling aside, and I likely have missed a lot of mistakes. But I'm not intending this to be complete, but rather a step in the right direction.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
