### PR TITLE
Codechange: Insert YAPF nodes using move semantics.

### DIFF
--- a/src/pathfinder/yapf/yapf_common.hpp
+++ b/src/pathfinder/yapf/yapf_common.hpp
@@ -36,9 +36,9 @@ public:
 		bool is_choice = (KillFirstBit(trackdirs) != TRACKDIR_BIT_NONE);
 		for (TrackdirBits tdb = trackdirs; tdb != TRACKDIR_BIT_NONE; tdb = KillFirstBit(tdb)) {
 			Trackdir td = (Trackdir)FindFirstBit(tdb);
-			Node &node = Yapf().CreateNewNode();
+			Node node;
 			node.Set(nullptr, tile, td, is_choice);
-			Yapf().AddStartupNode(node);
+			Yapf().AddStartupNode(std::move(node));
 		}
 	}
 };
@@ -64,15 +64,15 @@ public:
 			Trackdir reverse_td = INVALID_TRACKDIR, int reverse_penalty = 0)
 	{
 		if (forward_tile != INVALID_TILE && forward_td != INVALID_TRACKDIR) {
-			Node &node = Yapf().CreateNewNode();
+			Node node;
 			node.Set(nullptr, forward_tile, forward_td, false);
-			Yapf().AddStartupNode(node);
+			Yapf().AddStartupNode(std::move(node));
 		}
 		if (reverse_tile != INVALID_TILE && reverse_td != INVALID_TRACKDIR) {
-			Node &node = Yapf().CreateNewNode();
+			Node node;
 			node.Set(nullptr, reverse_tile, reverse_td, false);
 			node.cost = reverse_penalty;
-			Yapf().AddStartupNode(node);
+			Yapf().AddStartupNode(std::move(node));
 		}
 	}
 };

--- a/src/pathfinder/yapf/yapf_river_builder.cpp
+++ b/src/pathfinder/yapf/yapf_river_builder.cpp
@@ -59,9 +59,9 @@ public:
 	{
 		this->end_tile = end_tile;
 
-		Node &node = Yapf().CreateNewNode();
+		Node node;
 		node.Set(nullptr, start_tile, INVALID_TRACKDIR, false);
-		Yapf().AddStartupNode(node);
+		Yapf().AddStartupNode(std::move(node));
 	}
 
 	inline bool PfDetectDestination(Node &n) const
@@ -87,9 +87,9 @@ public:
 		for (DiagDirection d = DIAGDIR_BEGIN; d < DIAGDIR_END; ++d) {
 			const TileIndex t = old_node.GetTile() + TileOffsByDiagDir(d);
 			if (IsValidTile(t) && RiverFlowsDown(old_node.GetTile(), t)) {
-				Node &node = Yapf().CreateNewNode();
+				Node node;
 				node.Set(&old_node, t, INVALID_TRACKDIR, true);
-				Yapf().AddNewNode(node, RiverBuilderFollower{});
+				Yapf().AddNewNode(std::move(node), RiverBuilderFollower{});
 			}
 		}
 	}

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -115,9 +115,9 @@ public:
 		if (water_region_patch.label == INVALID_WATER_REGION_PATCH) return;
 		if (!HasOrigin(water_region_patch)) {
 			this->origin_keys.emplace_back(water_region_patch);
-			Node &node = Yapf().CreateNewNode();
+			Node node;
 			node.Set(nullptr, water_region_patch);
-			Yapf().AddStartupNode(node);
+			Yapf().AddStartupNode(std::move(node));
 		}
 	}
 
@@ -134,9 +134,9 @@ public:
 	inline void PfFollowNode(Node &old_node)
 	{
 		VisitWaterRegionPatchCallback visit_func = [&](const WaterRegionPatchDesc &water_region_patch) {
-			Node &node = Yapf().CreateNewNode();
+			Node node;
 			node.Set(&old_node, water_region_patch);
-			Yapf().AddNewNode(node, TrackFollower{});
+			Yapf().AddNewNode(std::move(node), TrackFollower{});
 		};
 		VisitWaterRegionPatchNeighbours(old_node.key.water_region_patch, visit_func);
 	}


### PR DESCRIPTION
## Motivation / Problem

The NodeList class has a mechanism to avoid unnecessary insertions. It works fine but the mechanism is a bit primitive and error-prone. Modern C++'s move semantics are a nicer alternative.

## Description

Remove NodeList's CreateNewNode function and have InsertOpenNode take the node by rvalue reference instead.

Currenly we require any node class used in the NodeList to have a Set function in order to set its members. With this change this is no longer required, we can just use a constructor instead. But that will be a separate PR.

## Limitations

I did not do a performance comparison but I don't expect it to have any (significant) impact.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
