### PR TITLE
Feature: [Script] Allow GS to implement custom engine preview behavior.

### DIFF
--- a/src/command_type.h
+++ b/src/command_type.h
@@ -267,6 +267,7 @@ enum class Commands : uint8_t {
 
 	SetCompanyManagerFace, ///< set the manager's face of the company
 	SetCompanyColour, ///< set the colour of the company
+	SetCompanyBlockPreview, ///< set the block_preview for the company
 
 	IncreaseLoan, ///< increase the loan from the bank
 	DecreaseLoan, ///< decrease the loan from the bank

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -1191,6 +1191,27 @@ CommandCost CmdSetCompanyColour(DoCommandFlags flags, LiveryScheme scheme, bool 
 }
 
 /**
+ * Set for how many quarters the company will be blocked from getting an exclusive engine preview.
+ * @param flags Operation to perform.
+ * @param quarters Number of quarters that the company is not allowed to get new exclusive engine previews.
+ * @return The cost of this operation or an error.
+ */
+CommandCost CmdSetCompanyBlockPreview(DoCommandFlags flags, uint8_t quarters)
+{
+	if (flags.Test(DoCommandFlag::Execute)) {
+		Company *c = Company::Get(_current_company);
+
+		auto old_value = c->block_preview;
+		c->block_preview = quarters;
+
+		CompanyAdminUpdate(c);
+		AI::NewEvent(c->index, new ScriptEventBlockEnginePreviewChanged(old_value));
+	}
+
+	return CommandCost();
+}
+
+/**
  * Is the given name in use as name of a company?
  * @param name Name to search.
  * @return \c true if the name us unique (that is, not in use), else \c false.

--- a/src/company_cmd.h
+++ b/src/company_cmd.h
@@ -24,6 +24,7 @@ CommandCost CmdRenameCompany(DoCommandFlags flags, const std::string &text);
 CommandCost CmdRenamePresident(DoCommandFlags flags, const std::string &text);
 CommandCost CmdSetCompanyManagerFace(DoCommandFlags flags, uint style, uint32_t bits);
 CommandCost CmdSetCompanyColour(DoCommandFlags flags, LiveryScheme scheme, bool primary, Colours colour);
+CommandCost CmdSetCompanyBlockPreview(DoCommandFlags flags, uint8_t quarters);
 
 DEF_CMD_TRAIT(Commands::CompanyControl, CmdCompanyCtrl, CommandFlags({CommandFlag::Spectator, CommandFlag::ClientID, CommandFlag::NoEst}), CommandType::ServerSetting)
 DEF_CMD_TRAIT(Commands::CompanyAllowListControl, CmdCompanyAllowListCtrl, CommandFlag::NoEst, CommandType::ServerSetting)
@@ -32,5 +33,6 @@ DEF_CMD_TRAIT(Commands::RenameCompany, CmdRenameCompany, {}, CommandType::Compan
 DEF_CMD_TRAIT(Commands::RenamePresident, CmdRenamePresident, {}, CommandType::CompanySetting)
 DEF_CMD_TRAIT(Commands::SetCompanyManagerFace, CmdSetCompanyManagerFace, {}, CommandType::CompanySetting)
 DEF_CMD_TRAIT(Commands::SetCompanyColour, CmdSetCompanyColour, {}, CommandType::CompanySetting)
+DEF_CMD_TRAIT(Commands::SetCompanyBlockPreview, CmdSetCompanyBlockPreview, {}, CommandType::CompanySetting)
 
 #endif /* COMPANY_CMD_H */

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1099,12 +1099,18 @@ static void NewVehicleAvailable(Engine *e)
 			 * as those are the only engines that can be given exclusive previews. */
 			auto num_engines = GetGroupNumEngines(c->index, ALL_GROUP, e->index);
 
+			uint8_t old_value = c->block_preview;
+
 			if (num_engines == 0) {
 				/* The company did not build this engine during preview. */
-				c->block_preview = 20;
+				/* GS could have added more quaters in the meantime. */
+				c->block_preview = std::max<uint8_t>(20, c->block_preview);
+
+				/* Notify the AI about the change. */
+				if (old_value != c->block_preview) AI::NewEvent(c->index, new ScriptEventBlockEnginePreviewChanged(old_value));
 			}
 
-			Game::NewEvent(new ScriptEventEnginePreviewEnded(e->index, c->index, num_engines));
+			Game::NewEvent(new ScriptEventEnginePreviewEnded(e->index, c->index, num_engines, old_value));
 		}
 	}
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -33,6 +33,7 @@
 #include "timer/timer.h"
 #include "timer/timer_game_tick.h"
 #include "timer/timer_game_calendar.h"
