### PR TITLE
Change: Record and show multiple errors for each NewGRF

### DIFF
--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -40,7 +40,7 @@ GRFConfig::GRFConfig(const GRFConfig &config) :
 	name(config.name),
 	info(config.info),
 	url(config.url),
-	error(config.error),
+	errors(config.errors),
 	version(config.version),
 	min_loadable_version(config.min_loadable_version),
 	flags(config.flags),
@@ -155,15 +155,6 @@ GRFConfigList _grfconfig;
 GRFConfigList _grfconfig_newgame;
 GRFConfigList _grfconfig_static;
 uint _missing_extra_graphics = 0;
-
-/**
- * Construct a new GRFError.
- * @param severity The severity of this error.
- * @param message The actual error-string.
- */
-GRFError::GRFError(StringID severity, StringID message) : message(message), severity(severity)
-{
-}
 
 /**
  * Get the value of the given user-changeable parameter.
@@ -472,7 +463,7 @@ compatible_grf:
 				c->ident.md5sum = f->ident.md5sum;
 				c->name = f->name;
 				c->info = f->name;
-				c->error.reset();
+				c->errors.clear();
 				c->version = f->version;
 				c->min_loadable_version = f->min_loadable_version;
 				c->num_valid_params = f->num_valid_params;

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -107,12 +107,14 @@ struct GRFIdentifier {
 
 /** Information about why GRF had problems during initialisation */
 struct GRFError {
-	GRFError(StringID severity, StringID message = {});
+	GRFError(StringID severity, uint32_t nfo_line, StringID message = {})
+		: message(message), severity(severity), nfo_line(nfo_line) {}
 
 	std::string custom_message{}; ///< Custom message (if present)
 	std::string data{}; ///< Additional data for message and custom_message
 	StringID message{}; ///< Default message
 	StringID severity{}; ///< Info / Warning / Error / Fatal
+	uint32_t nfo_line; ///< Line within NewGRF of error.
 	std::array<uint32_t, 2> param_value{}; ///< Values of GRF parameters to show for message and custom_message
 };
 
@@ -169,7 +171,7 @@ struct GRFConfig {
 	GRFTextWrapper name{}; ///< NOSAVE: GRF name (Action 0x08)
 	GRFTextWrapper info{}; ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
 	GRFTextWrapper url{}; ///< NOSAVE: URL belonging to this GRF.
-	std::optional<GRFError> error = std::nullopt; ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
+	std::vector<GRFError> errors; ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
 
 	uint32_t version = 0; ///< NOSAVE: Version a NewGRF can set so only the newest NewGRF is shown
 	uint32_t min_loadable_version = 0; ///< NOSAVE: Minimum compatible version a NewGRF can define


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #14654, the current prioritisation of NewGRF error messages can cause confusion.

Only the first error is recorded, unless a fatal error occurs later on which replaces the recorded error.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, record all errors, and display them all in the NewGRF window.

For the error popup, only the last error is displayed, which should match existing behaviour as it will be the fatal error message.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

I had a change to do this very very long ago but it was rejected as unnecessary. However it was in the pre-C++ days, so would have involved extra complexity of manual memory management (I think it was a linked list...)

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
