### PR TITLE
Fix 98700ee #14815: Properly handle picker window invalidation.

### DIFF
--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -468,7 +468,7 @@ void PickerWindow::OnDropdownSelect(WidgetID widget, int index, int click_result
 			}
 
 			/* We need to refresh if a filter is removed. */
-			this->InvalidateData({PickerInvalidation::Type, PickerInvalidation::Filter});
+			this->InvalidateData({PickerInvalidation::Type, PickerInvalidation::Filter, PickerInvalidation::Position});
 			break;
 		}
 
@@ -479,7 +479,7 @@ void PickerWindow::OnDropdownSelect(WidgetID widget, int index, int click_result
 				} else {
 					SetBadgeFilter(this->badge_filter_choices, BadgeID(index));
 				}
-				this->InvalidateData({PickerInvalidation::Type, PickerInvalidation::Filter});
+				this->InvalidateData({PickerInvalidation::Type, PickerInvalidation::Filter, PickerInvalidation::Position});
 			}
 			break;
 	}
@@ -555,7 +555,7 @@ void PickerWindow::OnEditboxChanged(WidgetID wid)
 			} else {
 				this->type_string_filter.btf.reset();
 			}
-			this->InvalidateData({PickerInvalidation::Type, PickerInvalidation::Filter});
+			this->InvalidateData({PickerInvalidation::Type, PickerInvalidation::Filter, PickerInvalidation::Position});
 			break;
 
 		default:
@@ -693,7 +693,6 @@ void PickerWindow::BuildPickerTypeList()
 
 	if (!this->has_type_picker) return;
 	this->GetWidget<NWidgetMatrix>(WID_PW_TYPE_MATRIX)->SetCount(static_cast<int>(this->types.size()));
-	this->EnsureSelectedTypeIsVisible();
 }
 
 void PickerWindow::EnsureSelectedTypeIsValid()


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Solve #14815.

(https://github.com/OpenTTD/OpenTTD/commit/98700eee43bbb236cd8834c33e11b6c5e2ce23d0) added EnsureSelectedTypeIsVisible call into the BuildPickerTypeList, which is not correct. 

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Use proper invalidation flag in the InvalidateData calls instead.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
There might be an InvalidateData call that I don't know about.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
~* This PR touches english.txt or translations? Check the [guidelines]~(https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
~* This PR affects the GS/AI API? (label 'needs review: Script API')~
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
~* This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
