### PR TITLE
Change: Adjust landscape toolbar placement if linking to construction toolbars enabled

### DIFF
--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -367,6 +367,11 @@ Window *ShowTerraformToolbar(Window *link)
 	Window *w;
 	if (link == nullptr) {
 		w = AllocateWindowDescFront<TerraformToolbarWindow>(_terraform_desc, 0);
+		if (_settings_client.gui.link_terraform_toolbar) {
+			/* Align the terraform toolbar under the main toolbar. */
+			w->top -= w->height;
+			w->SetDirty();
+		}
 		return w;
 	}
 

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -257,6 +257,7 @@ struct TerraformToolbarWindow : Window {
 	Point OnInitialPosition([[maybe_unused]] int16_t sm_width, [[maybe_unused]] int16_t sm_height, [[maybe_unused]] int window_number) override
 	{
 		Point pt = GetToolbarAlignedWindowPosition(sm_width);
+		if (_settings_client.gui.link_terraform_toolbar) return pt;
 		pt.y += sm_height;
 		return pt;
 	}
@@ -367,20 +368,12 @@ Window *ShowTerraformToolbar(Window *link)
 	Window *w;
 	if (link == nullptr) {
 		w = AllocateWindowDescFront<TerraformToolbarWindow>(_terraform_desc, 0);
-		if (_settings_client.gui.link_terraform_toolbar) {
-			/* Align the terraform toolbar under the main toolbar. */
-			w->top -= w->height;
-			w->SetDirty();
-		}
 		return w;
 	}
 
 	/* Delete the terraform toolbar to place it again. */
 	CloseWindowById(WC_SCEN_LAND_GEN, 0, true);
 	w = AllocateWindowDescFront<TerraformToolbarWindow>(_terraform_desc, 0);
-	/* Align the terraform toolbar under the main toolbar. */
-	w->top -= w->height;
-	w->SetDirty();
 	/* Put the linked toolbar to the left / right of it. */
 	link->left = w->left + (_current_text_dir == TD_RTL ? w->width : -link->width);
 	link->top  = w->top;


### PR DESCRIPTION
## Motivation / Problem

Currently the landscape toolbar is placed below where the construction toolbars are when opened by itself, regardless of if it's set to be linked to the construction toolbars. This is gap is ugly, but necessary if linking is disabled.


## Description

Changes the placement of the landscape toolbar to be aligned with the main toolbar if linking is enabled.


## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
