### PR TITLE
Fix: Do not pre-fill industry production history for unused production slots

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1835,13 +1835,13 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 		if (indspec->callback_mask.Test(IndustryCallbackMask::Production256Ticks)) {
 			IndustryProductionCallback(i, 1);
 			for (auto &p : i->produced) {
-				p.history[LAST_MONTH].production = ScaleByCargoScale(p.waiting * 8, false);
+				if (IsValidCargoType(p.cargo)) p.history[LAST_MONTH].production = ScaleByCargoScale(p.waiting * 8, false);
 				p.waiting = 0;
 			}
 		}
 
 		for (auto &p : i->produced) {
-			p.history[LAST_MONTH].production += ScaleByCargoScale(p.rate * 8, false);
+			if (IsValidCargoType(p.cargo)) p.history[LAST_MONTH].production += ScaleByCargoScale(p.rate * 8, false);
 		}
 
 		UpdateValidHistory(i->valid_history, HISTORY_YEAR, TimerGameEconomy::month);


### PR DESCRIPTION
## Motivation / Problem

The production history for unused production slots is not saved, and therefore should not be initialised with non-zero values during map generation.
This is particularly problematic with GRFs such as "Logging Camp" on bananas, which leave production slot 0 unused but then read its production value via var 0x9E to make (incorrect) production change decisions, creating desync issues if the server game is generated instead of loaded.

## Description

Do not pre-fill industry production history for unused production slots during map generation.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
