### PR TITLE
Fix 509cbed: Don't give up erroneously when building lakes

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1077,7 +1077,7 @@ static void MakeLake(TileIndex lake_centre, uint height_lake)
 				TileIndex t = tile + TileOffsByDiagDir(d);
 				if (IsWaterTile(t)) {
 					MakeRiverAndModifyDesertZoneAround(tile);
-					return;
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

Per #14811, some rivers just end, with no lake or wetland.

If you generate enough maps, you'll notice that you never see a lake...


## Description

In #14784 I refactored `MakeLake()` to make the entire lake in one call, instead of being called multiple times and just making one tile. Thus, the `return` to break out of the loop and move on to the next tile should instead be a `break`.

Lakes now appear again at the ends of rivers, instead of having their construction aborted early.

Fixes #14811.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
