### PR TITLE
Proof of concept: Hierarchical build railtype menu

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -539,7 +539,7 @@ public:
 			}
 
 			case WID_RV_RAIL_TYPE_DROPDOWN: // Railtype selection dropdown menu
-				ShowDropDownList(this, GetRailTypeDropDownList(true, true), this->sel_railtype, widget);
+				ShowDropDownList(this, GetRailTypeDropDownList(INVALID_RAILTYPE, true, true), this->sel_railtype, widget);
 				break;
 
 			case WID_RV_ROAD_TYPE_DROPDOWN: // Roadtype selection dropdown menu

--- a/src/dropdown_common_type.h
+++ b/src/dropdown_common_type.h
@@ -22,6 +22,33 @@
 #include "table/strings.h"
 
 /**
+ * Drop down submenu component.
+ */
+class DropDownSubmenuItem : public DropDownListItem {
+	Dimension dim; ///< Dimension of arrow.
+
+public:
+	DropDownList list{}; ///< List with dropdown sub-menu items.
+
+	explicit DropDownSubmenuItem(DropDownList &&list, int result, bool masked = false, bool shaded = false) : DropDownListItem(result, masked, shaded), list(std::move(list))
+	{
+		assert(!this->list.empty());
+
+		this->dim = GetStringBoundingBox(_current_text_dir == TD_RTL ? STR_JUST_LEFT_ARROW : STR_JUST_RIGHT_ARROW);
+	}
+
+	uint Height() const override { return std::max<uint>(this->dim.height, this->DropDownListItem::Height()); }
+	uint Width() const override { return this->dim.width + WidgetDimensions::scaled.hsep_wide + this->DropDownListItem::Width(); }
+
+	void Draw(const Rect &full, const Rect &r, bool sel, int click_result, Colours bg_colour) const override
+	{
+		bool rtl = _current_text_dir == TD_RTL;
+		DrawStringMultiLine(r.WithWidth(this->dim.width, !rtl), rtl ? STR_JUST_LEFT_ARROW : STR_JUST_RIGHT_ARROW, this->GetColour(sel), SA_CENTER, false);
+		this->DropDownListItem::Draw(full, r.Indent(this->dim.width + WidgetDimensions::scaled.hsep_wide, !rtl), sel, click_result, bg_colour);
+	}
+};
+
+/**
  * Drop down divider component.
  * @tparam TBase Base component.
  * @tparam TFs Font size -- used to determine height.

--- a/src/rail_gui.h
+++ b/src/rail_gui.h
@@ -17,7 +17,7 @@ struct Window *ShowBuildRailToolbar(RailType railtype);
 void ReinitGuiAfterToggleElrail(bool disable);
 void ResetSignalVariant(int32_t = 0);
 void InitializeRailGUI();
-DropDownList GetRailTypeDropDownList(bool for_replacement = false, bool all_option = false);
+DropDownList GetRailTypeDropDownList(RailType last_built_railtype, bool for_replacement = false, bool all_option = false);
 
 /** Settings for which signals are shown by the signal GUI. */
 enum SignalGUISettings : uint8_t {

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -875,7 +875,7 @@ static CallBackFunction ToolbarZoomOutClick(Window *w)
 
 static CallBackFunction ToolbarBuildRailClick(Window *w)
 {
-	ShowDropDownList(w, GetRailTypeDropDownList(), _last_built_railtype, WID_TN_RAILS, 140, GetToolbarDropDownOptions());
+	ShowDropDownList(w, GetRailTypeDropDownList(_last_built_railtype), _last_built_railtype, WID_TN_RAILS, 140, GetToolbarDropDownOptions());
 	return CBF_NONE;
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -629,7 +629,7 @@ static void DispatchLeftClickEvent(Window *w, int x, int y, int click_count)
 		if (!w->window_desc.flags.Test(WindowDefaultFlag::NoFocus) && widget_type != WWT_CLOSEBOX) {
 			focused_widget_changed = true;
 			SetFocusedWindow(w);
-		} else if (_focused_window != nullptr && _focused_window->window_class == WC_DROPDOWN_MENU) {
+		} else if (_focused_window != nullptr && _focused_window->window_class == WC_DROPDOWN_MENU && w->window_class != WC_DROPDOWN_MENU) {
 			/* The previously focused window was a dropdown menu, but the user clicked on another window that
 			 * isn't focusable. Close the dropdown menu anyway. */
 			SetFocusedWindow(nullptr);


### PR DESCRIPTION
## Motivation / Problem

With 64 railtypes (and just maybe even more), the build railtype dropdown menu can become unwieldy.

Various ideas are floating around how to make it better (e.g. #14717) and this PR is another proof of concept of a different idea.

## Description

The recent badge feature is used to generate sub-menus in the build railtype dropdown. When building the dropdown menu, all badges belonging to the `category` class-badge of all visible railtypes are collected. For each category, a dropdown sub-menu item is added that expands to show all railtypes with that category badge. Using the `category` class-badge and not some other name is an arbitrary decision.

Railtypes can be in multiple categories and the amount of categories is not limited. Railtypes that have no assigned category badge are shown above the category items in the dropdown. This allows NewGRF authors to develop a categorization system that fits their set.

To make re-selecting the last used railtype easier (and visualize the button click effect with the classic dropdown behaviour), the last used railtype is shown as the first item in the dropdown. If it has a category, it will still be shown in the appropriate submenus, if not, it will only be shown once in the top spot.

Works with both dragging and click dropdown behaviour.

## Limitations

The current PR only handles the build railtype toolbar dropdown. The autoreplace list is ignored, which would need to be rectified for a mergeable PR. Also, the whole dropdown code still feels a bit wonky (`dynamic_cast` and stuff), but I don't really have better ideas.

By allowing arbitrary category badges, the railtype dropdown could actually become longer than without the categories if NewGRF authors assign superfluous and much too detailed categories or refuse to "share" categories. This is not solvable unless OpenTTD prescribes a fixed, limited set of possible categories. As such, this approach to the railtype dropdown does rely on NewGRF authors being reasonable, which is not always guaranteed.

Submenus of different width are currently not aligned identical. This could be changed but would require pre-measuring all dropdown entries no matter if they are ever shown or not.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
