### PR TITLE
Codechange: [Script] Use std::optional for script list next iteration item

### DIFF
--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -590,7 +590,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     0 => 5  (true)
     2 => 6  (true)
     3 => 6  (true)
-    9 => 0  (false)
+    0 => 5  (false)
   Clone ListDump:
     1005 => 1005
     4000 => 50


### PR DESCRIPTION
## Motivation / Problem

Leftover values instead of the invalid iteration value being returned in `Next()` when `IsEnd()` is true.
  False positive invalidation behaviour in sorter `Remove()` when the next item is the end, but `has_no_more_items` is not true.

## Description

Use std::optional for script list next iteration item. This is to avoid false positive updates in Remove when iterating the final item, as the next item is now std::nullopt instead of some leftover value and prevents leftover values being returned when IsEnd is true.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
