### PR TITLE
Change: Ask for confirmation before deleting a savegame / scenario / heightmap.

### DIFF
--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -349,6 +349,21 @@ private:
 		if (confirmed) _switch_mode = SM_SAVE_HEIGHTMAP;
 	}
 
+	static void DeleteFileConfirmationCallback(Window *window, bool confirmed)
+	{
+		auto *save_load_window = static_cast<SaveLoadWindow*>(window);
+
+		if (confirmed) {
+			if (!FiosDelete(save_load_window->filename_editbox.text.GetText())) {
+				ShowErrorMessage(GetEncodedString(STR_ERROR_UNABLE_TO_DELETE_FILE), {}, WL_ERROR);
+			} else {
+				save_load_window->InvalidateData(SLIWD_RESCAN_FILES);
+				/* Reset file name to current date on successful delete */
+				if (save_load_window->abstract_filetype == FT_SAVEGAME) save_load_window->GenerateFileName();
+			}
+		}
+	}
+
 public:
 
 	/** Generate a default save filename. */
@@ -806,31 +821,22 @@ public:
 		if (this->fop != SLO_SAVE) return;
 
 		if (this->IsWidgetLowered(WID_SL_DELETE_SELECTION)) { // Delete button clicked
-			if (!FiosDelete(this->filename_editbox.text.GetText())) {
-				ShowErrorMessage(GetEncodedString(STR_ERROR_UNABLE_TO_DELETE_FILE), {}, WL_ERROR);
-			} else {
-				this->InvalidateData(SLIWD_RESCAN_FILES);
-				/* Reset file name to current date on successful delete */
-				if (this->abstract_filetype == FT_SAVEGAME) GenerateFileName();
-			}
+			ShowQuery(GetEncodedString(STR_SAVELOAD_DELETE_TITLE), GetEncodedString(STR_SAVELOAD_DELETE_WARNING),
+					this, SaveLoadWindow::DeleteFileConfirmationCallback);
 		} else if (this->IsWidgetLowered(WID_SL_SAVE_GAME)) { // Save button clicked
 			if (this->abstract_filetype == FT_SAVEGAME || this->abstract_filetype == FT_SCENARIO) {
 				_file_to_saveload.name = FiosMakeSavegameName(this->filename_editbox.text.GetText());
 				if (FioCheckFileExists(_file_to_saveload.name, Subdirectory::SAVE_DIR)) {
-					ShowQuery(
-						GetEncodedString(STR_SAVELOAD_OVERWRITE_TITLE),
-						GetEncodedString(STR_SAVELOAD_OVERWRITE_WARNING),
-						this, SaveLoadWindow::SaveGameConfirmationCallback);
+					ShowQuery(GetEncodedString(STR_SAVELOAD_OVERWRITE_TITLE), GetEncodedString(STR_SAVELOAD_OVERWRITE_WARNING),
+							this, SaveLoadWindow::SaveGameConfirmationCallback);
 				} else {
 					_switch_mode = SM_SAVE_GAME;
 				}
 			} else {
 				_file_to_saveload.name = FiosMakeHeightmapName(this->filename_editbox.text.GetText());
 				if (FioCheckFileExists(_file_to_saveload.name, Subdirectory::SAVE_DIR)) {
-					ShowQuery(
-						GetEncodedString(STR_SAVELOAD_OVERWRITE_TITLE),
-						GetEncodedString(STR_SAVELOAD_OVERWRITE_WARNING),
-						this, SaveLoadWindow::SaveHeightmapConfirmationCallback);
+					ShowQuery(GetEncodedString(STR_SAVELOAD_OVERWRITE_TITLE), GetEncodedString(STR_SAVELOAD_OVERWRITE_WARNING),
+							this, SaveLoadWindow::SaveHeightmapConfirmationCallback);
 				} else {
 					_switch_mode = SM_SAVE_HEIGHTMAP;
 				}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3348,6 +3348,8 @@ STR_SAVELOAD_DETAIL_GRFSTATUS                                   :{SILVER}NewGRF:
 STR_SAVELOAD_FILTER_TITLE                                       :{BLACK}Filter:
 STR_SAVELOAD_OVERWRITE_TITLE                                    :{WHITE}Overwrite File
 STR_SAVELOAD_OVERWRITE_WARNING                                  :{YELLOW}Are you sure you want to overwrite the existing file?
+STR_SAVELOAD_DELETE_TITLE                                       :{WHITE}Delete File
+STR_SAVELOAD_DELETE_WARNING                                     :{YELLOW}Are you sure you want to delete the file?
 STR_SAVELOAD_DIRECTORY                                          :{RAW_STRING} (Directory)
 STR_SAVELOAD_PARENT_DIRECTORY                                   :{RAW_STRING} (Parent directory)
 


### PR DESCRIPTION
## Motivation / Problem

I wanted to save a game and had an existing file selected, not one that I wanted to overwrite. I then accidentally clicked the Delete button instead of the Save button, and the file was deleted without any warning. The file I lost was just a test save, but it would have sucked to lose an important file this way.

We ask the user if they want to overwrite an existing file, so it would make sense to do the same when they want to delete a file.

## Description

Ask the user for confirmation prior to deleting the file. This applies to deleting savegames, scenarios and heightmaps.

## Limitations

This was a bit of a me-problem, but not entirely unlikely to happen to others when running low on caffeine.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
