### PR TITLE
Fix #14666: charge maintenance for depots

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4021,7 +4021,7 @@ STR_COMPANY_INFRASTRUCTURE_VIEW_SIGNALS                         :{WHITE}Signals
 STR_COMPANY_INFRASTRUCTURE_VIEW_ROAD_SECT                       :{GOLD}Road pieces:
 STR_COMPANY_INFRASTRUCTURE_VIEW_TRAM_SECT                       :{GOLD}Tram pieces:
 STR_COMPANY_INFRASTRUCTURE_VIEW_WATER_SECT                      :{GOLD}Water tiles:
-STR_COMPANY_INFRASTRUCTURE_VIEW_CANALS                          :{WHITE}Canals
+STR_COMPANY_INFRASTRUCTURE_VIEW_CANALS                          :{WHITE}Water infrastructure
 STR_COMPANY_INFRASTRUCTURE_VIEW_STATION_SECT                    :{GOLD}Stations:
 STR_COMPANY_INFRASTRUCTURE_VIEW_STATIONS                        :{WHITE}Station tiles
 STR_COMPANY_INFRASTRUCTURE_VIEW_AIRPORTS                        :{WHITE}Airports

--- a/src/rail.h
+++ b/src/rail.h
@@ -493,7 +493,9 @@ inline Money RailConvertCost(RailType from, RailType to)
 inline Money RailMaintenanceCost(RailType railtype, uint32_t num, uint32_t total_num)
 {
 	assert(railtype < RAILTYPE_END);
-	return (_price[PR_INFRASTRUCTURE_RAIL] * GetRailTypeInfo(railtype)->maintenance_multiplier * num * (1 + IntSqrt(total_num))) >> 11; // 4 bits fraction for the multiplier and 7 bits scaling.
+	Money cost = (_price[PR_INFRASTRUCTURE_RAIL] * GetRailTypeInfo(railtype)->maintenance_multiplier * num * (1 + IntSqrt(total_num))) >> 11; // 4 bits fraction for the multiplier and 7 bits scaling.
+	if (num != 0 && cost == 0) cost = 1;
+	return cost;
 }
 
 /**

--- a/src/road_func.h
+++ b/src/road_func.h
@@ -125,7 +125,9 @@ inline RoadBits AxisToRoadBits(Axis a)
 inline Money RoadMaintenanceCost(RoadType roadtype, uint32_t num, uint32_t total_num)
 {
 	assert(roadtype < ROADTYPE_END);
-	return (_price[PR_INFRASTRUCTURE_ROAD] * GetRoadTypeInfo(roadtype)->maintenance_multiplier * num * (1 + IntSqrt(total_num))) >> 12;
+	Money cost = (_price[PR_INFRASTRUCTURE_ROAD] * GetRoadTypeInfo(roadtype)->maintenance_multiplier * num * (1 + IntSqrt(total_num))) >> 12;
+	if (num != 0 && cost == 0) cost = 1;
+	return cost;
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure depots contribute to infrastructure maintenance regardless of network size
- align the infrastructure window terminology with what the finance ledger actually counts

## Problem & Motivation
Infrastructure maintenance is supposed to make depots part of the running costs once the economy setting is enabled. Issue #14666 pointed out that this is true for ship depots, yet rail and road depots remained free: the maintenance calculation overflowed down to zero when the company only owned the depot tile. That meant companies could spam rail or road depots with no financial penalty, defeating the purpose of the setting.

## Solution Details
- add a defensive floor of one currency unit in both `RailMaintenanceCost` and `RoadMaintenanceCost`. Whenever we have track bits on the company ledger but the scaled result rounds to zero, we now charge a token amount so the ledger matches the actual infrastructure present.
- rename the “Canals” row in the infrastructure window to “Water infrastructure”. The ledger already lumps ship depots and canals together, so this makes the UI line up with the now-consistent costs across transport types.


Fixes #14666.