### PR TITLE
Fix #14777: authorized_key: Correctly target key type for add/remove

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2167,7 +2167,7 @@ static bool ConNetworkAuthorizedKey(std::span<std::string_view> argv)
 	}
 
 	for (auto [name, authorized_keys] : _console_cmd_authorized_keys) {
-		if (StrEqualsIgnoreCase(type, name)) continue;
+		if (!StrEqualsIgnoreCase(type, name)) continue;
 
 		PerformNetworkAuthorizedKeyAction(name, authorized_keys, action, authorized_key);
 		return true;


### PR DESCRIPTION
The logic in ConNetworkAuthorizedKey for the `authorized_key` command was inverted. The check `if (StrEqualsIgnoreCase(type, name)) continue;` caused the action (add/remove) to be incorrectly executed on the first key type encountered that *did not* match the requested type, rather than the intended one. This resulted in keys specified for 'admin' being added to 'rcon', for example.

This commit inverts the condition to ensure the action is performed only when the requested type matches the iterated key name.

Commit message: Codefix #14777: authorized_key: Correctly target key type for add/remove

## Motivation / Problem

* **What problem does this solve?**
    This fixes a critical bug where the `authorized_key add <type> <key>` and `authorized_key remove <type> <key>` commands would incorrectly target the wrong authorized key list.

* **If there is already an issue, link the issue, otherwise describe the problem here.**
    The issue is described in detail here: #14777.

    The actual behavior was that the command was executed on the first key type encountered that ***did not*** match the requested type. For example, a key intended for the 'admin' list was incorrectly added to the 'rcon' list (as shown in the issue logs), leading to incorrect permission setup and configuration errors.

## Description
**How is the problem solved?**
    This PR inverts the condition to:
`    if (!StrEqualsIgnoreCase(type, name)) continue;
`
    This ensures that the `PerformNetworkAuthorizedKeyAction` is only called when the requested key type (`type`) correctly matches the iterated key name (`name`), resolving the bug for both `add` and `remove` actions.

**Tests performed on Server Console**
`
authorized_key remove all 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423
Not removed 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423 from admin as it does not exist.
Removed 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423 from rcon.
Not removed 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423 from server as it does not exist.
authorized_key add admin 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423
Added 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423 to admin.
save_config
Saved config.
authorized_key add server 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423
Added 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423 to server.
save_config
Saved config.
authorized_key add rcon 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423
Added 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423 to rcon.
save_config
Saved config.
authorized_key remove all 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423
Removed 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423 from admin.
Removed 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423 from rcon.
Removed 66A313EC317E91D4DC6375DFC7717F443555F27EC43E80D2FA796A0F2422B423 from server.
`
## Limitations

The problem is fully solved. No known limitations.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested') : **Yes**
* This PR touches english.txt or translations? **No**
* This PR affects the GS/AI API? **No**
* This PR affects the NewGRF API? **No**