+#include "game/game.hpp"
 
 #include "table/strings.h"
 #include "table/engines.h"
@@ -900,6 +901,9 @@ static void AcceptEnginePreview(EngineID eid, CompanyID company, int recursion_d
 	 */
 	InvalidateWindowData(WC_ENGINE_PREVIEW, eid);
 
+	/* Also notify game script. */
+	Game::NewEvent(new ScriptEventEnginePreviewAccepted(eid, company));
+
 	/* Don't search for variants to include if we are 10 levels deep already. */
 	if (recursion_depth >= 10) return;
 
@@ -1093,10 +1097,14 @@ static void NewVehicleAvailable(Engine *e)
 
 			/* Check the company's 'ALL_GROUP' group statistics. This only includes countable vehicles, which is fine
 			 * as those are the only engines that can be given exclusive previews. */
-			if (GetGroupNumEngines(c->index, ALL_GROUP, e->index) == 0) {
+			auto num_engines = GetGroupNumEngines(c->index, ALL_GROUP, e->index);
+
+			if (num_engines == 0) {
 				/* The company did not build this engine during preview. */
 				c->block_preview = 20;
 			}
+
+			Game::NewEvent(new ScriptEventEnginePreviewEnded(e->index, c->index, num_engines));
 		}
 	}
 

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -19,6 +19,10 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li AIEventBlockEnginePreviewChanged
+ * \li AICompany::GetBlockPreview
+ *
  * \b 15.0
  *
  * API additions:

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -19,6 +19,11 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li GSEventCompanyEngine
+ * \li GSEventEnginePreviewAccepted
+ * \li GSEventEnginePreviewEnded
+ *
  * \b 15.0
  *
  * API additions:

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -23,6 +23,8 @@
  * \li GSEventCompanyEngine
  * \li GSEventEnginePreviewAccepted
  * \li GSEventEnginePreviewEnded
+ * \li GSCompany::SetBlockPreview
+ * \li GSCompany::GetBlockPreview
  *
  * \b 15.0
  *

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -390,3 +390,17 @@
 	const Company *c = ::Company::Get(ScriptObject::GetCompany());
 	return (ScriptCompany::Colours)c->livery[scheme].colour2;
 }
+
+/* static */ bool ScriptCompany::SetBlockPreview(SQInteger quarters)
+{
+	EnforceCompanyModeValid(false);
+	EnforcePrecondition(false, quarters >= 0);
+	return ScriptObject::Command<Commands::SetCompanyBlockPreview>::Do(quarters);
+}
+
+/* static */ SQInteger ScriptCompany::GetBlockPreview(ScriptCompany::CompanyID company)
+{
+	company = ResolveCompanyID(company);
+	if (company == ScriptCompany::COMPANY_INVALID) return GENDER_INVALID;
+	return ::Company::Get(ScriptCompany::FromScriptCompanyID(company))->block_preview;
+}

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -466,6 +466,24 @@ public:
 	 * @return Secondary colour of livery.
 	 */
 	static ScriptCompany::Colours GetSecondaryLiveryColour(LiveryScheme scheme);
+
+	/**
+	 * Set how long company will not be able to get engine preview offer.
+	 * @param quarters Number of quarters that the company is not allowed to get new exclusive engine previews.
+	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
+	 * @pre quarters >= 0.
+	 * @return True if the block preview was changed.
+	 * @api -ai
+	 */
+	static bool SetBlockPreview(SQInteger quarters);
+
+	/**
+	 * Get number of quarters in wich the company will not be offered an engine preview.
+	 * @param company The company to get the block preview off.
+	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
+	 * @return Number of quarters that the company is not allowed to get new exclusive engine previews.
+	 */
+	static SQInteger GetBlockPreview(ScriptCompany::CompanyID company);
 };
 
 DECLARE_INCREMENT_DECREMENT_OPERATORS(ScriptCompany::CompanyID)

--- a/src/script/api/script_event.hpp
+++ b/src/script/api/script_event.hpp
@@ -59,6 +59,8 @@ public:
 		ET_STORYPAGE_VEHICLE_SELECT,
 		ET_COMPANY_RENAMED,
 		ET_PRESIDENT_RENAMED,
