### PR TITLE
Fix #14278, ccd586a7: [Script] Don't set members inside operator new()

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqapi.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqapi.cpp
@@ -58,7 +58,7 @@ HSQUIRRELVM sq_open(SQInteger initialstacksize)
 	SQVM *v;
 	sq_new(ss, SQSharedState);
 	v = (SQVM *)SQ_MALLOC(sizeof(SQVM));
-	new (v) SQVM(ss);
+	new (v, sizeof(SQVM)) SQVM(ss);
 	ss->_root_vm = v;
 	if(v->Init(nullptr, initialstacksize)) {
 		return v;
@@ -76,7 +76,7 @@ HSQUIRRELVM sq_newthread(HSQUIRRELVM friendvm, SQInteger initialstacksize)
 	ss=_ss(friendvm);
 
 	v= (SQVM *)SQ_MALLOC(sizeof(SQVM));
-	new (v) SQVM(ss);
+	new (v, sizeof(SQVM)) SQVM(ss);
 
 	if(v->Init(friendvm, initialstacksize)) {
 		friendvm->Push(v);

--- a/src/3rdparty/squirrel/squirrel/sqarray.h
+++ b/src/3rdparty/squirrel/squirrel/sqarray.h
@@ -13,7 +13,7 @@ private:
 public:
 	static SQArray* Create(SQSharedState *ss,SQInteger nInitialSize){
 		SQArray *newarray=(SQArray*)SQ_MALLOC(sizeof(SQArray));
-		new (newarray) SQArray(ss,nInitialSize);
+		new (newarray, sizeof(SQArray)) SQArray(ss,nInitialSize);
 		return newarray;
 	}
 #ifndef NO_GARBAGE_COLLECTOR

--- a/src/3rdparty/squirrel/squirrel/sqclass.h
+++ b/src/3rdparty/squirrel/squirrel/sqclass.h
@@ -34,7 +34,7 @@ struct SQClass : public CHAINABLE_OBJ
 public:
 	static SQClass* Create(SQSharedState *ss,SQClass *base) {
 		SQClass *newclass = (SQClass *)SQ_MALLOC(sizeof(SQClass));
-		new (newclass) SQClass(ss, base);
+		new (newclass, sizeof(SQClass)) SQClass(ss, base);
 		return newclass;
 	}
 	~SQClass();
@@ -90,7 +90,7 @@ public:
 
 		SQInteger size = calcinstancesize(theclass);
 		SQInstance *newinst = (SQInstance *)SQ_MALLOC(size);
-		new (newinst) SQInstance(ss, theclass,size);
+		new (newinst, size) SQInstance(ss, theclass,size);
 		if(theclass->_udsize) {
 			newinst->_userpointer = ((unsigned char *)newinst) + (size - theclass->_udsize);
 		}
@@ -100,7 +100,7 @@ public:
 	{
 		SQInteger size = calcinstancesize(_class);
 		SQInstance *newinst = (SQInstance *)SQ_MALLOC(size);
-		new (newinst) SQInstance(ss, this,size);
+		new (newinst, size) SQInstance(ss, this,size);
 		if(_class->_udsize) {
 			newinst->_userpointer = ((unsigned char *)newinst) + (size - _class->_udsize);
 		}

--- a/src/3rdparty/squirrel/squirrel/sqclosure.h
+++ b/src/3rdparty/squirrel/squirrel/sqclosure.h
@@ -11,7 +11,7 @@ private:
 public:
 	static SQClosure *Create(SQSharedState *ss,SQFunctionProto *func){
 		SQClosure *nc=(SQClosure*)SQ_MALLOC(sizeof(SQClosure));
-		new (nc) SQClosure(ss,func);
+		new (nc, sizeof(SQClosure)) SQClosure(ss,func);
 		return nc;
 	}
 	void Release() override {
@@ -49,7 +49,7 @@ private:
 public:
 	static SQGenerator *Create(SQSharedState *ss,SQClosure *closure){
 		SQGenerator *nc=(SQGenerator*)SQ_MALLOC(sizeof(SQGenerator));
-		new (nc) SQGenerator(ss,closure);
+		new (nc, sizeof(SQGenerator)) SQGenerator(ss,closure);
 		return nc;
 	}
 	~SQGenerator()
@@ -85,7 +85,7 @@ public:
 	static SQNativeClosure *Create(SQSharedState *ss,SQFUNCTION func)
 	{
 		SQNativeClosure *nc=(SQNativeClosure*)SQ_MALLOC(sizeof(SQNativeClosure));
-		new (nc) SQNativeClosure(ss,func);
+		new (nc, sizeof(SQNativeClosure)) SQNativeClosure(ss,func);
 		return nc;
 	}
 	SQNativeClosure *Clone()

--- a/src/3rdparty/squirrel/squirrel/sqfuncproto.h
+++ b/src/3rdparty/squirrel/squirrel/sqfuncproto.h
@@ -99,8 +99,9 @@ public:
 	{
 		SQFunctionProto *f;
 		//I compact the whole class and members in a single memory allocation
-		f = (SQFunctionProto *)sq_vm_malloc(_FUNC_SIZE(ninstructions,nliterals,nparameters,nfunctions,noutervalues,nlineinfos,nlocalvarinfos,ndefaultparams));
-		new (f) SQFunctionProto(ninstructions, nliterals, nparameters, nfunctions, noutervalues, nlineinfos, nlocalvarinfos, ndefaultparams);
+		SQInteger size = _FUNC_SIZE(ninstructions, nliterals, nparameters, nfunctions, noutervalues, nlineinfos, nlocalvarinfos, ndefaultparams);
+		f = (SQFunctionProto *)sq_vm_malloc(size);
+		new (f, size) SQFunctionProto(ninstructions, nliterals, nparameters, nfunctions, noutervalues, nlineinfos, nlocalvarinfos, ndefaultparams);
 		return f;
 	}
 	void Release() override {

--- a/src/3rdparty/squirrel/squirrel/sqobject.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqobject.cpp
@@ -91,7 +91,8 @@ SQUnsignedInteger TranslateIndex(const SQObjectPtr &idx)
 SQWeakRef *SQRefCounted::GetWeakRef(SQObjectType type)
 {
 	if(!_weakref) {
-		sq_new(_weakref,SQWeakRef);
+		_weakref = (SQWeakRef *)sq_vm_malloc(sizeof(SQWeakRef));
+		new (_weakref, sizeof(SQWeakRef)) SQWeakRef();
 		_weakref->_obj._type = type;
 		_weakref->_obj._unVal.pRefCounted = this;
 	}

--- a/src/3rdparty/squirrel/squirrel/sqobject.h
+++ b/src/3rdparty/squirrel/squirrel/sqobject.h
@@ -64,22 +64,19 @@ struct SQRefCounted
 	virtual void Release()=0;
 
 	/* Placement new/delete to prevent memory leaks if constructor throws an exception. */
-	inline void *operator new(size_t size, SQRefCounted *place)
+	inline void *operator new([[maybe_unused]] size_t size, void *ptr, [[maybe_unused]] size_t real_size)
 	{
-		place->size = size;
-		return place;
+		assert(size <= real_size);
+		return ptr;
 	}
 
-	inline void operator delete(void *ptr, SQRefCounted *place)
+	inline void operator delete(void *ptr, void *, size_t real_size)
 	{
-		SQ_FREE(ptr, place->size);
+		SQ_FREE(ptr, real_size);
 	}
 
 	/* Never used but required. */
 	inline void operator delete(void *) { NOT_REACHED(); }
-
-private:
-	size_t size = 0;
 };
 
 struct SQWeakRef : SQRefCounted

--- a/src/3rdparty/squirrel/squirrel/sqstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqstate.cpp
@@ -553,7 +553,7 @@ SQString *SQStringTable::Add(std::string_view new_string)
 	}
 
 	SQString *t=(SQString *)SQ_MALLOC(len+sizeof(SQString));
-	new (t) SQString(new_string);
+	new (t, len+sizeof(SQString)) SQString(new_string);
 	t->_next = _strings[slot];
 	_strings[slot] = t;
 	_slotused++;

--- a/src/3rdparty/squirrel/squirrel/sqtable.h
+++ b/src/3rdparty/squirrel/squirrel/sqtable.h
@@ -46,7 +46,7 @@ public:
 	static SQTable* Create(SQSharedState *ss,SQInteger nInitialSize)
 	{
 		SQTable *newtable = (SQTable*)SQ_MALLOC(sizeof(SQTable));
-		new (newtable) SQTable(ss, nInitialSize);
+		new (newtable, sizeof(SQTable)) SQTable(ss, nInitialSize);
 		newtable->_delegate = nullptr;
 		return newtable;
 	}

--- a/src/3rdparty/squirrel/squirrel/squserdata.h
+++ b/src/3rdparty/squirrel/squirrel/squserdata.h
@@ -14,7 +14,7 @@ struct SQUserData : SQDelegable
 	static SQUserData* Create(SQSharedState *ss, SQInteger size)
 	{
 		SQUserData* ud = (SQUserData*)SQ_MALLOC(sizeof(SQUserData)+(size-1));
-		new (ud) SQUserData(ss, size);
+		new (ud, sizeof(SQUserData)+(size-1)) SQUserData(ss, size);
 		return ud;
 	}
 #ifndef NO_GARBAGE_COLLECTOR


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
#9589 tried to prevent memory leaks when constructor of a squirrel object throws, but it does it by setting a member of the object inside `operator new()` while the object as not yet been constructed (clearly a bad idea).
Also the "stored" size was the size of the to be constructed object, not the size of the allocated space for the object, so it could still leak.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Pass the allocated size as an extra parameter of placement new.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
