### PR TITLE
Feature: User-defined collections of saved items in the picker window

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2858,18 +2858,38 @@ STR_PICKER_PREVIEW_SHRINK_TOOLTIP                               :Reduce the heig
 STR_PICKER_PREVIEW_EXPAND                                       :+
 STR_PICKER_PREVIEW_EXPAND_TOOLTIP                               :Increase the height of preview images. Ctrl+Click to increase to maximum
 
+STR_PICKER_DEFAULT_COLLECTION                                   :Default collection
+STR_PICKER_SELECT_COLLECTION_TOOLTIP                            :Select a collection
+STR_PICKER_COLLECTION_ADD                                       :Add
+STR_PICKER_COLLECTION_ADD_TOOLTIP                               :Create a new collection
+STR_PICKER_COLLECTION_RENAME                                    :Rename
+STR_PICKER_COLLECTION_RENAME_TOOLTIP                            :Rename a collection
+STR_PICKER_COLLECTION_DELETE                                    :Delete
+STR_PICKER_COLLECTION_DELETE_TOOLTIP                            :Delete a collection
+
+STR_PICKER_COLLECTION_RENAME_QUERY                              :Rename this collection
+STR_PICKER_COLLECTION_DELETE_QUERY                              :Delete collection
+STR_PICKER_COLLECTION_DELETE_QUERY_TEXT                         :{YELLOW}Are you sure you want to delete this collection?
+STR_PICKER_COLLECTION_DELETE_QUERY_DISABLED_TEXT                :{YELLOW}Are you sure you want to delete this collection? There are items from disabled NewGRFs in it!
+
 STR_PICKER_STATION_CLASS_TOOLTIP                                :Select a station class to display
 STR_PICKER_STATION_TYPE_TOOLTIP                                 :Select a station type to build. Ctrl+Click to add or remove in saved items
+STR_PICKER_STATION_COLLECTION_TOOLTIP                           :Select a collection of stations to display
 STR_PICKER_WAYPOINT_CLASS_TOOLTIP                               :Select a waypoint class to display
 STR_PICKER_WAYPOINT_TYPE_TOOLTIP                                :Select a waypoint to build. Ctrl+Click to add or remove in saved items
+STR_PICKER_WAYPOINT_COLLECTION_TOOLTIP                          :Select a collection of waypoints to display
 STR_PICKER_ROADSTOP_BUS_CLASS_TOOLTIP                           :Select a bus station class to display
 STR_PICKER_ROADSTOP_BUS_TYPE_TOOLTIP                            :Select a bus station type to build. Ctrl+Click to add or remove in saved items
+STR_PICKER_ROADSTOP_BUS_COLLECTION_TOOLTIP                      :Select a collection of bus stations to display
 STR_PICKER_ROADSTOP_TRUCK_CLASS_TOOLTIP                         :Select a lorry station class to display
 STR_PICKER_ROADSTOP_TRUCK_TYPE_TOOLTIP                          :Select a lorry station type to build. Ctrl+Click to add or remove in saved items
+STR_PICKER_ROADSTOP_TRUCK_COLLECTION_TOOLTIP                    :Select a collection of lorry stations to display
 STR_PICKER_OBJECT_CLASS_TOOLTIP                                 :Select an object class to display
 STR_PICKER_OBJECT_TYPE_TOOLTIP                                  :Select an object type to build. Ctrl+Click to add or remove in saved items. Ctrl+Click+Drag to select the area diagonally. Also press Shift to show cost estimate only
+STR_PICKER_OBJECT_COLLECTION_TOOLTIP                            :Select a collection of objects to display
 STR_PICKER_HOUSE_CLASS_TOOLTIP                                  :Select a town zone to display
 STR_PICKER_HOUSE_TYPE_TOOLTIP                                   :Select a house type to build. Ctrl+Click to add or remove in saved items
