### PR TITLE
Feature: Allow placing an area of 1x1 houses

### DIFF
--- a/src/command_type.h
+++ b/src/command_type.h
@@ -299,6 +299,7 @@ enum Commands : uint8_t {
 	CMD_EXPAND_TOWN,                  ///< expand a town
 	CMD_DELETE_TOWN,                  ///< delete a town
 	CMD_PLACE_HOUSE,                  ///< place a house
+	CMD_PLACE_HOUSE_AREA,             ///< place an area of houses
 
 	CMD_ORDER_REFIT,                  ///< change the refit information of an order (for "goto depot" )
 	CMD_CLONE_ORDER,                  ///< clone (and share) an order

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -105,7 +105,7 @@ struct CompanyProperties {
 	uint32_t terraform_limit = 0; ///< Amount of tileheights we can (still) terraform (times 65536).
 	uint32_t clear_limit = 0; ///< Amount of tiles we can (still) clear (times 65536).
 	uint32_t tree_limit = 0; ///< Amount of trees we can (still) plant (times 65536).
-	uint32_t build_object_limit = 0; ///< Amount of tiles we can (still) build objects on (times 65536). Also applies to buying land.
+	uint32_t build_object_limit = 0; ///< Amount of tiles we can (still) build objects on (times 65536). Also applies to buying land and placing houses.
 
 	/**
 	 * If \c true, the company is (also) controlled by the computer (a NoAI program).

--- a/src/town_cmd.h
+++ b/src/town_cmd.h
@@ -28,6 +28,7 @@ CommandCost CmdTownSetText(DoCommandFlags flags, TownID town_id, const EncodedSt
 CommandCost CmdExpandTown(DoCommandFlags flags, TownID town_id, uint32_t grow_amount, TownExpandModes modes);
 CommandCost CmdDeleteTown(DoCommandFlags flags, TownID town_id);
 CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, bool house_protected, bool replace);
+CommandCost CmdPlaceHouseArea(DoCommandFlags flags, TileIndex tile, TileIndex start_tile, HouseID house, bool is_protected, bool replace, bool diagonal);
 
 DEF_CMD_TRAIT(CMD_FOUND_TOWN,       CmdFoundTown,      CommandFlags({CommandFlag::Deity, CommandFlag::NoTest}),  CommandType::LandscapeConstruction) // founding random town can fail only in exec run
 DEF_CMD_TRAIT(CMD_RENAME_TOWN,      CmdRenameTown,     CommandFlags({CommandFlag::Deity, CommandFlag::Server}),  CommandType::OtherManagement)
@@ -39,6 +40,8 @@ DEF_CMD_TRAIT(CMD_TOWN_SET_TEXT,    CmdTownSetText,    CommandFlags({CommandFlag
 DEF_CMD_TRAIT(CMD_EXPAND_TOWN,      CmdExpandTown,     CommandFlags({CommandFlag::Deity}),                       CommandType::LandscapeConstruction)
 DEF_CMD_TRAIT(CMD_DELETE_TOWN,      CmdDeleteTown,     CommandFlags({CommandFlag::Offline}),                     CommandType::LandscapeConstruction)
 DEF_CMD_TRAIT(CMD_PLACE_HOUSE,      CmdPlaceHouse,     CommandFlags({CommandFlag::Deity}),                       CommandType::OtherManagement)
+DEF_CMD_TRAIT(CMD_PLACE_HOUSE_AREA, CmdPlaceHouseArea, CommandFlags({ CommandFlag::Deity }),                     CommandType::OtherManagement)
+
 
 CommandCallback CcFoundTown;
 void CcFoundRandomTown(Commands cmd, const CommandCost &result, Money, TownID town_id);

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -124,6 +124,7 @@ enum ViewportDragDropSelectionProcess : uint8_t {
 	DDSP_PLANT_TREES,          ///< Plant trees
 	DDSP_BUILD_BRIDGE,         ///< Bridge placement
 	DDSP_BUILD_OBJECT,         ///< Build an object
+	DDSP_PLACE_HOUSE,          ///< Place a house
 
 	/* Rail specific actions */
 	DDSP_PLACE_RAIL,           ///< Rail placement


### PR DESCRIPTION
## Motivation / Problem

I've been using the house placer in a private multiplayer game, and wishing I could build an area of houses, as I can with objects, trees, etc.

## Description

Allow placing an area of houses, so long as the house is 1x1 tile (as with objects).

Placing houses is unlikely to be used on a public server, but the build object burst limitation applies just to be safe.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
