### PR TITLE
Codechange: Remove redundant data members from YAPF ship node.

### DIFF
--- a/src/pathfinder/yapf/yapf_node_ship.hpp
+++ b/src/pathfinder/yapf/yapf_node_ship.hpp
@@ -16,19 +16,8 @@
 #include "yapf_node.hpp"
 
 /** Yapf Node for ships */
-template <class Tkey_>
-struct CYapfShipNodeT : CYapfNodeT<Tkey_, CYapfShipNodeT<Tkey_>> {
-	typedef CYapfNodeT<Tkey_, CYapfShipNodeT<Tkey_>> base;
-
-	TileIndex segment_last_tile;
-	Trackdir segment_last_td;
-
-	void Set(CYapfShipNodeT *parent, TileIndex tile, Trackdir td, bool is_choice)
-	{
-		this->base::Set(parent, tile, td, is_choice);
-		this->segment_last_tile = tile;
-		this->segment_last_td   = td;
-	}
+template <class TKey>
+struct CYapfShipNodeT : CYapfNodeT<TKey, CYapfShipNodeT<TKey>> {
 };
 
 /* now define two major node types (that differ by key type) */

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -72,7 +72,7 @@ public:
 	/** Called by YAPF to detect if node ends in the desired destination. */
 	inline bool PfDetectDestination(Node &n)
 	{
-		return this->PfDetectDestinationTile(n.segment_last_tile, n.segment_last_td);
+		return this->PfDetectDestinationTile(n.GetTile(), n.GetTrackdir());
 	}
 
 	inline bool PfDetectDestinationTile(TileIndex tile, Trackdir trackdir)
@@ -101,7 +101,7 @@ public:
 			return true;
 		}
 
-		n.estimate = n.cost + OctileDistanceCost(n.segment_last_tile, n.segment_last_td, destination_tile);
+		n.estimate = n.cost + OctileDistanceCost(n.GetTile(), n.GetTrackdir(), destination_tile);
 		assert(n.estimate >= n.parent->estimate);
 		return true;
 	}


### PR DESCRIPTION
## Motivation / Problem

The YAPF ship node stores tile and trackdir data twice, in the node key and in the node data members itself. This is redundant and confusing.

## Description

Removed the redundant data members from the YAPF ship node.

## Limitations

I don't really agree with storing any data in the node key other than the key itself, but that's the way YAPF does things. Changing that is much more involved and outside the scope of this PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
