### PR TITLE
Add: Text filter searching to some dropdown lists.

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -540,11 +540,11 @@ public:
 			}
 
 			case WID_RV_RAIL_TYPE_DROPDOWN: // Railtype selection dropdown menu
-				ShowDropDownList(this, GetRailTypeDropDownList(true, true), this->sel_railtype, widget);
+				ShowDropDownList(this, GetRailTypeDropDownList(true, true), this->sel_railtype, widget, 0, DropDownOption::Filterable);
 				break;
 
 			case WID_RV_ROAD_TYPE_DROPDOWN: // Roadtype selection dropdown menu
-				ShowDropDownList(this, GetRoadTypeDropDownList(RTTB_ROAD | RTTB_TRAM, true, true), this->sel_roadtype, widget);
+				ShowDropDownList(this, GetRoadTypeDropDownList(RTTB_ROAD | RTTB_TRAM, true, true), this->sel_roadtype, widget, 0, DropDownOption::Filterable);
 				break;
 
 			case WID_RV_TRAIN_WAGONREMOVE_TOGGLE: {

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -539,13 +539,17 @@ public:
 				break;
 			}
 
-			case WID_RV_RAIL_TYPE_DROPDOWN: // Railtype selection dropdown menu
-				ShowDropDownList(this, GetRailTypeDropDownList(true, true), this->sel_railtype, widget, 0, DropDownOption::Filterable);
+			case WID_RV_RAIL_TYPE_DROPDOWN: { // Railtype selection dropdown menu
+				static std::string railtype_filter;
+				ShowDropDownList(this, GetRailTypeDropDownList(true, true), this->sel_railtype, widget, 0, DropDownOption::Filterable, &railtype_filter);
 				break;
+			}
 
