### PR TITLE
Change #13915: Share one window for engine preview pop ups.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4390,7 +4390,15 @@ STR_DEPOT_SELL_CONFIRMATION_TEXT                                :{YELLOW}You are
 
 # Engine preview window
 STR_ENGINE_PREVIEW_CAPTION                                      :{WHITE}Message from vehicle manufacturer
+STR_ENGINE_PREVIEW_CAPTION_COUNT                                :{WHITE}Message from vehicle manufacturer ({COMMA} of {COMMA})
 STR_ENGINE_PREVIEW_MESSAGE                                      :{GOLD}We have just designed a new {STRING} - would you be interested in a year's exclusive use of this vehicle, so we can see how it performs before making it universally available?
+
+STR_ENGINE_PREVIEW_PREVIOUS                                     :Previous
+STR_ENGINE_PREVIEW_PREVIOUS_TOOLTIP                             :Click to step to the previous new vehicle
+STR_ENGINE_PREVIEW_NEXT                                         :Next
+STR_ENGINE_PREVIEW_NEXT_TOOLTIP                                 :Click to step to the next new vehicle
+STR_ENGINE_PREVIEW_ENGINE_LIST                                  :{COMMA}: {ENGINE}
+STR_ENGINE_PREVIEW_ENGINE_LIST_TOOLTIP                          :Click to jump to a new vehicle
 
 STR_ENGINE_PREVIEW_RAILROAD_LOCOMOTIVE                          :railway locomotive
 STR_ENGINE_PREVIEW_ELRAIL_LOCOMOTIVE                            :electrified railway locomotive

--- a/src/widgets/engine_widget.h
+++ b/src/widgets/engine_widget.h
@@ -12,9 +12,13 @@
 
 /** Widgets of the #EnginePreviewWindow class. */
 enum EnginePreviewWidgets : WidgetID {
+	WID_EP_CAPTION, ///< The caption for the question.
 	WID_EP_QUESTION, ///< The container for the question.
 	WID_EP_NO,       ///< No button.
 	WID_EP_YES,      ///< Yes button.
+	WID_EP_PREV, ///< Previous button.
+	WID_EP_LIST, ///< Dropdown menu to jump to entries.
+	WID_EP_NEXT, ///< Next button.
 };
 
 #endif /* WIDGETS_ENGINE_WIDGET_H */

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -766,6 +766,7 @@ public:
 	 * A dropdown option associated to this window has been selected.
 	 * @param widget the widget (button) that the dropdown is associated with.
 	 * @param index  the element in the dropdown that is selected.
+	 * @param click_result dropdown element specific result data.
 	 */
 	virtual void OnDropdownSelect([[maybe_unused]] WidgetID widget, [[maybe_unused]] int index, [[maybe_unused]] int click_result) {}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Closes #13915.

As per #13915, if many engine previews occur at the same date, the game will spam the player with lots of windows.

#14605 adds selections, filtering, sorting etc to the preview window to solve this but, in my opinion, goes way over the top and makes this overly complex.

Therefore...

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add previous/next buttons to the engine preview window.

If more than one engine preview occurs at the same time, previous/next buttons allow the player to switch between engines.

The current "page" is shown in the window title. Clicking on "Yes" or "No" to accept to decline a preview will remove it from the list, and if a preview is not longer available it will be removed too.

If no previews are left, the window is closed.

[Screencast from 2025-10-06 23-01-46.webm](https://github.com/user-attachments/assets/b6017a98-d41b-4699-b3a8-c7010b655b65)


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Doesn't yet properly determine the largest window size to use, so goes by the first engine. I figured I'd gauge interest first.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
