### PR TITLE
Codefix: Clear unused map bits in MakeXXX() map helpers.

### DIFF
--- a/src/bridge_map.h
+++ b/src/bridge_map.h
@@ -135,6 +135,7 @@ inline void MakeBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDirection
 	t.m4() = 0;
 	t.m5() = 1 << 7 | tt << 2 | d;
 	SB(t.m6(), 2, 4, bridgetype);
+	SB(t.m6(), 6, 2, 0);
 	t.m7() = 0;
 	t.m8() = 0;
 }

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -274,7 +274,7 @@ inline void MakeField(Tile t, uint field_type, IndustryID industry)
 	t.m3() = field_type;
 	t.m4() = 0 << 5 | 0 << 2;
 	SetClearGroundDensity(t, CLEAR_FIELDS, 3);
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 	t.m8() = 0;
 }

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -285,6 +285,7 @@ inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8_t rand
 	SetIndustryGfx(t, gfx); // m5, part of m6
 	SetIndustryRandomTriggers(t, {}); // rest of m6
 	SetWaterClass(t, wc);
+	SB(t.m6(), 6, 2, 0);
 	t.m7() = 0;
 }
 

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -287,6 +287,7 @@ inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8_t rand
 	SetWaterClass(t, wc);
 	SB(t.m6(), 6, 2, 0);
 	t.m7() = 0;
+	t.m8() = 0;
 }
 
 #endif /* INDUSTRY_MAP_H */

--- a/src/object_map.h
+++ b/src/object_map.h
@@ -82,6 +82,7 @@ inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, uint8_t r
 	t.m5() = index.base() >> 16;
 	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
+	t.m8() = 0;
 }
 
 #endif /* OBJECT_MAP_H */

--- a/src/object_map.h
+++ b/src/object_map.h
@@ -80,7 +80,7 @@ inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, uint8_t r
 	t.m3() = random;
 	t.m4() = 0;
 	t.m5() = index.base() >> 16;
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 }
 

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -524,7 +524,7 @@ inline void MakeRailNormal(Tile t, Owner o, TrackBits b, RailType r)
 	t.m3() = 0;
 	t.m4() = 0;
 	t.m5() = RAIL_TILE_NORMAL << 6 | b;
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 	t.m8() = r;
 }
@@ -557,7 +557,7 @@ inline void MakeRailDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirectio
 	tile.m3() = 0;
 	tile.m4() = 0;
 	tile.m5() = RAIL_TILE_DEPOT << 6 | dir;
-	SB(tile.m6(), 2, 4, 0);
+	SB(tile.m6(), 2, 6, 0);
 	tile.m7() = 0;
 	tile.m8() = rail_type;
 }

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -621,6 +621,7 @@ inline void MakeRoadNormal(Tile t, RoadBits bits, RoadType road_rt, RoadType tra
 	t.m5() = (road_rt != INVALID_ROADTYPE ? bits : 0) | ROAD_TILE_NORMAL << 6;
 	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
+	t.m8() = 0;
 	SetRoadTypes(t, road_rt, tram_rt);
 	SetRoadOwner(t, RTT_TRAM, tram);
 }

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -619,7 +619,7 @@ inline void MakeRoadNormal(Tile t, RoadBits bits, RoadType road_rt, RoadType tra
 	t.m2() = town.base();
 	t.m3() = (tram_rt != INVALID_ROADTYPE ? bits : 0);
 	t.m5() = (road_rt != INVALID_ROADTYPE ? bits : 0) | ROAD_TILE_NORMAL << 6;
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 	SetRoadTypes(t, road_rt, tram_rt);
 	SetRoadOwner(t, RTT_TRAM, tram);
@@ -645,7 +645,7 @@ inline void MakeRoadCrossing(Tile t, Owner road, Owner tram, Owner rail, Axis ro
 	t.m3() = 0;
 	t.m4() = INVALID_ROADTYPE;
 	t.m5() = ROAD_TILE_CROSSING << 6 | roaddir;
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = road.base();
 	t.m8() = INVALID_ROADTYPE << 6 | rat;
 	SetRoadTypes(t, road_rt, tram_rt);
@@ -679,7 +679,7 @@ inline void MakeRoadDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirectio
 	tile.m3() = 0;
 	tile.m4() = INVALID_ROADTYPE;
 	tile.m5() = ROAD_TILE_DEPOT << 6 | dir;
-	SB(tile.m6(), 2, 4, 0);
+	SB(tile.m6(), 2, 6, 0);
 	tile.m7() = owner.base();
 	tile.m8() = INVALID_ROADTYPE << 6;
 	SetRoadType(tile, GetRoadTramType(rt), rt);

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -726,6 +726,7 @@ inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, uint8_t 
 	t.m5() = section;
 	SB(t.m6(), 2, 1, 0);
 	SB(t.m6(), 3, 4, to_underlying(st));
+	SB(t.m6(), 7, 1, 0);
 	t.m7() = 0;
 	t.m8() = 0;
 }

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -386,6 +386,7 @@ inline void MakeHouseTile(Tile t, TownID tid, uint8_t counter, uint8_t stage, Ho
 	SetHouseProtected(t, house_protected);
 	SetAnimationFrame(t, 0);
 	SetHouseProcessingTime(t, HouseSpec::Get(type)->processing_time);
+	SB(t.m8(), 12, 4, 0);
 }
 
 #endif /* TOWN_MAP_H */

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -250,7 +250,7 @@ inline void MakeTree(Tile t, TreeType type, uint count, TreeGrowthStage growth, 
 	t.m3() = type;
 	t.m4() = 0 << 5 | 0 << 2;
 	t.m5() = count << 6 | static_cast<uint>(growth);
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 }
 

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -252,6 +252,7 @@ inline void MakeTree(Tile t, TreeType type, uint count, TreeGrowthStage growth, 
 	t.m5() = count << 6 | static_cast<uint>(growth);
 	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
+	t.m8() = 0;
 }
 
 #endif /* TREE_MAP_H */

--- a/src/tunnel_map.h
+++ b/src/tunnel_map.h
@@ -55,7 +55,7 @@ inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType road_rt, R
 	t.m3() = 0;
 	t.m4() = 0;
 	t.m5() = TRANSPORT_ROAD << 2 | d;
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 	t.m8() = 0;
 	SetRoadOwner(t, RTT_ROAD, o);
@@ -78,7 +78,7 @@ inline void MakeRailTunnel(Tile t, Owner o, DiagDirection d, RailType r)
 	t.m3() = 0;
 	t.m4() = 0;
 	t.m5() = TRANSPORT_RAIL << 2 | d;
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 	t.m8() = 0;
 	SetRailType(t, r);

--- a/src/void_map.h
+++ b/src/void_map.h
@@ -27,6 +27,7 @@ inline void MakeVoid(Tile t)
 	t.m5() = 0;
 	t.m6() = 0;
 	t.m7() = 0;
+	t.m8() = 0;
 }
 
 #endif /* VOID_MAP_H */

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -393,6 +393,7 @@ inline void MakeShore(Tile t)
 	SetWaterTileType(t, WATER_TILE_COAST);
 	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
