### PR TITLE
Fix #14756: Invalidate nested focus before container is cleared.

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1334,8 +1334,7 @@ struct BuildVehicleWindow : Window {
 		this->badge_classes = GUIBadgeClasses(static_cast<GrfSpecFeature>(GSF_TRAINS + this->vehicle_type));
 		this->SetCargoFilterArray();
 
-		auto container = this->GetWidget<NWidgetContainer>(WID_BV_BADGE_FILTER);
-		this->badge_filters = AddBadgeDropdownFilters(*container, WID_BV_BADGE_FILTER, COLOUR_GREY, static_cast<GrfSpecFeature>(GSF_TRAINS + this->vehicle_type));
+		this->badge_filters = AddBadgeDropdownFilters(this, WID_BV_BADGE_FILTER, WID_BV_BADGE_FILTER, COLOUR_GREY, static_cast<GrfSpecFeature>(GSF_TRAINS + this->vehicle_type));
 
 		this->widget_lookup.clear();
 		this->nested_root->FillWidgetLookup(this->widget_lookup);

--- a/src/newgrf_badge_gui.cpp
+++ b/src/newgrf_badge_gui.cpp
@@ -21,6 +21,7 @@
 #include "strings_func.h"
 #include "timer/timer_game_calendar.h"
 #include "window_gui.h"
+#include "window_type.h"
 #include "zoom_func.h"
 
 #include "table/strings.h"
@@ -550,15 +551,17 @@ DropDownList NWidgetBadgeFilter::GetDropDownList(PaletteID palette) const
 
 /**
  * Add badge drop down filter widgets.
- * @param container Container widget to hold filter widgets.
+ * @param window Window that holds the container.
+ * @param container Container widget index to hold filter widgets.
  * @param widget Widget index to apply to first filter.
  * @param colour Background colour of widgets.
  * @param feature GRF feature for filters.
  * @return First and last widget indexes of filter widgets.
  */
-std::pair<WidgetID, WidgetID> AddBadgeDropdownFilters(NWidgetContainer &container, WidgetID widget, Colours colour, GrfSpecFeature feature)
+std::pair<WidgetID, WidgetID> AddBadgeDropdownFilters(Window *window, WidgetID container_id, WidgetID widget, Colours colour, GrfSpecFeature feature)
 {
-	container.Clear();
+	auto container = window->GetWidget<NWidgetContainer>(container_id);
+	container->Clear(window);
 	WidgetID first = ++widget;
 
 	/* Get list of classes used by feature. */
@@ -568,7 +571,7 @@ std::pair<WidgetID, WidgetID> AddBadgeDropdownFilters(NWidgetContainer &containe
 		const auto [config, _] = GetBadgeClassConfigItem(feature, GetClassBadge(class_index)->label);
 		if (!config.show_filter) continue;
 
-		container.Add(std::make_unique<NWidgetBadgeFilter>(colour, widget, feature, class_index));
+		container->Add(std::make_unique<NWidgetBadgeFilter>(colour, widget, feature, class_index));
 		++widget;
 	}
 

--- a/src/newgrf_badge_gui.h
+++ b/src/newgrf_badge_gui.h
@@ -57,7 +57,7 @@ std::unique_ptr<DropDownListItem> MakeDropDownListBadgeIconItem(const std::share
 DropDownList BuildBadgeClassConfigurationList(const class GUIBadgeClasses &badge_class, uint columns, std::span<const StringID> column_separators);
 bool HandleBadgeConfigurationDropDownClick(GrfSpecFeature feature, uint columns, int result, int click_result, BadgeFilterChoices &choices);
 
-std::pair<WidgetID, WidgetID> AddBadgeDropdownFilters(NWidgetContainer &container, WidgetID widget, Colours colour, GrfSpecFeature feature);
+std::pair<WidgetID, WidgetID> AddBadgeDropdownFilters(Window *window, WidgetID container_id, WidgetID widget, Colours colour, GrfSpecFeature feature);
 
 class NWidgetBadgeFilter : public NWidgetLeaf {
 public:

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -251,9 +251,7 @@ void PickerWindow::ConstructWindow()
 void PickerWindow::OnInit()
 {
 	this->badge_classes = GUIBadgeClasses(this->callbacks.GetFeature());
-
-	auto container = this->GetWidget<NWidgetContainer>(WID_PW_BADGE_FILTER);
-	this->badge_filters = AddBadgeDropdownFilters(*container, WID_PW_BADGE_FILTER, COLOUR_DARK_GREEN, this->callbacks.GetFeature());
+	this->badge_filters = AddBadgeDropdownFilters(this, WID_PW_BADGE_FILTER, WID_PW_BADGE_FILTER, COLOUR_DARK_GREEN, this->callbacks.GetFeature());
 
 	this->widget_lookup.clear();
 	this->nested_root->FillWidgetLookup(this->widget_lookup);

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -3476,3 +3476,20 @@ std::unique_ptr<NWidgetBase> MakeCompanyButtonRows(WidgetID widget_first, Widget
 	if (hor != nullptr) vert->Add(std::move(hor));
 	return vert;
 }
+
+/**
+ * Unfocuses the focused widget of the window,
+ * if the focused widget is contained inside the container.
+ * @param parent_window Window which contains this container.
+ */
+void NWidgetContainer::UnfocusWidgets(Window *parent_window)
+{
+	assert(parent_window != nullptr);
+	if (parent_window->nested_focus != nullptr) {
+		for (auto &widget : this->children) {
+			if (parent_window->nested_focus == widget.get()) {
+				parent_window->UnfocusFocusedWidget();
+			}
+		}
+	}
+}

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -484,7 +484,17 @@ public:
 	inline bool IsEmpty() { return this->children.empty(); }
 
 	NWidgetBase *GetWidgetOfType(WidgetType tp) override;
-	void Clear() { this->children.clear(); }
+	void UnfocusWidgets(Window *parent_window);
+
+	/**
+	 * Clears the container, deleting all widgets that were contained.
+	 * @param parent_window Window that contains the container.
+	 */
+	inline void Clear(Window *parent_window)
+	{
+		this->UnfocusWidgets(parent_window);
+		this->children.clear();
+	}
 
 protected:
 	std::vector<std::unique_ptr<NWidgetBase>> children{}; ///< Child widgets in container.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
When widget container is cleared (e.g. for the badge filter dropdowns) the window's nested_focus member isn't checked whether it points to one of the contained widgets. In some edge cases the nested_focus becomes invalid and points to the deleted widget. Then when a new widget is focused the window tries to unfocus deleted widget and access freed up memory. Reproduction of such edge case has been described in the #14756.

Fixes #14756.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Set the nested_focus to nullptr if it points to a widget inside the to be cleared container before clearing the container.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
