### PR TITLE
Codechange: Use helper function for company recolour offset

### DIFF
--- a/src/company_base.h
+++ b/src/company_base.h
@@ -180,6 +180,18 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 		return !Company::Get(index)->is_ai;
 	}
 
+	/**
+	 * Get offset for recolour palette of specific company.
+	 * @param livery_scheme Scheme to use for recolour.
+	 * @param use_secondary Specify whether to add secondary colour offset to the result.
+	 * @return palette offset.
+	 */
+	inline uint8_t GetCompanyRecolourOffset(LiveryScheme livery_scheme, bool use_secondary = true) const
+	{
+		const Livery &l = this->livery[livery_scheme];
+		return use_secondary ? l.colour1 + l.colour2 * 16 : l.colour1;
+	}
+
 	static void PostDestructor(size_t index);
 };
 

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -246,10 +246,8 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 
 			const Company *c = Company::GetIfValid(this->industry->founder);
 			if (c != nullptr) {
-				const Livery *l = &c->livery[LS_DEFAULT];
-
 				is_ai = c->is_ai;
-				colours = l->colour1 + l->colour2 * 16;
+				colours = c->GetCompanyRecolourOffset(LS_DEFAULT);
 			}
 
 			return this->industry->founder.base() | (is_ai ? 0x10000 : 0) | (colours << 24);

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -97,8 +97,7 @@ void BuildObject(ObjectType type, TileIndex tile, CompanyID owner, Town *town, u
 	if (owner == OWNER_NONE) {
 		o->colour = Random();
 	} else {
-		const Livery &l = Company::Get(owner)->livery[0];
-		o->colour = l.colour1 + l.colour2 * 16;
+		o->colour = Company::Get(owner)->GetCompanyRecolourOffset(LS_DEFAULT);
 	}
 
 	/* If the object wants only one colour, then give it that colour. */
@@ -193,8 +192,7 @@ void UpdateObjectColours(const Company *c)
 		/* Using the object colour callback, so not using company colour. */
 		if (spec->callback_mask.Test(ObjectCallbackMask::Colour)) continue;
 
-		const Livery &l = c->livery[0];
-		obj->colour = (spec->flags.Test(ObjectFlag::Uses2CC) ? (l.colour2 * 16) : 0) + l.colour1;
+		obj->colour = c->GetCompanyRecolourOffset(LS_DEFAULT, spec->flags.Test(ObjectFlag::Uses2CC));
 	}
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
[LordAro](https://github.com/LordAro) suggested using helper function to get company recolour palette in [#14732](https://github.com/OpenTTD/OpenTTD/pull/14732).

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Create the helper function and use it where possible.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
