### PR TITLE
Fix #14839, e4cf6ca0ba: do not set stacked widget height, which might not be shown

### DIFF
--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -240,7 +240,6 @@ struct TimetableWindow : Window {
 				}
 				[[fallthrough]];
 
-			case WID_VT_ARRIVAL_DEPARTURE_SELECTION:
 			case WID_VT_TIMETABLE_PANEL:
 				fill.height = resize.height = GetCharacterHeight(FS_NORMAL);
 				size.height = 8 * resize.height + padding.height;


### PR DESCRIPTION
## Motivation / Problem

Fix #14839.


## Description

Remove setting the height for a `NWidgetStacked`, as that might not be shown at all.


## Limitations

I'm not sure why you want to set the size of the `NWidgetStacked` at all. Is there a (good) reason for that?

In the same case you would already be setting the height of the widget within the `NWidgetStacked`, so I would kinda expect the `NWidgetStacked` to pick up that height.
Even if that's not the case, we `[[fallthrough]]` into that switch case from the main timetable widget that is next to it. In other words, even if `NWidgetStacked` does not pass on the height properly, the `NWidgetStacked` will get the right height when it is being  shown.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
