### PR TITLE
Fix 2b244441: [CMake] Regression tests failed if no previous crashes present

### DIFF
--- a/cmake/scripts/Regression.cmake
+++ b/cmake/scripts/Regression.cmake
@@ -27,7 +27,9 @@ endif()
 
 # Remove previous crash files
 file(GLOB CRASH_FILES "regression/crash*")
-file(REMOVE ${CRASH_FILES})
+if(CRASH_FILES)
+    file(REMOVE ${CRASH_FILES})
+endif()
 
 # Run the regression test
 execute_process(COMMAND ${OPENTTD_EXECUTABLE}


### PR DESCRIPTION
## Motivation / Problem

`file(REMOVE ${CRASH_FILES})` is not valid if `CRASH_FILES` is empty (which is hopefully the normal case) on CMake 3.x. The reported error is `file must be called with at least two arguments`.
The file claims to support CMake 3.17 or later.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
