### PR TITLE
Codechange: Shuffle MusicSongInfo members to reduce alignment padding.

### DIFF
--- a/src/base_media_music.h
+++ b/src/base_media_music.h
@@ -33,14 +33,14 @@ enum MusicTrackType : uint8_t {
 
 /** Metadata about a music track. */
 struct MusicSongInfo {
-	std::string songname;    ///< name of song displayed in UI
-	uint8_t tracknr;            ///< track number of song displayed in UI
-	std::string filename;    ///< file on disk containing song (when used in MusicSet class)
+	std::string songname; ///< name of song displayed in UI
+	std::string filename; ///< file on disk containing song (when used in MusicSet class)
+	int cat_index; ///< entry index in CAT file, for filetype==MTT_MPSMIDI
+	int override_start; ///< MIDI ticks to skip over in beginning
+	int override_end; ///< MIDI tick to end the song at (0 if no override)
+	uint8_t tracknr; ///< track number of song displayed in UI
 	MusicTrackType filetype; ///< decoder required for song file
-	int cat_index;           ///< entry index in CAT file, for filetype==MTT_MPSMIDI
-	bool loop;               ///< song should play in a tight loop if possible, never ending
-	int override_start;      ///< MIDI ticks to skip over in beginning
-	int override_end;        ///< MIDI tick to end the song at (0 if no override)
+	bool loop; ///< song should play in a tight loop if possible, never ending
 };
 
 template <> struct BaseSetTraits<struct MusicSet> {

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -39,8 +39,8 @@
 
 struct MusicSystem {
 	struct PlaylistEntry : MusicSongInfo {
-		const MusicSet *set;  ///< music set the song comes from
-		uint set_index;        ///< index of song in set
+		const MusicSet *set; ///< music set the song comes from
+		uint set_index; ///< index of song in set
 
 		PlaylistEntry(const MusicSet *set, uint set_index) : MusicSongInfo(set->songinfo[set_index]), set(set), set_index(set_index) { }
 		bool IsValid() const { return !this->songname.empty(); }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Gaps in `MusicSongInfo` struct due to member padding.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Shuffle members to reduce padding, saving around 16 bytes (of originally 96 bytes.)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