-			case WID_RV_ROAD_TYPE_DROPDOWN: // Roadtype selection dropdown menu
-				ShowDropDownList(this, GetRoadTypeDropDownList(RTTB_ROAD | RTTB_TRAM, true, true), this->sel_roadtype, widget, 0, DropDownOption::Filterable);
+			case WID_RV_ROAD_TYPE_DROPDOWN: { // Roadtype selection dropdown menu
+				static std::string roadtype_filter;
+				ShowDropDownList(this, GetRoadTypeDropDownList(RTTB_ROAD | RTTB_TRAM, true, true), this->sel_roadtype, widget, 0, DropDownOption::Filterable, &roadtype_filter);
 				break;
+			}
 
 			case WID_RV_TRAIN_WAGONREMOVE_TOGGLE: {
 				const Group *g = Group::GetIfValid(this->sel_group);

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1738,9 +1738,11 @@ struct BuildVehicleWindow : Window {
 				DisplayVehicleSortDropDown(this, this->vehicle_type, this->sort_criteria, WID_BV_SORT_DROPDOWN);
 				break;
 
-			case WID_BV_CARGO_FILTER_DROPDOWN: // Select cargo filtering criteria dropdown menu
-				ShowDropDownList(this, this->BuildCargoDropDownList(), this->cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
+			case WID_BV_CARGO_FILTER_DROPDOWN: { // Select cargo filtering criteria dropdown menu
+				static std::string cargo_filter;
+				ShowDropDownList(this, this->BuildCargoDropDownList(), this->cargo_filter_criteria, widget, 0, DropDownOption::Filterable, &cargo_filter);
 				break;
+			}
 
 			case WID_BV_CONFIGURE_BADGES:
 				if (this->badge_classes.GetClasses().empty()) break;

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1739,7 +1739,7 @@ struct BuildVehicleWindow : Window {
 				break;
 
 			case WID_BV_CARGO_FILTER_DROPDOWN: // Select cargo filtering criteria dropdown menu
-				ShowDropDownList(this, this->BuildCargoDropDownList(), this->cargo_filter_criteria, widget);
+				ShowDropDownList(this, this->BuildCargoDropDownList(), this->cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
 				break;
 
 			case WID_BV_CONFIGURE_BADGES:
@@ -1771,7 +1771,7 @@ struct BuildVehicleWindow : Window {
 			default:
 				if (IsInsideMM(widget, this->badge_filters.first, this->badge_filters.second)) {
 					PaletteID palette = SPR_2CCMAP_BASE + Company::Get(_local_company)->GetCompanyRecolourOffset(LS_DEFAULT);
-					ShowDropDownList(this, this->GetWidget<NWidgetBadgeFilter>(widget)->GetDropDownList(palette), -1, widget, 0);
+					ShowDropDownList(this, this->GetWidget<NWidgetBadgeFilter>(widget)->GetDropDownList(palette), -1, widget, 0, DropDownOption::Filterable);
 				}
 				break;
 		}

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -11,6 +11,8 @@
 #include "core/backup_type.hpp"
 #include "dropdown_type.h"
 #include "dropdown_func.h"
+#include "stringfilter_type.h"
+#include "querystring_gui.h"
 #include "strings_func.h"
 #include "sound_func.h"
 #include "timer/timer.h"
@@ -95,18 +97,27 @@ std::unique_ptr<DropDownListItem> MakeDropDownListCheckedItem(bool checked, Stri
 }
 
 static constexpr std::initializer_list<NWidgetPart> _nested_dropdown_menu_widgets = {
-	NWidget(NWID_HORIZONTAL),
-		NWidget(WWT_PANEL, COLOUR_END, WID_DM_ITEMS), SetScrollbar(WID_DM_SCROLL), EndContainer(),
-		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_DM_SHOW_SCROLL),
-			NWidget(NWID_VSCROLLBAR, COLOUR_END, WID_DM_SCROLL),
+	NWidget(NWID_VERTICAL),
+		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_DM_FILTER_SEL),
+			NWidget(WWT_PANEL, COLOUR_END, WID_DM_FILTER_PANEL),
+				NWidget(WWT_EDITBOX, COLOUR_END, WID_DM_FILTER), SetResize(1, 0), SetFill(1, 0), SetPadding(2), SetStringTip(STR_LIST_FILTER_OSKTITLE, STR_LIST_FILTER_TOOLTIP),
+			EndContainer(),
+		EndContainer(),
+		NWidget(NWID_HORIZONTAL),
+			NWidget(WWT_PANEL, COLOUR_END, WID_DM_ITEMS), SetScrollbar(WID_DM_SCROLL),
+			EndContainer(),
+			NWidget(NWID_SELECTION, INVALID_COLOUR, WID_DM_SHOW_SCROLL),
+				NWidget(NWID_VSCROLLBAR, COLOUR_END, WID_DM_SCROLL),
+			EndContainer(),
 		EndContainer(),
 	EndContainer(),
 };
 
+/** Window description for dropdown menus. */
 static WindowDesc _dropdown_desc(
 	WDP_MANUAL, {}, 0, 0,
 	WC_DROPDOWN_MENU, WC_NONE,
-	WindowDefaultFlag::NoFocus,
+	{},
 	_nested_dropdown_menu_widgets
 );
 
@@ -119,12 +130,17 @@ struct DropdownWindow : Window {
 	int selected_click_result = -1; ///< Click result value, from the OnClick handler of the selected item.
 	uint8_t click_delay = 0; ///< Timer to delay selection.
 	bool drag_mode = true;
+	bool above = false; ///< Set if the drop down list is above the drop down widget instead of below.
 	DropDownOptions options; ///< Options for this drop down menu.
 	int scrolling = 0; ///< If non-zero, auto-scroll the item list (one time).
 	Point position{}; ///< Position of the topleft corner of the window.
 	Scrollbar *vscroll = nullptr;
 
+	Dimension initial_dim{}; ///< Initial dimension of dropdown menu before filtering.
 	Dimension items_dim{}; ///< Calculated cropped and padded dimension for the items widget.
+
+	mutable StringFilter string_filter{}; ///< String filter for filter text.
+	QueryString editbox; ///< Editbox for filter text.
 
 	/**
 	 * Create a dropdown menu.
@@ -143,6 +159,7 @@ struct DropdownWindow : Window {
 			, list(std::move(list))
 			, selected_result(selected)
 			, options(options)
+			, editbox(60 * MAX_CHAR_LENGTH, 60)
 	{
 		assert(!this->list.empty());
 
@@ -150,12 +167,19 @@ struct DropdownWindow : Window {
 
 		this->CreateNestedTree();
 
+		this->GetWidget<NWidgetStacked>(WID_DM_FILTER_SEL)->SetDisplayedPlane(this->options.Test(DropDownOption::Filterable) ? 0 : SZSP_HORIZONTAL);
+		this->GetWidget<NWidgetCore>(WID_DM_FILTER_PANEL)->colour = wi_colour;
+		this->GetWidget<NWidgetCore>(WID_DM_FILTER)->colour = wi_colour;
 		this->GetWidget<NWidgetCore>(WID_DM_ITEMS)->colour = wi_colour;
 		this->GetWidget<NWidgetCore>(WID_DM_SCROLL)->colour = wi_colour;
 		this->vscroll = this->GetScrollbar(WID_DM_SCROLL);
 		this->UpdateSizeAndPosition();
 
+		this->querystrings[WID_DM_FILTER] = &this->editbox;
+
 		this->FinishInitNested(0);
+
+		if (this->options.Test(DropDownOption::Filterable)) this->SetFocusedWidget(WID_DM_FILTER);
 		this->flags.Reset(WindowFlag::WhiteBorder);
 	}
 
@@ -184,6 +208,18 @@ struct DropdownWindow : Window {
 	}
 
 	/**
+	 * Get height of filter edit panel.
+	 * @return Height of filter edit panel, or zero if not filtering.
+	 */
+	uint GetFilterBoxHeight() const
+	{
+		if (!this->options.Test(DropDownOption::Filterable)) return 0;
+
+		/* The edit panel widget does not exist yet so we don't know its real size. Calculate it instead. */
+		return GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.fullbevel.Vertical() * 3;
+	}
+
+	/**
 	 * Fit dropdown list into available height, rounding to average item size. Width is adjusted if scrollbar is present.
 	 * @param[in,out] desired Desired dimensions of dropdown list.
 	 * @param list Dimensions of the list itself, without padding or cropping.
@@ -191,6 +227,8 @@ struct DropdownWindow : Window {
 	 */
 	void FitAvailableHeight(Dimension &desired, const Dimension &list, uint available_height)
 	{
+		available_height -= this->GetFilterBoxHeight();
+
 		if (desired.height < available_height) return;
 
 		/* If the dropdown doesn't fully fit, we a need a dropdown. */
@@ -199,6 +237,20 @@ struct DropdownWindow : Window {
 
 		desired.width = std::max(list.width, desired.width - NWidgetScrollbar::GetVerticalDimension().width);
 		desired.height = rows * avg_height + WidgetDimensions::scaled.dropdownlist.Vertical();
+	}
+
+	/**
+	 * Get the height of the dropdown list, excluding filtered items.
+	 * @return Height of visible items in dropdown list.
+	 */
+	uint GetVisibleHeight() const
+	{
+		uint height = 0;
+		for (const auto &item : this->list) {
+			if (!this->FilterByText(*item)) continue;
+			height += item->Height();
+		}
+		return height;
 	}
 
 	/**
@@ -226,10 +278,14 @@ struct DropdownWindow : Window {
 		/* Is it better to place the dropdown above the widget? */
 		if (widget_dim.height > available_height_below && available_height_above > available_height_below) {
 			FitAvailableHeight(widget_dim, list_dim, available_height_above);
-			this->position.y = button_rect.top - widget_dim.height;
+			this->above = true;
+			this->position.y = button_rect.top - widget_dim.height - this->GetFilterBoxHeight();
+			this->GetWidget<NWidgetCore>(WID_DM_FILTER_PANEL)->GetParentWidget<NWidgetVertical>()->bottom_up = true;
 		} else {
 			FitAvailableHeight(widget_dim, list_dim, available_height_below);
+			this->above = false;
 			this->position.y = button_rect.bottom + 1;
+			this->GetWidget<NWidgetCore>(WID_DM_FILTER_PANEL)->GetParentWidget<NWidgetVertical>()->bottom_up = false;
 		}
 
 		if (_current_text_dir == TD_RTL) {
@@ -239,16 +295,17 @@ struct DropdownWindow : Window {
 			this->position.x = button_rect.left;
 		}
 
+		this->initial_dim = widget_dim;
 		this->items_dim = widget_dim;
 		this->GetWidget<NWidgetStacked>(WID_DM_SHOW_SCROLL)->SetDisplayedPlane(list_dim.height > widget_dim.height ? 0 : SZSP_NONE);
 
 		/* Capacity is the average number of items visible */
 		this->vscroll->SetCapacity(widget_dim.height - WidgetDimensions::scaled.dropdownlist.Vertical());
 		this->vscroll->SetStepSize(list_dim.height / this->list.size());
-		this->vscroll->SetCount(list_dim.height);
+		this->vscroll->SetCount(this->GetVisibleHeight());
 
 		/* If the dropdown is positioned above the parent widget, start selection at the bottom. */
-		if (this->position.y < button_rect.top && list_dim.height > widget_dim.height) this->vscroll->UpdatePosition(INT_MAX);
+		if (this->above) this->vscroll->SetPosition(INT_MAX);
 	}
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
@@ -277,6 +334,7 @@ struct DropdownWindow : Window {
 		int y_end = r.Height();
 
 		for (const auto &item : this->list) {
+			if (!this->FilterByText(*item)) continue;
 			int item_height = item->Height();
 
 			/* Skip items that are scrolled up */
@@ -293,6 +351,23 @@ struct DropdownWindow : Window {
 		return false;
 	}
 
+	/**
+	 * Filter individual dropdown item
+	 * @param item Item to filter.
+	 * @return true iff the item should appear in the filtered list.
+	 */
+	bool FilterByText(const DropDownListItem &item) const
+	{
+		/* Do not filter if the filter text box is empty */
+		if (this->string_filter.IsEmpty()) return true;
+
+		/* Filter table name */
+		this->string_filter.ResetState();
+		item.FilterText(this->string_filter);
+
+		return this->string_filter.GetState();
+	}
+
 	void DrawWidget(const Rect &r, WidgetID widget) const override
 	{
 		if (widget != WID_DM_ITEMS) return;
@@ -300,6 +375,7 @@ struct DropdownWindow : Window {
 		Colours colour = this->GetWidget<NWidgetCore>(widget)->colour;
 
 		Rect ir = r.Shrink(WidgetDimensions::scaled.dropdownlist);
+		if (ir.Height() == 0) return;
 
 		/* Setup a clipping rectangle... */
 		DrawPixelInfo tmp_dpi;
@@ -313,6 +389,7 @@ struct DropdownWindow : Window {
 		int y_end = ir.Height();
 
 		for (const auto &item : this->list) {
+			if (!this->FilterByText(*item)) continue;
 			int item_height = item->Height();
 
 			/* Skip items that are scrolled up */
@@ -397,10 +474,46 @@ struct DropdownWindow : Window {
 		this->list = std::move(list);
 		if (selected_result.has_value()) this->selected_result = *selected_result;
 		this->UpdateSizeAndPosition();
-		this->ReInit(0, 0);
+		this->ReInit();
 		this->InitializePositionSize(this->position.x, this->position.y, this->nested_root->smallest_x, this->nested_root->smallest_y);
 		this->FindWindowPlacementAndResize(this->window_desc.GetDefaultWidth(), this->window_desc.GetDefaultHeight(), true);
 		this->SetDirty();
+	}
+
+	void OnResize() override
+	{
+		this->vscroll->SetCapacity(this->items_dim.height - WidgetDimensions::scaled.dropdownlist.Vertical());
+	}
+
+	/**
+	 * Apply text filter to the items in the dropdown list, resizing the window as necessary.
+	 */
+	void UpdateFilter()
+	{
+		this->string_filter.SetFilterTerm(this->editbox.text.GetText());
+
+		uint height = this->GetVisibleHeight();
+		uint old_height = this->items_dim.height;
+		this->items_dim.height = std::min(this->initial_dim.height, height + WidgetDimensions::scaled.dropdownlist.Vertical());
+		this->vscroll->SetCount(height);
+
+		if (old_height != this->items_dim.height) {
+			this->ReInit();
+			if (this->above) {
+				/* Drop down list needs to be moved to near the parent drop down button. */
+				Rect button_rect = this->wi_rect.Translate(this->parent->left, this->parent->top);
+				this->top = button_rect.top - this->items_dim.height - this->GetFilterBoxHeight();
+				this->SetDirty();
+			}
+		} else {
+			this->SetDirty();
+		}
+	}
+
+	void OnEditboxChanged(WidgetID wid) override
+	{
+		if (wid != WID_DM_FILTER) return;
+		this->UpdateFilter();
 	}
 };
 
@@ -492,8 +605,9 @@ void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID but
  * @param disabled_mask Bitmask for disabled items (items with their bit set are displayed, but not selectable in the dropdown list).
  * @param hidden_mask   Bitmask for hidden items (items with their bit set are not copied to the dropdown list).
  * @param width         Minimum width of the dropdown menu.
+ * @param options Drop Down options for this menu
  */
-void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width)
+void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width, DropDownOptions options)
 {
 	DropDownList list;
 
@@ -505,5 +619,5 @@ void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected
 		++i;
 	}
 
-	if (!list.empty()) ShowDropDownList(w, std::move(list), selected, button, width, {});
+	if (!list.empty()) ShowDropDownList(w, std::move(list), selected, button, width, options);
 }

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -135,6 +135,7 @@ struct DropdownWindow : Window {
 	int scrolling = 0; ///< If non-zero, auto-scroll the item list (one time).
 	Point position{}; ///< Position of the topleft corner of the window.
 	Scrollbar *vscroll = nullptr;
+	std::string * const persistent_filter_text = nullptr; ///< Unmanaged pointer to string for retaining filter text.
 
 	Dimension initial_dim{}; ///< Initial dimension of dropdown menu before filtering.
 	Dimension items_dim{}; ///< Calculated cropped and padded dimension for the items widget.
@@ -151,14 +152,16 @@ struct DropdownWindow : Window {
 	 * @param wi_rect       Rect of the button that opened the dropdown.
 	 * @param wi_colour     Colour of the parent widget.
 	 * @param options Drop Down options for this menu.
+	 * @param persistent_filter_text Optional pointer to string for retaining filter text.
 	 */
-	DropdownWindow(Window *parent, DropDownList &&list, int selected, WidgetID button, const Rect wi_rect, Colours wi_colour, DropDownOptions options)
+	DropdownWindow(Window *parent, DropDownList &&list, int selected, WidgetID button, const Rect wi_rect, Colours wi_colour, DropDownOptions options, std::string * const persistent_filter_text)
 			: Window(_dropdown_desc)
 			, parent_button(button)
 			, wi_rect(wi_rect)
 			, list(std::move(list))
 			, selected_result(selected)
 			, options(options)
+			, persistent_filter_text(persistent_filter_text)
 			, editbox(60 * MAX_CHAR_LENGTH, 60)
 	{
 		assert(!this->list.empty());
@@ -179,7 +182,14 @@ struct DropdownWindow : Window {
 
 		this->FinishInitNested(0);
 
-		if (this->options.Test(DropDownOption::Filterable)) this->SetFocusedWidget(WID_DM_FILTER);
+		if (this->options.Test(DropDownOption::Filterable)) {
+			this->SetFocusedWidget(WID_DM_FILTER);
+			if (this->persistent_filter_text != nullptr && !this->persistent_filter_text->empty()) {
+				this->editbox.text.Assign(*this->persistent_filter_text);
+				this->UpdateFilter();
+			}
+		}
+
 		this->flags.Reset(WindowFlag::WhiteBorder);
 	}
 
@@ -188,6 +198,10 @@ struct DropdownWindow : Window {
 		/* Finish closing the dropdown, so it doesn't affect new window placement.
 		 * Also mark it dirty in case the callback deals with the screen. (e.g. screenshots). */
 		this->Window::Close();
+
+		if (this->persistent_filter_text != nullptr) {
+			*this->persistent_filter_text = this->editbox.text.GetText();
+		}
 
 		Point pt = _cursor.pos;
 		pt.x -= this->parent->left;
@@ -549,11 +563,12 @@ Dimension GetDropDownListDimension(const DropDownList &list)
  * @param wi_rect  Coord of the parent drop down button, used to position the dropdown menu.
  * @param wi_colour Colour of the parent widget.
  * @param options Drop Down options for this menu.
+ * @param persistent_filter_text Optional pointer to string for retaining filter text.
  */
-void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID button, Rect wi_rect, Colours wi_colour, DropDownOptions options)
+void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID button, Rect wi_rect, Colours wi_colour, DropDownOptions options, std::string * const persistent_filter_text)
 {
 	CloseWindowByClass(WC_DROPDOWN_MENU);
-	new DropdownWindow(w, std::move(list), selected, button, wi_rect, wi_colour, options);
+	new DropdownWindow(w, std::move(list), selected, button, wi_rect, wi_colour, options, persistent_filter_text);
 }
 
 /**
@@ -565,8 +580,9 @@ void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID b
  *                 the list's location.
  * @param width    Override the minimum width determined by the selected widget and list contents.
  * @param options Drop Down options for this menu.
+ * @param persistent_filter_text Optional pointer to string for retaining filter text.
  */
-void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, uint width, DropDownOptions options)
+void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, uint width, DropDownOptions options, std::string * const persistent_filter_text)
 {
 	/* Handle the beep of the player's click. */
 	SndClickBeep();
@@ -592,7 +608,7 @@ void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID but
 		}
 	}
 
-	ShowDropDownListAt(w, std::move(list), selected, button, wi_rect, wi_colour, options);
+	ShowDropDownListAt(w, std::move(list), selected, button, wi_rect, wi_colour, options, persistent_filter_text);
 }
 
 /**
@@ -606,8 +622,9 @@ void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID but
  * @param hidden_mask   Bitmask for hidden items (items with their bit set are not copied to the dropdown list).
  * @param width         Minimum width of the dropdown menu.
  * @param options Drop Down options for this menu
+ * @param persistent_filter_text Optional pointer to string for retaining filter text.
  */
-void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width, DropDownOptions options)
+void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width, DropDownOptions options, std::string * const persistent_filter_text)
 {
 	DropDownList list;
 
@@ -619,5 +636,5 @@ void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected
 		++i;
 	}
 
-	if (!list.empty()) ShowDropDownList(w, std::move(list), selected, button, width, options);
+	if (!list.empty()) ShowDropDownList(w, std::move(list), selected, button, width, options, persistent_filter_text);
 }

--- a/src/dropdown_common_type.h
+++ b/src/dropdown_common_type.h
@@ -16,6 +16,7 @@
 #include "palette_func.h"
 #include "settings_gui.h"
 #include "string_func.h"
+#include "stringfilter_type.h"
 #include "strings_func.h"
 #include "window_gui.h"
 
@@ -61,6 +62,13 @@ public:
 	explicit DropDownString(std::string &&string, Args&&... args) : TBase(std::forward<Args>(args)...)
 	{
 		this->SetString(std::move(string));
+	}
+
+	/** @copydoc DropDownListItem::FilterText */
+	void FilterText(StringFilter &string_filter) const override
+	{
+		string_filter.AddLine(this->string);
+		this->TBase::FilterText(string_filter);
 	}
 
 	void SetString(std::string &&string)

--- a/src/dropdown_func.h
+++ b/src/dropdown_func.h
@@ -15,7 +15,7 @@
 #include "window_gui.h"
 
 /* Show drop down menu containing a fixed list of strings */
-void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width = 0, DropDownOptions options = {});
+void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width = 0, DropDownOptions options = {}, std::string * const persistent_filter_text = nullptr);
 
 /* Helper functions for commonly used drop down list items. */
 std::unique_ptr<DropDownListItem> MakeDropDownListDividerItem();

