### PR TITLE
Fix c2d4098afa: Unconfigured badge classes should be visible by default.

### DIFF
--- a/src/newgrf_badge_config.h
+++ b/src/newgrf_badge_config.h
@@ -16,8 +16,8 @@
 class BadgeClassConfigItem {
 public:
 	std::string label; ///< Class label.
-	int column = -1; ///< UI column, feature-dependent.
-	bool show_icon = false; ///< Set if the badge icons should be displayed for this class.
+	uint column = 0; ///< UI column, feature-dependent.
+	bool show_icon = true; ///< Set if the badge icons should be displayed for this class.
 	bool show_filter = false; ///< Set if a drop down filter should be added for this class.
 };
 

--- a/src/newgrf_badge_gui.cpp
+++ b/src/newgrf_badge_gui.cpp
@@ -81,7 +81,7 @@ GUIBadgeClasses::GUIBadgeClasses(GrfSpecFeature feature) : UsedBadgeClasses(feat
 		const auto [config, sort_order] = GetBadgeClassConfigItem(feature, class_badge->label);
 
 		this->gui_classes.emplace_back(class_index, config.column, config.show_icon, sort_order, size, class_badge->label);
-		if (size.width != 0 && config.show_icon) max_column = std::max<uint>(max_column, config.column);
+		if (size.width != 0 && config.show_icon) max_column = std::max(max_column, config.column);
 	}
 
 	std::sort(std::begin(this->gui_classes), std::end(this->gui_classes));
@@ -436,7 +436,7 @@ static void BadgeClassMoveNext(GrfSpecFeature feature, Badge &class_badge, uint 
 
 	auto pos_cur = std::ranges::find(gui_classes.GetClasses(), class_badge.class_index, &GUIBadgeClasses::Element::class_index);
 	if (std::next(pos_cur) == std::end(gui_classes.GetClasses())) {
-		if (it->column < static_cast<int>(columns - 1)) ++it->column;
+		if (it->column < columns - 1) ++it->column;
 		return;
 	}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

For non-UI-configurable badge features, badge icons should be visible, but unfortunately I made the default value for `show_icon` be false, so they're not.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Fix the default value, so that non-UI-configurable features can show badges.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