+	t.m8() = 0;
 }
 
 /**
@@ -415,6 +416,7 @@ inline void MakeWater(Tile t, Owner o, WaterClass wc, uint8_t random_bits)
 	SetWaterTileType(t, WATER_TILE_CLEAR);
 	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
+	t.m8() = 0;
 }
 
 /**
@@ -470,6 +472,7 @@ inline void MakeShipDepot(Tile t, Owner o, DepotID did, DepotPart part, Axis a, 
 	SetWaterTileType(t, WATER_TILE_DEPOT);
 	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
+	t.m8() = 0;
 }
 
 /**
@@ -494,6 +497,7 @@ inline void MakeLockTile(Tile t, Owner o, LockPart part, DiagDirection dir, Wate
 	SetWaterTileType(t, WATER_TILE_LOCK);
 	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
+	t.m8() = 0;
 }
 
 /**

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -391,7 +391,7 @@ inline void MakeShore(Tile t)
 	t.m4() = 0;
 	t.m5() = 0;
 	SetWaterTileType(t, WATER_TILE_COAST);
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 }
 
@@ -413,7 +413,7 @@ inline void MakeWater(Tile t, Owner o, WaterClass wc, uint8_t random_bits)
 	t.m4() = random_bits;
 	t.m5() = 0;
 	SetWaterTileType(t, WATER_TILE_CLEAR);
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 }
 
@@ -468,7 +468,7 @@ inline void MakeShipDepot(Tile t, Owner o, DepotID did, DepotPart part, Axis a, 
 	t.m4() = 0;
 	t.m5() = part << WBL_DEPOT_PART | a << WBL_DEPOT_AXIS;
 	SetWaterTileType(t, WATER_TILE_DEPOT);
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 }
 
@@ -492,7 +492,7 @@ inline void MakeLockTile(Tile t, Owner o, LockPart part, DiagDirection dir, Wate
 	t.m4() = 0;
 	t.m5() = part << WBL_LOCK_PART_BEGIN | dir << WBL_LOCK_ORIENT_BEGIN;
 	SetWaterTileType(t, WATER_TILE_LOCK);
-	SB(t.m6(), 2, 4, 0);
+	SB(t.m6(), 2, 6, 0);
 	t.m7() = 0;
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Many MakeXXX() map helpers do not clear bits they don't use:

* `m6` bits 6-7 previously held bridge-above status, which was moved to `type` bits 2-3. The helpers don't seem to have been updated for this change.
* Many helpers ignore `m8`.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

* Also clear bits 6-7 of `m6`.
* Clear `m8`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