--- a/src/dropdown_func.h
+++ b/src/dropdown_func.h
@@ -15,7 +15,7 @@
 #include "window_gui.h"
 
 /* Show drop down menu containing a fixed list of strings */
-void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width = 0);
+void ShowDropDownMenu(Window *w, std::span<const StringID> strings, int selected, WidgetID button, uint32_t disabled_mask, uint32_t hidden_mask, uint width = 0, DropDownOptions options = {});
 
 /* Helper functions for commonly used drop down list items. */
 std::unique_ptr<DropDownListItem> MakeDropDownListDividerItem();

--- a/src/dropdown_type.h
+++ b/src/dropdown_type.h
@@ -11,6 +11,7 @@
 #define DROPDOWN_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "stringfilter_type.h"
 #include "window_type.h"
 #include "gfx_func.h"
 #include "gfx_type.h"
@@ -29,6 +30,12 @@ public:
 	explicit DropDownListItem(int result, bool masked = false, bool shaded = false) : result(result), masked(masked), shaded(shaded) {}
 	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~DropDownListItem() = default;
+
+	/**
+	 * Add text from this dropdown item to a string filter.
+	 * @param string_filter String filter to add text to.
+	 */
+	virtual void FilterText([[maybe_unused]] StringFilter &string_filter) const {}
 
 	/**
 	 * Can this dropdown item be selected?
@@ -93,6 +100,7 @@ typedef std::vector<std::unique_ptr<const DropDownListItem>> DropDownList;
 enum class DropDownOption : uint8_t {
 	InstantClose, ///< Set if releasing mouse button should close the list regardless of where the cursor is.
 	Persist, ///< Set if this dropdown should stay open after an option is selected.
+	Filterable, ///< Set if the dropdown is filterable.
 };
 using DropDownOptions = EnumBitSet<DropDownOption, uint8_t>;
 

--- a/src/dropdown_type.h
+++ b/src/dropdown_type.h
@@ -104,9 +104,9 @@ enum class DropDownOption : uint8_t {
 };
 using DropDownOptions = EnumBitSet<DropDownOption, uint8_t>;
 
-void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID button, Rect wi_rect, Colours wi_colour, DropDownOptions options = {});
+void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID button, Rect wi_rect, Colours wi_colour, DropDownOptions options = {}, std::string * const persistent_filter_text = nullptr);
 
-void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, uint width = 0, DropDownOptions options = {});
+void ShowDropDownList(Window *w, DropDownList &&list, int selected, WidgetID button, uint width = 0, DropDownOptions options = {}, std::string * const persistent_filter_text = nullptr);
 
 Dimension GetDropDownListDimension(const DropDownList &list);
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -752,9 +752,11 @@ public:
 				ShowDropDownMenu(this, this->GetVehicleSorterNames(), this->vehgroups.SortType(),  WID_GL_SORT_BY_DROPDOWN, 0, (this->vli.vtype == VEH_TRAIN || this->vli.vtype == VEH_ROAD) ? 0 : (1 << 10));
 				return;
 
-			case WID_GL_FILTER_BY_CARGO: // Select filtering criteria dropdown menu
-				ShowDropDownList(this, this->BuildCargoDropDownList(false), this->cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
+			case WID_GL_FILTER_BY_CARGO: { // Select filtering criteria dropdown menu
+				static std::string cargo_filter;
+				ShowDropDownList(this, this->BuildCargoDropDownList(false), this->cargo_filter_criteria, widget, 0, DropDownOption::Filterable, &cargo_filter);
 				break;
+			}
 
 			case WID_GL_ALL_VEHICLES: // All vehicles button
 				if (!IsAllGroupID(this->vli.ToGroupID())) {

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -753,7 +753,7 @@ public:
 				return;
 
 			case WID_GL_FILTER_BY_CARGO: // Select filtering criteria dropdown menu
-				ShowDropDownList(this, this->BuildCargoDropDownList(false), this->cargo_filter_criteria, widget);
+				ShowDropDownList(this, this->BuildCargoDropDownList(false), this->cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
 				break;
 
 			case WID_GL_ALL_VEHICLES: // All vehicles button

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1795,11 +1795,11 @@ public:
 				break;
 
 			case WID_ID_FILTER_BY_ACC_CARGO: // Cargo filter dropdown
-				ShowDropDownList(this, this->BuildCargoDropDownList(), this->accepted_cargo_filter_criteria, widget);
+				ShowDropDownList(this, this->BuildCargoDropDownList(), this->accepted_cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
 				break;
 
 			case WID_ID_FILTER_BY_PROD_CARGO: // Cargo filter dropdown
-				ShowDropDownList(this, this->BuildCargoDropDownList(), this->produced_cargo_filter_criteria, widget);
+				ShowDropDownList(this, this->BuildCargoDropDownList(), this->produced_cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
 				break;
 
 			case WID_ID_INDUSTRY_LIST: {
@@ -3085,7 +3085,7 @@ struct IndustryCargoesWindow : public Window {
 				}
 				if (!lst.empty()) {
 					int selected = (this->ind_cargo >= NUM_INDUSTRYTYPES) ? (int)(this->ind_cargo - NUM_INDUSTRYTYPES) : -1;
-					ShowDropDownList(this, std::move(lst), selected, WID_IC_CARGO_DROPDOWN);
+					ShowDropDownList(this, std::move(lst), selected, WID_IC_CARGO_DROPDOWN, 0, DropDownOption::Filterable);
 				}
 				break;
 			}
@@ -3099,7 +3099,7 @@ struct IndustryCargoesWindow : public Window {
 				}
 				if (!lst.empty()) {
 					int selected = (this->ind_cargo < NUM_INDUSTRYTYPES) ? (int)this->ind_cargo : -1;
-					ShowDropDownList(this, std::move(lst), selected, WID_IC_IND_DROPDOWN);
+					ShowDropDownList(this, std::move(lst), selected, WID_IC_IND_DROPDOWN, 0, DropDownOption::Filterable);
 				}
 				break;
 			}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1794,13 +1794,17 @@ public:
 				ShowDropDownMenu(this, IndustryDirectoryWindow::sorter_names, this->industries.SortType(), WID_ID_DROPDOWN_CRITERIA, 0, 0);
 				break;
 
-			case WID_ID_FILTER_BY_ACC_CARGO: // Cargo filter dropdown
-				ShowDropDownList(this, this->BuildCargoDropDownList(), this->accepted_cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
+			case WID_ID_FILTER_BY_ACC_CARGO: { // Cargo filter dropdown
+				static std::string acc_cargo_filter;
+				ShowDropDownList(this, this->BuildCargoDropDownList(), this->accepted_cargo_filter_criteria, widget, 0, DropDownOption::Filterable, &acc_cargo_filter);
 				break;
+			}
 
-			case WID_ID_FILTER_BY_PROD_CARGO: // Cargo filter dropdown
-				ShowDropDownList(this, this->BuildCargoDropDownList(), this->produced_cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
+			case WID_ID_FILTER_BY_PROD_CARGO: { // Cargo filter dropdown
+				static std::string prod_cargo_filter;
+				ShowDropDownList(this, this->BuildCargoDropDownList(), this->produced_cargo_filter_criteria, widget, 0, DropDownOption::Filterable, &prod_cargo_filter);
 				break;
+			}
 
 			case WID_ID_INDUSTRY_LIST: {
 				auto it = this->vscroll->GetScrolledItemFromWidget(this->industries, pt.y, this, WID_ID_INDUSTRY_LIST, WidgetDimensions::scaled.framerect.top);
@@ -3084,8 +3088,9 @@ struct IndustryCargoesWindow : public Window {
 					lst.push_back(MakeDropDownListIconItem(d, cs->GetCargoIcon(), PAL_NONE, cs->name, cs->Index()));
 				}
 				if (!lst.empty()) {
+					static std::string cargo_filter;
 					int selected = (this->ind_cargo >= NUM_INDUSTRYTYPES) ? (int)(this->ind_cargo - NUM_INDUSTRYTYPES) : -1;
-					ShowDropDownList(this, std::move(lst), selected, WID_IC_CARGO_DROPDOWN, 0, DropDownOption::Filterable);
+					ShowDropDownList(this, std::move(lst), selected, WID_IC_CARGO_DROPDOWN, 0, DropDownOption::Filterable, &cargo_filter);
 				}
 				break;
 			}
@@ -3098,8 +3103,9 @@ struct IndustryCargoesWindow : public Window {
 					lst.push_back(MakeDropDownListStringItem(indsp->name, ind));
 				}
 				if (!lst.empty()) {
+					static std::string cargo_filter;
 					int selected = (this->ind_cargo < NUM_INDUSTRYTYPES) ? (int)this->ind_cargo : -1;
-					ShowDropDownList(this, std::move(lst), selected, WID_IC_IND_DROPDOWN, 0, DropDownOption::Filterable);
+					ShowDropDownList(this, std::move(lst), selected, WID_IC_IND_DROPDOWN, 0, DropDownOption::Filterable, &cargo_filter);
 				}
 				break;
 			}

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -606,7 +606,7 @@ struct MusicTrackSelectionWindow : public Window {
 
 			case WID_MTS_MUSICSET: {
 				int selected = 0;
-				ShowDropDownList(this, BuildSetDropDownList<BaseMusic>(&selected), selected, widget);
+				ShowDropDownList(this, BuildSetDropDownList<BaseMusic>(&selected), selected, widget, 0, DropDownOption::Filterable);
 				break;
 			}
 

--- a/src/newgrf_badge_gui.cpp
+++ b/src/newgrf_badge_gui.cpp
@@ -203,6 +203,17 @@ public:
 		if (dim.width > 0) dim.width -= WidgetDimensions::scaled.hsep_normal;
 	}
 
+	/** @copydoc DropDownListItem::FilterText */
+	void FilterText(StringFilter &string_filter) const override
+	{
+		for (const BadgeID &badge_index : this->badges) {
+			const Badge *badge = GetBadge(badge_index);
+			if (badge->name == STR_NULL) continue;
+			string_filter.AddLine(GetString(badge->name));
+		}
+		this->TBase::FilterText(string_filter);
+	}
+
 	uint Height() const override
 	{
 		return std::max<uint>(this->dim.height, this->TBase::Height());

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -944,7 +944,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				}
 
 				this->CloseChildWindows(WC_QUERY_STRING); // Remove the parameter query window
