### PR TITLE
Change: Load missing font glyphs dynamically.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2326,7 +2326,7 @@ static bool ConContent(std::span<std::string_view> argv)
  */
 static std::string_view FontLoadReasonToName(FontLoadReason load_reason)
 {
-	static const std::string_view LOAD_REASON_TO_NAME[] = { "default", "configured", "language" };
+	static const std::string_view LOAD_REASON_TO_NAME[] = { "default", "configured", "language", "missing" };
 	static_assert(std::size(LOAD_REASON_TO_NAME) == to_underlying(FontLoadReason::End));
 	return LOAD_REASON_TO_NAME[to_underlying(load_reason)];
 }

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -24,6 +24,7 @@ enum class FontLoadReason : uint8_t {
 	Default,
 	Configured,
 	LanguageFallback,
+	MissingFallback,
 	End,
 };
 
@@ -51,7 +52,7 @@ protected:
 	FontCache(FontSize fs) : fs(fs) {}
 	static void Register(std::unique_ptr<FontCache> &&fc, FontLoadReason load_reason);
 	static void LoadDefaultFonts(FontSize fs);
-	static void LoadFallbackFonts(FontSize fs);
+	static void LoadFallbackFonts(FontSize fs, FontLoadReason load_reason);
 
 public:
 	virtual ~FontCache() = default;

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -10,10 +10,15 @@
 #include "stdafx.h"
 #include "core/math_func.hpp"
 #include "gfx_layout.h"
+#include "gfx_func.h"
 #include "string_func.h"
 #include "strings_func.h"
 #include "core/utf8.hpp"
 #include "debug.h"
+#include "timer/timer.h"
+#include "timer/timer_window.h"
+#include "viewport_func.h"
+#include "window_func.h"
 
 #include "table/control_codes.h"
 
@@ -36,6 +41,50 @@
 
 /** Cache of ParagraphLayout lines. */
 std::unique_ptr<Layouter::LineCache> Layouter::linecache;
+
+class RuntimeMissingGlyphSearcher : public MissingGlyphSearcher {
+	std::array<std::set<char32_t>, FS_END> glyphs{};
+public:
+	RuntimeMissingGlyphSearcher() : MissingGlyphSearcher(FONTSIZES_ALL) {}
+
+	FontLoadReason GetLoadReason() override { return FontLoadReason::MissingFallback; }
+
+	inline void Insert(FontSize fs, char32_t c)
+	{
+		this->glyphs[fs].insert(c);
+		this->search_timeout.Reset();
+	}
+
+	std::set<char32_t> GetRequiredGlyphs(FontSizes fontsizes) override
+	{
+		std::set<char32_t> r;
+		for (FontSize fs : fontsizes) {
+			r.merge(this->glyphs[fs]);
+		}
+		return r;
+	}
+
+	TimeoutTimer<TimerWindow> search_timeout{std::chrono::milliseconds(250), [this]()
+	{
+		FontSizes changed_fontsizes{};
+		for (FontSize fs = FS_BEGIN; fs != FS_END; ++fs) {
+			auto &missing = this->glyphs[fs];
+			if (missing.empty()) continue;
+
+			if (FontProviderManager::FindFallbackFont({}, fs, this)) changed_fontsizes.Set(fs);
+			missing.clear();
+		}
+
+		if (!changed_fontsizes.Any()) return;
+
+		FontCache::LoadFontCaches(changed_fontsizes);
+		LoadStringWidthTable(changed_fontsizes);
+		UpdateAllVirtCoords();
+		ReInitAllWindows(true);
+	}};
+};
+
+static RuntimeMissingGlyphSearcher _missing_glyphs;
 
 /**
  * Helper for getting a ParagraphLayouter of the given type.
@@ -98,6 +147,7 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, std::string_view s
 			FontIndex font_index = FontCache::GetFontIndexForCharacter(state.fontsize, c);
 
 			if (font_index == INVALID_FONT_INDEX) {
+				_missing_glyphs.Insert(state.fontsize, c);
 				font_index = FontCache::GetDefaultFontIndex(state.fontsize);
 			}
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Font detection is currently a one-shot activity that happens on start up and when the language choice is changed.

Unknown glyphs encountered in text after this will appear as empty placeholder boxes. This can occur from user input, text stored in savegames, network server list, online content, and multiplayer chat.

<img width="813" height="804" alt="image" src="https://github.com/user-attachments/assets/2198c3b4-67b0-4926-a076-bf90a4c6f926" />

<img width="436" height="393" alt="image" src="https://github.com/user-attachments/assets/e5baee8b-4f77-4058-a4b0-0ad35956edfb" />


<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR builds on top of #13303 and adds dynamic loading of fonts for missing glyphs found when rendering strings.

Unlike the initial font detection, which changes the bounding box of text to encompass all loaded fonts, dynamically loaded fonts do not affect the line-height of text. This ensures the UI does not suddenly change size when text is encountered.

<img width="813" height="804" alt="image" src="https://github.com/user-attachments/assets/70bdc471-ac81-480d-bed1-e2f427f17cd2" />

<img width="436" height="393" alt="image" src="https://github.com/user-attachments/assets/53ada3da-5213-44f1-9f98-290540b5b01b" />

Loaded fonts are shown in the console with the `font` command:

<img width="694" height="445" alt="image" src="https://github.com/user-attachments/assets/a678c4c8-1cee-4dc5-8a11-dcc1eb5af383" />

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Currently this tries to find one font for all missing glyphs, and won't try to split the list of missing glyphs into ranges to make finding a font more likely.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