+		ET_ENGINE_PREVIEW_ENDED, ///< Event Engine Preview Ended, indicating an engine preview has ended.
+		ET_ENGINE_PREVIEW_ACCEPTED, ///< Event Engine Preview Accepted, indicating a company has accepted an engine preview.
 	};
 
 #ifndef DOXYGEN_API

--- a/src/script/api/script_event.hpp
+++ b/src/script/api/script_event.hpp
@@ -61,6 +61,7 @@ public:
 		ET_PRESIDENT_RENAMED,
 		ET_ENGINE_PREVIEW_ENDED, ///< Event Engine Preview Ended, indicating an engine preview has ended.
 		ET_ENGINE_PREVIEW_ACCEPTED, ///< Event Engine Preview Accepted, indicating a company has accepted an engine preview.
+		ET_BLOCK_ENGINE_PREVIEW_CHANGED, ///< Event Block Engine Preview Changed, indicating that the date of the end of block has changed.
 	};
 
 #ifndef DOXYGEN_API

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -329,6 +329,108 @@ private:
 };
 
 /**
+ * Base class for events involving a engine and a company.
+ * @api game
+ */
+class ScriptEventCompanyEngine : public ScriptEvent {
+public:
+#ifndef DOXYGEN_API
+	/**
+	 * @param engine The EngineID of the engine involved into the event.
+	 * @param company The CompanyID of the company involved into the event.
+	 */
+	ScriptEventCompanyEngine(EngineID engine, ::CompanyID company, ScriptEvent::ScriptEventType type) :
+		ScriptEvent(type),
+		engine(engine),
+		company(ScriptCompany::ToScriptCompanyID(company))
+	{}
+#endif /* DOXYGEN_API */
+
+	/**
+	 * Convert an ScriptEvent to the real instance.
+	 * @param instance The instance to convert.
+	 * @return The converted instance.
+	 */
+	static ScriptEventCompanyEngine *Convert(ScriptEvent *instance) { return dynamic_cast<ScriptEventCompanyEngine *>(instance); }
+
+	/**
+	 * Get the EngineID of the engine involved into the event.
+	 * @return The EngineID of the engine.
+	 */
+	EngineID GetEngineID() { return this->engine; }
+
+	/**
+	 * Get the CompanyID of the company involved into the event.
+	 * @return The CompanyID of the company.
+	 */
+	ScriptCompany::CompanyID GetCompanyID() { return this->company; }
+
+private:
+	EngineID engine; ///< The involved engine.
+	ScriptCompany::CompanyID company; ///< The involved company.
+};
+
+/**
+ * @copydoc ET_ENGINE_PREVIEW_ACCEPTED
+ * @api game
+ */
+class ScriptEventEnginePreviewAccepted : public ScriptEventCompanyEngine {
+public:
+#ifndef DOXYGEN_API
+	/**
+	 * @param engine The previewed engine.
+	 * @param company Company that has accepted the preview.
+	 */
+	ScriptEventEnginePreviewAccepted(EngineID engine, ::CompanyID company) :
+		ScriptEventCompanyEngine(engine, company, ET_ENGINE_PREVIEW_ACCEPTED)
+	{}
+#endif /* DOXYGEN_API */
+
+	/**
+	 * Convert an ScriptEvent to the real instance.
+	 * @param instance The instance to convert.
+	 * @return The converted instance.
+	 */
+	static ScriptEventEnginePreviewAccepted *Convert(ScriptEvent *instance) { return dynamic_cast<ScriptEventEnginePreviewAccepted *>(instance); }
+};
+
+/**
+ * @copydoc ET_ENGINE_PREVIEW_ENDED
+ * @api game
+ */
+class ScriptEventEnginePreviewEnded : public ScriptEventCompanyEngine {
+public:
+#ifndef DOXYGEN_API
+	/**
+	 * @param engine The previewed engine.
+	 * @param company Company that had the preview.
+	 * @param created_instances Number of instance of the engine that company currenlty has.
+	 */
+	ScriptEventEnginePreviewEnded(EngineID engine, ::CompanyID company, int32_t created_instances) :
+		ScriptEventCompanyEngine(engine, company, ET_ENGINE_PREVIEW_ENDED),
+		created_instances(created_instances)
+	{}
+#endif /* DOXYGEN_API */
+
+	/**
+	 * Convert an ScriptEvent to the real instance.
+	 * @param instance The instance to convert.
+	 * @return The converted instance.
+	 */
+	static ScriptEventEnginePreviewEnded *Convert(ScriptEvent *instance) { return dynamic_cast<ScriptEventEnginePreviewEnded *>(instance); }
+
+	/**
+	 * Get quantity of engine instances that the company had when engine preview has ended.
+	 * Iff it is equal to zero, the company has been blocked from getting new preview offers for a few years.
+	 * @return The number of instances.
+	 */
+	int32_t GetNumberOfInstances() { return this->created_instances; }
+
+private:
+	int32_t created_instances; ///< Number of instances of the engine that company had when preview has ended.
+};
+
+/**
  * Event Company New, indicating a new company has been created.
  * @api ai game
  */

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -406,9 +406,10 @@ public:
 	 * @param company Company that had the preview.
 	 * @param created_instances Number of instance of the engine that company currenlty has.
 	 */
