### PR TITLE
Fix: BaseBitSet bit iteration for values which don't fit in 32 bits

### DIFF
--- a/src/core/base_bitset_type.hpp
+++ b/src/core/base_bitset_type.hpp
@@ -254,8 +254,8 @@ public:
 		return std::nullopt;
 	}
 
-	auto begin() const { return SetBitIterator<Tvalue_type>(this->data).begin(); }
-	auto end() const { return SetBitIterator<Tvalue_type>(this->data).end(); }
+	auto begin() const { return SetBitIterator<Tvalue_type, Tstorage>(this->data).begin(); }
+	auto end() const { return SetBitIterator<Tvalue_type, Tstorage>(this->data).end(); }
 
 private:
 	Tstorage data; ///< Bitmask of values.


### PR DESCRIPTION
## Motivation / Problem

Incorrect template parameters for SetBitIterator in BaseBitSet begin/end results in incorrect iteration for values which don't fit in 32 bits.
In particular this causes problems for the new multiple rail types per vehicle support.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
