### PR TITLE
Codechange: Moved PruneIntermediateNodeBranch to rail pathfinder.

### DIFF
--- a/src/pathfinder/yapf/yapf_base.hpp
+++ b/src/pathfinder/yapf/yapf_base.hpp
@@ -186,24 +186,6 @@ public:
 	}
 
 	/**
-	 * In some cases an intermediate node branch should be pruned.
-	 * The most prominent case is when a red EOL signal is encountered, but
-	 * there was a segment change (e.g. a rail type change) before that. If
-	 * the branch would not be pruned, the rail type change location would
-	 * remain the best intermediate node, and thus the vehicle would still
-	 * go towards the red EOL signal.
-	 */
-	void PruneIntermediateNodeBranch(Node *n)
-	{
-		bool intermediate_on_branch = false;
-		while (n != nullptr && !n->segment->end_segment_reason.Test(EndSegmentReason::ChoiceFollows)) {
-			if (n == Yapf().best_intermediate_node) intermediate_on_branch = true;
-			n = n->parent;
-		}
-		if (intermediate_on_branch) Yapf().best_intermediate_node = n;
-	}
-
-	/**
 	 * AddNewNode() - called by Tderived::PfFollowNode() for each child node.
 	 *  Nodes are evaluated here and added into open list
 	 */


### PR DESCRIPTION
## Motivation / Problem

`PruneIntermediateNodeBranch` is in `CYapfBaseT` (the core yapf implementation) but assumes the node it operates on is a rail node, and is only ever used in the rail pathfinder. It doesn't belong in the base class.

## Description

Moved it to the rail pathfinder.

## Limitations

More CRTP-from-hell...

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
