### PR TITLE
Fix #9071: Don't consider tram tracks when growing towns

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1476,9 +1476,7 @@ static inline bool RoadTypesAllowHouseHere(TileIndex t)
 		allow = true;
 
 		RoadType road_rt = GetRoadTypeRoad(cur_tile);
-		RoadType tram_rt = GetRoadTypeTram(cur_tile);
 		if (road_rt != INVALID_ROADTYPE && !GetRoadTypeInfo(road_rt)->flags.Test(RoadTypeFlag::NoHouses)) return true;
-		if (tram_rt != INVALID_ROADTYPE && !GetRoadTypeInfo(tram_rt)->flags.Test(RoadTypeFlag::NoHouses)) return true;
 	}
 
 	/* If no road was found surrounding the tile we can allow building the house since there is


### PR DESCRIPTION
## Motivation / Problem

Per #9071, houses grow along roads which don't allow them, if they are also adjacent to a tramway that has not banned houses.

The town growth walk doesn't consider tramway tiles as valid roads (see `GetTownRoadBits()`), so I think we should ignore them completely — in effect, making the "no houses" flag only functional for roads, and have no effect for tramways.

## Description

Ignore tram tracks when deciding whether to allow a house.

Here is a reproduction savegame to test in the 15.0 beta and compare it to this PR.
[TramGrowthTest.zip](https://github.com/user-attachments/files/23780769/TramGrowthTest.zip)

<img width="1032" height="601" alt="repro" src="https://github.com/user-attachments/assets/f7520bf8-f57d-4b5d-a3a5-bfff8c7a222e" />

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