-				ShowDropDownList(this, std::move(list), this->preset, WID_NS_PRESET_LIST);
+				ShowDropDownList(this, std::move(list), this->preset, WID_NS_PRESET_LIST, 0, DropDownOption::Filterable);
 				break;
 			}
 

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -527,7 +527,7 @@ void PickerWindow::OnClick(Point pt, WidgetID widget, int)
 		}
 
 		case WID_PW_COLEC_LIST: {
-			ShowDropDownList(this, this->BuildCollectionDropDownList(), -1, widget, 0);
+			ShowDropDownList(this, this->BuildCollectionDropDownList(), -1, widget, 0, DropDownOption::Filterable);
 			CloseWindowById(WC_SELECT_STATION, 0);
 			break;
 		}
@@ -566,7 +566,7 @@ void PickerWindow::OnClick(Point pt, WidgetID widget, int)
 			if (IsInsideMM(widget, this->badge_filters.first, this->badge_filters.second)) {
 				/* Houses have recolours but not related to the company colour and other items depend on gamemode. */
 				PaletteID palette = _game_mode != GM_NORMAL || this->callbacks.GetFeature() == GSF_HOUSES ? PAL_NONE : GetCompanyPalette(_local_company);
-				ShowDropDownList(this, this->GetWidget<NWidgetBadgeFilter>(widget)->GetDropDownList(palette), -1, widget, 0);
+				ShowDropDownList(this, this->GetWidget<NWidgetBadgeFilter>(widget)->GetDropDownList(palette), -1, widget, 0, DropDownOption::Filterable);
 			}
 			break;
 	}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1154,18 +1154,28 @@ struct GameOptionsWindow : Window {
 				ShowNetworkContentListWindow(nullptr, CONTENT_TYPE_BASE_MUSIC);
 				break;
 
-			case WID_GO_CURRENCY_DROPDOWN:
 			case WID_GO_AUTOSAVE_DROPDOWN:
-			case WID_GO_LANG_DROPDOWN:
 			case WID_GO_RESOLUTION_DROPDOWN:
-			case WID_GO_REFRESH_RATE_DROPDOWN:
+			case WID_GO_REFRESH_RATE_DROPDOWN: {
+				int selected;
+				DropDownList list = this->BuildDropDownList(widget, &selected);
+				if (!list.empty()) {
+					ShowDropDownList(this, std::move(list), selected, widget);
+				} else {
+					if (widget == WID_GO_RESOLUTION_DROPDOWN) ShowErrorMessage(GetEncodedString(STR_ERROR_RESOLUTION_LIST_FAILED), {}, WL_ERROR);
+				}
+				break;
+			}
+
+			case WID_GO_CURRENCY_DROPDOWN:
+			case WID_GO_LANG_DROPDOWN:
 			case WID_GO_BASE_GRF_DROPDOWN:
 			case WID_GO_BASE_SFX_DROPDOWN:
 			case WID_GO_BASE_MUSIC_DROPDOWN: {
 				int selected;
 				DropDownList list = this->BuildDropDownList(widget, &selected);
 				if (!list.empty()) {
-					ShowDropDownList(this, std::move(list), selected, widget);
+					ShowDropDownList(this, std::move(list), selected, widget, 0, DropDownOption::Filterable);
 				} else {
 					if (widget == WID_GO_RESOLUTION_DROPDOWN) ShowErrorMessage(GetEncodedString(STR_ERROR_RESOLUTION_LIST_FAILED), {}, WL_ERROR);
 				}

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -665,7 +665,7 @@ public:
 
 			case WID_STL_CARGODROPDOWN:
 				this->filter_expanded = false;
-				ShowDropDownList(this, this->BuildCargoDropDownList(this->filter_expanded), -1, widget, 0, DropDownOption::Persist);
+				ShowDropDownList(this, this->BuildCargoDropDownList(this->filter_expanded), -1, widget, 0, {DropDownOption::Persist, DropDownOption::Filterable});
 				break;
 		}
 	}

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -663,10 +663,12 @@ public:
 				ShowDropDownMenu(this, CompanyStationsWindow::sorter_names, this->stations.SortType(), WID_STL_SORTDROPBTN, 0, 0);
 				break;
 
