### PR TITLE
Fix #14620: Use full file path when deleting files.

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -230,16 +230,6 @@ std::string FiosMakeHeightmapName(std::string_view name)
 	return FiosMakeFilename(_fios_path, name, fmt::format(".{}", GetCurrentScreenshotExtension()));
 }
 
-/**
- * Delete a file.
- * @param name Filename to delete.
- * @return Whether the file deletion was successful.
- */
-bool FiosDelete(std::string_view name)
-{
-	return FioRemove(FiosMakeSavegameName(name));
-}
-
 typedef std::tuple<FiosType, std::string> FiosGetTypeAndNameProc(SaveLoadOperation fop, std::string_view filename, std::string_view ext);
 
 /**

--- a/src/fios.h
+++ b/src/fios.h
@@ -112,7 +112,6 @@ bool FiosBrowseTo(const FiosItem *item);
 
 std::string FiosGetCurrentPath();
 std::optional<uint64_t> FiosGetDiskFreeSpace(const std::string &path);
-bool FiosDelete(std::string_view name);
 std::string FiosMakeHeightmapName(std::string_view name);
 std::string FiosMakeSavegameName(std::string_view name);
 

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -327,13 +327,13 @@ private:
 	QueryString filename_editbox; ///< Filename editbox.
 	AbstractFileType abstract_filetype{}; /// Type of file to select.
 	SaveLoadOperation fop{}; ///< File operation to perform.
-	FileList fios_items{}; ///< Save game list.
+	FileList fios_items{}; ///< Item list.
 	FiosItem o_dir{}; ///< Original dir (home dir for this browser)
-	const FiosItem *selected = nullptr; ///< Selected game in #fios_items, or \c nullptr.
+	const FiosItem *selected = nullptr; ///< Selected item in #fios_items, or \c nullptr.
 	const FiosItem *highlighted = nullptr; ///< Item in fios_items highlighted by mouse pointer, or \c nullptr.
 	Scrollbar *vscroll = nullptr;
 
-	StringFilter string_filter{}; ///< Filter for available games.
+	StringFilter string_filter{}; ///< Filter for available items.
 	QueryString filter_editbox; ///< Filter editbox;
 	std::vector<FiosItem *> display_list{}; ///< Filtered display list
 
@@ -353,8 +353,10 @@ private:
 	{
 		auto *save_load_window = static_cast<SaveLoadWindow*>(window);
 
+		assert(save_load_window->selected != nullptr);
+
 		if (confirmed) {
-			if (!FiosDelete(save_load_window->filename_editbox.text.GetText())) {
+			if (!FioRemove(save_load_window->selected->name)) {
 				ShowErrorMessage(GetEncodedString(STR_ERROR_UNABLE_TO_DELETE_FILE), {}, WL_ERROR);
 			} else {
 				save_load_window->InvalidateData(SLIWD_RESCAN_FILES);
@@ -909,6 +911,8 @@ public:
 				/* Selection changes */
 				if (!gui_scope) break;
 
+				if (this->fop == SLO_SAVE) this->SetWidgetDisabledState(WID_SL_DELETE_SELECTION, this->selected == nullptr);
+
 				if (this->fop != SLO_LOAD) break;
 
 				switch (this->abstract_filetype) {
@@ -946,6 +950,11 @@ public:
 		if (wid == WID_SL_FILTER) {
 			this->string_filter.SetFilterTerm(this->filter_editbox.text.GetText());
 			this->InvalidateData(SLIWD_FILTER_CHANGES);
+		}
+
+		if (wid == WID_SL_SAVE_OSK_TITLE) {
+			this->selected = nullptr;
+			this->InvalidateData(SLIWD_SELECTION_CHANGES);
 		}
 	}
 };


### PR DESCRIPTION
## Motivation / Problem

#14620 

## Description

The current implementation assumes the file to be deleted is either a .sav or .scn file. This works for savegames and scenarios but fails for heightmaps (typically .png), and other file types we might add in the future.

The currently selected item holds a full path to the file, so I've used that path to delete the file. This takes away need to make assumptions about the file path. It does mean the Delete button should only be clicked when something is selected, so the button is automatically enabled/disabled.

## Limitations

Changing the text in the lower textbox clears the current selection if there is one. If you then change the text back to a file that exist then it won't automatically select it. IMO it's not really something that is necessary.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
