### PR TITLE
Change: Make picker label/text colours consistent.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2862,15 +2862,15 @@ STR_PICKER_HOUSE_CLASS_TOOLTIP                                  :Select a town z
 STR_PICKER_HOUSE_TYPE_TOOLTIP                                   :Select a house type to build. Ctrl+Click to add or remove in saved items
 
 STR_HOUSE_PICKER_CAPTION                                        :House Selection
-STR_HOUSE_PICKER_NAME                                           :{BLACK}Name: {ORANGE}{STRING}
-STR_HOUSE_PICKER_POPULATION                                     :{BLACK}Population: {ORANGE}{NUM}
-STR_HOUSE_PICKER_YEARS                                          :{BLACK}Years: {ORANGE}{NUM}-{NUM}
-STR_HOUSE_PICKER_YEARS_ANY                                      :{BLACK}Years: {ORANGE}Any
-STR_HOUSE_PICKER_YEARS_FROM                                     :{BLACK}Years: {ORANGE}From {NUM}
-STR_HOUSE_PICKER_YEARS_UNTIL                                    :{BLACK}Years: {ORANGE}Until {NUM}
-STR_HOUSE_PICKER_SIZE                                           :{BLACK}Size: {ORANGE}{NUM}x{NUM} tiles
-STR_HOUSE_PICKER_CARGO_ACCEPTED                                 :{BLACK}Cargo accepted: {ORANGE}
-STR_HOUSE_PICKER_CARGO_PRODUCED                                 :{BLACK}Cargo produced: {ORANGE}{CARGO_LIST}
+STR_HOUSE_PICKER_NAME                                           :{BLACK}Name: {GOLD}{STRING}
+STR_HOUSE_PICKER_POPULATION                                     :{BLACK}Population: {GOLD}{NUM}
+STR_HOUSE_PICKER_YEARS                                          :{BLACK}Years: {GOLD}{NUM}-{NUM}
+STR_HOUSE_PICKER_YEARS_ANY                                      :{BLACK}Years: {GOLD}Any
+STR_HOUSE_PICKER_YEARS_FROM                                     :{BLACK}Years: {GOLD}From {NUM}
+STR_HOUSE_PICKER_YEARS_UNTIL                                    :{BLACK}Years: {GOLD}Until {NUM}
+STR_HOUSE_PICKER_SIZE                                           :{BLACK}Size: {GOLD}{NUM}x{NUM} tiles
+STR_HOUSE_PICKER_CARGO_ACCEPTED                                 :{BLACK}Cargo accepted: {GOLD}
+STR_HOUSE_PICKER_CARGO_PRODUCED                                 :{BLACK}Cargo produced: {GOLD}{CARGO_LIST}
 
 STR_HOUSE_PICKER_CLASS_ZONE1                                    :Edge
 STR_HOUSE_PICKER_CLASS_ZONE2                                    :Outskirts

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -358,7 +358,7 @@ void PickerWindow::DrawWidget(const Rect &r, WidgetID widget) const
 		}
 
 		case WID_PW_TYPE_NAME:
-			DrawString(r, this->callbacks.GetTypeName(this->callbacks.GetSelectedClass(), this->callbacks.GetSelectedType()), TC_ORANGE, SA_CENTER);
+			DrawString(r, this->callbacks.GetTypeName(this->callbacks.GetSelectedClass(), this->callbacks.GetSelectedType()), TC_GOLD, SA_CENTER);
 			break;
 	}
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The attribute text in most picker windows is gold. The currently selected type name is, however, drawn in orange, and attributes for the house picker are also drawn in orange.

<img width="633" height="408" alt="image" src="https://github.com/user-attachments/assets/35ce268a-1ee7-41aa-aea7-95ae99bd8bad" />
<img width="633" height="495" alt="image" src="https://github.com/user-attachments/assets/5adb7b30-13e3-439d-9d5a-9554d9bcc6c0" />


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Draw selected type name in gold instead of orange, matching the rest of the picker window.

Use `{GOLD}` instead of `{ORANGE}` in house picker window, to match other picker windows.

<img width="633" height="408" alt="image" src="https://github.com/user-attachments/assets/edc0cc37-3d07-4e0b-9ad1-01cfaa7322a2" />
<img width="633" height="495" alt="image" src="https://github.com/user-attachments/assets/6d9ec720-e04a-47d2-b177-2f5196401208" />


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Colour is set in the language files, so requires translators to follow suit.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
