### PR TITLE
Change: Removed disable_node_optimization YAPF setting

### DIFF
--- a/src/pathfinder/yapf/yapf_node_rail.hpp
+++ b/src/pathfinder/yapf/yapf_node_rail.hpp
@@ -110,9 +110,8 @@ struct CYapfRailSegment {
 };
 
 /** Yapf Node for rail YAPF */
-template <class Tkey_>
-struct CYapfRailNodeT : CYapfNodeT<Tkey_, CYapfRailNodeT<Tkey_>> {
-	typedef CYapfNodeT<Tkey_, CYapfRailNodeT<Tkey_>> base;
+struct CYapfRailNode : CYapfNodeT<CYapfNodeKeyTrackDir, CYapfRailNode> {
+	typedef CYapfNodeT<CYapfNodeKeyTrackDir, CYapfRailNode> base;
 	typedef CYapfRailSegment CachedData;
 
 	CYapfRailSegment *segment;
@@ -128,7 +127,7 @@ struct CYapfRailNodeT : CYapfNodeT<Tkey_, CYapfRailNodeT<Tkey_>> {
 	SignalType last_red_signal_type;
 	SignalType last_signal_type;
 
-	inline void Set(CYapfRailNodeT *parent, TileIndex tile, Trackdir td, bool is_choice)
+	inline void Set(CYapfRailNode *parent, TileIndex tile, Trackdir td, bool is_choice)
 	{
 		this->base::Set(parent, tile, td, is_choice);
 		this->segment = nullptr;
@@ -206,12 +205,6 @@ struct CYapfRailNodeT : CYapfNodeT<Tkey_, CYapfRailNodeT<Tkey_>> {
 	}
 };
 
-/* now define two major node types (that differ by key type) */
-typedef CYapfRailNodeT<CYapfNodeKeyExitDir>  CYapfRailNodeExitDir;
-typedef CYapfRailNodeT<CYapfNodeKeyTrackDir> CYapfRailNodeTrackDir;
-
-/* Default NodeList types */
-typedef NodeList<CYapfRailNodeExitDir , 8, 10> CRailNodeListExitDir;
-typedef NodeList<CYapfRailNodeTrackDir, 8, 10> CRailNodeListTrackDir;
+typedef NodeList<CYapfRailNode, 8, 10> CRailNodeList;
 
 #endif /* YAPF_NODE_RAIL_HPP */

--- a/src/pathfinder/yapf/yapf_node_road.hpp
+++ b/src/pathfinder/yapf/yapf_node_road.hpp
@@ -16,14 +16,13 @@
 #include "yapf_node.hpp"
 
 /** Yapf Node for road YAPF */
-template <class Tkey_>
-struct CYapfRoadNodeT : CYapfNodeT<Tkey_, CYapfRoadNodeT<Tkey_>> {
-	typedef CYapfNodeT<Tkey_, CYapfRoadNodeT<Tkey_>> base;
+struct CYapfRoadNode : CYapfNodeT<CYapfNodeKeyExitDir, CYapfRoadNode> {
+	typedef CYapfNodeT<CYapfNodeKeyExitDir, CYapfRoadNode> base;
 
 	TileIndex segment_last_tile;
 	Trackdir segment_last_td;
 
-	void Set(CYapfRoadNodeT *parent, TileIndex tile, Trackdir td, bool is_choice)
+	void Set(CYapfRoadNode *parent, TileIndex tile, Trackdir td, bool is_choice)
 	{
 		this->base::Set(parent, tile, td, is_choice);
 		this->segment_last_tile = tile;
@@ -31,12 +30,6 @@ struct CYapfRoadNodeT : CYapfNodeT<Tkey_, CYapfRoadNodeT<Tkey_>> {
 	}
 };
 
-/* now define two major node types (that differ by key type) */
-typedef CYapfRoadNodeT<CYapfNodeKeyExitDir>  CYapfRoadNodeExitDir;
-typedef CYapfRoadNodeT<CYapfNodeKeyTrackDir> CYapfRoadNodeTrackDir;
-
-/* Default NodeList types */
-typedef NodeList<CYapfRoadNodeExitDir , 8, 10> CRoadNodeListExitDir;
-typedef NodeList<CYapfRoadNodeTrackDir, 8, 10> CRoadNodeListTrackDir;
+typedef NodeList<CYapfRoadNode, 8, 10> CRoadNodeList;
 
 #endif /* YAPF_NODE_ROAD_HPP */

--- a/src/pathfinder/yapf/yapf_node_ship.hpp
+++ b/src/pathfinder/yapf/yapf_node_ship.hpp
@@ -16,16 +16,9 @@
 #include "yapf_node.hpp"
 
 /** Yapf Node for ships */
-template <class TKey>
-struct CYapfShipNodeT : CYapfNodeT<TKey, CYapfShipNodeT<TKey>> {
+struct CYapfShipNode : CYapfNodeT<CYapfNodeKeyExitDir, CYapfShipNode> {
 };
 
-/* now define two major node types (that differ by key type) */
-typedef CYapfShipNodeT<CYapfNodeKeyExitDir>  CYapfShipNodeExitDir;
-typedef CYapfShipNodeT<CYapfNodeKeyTrackDir> CYapfShipNodeTrackDir;
-
-/* Default NodeList types */
-typedef NodeList<CYapfShipNodeExitDir , 10, 12> CShipNodeListExitDir;
-typedef NodeList<CYapfShipNodeTrackDir, 10, 12> CShipNodeListTrackDir;
+typedef NodeList<CYapfShipNode, 10, 12> CShipNodeList;
 
 #endif /* YAPF_NODE_SHIP_HPP */

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -528,13 +528,13 @@ public:
 	}
 };
 
-template <class Tpf_, class Ttrack_follower, class Tnode_list, template <class Types> class TdestinationT, template <class Types> class TfollowT>
+template <class Tpf_, class Ttrack_follower, template <class Types> class TdestinationT, template <class Types> class TfollowT>
 struct CYapfRail_TypesT {
-	typedef CYapfRail_TypesT<Tpf_, Ttrack_follower, Tnode_list, TdestinationT, TfollowT>  Types;
+	typedef CYapfRail_TypesT<Tpf_, Ttrack_follower, TdestinationT, TfollowT>  Types;
 
 	typedef Tpf_                                Tpf;
 	typedef Ttrack_follower                     TrackFollower;
-	typedef Tnode_list                          NodeList;
+	typedef CRailNodeList                       NodeList;
 	typedef Train                               VehicleType;
 	typedef CYapfBaseT<Types>                   PfBase;
 	typedef TfollowT<Types>                     PfFollow;
@@ -544,21 +544,21 @@ struct CYapfRail_TypesT {
 	typedef CYapfCostRailT<Types>               PfCost;
 };
 
-struct CYapfRail1         : CYapfT<CYapfRail_TypesT<CYapfRail1        , CFollowTrackRail    , CRailNodeListTrackDir, CYapfDestinationTileOrStationRailT, CYapfFollowRailT>> {};
-struct CYapfRail2         : CYapfT<CYapfRail_TypesT<CYapfRail2        , CFollowTrackRailNo90, CRailNodeListTrackDir, CYapfDestinationTileOrStationRailT, CYapfFollowRailT>> {};
+struct CYapfRail         : CYapfT<CYapfRail_TypesT<CYapfRail        , CFollowTrackRail    , CYapfDestinationTileOrStationRailT, CYapfFollowRailT>> {};
+struct CYapfRailNo90     : CYapfT<CYapfRail_TypesT<CYapfRailNo90    , CFollowTrackRailNo90, CYapfDestinationTileOrStationRailT, CYapfFollowRailT>> {};
 
-struct CYapfAnyDepotRail1 : CYapfT<CYapfRail_TypesT<CYapfAnyDepotRail1, CFollowTrackRail    , CRailNodeListTrackDir, CYapfDestinationAnyDepotRailT     , CYapfFollowAnyDepotRailT>> {};
-struct CYapfAnyDepotRail2 : CYapfT<CYapfRail_TypesT<CYapfAnyDepotRail2, CFollowTrackRailNo90, CRailNodeListTrackDir, CYapfDestinationAnyDepotRailT     , CYapfFollowAnyDepotRailT>> {};
+struct CYapfAnyDepotRail     : CYapfT<CYapfRail_TypesT<CYapfAnyDepotRail,     CFollowTrackRail    , CYapfDestinationAnyDepotRailT     , CYapfFollowAnyDepotRailT>> {};
+struct CYapfAnyDepotRailNo90 : CYapfT<CYapfRail_TypesT<CYapfAnyDepotRailNo90, CFollowTrackRailNo90, CYapfDestinationAnyDepotRailT     , CYapfFollowAnyDepotRailT>> {};
 
-struct CYapfAnySafeTileRail1 : CYapfT<CYapfRail_TypesT<CYapfAnySafeTileRail1, CFollowTrackFreeRail    , CRailNodeListTrackDir, CYapfDestinationAnySafeTileRailT , CYapfFollowAnySafeTileRailT>> {};
-struct CYapfAnySafeTileRail2 : CYapfT<CYapfRail_TypesT<CYapfAnySafeTileRail2, CFollowTrackFreeRailNo90, CRailNodeListTrackDir, CYapfDestinationAnySafeTileRailT , CYapfFollowAnySafeTileRailT>> {};
+struct CYapfAnySafeTileRail     : CYapfT<CYapfRail_TypesT<CYapfAnySafeTileRail    , CFollowTrackFreeRail    , CYapfDestinationAnySafeTileRailT , CYapfFollowAnySafeTileRailT>> {};
+struct CYapfAnySafeTileRailNo90 : CYapfT<CYapfRail_TypesT<CYapfAnySafeTileRailNo90, CFollowTrackFreeRailNo90, CYapfDestinationAnySafeTileRailT , CYapfFollowAnySafeTileRailT>> {};
 
 
 Track YapfTrainChooseTrack(const Train *v, TileIndex tile, DiagDirection enterdir, TrackBits tracks, bool &path_found, bool reserve_track, PBSTileInfo *target, TileIndex *dest)
 {
 	Trackdir td_ret = _settings_game.pf.forbid_90_deg
-		? CYapfRail2::stChooseRailTrack(v, tile, enterdir, tracks, path_found, reserve_track, target, dest)
-		: CYapfRail1::stChooseRailTrack(v, tile, enterdir, tracks, path_found, reserve_track, target, dest);
+		? CYapfRailNo90::stChooseRailTrack(v, tile, enterdir, tracks, path_found, reserve_track, target, dest)
+		: CYapfRail::stChooseRailTrack(v, tile, enterdir, tracks, path_found, reserve_track, target, dest);
 
 	return (td_ret != INVALID_TRACKDIR) ? TrackdirToTrack(td_ret) : FindFirstTrack(tracks);
 }
@@ -610,8 +610,8 @@ bool YapfTrainCheckReverse(const Train *v)
 	if (reverse_penalty == 0) reverse_penalty = 1;
 
 	bool reverse = _settings_game.pf.forbid_90_deg
-		? CYapfRail2::stCheckReverseTrain(v, tile, td, tile_rev, td_rev, reverse_penalty)
-		: CYapfRail1::stCheckReverseTrain(v, tile, td, tile_rev, td_rev, reverse_penalty);
+		? CYapfRailNo90::stCheckReverseTrain(v, tile, td, tile_rev, td_rev, reverse_penalty)
+		: CYapfRail::stCheckReverseTrain(v, tile, td, tile_rev, td_rev, reverse_penalty);
 
 	return reverse;
 }
@@ -625,15 +625,15 @@ FindDepotData YapfTrainFindNearestDepot(const Train *v, int max_penalty)
 	Trackdir td_rev = ReverseTrackdir(last_veh->GetVehicleTrackdir());
 
 	return _settings_game.pf.forbid_90_deg
-		? CYapfAnyDepotRail2::stFindNearestDepotTwoWay(v, origin.tile, origin.trackdir, last_tile, td_rev, max_penalty, YAPF_INFINITE_PENALTY)
-		: CYapfAnyDepotRail1::stFindNearestDepotTwoWay(v, origin.tile, origin.trackdir, last_tile, td_rev, max_penalty, YAPF_INFINITE_PENALTY);
+		? CYapfAnyDepotRailNo90::stFindNearestDepotTwoWay(v, origin.tile, origin.trackdir, last_tile, td_rev, max_penalty, YAPF_INFINITE_PENALTY)
+		: CYapfAnyDepotRail::stFindNearestDepotTwoWay(v, origin.tile, origin.trackdir, last_tile, td_rev, max_penalty, YAPF_INFINITE_PENALTY);
 }
 
 bool YapfTrainFindNearestSafeTile(const Train *v, TileIndex tile, Trackdir td, bool override_railtype)
 {
 	return _settings_game.pf.forbid_90_deg
-		? CYapfAnySafeTileRail2::stFindNearestSafeTile(v, tile, td, override_railtype)
-		: CYapfAnySafeTileRail1::stFindNearestSafeTile(v, tile, td, override_railtype);
+		? CYapfAnySafeTileRailNo90::stFindNearestSafeTile(v, tile, td, override_railtype)
+		: CYapfAnySafeTileRail::stFindNearestSafeTile(v, tile, td, override_railtype);
 }
 
 /** if any track changes, this counter is incremented - that will invalidate segment cost cache */

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -485,13 +485,13 @@ public:
 	}
 };
 
-template <class Tpf_, class Tnode_list, template <class Types> class Tdestination>
+template <class Tpf_, template <class Types> class Tdestination>
 struct CYapfRoad_TypesT {
-	typedef CYapfRoad_TypesT<Tpf_, Tnode_list, Tdestination>  Types;
+	typedef CYapfRoad_TypesT<Tpf_, Tdestination>  Types;
 
 	typedef Tpf_                              Tpf;
 	typedef CFollowTrackRoad                  TrackFollower;
-	typedef Tnode_list                        NodeList;
+	typedef CRoadNodeList                     NodeList;
 	typedef RoadVehicle                       VehicleType;
 	typedef CYapfBaseT<Types>                 PfBase;
 	typedef CYapfFollowRoadT<Types>           PfFollow;
@@ -501,18 +501,13 @@ struct CYapfRoad_TypesT {
 	typedef CYapfCostRoadT<Types>             PfCost;
 };
 
-struct CYapfRoad1         : CYapfT<CYapfRoad_TypesT<CYapfRoad1        , CRoadNodeListTrackDir, CYapfDestinationTileRoadT>> {};
-struct CYapfRoad2         : CYapfT<CYapfRoad_TypesT<CYapfRoad2        , CRoadNodeListExitDir , CYapfDestinationTileRoadT>> {};
+struct CYapfRoad : CYapfT<CYapfRoad_TypesT<CYapfRoad, CYapfDestinationTileRoadT>> {};
 
-struct CYapfRoadAnyDepot1 : CYapfT<CYapfRoad_TypesT<CYapfRoadAnyDepot1, CRoadNodeListTrackDir, CYapfDestinationAnyDepotRoadT>> {};
-struct CYapfRoadAnyDepot2 : CYapfT<CYapfRoad_TypesT<CYapfRoadAnyDepot2, CRoadNodeListExitDir , CYapfDestinationAnyDepotRoadT>> {};
-
+struct CYapfRoadAnyDepot : CYapfT<CYapfRoad_TypesT<CYapfRoadAnyDepot, CYapfDestinationAnyDepotRoadT>> {};
 
 Trackdir YapfRoadVehicleChooseTrack(const RoadVehicle *v, TileIndex tile, DiagDirection enterdir, TrackdirBits trackdirs, bool &path_found, RoadVehPathCache &path_cache)
 {
-	Trackdir td_ret = _settings_game.pf.yapf.disable_node_optimization
-		? CYapfRoad1::stChooseRoadTrack(v, tile, enterdir, path_found, path_cache) // Trackdir
-		: CYapfRoad2::stChooseRoadTrack(v, tile, enterdir, path_found, path_cache); // ExitDir, allow 90-deg
+	Trackdir td_ret = CYapfRoad::stChooseRoadTrack(v, tile, enterdir, path_found, path_cache);
 
 	return (td_ret != INVALID_TRACKDIR) ? td_ret : (Trackdir)FindFirstBit(trackdirs);
 }
@@ -526,7 +521,5 @@ FindDepotData YapfRoadVehicleFindNearestDepot(const RoadVehicle *v, int max_dist
 		return FindDepotData();
 	}
 
-	return _settings_game.pf.yapf.disable_node_optimization
-		? CYapfRoadAnyDepot1::stFindNearestDepot(v, tile, trackdir, max_distance) // Trackdir
-		: CYapfRoadAnyDepot2::stFindNearestDepot(v, tile, trackdir, max_distance); // ExitDir
+	return CYapfRoadAnyDepot::stFindNearestDepot(v, tile, trackdir, max_distance);
 }

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -398,13 +398,13 @@ public:
  * Config struct of YAPF for ships.
  * Defines all 6 base YAPF modules as classes providing services for CYapfBaseT.
  */
-template <class Tpf_, class Ttrack_follower, class Tnode_list>
+template <class Tpf_>
 struct CYapfShip_TypesT {
-	typedef CYapfShip_TypesT<Tpf_, Ttrack_follower, Tnode_list>  Types;         ///< Shortcut for this struct type.
-	typedef Tpf_                                                 Tpf;           ///< Pathfinder type.
-	typedef Ttrack_follower                                      TrackFollower; ///< Track follower helper class.
-	typedef Tnode_list                                           NodeList;
-	typedef Ship                                                 VehicleType;
+	typedef CYapfShip_TypesT<Tpf_> Types;         ///< Shortcut for this struct type.
+	typedef Tpf_                   Tpf;           ///< Pathfinder type.
+	typedef CFollowTrackWater      TrackFollower; ///< Track follower helper class.
+	typedef CShipNodeList          NodeList;
+	typedef Ship                   VehicleType;
 
 	/** Pathfinder components (modules). */
 	typedef CYapfBaseT<Types>                 PfBase;        ///< Base pathfinder class.
@@ -415,7 +415,7 @@ struct CYapfShip_TypesT {
 	typedef CYapfCostShipT<Types>             PfCost;        ///< Cost provider.
 };
 
-struct CYapfShip : CYapfT<CYapfShip_TypesT<CYapfShip, CFollowTrackWater, CShipNodeListExitDir>> {
+struct CYapfShip : CYapfT<CYapfShip_TypesT<CYapfShip>> {
 	explicit CYapfShip(int max_nodes) { this->max_search_nodes = max_nodes; }
 };
 

--- a/src/saveload/compat/settings_sl_compat.h
+++ b/src/saveload/compat/settings_sl_compat.h
@@ -185,7 +185,7 @@ const SaveLoadCompat _settings_sl_compat[] = {
 	SLC_NULL(4, SLV_47, SLV_TABLE_CHUNKS),
 	SLC_NULL(8, SLV_130, SLV_TABLE_CHUNKS),
 	SLC_NULL(4, SLV_131, SLV_TABLE_CHUNKS),
-	SLC_VAR("pf.yapf.disable_node_optimization"),
+	SLC_NULL(1, SLV_28, SLV_TABLE_CHUNKS),
 	SLC_VAR("pf.yapf.max_search_nodes"),
 	SLC_VAR("pf.yapf.rail_firstred_twoway_eol"),
 	SLC_VAR("pf.yapf.rail_firstred_penalty"),

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -431,7 +431,6 @@ struct ScriptSettings {
 
 /** Settings related to the yet another pathfinder. */
 struct YAPFSettings {
-	bool   disable_node_optimization;        ///< whether to use exit-dir instead of trackdir in node key
 	uint32_t max_search_nodes;                 ///< stop path-finding when this number of nodes visited
 	uint32_t maximum_go_to_depot_penalty;      ///< What is the maximum penalty that may be endured for going to a depot
 	uint32_t road_slope_penalty;               ///< penalty for up-hill slope

--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -98,12 +98,6 @@ min      = 1
 max      = 255
 cat      = SC_EXPERT
 
-[SDT_BOOL]
-var      = pf.yapf.disable_node_optimization
-from     = SLV_28
-def      = false
-cat      = SC_EXPERT
-
 [SDT_VAR]
 var      = pf.yapf.max_search_nodes
 type     = SLE_UINT


### PR DESCRIPTION
## Motivation / Problem

For a long time (pre-2008) we've had a setting to disable node optimization in YAPF. This is off by default (meaning optimization is on), and survey summaries show that either 0% or <0.1% of players changes this setting. This includes JGRPP.

With node optimization on (the default), YAPF considers a tile  + exit dir (whether a vehicle exits from the NE, NW, SE or SW side) to determine if a pathfinder node is unique. With optimization disabled it considers the tile + trackdir to determine if a node is unique. With 4 diagdirs vs 12 trackdirs we potentially get 3 times the amount of pathfinder nodes which will impact performance. 

There are certain niche cases where this could lead to a slightly sub-optimal path, but not enough to be bothersome according to our survey results. Note that the setting only applies to road vehicles. It used to apply to ships as well, but that was removed as part of the development of the new ship pathfinder (#10543).

Contrary to most other settings, this one has quite an impact on code since it introduces the need for additional templating and other logic / code bulk. YAPF code is already heavily templated and difficult to understand, cleaning up some of that mess helps with maintainability.

## Description

Removed the disable_node_optimization setting and removed some of the template clutter that was no longer required.

## Limitations

Technically we are taking away user freedom, and removing settings is always a touchy subject.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
