### PR TITLE
Feature: Alternate station rating algorithm

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1760,7 +1760,18 @@ static void LoadUnloadVehicle(Vehicle *front)
 
 		/* if last speed is 0, we treat that as if no vehicle has ever visited the station. */
 		ge->last_speed = ClampTo<uint8_t>(t);
-		ge->last_age = ClampTo<uint8_t>(TimerGameCalendar::year - front->build_year);
+
+		/* Value vehicle age based on the chosen station rating model. */
+		if (_settings_game.difficulty.station_rating_mode == SRM_IMPROVED) {
+			/* Only penalise vehicles old enough to need replacement (vehicle age, not model age). */
+			static const uint8_t MAX_RATING_AGE = 3; ///< The vehicle is old, penalise the rating by the maximum amount.
+			static const uint8_t NO_AGE_PENALTY = 0; ///< The vehicle is within its lifespan, do not penalise the rating.
+			bool old = front->age > front->max_age;
+			ge->last_age = old ? MAX_RATING_AGE : NO_AGE_PENALTY;
+		} else {
+			/* The original model has a steep dropoff for brand-new vehicles, store the actual age. */
+			ge->last_age = ClampTo<uint8_t>(TimerGameCalendar::year - front->build_year);
+		}
 
 		assert(v->cargo_cap >= v->cargo.StoredCount());
 		/* Capacity available for loading more cargo. */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1374,6 +1374,13 @@ STR_CONFIG_SETTING_CATCHMENT_HELPTEXT                           :Have differentl
 STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES                     :Company stations can serve industries with attached neutral stations: {STRING2}
 STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT            :When enabled, industries with attached stations (such as Oil Rigs) may also be served by company-owned stations built nearby. When disabled, these industries may only be served by their attached stations. Any nearby company stations won't be able to serve them, nor will the attached station serve anything else other than the industry
 
+STR_CONFIG_SETTING_STATION_RATING_MODE                          :Station rating calculation: {STRING2}
+STR_CONFIG_SETTING_STATION_RATING_MODE_HELPTEXT                 :Select the model for station ratings. The "original" model penalises slow vehicles, old vehicles, infrequent pickups, cargo waiting at the station, and whether the company has built a statue in the town. The "improved" model does other stuff ... TODO: finish writing this :)
+###length 3
+STR_CONFIG_SETTING_STATION_RATING_MODE_ORIGINAL                 :Original
+STR_CONFIG_SETTING_STATION_RATING_MODE_IMPROVED                 :Improved
+STR_CONFIG_SETTING_STATION_RATING_MODE_PERFECT                  :Perfect
+
 STR_CONFIG_SETTING_EXTRADYNAMITE                                :Allow removal of more town-owned roads, bridges and tunnels: {STRING2}
 STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT                       :Make it easier to remove town-owned infrastructure and buildings
 

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -819,6 +819,7 @@ SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("station.station_spread"));
 			limitations->Add(new SettingEntry("station.distant_join_stations"));
 			limitations->Add(new SettingEntry("station.modified_catchment"));
