### PR TITLE
Codefix: comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -451,7 +451,7 @@ static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, Ca
 		}
 	}
 
-	for (uint8_t i = 0; i < std::size(itspec->accepts_cargo); i++) {
+	for (size_t i = 0; i < std::size(itspec->accepts_cargo); i++) {
 		CargoType cargo = accepts_cargo[i];
 		if (!IsValidCargoType(cargo) || cargo_acceptance[i] <= 0) continue; // work only with valid cargoes
 


### PR DESCRIPTION
## Motivation / Problem

CodeQL complaining.

Not a real problem as the number of cargos can't be big enough right now, but CodeQL can't reasonably know that.


## Description

Change `uint8_t` to `size_t` for loop iteration.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
