### PR TITLE
Codechange: Split native and emscripten bootstrap windows.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,11 @@ add_files(
 )
 
 add_files(
+    bootstrap_emscripten_gui.cpp
+    CONDITION EMSCRIPTEN
+)
+
+add_files(
     gfx_layout_icu.cpp
     gfx_layout_icu.h
     CONDITION ICU_i18n_FOUND AND HARFBUZZ_FOUND
@@ -86,6 +91,7 @@ add_files(
     bitmap_type.h
     bmp.cpp
     bmp.h
+    bootstrap.cpp
     bootstrap_gui.cpp
     bridge.h
     bridge_gui.cpp

--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -1,0 +1,67 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file bootstrap.cpp Bootstrap OpenTTD, i.e. downloading the required content. */
+
+#include "stdafx.h"
+#include "base_media_graphics.h"
+#include "blitter/factory.hpp"
+#include "error_func.h"
+#include "network/network.h"
+#include "openttd.h"
+#include "video/video_driver.hpp"
+
+#include "safeguards.h"
+
+extern void HandleBootstrapGui();
+
+/**
+ * Handle all procedures for bootstrapping OpenTTD without a base graphics set.
+ * This requires all kinds of trickery that is needed to avoid the use of
+ * sprites from the base graphics set which are pretty interwoven.
+ * @return True if a base set exists, otherwise false.
+ */
+bool HandleBootstrap()
+{
+	if (BaseGraphics::GetUsedSet() != nullptr) return true;
+
+	/* No user interface, bail out with an error. */
+	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() == 0) goto failure;
+
+	/* If there is no network or no non-sprite font, then there is nothing we can do. Go straight to failure. */
+	if (!_network_available) goto failure;
+
+#if defined(__EMSCRIPTEN__) || defined(WITH_UNISCRIBE) || (defined(WITH_FREETYPE) && (defined(WITH_FONTCONFIG))) || defined(WITH_COCOA)
+
+	/* First tell the game we're bootstrapping. */
+	_game_mode = GM_BOOTSTRAP;
+
+	HandleBootstrapGui();
+
+	/* Process the user events. */
+	VideoDriver::GetInstance()->MainLoop();
+
+	/* _exit_game is used to get out of the video driver's main loop.
+	 * In case GM_BOOTSTRAP is still set we did not exit it via the
+	 * "download complete" event, so it was a manual exit. Obey it. */
+	_exit_game = _game_mode == GM_BOOTSTRAP;
+	if (_exit_game) return false;
+
+	/* Try to probe the graphics. Should work this time. */
+	if (!BaseGraphics::SetSet(nullptr)) goto failure;
+
+	/* Finally we can continue heading for the menu. */
+	_game_mode = GM_MENU;
+	return true;
+
+#endif /* defined(__EMSCRIPTEN__) || defined(WITH_UNISCRIBE) || (defined(WITH_FREETYPE) && (defined(WITH_FONTCONFIG))) || defined(WITH_COCOA) */
+
+	/* Failure to get enough working to get a graphics set. */
+failure:
+	UserError("Failed to find a graphics set. Please acquire a graphics set for OpenTTD. See section 1.4 of README.md.");
+	return false;
+}

--- a/src/bootstrap_emscripten_gui.cpp
+++ b/src/bootstrap_emscripten_gui.cpp
@@ -1,0 +1,88 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file bootstrap_emscripten_gui.cpp Barely used user interface for bootstrapping OpenTTD, i.e. downloading the required content. */
+
+#if defined(__EMSCRIPTEN__)
+
+#include "stdafx.h"
+#include "base_media_base.h"
+#include "network/network_content.h"
+#include "openttd.h"
+
+#include <emscripten.h>
+
+#include "safeguards.h"
+
+class BootstrapEmscripten : public ContentCallback {
+	bool downloading = false;
+	uint total_files = 0;
+	uint total_bytes = 0;
+	uint downloaded_bytes = 0;
+
+public:
+	BootstrapEmscripten()
+	{
+		_network_content_client.AddCallback(this);
+		_network_content_client.Connect();
+	}
+
+	~BootstrapEmscripten()
+	{
+		_network_content_client.RemoveCallback(this);
+	}
+
+	void OnConnect(bool success) override
+	{
+		if (!success) {
+			EM_ASM({ if (window["openttd_bootstrap_failed"]) openttd_bootstrap_failed(); });
+			return;
+		}
+
+		/* Once connected, request the metadata. */
+		_network_content_client.RequestContentList(CONTENT_TYPE_BASE_GRAPHICS);
+	}
+
+	void OnReceiveContentInfo(const ContentInfo &ci) override
+	{
+		if (this->downloading) return;
+
+		/* And once the metadata is received, start downloading it. */
+		_network_content_client.Select(ci.id);
+		_network_content_client.DownloadSelectedContent(this->total_files, this->total_bytes);
+		this->downloading = true;
+
+		EM_ASM({ if (window["openttd_bootstrap"]) openttd_bootstrap($0, $1); }, this->downloaded_bytes, this->total_bytes);
+	}
+
+	void OnDownloadProgress(const ContentInfo &, int bytes) override
+	{
+		/* A negative value means we are resetting; for example, when retrying or using a fallback. */
+		if (bytes < 0) {
+			this->downloaded_bytes = 0;
+		} else {
+			this->downloaded_bytes += bytes;
+		}
+
+		EM_ASM({ if (window["openttd_bootstrap"]) openttd_bootstrap($0, $1); }, this->downloaded_bytes, this->total_bytes);
+	}
+
+	void OnDownloadComplete(ContentID) override
+	{
+		/* _exit_game is used to break out of the outer video driver's MainLoop. */
+		_exit_game = true;
+
+		delete this;
+	}
+};
+
+void HandleBootstrapGui()
+{
+	new BootstrapEmscripten();
+}
+
+#endif /* __EMSCRIPTEN__ */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

While fixing a problem with where `safeguards.h` is included, I found that `bootstrap_gui.cpp` has a complicated set of ifdefs to enable two different GUIs depending on the environment.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Split native and emscripten bootstrap windows into separate files.

This simplifies testing defines and makes each part self-contained. And `safeguards.h` is now in the right place in each.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