+STR_PICKER_HOUSE_COLLECTION_TOOLTIP                             :Select a collection of houses to display
 
 STR_HOUSE_PICKER_CAPTION                                        :House Selection
 STR_HOUSE_PICKER_NAME                                           :{BLACK}Name: {GOLD}{STRING}

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -50,6 +50,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_OBJECT_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_OBJECT_TYPE_TOOLTIP; }
+	StringID GetCollectionTooltip() const override { return STR_PICKER_OBJECT_COLLECTION_TOOLTIP; }
 
 	bool IsActive() const override
 	{

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -66,7 +66,6 @@ public:
 	virtual StringID GetTypeTooltip() const = 0;
 	/** Get the number of types in a class. @note Used only to estimate space requirements. */
 	virtual int GetTypeCount(int cls_id) const = 0;
-
 	/** Get the selected type. */
 	virtual int GetSelectedType() const = 0;
 	/** Set the selected type. */
@@ -85,7 +84,31 @@ public:
 	/** Fill a set with all items that are used by the current player. */
 	virtual void FillUsedItems(std::set<PickerItem> &items) = 0;
 	/** Update link between grfid/localidx and class_index/index in saved items. */
-	virtual std::set<PickerItem> UpdateSavedItems(const std::set<PickerItem> &src) = 0;
+	virtual std::map<std::string, std::set<PickerItem>> UpdateSavedItems(const std::map<std::string, std::set<PickerItem>> &src) = 0;
+	/**
+	 * Initialize the list of active collections for sorting purposes.
+	 * @param collections The map of collections to check.
+	 * @return The set of collections with inactive items.
+	 */
+	inline std::set<std::string> InitializeInactiveCollections(const std::map<std::string, std::set<PickerItem>> collections)
+	{
+		std::set<std::string> inactive;
+
+		for (const auto &collection : collections) {
+			if ((collection.second.size() == 1 && collection.second.contains({})) || collection.first == "") continue;
+			for (const PickerItem &item : collection.second) {
+				if (item.class_index == -1 || item.index == -1) {
+					inactive.emplace(collection.first);
+					break;
+				}
+				if (GetTypeName(item.class_index, item.index) == INVALID_STRING_ID) {
+					inactive.emplace(collection.first);
+					break;
+				}
+			}
+		}
+		return inactive;
+	}
 
 	Listing class_last_sorting = { false, 0 }; ///< Default sorting of #PickerClassList.
 	Filtering class_last_filtering = { false, 0 }; ///< Default filtering of #PickerClassList.
@@ -93,13 +116,17 @@ public:
 	Listing type_last_sorting = { false, 0 }; ///< Default sorting of #PickerTypeList.
 	Filtering type_last_filtering = { false, 0 }; ///< Default filtering of #PickerTypeList.
 
+	Listing collection_last_sorting = { false, 0 }; ///< Default sorting of #PickerCollectionList.
+
 	const std::string ini_group; ///< Ini Group for saving favourites.
 	uint8_t mode = 0; ///< Bitmask of \c PickerFilterModes.
+	std::string sel_collection;          ///< Currently selected collection of saved items.
+	std::set<std::string> rm_collections; ///< Set of removed or renamed collections for updating ini file.
 
 	int preview_height = 0; ///< Previously adjusted height.
 
 	std::set<PickerItem> used; ///< Set of items used in the current game by the current company.
-	std::set<PickerItem> saved; ///< Set of saved favourite items.
+	std::map<std::string, std::set<PickerItem>> saved; ///< Set of saved collections of items.
 };
 
 /** Helper for PickerCallbacks when the class system is based on NewGRFClass. */
@@ -128,17 +155,24 @@ public:
 		return GetPickerItem(GetClass(cls_id)->GetSpec(id), cls_id, id);
 	}
 
