### PR TITLE
Fix: Two lighthouse spawn issues

### DIFF
--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -774,6 +774,9 @@ static bool TryBuildLightHouse()
 	for (int j = 0; j < 19; j++) {
 		int h;
 		if (IsTileType(tile, MP_CLEAR) && IsTileFlat(tile, &h) && h <= 2 && !IsBridgeAbove(tile)) {
+			for (auto t : SpiralTileSequence(tile, 9)) {
+				if (IsObjectTypeTile(t, OBJECT_LIGHTHOUSE)) return false;
+			}
 			BuildObject(OBJECT_LIGHTHOUSE, tile);
 			assert(tile < Map::Size());
 			return true;

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -769,7 +769,7 @@ static bool TryBuildLightHouse()
 	}
 
 	/* Only build lighthouses at tiles where the border is sea. */
-	if (!IsTileType(tile, MP_WATER)) return false;
+	if (!IsTileType(tile, MP_WATER) || GetWaterClass(tile) != WATER_CLASS_SEA) return false;
 
 	for (int j = 0; j < 19; j++) {
 		int h;


### PR DESCRIPTION
## Motivation / Problem

1. Lighthouses can spawn beside rivers, far from any ocean
2. Lighthouses can spawn too close together (pictured)

<img width="910" height="497" alt="lighthouses" src="https://github.com/user-attachments/assets/15d14ed8-6926-4ffc-ac1c-d932110af173" />

## Description

1. Properly check the water class to match the comment above.
2. Use the same logic for transmitters to keep lighthouses apart.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