-			case WID_STL_CARGODROPDOWN:
+			case WID_STL_CARGODROPDOWN: {
+				static std::string cargo_filter;
 				this->filter_expanded = false;
-				ShowDropDownList(this, this->BuildCargoDropDownList(this->filter_expanded), -1, widget, 0, {DropDownOption::Persist, DropDownOption::Filterable});
+				ShowDropDownList(this, this->BuildCargoDropDownList(this->filter_expanded), -1, widget, 0, {DropDownOption::Persist, DropDownOption::Filterable}, &cargo_filter);
 				break;
+			}
 		}
 	}
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -107,10 +107,15 @@ public:
 	}
 };
 
-static DropDownOptions GetToolbarDropDownOptions()
+/**
+ * Get options for toolbar dropdown menus,
+ * @param options Additional options to include.
+ * @return DropDownOptions to use for toolbar dropdown menus.
+ */
+static DropDownOptions GetToolbarDropDownOptions(DropDownOptions options = {})
 {
-	if (_settings_client.gui.toolbar_dropdown_autoselect) return DropDownOption::InstantClose;
-	return {};
+	if (_settings_client.gui.toolbar_dropdown_autoselect) options.Set(DropDownOption::InstantClose).Reset(DropDownOption::Filterable);
+	return options;
 }
 
 /**
@@ -878,7 +883,7 @@ static CallBackFunction ToolbarZoomOutClick(Window *w)
 
 static CallBackFunction ToolbarBuildRailClick(Window *w)
 {
-	ShowDropDownList(w, GetRailTypeDropDownList(), _last_built_railtype, WID_TN_RAILS, 140, GetToolbarDropDownOptions());
+	ShowDropDownList(w, GetRailTypeDropDownList(), _last_built_railtype, WID_TN_RAILS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
 	return CallBackFunction::None;
 }
 
@@ -899,7 +904,7 @@ static CallBackFunction MenuClickBuildRail(int index)
 
 static CallBackFunction ToolbarBuildRoadClick(Window *w)
 {
-	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TN_ROADS, 140, GetToolbarDropDownOptions());
+	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TN_ROADS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
 	return CallBackFunction::None;
 }
 
@@ -920,7 +925,7 @@ static CallBackFunction MenuClickBuildRoad(int index)
 
 static CallBackFunction ToolbarBuildTramClick(Window *w)
 {
-	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TN_TRAMS, 140, GetToolbarDropDownOptions());
+	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TN_TRAMS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
 	return CallBackFunction::None;
 }
 
@@ -1257,7 +1262,7 @@ static CallBackFunction ToolbarScenGenIndustry(Window *w)
 
 static CallBackFunction ToolbarScenBuildRoadClick(Window *w)
 {
-	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TE_ROADS, 140, GetToolbarDropDownOptions());
+	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TE_ROADS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
 	return CallBackFunction::None;
 }
 
@@ -1276,7 +1281,7 @@ static CallBackFunction ToolbarScenBuildRoad(int index)
 
 static CallBackFunction ToolbarScenBuildTramClick(Window *w)
 {
-	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TE_TRAMS, 140, GetToolbarDropDownOptions());
+	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TE_TRAMS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
 	return CallBackFunction::None;
 }
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -881,9 +881,13 @@ static CallBackFunction ToolbarZoomOutClick(Window *w)
 
 /* --- Rail button menu --- */
 
