### PR TITLE
Add: [Script] ScriptTile::IsHouseTile - Add a way to check if tile has a house on it

### DIFF
--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -30,6 +30,7 @@
  * \li AIVehicleList_Waypoint
  * \li AIError::ERR_BRIDGE_TOO_LOW
  * \li AIEngine::GetAllRailTypes
+ * \li AITile::IsHouseTile
  *
  * Other changes:
  * \li AIBridge::GetBridgeID renamed to AIBridge::GetBridgeType

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -31,6 +31,7 @@
  * \li GSBaseStation::GetOwner
  * \li GSError::ERR_BRIDGE_TOO_LOW
  * \li GSEngine::GetAllRailTypes
+ * \li GSTile::IsHouseTile
  *
  * Other changes:
  * \li GSBridge::GetBridgeID renamed to GSBridge::GetBridgeType

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -154,6 +154,13 @@
 	return (::IsTileType(tile, MP_CLEAR) && ::IsClearGround(tile, CLEAR_DESERT));
 }
 
+/* static */ bool ScriptTile::IsHouseTile(TileIndex tile)
+{
+	if (!::IsValidTile(tile)) return false;
+
+	return ::IsTileType(tile, MP_HOUSE);
+}
+
 /* static */ ScriptTile::TerrainType ScriptTile::GetTerrainType(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return TERRAIN_NORMAL;

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -276,6 +276,14 @@ public:
 	static bool IsDesertTile(TileIndex tile);
 
 	/**
+	 * Check if the tile is town house/building
+	 * @param tile The tile to check on.
+	 * @pre ScriptMap::IsValidTile(tile).
+	 * @return True if and only if the tile is house tile.
+	 */
+	static bool IsHouseTile(TileIndex tile);
+
+	/**
 	 * Get the type of terrain regardless of buildings or infrastructure.
 	 * @note When a desert or rainforest tile are changed, their terrain type will remain the same. In other words, a sea tile can be of the desert terrain type.
 	 * @note The snow terrain type can change to the normal terrain type and vice versa based on landscaping or variable snow lines from NewGRFs.


### PR DESCRIPTION
## Motivation / Problem

Currently script API has no direct way to check if tile has a house. One workaround is to check with all other ScripTile functions and it all return false, assume tile has a house.
A dedicated function would be more convenient.

## Description

Adding new API function bool `ScriptTile::IsHouseTile(TileIndex tile)` to check if tile has a house.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
