### PR TITLE
Codechange: make all Providers fully const (Font/Screenshot/Sound)

### DIFF
--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -229,8 +229,8 @@ public:
 		ProviderManager<FontCacheFactory>::Unregister(*this);
 	}
 
-	virtual std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) = 0;
-	virtual bool FindFallbackFont(struct FontCacheSettings *settings, const std::string &language_isocode, class MissingGlyphSearcher *callback) = 0;
+	virtual std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const = 0;
+	virtual bool FindFallbackFont(struct FontCacheSettings *settings, const std::string &language_isocode, class MissingGlyphSearcher *callback) const = 0;
 };
 
 class FontProviderManager : ProviderManager<FontCacheFactory> {

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -225,7 +225,7 @@ public:
 	 * format is 'font family name' or 'font family name, font style'.
 	 * @param fs The font size to load.
 	 */
-	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) override
+	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
 	{
 		if (fonttype != FontType::TrueType) return nullptr;
 
@@ -271,7 +271,7 @@ public:
 		return LoadFont(fs, face, font, GetFontCacheFontSize(fs));
 	}
 
-	bool FindFallbackFont(struct FontCacheSettings *settings, const std::string &language_isocode, class MissingGlyphSearcher *callback) override
+	bool FindFallbackFont(struct FontCacheSettings *settings, const std::string &language_isocode, class MissingGlyphSearcher *callback) const override
 	{
 #ifdef WITH_FONTCONFIG
 		if (FontConfigFindFallbackFont(settings, language_isocode, callback)) return true;

--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -157,14 +157,14 @@ class SpriteFontCacheFactory : public FontCacheFactory {
 public:
 	SpriteFontCacheFactory() : FontCacheFactory("sprite", "Sprite font provider") {}
 
-	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) override
+	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
 	{
 		if (fonttype != FontType::Sprite) return nullptr;
 
 		return std::make_unique<SpriteFontCache>(fs);
 	}
 
-	bool FindFallbackFont(struct FontCacheSettings *, const std::string &, class MissingGlyphSearcher *) override
+	bool FindFallbackFont(struct FontCacheSettings *, const std::string &, class MissingGlyphSearcher *) const override
 	{
 		return false;
 	}

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -211,7 +211,7 @@ public:
 	 * fallback search, use it. Otherwise, try to resolve it by font name.
 	 * @param fs The font size to load.
 	 */
-	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) override
+	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
 	{
 		if (fonttype != FontType::TrueType) return nullptr;
 
@@ -259,7 +259,7 @@ public:
 		return std::make_unique<CoreTextFontCache>(fs, std::move(font_ref), GetFontCacheFontSize(fs));
 	}
 
-	bool FindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback) override
+	bool FindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback) const override
 	{
 		/* Determine fallback font using CoreText. This uses the language isocode
 		 * to find a suitable font. CoreText is available from 10.5 onwards. */

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -276,7 +276,7 @@ public:
 	* fallback search, use it. Otherwise, try to resolve it by font name.
 	* @param fs The font size to load.
 	*/
-	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) override
+	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
 	{
 		if (fonttype != FontType::TrueType) return nullptr;
 
@@ -308,7 +308,7 @@ public:
 		return LoadWin32Font(fs, logfont, GetFontCacheFontSize(fs), font);
 	}
 
