### PR TITLE
Fix #14549: changing interface scale could underflow map zoom

### DIFF
--- a/src/zoom_type.h
+++ b/src/zoom_type.h
@@ -12,8 +12,12 @@
 
 #include "core/enum_type.hpp"
 
-/** All zoom levels we know. */
-enum class ZoomLevel : uint8_t {
+/**
+ * All zoom levels we know.
+ *
+ * The underlying type is signed so subtract-and-Clamp works without need for casting.
+ */
+enum class ZoomLevel : int8_t {
 	/* Our possible zoom-levels */
 	Begin = 0, ///< Begin for iteration.
 	Min = Begin, ///< Minimum zoom level.


### PR DESCRIPTION
## Motivation / Problem

Fixes #14549.

The actual bug happens in https://github.com/OpenTTD/OpenTTD/blob/bec4e71d53fe6bd638aeecfd97f0732dc6287270/src/gfx.cpp#L1847. The value calculated at line 1840 could underflow, causing `Clamp` to take the upper boundary instead of the conceptually expected lower boundary.


## Description

Change the underlying type of `ZoomLevel` to `int8_t`. This makes the result that is passed into `Clamp` slightly negative, causing a clamp to the lower boundary instead of the higher boundary.

Closes #14579, an alternative implementation with conditionals and casts.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
