### PR TITLE
Codechange: Use enum class and EnumBitSet for various order flags.

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -130,7 +130,7 @@ static StationID FindNearestHangar(const Aircraft *v)
 	const Station *next_dest = nullptr;
 	if (max_range != 0) {
 		if (v->current_order.IsType(OT_GOTO_STATION) ||
-				(v->current_order.IsType(OT_GOTO_DEPOT) && (v->current_order.GetDepotActionType() & ODATFB_NEAREST_DEPOT) == 0)) {
+				(v->current_order.IsType(OT_GOTO_DEPOT) && !v->current_order.GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot))) {
 			last_dest = Station::GetIfValid(v->last_station_visited);
 			next_dest = Station::GetIfValid(v->current_order.GetDestination().ToStationID());
 		} else {
@@ -428,7 +428,7 @@ static void CheckIfAircraftNeedsService(Aircraft *v)
 
 	/* only goto depot if the target airport has a depot */
 	if (st->airport.HasHangar() && CanVehicleUseStation(v, st)) {
-		v->current_order.MakeGoToDepot(st->index, ODTFB_SERVICE);
+		v->current_order.MakeGoToDepot(st->index, OrderDepotTypeFlag::Service);
 		SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);
 	} else if (v->current_order.IsType(OT_GOTO_DEPOT)) {
 		v->current_order.MakeDummy();
@@ -2176,7 +2176,7 @@ void UpdateAirplanesOnNewStation(const Station *st)
 		Order *o = &v->current_order;
 		/* The aircraft is heading to a hangar, but the new station doesn't have one,
 		 * or the aircraft can't land on the new station. Cancel current order. */
-		if (o->IsType(OT_GOTO_DEPOT) && !(o->GetDepotOrderType() & ODTFB_PART_OF_ORDERS) && o->GetDestination() == st->index &&
+		if (o->IsType(OT_GOTO_DEPOT) && !o->GetDepotOrderType().Test(OrderDepotTypeFlag::PartOfOrders) && o->GetDestination() == st->index &&
 				(!st->airport.HasHangar() || !CanVehicleUseStation(v, st))) {
 			o->MakeDummy();
 			SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);

--- a/src/order_backup.cpp
+++ b/src/order_backup.cpp
@@ -233,7 +233,7 @@ CommandCost CmdClearOrderBackup(DoCommandFlags flags, TileIndex tile, ClientID u
 	for (OrderBackup *ob : OrderBackup::Iterate()) {
 		for (Order &order : ob->orders) {
 			OrderType ot = order.GetType();
-			if (ot == OT_GOTO_DEPOT && (order.GetDepotActionType() & ODATFB_NEAREST_DEPOT) != 0) continue;
+			if (ot == OT_GOTO_DEPOT && order.GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot)) continue;
 			if (ot == OT_GOTO_DEPOT && hangar && !IsHangarTile(ob->tile)) continue; // Not an aircraft? Can't have a hangar order.
 			if (ot == OT_IMPLICIT || (IsHangarTile(ob->tile) && ot == OT_GOTO_DEPOT && !hangar)) ot = OT_GOTO_STATION;
 			if (ot == type && order.GetDestination() == destination) {

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -164,10 +164,10 @@ bool Order::Equals(const Order &other) const
 	 * evaluation. If we do not do this the order will continuously be seen as
 	 * a different order and it will try to find a "nearest depot" every tick. */
 	if ((this->IsType(OT_GOTO_DEPOT) && this->type == other.type) &&
-			((this->GetDepotActionType() & ODATFB_NEAREST_DEPOT) != 0 ||
-			 (other.GetDepotActionType() & ODATFB_NEAREST_DEPOT) != 0)) {
+			(this->GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot) ||
+			 other.GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot))) {
 		return this->GetDepotOrderType() == other.GetDepotOrderType() &&
-				(this->GetDepotActionType() & ~ODATFB_NEAREST_DEPOT) == (other.GetDepotActionType() & ~ODATFB_NEAREST_DEPOT);
+				this->GetDepotActionType().Reset(OrderDepotActionFlag::NearestDepot) == other.GetDepotActionType().Reset(OrderDepotActionFlag::NearestDepot);
 	}
 
 	return this->type == other.type && this->flags == other.flags && this->dest == other.dest;
@@ -185,11 +185,11 @@ uint16_t Order::MapOldOrder() const
 		case OT_GOTO_STATION:
 			if (this->GetUnloadType() & OUFB_UNLOAD) SetBit(order, 5);
 			if (this->GetLoadType() & OLFB_FULL_LOAD) SetBit(order, 6);
-			if (this->GetNonStopType() & ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS) SetBit(order, 7);
+			if (this->GetNonStopType().Test(OrderNonStopFlag::NoIntermediate)) SetBit(order, 7);
 			order |= GB(this->GetDestination().value, 0, 8) << 8;
 			break;
 		case OT_GOTO_DEPOT:
-			if (!(this->GetDepotOrderType() & ODTFB_PART_OF_ORDERS)) SetBit(order, 6);
+			if (!this->GetDepotOrderType().Test(OrderDepotTypeFlag::PartOfOrders)) SetBit(order, 6);
 			SetBit(order, 7);
 			order |= GB(this->GetDestination().value, 0, 8) << 8;
 			break;
@@ -331,7 +331,7 @@ VehicleOrderID OrderList::GetNextDecisionNode(VehicleOrderID next, uint hops) co
 
 	const Order &order_next = this->orders[next];
 	if (order_next.IsType(OT_CONDITIONAL)) {
-		if (order_next.GetConditionVariable() != OCV_UNCONDITIONALLY) return next;
+		if (order_next.GetConditionVariable() != OrderConditionVariable::Unconditionally) return next;
 
 		/* We can evaluate trivial conditions right away. They're conceptually
 		 * the same as regular order progression. */
@@ -341,7 +341,7 @@ VehicleOrderID OrderList::GetNextDecisionNode(VehicleOrderID next, uint hops) co
 	}
 
 	if (order_next.IsType(OT_GOTO_DEPOT)) {
-		if ((order_next.GetDepotActionType() & ODATFB_HALT) != 0) return INVALID_VEH_ORDER_ID;
+		if (order_next.GetDepotActionType().Test(OrderDepotActionFlag::Halt)) return INVALID_VEH_ORDER_ID;
 		if (order_next.IsRefit()) return next;
 	}
 
@@ -648,7 +648,7 @@ CommandCost CmdInsertOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 			}
 
 			/* Non stop only allowed for ground vehicles. */
-			if (new_order.GetNonStopType() != ONSF_STOP_EVERYWHERE && !v->IsGroundVehicle()) return CMD_ERROR;
+			if (new_order.GetNonStopType().Any() && !v->IsGroundVehicle()) return CMD_ERROR;
 
 			/* Filter invalid load/unload types. */
 			switch (new_order.GetLoadType()) {
@@ -671,12 +671,12 @@ CommandCost CmdInsertOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 
 			/* Filter invalid stop locations */
 			switch (new_order.GetStopLocation()) {
-				case OSL_PLATFORM_NEAR_END:
-				case OSL_PLATFORM_MIDDLE:
+				case OrderStopLocation::NearEnd:
+				case OrderStopLocation::Middle:
 					if (v->type != VEH_TRAIN) return CMD_ERROR;
 					[[fallthrough]];
 
-				case OSL_PLATFORM_FAR_END:
+				case OrderStopLocation::FarEnd:
 					break;
 
 				default:
@@ -687,7 +687,7 @@ CommandCost CmdInsertOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 		}
 
 		case OT_GOTO_DEPOT: {
-			if ((new_order.GetDepotActionType() & ODATFB_NEAREST_DEPOT) == 0) {
+			if (!new_order.GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot)) {
 				if (v->type == VEH_AIRCRAFT) {
 					const Station *st = Station::GetIfValid(new_order.GetDestination().ToStationID());
 
@@ -725,15 +725,22 @@ CommandCost CmdInsertOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 				}
 			}
 
-			if (new_order.GetNonStopType() != ONSF_STOP_EVERYWHERE && !v->IsGroundVehicle()) return CMD_ERROR;
-			if (new_order.GetDepotOrderType() & ~(ODTFB_PART_OF_ORDERS | ((new_order.GetDepotOrderType() & ODTFB_PART_OF_ORDERS) != 0 ? ODTFB_SERVICE : 0))) return CMD_ERROR;
-			if (new_order.GetDepotActionType() & ~(ODATFB_HALT | ODATFB_NEAREST_DEPOT | ODATFB_UNBUNCH)) return CMD_ERROR;
+			if (new_order.GetNonStopType().Any() && !v->IsGroundVehicle()) return CMD_ERROR;
+
+			/* Check depot order type is valid. */
+			OrderDepotTypeFlags depot_order_type = new_order.GetDepotOrderType();
+			if (depot_order_type.Test(OrderDepotTypeFlag::PartOfOrders)) depot_order_type.Reset(OrderDepotTypeFlag::Service);
+			depot_order_type.Reset(OrderDepotTypeFlag::PartOfOrders);
+			if (depot_order_type.Any()) return CMD_ERROR;
+
+			/* Check depot action type is valid. */
+			if (new_order.GetDepotActionType().Reset({OrderDepotActionFlag::Halt, OrderDepotActionFlag::NearestDepot, OrderDepotActionFlag::Unbunch}).Any()) return CMD_ERROR;
 
 			/* Vehicles cannot have a "service if needed" order that also has a depot action. */
-			if ((new_order.GetDepotOrderType() & ODTFB_SERVICE) && (new_order.GetDepotActionType() & (ODATFB_HALT | ODATFB_UNBUNCH))) return CMD_ERROR;
+			if (new_order.GetDepotOrderType().Test(OrderDepotTypeFlag::Service) && new_order.GetDepotActionType().Any({OrderDepotActionFlag::Halt, OrderDepotActionFlag::Unbunch})) return CMD_ERROR;
 
 			/* Check if we're allowed to have a new unbunching order. */
-			if ((new_order.GetDepotActionType() & ODATFB_UNBUNCH)) {
+			if (new_order.GetDepotActionType().Test(OrderDepotActionFlag::Unbunch)) {
 				if (v->HasFullLoadOrder()) return CommandCost(STR_ERROR_CAN_T_ADD_ORDER, STR_ERROR_UNBUNCHING_NO_UNBUNCHING_FULL_LOAD);
 				if (v->HasUnbunchingOrder()) return CommandCost(STR_ERROR_CAN_T_ADD_ORDER, STR_ERROR_UNBUNCHING_ONLY_ONE_ALLOWED);
 				if (v->HasConditionalOrder()) return CommandCost(STR_ERROR_CAN_T_ADD_ORDER, STR_ERROR_UNBUNCHING_NO_UNBUNCHING_CONDITIONAL);
@@ -776,35 +783,35 @@ CommandCost CmdInsertOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 			/* Order flags can be any of the following for waypoints:
 			 * [non-stop]
 			 * non-stop orders (if any) are only valid for trains and road vehicles */
-			if (new_order.GetNonStopType() != ONSF_STOP_EVERYWHERE && !v->IsGroundVehicle()) return CMD_ERROR;
+			if (new_order.GetNonStopType().Any() && !v->IsGroundVehicle()) return CMD_ERROR;
 			break;
 		}
 
 		case OT_CONDITIONAL: {
 			VehicleOrderID skip_to = new_order.GetConditionSkipToOrder();
 			if (skip_to != 0 && skip_to >= v->GetNumOrders()) return CMD_ERROR; // Always allow jumping to the first (even when there is no order).
-			if (new_order.GetConditionVariable() >= OCV_END) return CMD_ERROR;
+			if (new_order.GetConditionVariable() >= OrderConditionVariable::End) return CMD_ERROR;
 			if (v->HasUnbunchingOrder()) return CommandCost(STR_ERROR_UNBUNCHING_NO_CONDITIONAL);
 
 			OrderConditionComparator occ = new_order.GetConditionComparator();
-			if (occ >= OCC_END) return CMD_ERROR;
+			if (occ >= OrderConditionComparator::End) return CMD_ERROR;
 			switch (new_order.GetConditionVariable()) {
-				case OCV_REQUIRES_SERVICE:
-					if (occ != OCC_IS_TRUE && occ != OCC_IS_FALSE) return CMD_ERROR;
+				case OrderConditionVariable::RequiresService:
+					if (occ != OrderConditionComparator::IsTrue && occ != OrderConditionComparator::IsFalse) return CMD_ERROR;
 					break;
 
-				case OCV_UNCONDITIONALLY:
-					if (occ != OCC_EQUALS) return CMD_ERROR;
+				case OrderConditionVariable::Unconditionally:
+					if (occ != OrderConditionComparator::Equal) return CMD_ERROR;
 					if (new_order.GetConditionValue() != 0) return CMD_ERROR;
 					break;
 
-				case OCV_LOAD_PERCENTAGE:
-				case OCV_RELIABILITY:
+				case OrderConditionVariable::LoadPercentage:
+				case OrderConditionVariable::Reliability:
 					if (new_order.GetConditionValue() > 100) return CMD_ERROR;
 					[[fallthrough]];
 
 				default:
-					if (occ == OCC_IS_TRUE || occ == OCC_IS_FALSE) return CMD_ERROR;
+					if (occ == OrderConditionComparator::IsTrue || occ == OrderConditionComparator::IsFalse) return CMD_ERROR;
 					break;
 			}
 			break;
@@ -945,7 +952,7 @@ static void CancelLoadingDueToDeletedOrder(Vehicle *v)
 	assert(v->current_order.IsType(OT_LOADING));
 	/* NON-stop flag is misused to see if a train is in a station that is
 	 * on its order list or not */
-	v->current_order.SetNonStopType(ONSF_STOP_EVERYWHERE);
+	v->current_order.SetNonStopType({});
 	/* When full loading, "cancel" that order so the vehicle doesn't
 	 * stay indefinitely at this station anymore. */
 	if (v->current_order.GetLoadType() & OLFB_FULL_LOAD) v->current_order.SetLoadType(OLF_LOAD_IF_POSSIBLE);
@@ -1195,19 +1202,25 @@ CommandCost CmdModifyOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 	switch (mof) {
 		default: NOT_REACHED();
 
-		case MOF_NON_STOP:
+		case MOF_NON_STOP: {
 			if (!v->IsGroundVehicle()) return CMD_ERROR;
-			if (data >= ONSF_END) return CMD_ERROR;
-			if (data == order->GetNonStopType()) return CMD_ERROR;
+
+			OrderNonStopFlags nonstop_flags = static_cast<OrderNonStopFlags>(data);
+			if (nonstop_flags == order->GetNonStopType()) return CMD_ERROR;
+
+			/* Test for invalid flags. */
+			nonstop_flags.Reset({OrderNonStopFlag::NoIntermediate, OrderNonStopFlag::NoDestination});
+			if (nonstop_flags.Any()) return CMD_ERROR;
 			break;
+		}
 
 		case MOF_STOP_LOCATION:
 			if (v->type != VEH_TRAIN) return CMD_ERROR;
-			if (data >= OSL_END) return CMD_ERROR;
+			if (data >= to_underlying(OrderStopLocation::End)) return CMD_ERROR;
 			break;
 
 		case MOF_UNLOAD:
-			if (order->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION) return CMD_ERROR;
+			if (order->GetNonStopType().Test(OrderNonStopFlag::NoDestination)) return CMD_ERROR;
 			if ((data & ~(OUFB_UNLOAD | OUFB_TRANSFER | OUFB_NO_UNLOAD)) != 0) return CMD_ERROR;
 			/* Unload and no-unload are mutual exclusive and so are transfer and no unload. */
 			if (data != 0 && ((data & (OUFB_UNLOAD | OUFB_TRANSFER)) != 0) == ((data & OUFB_NO_UNLOAD) != 0)) return CMD_ERROR;
@@ -1215,52 +1228,58 @@ CommandCost CmdModifyOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 			break;
 
 		case MOF_LOAD:
-			if (order->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION) return CMD_ERROR;
+			if (order->GetNonStopType().Test(OrderNonStopFlag::NoDestination)) return CMD_ERROR;
 			if (data > OLFB_NO_LOAD || data == 1) return CMD_ERROR;
 			if (data == order->GetLoadType()) return CMD_ERROR;
 			if ((data & (OLFB_FULL_LOAD | OLF_FULL_LOAD_ANY)) && v->HasUnbunchingOrder()) return CommandCost(STR_ERROR_UNBUNCHING_NO_FULL_LOAD);
 			break;
 
-		case MOF_DEPOT_ACTION:
-			if (data >= DA_END) return CMD_ERROR;
+		case MOF_DEPOT_ACTION: {
+			OrderDepotAction depot_action = static_cast<OrderDepotAction>(data);
+			if (depot_action >= OrderDepotAction::End) return CMD_ERROR;
 			/* Check if we are allowed to add unbunching. We are always allowed to remove it. */
-			if (data == DA_UNBUNCH) {
+			if (depot_action == OrderDepotAction::Unbunch) {
 				/* Only one unbunching order is allowed in a vehicle's orders. If this order already has an unbunching action, no error is needed. */
-				if (v->HasUnbunchingOrder() && !(order->GetDepotActionType() & ODATFB_UNBUNCH)) return CommandCost(STR_ERROR_UNBUNCHING_ONLY_ONE_ALLOWED);
+				if (v->HasUnbunchingOrder() && !order->GetDepotActionType().Test(OrderDepotActionFlag::Unbunch)) return CommandCost(STR_ERROR_UNBUNCHING_ONLY_ONE_ALLOWED);
 				/* We don't allow unbunching if the vehicle has a conditional order. */
 				if (v->HasConditionalOrder()) return CommandCost(STR_ERROR_UNBUNCHING_NO_UNBUNCHING_CONDITIONAL);
 				/* We don't allow unbunching if the vehicle has a full load order. */
 				if (v->HasFullLoadOrder()) return CommandCost(STR_ERROR_UNBUNCHING_NO_UNBUNCHING_FULL_LOAD);
 			}
 			break;
+		}
 
-		case MOF_COND_VARIABLE:
-			if (data >= OCV_END) return CMD_ERROR;
+		case MOF_COND_VARIABLE: {
+			OrderConditionVariable cond_variable = static_cast<OrderConditionVariable>(data);
+			if (cond_variable >= OrderConditionVariable::End) return CMD_ERROR;
 			break;
+		}
 
-		case MOF_COND_COMPARATOR:
-			if (data >= OCC_END) return CMD_ERROR;
+		case MOF_COND_COMPARATOR: {
+			OrderConditionComparator cond_comparator = static_cast<OrderConditionComparator>(data);
+			if (cond_comparator >= OrderConditionComparator::End) return CMD_ERROR;
 			switch (order->GetConditionVariable()) {
-				case OCV_UNCONDITIONALLY: return CMD_ERROR;
+				case OrderConditionVariable::Unconditionally: return CMD_ERROR;
 
-				case OCV_REQUIRES_SERVICE:
-					if (data != OCC_IS_TRUE && data != OCC_IS_FALSE) return CMD_ERROR;
+				case OrderConditionVariable::RequiresService:
+					if (cond_comparator != OrderConditionComparator::IsTrue && cond_comparator != OrderConditionComparator::IsFalse) return CMD_ERROR;
 					break;
 
 				default:
-					if (data == OCC_IS_TRUE || data == OCC_IS_FALSE) return CMD_ERROR;
+					if (cond_comparator == OrderConditionComparator::IsTrue || cond_comparator == OrderConditionComparator::IsFalse) return CMD_ERROR;
 					break;
 			}
 			break;
+		}
 
 		case MOF_COND_VALUE:
 			switch (order->GetConditionVariable()) {
-				case OCV_UNCONDITIONALLY:
-				case OCV_REQUIRES_SERVICE:
+				case OrderConditionVariable::Unconditionally:
+				case OrderConditionVariable::RequiresService:
 					return CMD_ERROR;
 
-				case OCV_LOAD_PERCENTAGE:
-				case OCV_RELIABILITY:
+				case OrderConditionVariable::LoadPercentage:
+				case OrderConditionVariable::Reliability:
 					if (data > 100) return CMD_ERROR;
 					break;
 
@@ -1278,8 +1297,8 @@ CommandCost CmdModifyOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 	if (flags.Test(DoCommandFlag::Execute)) {
 		switch (mof) {
 			case MOF_NON_STOP:
-				order->SetNonStopType((OrderNonStopFlags)data);
-				if (data & ONSF_NO_STOP_AT_DESTINATION_STATION) {
+				order->SetNonStopType(static_cast<OrderNonStopFlags>(data));
+				if (order->GetNonStopType().Test(OrderNonStopFlag::NoDestination)) {
 					order->SetRefit(CARGO_NO_REFIT);
 					order->SetLoadType(OLF_LOAD_IF_POSSIBLE);
 					order->SetUnloadType(OUF_UNLOAD_IF_POSSIBLE);
@@ -1287,7 +1306,7 @@ CommandCost CmdModifyOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 				break;
 
 			case MOF_STOP_LOCATION:
-				order->SetStopLocation((OrderStopLocation)data);
+				order->SetStopLocation(static_cast<OrderStopLocation>(data));
 				break;
 
 			case MOF_UNLOAD:
@@ -1300,31 +1319,27 @@ CommandCost CmdModifyOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 				break;
 
 			case MOF_DEPOT_ACTION: {
-				switch (data) {
-					case DA_ALWAYS_GO:
-						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
-						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_HALT));
-						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_UNBUNCH));
+				switch (static_cast<OrderDepotAction>(data)) {
+					case OrderDepotAction::AlwaysGo:
+						order->SetDepotOrderType(order->GetDepotOrderType().Reset(OrderDepotTypeFlag::Service));
+						order->SetDepotActionType(order->GetDepotActionType().Reset({OrderDepotActionFlag::Halt, OrderDepotActionFlag::Unbunch}));
 						break;
 
-					case DA_SERVICE:
-						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() | ODTFB_SERVICE));
-						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_HALT));
-						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_UNBUNCH));
+					case OrderDepotAction::Service:
+						order->SetDepotOrderType(order->GetDepotOrderType().Set(OrderDepotTypeFlag::Service));
+						order->SetDepotActionType(order->GetDepotActionType().Reset({OrderDepotActionFlag::Halt, OrderDepotActionFlag::Unbunch}));
 						order->SetRefit(CARGO_NO_REFIT);
 						break;
 
-					case DA_STOP:
-						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
-						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() | ODATFB_HALT));
-						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_UNBUNCH));
+					case OrderDepotAction::Stop:
+						order->SetDepotOrderType(order->GetDepotOrderType().Reset(OrderDepotTypeFlag::Service));
+						order->SetDepotActionType(order->GetDepotActionType().Set(OrderDepotActionFlag::Halt).Reset(OrderDepotActionFlag::Unbunch));
 						order->SetRefit(CARGO_NO_REFIT);
 						break;
 
-					case DA_UNBUNCH:
-						order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
-						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_HALT));
-						order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() | ODATFB_UNBUNCH));
+					case OrderDepotAction::Unbunch:
+						order->SetDepotOrderType(order->GetDepotOrderType().Reset(OrderDepotTypeFlag::Service));
+						order->SetDepotActionType(order->GetDepotActionType().Reset(OrderDepotActionFlag::Halt).Set(OrderDepotActionFlag::Unbunch));
 						break;
 
 					default:
@@ -1338,23 +1353,23 @@ CommandCost CmdModifyOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 
 				OrderConditionComparator occ = order->GetConditionComparator();
 				switch (order->GetConditionVariable()) {
-					case OCV_UNCONDITIONALLY:
-						order->SetConditionComparator(OCC_EQUALS);
+					case OrderConditionVariable::Unconditionally:
+						order->SetConditionComparator(OrderConditionComparator::Equal);
 						order->SetConditionValue(0);
 						break;
 
-					case OCV_REQUIRES_SERVICE:
-						if (occ != OCC_IS_TRUE && occ != OCC_IS_FALSE) order->SetConditionComparator(OCC_IS_TRUE);
+					case OrderConditionVariable::RequiresService:
+						if (occ != OrderConditionComparator::IsTrue && occ != OrderConditionComparator::IsFalse) order->SetConditionComparator(OrderConditionComparator::IsTrue);
 						order->SetConditionValue(0);
 						break;
 
-					case OCV_LOAD_PERCENTAGE:
-					case OCV_RELIABILITY:
+					case OrderConditionVariable::LoadPercentage:
+					case OrderConditionVariable::Reliability:
 						if (order->GetConditionValue() > 100) order->SetConditionValue(100);
 						[[fallthrough]];
 
 					default:
-						if (occ == OCC_IS_TRUE || occ == OCC_IS_FALSE) order->SetConditionComparator(OCC_EQUALS);
+						if (occ == OrderConditionComparator::IsTrue || occ == OrderConditionComparator::IsFalse) order->SetConditionComparator(OrderConditionComparator::Equal);
 						break;
 				}
 				break;
