### PR TITLE
Change: Add lock penalty to ship pathfinder.

### DIFF
--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -388,6 +388,13 @@ public:
 		uint8_t speed_frac = (GetEffectiveWaterClass(n.GetTile()) == WATER_CLASS_SEA) ? svi->ocean_speed_frac : svi->canal_speed_frac;
 		if (speed_frac > 0) c += YAPF_TILE_LENGTH * (1 + tf->tiles_skipped) * speed_frac / (256 - speed_frac);
 
+		/* Lock penalty. */
+		if (IsTileType(n.GetTile(), MP_WATER) && IsLock(n.GetTile()) && GetLockPart(n.GetTile()) == LOCK_PART_MIDDLE) {
+			const uint canal_speed = svi->ApplyWaterClassSpeedFrac(svi->max_speed, false);
+			/* Cost is proportional to the vehicle's speed as the vehicle stops in the lock. */
+			c += (TILE_HEIGHT * YAPF_TILE_LENGTH * canal_speed) / 128;
+		}
+
 		/* Apply it. */
 		n.cost = n.parent->cost + c;
 		return true;


### PR DESCRIPTION
## Motivation / Problem

Locks slow down ships significantly, but the ship pathfinder doesn't include them in the cost calculation.

I got inspiration for this from a recent Master Hellish video about ships. There was this part about locks: https://youtu.be/PCGLg9qpv1Q?si=j66eVzdDKZ2ihrgF&t=1494

## Description

A ship has to come to a full stop in order to go up or down a lock. The faster the ship the more impact this has. In addition the ship needs to come back up to speed which generally takes longer for faster ships. So I made the cost proportional to the canal speed. I didn't feel a need to include acceleration and make it an exact science.

I compared two ships of the same type, one going through locks and another one taking a detour of a certain amount of tiles. I did this for some slow and fast ships and ended up with the magic divide-by-16 value.

## Limitations

This only applies to the low-level ship pathfinder and therefore only has a local effect. The high-level pathfinder uses an abstraction of the water world and can't take locks (or any low-level details for that matter) into account. So the ship might still end up taking a path with many locks where taking a large detour would technically be quicker. That's the nature of a two-tiered pathfinder: fast but inaccurate sometimes.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