-	bool FindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback) override
+	bool FindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback) const override
 	{
 		Debug(fontcache, 1, "Trying fallback fonts");
 		EFCParam langInfo;

--- a/src/provider_manager.h
+++ b/src/provider_manager.h
@@ -25,7 +25,7 @@ public:
 
 	ProviderManager &operator=(ProviderManager const &) = delete;
 
-	static void Register(TProviderType &instance)
+	static void Register(const TProviderType &instance)
 	{
 		/* Insert according to comparator. */
 		auto &providers = GetProviders();
@@ -33,7 +33,7 @@ public:
 		providers.insert(it, &instance);
 	}
 
-	static void Unregister(TProviderType &instance)
+	static void Unregister(const TProviderType &instance)
 	{
 		auto &providers = GetProviders();
 		providers.erase(std::find(std::begin(providers), std::end(providers), &instance));
@@ -43,9 +43,9 @@ public:
 	 * Get the currently known providers.
 	 * @return The known providers.
 	 */
-	static std::vector<TProviderType *> &GetProviders()
+	static std::vector<const TProviderType *> &GetProviders()
 	{
-		static std::vector<TProviderType *> providers{};
+		static std::vector<const TProviderType *> providers{};
 		return providers;
 	}
 };

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -46,7 +46,7 @@ uint _heightmap_highest_peak;         ///< When saving a heightmap, this contain
  * If the selected provider is not found, then the first provider will be used instead.
  * @returns ScreenshotProvider, or null if none exist.
  */
-static ScreenshotProvider *GetScreenshotProvider()
+static const ScreenshotProvider *GetScreenshotProvider()
 {
 	auto providers = ProviderManager<ScreenshotProvider>::GetProviders();
 	if (providers.empty()) return nullptr;

--- a/src/screenshot_bmp.cpp
+++ b/src/screenshot_bmp.cpp
@@ -43,7 +43,7 @@ class ScreenshotProvider_Bmp : public ScreenshotProvider {
 public:
 	ScreenshotProvider_Bmp() : ScreenshotProvider("bmp", "BMP", 10) {}
 
-	bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
+	bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) const override
 	{
 		uint bpp; // bytes per pixel
 		switch (pixelformat) {

--- a/src/screenshot_pcx.cpp
+++ b/src/screenshot_pcx.cpp
@@ -41,7 +41,7 @@ class ScreenshotProvider_Pcx : public ScreenshotProvider {
 public:
 	ScreenshotProvider_Pcx() : ScreenshotProvider("pcx", "PCX", 20) {}
 
-	bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
+	bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) const override
 	{
 		uint maxlines;
 		uint y;

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -31,7 +31,7 @@ class ScreenshotProvider_Png : public ScreenshotProvider {
 public:
 	ScreenshotProvider_Png() : ScreenshotProvider("png", "PNG", 0) {}
 
-	bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) override
+	bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) const override
 	{
 		png_color rq[256];
 		uint i, y, n;

--- a/src/screenshot_type.h
+++ b/src/screenshot_type.h
@@ -36,7 +36,7 @@ public:
 		ProviderManager<ScreenshotProvider>::Unregister(*this);
 	}
 
-	virtual bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) = 0;
+	virtual bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) const = 0;
 };
 
 #endif /* SCREENSHOT_TYPE_H */

--- a/src/soundloader_opus.cpp
+++ b/src/soundloader_opus.cpp
@@ -34,7 +34,7 @@ public:
 	static constexpr size_t DECODE_BUFFER_SAMPLES = 5760 * 2;
 	static constexpr size_t DECODE_BUFFER_BYTES = DECODE_BUFFER_SAMPLES * sizeof(opus_int16);
 
-	bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) override
+	bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) const override
 	{
 		if (!new_format) return false;
 

--- a/src/soundloader_raw.cpp
+++ b/src/soundloader_raw.cpp
@@ -22,7 +22,7 @@ public:
 	static constexpr uint16_t RAW_SAMPLE_RATE = 11025; ///< Sample rate of raw pcm samples.
 	static constexpr uint8_t RAW_SAMPLE_BITS = 8; ///< Bit depths of raw pcm samples.
 
-	bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) override
+	bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) const override
 	{
 		/* Raw sounds are apecial case for the jackhammer sound (name in Windows sample.cat is "Corrupt sound")
 		 * It's not a RIFF file, but raw PCM data.

--- a/src/soundloader_type.h
+++ b/src/soundloader_type.h
@@ -26,7 +26,7 @@ public:
 		ProviderManager<SoundLoader>::Unregister(*this);
 	}
 
-	virtual bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) = 0;
+	virtual bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) const = 0;
 };
 
 #endif /* SOUNDLOADER_TYPE_H */

--- a/src/soundloader_wav.cpp
+++ b/src/soundloader_wav.cpp
@@ -23,7 +23,7 @@ public:
 
 	static constexpr uint16_t DEFAULT_SAMPLE_RATE = 11025;
 
-	bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) override
+	bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) const override
 	{
 		RandomAccessFile &file = *sound.file;
 


### PR DESCRIPTION
## Motivation / Problem

`MakeImage` in the `ScreenshotProvider` should not and does not change the provider, so why isn't it `const`?
The same holds for the functions of `FontProvider` and `SoundProvider`.
And since every function of the class is `const`, why not have the `ProviderManager` retain a `vector` of `const ScreenshotProvider` pointers?


## Description

Make the `Provider`'s functions `const` and make `GetScreenshotProvider` return a `const` pointer.
Make the `ProviderManager` use `const` types where applicable.


## Limitations

Might, or might not, conflict with #14681.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
