### PR TITLE
Fix 4eaeccd: FioRemove should return false if the file does not exist.

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -328,9 +328,12 @@ bool FioRemove(const std::string &filename)
 {
 	std::filesystem::path path = OTTD2FS(filename);
 	std::error_code error_code;
-	std::filesystem::remove(path, error_code);
-	if (error_code) {
-		Debug(misc, 0, "Removing {} failed: {}", filename, error_code.message());
+	if (!std::filesystem::remove(path, error_code)) {
+		if (error_code) {
+			Debug(misc, 0, "Removing {} failed: {}", filename, error_code.message());
+		} else {
+			Debug(misc, 0, "Removing {} failed: file does not exist", filename);
+		}
 		return false;
 	}
 	return true;


### PR DESCRIPTION
## Motivation / Problem

FioRemove returns true even if the file doesn't exist. IMO that shouldn't silently be ignored.

## Description

According to cppreference std::filesystem::remove returns false if the file doesn't exist. No error code is set in such a case, so we need to handle that case separately.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
