### PR TITLE
Fix: always try to create at least one town

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2448,7 +2448,7 @@ bool GenerateTowns(TownLayout layout, std::optional<uint> number)
 		total = Map::ScaleByLandProportion(GetDefaultTownsForMapSize() + (Random() & 7));
 	}
 
-	total = std::min<uint>(TownPool::MAX_SIZE, total);
+	total = Clamp<uint>(total, 1, TownPool::MAX_SIZE);
 	uint32_t townnameparts;
 	TownNames town_names;
 


### PR DESCRIPTION
## Motivation / Problem

```
openttd: /openttd/src/genworld_gui.cpp:1476: void _SetGeneratingWorldProgress(GenWorldProgress, uint, uint): Assertion `GenWorldStatus::cls == _generation_class_table[cls]' failed.

Thread 1 "openttd" received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
warning: 44     ./nptl/pthread_kill.c: No such file or directory
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x00007ffff6c9e9ff in __pthread_kill_internal (threadid=<optimized out>, signo=6) at ./nptl/pthread_kill.c:89
#2  0x00007ffff6c49cc2 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007ffff6c324ac in __GI_abort () at ./stdlib/abort.c:73
#4  0x00007ffff6c32420 in __assert_fail_base (fmt=<optimized out>, assertion=<optimized out>, file=<optimized out>, line=1476, function=<optimized out>) at ./assert/assert.c:118
#5  0x0000555556fceb02 in _SetGeneratingWorldProgress (cls=GWP_TOWN, progress=1, total=0) at /openttd/src/genworld_gui.cpp:1476
#6  0x0000555556fcee33 in IncreaseGeneratingWorldProgress (cls=GWP_TOWN) at /openttd/src/genworld_gui.cpp:1537
#7  0x0000555557435be0 in GenerateTowns (layout=TL_BEGIN, number=std::optional [no contained value]) at /openttd/src/town_cmd.cpp:2471
#8  0x0000555556fc8d9a in _GenerateWorld () at /openttd/src/genworld.cpp:152
#9  0x0000555556fc96b1 in GenerateWorld (mode=GWM_NEWGAME, size_x=64, size_y=64, reset_settings=true) at /openttd/src/genworld.cpp:353
#10 0x00005555571ca499 in MakeNewGame (from_heightmap=false, reset_settings=true) at /openttd/src/openttd.cpp:911
#11 0x00005555571cacb7 in SwitchToMode (new_mode=SM_NEWGAME) at /openttd/src/openttd.cpp:1093
#12 0x00005555571cbb5b in GameLoop () at /openttd/src/openttd.cpp:1366
#13 0x0000555556e75690 in VideoDriver_Null::MainLoop (this=0x555558528800) at /openttd/src/video/null_v.cpp:54
#14 0x00005555571c9d60 in openttd_main (arguments=Python Exception <class 'gdb.error'>: No symbol "static_cast" in current context.
```

Which is triggered by `count` being 0 in `GenerateTowns`. It can be 0 when it's specifically passed as such, or when scaling by land proportion with the map being 64x64. In the latter case it won't reproduce reliably, because `Random() & 7` needs to be 0 as well.

Note that without assertions there would be `UINT_MAX` attempts to create a town.


## Description

Replace the `std::min` with a `Clamp` that also forces the minimum to be at least 1.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
