### PR TITLE
Change: Iterate tiles in 16x16 pattern to improve tile loop speed

### DIFF
--- a/src/landscape.h
+++ b/src/landscape.h
@@ -135,6 +135,7 @@ bool HasFoundationNW(TileIndex tile, Slope slope_here, uint z_here);
 bool HasFoundationNE(TileIndex tile, Slope slope_here, uint z_here);
 
 void DoClearSquare(TileIndex tile);
+void GenerateTileLoopPattern();
 void RunTileLoop();
 
 void InitializeLandscape();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -36,7 +36,7 @@
 
 #include "safeguards.h"
 
-extern TileIndex _cur_tileloop_tile;
+extern uint32_t _cur_tileloop_tile;
 extern void MakeNewgameSettingsLive();
 
 void InitializeSound();
@@ -100,7 +100,8 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	_pause_mode = {};
 	_game_speed = 100;
 	TimerGameTick::counter = 0;
-	_cur_tileloop_tile = TileIndex{1};
+	_cur_tileloop_tile = 0;
+	GenerateTileLoopPattern();
 	_thd.redsq = INVALID_TILE;
 	if (reset_settings) MakeNewgameSettingsLive();
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -561,9 +561,7 @@ bool AfterLoadGame()
 {
 	SetSignalHandlers();
 
-	extern TileIndex _cur_tileloop_tile; // From landscape.cpp.
-	/* The LFSR used in RunTileLoop iteration cannot have a zeroed state, make it non-zeroed. */
-	if (_cur_tileloop_tile == 0) _cur_tileloop_tile = TileIndex{1};
+	GenerateTileLoopPattern();
 
 	if (IsSavegameVersionBefore(SLV_98)) _gamelog.Oldver();
 

--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -26,7 +26,7 @@
 
 #include "../safeguards.h"
 
-extern TileIndex _cur_tileloop_tile;
+extern uint32_t _cur_tileloop_tile;
 extern uint16_t _disaster_delay;
 extern uint8_t _trees_tick_ctr;
 

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1618,7 +1618,7 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 	return true;
 }
 
-extern TileIndex _cur_tileloop_tile;
+extern uint32_t _cur_tileloop_tile;
 extern uint16_t _disaster_delay;
 extern uint8_t _trees_tick_ctr;
 extern uint8_t _age_cargo_skip_counter; // From misc_sl.cpp


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

On large maps with many players game becomes unplayable due to lag after several hours. And while the main culprit is vehicle performance every little bit saved in the tile loop helps too.

## Description

Instead of randomly walking the whole map this PR generates a 16x16 pattern and repeats it over the map. Due to better cache locality it significantly increases performance of the whole tile loop.
Initially I used 64x64 pattern in #11955 and that is completely unnoticeable afaict. But 16x16 offers better performance and is more convenient (and efficient) to implement, while still being barely noticeable. Because TILE_UPDATE_FREQUENCY == 256 each tick only one tile in the pattern is iterated.

In my tests I observed around 1.4-2x increase in the tile loop speed.

[Screencast from 2025-11-03 02-20-42.webm](https://github.com/user-attachments/assets/5845c48a-2d6c-455b-b9f0-bb771c282085)

Two saves I'm testing this the most on. They're from 2021 Master Hellish Christmas event where first game couldn't be finished as too many players got lagged out and disconnected. Second save is from the second game on that same map, it was shorter so there is less vehicles.
[hellish-christmas-2021.zip](https://github.com/user-attachments/files/23501689/hellish-christmas-2021.zip)

## Limitations

- Not sure I removed _cur_tileloop_tile frome the save correctly as there don't seem to be any docs or examples on how to do so.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
