### PR TITLE
Fix ed67aedabf: Saved default houses had incorrect class and index information.

### DIFF
--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -136,9 +136,9 @@ public:
 		for (const auto &item : src) {
 			const auto *spec = T::GetByGrf(item.grfid, item.local_id);
 			if (spec == nullptr) {
-				dst.insert({item.grfid, item.local_id, -1, -1});
+				dst.emplace(item.grfid, item.local_id, -1, -1);
 			} else {
-				dst.insert(GetPickerItem(spec));
+				dst.emplace(GetPickerItem(spec));
 			}
 		}
 		return dst;

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1588,16 +1588,19 @@ public:
 		std::set<PickerItem> dst;
 		for (const auto &item : src) {
 			if (item.grfid == 0) {
-				dst.insert(item);
+				const HouseSpec *hs = HouseSpec::Get(item.local_id);
+				if (hs == nullptr) continue;
+				int class_index = GetClassIdFromHouseZone(hs->building_availability);
+				dst.emplace(item.grfid, item.local_id, class_index, item.local_id);
 			} else {
 				/* Search for spec by grfid and local index. */
 				auto it = std::ranges::find_if(specs, [&item](const HouseSpec &spec) { return spec.grf_prop.grfid == item.grfid && spec.grf_prop.local_id == item.local_id; });
 				if (it == specs.end()) {
 					/* Not preset, hide from UI. */
-					dst.insert({item.grfid, item.local_id, -1, -1});
+					dst.emplace(item.grfid, item.local_id, -1, -1);
 				} else {
 					int class_index = GetClassIdFromHouseZone(it->building_availability);
-					dst.insert( {item.grfid, item.local_id, class_index, it->Index()});
+					dst.emplace(item.grfid, item.local_id, class_index, it->Index());
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Saved default houses would not appear properly in the 'Saved' tab after restarting the game.

Found by @mmtunligit 

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Populate house class and index information when updating saved house information. This is technically not necessary for items saved during the current game, but is always applied for simplicity.

Also use `emplace(...)` instead of `insert({...})`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