-	ScriptEventEnginePreviewEnded(EngineID engine, ::CompanyID company, int32_t created_instances) :
+	ScriptEventEnginePreviewEnded(EngineID engine, ::CompanyID company, int32_t created_instances, uint8_t old_block_preview_value) :
 		ScriptEventCompanyEngine(engine, company, ET_ENGINE_PREVIEW_ENDED),
-		created_instances(created_instances)
+		created_instances(created_instances),
+		old_block_preview_value(old_block_preview_value)
 	{}
 #endif /* DOXYGEN_API */
 
@@ -426,8 +427,48 @@ public:
 	 */
 	int32_t GetNumberOfInstances() { return this->created_instances; }
 
+	/**
+	 * Get the value of the block preview just before the preview has ended.
+	 * @return The old value of block_preview member.
+	 */
+	int32_t GetOldValue() { return this->old_block_preview_value; }
+
 private:
 	int32_t created_instances; ///< Number of instances of the engine that company had when preview has ended.
+	int32_t old_block_preview_value; ///< The old value of block_preview member.
+};
+
+/**
+ * @copydoc ET_BLOCK_ENGINE_PREVIEW_CHANGED
+ * @api ai
+ */
+class ScriptEventBlockEnginePreviewChanged : public ScriptEvent {
+public:
+#ifndef DOXYGEN_API
+	/**
+	 * @param old_value The old value of block_preview member.
+	 */
+	ScriptEventBlockEnginePreviewChanged(uint8_t old_value) :
+		ScriptEvent(ET_BLOCK_ENGINE_PREVIEW_CHANGED),
+		old_value(old_value)
+	{}
+#endif /* DOXYGEN_API */
+
+	/**
+	 * Convert an ScriptEvent to the real instance.
+	 * @param instance The instance to convert.
+	 * @return The converted instance.
+	 */
+	static ScriptEventBlockEnginePreviewChanged *Convert(ScriptEvent *instance) { return dynamic_cast<ScriptEventBlockEnginePreviewChanged *>(instance); }
+
+	/**
+	 * Get the value of the block preview before it was changed.
+	 * @return The old value of block_preview member.
+	 */
+	int32_t GetOldValue() { return this->old_value; }
+
+private:
+	int32_t old_value; ///< The old value of block_preview member.
 };
 
 /**


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
- Currently there is no clear message whether the preview was successful or not.
- The current punishment for not building engine during preview is not very painful and can't really strike the company.
- Also there is not so much profit from the preview, because engine tends to break more often than other vehicles and a year is not much time to get significant advantage over the competitors.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
__Edit: This one is outdated, please fast forward [here](https://github.com/OpenTTD/OpenTTD/pull/14637#issuecomment-3618875552).__

<details>
<summary>Old description.</summary>

Give a reward or fine to the company that accepted the preview after the engine became available to everyone.
The reward is calculated based on the amount of bought copies of the previewed engine in the way that smaller companies get more money per copy than the bigger ones.
The fine is calculated based on the number of all company vehicles in the way that bigger companies have to pay more per vehicle than smaller ones.
Both amounts depend on the cost of the previewed engine.

<img width="526" height="294" alt="Zrzut ekranu z 2025-09-20 18-30-04" src="https://github.com/user-attachments/assets/159e34f2-15cb-4e55-9ced-69d36c9d82ca" />
<img width="526" height="317" alt="Zrzut ekranu z 2025-09-20 18-30-12" src="https://github.com/user-attachments/assets/bd390450-3458-4fe0-afe0-fcee1f561343" />

</details>

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
There is no convenient way to check which engines are currently accepted by the local company, so players have to remember what they have accepted.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
