### PR TITLE
Fix #14737: Don't scale custom town and industry counts by land area

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2494,8 +2494,8 @@ void GenerateIndustries()
 		/* Total number of industries scaled by land/water proportion. */
 		uint total_amount = p.total * GetNumberOfIndustries() / (lprob.total + wprob.total);
 
-		/* Scale land-based industries to the land proportion. */
-		if (!water) total_amount = Map::ScaleByLandProportion(total_amount);
+		/* Scale land-based industries to the land proportion, unless the player has set a custom industry count. */
+		if (!water && _settings_game.difficulty.industry_density != ID_CUSTOM) total_amount = Map::ScaleByLandProportion(total_amount);
 
 		/* Ensure that forced industries are generated even if the scaled amounts are too low. */
 		if (p.total == 0 || total_amount < p.num_forced) {

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2421,7 +2421,7 @@ bool GenerateTowns(TownLayout layout, std::optional<uint> number)
 	if (number.has_value()) {
 		total = number.value();
 	} else if (_settings_game.difficulty.number_towns == static_cast<uint>(CUSTOM_TOWN_NUMBER_DIFFICULTY)) {
-		total = Map::ScaleByLandProportion(GetDefaultTownsForMapSize());
+		total = GetDefaultTownsForMapSize();
 	} else {
 		total = Map::ScaleByLandProportion(GetDefaultTownsForMapSize() + (Random() & 7));
 	}


### PR DESCRIPTION
## Motivation / Problem

PR #10063 scaled town and industry counts by actual land area, which is good.

Due in part to an inattentive reviewer, this happened even when the player set a custom town or industry count, which is bad.

## Description

Don't scale the target count if the player has set a custom number, for either towns or industries.

Closes #14737.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
