### PR TITLE
Add: Setting to disable transmitters and lighthouses

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1631,6 +1631,9 @@ STR_CONFIG_SETTING_VARIETY_HELPTEXT                             :Choose if the m
 STR_CONFIG_SETTING_RIVER_AMOUNT                                 :River amount: {STRING2}
 STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT                        :Choose how many rivers to generate
 
+STR_CONFIG_SETTING_GENERATE_OBSTACLES                           :Generate obstacles: {STRING2}
+STR_CONFIG_SETTING_GENERATE_OBSTACLES_HELPTEXT                  :Choose whether to generate obstacles (transmitters and lighthouses)
+
 STR_CONFIG_SETTING_TREE_PLACER                                  :Tree placer algorithm: {STRING2}
 STR_CONFIG_SETTING_TREE_PLACER_HELPTEXT                         :Choose the distribution of trees on the map: 'Original' plants trees uniformly scattered, 'Improved' plants them in groups
 ###length 3

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -829,6 +829,10 @@ void GenerateObjects()
 		/* Continue, if the object was never available till now or shall not be placed */
 		if (!spec.WasEverAvailable() || spec.generate_amount == 0) continue;
 
+		/* If transmitters and lighthouses are disabled, do not place them */
+		if ((spec.Index() == OBJECT_TRANSMITTER || spec.Index() == OBJECT_LIGHTHOUSE)
+				&& !_settings_newgame.game_creation.generate_obstacles) continue;
+
 		uint16_t amount = spec.generate_amount;
 
 		/* Scale by map size */

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -847,6 +847,7 @@ SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("game_creation.snow_line_height"));
 			genworld->Add(new SettingEntry("game_creation.desert_coverage"));
 			genworld->Add(new SettingEntry("game_creation.amount_of_rivers"));
+			genworld->Add(new SettingEntry("game_creation.generate_obstacles"));
 		}
 
 		SettingsPage *environment = main->Add(new SettingsPage(STR_CONFIG_SETTING_ENVIRONMENT));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -392,6 +392,7 @@ struct GameCreationSettings {
 	uint8_t min_river_length;                 ///< the minimum river length
 	uint8_t river_route_random;               ///< the amount of randomicity for the route finding
 	uint8_t amount_of_rivers;                 ///< the amount of rivers
+	bool generate_obstacles;                  ///< generate transmitters and lighthouses
 };
 
 /** Settings related to construction in-game */

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -340,6 +340,15 @@ str      = STR_CONFIG_SETTING_RIVER_AMOUNT
 strhelp  = STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT
 strval   = STR_RIVERS_NONE
 
+[SDT_BOOL]
+var      = game_creation.generate_obstacles
+from     = SLV_ENGINE_MULTI_RAILTYPE
+flags    = SettingFlag::NewgameOnly
+def      = true
+str      = STR_CONFIG_SETTING_GENERATE_OBSTACLES
+strhelp  = STR_CONFIG_SETTING_GENERATE_OBSTACLES_HELPTEXT
+cat      = SC_BASIC
+
 [SDT_VAR]
 var      = construction.map_height_limit
 type     = SLE_UINT8


### PR DESCRIPTION
## Motivation / Problem
Not everyone may want these obstacles in their game. The only way to get rid of them is the "magic bulldozer", which is a ~cheat~ sandbox setting. This seems like something that should be a world generation option.


## Description
Add a setting for whether transmitters and lighthouses should be generated.


## Limitations
- Maybe this doesn't really need to be a setting, and the magic bulldozer is enough? Is this "too many settings"?
- Maybe the amount of such obstacles should be configurable, rather than just turning them off and on? (Like rivers, industries etc)
- In the `ini` file, I have just added the latest savegame version as the "from" version. I have no idea if this is the correct way to do that.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
