### PR TITLE
Feature: Highlight company infrastructure on the map

### DIFF
--- a/src/company_gui.h
+++ b/src/company_gui.h
@@ -25,5 +25,6 @@ void ShowCompany(CompanyID company);
 void InvalidateCompanyWindows(const Company *c);
 void CloseCompanyWindows(CompanyID company);
 void DirtyCompanyInfrastructureWindows(CompanyID company);
+Owner GetHighlightedInfrastructureCompany();
 
 #endif /* COMPANY_GUI_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4034,6 +4034,8 @@ STR_COMPANY_INFRASTRUCTURE_VIEW_STATIONS                        :{WHITE}Station 
 STR_COMPANY_INFRASTRUCTURE_VIEW_AIRPORTS                        :{WHITE}Airports
 STR_COMPANY_INFRASTRUCTURE_VIEW_TOTAL_YEAR                      :{WHITE}{CURRENCY_LONG}/year
 STR_COMPANY_INFRASTRUCTURE_VIEW_TOTAL_PERIOD                    :{WHITE}{CURRENCY_LONG}/period
+STR_COMPANY_INFRASTRUCTURE_VIEW_HIGHLIGHT_INFRASTRUCTURE        :{BLACK}Highlight infrastructure
+STR_COMPANY_INFRASTRUCTURE_VIEW_HIGHLIGHT_INFRASTRUCTURE_TOOLTIP :{BLACK}Highlight all tiles with infrastructure owned by this company
 
 # Industry directory
 STR_INDUSTRY_DIRECTORY_CAPTION                                  :{WHITE}Industries ({COMMA} of {COMMA})

--- a/src/widgets/company_widget.h
+++ b/src/widgets/company_widget.h
@@ -123,6 +123,7 @@ enum CompanyInfrastructureWidgets : WidgetID {
 	WID_CI_CAPTION, ///< Caption of window.
 	WID_CI_LIST, ///< Infrastructure list.
 	WID_CI_SCROLLBAR, ///< Infrastructure list scrollbar.
+	WID_CI_HIGHLIGHT_INFRASTRUCTURE, ///< Highlight infrastructure button.
 };
 
 /** Widgets of the #BuyCompanyWindow class. */


### PR DESCRIPTION
## Motivation / Problem

This pull request is inspired by https://github.com/OpenTTD/OpenTTD/pull/12164 , and implements exactly the same functionality:

> When playing with infrastructure costs on it is often difficult to figure out what pieces of infrastructure you are paying for and what pieces you aren't, for example roads in a town. This can be very frustrating especially in the early game when every dollar matters.

## Description

This highlights in white (the select tile coloring) all pieces of the infrastructure of selected company. This only happens when you open the company infrastructure window and click "Highlight infrastructure" button. The highlight is removed when the window is closed.

Related issue https://github.com/OpenTTD/OpenTTD/issues/13231

## GIF

![output](https://github.com/user-attachments/assets/b4b5f7f8-8c9e-44db-9cda-968c8cea5155)

[backup link](https://imgur.com/a/QHFO5zk)

## Checklist for review

**Disclaimer:** code was generated by Cursor from a prompt, however I reviewed it and added minor improvements/fixes, to best of my abilities. 


Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
