### PR TITLE
Cleanup 3ac1a2f1e4: Don't load/save a train's railtypes property.

### DIFF
--- a/src/saveload/compat/vehicle_sl_compat.h
+++ b/src/saveload/compat/vehicle_sl_compat.h
@@ -100,7 +100,7 @@ const SaveLoadCompat _vehicle_train_sl_compat[] = {
 	SLC_VAR("common"),
 	SLC_VAR("crash_anim_pos"),
 	SLC_VAR("force_proceed"),
-	SLC_VAR("railtype"),
+	SLC_NULL(1, SL_MIN_VERSION, SLV_ENGINE_MULTI_RAILTYPE),
 	SLC_VAR("track"),
 	SLC_VAR("flags"),
 	SLC_NULL(2, SLV_2, SLV_60),

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1060,13 +1060,12 @@ static bool LoadOldCompany(LoadgameState &ls, int num)
 static uint32_t _old_order_ptr;
 static uint16_t _old_next_ptr;
 static typename VehicleID::BaseType _current_vehicle_id;
-static RailType _old_railtype;
 
 static const OldChunks vehicle_train_chunk[] = {
 	OCL_SVAR(  OC_UINT8, Train, track ),
 	OCL_SVAR(  OC_UINT8, Train, force_proceed ),
 	OCL_SVAR( OC_UINT16, Train, crash_anim_pos ),
-	OCL_VAR (  OC_UINT8, 1, &_old_railtype),
+	OCL_NULL( 1 ), // railtype
 
 	OCL_NULL( 5 ), ///< Junk
 
@@ -1306,8 +1305,6 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 					};
 					if (v->spritenum / 2 >= lengthof(spriteset_rail)) return false;
 					v->spritenum = spriteset_rail[v->spritenum / 2]; // adjust railway sprite set offset
-					/* Should be the original values for monorail / rail, can't use RailType constants */
-					Train::From(v)->railtypes = static_cast<RailType>(type == 0x25 ? 1 : 0);
 					break;
 				}
 
@@ -1367,10 +1364,6 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 			if (v->index != _current_vehicle_id) {
 				Debug(oldloader, 0, "Loading failed - vehicle-array is invalid");
 				return false;
-			}
-
-			if (v->type == VEH_TRAIN) {
-				Train::From(v)->railtypes = _old_railtype;
 			}
 		}
 

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -793,16 +793,12 @@ public:
 	}
 };
 
-static RailType _old_railtype;
-
 class SlVehicleTrain : public DefaultSaveLoadHandler<SlVehicleTrain, Vehicle> {
 public:
 	static inline const SaveLoad description[] = {
 		 SLEG_STRUCT("common", SlVehicleCommon),
 		     SLE_VAR(Train, crash_anim_pos,      SLE_UINT16),
 		     SLE_VAR(Train, force_proceed,       SLE_UINT8),
-		SLEG_CONDVAR("railtype", _old_railtype,  SLE_UINT8, SL_MIN_VERSION, SLV_ENGINE_MULTI_RAILTYPE),
-			 SLE_VAR(Train, railtypes,           SLE_UINT64),
 		     SLE_VAR(Train, track,               SLE_UINT8),
 
 		 SLE_CONDVAR(Train, flags,               SLE_FILE_U8  | SLE_VAR_U16,   SLV_2,  SLV_100),
@@ -822,10 +818,6 @@ public:
 	{
 		if (v->type != VEH_TRAIN) return;
 		SlObject(v, this->GetLoadDescription());
-
-		if (IsSavegameVersionBefore(SLV_ENGINE_MULTI_RAILTYPE)) {
-			Train::From(v)->railtypes = _old_railtype;
-		}
 	}
 
 	void FixPointers(Vehicle *v) const override


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

#14357 changed savegame storage for a `Train`'s `railtype` property to `railtypes` as a 64-bit value, and added saveload conversion.

However, the `railtypes` property is force set from the `Engine`'s `RailVehicleInfo` during load for old savegames before save version 24, and is always set later in the saveload process by a call to `Train::ConsistChanged()` in `AfterLoadVehiclesPhase2`.

Therefore I don't think this property needs to be loaded or saved in games.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove saveload of a `Train`'s `railtypes` and associated conversion code.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
