### PR TITLE
Feature: Allow badge classes to be plural.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -8,6 +8,7 @@
 ##decimalsep .
 ##winlangid 0x0809
 ##grflangid 0x01
+##gender s p
 
 
 # This file is part of OpenTTD.
@@ -5974,4 +5975,4 @@ STR_BADGE_CONFIG_FILTERS                                        :{WHITE}Badge Fi
 STR_BADGE_CONFIG_PREVIEW                                        :Preview Image
 STR_BADGE_CONFIG_NAME                                           :Name
 STR_BADGE_FILTER_ANY_LABEL                                      :Any {STRING}
-STR_BADGE_FILTER_IS_LABEL                                       :{STRING} is {STRING}
+STR_BADGE_FILTER_IS_LABEL                                       :{STRING} {G 0 is are} {STRING}

--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -8,6 +8,7 @@
 ##decimalsep .
 ##winlangid 0x0c09
 ##grflangid 0x3d
+##gender s p
 
 
 # This file is part of OpenTTD.

--- a/src/lang/english_US.txt
+++ b/src/lang/english_US.txt
@@ -8,6 +8,7 @@
 ##decimalsep .
 ##winlangid 0x0409
 ##grflangid 0x00
+##gender s p
 
 
 # This file is part of OpenTTD.

--- a/src/lang/polish.txt
+++ b/src/lang/polish.txt
@@ -8,7 +8,7 @@
 ##decimalsep ,
 ##winlangid 0x0415
 ##grflangid 0x30
-##gender m f n
+##gender m f n mo nmo
 ##case d c b n m w
 
 

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -145,7 +145,6 @@ void FileStringReader::HandlePragma(std::string_view str, LanguagePackHeader &la
 		}
 		lang.newgrflangid = static_cast<uint8_t>(langid);
 	} else if (name == "gender") {
-		if (this->master) FatalError("Genders are not allowed in the base translation.");
 		for (;;) {
 			auto s = ParseWord(consumer);
 

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -279,7 +279,11 @@ void EmitGender(StringBuilder &builder, std::string_view param, char32_t)
 		/* This is a {G=DER} command */
 		auto gender = consumer.Read(StringConsumer::npos);
 		auto nw = _strgen.lang.GetGenderIndex(gender);
-		if (nw >= MAX_NUM_GENDERS) StrgenFatal("G argument '{}' invalid", gender);
+		if (nw >= MAX_NUM_GENDERS) {
+			/* Show only warning since english has genders. */
+			StrgenWarning("G argument '{}' invalid", gender);
+			return; // Do not add the gender if index is invalid.
+		}
 
 		/* now nw contains the gender index */
 		builder.PutUtf8(SCC_GENDER_INDEX);
@@ -302,7 +306,11 @@ void EmitGender(StringBuilder &builder, std::string_view param, char32_t)
 			if (!word.has_value()) break;
 			words.emplace_back(*word);
 		}
-		if (words.size() != _strgen.lang.num_genders) StrgenFatal("Bad # of arguments for gender command");
+		if (words.size() != _strgen.lang.num_genders) {
+			/* Show only warning since english has genders. */
+			StrgenWarning("Bad # of arguments for gender command");
+			words.resize(_strgen.lang.num_genders, words[0]);
+		}
 
 		assert(IsInsideBS(cmd->value, SCC_CONTROL_START, UINT8_MAX));
 		builder.PutUtf8(SCC_GENDER_LIST);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Badge classes look wrong in the filters. And as in the following image Benches/Lanterns could be changed to Bench/Lantern there are some words that can't e.g. scissors, media or people.

<img width="269" height="46" alt="Zrzut ekranu z 2025-12-02 19-49-06" src="https://github.com/user-attachments/assets/101ab61c-2317-49c5-8b61-babad5ef3c40" />

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
In definitions of other languages I found to ways of defining plural form:
1. with use of genders as in german
2. with use of cases as in hebrew
Because one string should define all cases and can have only one gender this PR goes with the first solution.
Defining two genders for english `s` - singular and `p` - plural.

<img width="269" height="46" alt="Zrzut ekranu z 2025-12-02 19-48-05" src="https://github.com/user-attachments/assets/30cd3dac-1f16-4c42-a857-a29933b88fd5" />

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Only adds plural genders to english and polish as (except german) I don't speak any other languages.
I don't know if this PR will work with etnis.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
