### PR TITLE
Fix 98481ecc: Incorrect parsing of var 6x parameter in NewGRF debug window

### DIFF
--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -594,7 +594,7 @@ struct NewGRFInspectWindow : Window {
 	{
 		if (!str.has_value()) return;
 
-		auto val = ParseInteger<int32_t>(*str, 10, true);
+		auto val = ParseInteger<uint32_t>(*str, 16, true);
 		if (!val.has_value()) return;
 		NewGRFInspectWindow::var60params[GetFeatureNum(this->window_number)][this->current_edit_param - 0x60] = *val;
 		this->SetDirty();


### PR DESCRIPTION
## Motivation / Problem

The parameter value for var 6x NewGRF variables is parsed incorrectly since 98481ecc.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
