### PR TITLE
Change: Support interface scaling in network client list window.

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1339,7 +1339,7 @@ public:
 		colour(colour),
 		disabled(disabled)
 	{
-		Dimension d = GetSpriteSize(sprite);
+		Dimension d = GetScaledSpriteSize(sprite);
 		this->height = d.height + WidgetDimensions::scaled.framerect.Vertical();
 		this->width = d.width + WidgetDimensions::scaled.framerect.Horizontal();
 	}
@@ -1463,7 +1463,7 @@ public:
 		bool rtl = _current_text_dir == TD_RTL;
 		r = this->DrawButtons(r);
 
-		Dimension d = GetSpriteSize(SPR_COMPANY_ICON);
+		Dimension d = GetScaledSpriteSize(SPR_COMPANY_ICON);
 		PaletteID pal = Company::IsValidID(this->company_id) ? GetCompanyPalette(this->company_id) : PALETTE_TO_GREY;
 		DrawSpriteIgnorePadding(SPR_COMPANY_ICON, pal, r.WithWidth(d.width, rtl), SA_CENTER);
 
@@ -1503,7 +1503,7 @@ public:
 		}
 
 		if (player_icon != 0) {
-			Dimension d = GetSpriteSize(player_icon);
+			Dimension d = GetScaledSpriteSize(player_icon);
 			DrawSpriteIgnorePadding(player_icon, PALETTE_TO_GREY, r.WithWidth(d.width, rtl), SA_CENTER);
 			tr = tr.Indent(d.width + WidgetDimensions::scaled.hsep_normal, rtl);
 		}
@@ -1514,7 +1514,7 @@ public:
 	std::optional<EncodedString> GetTooltip(Rect r, const Point &pt) const override
 	{
 		bool rtl = _current_text_dir == TD_RTL;
-		Dimension d = GetSpriteSize(SPR_PLAYER_SELF);
+		Dimension d = GetScaledSpriteSize(SPR_PLAYER_SELF);
 
 		if (r.WithWidth(d.width, rtl).Contains(pt)) {
 			const NetworkClientInfo *ci = NetworkClientInfo::GetIfValid(this->client_pool_id);
@@ -1754,7 +1754,7 @@ public:
 				break;
 
 			case WID_CL_MATRIX: {
-				uint height = std::max({GetSpriteSize(SPR_COMPANY_ICON).height, GetSpriteSize(SPR_JOIN).height, GetSpriteSize(SPR_ADMIN).height, GetSpriteSize(SPR_CHAT).height});
+				uint height = std::max({GetScaledSpriteSize(SPR_COMPANY_ICON).height, GetScaledSpriteSize(SPR_JOIN).height, GetScaledSpriteSize(SPR_ADMIN).height, GetScaledSpriteSize(SPR_CHAT).height});
 				height += WidgetDimensions::scaled.framerect.Vertical();
 				this->line_height = std::max(height, (uint)GetCharacterHeight(FS_NORMAL)) + padding.height;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The buttons in the network client list window are scaled by sprite size (powers-of-2) rather than interface scaled sprite size (fractional). This means that when the UI is at (e.g.) 1.75x scale, they are still drawn at 1x size. Using fractionally scaled buttons keeps the interface sizing consistent.

While updating the code to support rendering with Rects and interface scaling, I noticed that duplicate work to decide what rows to draw is performed: once on invalidation to create all the buttons to be drawn, and again during drawing.

<img width="552" height="624" alt="image" src="https://github.com/user-attachments/assets/2d6fe675-5bf1-4e66-ba2e-ec12f846ee60" />

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR extends the network client list window so that the state needed to draw the rows is also recorded along with the buttons during invalidation. There are two types of row, `CompanyButtonLine` and `ClientButtonLine`, and each type knows how to draw itself. It's even slightly less code.

This new drawing system accepts Rects instead of manually dealing with just an x-coordinate, and it now uses interface-scaled buttons.

<img width="552" height="624" alt="image" src="https://github.com/user-attachments/assets/13b34a1b-fdea-4914-8830-bbf88f5e3deb" />

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