+			limitations->Add(new SettingEntry("difficulty.station_rating_mode"));
 			limitations->Add(new SettingEntry("construction.road_stop_on_town_road"));
 			limitations->Add(new SettingEntry("construction.road_stop_on_competitor_road"));
 			limitations->Add(new SettingEntry("construction.crossing_with_competitor"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -98,6 +98,13 @@ enum PlaceHouses : uint8_t {
 	PH_ALLOWED_CONSTRUCTED,
 };
 
+/** Possible values for the "station_rating_mode" setting. */
+enum StationRatingMode : uint8_t {
+	SRM_ORIGINAL = 0,
+	SRM_IMPROVED,
+	SRM_PERFECT,
+};
+
 /** Settings related to the difficulty of the game */
 struct DifficultySettings {
 	uint8_t competitor_start_time;            ///< Unused value, used to load old savegames.
@@ -122,6 +129,7 @@ struct DifficultySettings {
 	bool   disasters;                        ///< are disasters enabled
 	uint8_t town_council_tolerance;           ///< minimum required town ratings to be allowed to demolish stuff
 	bool   infinite_money;                   ///< whether spending money despite negative balance is allowed
+	uint8_t station_rating_mode;                 ///< the mode of station rating calculation
 };
 
 /** Settings relating to viewport/smallmap scrolling. */

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -495,11 +495,14 @@ void Station::RecomputeCatchment(bool no_clear_nearby_lists)
 
 	/* Loop finding all station tiles */
 	TileArea ta(TileXY(this->rect.left, this->rect.top), TileXY(this->rect.right, this->rect.bottom));
+	this->station_tiles = 0;
 	for (TileIndex tile : ta) {
 		if (!IsTileType(tile, MP_STATION) || GetStationIndex(tile) != this->index) continue;
 
 		uint r = GetTileCatchmentRadius(tile, this);
 		if (r == CA_NONE) continue;
+
+		this->station_tiles++;
 
 		/* This tile sub-loop doesn't need to test any tiles, they are simply added to the catchment set. */
 		TileArea ta2 = TileArea(tile, 1, 1).Expand(r);

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -22,6 +22,7 @@
 
 static const uint8_t INITIAL_STATION_RATING = 175;
 static const uint8_t MAX_STATION_RATING = 255;
+static const uint8_t STATION_SIZE_FACTOR = 10; ///< "Average" amount of station tiles for station rating calculations. "Game balance eh?"
 
 /**
  * Flow statistics telling how much flow should be sent along a link. This is
@@ -518,6 +519,7 @@ public:
 	IndustryType indtype = IT_INVALID; ///< Industry type to get the name from
 
 	BitmapTileArea catchment_tiles{}; ///< NOSAVE: Set of individual tiles covered by catchment area
+	uint station_tiles; ///< NOSAVE: Count of station tiles owned by this station
 
 	StationHadVehicleOfType had_vehicle_of_type{};
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4016,8 +4016,16 @@ static void UpdateStationRating(Station *st)
 			}
 
 			if (!skip) {
-				int b = ge->last_speed - 85;
-				if (b >= 0) rating += b >> 2;
+				/* Maybe consider the speed of the last vehicle. */
+				if (_settings_game.difficulty.station_rating_mode == SRM_IMPROVED) {
+					/* Don't consider vehicle speed at all. */
+					static const uint8_t MAX_SPEED_RATING_VALUE = 42; ///< Rating point value of the fastest possible vehicle.
+					rating += MAX_SPEED_RATING_VALUE;
+				} else {
+					/* Vehicle speed matters. */
+					int b = ge->last_speed - 85;
+					if (b >= 0) rating += b >> 2;
+				}
 
 				uint waittime = ge->time_since_pickup;
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4019,7 +4019,18 @@ static void UpdateStationRating(Station *st)
 				int b = ge->last_speed - 85;
 				if (b >= 0) rating += b >> 2;
 
-				uint8_t waittime = ge->time_since_pickup;
+				uint waittime = ge->time_since_pickup;
+
+				/* The cargo's time sensitivity might affect how much we care about wait time. */
+				if (_settings_game.difficulty.station_rating_mode == SRM_IMPROVED) {
+					/** Calculate sensitivity from the combination of the "time until penalty is applied" and "length of penalty interval."
+					 *  Scale the result to a suitable amount, so that passengers are 2.7 times more sensitive, while coal is 1/4 as sensitive as in TTD.
+					 */
+					const uint transit_sensitivity = std::max(1, cs->transit_periods[0] + cs->transit_periods[1]);
+					const uint WAIT_TIME_SCALAR = 32;
+					waittime = (waittime * WAIT_TIME_SCALAR) / transit_sensitivity;
+				}
+
 				if (st->last_vehicle_type == VEH_SHIP) waittime >>= 2;
 				if (waittime <= 21) rating += 25;
 				if (waittime <= 12) rating += 25;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4027,11 +4027,19 @@ static void UpdateStationRating(Station *st)
 				if (waittime <= 3) rating += 35;
 
 				rating -= 90;
-				if (ge->max_waiting_cargo <= 1500) rating += 55;
-				if (ge->max_waiting_cargo <= 1000) rating += 35;
-				if (ge->max_waiting_cargo <= 600) rating += 10;
-				if (ge->max_waiting_cargo <= 300) rating += 20;
-				if (ge->max_waiting_cargo <= 100) rating += 10;
+
+				/* The number of station tiles might affect rating drop for "too much waiting cargo." */
+				uint normalised_max_waiting_cargo = ge->max_waiting_cargo;
+				if (_settings_game.difficulty.station_rating_mode == SRM_IMPROVED) {
+					normalised_max_waiting_cargo *= STATION_SIZE_FACTOR;
+					if (st->station_tiles > 1) normalised_max_waiting_cargo /= st->station_tiles;
+				}
+
+				if (normalised_max_waiting_cargo <= 1500) rating += 55;
+				if (normalised_max_waiting_cargo <= 1000) rating += 35;
+				if (normalised_max_waiting_cargo <= 600) rating += 10;
+				if (normalised_max_waiting_cargo <= 300) rating += 20;
+				if (normalised_max_waiting_cargo <= 100) rating += 10;
 			}
 
 			if (Company::IsValidID(st->owner) && st->town->statues.Test(st->owner)) rating += 26;
@@ -4041,12 +4049,13 @@ static void UpdateStationRating(Station *st)
 			if (age < 2) rating += 10;
 			if (age < 1) rating += 13;
 
-			{
-				int or_ = ge->rating; // old rating
+			int or_ = ge->rating; // old rating
 
-				/* only modify rating in steps of -2, -1, 0, 1 or 2 */
-				ge->rating = rating = ClampTo<uint8_t>(or_ + Clamp(rating - or_, -2, 2));
+			/* only modify rating in steps of -2, -1, 0, 1 or 2 */
+			ge->rating = rating = ClampTo<uint8_t>(or_ + Clamp(rating - or_, -2, 2));
 
+			/* Original station rating removes random goods. */
+			if (_settings_game.difficulty.station_rating_mode == SRM_ORIGINAL) {
 				/* if rating is <= 64 and more than 100 items waiting on average per destination,
 				 * remove some random amount of goods from the station */
 				if (rating <= 64 && waiting_avg >= 100) {
@@ -4065,34 +4074,39 @@ static void UpdateStationRating(Station *st)
 						waiting_changed = true;
 					}
 				}
+			}
 
-				/* At some point we really must cap the cargo. Previously this
-				 * was a strict 4095, but now we'll have a less strict, but
-				 * increasingly aggressive truncation of the amount of cargo. */
-				static const uint WAITING_CARGO_THRESHOLD  = 1 << 12;
-				static const uint WAITING_CARGO_CUT_FACTOR = 1 <<  6;
-				static const uint MAX_WAITING_CARGO        = 1 << 15;
+			/* We also remove goods that are above a certain cap. */
+			static const uint WAITING_CARGO_THRESHOLD  = 1 << 12;
+			static const uint WAITING_CARGO_CUT_FACTOR = 1 <<  6;
+			static const uint MAX_WAITING_CARGO        = 1 << 15;
 
-				if (waiting > WAITING_CARGO_THRESHOLD) {
-					uint difference = waiting - WAITING_CARGO_THRESHOLD;
-					waiting -= (difference / WAITING_CARGO_CUT_FACTOR);
+			/* The number of station tiles might affect cargo truncation. */
+			uint normalised_waiting_cargo_threshold = WAITING_CARGO_THRESHOLD;
+			if (_settings_game.difficulty.station_rating_mode == SRM_IMPROVED) {
+				if (st->station_tiles > 1) normalised_waiting_cargo_threshold *= st->station_tiles;
+				normalised_waiting_cargo_threshold /= STATION_SIZE_FACTOR;
+			}
 
-					waiting = std::min(waiting, MAX_WAITING_CARGO);
-					waiting_changed = true;
-				}
+			if (waiting > normalised_waiting_cargo_threshold) {
+				const uint difference = waiting - normalised_waiting_cargo_threshold;
+				waiting -= (difference / WAITING_CARGO_CUT_FACTOR);
 
-				/* We can't truncate cargo that's already reserved for loading.
-				 * Thus StoredCount() here. */
-				if (waiting_changed && waiting < (ge->HasData() ? ge->GetData().cargo.AvailableCount() : 0)) {
-					/* Feed back the exact own waiting cargo at this station for the
-					 * next rating calculation. */
-					ge->max_waiting_cargo = 0;
+				waiting = std::min(waiting, MAX_WAITING_CARGO);
+				waiting_changed = true;
+			}
 
-					TruncateCargo(cs, ge, ge->GetData().cargo.AvailableCount() - waiting);
-				} else {
-					/* If the average number per next hop is low, be more forgiving. */
-					ge->max_waiting_cargo = waiting_avg;
-				}
+			/* We can't truncate cargo that's already reserved for loading.
+			 * Thus StoredCount() here. */
+			if (waiting_changed && waiting < (ge->HasData() ? ge->GetData().cargo.AvailableCount() : 0)) {
+				/* Feed back the exact own waiting cargo at this station for the
+				 * next rating calculation. */
+				ge->max_waiting_cargo = 0;
+
+				TruncateCargo(cs, ge, ge->GetData().cargo.AvailableCount() - waiting);
+			} else {
+				/* If the average number per next hop is low, be more forgiving. */
+				ge->max_waiting_cargo = waiting_avg;
 			}
 		}
 	}

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -309,3 +309,14 @@ strhelp  = STR_CONFIG_SETTING_INFINITE_MONEY_HELPTEXT
 cat      = SC_BASIC
 post_cb  = [](auto) { SetWindowDirty(WC_STATUS_BAR, 0); }
 
+[SDT_VAR]
+var      = difficulty.station_rating_mode
+type     = SLE_UINT8
+flags    = SettingFlag::GuiDropdown
+def      = SRM_ORIGINAL
+min      = SRM_ORIGINAL
+max      = SRM_PERFECT
+str      = STR_CONFIG_SETTING_STATION_RATING_MODE
+strhelp  = STR_CONFIG_SETTING_STATION_RATING_MODE_HELPTEXT
+strval   = STR_CONFIG_SETTING_STATION_RATING_MODE_ORIGINAL
+cat      = SC_BASIC


### PR DESCRIPTION
## Motivation / Problem

_This is very much a draft, curious to hear your opinions._

The original station rating algorithm encourages several antipatterns, including:
* Running more vehicles on a route than is required, so that one is always loading at the cargo source
* Replacing vehicles after only a couple years in service, to keep them 0-2 years old
* Running fast vehicles even on short routes where slower, high-capacity vehicles would better keep up with demand and still make the same amount of money (based on the cargo profit curve)

Players who don't wish to follow these antipatterns either claim perfect ratings are impossible (a common question of new players) or use the 100% station ratings cheat. 

## Description

Implement a new station rating mode, based on player feedback from #14381 and settings from JGRPP.

For review, each change is its own commit. I will squash when (if) merging.

### Waiting cargo tolerance depends on station size
* The more tiles belonging to the station, the more cargo it can hold. Simulates freight storage and large passenger stations with many passengers changing trains.
* This affects both station rating and cargo truncation
* Random cargo truncation is eliminated in favor of only total-cargo truncation
* The existing cargo tolerance matches the new when a station has 10 tiles; smaller stations are less tolerant and larger stations are more tolerant. Most waiting cargo penalty comes if a station has more than 1000 units of cargo. At a scale of 10 tiles, this means a one-tile bus stop hits penalties when >100 passengers are waiting, while large stations and airports can handle thousands of units of cargo.

### Wait time tolerance depends on cargo payment curve
* Cargos already have data for time sensitivity. Apply this to rating based on when the last vehicle loaded this cargo at the station.

### Only penalize vehicles older than their max age
* Vehicles already have an age at which they complain about being old. Penalize old vehicles, anything less than this gets no penalty.

### Don't consider vehicle speed at all
* Some vehicles are slow, some modes of transport are slow. Don't penalize this.

## To Do

- [ ] Remove the 100% station rating cheat to use this setting instead
- [ ] Finish writing strings and doxygen for "game balance" constants
- [ ] Test thoroughly for balance -- I started work on a PR to add debugging to show what factors are affecting station ratings, but got stuck.
- [ ] Allow community members to test thoroughly for balance and missing features

## Limitations

* Not added to Sandbox Options, since dropdowns are currently broken there. 🙂 
* Calling the new algorithm "Improved" is not a claim it's better, just following the pattern set by the settings for vehicle acceleration and effects, town road patterns, etc. I welcome alternate wording suggestions.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)