### PR TITLE
Change: Determine automatic interface scale by window size.

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1325,6 +1325,10 @@ void ScreenSizeChanged()
 
 	/* screen size changed and the old bitmap is invalid now, so we don't want to undraw it */
 	_cursor.visible = false;
+
+	if (VideoDriver::GetInstance() != nullptr) {
+		if (AdjustGUIZoom(true)) ReInitAllWindows(true);
+	}
 }
 
 void UndrawMouseCursor()
@@ -1785,7 +1789,12 @@ void UpdateGUIZoom()
 {
 	/* Determine real GUI zoom to use. */
 	if (_gui_scale_cfg == -1) {
-		_gui_scale = VideoDriver::GetInstance()->GetSuggestedUIScale();
+		/* Minimum design size of the game is 640x480. */
+		float xs = _screen.width / 640.f;
+		float ys = _screen.height / 480.f;
+		int scale = std::min(xs, ys) * 100;
+		/* Round down scaling to 25% increments and clamp to limits. */
+		_gui_scale = Clamp((scale / 25) * 25, MIN_INTERFACE_SCALE, MAX_INTERFACE_SCALE);
 	} else {
 		_gui_scale = Clamp(_gui_scale_cfg, MIN_INTERFACE_SCALE, MAX_INTERFACE_SCALE);
 	}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -417,10 +417,11 @@ struct GameOptionsWindow : Window {
 
 	GameSettings *opt = nullptr;
 	bool reload = false;
+	bool gui_scale_changed = false;
 	int gui_scale = 0;
 	static inline WidgetID active_tab = WID_GO_TAB_GENERAL;
 
-	GameOptionsWindow(WindowDesc &desc) : Window(desc), filter_editbox(50), gui_scale(_gui_scale)
+	GameOptionsWindow(WindowDesc &desc) : Window(desc), filter_editbox(50)
 	{
 		this->opt = &GetGameSettings();
 
@@ -453,6 +454,7 @@ struct GameOptionsWindow : Window {
 	void OnInit() override
 	{
 		_setting_circle_size = maxdim(GetSpriteSize(SPR_CIRCLE_FOLDED), GetSpriteSize(SPR_CIRCLE_UNFOLDED));
+		this->gui_scale = _gui_scale;
 	}
 
 	void Close([[maybe_unused]] int data = 0) override
@@ -1057,7 +1059,16 @@ struct GameOptionsWindow : Window {
 #endif /* HAS_TRUETYPE_FONT */
 
 			case WID_GO_GUI_SCALE:
+				/* Any click on the slider deactivates automatic interface scaling, setting it to the current value before being adjusted. */
+				if (_gui_scale_cfg == -1) {
+					_gui_scale_cfg = this->gui_scale;
+					this->SetWidgetLoweredState(WID_GO_GUI_SCALE_AUTO, false);
+					this->SetWidgetDirty(WID_GO_GUI_SCALE_AUTO);
+					this->SetWidgetDirty(WID_GO_GUI_SCALE_AUTO_TEXT);
+				}
+
 				if (ClickSliderWidget(this->GetWidget<NWidgetBase>(widget)->GetCurrentRect(), pt, MIN_INTERFACE_SCALE, MAX_INTERFACE_SCALE, _ctrl_pressed ? 0 : SCALE_NMARKS, this->gui_scale)) {
+					this->gui_scale_changed = true;
 					this->SetWidgetDirty(widget);
 				}
 
@@ -1383,8 +1394,9 @@ struct GameOptionsWindow : Window {
 
 	void OnMouseLoop() override
 	{
-		if (_left_button_down || this->gui_scale == _gui_scale) return;
+		if (_left_button_down || !this->gui_scale_changed) return;
 
+		this->gui_scale_changed = false;
 		_gui_scale_cfg = this->gui_scale;
 
 		if (AdjustGUIZoom(false)) {

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -64,7 +64,6 @@ protected:
 	bool buffer_locked; ///< Video buffer was locked by the main thread.
 
 	Dimension GetScreenSize() const override;
-	float GetDPIScale() override;
 	void InputLoop() override;
 	bool LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -283,12 +283,6 @@ Dimension VideoDriver_Cocoa::GetScreenSize() const
 	return { static_cast<uint>(NSWidth(frame)), static_cast<uint>(NSHeight(frame)) };
 }
 
-/** Get DPI scale of our window. */
-float VideoDriver_Cocoa::GetDPIScale()
-{
-	return this->cocoaview != nil ? [ this->cocoaview getContentsScale ] : 1.0f;
-}
-
 /** Lock video buffer for drawing if it isn't already mapped. */
 bool VideoDriver_Cocoa::LockVideoBuffer()
 {

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -166,16 +166,6 @@ public:
 		return {};
 	}
 
-	/**
-	 * Get a suggested default GUI scale taking screen DPI into account.
-	 */
-	virtual int GetSuggestedUIScale()
-	{
-		float dpi_scale = this->GetDPIScale();
-
-		return Clamp(dpi_scale * 100, MIN_INTERFACE_SCALE, MAX_INTERFACE_SCALE);
-	}
-
 	virtual std::string_view GetInfoString() const
 	{
 		return this->GetName();
@@ -232,12 +222,6 @@ protected:
 	 * Get the resolution of the main screen.
 	 */
 	virtual Dimension GetScreenSize() const { return { DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT }; }
-
-	/**
-	 * Get DPI scaling factor of the screen OTTD is displayed on.
-	 * @return 1.0 for default platform DPI, > 1.0 for higher DPI values, and < 1.0 for smaller DPI values.
-	 */
-	virtual float GetDPIScale() { return 1.0f; }
 
 	/**
 	 * Apply resolution auto-detection and clamp to sensible defaults.

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -49,7 +49,6 @@ protected:
 	bool buffer_locked;     ///< Video buffer was locked by the main thread.
 
 	Dimension GetScreenSize() const override;
-	float GetDPIScale() override;
 	void InputLoop() override;
 	bool LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

OpenTTD's interface is pretty small compared to any modern game.

While we do have built-in interface scaling, the default for this is to use OS-provided interface scaling. But this has a couple of problems:

* It doesn't exist for Linux, only Windows and mac OS.
* On a supported platform, it relies on the user having configured that platform to use interface scaling. However, this often is not needed because the UI of the OS itself is larger than OpenTTD's UI.

So most players first experience of the game will be at 1x interface scaling, resulting in tiny text and tiny icons and tiny buttons.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace OS-dependent interface scaling with scaling dependent on the window size. The scaling ratio is determined by the size of the window relative to the minimum supported window size.

This works on all platforms and should provide a more comfortable experience for new players.

Manual interface scale setting works as before.

<img width="660" height="535" alt="image" src="https://github.com/user-attachments/assets/7af78c96-c157-4e0e-834d-81924bb68c7a" />
<img width="1044" height="823" alt="image" src="https://github.com/user-attachments/assets/9623f2d9-8db7-4035-aec6-a5e9de7bd43f" />
<img width="1940" height="1135" alt="image" src="https://github.com/user-attachments/assets/dd97c47a-589c-467e-8dbd-4624854d4784" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/6c7feca7-4c40-4aef-9d4e-6e756027ad22" />


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
