### PR TITLE
Fix 741c431: Miscalculated cargo penalty for poor station rating

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4073,7 +4073,7 @@ static void UpdateStationRating(Station *st)
 				uint32_t r = Random();
 				if (rating <= (int)GB(r, 0, 7)) {
 					/* Need to have int, otherwise it will just overflow etc. */
-					waiting = std::max((int)waiting - (int)((GB(r, 8, 2) - 1) * num_dests), 0);
+					waiting = std::max((int)waiting - (int)((GB(r, 8, 2) + 1) * num_dests), 0);
 					waiting_changed = true;
 				}
 			}


### PR DESCRIPTION
## Motivation / Problem

The amount of cargo deducted from stations with a rating of 127 (50%) or under was incorrect.

## Description

Commit https://github.com/OpenTTD/OpenTTD/commit/741c431caa59670bbe53740cc8a864992ce1bbd2#diff-6f68813e77c5367caff0a0f43ffd7fb5c9d9d4707c66c05e5fa66a939383e3bbR3325 accidentally altered the random value of the cargo decrement in the case where the station rating was 127 or under.

Previously, the formula was:
`waiting - two_bit_random_number - 1`

The change reversed the effect of the subtraction of the 1:
`waiting - ((two_bit_random_number - 1) * num_dests)`

This meant that instead of subtracting 1 to 4 cargo units, we would subtract -1 to 2 units (multiplied by num_dests).

The actual waiting cargo wouldn't increase due to this bug, because TruncateCargo is only called if the value of `waiting` decreases during an UpdateStationRating cycle - the effect was to make the subtracted cargo 0, 0, 1 or 2 instead of 1, 2, 3 or 4.

## Fix

This single-character change restores the initial decrement value to (two-bit random number + 1) - i.e. 1, 2, 3, 4 - before multiplying by num_dests.

## Checklist for review
Some things are not automated, and forgotten often. This list is a reminder for the reviewers.

The bug fix is important enough to be backported? (label: 'backport requested')
This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
This PR affects the GS/AI API? (label 'needs review: Script API')
ai_changelog.hpp, game_changelog.hpp need updating.
The compatibility wrappers (compat_*.nut) need updating.
This PR affects the NewGRF API? (label 'needs review: NewGRF')
newgrf_debug_data.h may need updating.
[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)