### PR TITLE
Codefix: Make sure safeguards.h is the last included non-table header.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -46,6 +46,10 @@
 #include "company_cmd.h"
 #include "misc_cmd.h"
 
+#if defined(WITH_ZLIB)
+#include "network/network_content.h"
+#endif /* WITH_ZLIB */
+
 #include "table/strings.h"
 
 #include "safeguards.h"
@@ -2176,7 +2180,6 @@ static bool ConNetworkAuthorizedKey(std::span<std::string_view> argv)
 
 /* Content downloading only is available with ZLIB */
 #if defined(WITH_ZLIB)
-#include "network/network_content.h"
 
 /** Resolve a string to a content type. */
 static ContentType StringToContentType(std::string_view str)

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -7,6 +7,8 @@
 
 /** @file freetypefontcache.cpp FreeType font cache implementation. */
 
+#ifdef WITH_FREETYPE
+
 #include "../stdafx.h"
 
 #include "../debug.h"
@@ -20,13 +22,12 @@
 
 #include "../table/control_codes.h"
 
-#include "../safeguards.h"
-
-#ifdef WITH_FREETYPE
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 #include FT_TRUETYPE_TABLES_H
+
+#include "../safeguards.h"
 
 /** Font cache for fonts that are based on a freetype font. */
 class FreeTypeFontCache : public TrueTypeFontCache {

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -22,6 +22,10 @@
 
 #include "table/strings.h"
 
+#ifdef WITH_PNG
+#include <png.h>
+#endif /* WITH_PNG */
+
 #include "safeguards.h"
 
 /**
@@ -71,8 +75,6 @@ static inline uint8_t RGBToGreyscale(uint8_t red, uint8_t green, uint8_t blue)
 
 
 #ifdef WITH_PNG
-
-#include <png.h>
 
 /**
  * The PNG Heightmap loader.

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -88,12 +88,12 @@
 
 #include "table/strings.h"
 
-#include "safeguards.h"
-
 #ifdef __EMSCRIPTEN__
 #	include <emscripten.h>
 #	include <emscripten/html5.h>
 #endif
+
+#include "safeguards.h"
 
 void CallLandscapeTick();
 void DoPaletteAnimations();

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -14,7 +14,6 @@
 #include "../../fios.h"
 #include "../../thread.h"
 
-
 #include <dirent.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -25,6 +24,10 @@
 #ifdef WITH_SDL2
 #include <SDL.h>
 #endif
+
+#ifdef WITH_ICONV
+#include <iconv.h>
+#endif /* WITH_ICONV */
 
 #ifdef __EMSCRIPTEN__
 #	include <emscripten.h>
@@ -84,10 +87,6 @@ bool FiosIsHiddenFile(const std::filesystem::path &path)
 }
 
 #ifdef WITH_ICONV
-
-#include <iconv.h>
-#include "../../debug.h"
-#include "../../string_func.h"
 
 std::optional<std::string> GetCurrentLocale(const char *param);
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -56,6 +56,18 @@
 #	include <emscripten.h>
 #endif
 
+#ifdef WITH_LZO
+#include <lzo/lzo1x.h>
+#endif
+
+#if defined(WITH_ZLIB)
+#include <zlib.h>
+#endif /* WITH_ZLIB */
+
+#if defined(WITH_LIBLZMA)
+#include <lzma.h>
+#endif /* WITH_LIBLZMA */
+
 #include "table/strings.h"
 
 #include "../safeguards.h"
@@ -2417,7 +2429,6 @@ struct FileWriter : SaveFilter {
  *******************************************/
 
 #ifdef WITH_LZO
-#include <lzo/lzo1x.h>
 
 /** Buffer size for the LZO compressor */
 static const uint LZO_BUFFER_SIZE = 8192;
@@ -2546,7 +2557,6 @@ struct NoCompSaveFilter : SaveFilter {
  ********************************************/
 
 #if defined(WITH_ZLIB)
-#include <zlib.h>
 
 /** Filter using Zlib compression. */
 struct ZlibLoadFilter : LoadFilter {
@@ -2665,7 +2675,6 @@ struct ZlibSaveFilter : SaveFilter {
  ********************************************/
 
 #if defined(WITH_LIBLZMA)
-#include <lzma.h>
 
 /**
  * Have a copy of an initialised LZMA stream. We need this as it's

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -28,7 +28,10 @@
 
 #ifdef WITH_ICU_I18N
 /* Required by StrNaturalCompare. */
+#	include <unicode/brkiter.h>
+#	include <unicode/stsearch.h>
 #	include <unicode/ustring.h>
+#	include <unicode/utext.h>
 #	include "language.h"
 #	include "gfx_func.h"
 #endif /* WITH_ICU_I18N */
@@ -453,8 +456,6 @@ int StrNaturalCompare(std::string_view s1, std::string_view s2, bool ignore_garb
 
 #ifdef WITH_ICU_I18N
 
-#include <unicode/stsearch.h>
-
 /**
  * Search if a string is contained in another string using the current locale.
  *
@@ -600,9 +601,6 @@ bool ConvertHexToBytes(std::string_view hex, std::span<uint8_t> bytes)
 }
 
 #elif defined(WITH_ICU_I18N)
-
-#include <unicode/utext.h>
-#include <unicode/brkiter.h>
 
 /** String iterator using ICU as a backend. */
 class IcuStringIterator : public StringIterator

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -28,13 +28,13 @@
 #include "allegro_v.h"
 #include <allegro.h>
 
-#include "../safeguards.h"
-
 #ifdef _DEBUG
 /* Allegro replaces SEGV/ABRT signals meaning that the debugger will never
  * be triggered, so rereplace the signals and make the debugger useful. */
 #include <signal.h>
 #endif
+
+#include "../safeguards.h"
 
 static FVideoDriver_Allegro iFVideoDriver_Allegro;
 

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -32,6 +32,13 @@
 #include <winrt/Windows.UI.ViewManagement.h>
 #endif
 
+#ifdef WITH_OPENGL
+#include <GL/gl.h>
+#include "../3rdparty/opengl/glext.h"
+#include "../3rdparty/opengl/wglext.h"
+#include "opengl.h"
+#endif /* WITH_OPENGL */
+
 #include "../safeguards.h"
 
 /* Missing define in MinGW headers. */
@@ -1284,11 +1291,6 @@ void VideoDriver_Win32GDI::Paint()
 #endif
 
 #ifdef WITH_OPENGL
-
-#include <GL/gl.h>
-#include "../3rdparty/opengl/glext.h"
-#include "../3rdparty/opengl/wglext.h"
-#include "opengl.h"
 
 #ifndef PFD_SUPPORT_COMPOSITION
 #	define PFD_SUPPORT_COMPOSITION 0x00008000


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Compilation errors due to (sometimes conditional) some includes being included after `safeguards.h`

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Move includes so that `safeguards.h` is the last included file. (Some `table/` may still occur after, however.)

This ensures that local and system includes are not affected by the safeguards.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
