### PR TITLE
Codechange: Simplify YAPF debug helpers a little.

### DIFF
--- a/src/misc/dbg_helpers.cpp
+++ b/src/misc/dbg_helpers.cpp
@@ -23,13 +23,13 @@ static const std::string_view trackdir_names[] = {
 /** Return name of given Trackdir. */
 std::string ValueStr(Trackdir td)
 {
-	return fmt::format("{} ({})", to_underlying(td), ItemAtT(td, trackdir_names, "UNK", INVALID_TRACKDIR, "INV"));
+	return fmt::format("{} ({})", to_underlying(td), ItemAt(td, trackdir_names, "UNK", INVALID_TRACKDIR, "INV"));
 }
 
 /** Return composed name of given TrackdirBits. */
 std::string ValueStr(TrackdirBits td_bits)
 {
-	return fmt::format("{} ({})", to_underlying(td_bits), ComposeNameT(td_bits, trackdir_names, "UNK", INVALID_TRACKDIR_BIT, "INV"));
+	return fmt::format("{} ({})", to_underlying(td_bits), ComposeName(td_bits, trackdir_names, "UNK", INVALID_TRACKDIR_BIT, "INV"));
 }
 
 
@@ -41,7 +41,7 @@ static const std::string_view diagdir_names[] = {
 /** Return name of given DiagDirection. */
 std::string ValueStr(DiagDirection dd)
 {
-	return fmt::format("{} ({})", to_underlying(dd), ItemAtT(dd, diagdir_names, "UNK", INVALID_DIAGDIR, "INV"));
+	return fmt::format("{} ({})", to_underlying(dd), ItemAt(dd, diagdir_names, "UNK", INVALID_DIAGDIR, "INV"));
 }
 
 
@@ -53,7 +53,7 @@ static const std::string_view signal_type_names[] = {
 /** Return name of given SignalType. */
 std::string ValueStr(SignalType t)
 {
-	return fmt::format("{} ({})", to_underlying(t), ItemAtT(t, signal_type_names, "UNK"));
+	return fmt::format("{} ({})", to_underlying(t), ItemAt(t, signal_type_names, "UNK"));
 }
 
 

--- a/src/misc/dbg_helpers.h
+++ b/src/misc/dbg_helpers.h
@@ -18,24 +18,14 @@
 #include "../track_type.h"
 #include "../core/format.hpp"
 
-/** Helper template class that provides C array length and item type */
-template <typename T> struct ArrayT;
-
-/** Helper template class that provides C array length and item type */
-template <typename T, size_t N> struct ArrayT<T[N]> {
-	static const size_t length = N;
-	using Item = T;
-};
-
-
 /**
  * Helper template function that returns item of array at given index
  * or t_unk when index is out of bounds.
  */
-template <typename E, typename T>
-inline typename ArrayT<T>::Item ItemAtT(E idx, const T &t, typename ArrayT<T>::Item t_unk)
+template <typename E>
+inline std::string_view ItemAt(E idx, std::span<const std::string_view> t, std::string_view t_unk)
 {
-	if (static_cast<size_t>(idx) >= ArrayT<T>::length) {
+	if (static_cast<size_t>(idx) >= std::size(t)) {
 		return t_unk;
 	}
 	return t[idx];
@@ -46,16 +36,13 @@ inline typename ArrayT<T>::Item ItemAtT(E idx, const T &t, typename ArrayT<T>::I
  * or t_inv when index == idx_inv
  * or t_unk when index is out of bounds.
  */
-template <typename E, typename T>
-inline typename ArrayT<T>::Item ItemAtT(E idx, const T &t, typename ArrayT<T>::Item t_unk, E idx_inv, typename ArrayT<T>::Item t_inv)
+template <typename E>
+inline std::string_view ItemAt(E idx, std::span<const std::string_view> t, std::string_view t_unk, E idx_inv, std::string_view t_inv)
 {
-	if (static_cast<size_t>(idx) < ArrayT<T>::length) {
-		return t[idx];
-	}
 	if (idx == idx_inv) {
 		return t_inv;
 	}
-	return t_unk;
+	return ItemAt(idx, t, t_unk);
 }
 
 /**
@@ -64,8 +51,8 @@ inline typename ArrayT<T>::Item ItemAtT(E idx, const T &t, typename ArrayT<T>::I
  * or t_inv when index == idx_inv
  * or t_unk when index is out of bounds.
  */
-template <typename E, typename T>
-inline std::string ComposeNameT(E value, T &t, std::string_view t_unk, E val_inv, std::string_view name_inv)
+template <typename E>
+inline std::string ComposeName(E value, std::span<const std::string_view> t, std::string_view t_unk, E val_inv, std::string_view name_inv)
 {
 	std::string out;
 	if (value == val_inv) {
@@ -73,7 +60,7 @@ inline std::string ComposeNameT(E value, T &t, std::string_view t_unk, E val_inv
 	} else if (value == 0) {
 		out = "<none>";
 	} else {
-		for (size_t i = 0; i < ArrayT<T>::length; i++) {
+		for (size_t i = 0; i < std::size(t); i++) {
 			if ((value & (1 << i)) == 0) continue;
 			out += (!out.empty() ? "+" : "");
 			out += t[i];
@@ -93,7 +80,7 @@ inline std::string ComposeNameT(E value, T &t, std::string_view t_unk, E val_inv
  * or unknown_name when index is out of bounds.
  */
 template <typename E>
-inline std::string ComposeNameT(E value, std::span<const std::string_view> names, std::string_view unknown_name)
+inline std::string ComposeName(E value, std::span<const std::string_view> names, std::string_view unknown_name)
 {
 	std::string out;
 	if (value.base() == 0) {

--- a/src/pathfinder/yapf/yapf_type.hpp
+++ b/src/pathfinder/yapf/yapf_type.hpp
@@ -72,7 +72,7 @@ inline std::string ValueStr(EndSegmentReasons flags)
 		"PATH_TOO_LONG", "FIRST_TWO_WAY_RED", "LOOK_AHEAD_END", "TARGET_REACHED"
 	};
 
-	return fmt::format("0x{:04X} ({})", flags.base(), ComposeNameT(flags, end_segment_reason_names, "UNK"));
+	return fmt::format("0x{:04X} ({})", flags.base(), ComposeName(flags, end_segment_reason_names, "UNK"));
 }
 
 #endif /* YAPF_TYPE_HPP */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`dbh_helper.h` has helper templates to handle C-style arrays, and uses templates for return values. All callers return a std::string_view.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Simplify YAPF debug helpers:

Remove template magic to get C-array size, pass arrays as a `std::span` instead.
Remove templated return type, as its always `std::string_view`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
