### PR TITLE
Codechange: Blit with fullscreen triangle

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -697,14 +697,13 @@ std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 	_glBindBuffer(GL_PIXEL_UNPACK_BUFFER, this->anim_pbo);
 	if (_glGetError() != GL_NO_ERROR) return "Can't allocate pixel buffer for video buffer";
 
-	/* Prime vertex buffer with a full-screen quad and store
+	/* Prime vertex buffer with a full-screen triangle and store
 	 * the corresponding state in a vertex array object. */
 	static const Simple2DVertex vert_array[] = {
 		/*  x     y    u    v */
-		{  1.f, -1.f, 1.f, 1.f },
-		{  1.f,  1.f, 1.f, 0.f },
-		{ -1.f, -1.f, 0.f, 1.f },
 		{ -1.f,  1.f, 0.f, 0.f },
+		{  3.f,  1.f, 2.f, 0.f },
+		{ -1.f, -3.f, 0.f, 2.f },
 	};
 
 	/* Create VAO. */
@@ -1060,7 +1059,7 @@ void OpenGLBackend::Paint()
 		_glUseProgram(BlitterFactory::GetCurrentBlitter()->GetScreenDepth() == 8 ? this->pal_program : this->vid_program);
 	}
 	_glBindVertexArray(this->vao_quad);
-	_glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	_glDrawArrays(GL_TRIANGLE_STRIP, 0, 3);
 
 	_glEnable(GL_BLEND);
 }


### PR DESCRIPTION
<!--
Commit message: Codechange: Blit with fullscreen triangle

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Blitting with a fullscreen quad results in unnecessary fragment shader invocations along the seam of the two triangles. The pixel quads along these diagonals will be invoked twice, once per triangle.

Ref:
https://wallisc.github.io/rendering/2021/04/18/Fullscreen-Pass.html

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Adjusts the vertex position/uv array used for blitting the image to the screen to use a single triangle that is twice the size of the clip-space cube.

The performance benefits of this are most likely negligible, but it's probably worthwhile to avoid any unnecessary fragment shader invocations regardless.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
