### PR TITLE
Fix #14755: Remove clicked type selection when not visible

### DIFF
--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -693,6 +693,7 @@ void PickerWindow::BuildPickerTypeList()
 
 	if (!this->has_type_picker) return;
 	this->GetWidget<NWidgetMatrix>(WID_PW_TYPE_MATRIX)->SetCount(static_cast<int>(this->types.size()));
+	this->EnsureSelectedTypeIsVisible();
 }
 
 void PickerWindow::EnsureSelectedTypeIsValid()
@@ -729,9 +730,11 @@ void PickerWindow::EnsureSelectedTypeIsVisible()
 	int index = this->callbacks.GetSelectedType();
 
 	auto it = std::ranges::find_if(this->types, [class_index, index](const auto &item) { return item.class_index == class_index && item.index == index; });
-	if (it == std::end(this->types)) return;
+	int pos = -1;
+	if (it != std::end(this->types)) {
+		pos = static_cast<int>(std::distance(std::begin(this->types), it));
+	}
 
-	int pos = static_cast<int>(std::distance(std::begin(this->types), it));
 	this->GetWidget<NWidgetMatrix>(WID_PW_TYPE_MATRIX)->SetClicked(pos);
 }
 


### PR DESCRIPTION
## Motivation / Problem

Original issue https://github.com/OpenTTD/OpenTTD/issues/14755

When list of types is being filtered in `PickerWindow::BuildPickerTypeList()`, currently clicked widget stays clicked. This is misleading, as previously selected item in matrix changes its position due to filter, or even disappear completely from the matrix. 

## Description

The solution is simple - if selected type is not found - do not mark any widget item in matrix as clicked. Additionally, this is verified each time filtering term changed.

### Before

![openttd-type-filter-bug](https://github.com/user-attachments/assets/465515c1-862d-42da-8309-cb032fa49afc)

### After

![openttd-type-filter-fix](https://github.com/user-attachments/assets/f79e39b2-5f28-438c-9415-0333cee31e10)

## Limitations

<del>Similar bug may occur with class filter as well, that deserves verification.</del> Class filtering is okay.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