+static std::string _railtype_filter; ///< Persistent filter text for railtype dropdown menu.
+static std::string _roadtype_filter; ///< Persistent filter text for roadtype dropdown menu.
+static std::string _tramtype_filter; ///< Persistent filter text for tramtype dropdown menu.
+
 static CallBackFunction ToolbarBuildRailClick(Window *w)
 {
-	ShowDropDownList(w, GetRailTypeDropDownList(), _last_built_railtype, WID_TN_RAILS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
+	ShowDropDownList(w, GetRailTypeDropDownList(), _last_built_railtype, WID_TN_RAILS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable), &_railtype_filter);
 	return CallBackFunction::None;
 }
 
@@ -904,7 +908,7 @@ static CallBackFunction MenuClickBuildRail(int index)
 
 static CallBackFunction ToolbarBuildRoadClick(Window *w)
 {
-	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TN_ROADS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
+	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TN_ROADS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable), &_roadtype_filter);
 	return CallBackFunction::None;
 }
 
@@ -925,7 +929,7 @@ static CallBackFunction MenuClickBuildRoad(int index)
 
 static CallBackFunction ToolbarBuildTramClick(Window *w)
 {
-	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TN_TRAMS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
+	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TN_TRAMS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable), &_tramtype_filter);
 	return CallBackFunction::None;
 }
 
