### PR TITLE
Fix #14802: close NewGRF inspection window when overbuilding with default station/waypoint

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1558,6 +1558,7 @@ CommandCost CmdBuildRailStation(DoCommandFlags flags, TileIndex tile_org, RailTy
 				MakeRailStation(tile, st->owner, st->index, axis, *it, rt);
 				/* Free the spec if we overbuild something */
 				DeallocateSpecFromStation(st, old_specindex);
+				if (statspec == nullptr) DeleteNewGRFInspectWindow(GSF_STATIONS, tile);
 
 				SetCustomStationSpecIndex(tile, *specindex);
 				SetStationTileRandomBits(tile, GB(Random(), 0, 4));

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -26,6 +26,7 @@
 #include "vehicle_func.h"
 #include "string_func.h"
 #include "company_func.h"
+#include "newgrf_debug.h"
 #include "newgrf_station.h"
 #include "newgrf_roadstop.h"
 #include "company_base.h"
@@ -315,6 +316,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 			MarkTileDirtyByTile(tile);
 
 			DeallocateSpecFromStation(wp, old_specindex);
+			if (spec == nullptr) DeleteNewGRFInspectWindow(GSF_STATIONS, tile);
 			YapfNotifyTrackLayoutChange(tile, AxisToTrack(axis));
 		}
 		DirtyCompanyInfrastructureWindows(wp->owner);


### PR DESCRIPTION
## Motivation / Problem

Fixes #14802.


## Description

The NewGRF station debug window is tile-based, so just close the window when we (over)build a default station/waypoint.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
