### PR TITLE
Feature: [Script] Allow Game Scripts to post news items with engine ID.

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1123,7 +1123,8 @@ static void NewVehicleAvailable(Engine *e)
 		AddNewsItem(GetEncodedString(STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE,
 				GetEngineCategoryName(index),
 				PackEngineNameDParam(index, EngineNameContext::PreviewNews)),
-			NewsType::NewVehicles, NewsStyle::Vehicle, {}, index);
+			NewsType::NewVehicles, NewsStyle::Vehicle, {}, index, {},
+			std::make_unique<EnginePreviewNewsInformation>(GetString(STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE, GetEngineCategoryName(index))));
 	}
 
 	/* Update the toolbar. */

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1159,7 +1159,8 @@ static void NewVehicleAvailable(Engine *e)
 		AddNewsItem(GetEncodedString(STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE,
 				GetEngineCategoryName(index),
 				PackEngineNameDParam(index, EngineNameContext::PreviewNews)),
-			NewsType::NewVehicles, NewsStyle::Vehicle, {}, index);
+			NewsType::NewVehicles, NewsStyle::Vehicle, {}, index, {},
+			std::make_unique<EnginePreviewNewsInformation>(GetString(STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE, GetEngineCategoryName(index))));
 	}
 
 	/* Update the toolbar. */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -940,7 +940,8 @@ STR_NEWS_AIRCRAFT_DEST_TOO_FAR                                  :{WHITE}{VEHICLE
 STR_NEWS_ORDER_REFIT_FAILED                                     :{WHITE}{VEHICLE} stopped because an ordered refit failed
 STR_NEWS_VEHICLE_AUTORENEW_FAILED                               :{WHITE}Autorenew failed on {VEHICLE}{}{STRING1}
 
-STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE                              :{BIG_FONT}{BLACK}New {STRING} now available!
+STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE                              :New {STRING} now available!
+STR_NEWS_NEW_VEHICLE_TITLE_PREFIX                               :{BIG_FONT}{BLACK}
 STR_NEWS_NEW_VEHICLE_TYPE                                       :{BIG_FONT}{BLACK}{ENGINE}
 STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE                    :{BLACK}New {STRING} now available!  -  {ENGINE}
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -942,7 +942,8 @@ STR_NEWS_AIRCRAFT_DEST_TOO_FAR                                  :{WHITE}{VEHICLE
 STR_NEWS_ORDER_REFIT_FAILED                                     :{WHITE}{VEHICLE} stopped because an ordered refit failed
 STR_NEWS_VEHICLE_AUTORENEW_FAILED                               :{WHITE}Autorenew failed on {VEHICLE}{}{STRING1}
 
-STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE                              :{BIG_FONT}{BLACK}New {STRING} now available!
+STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE                              :New {STRING} now available!
+STR_NEWS_NEW_VEHICLE_TITLE_PREFIX                               :{BIG_FONT}{BLACK}{RAW_STRING}
 STR_NEWS_NEW_VEHICLE_TYPE                                       :{BIG_FONT}{BLACK}{ENGINE}
 STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE                    :{BLACK}New {STRING} now available!  -  {ENGINE}
 

--- a/src/news_cmd.h
+++ b/src/news_cmd.h
@@ -14,7 +14,7 @@
 #include "company_type.h"
 #include "news_func.h"
 
-CommandCost CmdCustomNewsItem(DoCommandFlags flags, NewsType type, CompanyID company, NewsReference reference, const EncodedString &text);
+CommandCost CmdCustomNewsItem(DoCommandFlags flags, NewsType type, CompanyID company, NewsReference reference, const EncodedString &title, const EncodedString &text, const EncodedString &add_msg1, const EncodedString &add_msg2);
 
 DEF_CMD_TRAIT(CMD_CUSTOM_NEWS_ITEM, CmdCustomNewsItem, CommandFlags({CommandFlag::StrCtrl, CommandFlag::Deity}), CommandType::OtherManagement)
 

--- a/src/news_cmd.h
+++ b/src/news_cmd.h
@@ -14,7 +14,7 @@
 #include "company_type.h"
 #include "news_func.h"
 
-CommandCost CmdCustomNewsItem(DoCommandFlags flags, NewsType type, CompanyID company, NewsReference reference, const EncodedString &text);
+CommandCost CmdCustomNewsItem(DoCommandFlags flags, NewsType type, CompanyID company, NewsReference reference, const EncodedString &title, const EncodedString &text, const EncodedString &add_msg1, const EncodedString &add_msg2);
 
 DEF_CMD_TRAIT(Commands::CreateCustomNewsItem, CmdCustomNewsItem, CommandFlags({CommandFlag::StrCtrl, CommandFlag::Deity}), CommandType::OtherManagement)
 

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -34,6 +34,7 @@
 #include "zoom_func.h"
 #include "news_cmd.h"
 #include "news_func.h"
+#include "core/string_builder.hpp"
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 #include "timer/timer_game_calendar.h"
@@ -677,15 +678,28 @@ private:
 
 	std::string GetNewVehicleMessageString(WidgetID widget) const
 	{
-		assert(std::holds_alternative<EngineID>(ni->ref1));
-		EngineID engine = std::get<EngineID>(this->ni->ref1);
+		const EnginePreviewNewsInformation *epni = dynamic_cast<const EnginePreviewNewsInformation*>(this->ni->data.get());
+		if (epni == nullptr) return {};
 
 		switch (widget) {
 			case WID_N_VEH_TITLE:
-				return GetString(STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE, GetEngineCategoryName(engine));
+				return GetString(STR_NEWS_NEW_VEHICLE_TITLE_PREFIX, epni->title);
 
-			case WID_N_VEH_NAME:
-				return GetString(STR_NEWS_NEW_VEHICLE_TYPE, PackEngineNameDParam(engine, EngineNameContext::PreviewNews));
+			case WID_N_VEH_NAME: {
+				assert(std::holds_alternative<EngineID>(ni->ref1));
+				EngineID engine = std::get<EngineID>(this->ni->ref1);
+
+				std::string message = "";
+				StringBuilder builder(message);
+
+				for (std::string s : epni->additional_messages) {
+					builder.PutUtf8(SCC_BLACK);
+					builder.Put(s);
+				}
+				builder.Put(GetString(STR_NEWS_NEW_VEHICLE_TYPE, PackEngineNameDParam(engine, EngineNameContext::PreviewNews)));
+
+				return message;
+			}
 
 			default:
 				NOT_REACHED();
@@ -893,9 +907,10 @@ NewsItem::NewsItem(EncodedString &&headline, NewsType type, NewsStyle style, New
 std::string NewsItem::GetStatusText() const
 {
 	if (this->data != nullptr) {
-		/* CompanyNewsInformation is the only type of additional data used. */
-		const CompanyNewsInformation &cni = *static_cast<const CompanyNewsInformation*>(this->data.get());
-		return GetString(STR_MESSAGE_NEWS_FORMAT, cni.title, this->headline.GetDecodedString());
+		const CompanyNewsInformation *cni = dynamic_cast<const CompanyNewsInformation*>(this->data.get());
+		if (cni != nullptr) {
+			return GetString(STR_MESSAGE_NEWS_FORMAT, cni->title, this->headline.GetDecodedString());
+		}
 	}
 
 	return this->headline.GetDecodedString();
@@ -956,9 +971,12 @@ uint32_t SerialiseNewsReference(const NewsReference &reference)
  * @param company Company this news message is for.
  * @param reference First reference of the news message.
  * @param text The text of the news message.
+ * @param title The title of the popup window. Only used if \a reference is an EngineID.
+ * @param add_msg1 Firts additional message between the title and engine's properties. Only used if \a reference is an EngineID.
+ * @param add_msg2 Second additional message between the title and engine's properties. Only used if \a reference is an EngineID.
  * @return the cost of this operation or an error
  */
-CommandCost CmdCustomNewsItem(DoCommandFlags flags, NewsType type, CompanyID company, NewsReference reference, const EncodedString &text)
+CommandCost CmdCustomNewsItem(DoCommandFlags flags, NewsType type, CompanyID company, NewsReference reference, const EncodedString &text, const EncodedString &title, const EncodedString &add_msg1, const EncodedString &add_msg2)
 {
 	if (_current_company != OWNER_DEITY) return CMD_ERROR;
 
@@ -981,7 +999,14 @@ CommandCost CmdCustomNewsItem(DoCommandFlags flags, NewsType type, CompanyID com
 	if (company != INVALID_OWNER && company != _local_company) return CommandCost();
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		AddNewsItem(EncodedString{text}, type, NewsStyle::Normal, {}, reference, {});
+		if (std::holds_alternative<EngineID>(reference)) {
+			auto epni = std::make_unique<EnginePreviewNewsInformation>(title);
+			if (!add_msg1.empty()) epni->AddAdditionalMessage(add_msg1);
+			if (!add_msg2.empty()) epni->AddAdditionalMessage(add_msg2);
+			AddNewsItem(EncodedString{text}, type, NewsStyle::Vehicle, {}, reference, {}, std::move(epni));
+		} else {
+			AddNewsItem(EncodedString{text}, type, NewsStyle::Normal, {}, reference, {});
+		}
 	}
 
 	return CommandCost();

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -23,6 +23,8 @@
 #include "town_type.h"
 #include "vehicle_type.h"
 
+#include "table/strings.h"
+
 /**
  * Type of news.
  */
@@ -169,6 +171,44 @@ struct CompanyNewsInformation : NewsAllocatedData {
 	Colours colour; ///< The colour related to the company
 
 	CompanyNewsInformation(StringID title, const struct Company *c, const struct Company *other = nullptr);
+
+	CompanyNewsInformation &operator=(const CompanyNewsInformation &b)
+	{
+		this->company_name = b.company_name;
+		this->president_name = b.president_name;
+		this->other_company_name = b.other_company_name;
+		this->title = b.title;
+		this->face = b.face;
+		this->colour = b.colour;
+		return *this;
+	}
+
+	CompanyNewsInformation(const CompanyNewsInformation &b) { this->operator=(b); }
+};
+
+/**
+ * Data that needs to be stored for massage with an engine.
+ */
+struct EnginePreviewNewsInformation : NewsAllocatedData {
+	std::string title;
+	std::vector<std::string> additional_messages;
+
+	EnginePreviewNewsInformation(const EncodedString &p_title) : title(p_title.GetDecodedString()) {}
+	EnginePreviewNewsInformation(const std::string &p_title) : title(p_title) {}
+
+	EnginePreviewNewsInformation &operator=(const EnginePreviewNewsInformation &b)
+	{
+		this->title = b.title;
+		this->additional_messages = b.additional_messages;
+		return *this;
+	}
+
+	EnginePreviewNewsInformation(const EnginePreviewNewsInformation &b) { this->operator=(b); }
+
+	void AddAdditionalMessage(const EncodedString &message)
+	{
+		this->additional_messages.push_back(message.GetDecodedString() + '\n');
+	}
 };
 
 using NewsContainer = std::list<NewsItem>; ///< Container type for storing news items.

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -174,6 +174,30 @@ struct CompanyNewsInformation : NewsAllocatedData {
 	CompanyNewsInformation(StringID title, const struct Company *c, const struct Company *other = nullptr);
 };
 
+/**
+ * Data that needs to be stored for massage with an engine.
+ */
+struct EnginePreviewNewsInformation : NewsAllocatedData {
+	std::string title; ///< The title of the popup window.
+	std::vector<std::string> additional_messages; ///< Additional information inserted between the title and engine's properties.
+
+	/**
+	 * Constructs new EnginePreviewNewsInformation.
+	 * @param p_title The title of the popup window.
+	 */
+	EnginePreviewNewsInformation(const EncodedString &p_title) : title(p_title.GetDecodedString()) {}
+	EnginePreviewNewsInformation(const std::string &p_title) : title(p_title) {} ///< @copydoc EnginePreviewNewsInformation::EnginePreviewNewsInformation
+
+	/**
+	 * Appends a new string to the additional information.
+	 * @param message The string to append.
+	 */
+	void AddAdditionalMessage(const EncodedString &message)
+	{
+		this->additional_messages.push_back(message.GetDecodedString() + '\n');
+	}
+};
+
 using NewsContainer = std::list<NewsItem>; ///< Container type for storing news items.
 using NewsIterator = NewsContainer::const_iterator; ///< Iterator type for news items.
 

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -34,6 +34,9 @@
  * \li GSError::ERR_BRIDGE_TOO_LOW
  * \li GSEngine::GetAllRailTypes
  * \li GSTile::IsHouseTile
+ * \li GSNews::NewsType::NT_PREVIEW_RESULT
+ * \li GSNews::NewsReferenceType::NR_ENGINE
+ * \li GSNews::CreateWithInfo
  *
  * Other changes:
  * \li GSBridge::GetBridgeID renamed to GSBridge::GetBridgeType

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -38,6 +38,9 @@
  * \li GSError::ERR_BRIDGE_TOO_LOW
  * \li GSEngine::GetAllRailTypes
  * \li GSTile::IsHouseTile
+ * \li GSNews::NewsType::NT_PREVIEW_RESULT
+ * \li GSNews::NewsReferenceType::NR_ENGINE
+ * \li GSNews::CreateWithInfo
  *
  * Other changes:
  * \li GSBridge::GetBridgeID renamed to GSBridge::GetBridgeType

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -13,6 +13,7 @@
 #include "script_station.hpp"
 #include "script_map.hpp"
 #include "script_town.hpp"
+#include "script_engine.hpp"
 #include "script_error.hpp"
 #include "../../command_type.h"
 #include "../../string_func.h"
@@ -28,11 +29,16 @@ static NewsReference CreateReference(ScriptNews::NewsReferenceType ref_type, SQI
 		case ScriptNews::NR_STATION: return static_cast<StationID>(reference);
 		case ScriptNews::NR_INDUSTRY: return static_cast<IndustryID>(reference);
 		case ScriptNews::NR_TOWN: return static_cast<TownID>(reference);
+		case ScriptNews::NR_ENGINE: return static_cast<EngineID>(reference);
 		default: NOT_REACHED();
 	}
 }
 
-/* static */ bool ScriptNews::Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference)
+/**
+ * Internal function performing operations from ScriptNews::Create and ScriptNews::CreateWithInfo.
+ * @copydetails ScriptNews::CreateWithInfo
+ */
+/* static */ bool ScriptNews::CreateHelper(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference, const EncodedString &title, const EncodedString &additional_message1, const EncodedString &additional_message2)
 {
 	ScriptObjectRef counter(text);
 
@@ -40,15 +46,30 @@ static NewsReference CreateReference(ScriptNews::NewsReferenceType ref_type, SQI
 	EnforcePrecondition(false, text != nullptr);
 	EncodedString encoded = text->GetEncodedText();
 	EnforcePreconditionEncodedText(false, encoded);
-	EnforcePrecondition(false, type == NT_ECONOMY || type == NT_SUBSIDIES || type == NT_GENERAL);
+	EnforcePrecondition(false, type == NT_ECONOMY || type == NT_SUBSIDIES || type == NT_GENERAL || type == NT_PREVIEW_RESULT);
 	EnforcePrecondition(false, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
 	EnforcePrecondition(false, (ref_type == NR_NONE) ||
 	                           (ref_type == NR_TILE     && ScriptMap::IsValidTile(::TileIndex(reference))) ||
 	                           (ref_type == NR_STATION  && ScriptStation::IsValidStation(static_cast<StationID>(reference))) ||
 	                           (ref_type == NR_INDUSTRY && ScriptIndustry::IsValidIndustry(static_cast<IndustryID>(reference))) ||
+	                           (ref_type == NR_ENGINE   && ScriptEngine::IsValidEngine(static_cast<EngineID>(reference))) ||
 	                           (ref_type == NR_TOWN     && ScriptTown::IsValidTown(static_cast<TownID>(reference))));
 
 	::CompanyID c = ScriptCompany::FromScriptCompanyID(company);
 
-	return ScriptObject::Command<Commands::CreateCustomNewsItem>::Do((::NewsType)type, c, CreateReference(ref_type, reference), encoded);
+	return ScriptObject::Command<Commands::CreateCustomNewsItem>::Do(static_cast<::NewsType>(type), c, CreateReference(ref_type, reference), encoded, title, additional_message1, additional_message2);
+}
+
+/* static */ bool ScriptNews::Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference)
+{
+	return ScriptNews::CreateHelper(type, text, company, ref_type, reference, text->GetEncodedText(), {}, {});
+}
+
+/* static */ bool ScriptNews::CreateWithInfo(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference, Text *title, Text *additional_message1, Text *additional_message2)
+{
+	EncodedString msg1 = additional_message1->GetEncodedText();
+	EncodedString msg2 = additional_message2->GetEncodedText();
+	EncodedString encoded_title = title->GetEncodedText();
+
+	return ScriptNews::CreateHelper(type, text, company, ref_type, reference, encoded_title, msg1, msg2);
 }

--- a/src/script/api/script_news.hpp
+++ b/src/script/api/script_news.hpp
@@ -31,6 +31,7 @@ public:
 		NT_ACCEPTANCE        = to_underlying(::NewsType::Acceptance),       ///< Category acceptance changes.
 		NT_SUBSIDIES         = to_underlying(::NewsType::Subsidies),        ///< Category subsidies.
 		NT_GENERAL           = to_underlying(::NewsType::General),          ///< Category general.
+		NT_PREVIEW_RESULT    = to_underlying(::NewsType::NewVehicles),      ///< Category new vehicle available.
 	};
 
 	/**
@@ -43,6 +44,7 @@ public:
 		NR_STATION, ///< Reference station, scroll to the station when clicking on the news. Delete news when the station is deleted.
 		NR_INDUSTRY, ///< Reference industry, scrolls to the industry when clicking on the news. Delete news when the industry is deleted.
 		NR_TOWN, ///< Reference town, scroll to the town when clicking on the news.
+		NR_ENGINE, ///< Reference engine(only available for NT_PREVIEW_RESULT), aditionally shows its properties.
 	};
 
 	/**
@@ -57,14 +59,40 @@ public:
 	 *  - For #NR_STATION this parameter should be a valid stationID (ScriptStation::IsValidStation).
 	 *  - For #NR_INDUSTRY this parameter should be a valid industryID (ScriptIndustry::IsValidIndustry).
 	 *  - For #NR_TOWN this parameter should be a valid townID (ScriptTown::IsValidTown).
+	 *  - For #NR_ENGINE this parameter should be a valid engineID (ScriptEngine::IsValidEngine).
 	 * @return True if the action succeeded.
-	 * @pre type must be #NewsType::Economy, #NewsType::Subsidies, or #NewsType::General.
+	 * @pre type must be NT_ECONOMY, NT_SUBSIDIES, NT_GENERAL, or NT_PREVIEW_RESULT.
 	 * @pre text != null.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre The \a reference condition must be fulfilled.
 	 * @pre ScriptCompanyMode::IsDeity().
 	 */
 	static bool Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference);
+
+	/**
+	 * Create a news message for everybody, or for one company.
+	 * @param type The type of the news.
+	 * @param text The text message to show (can be either a raw string, or a ScriptText object).
+	 * @param company The company, or COMPANY_INVALID for all companies.
+	 * @param ref_type Type of referred game element.
+	 * @param reference The referenced game element of \a ref_type.
+	 *  - For #NR_NONE this parameter is ignored.
+	 *  - For #NR_TILE this parameter should be a valid location (ScriptMap::IsValidTile).
+	 *  - For #NR_STATION this parameter should be a valid stationID (ScriptStation::IsValidStation).
+	 *  - For #NR_INDUSTRY this parameter should be a valid industryID (ScriptIndustry::IsValidIndustry).
+	 *  - For #NR_TOWN this parameter should be a valid townID (ScriptTown::IsValidTown).
+	 *  - For #NR_ENGINE this parameter should be a valid engineID (ScriptEngine::IsValidEngine).
+	 * @param title The title of the window.
+	 * @param additional_message1 Firts additional message between the title and engines properties.
+	 * @param additional_message2 Second additional message between the title and engines properties.
+	 * @return True if the action succeeded.
+	 * @pre type must be NT_ECONOMY, NT_SUBSIDIES, NT_GENERAL, or NT_PREVIEW_RESULT.
+	 * @pre text != null.
+	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
+	 * @pre The \a reference condition must be fulfilled.
+	 * @pre ScriptCompanyMode::IsDeity().
+	 */
+	static bool CreateWithInfo(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference, Text *title, Text *additional_message1, Text *additional_message2);
 };
 
 #endif /* SCRIPT_NEWS_HPP */

--- a/src/script/api/script_news.hpp
+++ b/src/script/api/script_news.hpp
@@ -31,6 +31,7 @@ public:
 		NT_ACCEPTANCE        = to_underlying(::NewsType::Acceptance),       ///< Category acceptance changes.
 		NT_SUBSIDIES         = to_underlying(::NewsType::Subsidies),        ///< Category subsidies.
 		NT_GENERAL           = to_underlying(::NewsType::General),          ///< Category general.
+		NT_PREVIEW_RESULT    = to_underlying(::NewsType::NewVehicles),      ///< Category new vehicle available.
 	};
 
 	/**
@@ -43,6 +44,7 @@ public:
 		NR_STATION, ///< Reference station, scroll to the station when clicking on the news. Delete news when the station is deleted.
 		NR_INDUSTRY, ///< Reference industry, scrolls to the industry when clicking on the news. Delete news when the industry is deleted.
 		NR_TOWN, ///< Reference town, scroll to the town when clicking on the news.
+		NR_ENGINE, ///< Reference engine(only available for NT_PREVIEW_RESULT), aditionally shows its properties.
 	};
 
 	/**
@@ -57,14 +59,43 @@ public:
 	 *  - For #NR_STATION this parameter should be a valid stationID (ScriptStation::IsValidStation).
 	 *  - For #NR_INDUSTRY this parameter should be a valid industryID (ScriptIndustry::IsValidIndustry).
 	 *  - For #NR_TOWN this parameter should be a valid townID (ScriptTown::IsValidTown).
+	 *  - For #NR_ENGINE this parameter should be a valid engineID (ScriptEngine::IsValidEngine).
 	 * @return True if the action succeeded.
-	 * @pre type must be #NewsType::Economy, #NewsType::Subsidies, or #NewsType::General.
+	 * @pre type must be NT_ECONOMY, NT_SUBSIDIES, NT_GENERAL, or NT_PREVIEW_RESULT.
 	 * @pre text != null.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre The \a reference condition must be fulfilled.
 	 * @pre ScriptCompanyMode::IsDeity().
 	 */
 	static bool Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference);
+
+	/**
+	 * Create a news message for everybody, or for one company.
+	 * @param type The type of the news.
+	 * @param text The text message to show (can be either a raw string, or a ScriptText object).
+	 * @param company The company, or COMPANY_INVALID for all companies.
+	 * @param ref_type Type of referred game element.
+	 * @param reference The referenced game element of \a ref_type.
+	 *  - For #NR_NONE this parameter is ignored.
+	 *  - For #NR_TILE this parameter should be a valid location (ScriptMap::IsValidTile).
+	 *  - For #NR_STATION this parameter should be a valid stationID (ScriptStation::IsValidStation).
+	 *  - For #NR_INDUSTRY this parameter should be a valid industryID (ScriptIndustry::IsValidIndustry).
+	 *  - For #NR_TOWN this parameter should be a valid townID (ScriptTown::IsValidTown).
+	 *  - For #NR_ENGINE this parameter should be a valid engineID (ScriptEngine::IsValidEngine).
+	 * @param title The title of the popup window. Only used if \a ref_type is an #NR_ENGINE.
+	 * @param additional_message1 Firts additional message between the title and engine's properties. Only used if \a ref_type is an #NR_ENGINE.
+	 * @param additional_message2 Second additional message between the title and engine's properties. Only used if \a ref_type is an #NR_ENGINE.
+	 * @return True if the action succeeded.
+	 * @pre type must be NT_ECONOMY, NT_SUBSIDIES, NT_GENERAL, or NT_PREVIEW_RESULT.
+	 * @pre text != null.
+	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
+	 * @pre The \a reference condition must be fulfilled.
+	 * @pre ScriptCompanyMode::IsDeity().
+	 */
+	static bool CreateWithInfo(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference, Text *title, Text *additional_message1, Text *additional_message2);
+
+private:
+	static bool CreateHelper(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference, const EncodedString &title, const EncodedString &additional_message1, const EncodedString &additional_message2);
 };
 
 #endif /* SCRIPT_NEWS_HPP */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