@@ -1262,7 +1266,7 @@ static CallBackFunction ToolbarScenGenIndustry(Window *w)
 
 static CallBackFunction ToolbarScenBuildRoadClick(Window *w)
 {
-	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TE_ROADS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
+	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TE_ROADS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable), &_roadtype_filter);
 	return CallBackFunction::None;
 }
 
@@ -1281,7 +1285,7 @@ static CallBackFunction ToolbarScenBuildRoad(int index)
 
 static CallBackFunction ToolbarScenBuildTramClick(Window *w)
 {
-	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TE_TRAMS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable));
+	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TE_TRAMS, 140, GetToolbarDropDownOptions(DropDownOption::Filterable), &_tramtype_filter);
 	return CallBackFunction::None;
 }
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2137,9 +2137,11 @@ public:
 						(this->vli.vtype == VEH_TRAIN || this->vli.vtype == VEH_ROAD) ? 0 : (1 << 10));
 				return;
 
-			case WID_VL_FILTER_BY_CARGO: // Cargo filter dropdown
-				ShowDropDownList(this, this->BuildCargoDropDownList(false), this->cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
+			case WID_VL_FILTER_BY_CARGO: { // Cargo filter dropdown
+				static std::string cargo_filter;
+				ShowDropDownList(this, this->BuildCargoDropDownList(false), this->cargo_filter_criteria, widget, 0, DropDownOption::Filterable, &cargo_filter);
 				break;
+			}
 
 			case WID_VL_LIST: { // Matrix to show vehicles
 				auto it = this->vscroll->GetScrolledItemFromWidget(this->vehgroups, pt.y, this, WID_VL_LIST);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2138,7 +2138,7 @@ public:
 				return;
 
 			case WID_VL_FILTER_BY_CARGO: // Cargo filter dropdown
-				ShowDropDownList(this, this->BuildCargoDropDownList(false), this->cargo_filter_criteria, widget);
+				ShowDropDownList(this, this->BuildCargoDropDownList(false), this->cargo_filter_criteria, widget, 0, DropDownOption::Filterable);
 				break;
 
 			case WID_VL_LIST: { // Matrix to show vehicles

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1873,14 +1873,16 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint g
 	}
 
 	/* Third loop: Compute position and call the child. */
-	uint position = pre; // Place to put next child relative to origin of the container.
+	uint position = this->bottom_up ? this->current_y - pre : pre; // Place to put next child relative to origin of the container.
 	for (const auto &child_wid : this->children) {
-		uint child_x = x + (rtl ? child_wid->padding.right : child_wid->padding.left);
 		uint child_height = child_wid->current_y;
+		uint child_x = x + (rtl ? child_wid->padding.right : child_wid->padding.left);
+		uint child_y = y + (this->bottom_up ? position - child_height - child_wid->padding.top : position + child_wid->padding.top);
 
-		child_wid->AssignSizePosition(sizing, child_x, y + position + child_wid->padding.top, child_wid->current_x, child_height, rtl);
+		child_wid->AssignSizePosition(sizing, child_x, child_y, child_wid->current_x, child_height, rtl);
 		if (child_wid->current_y != 0) {
-			position += child_height + child_wid->padding.Vertical() + inter;
+			uint padded_child_height = child_height + child_wid->padding.Vertical() + inter;
+			position = this->bottom_up ? position - padded_child_height : position + padded_child_height;
 		}
 	}
 }

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -626,6 +626,8 @@ public:
 
 	void SetupSmallestSize(Window *w) override;
 	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override;
+
+	bool bottom_up = false; ///< Set to flow the widget from bottom-to-top instead of top-to-bottom.
 };
 
 /**

--- a/src/widgets/dropdown_widget.h
+++ b/src/widgets/dropdown_widget.h
@@ -12,9 +12,12 @@
 
 /** Widgets of the #DropdownWindow class. */
 enum DropdownMenuWidgets : WidgetID {
-	WID_DM_ITEMS,        ///< Panel showing the dropdown items.
-	WID_DM_SHOW_SCROLL,  ///< Hide scrollbar if too few items.
-	WID_DM_SCROLL,       ///< Scrollbar.
+	WID_DM_FILTER_SEL, ///< Selection for item filter.
+	WID_DM_FILTER_PANEL, ///< Panel for item filter.
+	WID_DM_FILTER, ///< Item filter.
+	WID_DM_ITEMS, ///< Panel showing the dropdown items.
+	WID_DM_SHOW_SCROLL, ///< Hide scrollbar if too few items.
+	WID_DM_SCROLL, ///< Scrollbar.
 };
 
 #endif /* WIDGETS_DROPDOWN_WIDGET_H */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When dropdown lists have a lot of options, scrolling and finding the entry you want can be annoying.