@@ -1605,8 +1620,8 @@ CommandCost CmdOrderRefit(DoCommandFlags flags, VehicleID veh, VehicleOrderID or
 
 		/* Make the depot order an 'always go' order. */
 		if (cargo != CARGO_NO_REFIT && order->IsType(OT_GOTO_DEPOT)) {
-			order->SetDepotOrderType((OrderDepotTypeFlags)(order->GetDepotOrderType() & ~ODTFB_SERVICE));
-			order->SetDepotActionType((OrderDepotActionFlags)(order->GetDepotActionType() & ~ODATFB_HALT));
+			order->SetDepotOrderType(order->GetDepotOrderType().Reset(OrderDepotTypeFlag::Service));
+			order->SetDepotActionType(order->GetDepotActionType().Reset(OrderDepotActionFlag::Halt));
 		}
 
 		for (Vehicle *u = v->FirstShared(); u != nullptr; u = u->NextShared()) {
@@ -1614,7 +1629,7 @@ CommandCost CmdOrderRefit(DoCommandFlags flags, VehicleID veh, VehicleOrderID or
 			InvalidateVehicleOrder(u, VIWD_MODIFY_ORDERS);
 
 			/* If the vehicle already got the current depot set as current order, then update current order as well */
-			if (u->cur_real_order_index == order_number && (u->current_order.GetDepotOrderType() & ODTFB_PART_OF_ORDERS)) {
+			if (u->cur_real_order_index == order_number && u->current_order.GetDepotOrderType().Test(OrderDepotTypeFlag::PartOfOrders)) {
 				u->current_order.SetRefit(cargo);
 			}
 		}
@@ -1725,7 +1740,7 @@ void RemoveOrderFromAllVehicles(OrderType type, DestinationID destination, bool 
 			next_id = id + 1;
 			Order *order = v->orders->GetOrderAt(id);
 			OrderType ot = order->GetType();
-			if (ot == OT_GOTO_DEPOT && (order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) != 0) continue;
+			if (ot == OT_GOTO_DEPOT && order->GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot)) continue;
 			if (ot == OT_GOTO_DEPOT && hangar && v->type != VEH_AIRCRAFT) continue; // Not an aircraft? Can't have a hangar order.
 			if (ot == OT_IMPLICIT || (v->type == VEH_AIRCRAFT && ot == OT_GOTO_DEPOT && !hangar)) ot = OT_GOTO_STATION;
 			if (ot == type && order->GetDestination() == destination) {
@@ -1844,14 +1859,14 @@ static bool CheckForValidOrders(const Vehicle *v)
 static bool OrderConditionCompare(OrderConditionComparator occ, int variable, int value)
 {
 	switch (occ) {
-		case OCC_EQUALS:      return variable == value;
-		case OCC_NOT_EQUALS:  return variable != value;
-		case OCC_LESS_THAN:   return variable <  value;
-		case OCC_LESS_EQUALS: return variable <= value;
-		case OCC_MORE_THAN:   return variable >  value;
-		case OCC_MORE_EQUALS: return variable >= value;
-		case OCC_IS_TRUE:     return variable != 0;
-		case OCC_IS_FALSE:    return variable == 0;
+		case OrderConditionComparator::Equal: return variable == value;
+		case OrderConditionComparator::NotEqual: return variable != value;
+		case OrderConditionComparator::LessThan: return variable < value;
+		case OrderConditionComparator::LessThanOrEqual: return variable <= value;
+		case OrderConditionComparator::MoreThan: return variable > value;
+		case OrderConditionComparator::MoreThanOrEqual: return variable >= value;
+		case OrderConditionComparator::IsTrue: return variable != 0;
+		case OrderConditionComparator::IsFalse: return variable == 0;
 		default: NOT_REACHED();
 	}
 }
@@ -1876,14 +1891,14 @@ VehicleOrderID ProcessConditionalOrder(const Order *order, const Vehicle *v)
 	uint16_t value = order->GetConditionValue();
 
 	switch (order->GetConditionVariable()) {
-		case OCV_LOAD_PERCENTAGE:    skip_order = OrderConditionCompare(occ, CalcPercentVehicleFilled(v, nullptr), value); break;
-		case OCV_RELIABILITY:        skip_order = OrderConditionCompare(occ, ToPercent16(v->reliability),       value); break;
-		case OCV_MAX_RELIABILITY:    skip_order = OrderConditionCompare(occ, ToPercent16(v->GetEngine()->reliability),   value); break;
-		case OCV_MAX_SPEED:          skip_order = OrderConditionCompare(occ, v->GetDisplayMaxSpeed() * 10 / 16, value); break;
-		case OCV_AGE:                skip_order = OrderConditionCompare(occ, TimerGameCalendar::DateToYear(v->age),                value); break;
-		case OCV_REQUIRES_SERVICE:   skip_order = OrderConditionCompare(occ, v->NeedsServicing(),               value); break;
-		case OCV_UNCONDITIONALLY:    skip_order = true; break;
-		case OCV_REMAINING_LIFETIME: skip_order = OrderConditionCompare(occ, std::max(TimerGameCalendar::DateToYear(v->max_age - v->age + CalendarTime::DAYS_IN_LEAP_YEAR - 1), TimerGameCalendar::Year(0)), value); break;
+		case OrderConditionVariable::LoadPercentage: skip_order = OrderConditionCompare(occ, CalcPercentVehicleFilled(v, nullptr), value); break;
+		case OrderConditionVariable::Reliability: skip_order = OrderConditionCompare(occ, ToPercent16(v->reliability), value); break;
+		case OrderConditionVariable::MaxReliability: skip_order = OrderConditionCompare(occ, ToPercent16(v->GetEngine()->reliability), value); break;
+		case OrderConditionVariable::MaxSpeed: skip_order = OrderConditionCompare(occ, v->GetDisplayMaxSpeed() * 10 / 16, value); break;
+		case OrderConditionVariable::Age: skip_order = OrderConditionCompare(occ, TimerGameCalendar::DateToYear(v->age), value); break;
+		case OrderConditionVariable::RequiresService: skip_order = OrderConditionCompare(occ, v->NeedsServicing(), value); break;
+		case OrderConditionVariable::Unconditionally: skip_order = true; break;
+		case OrderConditionVariable::RemainingLifetime: skip_order = OrderConditionCompare(occ, std::max(TimerGameCalendar::DateToYear(v->max_age - v->age + CalendarTime::DAYS_IN_LEAP_YEAR - 1), TimerGameCalendar::Year(0)), value); break;
 		default: NOT_REACHED();
 	}
 
@@ -1911,14 +1926,14 @@ bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth, bool
 			return true;
 
 		case OT_GOTO_DEPOT:
-			if ((order->GetDepotOrderType() & ODTFB_SERVICE) && !v->NeedsServicing()) {
+			if (order->GetDepotOrderType().Test(OrderDepotTypeFlag::Service) && !v->NeedsServicing()) {
 				assert(!pbs_look_ahead);
 				UpdateVehicleTimetable(v, true);
 				v->IncrementRealOrderIndex();
 				break;
 			}
 
-			if (v->current_order.GetDepotActionType() & ODATFB_NEAREST_DEPOT) {
+			if (v->current_order.GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot)) {
 				/* If the vehicle can't find its destination, delay its next search.
 				 * In case many vehicles are in this state, use the vehicle index to spread out pathfinder calls. */
 				if (v->dest_tile == 0 && TimerGameEconomy::date_fract != (v->index % Ticks::DAY_TICKS)) break;
@@ -2031,7 +2046,7 @@ bool ProcessOrders(Vehicle *v)
 	switch (v->current_order.GetType()) {
 		case OT_GOTO_DEPOT:
 			/* Let a depot order in the orderlist interrupt. */
-			if (!(v->current_order.GetDepotOrderType() & ODTFB_PART_OF_ORDERS)) return false;
+			if (!v->current_order.GetDepotOrderType().Test(OrderDepotTypeFlag::PartOfOrders)) return false;
 			break;
 
 		case OT_LOADING:
@@ -2054,7 +2069,7 @@ bool ProcessOrders(Vehicle *v)
 	bool may_reverse = v->current_order.IsType(OT_NOTHING);
 
 	/* Check if we've reached a 'via' destination. */
-	if (((v->current_order.IsType(OT_GOTO_STATION) && (v->current_order.GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION)) || v->current_order.IsType(OT_GOTO_WAYPOINT)) &&
+	if (((v->current_order.IsType(OT_GOTO_STATION) && v->current_order.GetNonStopType().Test(OrderNonStopFlag::NoDestination)) || v->current_order.IsType(OT_GOTO_WAYPOINT)) &&
 			IsTileType(v->tile, MP_STATION) &&
 			v->current_order.GetDestination() == GetStationIndex(v->tile)) {
 		v->DeleteUnreachedImplicitOrders();
@@ -2128,16 +2143,16 @@ bool Order::ShouldStopAtStation(const Vehicle *v, StationID station) const
 {
 	bool is_dest_station = this->IsType(OT_GOTO_STATION) && this->dest == station;
 
-	return (!this->IsType(OT_GOTO_DEPOT) || (this->GetDepotOrderType() & ODTFB_PART_OF_ORDERS) != 0) &&
+	return (!this->IsType(OT_GOTO_DEPOT) || this->GetDepotOrderType().Test(OrderDepotTypeFlag::PartOfOrders)) &&
 			v->last_station_visited != station && // Do stop only when we've not just been there
 			/* Finally do stop when there is no non-stop flag set for this type of station. */
-			!(this->GetNonStopType() & (is_dest_station ? ONSF_NO_STOP_AT_DESTINATION_STATION : ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS));
+			!this->GetNonStopType().Test(is_dest_station ? OrderNonStopFlag::NoDestination : OrderNonStopFlag::NoIntermediate);
 }
 
 bool Order::CanLoadOrUnload() const
 {
 	return (this->IsType(OT_GOTO_STATION) || this->IsType(OT_IMPLICIT)) &&
-			(this->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION) == 0 &&
+			!this->GetNonStopType().Test(OrderNonStopFlag::NoDestination) &&
 			((this->GetLoadType() & OLFB_NO_LOAD) == 0 ||
 			(this->GetUnloadType() & OUFB_NO_UNLOAD) == 0);
 }

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -84,72 +84,72 @@ enum OrderLoadFlags : uint8_t {
 /**
  * Non-stop order flags.
  */
-enum OrderNonStopFlags : uint8_t {
-	ONSF_STOP_EVERYWHERE                  = 0, ///< The vehicle will stop at any station it passes and the destination.
-	ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS = 1, ///< The vehicle will not stop at any stations it passes except the destination.
-	ONSF_NO_STOP_AT_DESTINATION_STATION   = 2, ///< The vehicle will stop at any station it passes except the destination.
-	ONSF_NO_STOP_AT_ANY_STATION           = 3, ///< The vehicle will not stop at any stations it passes including the destination.
-	ONSF_END
+enum class OrderNonStopFlag : uint8_t {
+	NoIntermediate = 0, ///< The vehicle will not stop at any stations it passes except the destination, aka non-stop.
+	NoDestination = 1, ///< The vehicle will stop at any station it passes except the destination, aka via.
 };
+
+using OrderNonStopFlags = EnumBitSet<OrderNonStopFlag, uint8_t>;
 
 /**
  * Where to stop the trains.
  */
-enum OrderStopLocation : uint8_t {
-	OSL_PLATFORM_NEAR_END = 0, ///< Stop at the near end of the platform
-	OSL_PLATFORM_MIDDLE   = 1, ///< Stop at the middle of the platform
-	OSL_PLATFORM_FAR_END  = 2, ///< Stop at the far end of the platform
-	OSL_END
+enum class OrderStopLocation : uint8_t {
+	NearEnd = 0, ///< Stop at the near end of the platform
+	Middle = 1, ///< Stop at the middle of the platform
+	FarEnd = 2, ///< Stop at the far end of the platform
+	End,
 };
 
 /**
  * Reasons that could cause us to go to the depot.
  */
-enum OrderDepotTypeFlags : uint8_t {
-	ODTF_MANUAL          = 0,      ///< Manually initiated order.
-	ODTFB_SERVICE        = 1 << 0, ///< This depot order is because of the servicing limit.
-	ODTFB_PART_OF_ORDERS = 1 << 1, ///< This depot order is because of a regular order.
+enum class OrderDepotTypeFlag : uint8_t {
+	Service = 0, ///< This depot order is because of the servicing limit.
+	PartOfOrders = 1, ///< This depot order is because of a regular order.
 };
+
+using OrderDepotTypeFlags = EnumBitSet<OrderDepotTypeFlag, uint8_t>;
 
 /**
  * Actions that can be performed when the vehicle enters the depot.
  */
-enum OrderDepotActionFlags : uint8_t {
-	ODATF_SERVICE_ONLY   = 0,      ///< Only service the vehicle.
-	ODATFB_HALT          = 1 << 0, ///< Service the vehicle and then halt it.
-	ODATFB_NEAREST_DEPOT = 1 << 1, ///< Send the vehicle to the nearest depot.
-	ODATFB_UNBUNCH       = 1 << 2, ///< Service the vehicle and then unbunch it.
+enum class OrderDepotActionFlag : uint8_t {
+	Halt = 0, ///< Service the vehicle and then halt it.
+	NearestDepot = 1, ///< Send the vehicle to the nearest depot.
+	Unbunch = 2, ///< Service the vehicle and then unbunch it.
 };
-DECLARE_ENUM_AS_BIT_SET(OrderDepotActionFlags)
+
+using OrderDepotActionFlags = EnumBitSet<OrderDepotActionFlag, uint8_t>;
 
 /**
  * Variables (of a vehicle) to 'cause' skipping on.
  */
-enum OrderConditionVariable : uint8_t {
-	OCV_LOAD_PERCENTAGE,    ///< Skip based on the amount of load
-	OCV_RELIABILITY,        ///< Skip based on the reliability
-	OCV_MAX_SPEED,          ///< Skip based on the maximum speed
-	OCV_AGE,                ///< Skip based on the age
-	OCV_REQUIRES_SERVICE,   ///< Skip when the vehicle requires service
-	OCV_UNCONDITIONALLY,    ///< Always skip
-	OCV_REMAINING_LIFETIME, ///< Skip based on the remaining lifetime
-	OCV_MAX_RELIABILITY,    ///< Skip based on the maximum reliability
-	OCV_END
+enum class OrderConditionVariable : uint8_t {
+	LoadPercentage = 0, ///< Skip based on the amount of load
+	Reliability = 1, ///< Skip based on the reliability
+	MaxSpeed = 2, ///< Skip based on the maximum speed
+	Age = 3, ///< Skip based on the age
+	RequiresService = 4, ///< Skip when the vehicle requires service
+	Unconditionally = 5, ///< Always skip
+	RemainingLifetime = 6, ///< Skip based on the remaining lifetime
+	MaxReliability = 7, ///< Skip based on the maximum reliability
+	End,
 };
 
 /**
  * Comparator for the skip reasoning.
  */
-enum OrderConditionComparator : uint8_t {
-	OCC_EQUALS,      ///< Skip if both values are equal
-	OCC_NOT_EQUALS,  ///< Skip if both values are not equal
-	OCC_LESS_THAN,   ///< Skip if the value is less than the limit
-	OCC_LESS_EQUALS, ///< Skip if the value is less or equal to the limit
-	OCC_MORE_THAN,   ///< Skip if the value is more than the limit
-	OCC_MORE_EQUALS, ///< Skip if the value is more or equal to the limit
-	OCC_IS_TRUE,     ///< Skip if the variable is true
-	OCC_IS_FALSE,    ///< Skip if the variable is false
-	OCC_END
+enum class OrderConditionComparator : uint8_t {
+	Equal = 0, ///< Skip if both values are equal
+	NotEqual = 1, ///< Skip if both values are not equal
+	LessThan = 2, ///< Skip if the value is less than the limit
+	LessThanOrEqual = 3, ///< Skip if the value is less or equal to the limit
+	MoreThan = 4, ///< Skip if the value is more than the limit
+	MoreThanOrEqual = 5, ///< Skip if the value is more or equal to the limit
+	IsTrue = 6, ///< Skip if the variable is true
+	IsFalse = 7, ///< Skip if the variable is false
+	End,
 };
 
 
@@ -172,12 +172,12 @@ enum ModifyOrderFlags : uint8_t {
 /**
  * Depot action to switch to when doing a #MOF_DEPOT_ACTION.
  */
-enum OrderDepotAction : uint8_t {
-	DA_ALWAYS_GO, ///< Always go to the depot
-	DA_SERVICE,   ///< Service only if needed
-	DA_STOP,      ///< Go to the depot and stop there
-	DA_UNBUNCH,   ///< Go to the depot and unbunch
-	DA_END
+enum class OrderDepotAction : uint8_t {
+	AlwaysGo = 0, ///< Always go to the depot
+	Service = 1, ///< Service only if needed
+	Stop = 2, ///< Go to the depot and stop there
+	Unbunch = 3, ///< Go to the depot and unbunch
+	End
 };
 
 /**

--- a/src/pathfinder/yapf/yapf_destrail.hpp
+++ b/src/pathfinder/yapf/yapf_destrail.hpp
@@ -152,7 +152,7 @@ public:
 				break;
 
 			case OT_GOTO_DEPOT:
-				if (v->current_order.GetDepotActionType() & ODATFB_NEAREST_DEPOT) {
+				if (v->current_order.GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot)) {
 					this->any_depot = true;
 				}
 				[[fallthrough]];

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1700,13 +1700,13 @@ static void CheckIfRoadVehNeedsService(RoadVehicle *v)
 	DepotID depot = GetDepotIndex(rfdd.tile);
 
 	if (v->current_order.IsType(OT_GOTO_DEPOT) &&
-			v->current_order.GetNonStopType() & ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS &&
+			v->current_order.GetNonStopType().Test(OrderNonStopFlag::NoIntermediate) &&
 			!Chance16(1, 20)) {
 		return;
 	}
 
 	SetBit(v->gv_flags, GVF_SUPPRESS_IMPLICIT_ORDERS);
-	v->current_order.MakeGoToDepot(depot, ODTFB_SERVICE);
+	v->current_order.MakeGoToDepot(depot, OrderDepotTypeFlag::Service);
 	v->SetDestTile(rfdd.tile);
 	SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);
 }

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1823,7 +1823,7 @@ bool AfterLoadGame()
 
 			v->current_order.ConvertFromOldSavegame();
 			if (v->type == VEH_ROAD && v->IsPrimaryVehicle() && v->FirstShared() == v) {
-				for (Order &order : v->Orders()) order.SetNonStopType(ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS);
+				for (Order &order : v->Orders()) order.SetNonStopType(OrderNonStopFlag::NoIntermediate);
 			}
 		}
 	} else if (IsSavegameVersionBefore(SLV_94)) {
@@ -1848,13 +1848,13 @@ bool AfterLoadGame()
 		for (OrderList *orderlist : OrderList::Iterate()) {
 			for (Order &order : orderlist->GetOrders()) {
 				if (!order.IsType(OT_GOTO_DEPOT)) continue;
-				order.SetDepotActionType((OrderDepotActionFlags)(order.GetDepotActionType() >> 1));
+				order.SetDepotActionType(static_cast<OrderDepotActionFlags>(order.GetDepotActionType().base() >> 1));
 			}
 		}
 
 		for (Vehicle *v : Vehicle::Iterate()) {
 			if (!v->current_order.IsType(OT_GOTO_DEPOT)) continue;
-			v->current_order.SetDepotActionType((OrderDepotActionFlags)(v->current_order.GetDepotActionType() >> 1));
+			v->current_order.SetDepotActionType(static_cast<OrderDepotActionFlags>(v->current_order.GetDepotActionType().base() >> 1));
 		}
 	}
 
@@ -2213,7 +2213,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_117)) {
 		for (OrderList *orderlist : OrderList::Iterate()) {
 			for (Order &o : orderlist->GetOrders()) {
-				if (o.IsType(OT_GOTO_STATION)) o.SetStopLocation(OSL_PLATFORM_FAR_END);
+				if (o.IsType(OT_GOTO_STATION)) o.SetStopLocation(OrderStopLocation::FarEnd);
 			}
 		}
 	}

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -64,7 +64,7 @@ static const Order *ResolveOrder(VehicleID vehicle_id, ScriptOrder::OrderPositio
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
 	if (order_position == ScriptOrder::ORDER_CURRENT) {
 		const Order *order = &v->current_order;
-		if (order->GetType() == OT_GOTO_DEPOT && !(order->GetDepotOrderType() & ODTFB_PART_OF_ORDERS)) return order;
+		if (order->GetType() == OT_GOTO_DEPOT && !order->GetDepotOrderType().Test(OrderDepotTypeFlag::PartOfOrders)) return order;
 		order_position = ScriptOrder::ResolveOrderPosition(vehicle_id, order_position);
 		if (order_position == ScriptOrder::ORDER_INVALID) return nullptr;
 	}
@@ -170,7 +170,7 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 
 	const Order *order = &::Vehicle::Get(vehicle_id)->current_order;
 	if (order->GetType() != OT_GOTO_DEPOT) return true;
-	return (order->GetDepotOrderType() & ODTFB_PART_OF_ORDERS) != 0;
+	return order->GetDepotOrderType().Test(OrderDepotTypeFlag::PartOfOrders);
 }
 
 /* static */ ScriptOrder::OrderPosition ScriptOrder::ResolveOrderPosition(VehicleID vehicle_id, OrderPosition order_position)
@@ -249,7 +249,7 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 	switch (order->GetType()) {
 		case OT_GOTO_DEPOT: {
 			/* We don't know where the nearest depot is... (yet) */
-			if (order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) return INVALID_TILE;
+			if (order->GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot)) return INVALID_TILE;
 
 			if (v->type != VEH_AIRCRAFT) return ::Depot::Get(order->GetDestination().ToDepotID())->xy;
 			/* Aircraft's hangars are referenced by StationID, not DepotID */
@@ -306,12 +306,12 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 	if (order == nullptr || order->GetType() == OT_CONDITIONAL || order->GetType() == OT_DUMMY) return OF_INVALID;
 
 	ScriptOrderFlags order_flags = OF_NONE;
-	order_flags |= (ScriptOrderFlags)order->GetNonStopType();
+	order_flags |= static_cast<ScriptOrderFlags>(order->GetNonStopType().base());
 	switch (order->GetType()) {
 		case OT_GOTO_DEPOT:
-			if (order->GetDepotOrderType() & ODTFB_SERVICE) order_flags |= OF_SERVICE_IF_NEEDED;
-			if (order->GetDepotActionType() & ODATFB_HALT) order_flags |= OF_STOP_IN_DEPOT;
-			if (order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) order_flags |= OF_GOTO_NEAREST_DEPOT;
+			if (order->GetDepotOrderType().Test(OrderDepotTypeFlag::Service)) order_flags |= OF_SERVICE_IF_NEEDED;
+			if (order->GetDepotActionType().Test(OrderDepotActionFlag::Halt)) order_flags |= OF_STOP_IN_DEPOT;
+			if (order->GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot)) order_flags |= OF_GOTO_NEAREST_DEPOT;
 			break;
 
 		case OT_GOTO_STATION:
@@ -359,7 +359,7 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 
 	const Order *order = ::ResolveOrder(vehicle_id, order_position);
 	SQInteger value = order->GetConditionValue();
-	if (order->GetConditionVariable() == OCV_MAX_SPEED) value = value * 16 / 10;
+	if (order->GetConditionVariable() == OrderConditionVariable::MaxSpeed) value = value * 16 / 10;
 	return value;
 }
 
@@ -484,11 +484,16 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 	OrderType ot = (order_flags & OF_GOTO_NEAREST_DEPOT) ? OT_GOTO_DEPOT : ::GetOrderTypeByTile(destination);
 	switch (ot) {
 		case OT_GOTO_DEPOT: {
-			OrderDepotTypeFlags odtf = (OrderDepotTypeFlags)(ODTFB_PART_OF_ORDERS | ((order_flags & OF_SERVICE_IF_NEEDED) ? ODTFB_SERVICE : 0));
-			OrderDepotActionFlags odaf = (OrderDepotActionFlags)(ODATF_SERVICE_ONLY | ((order_flags & OF_STOP_IN_DEPOT) ? ODATFB_HALT : 0));
-			if (order_flags & OF_GOTO_NEAREST_DEPOT) odaf |= ODATFB_NEAREST_DEPOT;
-			OrderNonStopFlags onsf = (OrderNonStopFlags)((order_flags & OF_NON_STOP_INTERMEDIATE) ? ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS : ONSF_STOP_EVERYWHERE);
-			if (order_flags & OF_GOTO_NEAREST_DEPOT) {
+			OrderDepotTypeFlags odtf = OrderDepotTypeFlag::PartOfOrders;
+			if ((order_flags & OF_SERVICE_IF_NEEDED) != 0) odtf.Set(OrderDepotTypeFlag::Service);
+
+			OrderDepotActionFlags odaf{};
+			if ((order_flags & OF_STOP_IN_DEPOT) != 0) odaf.Set(OrderDepotActionFlag::Halt);
+			if ((order_flags & OF_GOTO_NEAREST_DEPOT) != 0) odaf.Set(OrderDepotActionFlag::NearestDepot);
+
+			OrderNonStopFlags onsf{};
+			if ((order_flags & OF_NON_STOP_INTERMEDIATE) != 0) onsf.Set(OrderNonStopFlag::NoIntermediate);
+			if ((order_flags & OF_GOTO_NEAREST_DEPOT) != 0) {
 				order.MakeGoToDepot(DepotID::Invalid(), odtf, onsf, odaf);
 			} else {
 				/* Check explicitly if the order is to a station (for aircraft) or
@@ -508,7 +513,7 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 			order.MakeGoToStation(::GetStationIndex(destination));
 			order.SetLoadType((OrderLoadFlags)GB(order_flags, 5, 3));
 			order.SetUnloadType((OrderUnloadFlags)GB(order_flags, 2, 3));
-			order.SetStopLocation(OSL_PLATFORM_FAR_END);
+			order.SetStopLocation(OrderStopLocation::FarEnd);
 			break;
 
 		case OT_GOTO_WAYPOINT:
@@ -519,7 +524,7 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 			return false;
 	}
 
-	order.SetNonStopType((OrderNonStopFlags)GB(order_flags, 0, 2));
+	order.SetNonStopType(static_cast<OrderNonStopFlags>(GB(order_flags, 0, 2)));
 
 	int order_pos = ScriptOrderPositionToRealOrderPosition(vehicle_id, order_position);
 	return ScriptObject::Command<CMD_INSERT_ORDER>::Do(0, vehicle_id, order_pos, order);
@@ -613,10 +618,10 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance &instance)
 	switch (order->GetType()) {
 		case OT_GOTO_DEPOT:
 			if ((current & OF_DEPOT_FLAGS) != (order_flags & OF_DEPOT_FLAGS)) {
-				uint data = DA_ALWAYS_GO;
-				if (order_flags & OF_SERVICE_IF_NEEDED) data = DA_SERVICE;
-				if (order_flags & OF_STOP_IN_DEPOT) data = DA_STOP;
-				return ScriptObject::Command<CMD_MODIFY_ORDER>::Do(&::_DoCommandReturnSetOrderFlags, vehicle_id, order_pos, MOF_DEPOT_ACTION, data);
+				OrderDepotAction data = OrderDepotAction::AlwaysGo;
+				if ((order_flags & OF_SERVICE_IF_NEEDED) != 0) data = OrderDepotAction::Service;
+				if ((order_flags & OF_STOP_IN_DEPOT) != 0) data = OrderDepotAction::Stop;
+				return ScriptObject::Command<CMD_MODIFY_ORDER>::Do(&::_DoCommandReturnSetOrderFlags, vehicle_id, order_pos, MOF_DEPOT_ACTION, to_underlying(data));
 			}
 			break;
 

--- a/src/script/api/script_order.hpp
+++ b/src/script/api/script_order.hpp
@@ -89,14 +89,14 @@ public:
 	 */
 	enum OrderCondition {
 		/* Note: these values represent part of the in-game OrderConditionVariable enum */
-		OC_LOAD_PERCENTAGE     = ::OCV_LOAD_PERCENTAGE,    ///< Skip based on the amount of load, value is in tons.
-		OC_RELIABILITY         = ::OCV_RELIABILITY,        ///< Skip based on the reliability, value is percent (0..100).
-		OC_MAX_RELIABILITY     = ::OCV_MAX_RELIABILITY,    ///< Skip based on the maximum reliability.  Value in percent
-		OC_MAX_SPEED           = ::OCV_MAX_SPEED,          ///< Skip based on the maximum speed, value is in OpenTTD's internal speed unit, see ScriptEngine::GetMaxSpeed.
-		OC_AGE                 = ::OCV_AGE,                ///< Skip based on the age, value is in calendar-years. @see \ref ScriptCalendarTime
-		OC_REQUIRES_SERVICE    = ::OCV_REQUIRES_SERVICE,   ///< Skip when the vehicle requires service, no value.
-		OC_UNCONDITIONALLY     = ::OCV_UNCONDITIONALLY,    ///< Always skip, no compare function, no value.
-		OC_REMAINING_LIFETIME  = ::OCV_REMAINING_LIFETIME, ///< Skip based on the remaining lifetime in calendar-years. @see \ref ScriptCalendarTime
+		OC_LOAD_PERCENTAGE     = to_underlying(::OrderConditionVariable::LoadPercentage), ///< Skip based on the amount of load, value is in tons.
+		OC_RELIABILITY         = to_underlying(::OrderConditionVariable::Reliability), ///< Skip based on the reliability, value is percent (0..100).
+		OC_MAX_RELIABILITY     = to_underlying(::OrderConditionVariable::MaxReliability), ///< Skip based on the maximum reliability.  Value in percent
+		OC_MAX_SPEED           = to_underlying(::OrderConditionVariable::MaxSpeed), ///< Skip based on the maximum speed, value is in OpenTTD's internal speed unit, see ScriptEngine::GetMaxSpeed.
+		OC_AGE                 = to_underlying(::OrderConditionVariable::Age), ///< Skip based on the age, value is in calendar-years. @see \ref ScriptCalendarTime
+		OC_REQUIRES_SERVICE    = to_underlying(::OrderConditionVariable::RequiresService), ///< Skip when the vehicle requires service, no value.
+		OC_UNCONDITIONALLY     = to_underlying(::OrderConditionVariable::Unconditionally), ///< Always skip, no compare function, no value.
+		OC_REMAINING_LIFETIME  = to_underlying(::OrderConditionVariable::RemainingLifetime), ///< Skip based on the remaining lifetime in calendar-years. @see \ref ScriptCalendarTime
 
 		/* Custom added value, only valid for this API */
 		OC_INVALID             = -1,                       ///< An invalid condition, do not use.
@@ -107,14 +107,14 @@ public:
 	 */
 	enum CompareFunction {
 		/* Note: these values represent part of the in-game OrderConditionComparator enum */
-		CF_EQUALS        = ::OCC_EQUALS,       ///< Skip if both values are equal
-		CF_NOT_EQUALS    = ::OCC_NOT_EQUALS,   ///< Skip if both values are not equal
-		CF_LESS_THAN     = ::OCC_LESS_THAN,    ///< Skip if the value is less than the limit
-		CF_LESS_EQUALS   = ::OCC_LESS_EQUALS,  ///< Skip if the value is less or equal to the limit
-		CF_MORE_THAN     = ::OCC_MORE_THAN,    ///< Skip if the value is more than the limit
-		CF_MORE_EQUALS   = ::OCC_MORE_EQUALS,  ///< Skip if the value is more or equal to the limit
-		CF_IS_TRUE       = ::OCC_IS_TRUE,      ///< Skip if the variable is true
-		CF_IS_FALSE      = ::OCC_IS_FALSE,     ///< Skip if the variable is false
+		CF_EQUALS        = to_underlying(::OrderConditionComparator::Equal), ///< Skip if both values are equal
+		CF_NOT_EQUALS    = to_underlying(::OrderConditionComparator::NotEqual), ///< Skip if both values are not equal
+		CF_LESS_THAN     = to_underlying(::OrderConditionComparator::LessThan), ///< Skip if the value is less than the limit
+		CF_LESS_EQUALS   = to_underlying(::OrderConditionComparator::LessThanOrEqual), ///< Skip if the value is less or equal to the limit
+		CF_MORE_THAN     = to_underlying(::OrderConditionComparator::MoreThan), ///< Skip if the value is more than the limit
+		CF_MORE_EQUALS   = to_underlying(::OrderConditionComparator::MoreThanOrEqual), ///< Skip if the value is more or equal to the limit
+		CF_IS_TRUE       = to_underlying(::OrderConditionComparator::IsTrue), ///< Skip if the variable is true
+		CF_IS_FALSE      = to_underlying(::OrderConditionComparator::IsFalse), ///< Skip if the variable is false
 
 		/* Custom added value, only valid for this API */
 		CF_INVALID       = -1,                 ///< Invalid compare function, do not use.

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -169,7 +169,7 @@ struct GUISettings {
 	bool   show_finances;                    ///< show finances at end of year
 	bool   sg_new_nonstop;                   ///< ttdpatch compatible nonstop handling read from pre v93 savegames
 	bool   new_nonstop;                      ///< ttdpatch compatible nonstop handling
-	uint8_t  stop_location;                    ///< what is the default stop location of trains?
+	OrderStopLocation stop_location; ///< what is the default stop location of trains?
 	uint8_t  auto_scrolling;                   ///< scroll when moving mouse to the edge (see #ViewportAutoscrolling)
 	uint8_t errmsg_duration;                  ///< duration of error message
 	uint16_t hover_delay_ms;                   ///< time required to activate a hover event, in milliseconds

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -220,7 +220,7 @@ static void CheckIfShipNeedsService(Vehicle *v)
 		return;
 	}
 
-	v->current_order.MakeGoToDepot(depot->index, ODTFB_SERVICE);
+	v->current_order.MakeGoToDepot(depot->index, OrderDepotTypeFlag::Service);
 	v->SetDestTile(depot->xy);
 	SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);
 }

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -167,7 +167,7 @@ CommandCost CmdChangeTimetable(DoCommandFlags flags, VehicleID veh, VehicleOrder
 	if (wait_time != order->GetWaitTime()) {
 		switch (order->GetType()) {
 			case OT_GOTO_STATION:
-				if (order->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION) return CommandCost(STR_ERROR_TIMETABLE_NOT_STOPPING_HERE);
+				if (order->GetNonStopType().Test(OrderNonStopFlag::NoDestination)) return CommandCost(STR_ERROR_TIMETABLE_NOT_STOPPING_HERE);
 				break;
 
 			case OT_CONDITIONAL:
@@ -317,8 +317,8 @@ static bool VehicleTimetableSorter(Vehicle * const &a, Vehicle * const &b)
 	int j = (int)b_order - (int)a_order;
 
 	/* Are we currently at an ordered station (un)loading? */
-	bool a_load = a->current_order.IsType(OT_LOADING) && a->current_order.GetNonStopType() != ONSF_STOP_EVERYWHERE;
-	bool b_load = b->current_order.IsType(OT_LOADING) && b->current_order.GetNonStopType() != ONSF_STOP_EVERYWHERE;
+	bool a_load = a->current_order.IsType(OT_LOADING) && a->current_order.GetNonStopType().Any();
+	bool b_load = b->current_order.IsType(OT_LOADING) && b->current_order.GetNonStopType().Any();
 
 	/* If the current order is not loading at the ordered station, decrease the order index by one since we have
 	 * not yet arrived at the station (and thus the timetable entry; still in the travelling of the previous one).

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -110,7 +110,7 @@ static bool CanDetermineTimeTaken(const Order &order, bool travelling)
 	if (travelling && !order.IsTravelTimetabled()) return false;
 	/* No wait time but we are loading at this timetabled station */
 	if (!travelling && !order.IsWaitTimetabled() && order.IsType(OT_GOTO_STATION) &&
-			!(order.GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION)) {
+			!order.GetNonStopType().Test(OrderNonStopFlag::NoDestination)) {
 		return false;
 	}
 
@@ -208,7 +208,7 @@ struct TimetableWindow : Window {
 	{
 		assert(v->vehicle_flags.Test(VehicleFlag::TimetableStarted));
 
-		bool travelling = (!v->current_order.IsType(OT_LOADING) || v->current_order.GetNonStopType() == ONSF_STOP_EVERYWHERE);
+		bool travelling = (!v->current_order.IsType(OT_LOADING) || v->current_order.GetNonStopType().None());
 		TimerGameTick::Ticks start_time = -v->current_order_time;
 
 		/* If arrival and departure times are in days, compensate for the current date_fract. */
@@ -349,7 +349,7 @@ struct TimetableWindow : Window {
 				if (selected % 2 != 0) {
 					disable = order != nullptr && (order->IsType(OT_CONDITIONAL) || order->IsType(OT_IMPLICIT));
 				} else {
-					disable = order == nullptr || ((!order->IsType(OT_GOTO_STATION) || (order->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION)) && !order->IsType(OT_CONDITIONAL));
+					disable = order == nullptr || ((!order->IsType(OT_GOTO_STATION) || order->GetNonStopType().Test(OrderNonStopFlag::NoDestination)) && !order->IsType(OT_CONDITIONAL));
 				}
 			}
 			bool disable_speed = disable || selected % 2 == 0 || v->type == VEH_AIRCRAFT;

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3159,11 +3159,11 @@ public:
 				if (v->current_order.GetDestination() == DepotID::Invalid()) return {};
 
 				auto params = MakeParameters(v->type, v->current_order.GetDestination(), PackVelocity(v->GetDisplaySpeed(), v->type));
-				if (v->current_order.GetDepotActionType() & ODATFB_HALT) {
+				if (v->current_order.GetDepotActionType().Test(OrderDepotActionFlag::Halt)) {
 					return GetStringWithArgs(v->vehicle_flags.Test(VehicleFlag::PathfinderLost) ? STR_VEHICLE_STATUS_CANNOT_REACH_DEPOT_VEL : STR_VEHICLE_STATUS_HEADING_FOR_DEPOT_VEL, params);
 				}
 
-				if (v->current_order.GetDepotActionType() & ODATFB_UNBUNCH) {
+				if (v->current_order.GetDepotActionType().Test(OrderDepotActionFlag::Unbunch)) {
 					return GetStringWithArgs(v->vehicle_flags.Test(VehicleFlag::PathfinderLost) ? STR_VEHICLE_STATUS_CANNOT_REACH_DEPOT_SERVICE_VEL : STR_VEHICLE_STATUS_HEADING_FOR_DEPOT_UNBUNCH_VEL, params);
 				}
 

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -114,7 +114,7 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 		case VL_DEPOT_LIST:
 			FindVehiclesWithOrder(
 				[&vli](const Vehicle *v) { return v->type == vli.vtype; },
-				[&vli](const Order *order) { return order->IsType(OT_GOTO_DEPOT) && !(order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) && order->GetDestination() == vli.ToDestinationID(); },
+				[&vli](const Order *order) { return order->IsType(OT_GOTO_DEPOT) && !order->GetDepotActionType().Test(OrderDepotActionFlag::NearestDepot) && order->GetDestination() == vli.ToDestinationID(); },
 				[&list](const Vehicle *v) { list->push_back(v); }
 			);
 			break;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Various order flags are used as bit sets in non-intuitive ways, sometimes mixed with values.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Convert to `enum class` and `EnumBitSet`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

`OrderLoadFlags` and `OrderUnloadFlags` actually seem to have mutually exclusive values, which suggests they shouldn't really be bitsets anyway.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
