### PR TITLE
Codechange: Set YAPF startup nodes directly.

### DIFF
--- a/src/pathfinder/yapf/yapf_base.hpp
+++ b/src/pathfinder/yapf/yapf_base.hpp
@@ -35,7 +35,6 @@
  *  Requirements to your pathfinder class derived from CYapfBaseT:
  *  --------------------------------------------------------------
  *  Your pathfinder derived class needs to implement following methods:
- *    inline void PfSetStartupNodes()
  *    inline void PfFollowNode(Node &org)
  *    inline bool PfCalcCost(Node &n)
  *    inline bool PfCalcEstimate(Node &n)
@@ -104,8 +103,6 @@ public:
 	{
 		this->vehicle = v;
 
-		Yapf().PfSetStartupNodes();
-
 		for (;;) {
 			this->num_steps++;
 			Node *best_open_node = this->nodes.GetBestOpenNode();
@@ -162,14 +159,13 @@ public:
 	/** Add new node (created by CreateNewNode and filled with data) into open list */
 	inline void AddStartupNode(Node &n)
 	{
+		assert(n.parent == nullptr);
+		assert(this->num_steps == 0);
+
 		Yapf().PfNodeCacheFetch(n);
 		/* insert the new node only if it is not there */
 		if (this->nodes.FindOpenNode(n.key) == nullptr) {
 			this->nodes.InsertOpenNode(n);
-		} else {
-			/* if we are here, it means that node is already there - how it is possible?
-			 *   probably the train is in the position that both its ends point to the same tile/exit-dir
-			 *   very unlikely, but it happened */
 		}
 	}
 
@@ -209,6 +205,8 @@ public:
 	 */
 	void AddNewNode(Node &n, const TrackFollower &tf)
 	{
+		assert(n.parent != nullptr);
+
 		/* evaluate the node */
 		bool cached = Yapf().PfNodeCacheFetch(n);
 		if (!cached) {

--- a/src/pathfinder/yapf/yapf_common.hpp
+++ b/src/pathfinder/yapf/yapf_common.hpp
@@ -23,9 +23,6 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables
 
 protected:
-	TileIndex origin_tile; ///< origin tile
-	TrackdirBits origin_trackdirs; ///< origin trackdir mask
-
 	/** to access inherited path finder */
 	inline Tpf &Yapf()
 	{
@@ -36,19 +33,12 @@ public:
 	/** Set origin tile / trackdir mask */
 	void SetOrigin(TileIndex tile, TrackdirBits trackdirs)
 	{
-		this->origin_tile = tile;
-		this->origin_trackdirs = trackdirs;
-	}
-
-	/** Called when YAPF needs to place origin nodes into open list */
-	void PfSetStartupNodes()
-	{
-		bool is_choice = (KillFirstBit(this->origin_trackdirs) != TRACKDIR_BIT_NONE);
-		for (TrackdirBits tdb = this->origin_trackdirs; tdb != TRACKDIR_BIT_NONE; tdb = KillFirstBit(tdb)) {
+		bool is_choice = (KillFirstBit(trackdirs) != TRACKDIR_BIT_NONE);
+		for (TrackdirBits tdb = trackdirs; tdb != TRACKDIR_BIT_NONE; tdb = KillFirstBit(tdb)) {
 			Trackdir td = (Trackdir)FindFirstBit(tdb);
-			Node &n1 = Yapf().CreateNewNode();
-			n1.Set(nullptr, this->origin_tile, td, is_choice);
-			Yapf().AddStartupNode(n1);
+			Node &node = Yapf().CreateNewNode();
+			node.Set(nullptr, tile, td, is_choice);
+			Yapf().AddStartupNode(node);
 		}
 	}
 };
@@ -62,12 +52,6 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables
 
 protected:
-	TileIndex origin_tile; ///< first origin tile
-	Trackdir origin_td; ///< first origin trackdir
-	TileIndex reverse_tile; ///< second (reverse) origin tile
-	Trackdir reverse_td; ///< second (reverse) origin trackdir
-	int reverse_penalty; ///< penalty to be added for using the reverse origin
-
 	/** to access inherited path finder */
 	inline Tpf &Yapf()
 	{
@@ -76,28 +60,19 @@ protected:
 
 public:
 	/** set origin (tiles, trackdirs, etc.) */
-	void SetOrigin(TileIndex tile, Trackdir td, TileIndex tiler = INVALID_TILE, Trackdir tdr = INVALID_TRACKDIR, int reverse_penalty = 0)
+	void SetOrigin(TileIndex forward_tile, Trackdir forward_td, TileIndex reverse_tile = INVALID_TILE,
+			Trackdir reverse_td = INVALID_TRACKDIR, int reverse_penalty = 0)
 	{
-		this->origin_tile = tile;
-		this->origin_td = td;
-		this->reverse_tile = tiler;
-		this->reverse_td = tdr;
-		this->reverse_penalty = reverse_penalty;
-	}
-
-	/** Called when YAPF needs to place origin nodes into open list */
-	void PfSetStartupNodes()
-	{
-		if (this->origin_tile != INVALID_TILE && this->origin_td != INVALID_TRACKDIR) {
-			Node &n1 = Yapf().CreateNewNode();
-			n1.Set(nullptr, this->origin_tile, this->origin_td, false);
-			Yapf().AddStartupNode(n1);
+		if (forward_tile != INVALID_TILE && forward_td != INVALID_TRACKDIR) {
+			Node &node = Yapf().CreateNewNode();
+			node.Set(nullptr, forward_tile, forward_td, false);
+			Yapf().AddStartupNode(node);
 		}
-		if (this->reverse_tile != INVALID_TILE && this->reverse_td != INVALID_TRACKDIR) {
-			Node &n2 = Yapf().CreateNewNode();
-			n2.Set(nullptr, this->reverse_tile, this->reverse_td, false);
-			n2.cost = this->reverse_penalty;
-			Yapf().AddStartupNode(n2);
+		if (reverse_tile != INVALID_TILE && reverse_td != INVALID_TRACKDIR) {
+			Node &node = Yapf().CreateNewNode();
+			node.Set(nullptr, reverse_tile, reverse_td, false);
+			node.cost = reverse_penalty;
+			Yapf().AddStartupNode(node);
 		}
 	}
 };

--- a/src/pathfinder/yapf/yapf_river_builder.cpp
+++ b/src/pathfinder/yapf/yapf_river_builder.cpp
@@ -47,7 +47,6 @@ public:
 	using Key = Node::Key;
 
 protected:
-	TileIndex start_tile; ///< Start tile of the river
 	TileIndex end_tile; ///< End tile of the river
 
 	inline YapfRiverBuilder &Yapf()
@@ -58,14 +57,10 @@ protected:
 public:
 	YapfRiverBuilder(TileIndex start_tile, TileIndex end_tile)
 	{
-		this->start_tile = start_tile;
 		this->end_tile = end_tile;
-	}
 
-	void PfSetStartupNodes()
-	{
 		Node &node = Yapf().CreateNewNode();
-		node.Set(nullptr, this->start_tile, INVALID_TRACKDIR, false);
+		node.Set(nullptr, start_tile, INVALID_TRACKDIR, false);
 		Yapf().AddStartupNode(node);
 	}
 

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -113,7 +113,12 @@ public:
 	void AddOrigin(const WaterRegionPatchDesc &water_region_patch)
 	{
 		if (water_region_patch.label == INVALID_WATER_REGION_PATCH) return;
-		if (!HasOrigin(water_region_patch)) this->origin_keys.emplace_back(water_region_patch);
+		if (!HasOrigin(water_region_patch)) {
+			this->origin_keys.emplace_back(water_region_patch);
+			Node &node = Yapf().CreateNewNode();
+			node.Set(nullptr, water_region_patch);
+			Yapf().AddStartupNode(node);
+		}
 	}
 
 	bool HasOrigin(const WaterRegionPatchDesc &water_region_patch)
@@ -124,15 +129,6 @@ public:
 	void SetDestination(const WaterRegionPatchDesc &water_region_patch)
 	{
 		this->dest.Set(water_region_patch);
-	}
-
-	void PfSetStartupNodes()
-	{
-		for (const WaterRegionPatchKey &origin_key : this->origin_keys) {
-			Node &node = Yapf().CreateNewNode();
-			node.Set(nullptr, origin_key);
-			Yapf().AddStartupNode(node);
-		}
 	}
 
 	inline void PfFollowNode(Node &old_node)


### PR DESCRIPTION
## Motivation / Problem

Currently YAPF calls `PfSetStartupNodes()` to set the initial pathfinder nodes. This requires storing all relevant origin data until it's time to add the startup nodes.

## Description

Call AddStartupNode directly.

## Limitations

Technically this makes it possible to call AddStartupNode in the middle of a PF run. I've added some asserts that should prevent this.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
