### PR TITLE
Codechange: HighScore sorting to use std::vector

### DIFF
--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -87,20 +87,19 @@ static bool HighScoreSorter(const Company * const &a, const Company * const &b)
  */
 int8_t SaveHighScoreValueNetwork()
 {
-	const Company *cl[MAX_COMPANIES];
-	size_t count = 0;
+	std::vector<const Company *> cl;
 	int8_t local_company_place = -1;
 
 	/* Sort all active companies with the highest score first */
-	for (const Company *c : Company::Iterate()) cl[count++] = c;
+	for (const Company *c : Company::Iterate()) cl.push_back(c);
 
-	std::sort(std::begin(cl), std::begin(cl) + count, HighScoreSorter);
+	std::ranges::sort(cl, HighScoreSorter);
 
 	/* Clear the high scores from the previous network game. */
 	auto &highscores = _highscore_table[SP_MULTIPLAYER];
 	std::fill(highscores.begin(), highscores.end(), HighScore{});
 
-	for (size_t i = 0; i < count && i < highscores.size(); i++) {
+	for (size_t i = 0; i < cl.size() && i < highscores.size(); i++) {
 		const Company *c = cl[i];
 		auto &highscore = highscores[i];
 		highscore.name = GetString(STR_HIGHSCORE_NAME, c->index, c->index); // get manager/company name string


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
gcc complains while building:

```
[build] In file included from /usr/include/c++/13/bits/stl_algo.h:61,
[build]                  from /usr/include/c++/13/algorithm:61,
[build]                  from /home/ricardo/OpenTTD/src/stdafx.h:43,
[build]                  from /home/ricardo/OpenTTD/build/CMakeFiles/openttd_lib.dir/cmake_pch.hxx:5,
[build]                  from <command-line>:
[build] In function ‘constexpr void std::__adjust_heap(_RandomAccessIterator, _Distance, _Distance, _Tp, _Compare) [with _RandomAccessIterator = const Company**; _Distance = long int; _Tp = const Company*; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<bool (*)(const Company* const&, const Company* const&)>]’,
[build]     inlined from ‘constexpr void std::__make_heap(_RandomAccessIterator, _RandomAccessIterator, _Compare&) [with _RandomAccessIterator = const Company**; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<bool (*)(const Company* const&, const Company* const&)>]’ at /usr/include/c++/13/bits/stl_heap.h:356:22,
[build]     inlined from ‘constexpr void std::__heap_select(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = const Company**; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<bool (*)(const Company* const&, const Company* const&)>]’ at /usr/include/c++/13/bits/stl_algo.h:1635:23,
[build]     inlined from ‘constexpr void std::__partial_sort(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = const Company**; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<bool (*)(const Company* const&, const Company* const&)>]’ at /usr/include/c++/13/bits/stl_algo.h:1910:25,
[build]     inlined from ‘constexpr void std::__introsort_loop(_RandomAccessIterator, _RandomAccessIterator, _Size, _Compare) [with _RandomAccessIterator = const Company**; _Size = long int; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<bool (*)(const Company* const&, const Company* const&)>]’ at /usr/include/c++/13/bits/stl_algo.h:1926:27,
[build]     inlined from ‘constexpr void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = const Company**; _Compare = __gnu_cxx::__ops::_Iter_comp_iter<bool (*)(const Company* const&, const Company* const&)>]’ at /usr/include/c++/13/bits/stl_algo.h:1947:25,
[build]     inlined from ‘constexpr void std::sort(_RAIter, _RAIter, _Compare) [with _RAIter = const Company**; _Compare = bool (*)(const Company* const&, const Company* const&)]’ at /usr/include/c++/13/bits/stl_algo.h:4894:18,
[build]     inlined from ‘int8_t SaveHighScoreValueNetwork()’ at /home/ricardo/OpenTTD/src/highscore.cpp:97:11:
[build] /usr/include/c++/13/bits/stl_heap.h:241:36: warning: array subscript 15 is outside array bounds of ‘const Company* [15]’ [-Warray-bounds=]
[build]   241 |           *(__first + __holeIndex) = _GLIBCXX_MOVE(*(__first
[build]       |                                    ^
[build] /home/ricardo/OpenTTD/src/highscore.cpp: In function ‘int8_t SaveHighScoreValueNetwork()’:
[build] /home/ricardo/OpenTTD/src/highscore.cpp:90:24: note: at offset 120 into object ‘cl’ of size 120
[build]    90 |         const Company *cl[MAX_COMPANIES];
[build]       |                        ^~
```

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Replaces the fixed-size array for company sorting with a std::vector and updates sorting to use std::ranges::sort. This removes the need for manual count management.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
None.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
