### PR TITLE
Feature: Scale cargo payment aging rate

### DIFF
--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -356,4 +356,29 @@ constexpr uint64_t PowerOfTen(int power)
 
 uint32_t IntSqrt(uint32_t num);
 
+/**
+ * Scale a number by the required percentage.
+ *
+ * Calculation is performed in the type U of the num parameter.
+ * The result is clamped to the limits of type T if needed.
+ *
+ * @param num The number to scale.
+ * @param percentage The percentage value. 100% = don't scale.
+ * @return The number scaled by the percentage value.
+ */
+template <typename T, typename U>
+constexpr T ScaleByPercentage(U num, uint16_t percentage)
+{
+	U scaled;
+	/* We might not need to do anything. */
+	if (percentage == 100) {
+		scaled = num;
+	} else {
+		scaled = (num * static_cast<U>(percentage)) / 100;
+	}
+
+	/* Make sure the value fits resulting type T. */
+	return ClampTo<T>(scaled);
+}
+
 #endif /* MATH_FUNC_HPP */

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -959,6 +959,9 @@ Money GetTransportedGoodsIncome(uint num_pieces, uint dist, uint16_t transit_per
 		return 0;
 	}
 
+	/* Scale transit periods according to the game setting. We also pass this scaled value to the NewGRF callback. */
+	transit_periods = ScaleByPercentage<uint16_t, uint32_t>(transit_periods, _settings_game.economy.cargo_aging_rate);
+
 	/* Use callback to calculate cargo profit, if available */
 	if (cs->callback_mask.Test(CargoCallbackMask::ProfitCalc)) {
 		uint32_t var18 = ClampTo<uint16_t>(dist) | (ClampTo<uint8_t>(num_pieces) << 16) | (ClampTo<uint8_t>(transit_periods) << 24);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1563,6 +1563,12 @@ STR_CONFIG_SETTING_INDUSTRY_CARGO_SCALE                         :Scale industry 
 STR_CONFIG_SETTING_INDUSTRY_CARGO_SCALE_HELPTEXT                :Scale the cargo production of industries by this percentage
 STR_CONFIG_SETTING_CARGO_SCALE_VALUE                            :{NUM}%
 
+STR_CONFIG_SETTING_CARGO_AGING_RATE                             :Scale cargo payment aging rate: {STRING2}
+STR_CONFIG_SETTING_CARGO_AGING_RATE_HELPTEXT                    :Adjust how quickly cargo loaded on a vehicle decreases in value over time
+STR_CONFIG_SETTING_CARGO_AGING_RATE_VALUE                       :{NUM}%
+###setting-zero-is-special
+STR_CONFIG_SETTING_CARGO_AGING_RATE_ZERO                        :No decay
+
 STR_CONFIG_SETTING_AUTORENEW_VEHICLE                            :Autorenew vehicle when it gets old: {STRING2}
 STR_CONFIG_SETTING_AUTORENEW_VEHICLE_HELPTEXT                   :When enabled, a vehicle nearing its end of life gets automatically replaced when the renew conditions are fulfilled
 

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -717,6 +717,7 @@ SettingsContainer &GetSettingsTree()
 			accounting->Add(new SettingEntry("economy.infrastructure_maintenance"));
 			accounting->Add(new SettingEntry("difficulty.vehicle_costs"));
 			accounting->Add(new SettingEntry("difficulty.construction_cost"));
+			accounting->Add(new SettingEntry("economy.cargo_aging_rate"));
 		}
 
 		SettingsPage *vehicles = main->Add(new SettingsPage(STR_CONFIG_SETTING_VEHICLES));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -610,6 +610,7 @@ struct EconomySettings {
 	uint16_t minutes_per_calendar_year; ///< minutes per calendar year. Special value 0 means that calendar time is frozen.
 	uint16_t town_cargo_scale; ///< scale cargo production of towns by this percentage.
 	uint16_t industry_cargo_scale; ///< scale cargo production of industries by this percentage.
+	uint8_t cargo_aging_rate; ///< scale the delivery time factor of cargo delivery payments by this percentage.
 	uint16_t town_min_distance; ///< minimum distance between towns.
 };
 

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -372,3 +372,17 @@ str      = STR_CONFIG_SETTING_INDUSTRY_CARGO_SCALE
 strhelp  = STR_CONFIG_SETTING_INDUSTRY_CARGO_SCALE_HELPTEXT
 strval   = STR_CONFIG_SETTING_CARGO_SCALE_VALUE
 cat      = SC_BASIC
+
+[SDT_VAR]
+var      = economy.cargo_aging_rate
+type     = SLE_UINT8
+flags    = SettingFlag::GuiZeroIsSpecial, SettingFlag::NoNetwork
+def      = 100
+min      = 0
+max      = 250
+interval = 10
+str      = STR_CONFIG_SETTING_CARGO_AGING_RATE
+strhelp  = STR_CONFIG_SETTING_CARGO_AGING_RATE_HELPTEXT
+strval   = STR_CONFIG_SETTING_CARGO_AGING_RATE_VALUE
+cat      = SC_EXPERT
+post_cb  = [](auto) { InvalidateWindowData(WC_PAYMENT_RATES, 0); }


### PR DESCRIPTION
## Motivation / Problem

I really like #11926, but it needs updating based on feedback, so I adopted it. From the original PR:

> In the aftermath of https://github.com/OpenTTD/OpenTTD/pull/10596, it has become apparent that certain players favor very lengthy routes. As a result, cargo profits, originally optimized for specific distances, do not align with every playstyle. Compounding the issue is that, in some cases (such as maglev), peak distances extend beyond the boundaries, even on a 4k*4k map. Before https://github.com/OpenTTD/OpenTTD/pull/10596, this situation was somewhat mitigated by the payment formula not being tailored for large distances, yielding some illogical income figures. However, a more comprehensive solution is now imperative.

>
> While a similar effect can be achieved through cargo aging in a newgrf, this property is associated with the vehicle, not the cargo. Expecting every vehicle newgrf to introduce a scaling parameter is unreasonable, and it doesn't address pure vanilla gameplay.

## Description

> Given that the desired optimal profit distance is a characteristic of playstyle and not directly correlated with map size, it cannot be automatically inferred. Therefore, this PR introduces a separate setting that scales time for payment calculations. Players who prefer longer distances can set the scaling below 100%, while those aiming to optimize for shorter distances can set it above 100%. There is also the option to set it to 0 for achieving "flat" payment rates, although the practicality of this is uncertain.
>
> [Screencast from 30-01-24 17:37:10.webm](https://github.com/OpenTTD/OpenTTD/assets/413570/eb2620f9-4c23-4382-8bd1-576ea2d2e019)

I have rewritten most of the strings and added a "zero is special" string for no decay.

Supersedes and closes #11926.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
