### PR TITLE
Codechange: silence CodeQL complaints about long switches

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -10,3 +10,5 @@ query-filters:
     - cpp/irregular-enum-init
     # Our GUI code tends to use switches for OnClick handlers, DrawWidget, and UpdateWidgetSize. Sometimes GUIs just don't have many elements, but we want to keep consistency.
     - cpp/trivial-switch
+    # Our (GUI) code tends to use long switches.
+    - cpp/long-switch


### PR DESCRIPTION
## Motivation / Problem

CodeQL is great, and the integration with GitHub for showing an overview for potential security issues is even better. I'm talking about the number next to 'Security' in the top bar, for those that have the rights to see that.

However, long switch statements also end up as 'security' issue, and randomly previously dismissed alerts pop up over and over again (e.g. when a file is touched). This makes the signal that there is an actual issue much weaker, and as such action is taken at a much slower rate.

Furthermore new code still adds long switch statements, so essentially long switches are a coding style. As such I propose to just ignore this 'maintenance' / 'readability' warning from CodeQL. As I want to stop playing whack-a-mole on this specific warning.


## Description

Ignore long switches for the CodeQL-generated issues.


## Limitations

There's no incentive any more to reduce the length of long switches.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