Someone asked about how best to add a text filter to dropdown lists ... and I decided to give it a go.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add an optional edit box to the dropdown list system to allow filtering of dropdown items. Filtering is separate from text display, and so is able to filter for text that isn't visible, which is useful for badge names.

In some cases, where a dropdown list is frequently used, it could be desirable to remember the last entered filter text, so this is also supported. Remembered text is only remembered for the current session and is lost when exiting.

Filtering is enabled for rail type, road type, tram type and cargo type dropdown lists, and in those instances the filter is remembered.
Filtering is also enabled for basesets, language and currency, though they these don't remember the text.

<img width="817" height="197" alt="image" src="https://github.com/user-attachments/assets/24f09cdc-08fd-4afa-9602-211aa58d2b5f" />

<img width="825" height="682" alt="image" src="https://github.com/user-attachments/assets/5e6e8616-60f1-47fe-8c25-920d7acf8102" />

If the dropdown menu appears above the dropdown widget, bottom-up, then the text filter appears at the bottom of the list. This seems sensible, otherwise the edit box would move up and down as items are filtered.

<img width="849" height="418" alt="image" src="https://github.com/user-attachments/assets/b2acbfd0-4d3a-466a-a4ab-e42e4b3e7543" />

This is not intended to supersede any of the existing rail type / road type dropdown menu enhancements, and is intended as a more generalised filter.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Currently it's not possible to NOT filter some items. This could be added if needed.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
