### PR TITLE
Codechange: Add constant for INVALID_WIDGET.

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -84,7 +84,7 @@ static void PlaceAirport(TileIndex tile)
 
 /** Airport build toolbar window handler. */
 struct BuildAirToolbarWindow : Window {
-	int last_user_action = INVALID_WID_AT; // Last started user action.
+	WidgetID last_user_action = INVALID_WIDGET; // Last started user action.
 
 	BuildAirToolbarWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -260,7 +260,7 @@ struct DepotWindow : Window {
 	VehicleType type = VEH_INVALID;
 	bool generate_list = true;
 	bool check_unitnumber_digits = true;
-	WidgetID hovered_widget = -1; ///< Index of the widget being hovered during drag/drop. -1 if no drag is in progress.
+	WidgetID hovered_widget = INVALID_WIDGET; ///< Index of the widget being hovered during drag/drop. \c INVALID_WIDGET if no drag is in progress.
 	VehicleList vehicle_list{};
 	VehicleList wagon_list{};
 	uint unitnumber_digits = 2;
@@ -1001,10 +1001,10 @@ struct DepotWindow : Window {
 		this->vehicle_over = VehicleID::Invalid();
 		this->SetWidgetDirty(WID_D_MATRIX);
 
-		if (this->hovered_widget != -1) {
+		if (this->hovered_widget != INVALID_WIDGET) {
 			this->SetWidgetLoweredState(this->hovered_widget, false);
 			this->SetWidgetDirty(this->hovered_widget);
-			this->hovered_widget = -1;
+			this->hovered_widget = INVALID_WIDGET;
 		}
 	}
 
@@ -1116,7 +1116,7 @@ struct DepotWindow : Window {
 				this->SetDirty();
 				break;
 		}
-		this->hovered_widget = -1;
+		this->hovered_widget = INVALID_WIDGET;
 		_cursor.vehchain = false;
 	}
 

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -98,7 +98,7 @@ static TileIndex GetOtherAqueductEnd(TileIndex tile_from, TileIndex *tile_to = n
 
 /** Toolbar window for constructing water infrastructure. */
 struct BuildDocksToolbarWindow : Window {
-	DockToolbarWidgets last_clicked_widget = WID_DT_INVALID; ///< Contains the last widget that has been clicked on this toolbar.
+	WidgetID last_clicked_widget = INVALID_WIDGET; ///< Contains the last widget that has been clicked on this toolbar.
 
 	BuildDocksToolbarWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
@@ -189,7 +189,7 @@ struct BuildDocksToolbarWindow : Window {
 
 			default: return;
 		}
-		this->last_clicked_widget = (DockToolbarWidgets)widget;
+		this->last_clicked_widget = widget;
 	}
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -438,7 +438,7 @@ static void HandleAutoSignalPlacement()
 /** Rail toolbar management class. */
 struct BuildRailToolbarWindow : Window {
 	RailType railtype = INVALID_RAILTYPE; ///< Rail type to build.
-	int last_user_action = INVALID_WID_RAT; ///< Last started user action.
+	WidgetID last_user_action = INVALID_WIDGET; ///< Last started user action.
 
 	BuildRailToolbarWindow(WindowDesc &desc, RailType railtype) : Window(desc), railtype(railtype)
 	{

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -344,7 +344,7 @@ static bool RoadToolbar_CtrlChanged(Window *w)
 /** Road toolbar window handler. */
 struct BuildRoadToolbarWindow : Window {
 	RoadType roadtype = INVALID_ROADTYPE; ///< Road type to build.
-	int last_started_action = INVALID_WID_ROT; ///< Last started user action.
+	WidgetID last_started_action = INVALID_WIDGET; ///< Last started user action.
 
 	BuildRoadToolbarWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc), roadtype(_cur_roadtype)
 	{

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -155,7 +155,7 @@ void PlaceProc_DemolishArea(TileIndex tile)
 
 /** Terra form toolbar managing class. */
 struct TerraformToolbarWindow : Window {
-	int last_user_action = INVALID_WID_TT; ///< Last started user action.
+	WidgetID last_user_action = INVALID_WIDGET; ///< Last started user action.
 
 	TerraformToolbarWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{
@@ -529,7 +529,7 @@ static void ResetLandscapeConfirmationCallback(Window *, bool confirmed)
 
 /** Landscape generation window handler in the scenario editor. */
 struct ScenarioEditorLandscapeGenerationWindow : Window {
-	int last_user_action = INVALID_WID_ETT; ///< Last started user action.
+	WidgetID last_user_action = INVALID_WIDGET; ///< Last started user action.
 
 	ScenarioEditorLandscapeGenerationWindow(WindowDesc &desc, WindowNumber window_number) : Window(desc)
 	{

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -269,12 +269,12 @@ void ScrollbarClickHandler(Window *w, NWidgetCore *nw, int x, int y)
  * @param *w Window to look inside
  * @param  x The Window client X coordinate
  * @param  y The Window client y coordinate
- * @return A widget index, or -1 if no widget was found.
+ * @return A widget index, or \c INVALID_WIDGET if no widget was found.
  */
 WidgetID GetWidgetFromPos(const Window *w, int x, int y)
 {
 	NWidgetCore *nw = w->nested_root->GetWidgetFromPos(x, y);
-	return (nw != nullptr) ? nw->GetIndex() : -1;
+	return (nw != nullptr) ? nw->GetIndex() : INVALID_WIDGET;
 }
 
 /**
@@ -1885,7 +1885,7 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint g
  * @param width  Horizontal size of the spacer widget.
  * @param height Vertical size of the spacer widget.
  */
-NWidgetSpacer::NWidgetSpacer(int width, int height) : NWidgetResizeBase(NWID_SPACER, -1, 0, 0)
+NWidgetSpacer::NWidgetSpacer(int width, int height) : NWidgetResizeBase(NWID_SPACER, INVALID_WIDGET, 0, 0)
 {
 	this->SetMinimalSize(width, height);
 	this->SetResize(0, 0);
@@ -3408,7 +3408,7 @@ std::unique_ptr<NWidgetBase> MakeWindowNWidgetTree(std::span<const NWidgetPart> 
 
 	if (hor_cont != nullptr && hor_cont->GetWidgetOfType(WWT_CAPTION) != nullptr && hor_cont->GetWidgetOfType(WWT_SHADEBOX) != nullptr) {
 		/* If the first widget has a title bar and a shade box, silently add a shade selection widget in the tree. */
-		auto shade_stack = std::make_unique<NWidgetStacked>(-1);
+		auto shade_stack = std::make_unique<NWidgetStacked>(INVALID_WIDGET);
 		*shade_select = shade_stack.get();
 		/* Load the remaining parts into the shade stack. */
 		shade_stack->Add(MakeNWidgets({nwid_begin, nwid_end}, std::make_unique<NWidgetVertical>()));

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -136,7 +136,7 @@ using WidgetLookup = std::map<WidgetID, class NWidgetBase *>;
  */
 class NWidgetBase {
 public:
-	NWidgetBase(WidgetType tp, WidgetID index = -1) : type(tp), index(index) {}
+	NWidgetBase(WidgetType tp, WidgetID index = INVALID_WIDGET) : type(tp), index(index) {}
 	virtual ~NWidgetBase() = default;
 
 	void ApplyAspectRatio();
@@ -249,7 +249,7 @@ public:
 	NWidgetBase *parent = nullptr; ///< Parent widget of this widget, automatically filled in when added to container.
 
 protected:
-	const WidgetID index = -1; ///< Index of the nested widget (\c -1 means 'not used').
+	const WidgetID index = INVALID_WIDGET; ///< Index of the nested widget (\c INVALID_WIDGET means 'not used').
 
 	inline void StoreSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height);
 };
@@ -402,7 +402,7 @@ public:
 protected:
 	WidgetData widget_data{}; ///< Data of the widget. @see Widget::data
 	StringID tool_tip{}; ///< Tooltip of the widget. @see Widget::tool_tips
-	WidgetID scrollbar_index = -1; ///< Index of an attached scrollbar.
+	WidgetID scrollbar_index = INVALID_WIDGET; ///< Index of an attached scrollbar.
 	TextColour highlight_colour{}; ///< Colour of highlight.
 	TextColour text_colour{}; ///< Colour of text within widget.
 	FontSize text_size = FS_NORMAL; ///< Size of text within widget.
@@ -471,7 +471,7 @@ inline bool NWidgetCore::IsDisabled() const
  */
 class NWidgetContainer : public NWidgetBase {
 public:
-	NWidgetContainer(WidgetType tp, WidgetID index = -1) : NWidgetBase(tp, index) {}
+	NWidgetContainer(WidgetType tp, WidgetID index = INVALID_WIDGET) : NWidgetBase(tp, index) {}
 
 	void AdjustPaddingForZoom() override;
 	void Add(std::unique_ptr<NWidgetBase> &&wid);
@@ -537,7 +537,7 @@ using NWidContainerFlags = EnumBitSet<NWidContainerFlag, uint8_t>;
 /** Container with pre/inter/post child space. */
 class NWidgetPIPContainer : public NWidgetContainer {
 public:
-	NWidgetPIPContainer(WidgetType tp, NWidContainerFlags flags = {}, WidgetID index = -1) : NWidgetContainer(tp, index), flags(flags) {}
+	NWidgetPIPContainer(WidgetType tp, NWidContainerFlags flags = {}, WidgetID index = INVALID_WIDGET) : NWidgetContainer(tp, index), flags(flags) {}
 
 	void AdjustPaddingForZoom() override;
 	void SetPIP(uint8_t pip_pre, uint8_t pip_inter, uint8_t pip_post);
@@ -565,7 +565,7 @@ protected:
  */
 class NWidgetHorizontal : public NWidgetPIPContainer {
 public:
-	NWidgetHorizontal(NWidContainerFlags flags = {}, WidgetID index = -1, WidgetType type = NWID_HORIZONTAL) : NWidgetPIPContainer(type, flags, index) {}
+	NWidgetHorizontal(NWidContainerFlags flags = {}, WidgetID index = INVALID_WIDGET, WidgetType type = NWID_HORIZONTAL) : NWidgetPIPContainer(type, flags, index) {}
 
 	void SetupSmallestSize(Window *w) override;
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
@@ -577,7 +577,7 @@ public:
  */
 class NWidgetHorizontalLTR : public NWidgetHorizontal {
 public:
-	NWidgetHorizontalLTR(NWidContainerFlags flags = {}, WidgetID index = -1) : NWidgetHorizontal(flags, index, NWID_HORIZONTAL_LTR) {}
+	NWidgetHorizontalLTR(NWidContainerFlags flags = {}, WidgetID index = INVALID_WIDGET) : NWidgetHorizontal(flags, index, NWID_HORIZONTAL_LTR) {}
 
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
 };
@@ -588,7 +588,7 @@ public:
  */
 class NWidgetVertical : public NWidgetPIPContainer {
 public:
-	NWidgetVertical(NWidContainerFlags flags = {}, WidgetID index = -1) : NWidgetPIPContainer(NWID_VERTICAL, flags, index) {}
+	NWidgetVertical(NWidContainerFlags flags = {}, WidgetID index = INVALID_WIDGET) : NWidgetPIPContainer(NWID_VERTICAL, flags, index) {}
 
 	void SetupSmallestSize(Window *w) override;
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
@@ -1412,7 +1412,7 @@ constexpr NWidgetPart SetAspect(float ratio, AspectFlags flags = AspectFlag::Res
  *       Child widgets must have a index bigger than the parent index.
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart NWidget(WidgetType tp, Colours col, WidgetID idx = -1)
+constexpr NWidgetPart NWidget(WidgetType tp, Colours col, WidgetID idx = INVALID_WIDGET)
 {
 	return NWidgetPart{tp, NWidgetPartWidget{col, idx}};
 }
@@ -1423,7 +1423,7 @@ constexpr NWidgetPart NWidget(WidgetType tp, Colours col, WidgetID idx = -1)
  * @param cont_flags Flags for the containers (#NWID_HORIZONTAL and #NWID_VERTICAL).
  * @ingroup NestedWidgetParts
  */
-constexpr NWidgetPart NWidget(WidgetType tp, NWidContainerFlags cont_flags = {}, WidgetID idx = -1)
+constexpr NWidgetPart NWidget(WidgetType tp, NWidContainerFlags cont_flags = {}, WidgetID idx = INVALID_WIDGET)
 {
 	return NWidgetPart{tp, NWidgetPartContainer{cont_flags, idx}};
 }

--- a/src/widgets/airport_widget.h
+++ b/src/widgets/airport_widget.h
@@ -14,8 +14,6 @@
 enum AirportToolbarWidgets : WidgetID {
 	WID_AT_AIRPORT,  ///< Build airport button.
 	WID_AT_DEMOLISH, ///< Demolish button.
-
-	INVALID_WID_AT = -1,
 };
 
 /** Widgets of the #BuildAirportWindow class. */

--- a/src/widgets/dock_widget.h
+++ b/src/widgets/dock_widget.h
@@ -27,8 +27,6 @@ enum DockToolbarWidgets : WidgetID {
 	WID_DT_BUOY,           ///< Build buoy button.
 	WID_DT_RIVER,          ///< Build river button (in scenario editor).
 	WID_DT_BUILD_AQUEDUCT, ///< Build aqueduct button.
-
-	WID_DT_INVALID,        ///< Used to initialize a variable.
 };
 
 #endif /* WIDGETS_DOCK_WIDGET_H */

--- a/src/widgets/game_widget.h
+++ b/src/widgets/game_widget.h
@@ -24,7 +24,7 @@ enum GSConfigWidgets : WidgetID {
 	WID_GSC_CONTENT_DOWNLOAD = WID_GSC_TEXTFILE + TFT_CONTENT_END, ///< Download content button.
 	WID_GSC_RESET,            ///< Reset button.
 
-	WID_GSC_SETTING_DROPDOWN = -1, ///< Dynamically created dropdown for changing setting value.
+	WID_GSC_SETTING_DROPDOWN = INVALID_WIDGET, ///< Dynamically created dropdown for changing setting value.
 };
 
 #endif /* WIDGETS_GS_WIDGET_H */

--- a/src/widgets/rail_widget.h
+++ b/src/widgets/rail_widget.h
@@ -28,8 +28,6 @@ enum RailToolbarWidgets : WidgetID {
 	WID_RAT_BUILD_TUNNEL,   ///< Build a tunnel.
 	WID_RAT_REMOVE,         ///< Bulldozer to remove rail.
 	WID_RAT_CONVERT_RAIL,   ///< Convert other rail to this type.
-
-	INVALID_WID_RAT = -1,
 };
 
 /** Widgets of the #BuildRailStationWindow class. */

--- a/src/widgets/road_widget.h
+++ b/src/widgets/road_widget.h
@@ -27,8 +27,6 @@ enum RoadToolbarWidgets : WidgetID {
 	WID_ROT_BUILD_TUNNEL,   ///< Build tunnel.
 	WID_ROT_REMOVE,         ///< Remove road.
 	WID_ROT_CONVERT_ROAD,   ///< Convert road.
-
-	INVALID_WID_ROT = -1,
 };
 
 /** Widgets of the #BuildRoadDepotWindow class. */

--- a/src/widgets/script_widget.h
+++ b/src/widgets/script_widget.h
@@ -28,7 +28,7 @@ enum ScriptSettingsWidgets : WidgetID {
 	WID_SCRS_SCROLLBAR,  ///< Scrollbar to scroll through all settings.
 	WID_SCRS_RESET,      ///< Reset button.
 
-	WID_SCRS_SETTING_DROPDOWN = -1, ///< Dynamically created dropdown for changing setting value.
+	WID_SCRS_SETTING_DROPDOWN = INVALID_WIDGET, ///< Dynamically created dropdown for changing setting value.
 };
 
 /** Widgets of the #ScriptDebugWindow class. */

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -85,7 +85,7 @@ enum GameOptionsWidgets : WidgetID {
 	WID_GO_RESTRICT_DROPDOWN,  ///< The drop down box to restrict the list of settings
 	WID_GO_TYPE_DROPDOWN,      ///< The drop down box to choose client/game/company/all settings
 
-	WID_GO_SETTING_DROPDOWN = -1, ///< Dynamically created dropdown for changing setting value.
+	WID_GO_SETTING_DROPDOWN = INVALID_WIDGET, ///< Dynamically created dropdown for changing setting value.
 };
 
 /** Widgets of the #CustomCurrencyWindow class. */

--- a/src/widgets/terraform_widget.h
+++ b/src/widgets/terraform_widget.h
@@ -22,8 +22,6 @@ enum TerraformToolbarWidgets : WidgetID {
 	WID_TT_PLANT_TREES,                       ///< Plant trees button (note: opens separate window, no place-push-button).
 	WID_TT_PLACE_SIGN,                        ///< Place sign button.
 	WID_TT_PLACE_OBJECT,                      ///< Place object button.
-
-	INVALID_WID_TT = -1,
 };
 
 /** Widgets of the #ScenarioEditorLandscapeGenerationWindow class. */
@@ -44,8 +42,6 @@ enum EditorTerraformToolbarWidgets : WidgetID {
 	WID_ETT_DECREASE_SIZE,                       ///< Downwards arrow button to decrease terraforming size.
 	WID_ETT_NEW_SCENARIO,                        ///< Button for generating a new scenario.
 	WID_ETT_RESET_LANDSCAPE,                     ///< Button for removing all company-owned property.
-
-	INVALID_WID_ETT = -1,
 };
 
 #endif /* WIDGETS_TERRAFORM_WIDGET_H */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1809,7 +1809,7 @@ void Window::InitNested(WindowNumber window_number)
  * Empty constructor, initialization has been moved to #InitNested() called from the constructor of the derived class.
  * @param desc The description of the window.
  */
-Window::Window(WindowDesc &desc) : window_desc(desc), scale(_gui_scale), mouse_capture_widget(-1)
+Window::Window(WindowDesc &desc) : window_desc(desc), scale(_gui_scale), mouse_capture_widget(INVALID_WIDGET)
 {
 	this->z_position = _z_windows.insert(_z_windows.end(), this);
 }
@@ -1891,7 +1891,7 @@ static void DecreaseWindowCounters()
 					NWidgetScrollbar *sb = static_cast<NWidgetScrollbar*>(nwid);
 					if (sb->disp_flags.Any({NWidgetDisplayFlag::ScrollbarUp, NWidgetDisplayFlag::ScrollbarDown})) {
 						sb->disp_flags.Reset({NWidgetDisplayFlag::ScrollbarUp, NWidgetDisplayFlag::ScrollbarDown});
-						w->mouse_capture_widget = -1;
+						w->mouse_capture_widget = INVALID_WIDGET;
 						sb->SetDirty(w);
 					}
 				}
@@ -2390,7 +2390,7 @@ static EventState HandleActiveWidget()
 			/* Abort if no button is clicked any more. */
 			if (!_left_button_down) {
 				w->SetWidgetDirty(w->mouse_capture_widget);
-				w->mouse_capture_widget = -1;
+				w->mouse_capture_widget = INVALID_WIDGET;
 				return ES_HANDLED;
 			}
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -323,7 +323,7 @@ public:
 	NWidgetStacked *shade_select = nullptr; ///< Selection widget (#NWID_SELECTION) to use for shading the window. If \c nullptr, window cannot shade.
 	Dimension unshaded_size{}; ///< Last known unshaded size (only valid while shaded).
 
-	WidgetID mouse_capture_widget = -1; ///< ID of current mouse capture widget (e.g. dragged scrollbar). -1 if no widget has mouse capture.
+	WidgetID mouse_capture_widget = INVALID_WIDGET; ///< ID of current mouse capture widget (e.g. dragged scrollbar). \c INVALID_WIDGET if no widget has mouse capture.
 
 	Window *parent = nullptr; ///< Parent window.
 	WindowList::iterator z_position{};

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -19,6 +19,9 @@
  */
 using WidgetID = int;
 
+/** An invalid widget index. */
+static constexpr WidgetID INVALID_WIDGET = -1;
+
 /** %Window numbers. */
 enum WindowNumberEnum : uint8_t {
 	WN_GAME_OPTIONS_AI = 0,          ///< AI settings.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

An invalid widget index is indicated by a value of -1, but there is no constant for this.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add constant for INVALID_WIDGET to replace direct use of -1, making it easier to find.
Removes some window-specific invalid widgets in favour of the generic constant.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

The "dynamic dropdown widget" is a bit weird, but...

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
