### PR TITLE
Codefix 0455627d16: Don't make temporary copies of order when converting old orders.

### DIFF
--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -191,7 +191,7 @@ struct ORDRChunkHandler : ChunkHandler {
 
 			/* Update all the next pointer. The orders were built like this:
 			 * While the order is valid, the previous order will get its next pointer set */
-			for (uint32_t num = 1; OldOrderSaveLoadItem item : _old_order_saveload_pool) {
+			for (uint32_t num = 1; const OldOrderSaveLoadItem &item : _old_order_saveload_pool) {
 				if (!item.order.IsType(OT_NOTHING) && num > 1) {
 					OldOrderSaveLoadItem *prev = GetOldOrder(num - 1);
 					if (prev != nullptr) prev->next = num;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When converting old orders from pool items to order lists the temporary orders are iterated, but neglecting to take a reference, so a temporary copy might be used instead.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use const reference to ensure old order pool is iterated without copying each item.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
