### PR TITLE
Fix bff8501: Gcc 15 warns about duplicate type.

### DIFF
--- a/src/pathfinder/yapf/yapf_river_builder.cpp
+++ b/src/pathfinder/yapf/yapf_river_builder.cpp
@@ -22,7 +22,7 @@ struct YapfRiverBuilderNode : CYapfNodeT<CYapfNodeKeyTrackDir, YapfRiverBuilderN
 using RiverBuilderNodeList = NodeList<YapfRiverBuilderNode, 8, 10>;
 
 /* We don't need a follower but YAPF requires one. */
-struct DummyFollower {};
+struct RiverBuilderFollower {};
 
 /* We don't need a vehicle but YAPF requires one. */
 struct DummyVehicle : Vehicle {};
@@ -32,7 +32,7 @@ class YapfRiverBuilder;
 /* Types struct required for YAPF components. */
 struct RiverBuilderTypes {
 	using Tpf = YapfRiverBuilder;
-	using TrackFollower = DummyFollower;
+	using TrackFollower = RiverBuilderFollower;
 	using NodeList = RiverBuilderNodeList;
 	using VehicleType = DummyVehicle;
 };
@@ -74,7 +74,7 @@ public:
 		return n.GetTile() == this->end_tile;
 	}
 
-	inline bool PfCalcCost(Node &n, const DummyFollower *)
+	inline bool PfCalcCost(Node &n, const RiverBuilderFollower *)
 	{
 		n.cost = n.parent->cost + 1 + RandomRange(_settings_game.game_creation.river_route_random);
 		return true;
@@ -94,7 +94,7 @@ public:
 			if (IsValidTile(t) && RiverFlowsDown(old_node.GetTile(), t)) {
 				Node &node = Yapf().CreateNewNode();
 				node.Set(&old_node, t, INVALID_TRACKDIR, true);
-				Yapf().AddNewNode(node, DummyFollower{});
+				Yapf().AddNewNode(node, RiverBuilderFollower{});
 			}
 		}
 	}

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -76,14 +76,14 @@ struct WaterRegionNode : CYapfNodeT<WaterRegionPatchKey, WaterRegionNode> {
 using WaterRegionNodeList = NodeList<WaterRegionNode, NODE_LIST_HASH_BITS_OPEN, NODE_LIST_HASH_BITS_CLOSED>;
 
 /* We don't need a follower but YAPF requires one. */
-struct DummyFollower : public CFollowTrackWater {};
+struct WaterRegionFollower : public CFollowTrackWater {};
 
 class YapfShipRegions;
 
 /* Types struct required for YAPF internals. */
 struct WaterRegionTypes {
 	using Tpf = YapfShipRegions;
-	using TrackFollower = DummyFollower;
+	using TrackFollower = WaterRegionFollower;
 	using NodeList = WaterRegionNodeList;
 	using VehicleType = Ship;
 };


### PR DESCRIPTION
## Motivation / Problem

With the addition of the YAPF river builder (#14606) there are now two types called DummyFollower. Heiki mentioned it in the dev discord: https://discord.com/channels/142724111502802944/1008473233844097104/1420845341951135757

## Description

Renamed types to RiverBuilderFollower and WaterRegionFollower to avoid name clash.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