-	std::set<PickerItem> UpdateSavedItems(const std::set<PickerItem> &src) override
+	std::map<std::string, std::set<PickerItem>> UpdateSavedItems(const std::map<std::string, std::set<PickerItem>> &src) override
 	{
 		if (src.empty()) return {};
 
-		std::set<PickerItem> dst;
-		for (const auto &item : src) {
-			const auto *spec = T::GetByGrf(item.grfid, item.local_id);
-			if (spec == nullptr) {
-				dst.emplace(item.grfid, item.local_id, -1, -1);
-			} else {
-				dst.emplace(GetPickerItem(spec));
+		std::map<std::string, std::set<PickerItem>> dst;
+		for (auto it = src.begin(); it != src.end(); it++) {
+			if (it->second.empty() || (it->second.size() == 1 && it->second.contains({}))) {
+				dst[it->first];
+				continue;
+			}
+
+			for (const auto &item : it->second) {
+				const auto *spec = T::GetByGrf(item.grfid, item.local_id);
+				if (spec == nullptr) {
+					dst[it->first].emplace(item.grfid, item.local_id, -1, -1);
+				} else {
+					dst[it->first].emplace(GetPickerItem(spec));
+				}
 			}
 		}
 		return dst;
@@ -153,6 +187,7 @@ struct PickerFilterData : StringFilter {
 
 using PickerClassList = GUIList<int, std::nullptr_t, PickerFilterData &>; ///< GUIList holding classes to display.
 using PickerTypeList = GUIList<PickerItem, std::nullptr_t, PickerFilterData &>; ///< GUIList holding classes/types to display.
+using PickerCollectionList = GUIList<std::string, std::nullptr_t, PickerFilterData &>; ///< GUIList holding collections to display.
 
 class PickerWindow : public PickerWindowBase {
 public:
@@ -166,6 +201,7 @@ public:
 	enum class PickerInvalidation : uint8_t {
 		Class, ///< Refresh the class list.
 		Type, ///< Refresh the type list.
+		Collection, ///< Refresh the collection list.
 		Position, ///< Update scroll positions.
 		Validate, ///< Validate selected item.
 		Filter, ///< Update filter state.
@@ -187,6 +223,7 @@ public:
 	bool has_class_picker = false; ///< Set if this window has a class picker 'component'.
 	bool has_type_picker = false; ///< Set if this window has a type picker 'component'.
 	int preview_height = 0; ///< Height of preview images.
+	std::set<std::string> inactive; ///< Set of collections with inactive items.
 
 	PickerWindow(WindowDesc &desc, Window *parent, int window_number, PickerCallbacks &callbacks);
 	void OnInit() override;
@@ -230,6 +267,10 @@ private:
 	void BuildPickerTypeList();
 	void EnsureSelectedTypeIsValid();
 	void EnsureSelectedTypeIsVisible();
+
+	PickerCollectionList collections; ///< List of collections.
+
+	void BuildPickerCollectionList();
 
 	GUIBadgeClasses badge_classes;
 	std::pair<WidgetID, WidgetID> badge_filters{};

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -81,6 +81,10 @@ public:
 	/** Draw preview image of an item. */
 	virtual void DrawType(int x, int y, int cls_id, int id) const = 0;
 
+	/* Collection Callbacks */
+	/** Get the tooltip string for the collection list. */
+	virtual StringID GetCollectionTooltip() const = 0;
+
 	/** Fill a set with all items that are used by the current player. */
 	virtual void FillUsedItems(std::set<PickerItem> &items) = 0;
 	/** Update link between grfid/localidx and class_index/index in saved items. */
@@ -120,7 +124,9 @@ public:
 
 	const std::string ini_group; ///< Ini Group for saving favourites.
 	uint8_t mode = 0; ///< Bitmask of \c PickerFilterModes.
+	bool rename_collection = false;      ///< Are we renaming a collection?
 	std::string sel_collection;          ///< Currently selected collection of saved items.
+	std::string edit_collection;         ///< Collection to rename or delete.
 	std::set<std::string> rm_collections; ///< Set of removed or renamed collections for updating ini file.
 
 	int preview_height = 0; ///< Previously adjusted height.
@@ -222,6 +228,7 @@ public:
 
 	bool has_class_picker = false; ///< Set if this window has a class picker 'component'.
 	bool has_type_picker = false; ///< Set if this window has a type picker 'component'.
+	bool has_collection_picker = false; ///< Set if this window has a collection picker 'component'.
 	int preview_height = 0; ///< Height of preview images.
 	std::set<std::string> inactive; ///< Set of collections with inactive items.
 
@@ -230,10 +237,13 @@ public:
 	void Close(int data = 0) override;
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, const Dimension &padding, Dimension &fill, Dimension &resize) override;
 	std::string GetWidgetString(WidgetID widget, StringID stringid) const override;
+	DropDownList BuildCollectionDropDownList();
 	void DrawWidget(const Rect &r, WidgetID widget) const override;
 	void OnDropdownSelect(WidgetID widget, int index, int click_result) override;
 	void OnResize() override;
+	void static DeletePickerCollectionCallback(Window *win, bool confirmed);
 	void OnClick(Point pt, WidgetID widget, int click_count) override;
+	void OnQueryTextFinished(std::optional<std::string> str) override;
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override;
 	EventState OnHotkey(int hotkey) override;
 	void OnEditboxChanged(WidgetID wid) override;

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -978,6 +978,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_STATION_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_STATION_TYPE_TOOLTIP; }
+	StringID GetCollectionTooltip() const override { return STR_PICKER_STATION_COLLECTION_TOOLTIP; }
 
 	bool IsActive() const override
 	{
@@ -1796,6 +1797,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_WAYPOINT_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_WAYPOINT_TYPE_TOOLTIP; }
+	StringID GetCollectionTooltip() const override { return STR_PICKER_WAYPOINT_COLLECTION_TOOLTIP; }
 
 	bool IsActive() const override
 	{

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1200,6 +1200,7 @@ public:
 
 	StringID GetClassTooltip() const override;
 	StringID GetTypeTooltip() const override;
+	StringID GetCollectionTooltip() const override;
 
 	bool IsActive() const override
 	{
@@ -1290,9 +1291,11 @@ public:
 
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Bus>::GetClassTooltip() const { return STR_PICKER_ROADSTOP_BUS_CLASS_TOOLTIP; }
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Bus>::GetTypeTooltip() const { return STR_PICKER_ROADSTOP_BUS_TYPE_TOOLTIP; }
+template <> StringID RoadStopPickerCallbacks<RoadStopType::Bus>::GetCollectionTooltip() const { return STR_PICKER_ROADSTOP_BUS_COLLECTION_TOOLTIP; }
 
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Truck>::GetClassTooltip() const { return STR_PICKER_ROADSTOP_TRUCK_CLASS_TOOLTIP; }
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Truck>::GetTypeTooltip() const { return STR_PICKER_ROADSTOP_TRUCK_TYPE_TOOLTIP; }
+template <> StringID RoadStopPickerCallbacks<RoadStopType::Truck>::GetCollectionTooltip() const { return STR_PICKER_ROADSTOP_TRUCK_COLLECTION_TOOLTIP; }
 
 static RoadStopPickerCallbacks<RoadStopType::Bus> _bus_callback_instance("fav_passenger_roadstops");
 static RoadStopPickerCallbacks<RoadStopType::Truck> _truck_callback_instance("fav_freight_roadstops");
@@ -1632,6 +1635,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_WAYPOINT_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_WAYPOINT_TYPE_TOOLTIP; }
+	StringID GetCollectionTooltip() const override { return STR_PICKER_WAYPOINT_COLLECTION_TOOLTIP; }
 
 	bool IsActive() const override
 	{

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1491,6 +1491,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_HOUSE_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_HOUSE_TYPE_TOOLTIP; }
+	StringID GetCollectionTooltip() const override { return STR_PICKER_HOUSE_COLLECTION_TOOLTIP; }
 	bool IsActive() const override { return true; }
 
 	bool HasClassChoice() const override { return true; }

--- a/src/widgets/picker_widget.h
+++ b/src/widgets/picker_widget.h
@@ -19,6 +19,11 @@ enum PickerClassWindowWidgets : WidgetID {
 	WID_PW_CLASS_LIST, ///< List of classes.
 	WID_PW_CLASS_SCROLL, ///< Scrollbar for list of classes.
 
+	WID_PW_COLEC_LIST,   ///< List of collections.
+	WID_PW_COLEC_ADD,    ///< Button to create a new collections.
+	WID_PW_COLEC_RENAME, ///< Button to rename a collections.
+	WID_PW_COLEC_DELETE, ///< Button to delete a collection.
+
 	WID_PW_TYPE_SEL, ///< Stack to hide the type picker.
 	WID_PW_TYPE_FILTER, ///< Text filter.
 	WID_PW_MODE_ALL, ///< Toggle "Show all" filter mode.
@@ -32,7 +37,7 @@ enum PickerClassWindowWidgets : WidgetID {
 	WID_PW_TYPE_NAME, ///< Name of selected item.
 	WID_PW_TYPE_RESIZE, ///< Type resize handle.
 	WID_PW_CONFIGURE_BADGES, ///< Button to configure badges.
-	WID_PW_BADGE_FILTER, ///< Container for dropdown badge filters.
+	WID_PW_BADGE_FILTER, ///< Container for dropdown badge filters. Must be last in this list.
 };
 
 #endif /* WIDGETS_PICKER_WIDGET_H */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Players with large number of newGRFs often use the same sorts of items together, but may want different sets in different areas. With the current saved tab, all the commonly used items have to be lumped together, diluting the effectiveness of the tab.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
This PR enables players to create, delete, and rename their own named groups in the saved tab and add items to them, allowing for increased ease of tracking down frequently used items. Additionally, saved items from versions without this feature will be placed in an autogenerated group called "Default collections".

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

- If moving between saves with different newGRFs, the player will see a bunch of empty groups in the list. This is denoted by collections with inactive items being greyed out (though still editable). This can be further mitigated with good naming conventions. 
- The list of collections is not filterable. This would be trivially fixable if #14842 is completed and merged.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