#14637 and #14639.


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Allows game scripts to use EngineID as a reference when creating a new news item.
Also allow them to identify their messages as NewsType::NewVehicles with NT_PREVIEW_RESULT key.
Additionally allow to include more text before the engine informations with the use of GSNews::CreateWithInfo.


## GS code examples

Both of the following examples have similar appearance in message history window.
<img width="365" height="47" alt="Zrzut ekranu z 2025-10-18 13-01-44" src="https://github.com/user-attachments/assets/86379c26-914e-4511-bcdd-0641d5a8ac1b" />

### Example 1
```squirrel
	local text = "Just a simple text.";
	local company = GSCompany.COMPANY_INVALID;
	local type = GSNews.NT_GENERAL;
	local reference = GSNews.NR_ENGINE;
	GSNews.Create(type, text, company, reference, 0);
```
<img width="526" height="225" alt="Zrzut ekranu z 2025-10-18 13-01-14" src="https://github.com/user-attachments/assets/7ef85265-1b7a-4ba7-8210-cc57509a84be" />

### Example 2
```squirrel
	local text0 = "Just a simple text.";
	local text1 = "More simple text.";
	local text2 = "Complex text that describes how to write a text. First an editor has to be opened...";
	local company = GSCompany.COMPANY_INVALID;
	local type = GSNews.NT_PREVIEW_RESULT;
	local reference = GSNews.NR_ENGINE;
	GSNews.CreateWithInfo(type, text0, company, reference, 0, "Title", text1, text2);
```
<img width="526" height="264" alt="Zrzut ekranu z 2025-10-18 13-01-09" src="https://github.com/user-attachments/assets/f0a546f5-6835-421a-b2ef-8d69eb126063" />

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Not really useful without the ability to define custom engine preview behavior.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
