### PR TITLE
Codefix: Leading newlines in Squirrel error/callstack prints

### DIFF
--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -10116,8 +10116,10 @@ ERROR: IsEnd() is invalid as Begin() is never called
 constructor failed with: excessive CPU usage in list filter function
 Your script made an error: excessive CPU usage in valuator function
 
+CALLSTACK
 *FUNCTION [Start()] regression/main.nut line [2184]
 
+LOCALS
 [Infinite] CLOSURE
 [list] INSTANCE
 [this] INSTANCE

--- a/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
+++ b/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp
@@ -18,7 +18,8 @@ void sqstd_printcallstack(HSQUIRRELVM v)
 		SQFloat f;
 		SQInteger level=1; //1 is to skip this function that is level 0
 		SQInteger seq=0;
-		pf(v,"\nCALLSTACK\n");
+		pf(v,"\n");
+		pf(v,"CALLSTACK\n");
 		while(SQ_SUCCEEDED(sq_stackinfos(v,level,&si)))
 		{
 			std::string_view fn="unknown";
@@ -37,7 +38,8 @@ void sqstd_printcallstack(HSQUIRRELVM v)
 			level++;
 		}
 		level=0;
-		pf(v,"\nLOCALS\n");
+		pf(v,"\n");
+		pf(v,"LOCALS\n");
 
 		for(level=0;level<10;level++){
 			seq=0;
@@ -116,11 +118,12 @@ static SQInteger _sqstd_aux_printerror(HSQUIRRELVM v)
 	if(pf) {
 		std::string_view error;
 		if(sq_gettop(v)>=1) {
+			pf(v,"\n");
 			if(SQ_SUCCEEDED(sq_getstring(v,2,error))) {
-				pf(v,fmt::format("\nAN ERROR HAS OCCURRED [{}]\n",error));
+				pf(v,fmt::format("AN ERROR HAS OCCURRED [{}]\n",error));
 			}
 			else{
-				pf(v,"\nAN ERROR HAS OCCURRED [unknown]\n");
+				pf(v,"AN ERROR HAS OCCURRED [unknown]\n");
 			}
 			sqstd_printcallstack(v);
 		}


### PR DESCRIPTION
## Motivation / Problem

Error/callstack printing in `sqstd_printcallstack` and `_sqstd_aux_printerror` includes output strings with leading newlines to simulate an empty line break.
Under normal conditions these messages are routed to `ScriptLog::Log` which truncates messages at the first newline, so the actual message content is lost, which is not very useful.

## Description

Move the leading newlines to separate output strings.

## Limitations

`_sqstd_aux_printerror` and the related functions appear to be dead/unused, but are fixed for completeness anyway.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
