### PR TITLE
Codechange: Make order load/unload flags value types.

### DIFF
--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -425,14 +425,14 @@ void VehicleCargoList::AgeCargo()
  * @param accepted If the cargo will be accepted at the station.
  * @param current_station ID of the station.
  * @param next_station ID of the station the vehicle will go to next.
- * @param order_flags OrderUnloadFlags that will apply to the unload operation.
+ * @param unload_type OrderUnloadType that will apply to the unload operation.
  * @param ge GoodsEntry for getting the flows.
  * @param cargo The cargo type of the cargo.
  * @param payment Payment object for registering transfers.
  * @param current_tile Current tile the cargo handling is happening on.
  * return If any cargo will be unloaded.
  */
-bool VehicleCargoList::Stage(bool accepted, StationID current_station, std::span<const StationID> next_station, uint8_t order_flags, const GoodsEntry *ge, CargoType cargo, CargoPayment *payment, TileIndex current_tile)
+bool VehicleCargoList::Stage(bool accepted, StationID current_station, std::span<const StationID> next_station, OrderUnloadType unload_type, const GoodsEntry *ge, CargoType cargo, CargoPayment *payment, TileIndex current_tile)
 {
 	this->AssertCountConsistency();
 	assert(this->action_counts[MTA_LOAD] == 0);
@@ -444,9 +444,9 @@ bool VehicleCargoList::Stage(bool accepted, StationID current_station, std::span
 	static const FlowStatMap EMPTY_FLOW_STAT_MAP = {};
 	const FlowStatMap &flows = ge->HasData() ? ge->GetData().flows : EMPTY_FLOW_STAT_MAP;
 
-	bool force_keep = (order_flags & OUFB_NO_UNLOAD) != 0;
-	bool force_unload = (order_flags & OUFB_UNLOAD) != 0;
-	bool force_transfer = (order_flags & (OUFB_TRANSFER | OUFB_UNLOAD)) != 0;
+	bool force_keep = unload_type == OrderUnloadType::NoUnload;
+	bool force_unload = unload_type == OrderUnloadType::Unload;
+	bool force_transfer = unload_type == OrderUnloadType::Transfer || unload_type == OrderUnloadType::Unload;
 	assert(this->count > 0 || it == this->packets.end());
 	while (sum < this->count) {
 		CargoPacket *cp = *it;

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -469,7 +469,7 @@ public:
 
 	void InvalidateCache();
 
-	bool Stage(bool accepted, StationID current_station, std::span<const StationID> next_station, uint8_t order_flags, const GoodsEntry *ge, CargoType cargo, CargoPayment *payment, TileIndex current_tile);
+	bool Stage(bool accepted, StationID current_station, std::span<const StationID> next_station, OrderUnloadType unload_type, const GoodsEntry *ge, CargoType cargo, CargoPayment *payment, TileIndex current_tile);
 
 	/**
 	 * Marks all cargo in the vehicle as to be kept. This is mostly useful for

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2816,13 +2816,13 @@ int WhoCanServiceIndustry(Industry *ind)
 		 * may have a different cargo type.
 		 */
 		for (const Order &o : v->Orders()) {
-			if (o.IsType(OT_GOTO_STATION) && !(o.GetUnloadType() & OUFB_TRANSFER)) {
+			if (o.IsType(OT_GOTO_STATION) && o.GetUnloadType() != OrderUnloadType::Transfer) {
 				/* Vehicle visits a station to load or unload */
 				Station *st = Station::Get(o.GetDestination().ToStationID());
 				assert(st != nullptr);
 
 				/* Same cargo produced by industry is dropped here => not serviced by vehicle v */
-				if ((o.GetUnloadType() & OUFB_UNLOAD) && !c_accepts) break;
+				if (o.GetUnloadType() == OrderUnloadType::Unload && !c_accepts) break;
 
 				if (ind->stations_near.find(st) != ind->stations_near.end()) {
 					if (v->owner == _local_company) return 2; // Company services industry

--- a/src/linkgraph/refresh.cpp
+++ b/src/linkgraph/refresh.cpp
@@ -203,7 +203,7 @@ void LinkRefresher::RefreshStats(VehicleOrderID cur, VehicleOrderID next)
 			}
 
 			/* A link is at least partly restricted if a vehicle can't load at its source. */
-			EdgeUpdateMode restricted_mode = (orders[cur].GetLoadType() & OLFB_NO_LOAD) == 0 ?
+			EdgeUpdateMode restricted_mode = orders[cur].GetLoadType() != OrderLoadType::NoLoad ?
 						EdgeUpdateMode::Unrestricted : EdgeUpdateMode::Restricted;
 			/* This estimates the travel time of the link as the time needed
 			 * to travel between the stations at half the max speed of the consist.

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1020,7 +1020,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 	}
 
 	const Order &order = v->First()->current_order;
-	bool not_loading = (order.GetUnloadType() & OUFB_NO_UNLOAD) && (order.GetLoadType() & OLFB_NO_LOAD);
+	bool not_loading = order.GetUnloadType() == OrderUnloadType::NoUnload && order.GetLoadType() == OrderLoadType::NoLoad;
 	bool in_motion = !order.IsType(OT_LOADING) || not_loading;
 
 	uint totalsets = static_cast<uint>(in_motion ? group.loaded.size() : group.loading.size());

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -128,10 +128,20 @@ public:
 
 	void SetRefit(CargoType cargo);
 
+	/**
+	 * Is this order a OrderLoadType::FullLoad or OrderLoadType::FullLoadAny?
+	 * @return true iff the order is a full load or full load any order.
+	 */
+	inline bool IsFullLoadOrder() const
+	{
+		OrderLoadType type = GetLoadType();
+		return type == OrderLoadType::FullLoad || type == OrderLoadType::FullLoadAny;
+	}
+
 	/** How must the consist be loaded? */
-	inline OrderLoadFlags GetLoadType() const { return (OrderLoadFlags)GB(this->flags, 4, 3); }
+	inline OrderLoadType GetLoadType() const { return static_cast<OrderLoadType>(GB(this->flags, 4, 3)); }
 	/** How must the consist be unloaded? */
-	inline OrderUnloadFlags GetUnloadType() const { return (OrderUnloadFlags)GB(this->flags, 0, 3); }
+	inline OrderUnloadType GetUnloadType() const { return static_cast<OrderUnloadType>(GB(this->flags, 0, 3)); }
 	/** At which stations must we stop? */
 	inline OrderNonStopFlags GetNonStopType() const { return static_cast<OrderNonStopFlags>(GB(this->type, 6, 2)); }
 	/** Where must we stop at the platform? */
@@ -150,9 +160,9 @@ public:
 	inline uint16_t GetConditionValue() const { return GB(this->dest.value, 0, 11); }
 
 	/** Set how the consist must be loaded. */
-	inline void SetLoadType(OrderLoadFlags load_type) { SB(this->flags, 4, 3, load_type); }
+	inline void SetLoadType(OrderLoadType load_type) { SB(this->flags, 4, 3, to_underlying(load_type)); }
 	/** Set how the consist must be unloaded. */
-	inline void SetUnloadType(OrderUnloadFlags unload_type) { SB(this->flags, 0, 3, unload_type); }
+	inline void SetUnloadType(OrderUnloadType unload_type) { SB(this->flags, 0, 3, to_underlying(unload_type)); }
 	/** Set whether we must stop at stations or not. */
 	inline void SetNonStopType(OrderNonStopFlags non_stop_type) { SB(this->type, 6, 2, non_stop_type.base()); }
 	/** Set where we must stop at the platform. */

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -62,23 +62,23 @@ enum OrderType : uint8_t {
 };
 
 /**
- * Flags related to the unloading order.
+ * Unloading order types.
  */
-enum OrderUnloadFlags : uint8_t {
-	OUF_UNLOAD_IF_POSSIBLE = 0,      ///< Unload all cargo that the station accepts.
-	OUFB_UNLOAD            = 1 << 0, ///< Force unloading all cargo onto the platform, possibly not getting paid.
-	OUFB_TRANSFER          = 1 << 1, ///< Transfer all cargo onto the platform.
-	OUFB_NO_UNLOAD         = 1 << 2, ///< Totally no unloading will be done.
+enum class OrderUnloadType : uint8_t {
+	UnloadIfPossible = 0, ///< Unload all cargo that the station accepts.
+	Unload = 1, ///< Force unloading all cargo onto the platform, possibly not getting paid.
+	Transfer = 2, ///< Transfer all cargo onto the platform.
+	NoUnload = 4, ///< Totally no unloading will be done.
 };
 
 /**
- * Flags related to the loading order.
+ * Loading order types.
  */
-enum OrderLoadFlags : uint8_t {
-	OLF_LOAD_IF_POSSIBLE = 0,      ///< Load as long as there is cargo that fits in the train.
-	OLFB_FULL_LOAD       = 1 << 1, ///< Full load all cargoes of the consist.
-	OLF_FULL_LOAD_ANY    = 3,      ///< Full load a single cargo of the consist.
-	OLFB_NO_LOAD         = 4,      ///< Do not load anything.
+enum class OrderLoadType : uint8_t {
+	LoadIfPossible = 0, ///< Load as long as there is cargo that fits in the train.
+	FullLoad = 2, ///< Full load all cargoes of the consist.
+	FullLoadAny = 3, ///< Full load a single cargo of the consist.
+	NoLoad = 4, ///< Do not load anything.
 };
 
 /**

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1830,17 +1830,17 @@ bool AfterLoadGame()
 		/* Unload and transfer are now mutual exclusive. */
 		for (OrderList *orderlist : OrderList::Iterate()) {
 			for (Order &order : orderlist->GetOrders()) {
-				if ((order.GetUnloadType() & (OUFB_UNLOAD | OUFB_TRANSFER)) == (OUFB_UNLOAD | OUFB_TRANSFER)) {
-					order.SetUnloadType(OUFB_TRANSFER);
-					order.SetLoadType(OLFB_NO_LOAD);
+				if (order.GetUnloadType() == OrderUnloadType{3}) { // 3 used to mean transfer and don't load.
+					order.SetUnloadType(OrderUnloadType::Transfer);
+					order.SetLoadType(OrderLoadType::NoLoad);
 				}
 			}
 		}
 
 		for (Vehicle *v : Vehicle::Iterate()) {
-			if ((v->current_order.GetUnloadType() & (OUFB_UNLOAD | OUFB_TRANSFER)) == (OUFB_UNLOAD | OUFB_TRANSFER)) {
-				v->current_order.SetUnloadType(OUFB_TRANSFER);
-				v->current_order.SetLoadType(OLFB_NO_LOAD);
+			if (v->current_order.GetUnloadType() == OrderUnloadType{3}) { // 3 used to mean transfer and don't load.
+				v->current_order.SetUnloadType(OrderUnloadType::Transfer);
+				v->current_order.SetLoadType(OrderLoadType::NoLoad);
 			}
 		}
 	} else if (IsSavegameVersionBefore(SLV_DEPOT_UNBUNCHING)) {

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -45,23 +45,23 @@ void Order::ConvertFromOldSavegame()
 	if (this->GetType() != OT_GOTO_DEPOT) {
 		/* Then the load flags */
 		if ((old_flags & 2) != 0) { // OFB_UNLOAD
-			this->SetLoadType(OLFB_NO_LOAD);
+			this->SetLoadType(OrderLoadType::NoLoad);
 		} else if ((old_flags & 4) == 0) { // !OFB_FULL_LOAD
-			this->SetLoadType(OLF_LOAD_IF_POSSIBLE);
+			this->SetLoadType(OrderLoadType::LoadIfPossible);
 		} else {
 			/* old OTTD versions stored full_load_any in config file - assume it was enabled when loading */
-			this->SetLoadType(_settings_client.gui.sg_full_load_any || IsSavegameVersionBefore(SLV_22) ? OLF_FULL_LOAD_ANY : OLFB_FULL_LOAD);
+			this->SetLoadType(_settings_client.gui.sg_full_load_any || IsSavegameVersionBefore(SLV_22) ? OrderLoadType::FullLoadAny : OrderLoadType::FullLoad);
 		}
 
 		if (this->IsType(OT_GOTO_STATION)) this->SetStopLocation(OrderStopLocation::FarEnd);
 
 		/* Finally fix the unload flags */
 		if ((old_flags & 1) != 0) { // OFB_TRANSFER
-			this->SetUnloadType(OUFB_TRANSFER);
+			this->SetUnloadType(OrderUnloadType::Transfer);
 		} else if ((old_flags & 2) != 0) { // OFB_UNLOAD
-			this->SetUnloadType(OUFB_UNLOAD);
+			this->SetUnloadType(OrderUnloadType::Unload);
 		} else {
-			this->SetUnloadType(OUF_UNLOAD_IF_POSSIBLE);
+			this->SetUnloadType(OrderUnloadType::UnloadIfPossible);
 		}
 	} else {
 		/* Then the depot action flags */

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -315,8 +315,8 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 			break;
 
 		case OT_GOTO_STATION:
-			order_flags |= (ScriptOrderFlags)(order->GetLoadType()   << 5);
-			order_flags |= (ScriptOrderFlags)(order->GetUnloadType() << 2);
+			order_flags |= static_cast<ScriptOrderFlags>(to_underlying(order->GetLoadType())   << 5);
+			order_flags |= static_cast<ScriptOrderFlags>(to_underlying(order->GetUnloadType()) << 2);
 			break;
 
 		default: break;
@@ -511,8 +511,8 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 
 		case OT_GOTO_STATION:
 			order.MakeGoToStation(::GetStationIndex(destination));
-			order.SetLoadType((OrderLoadFlags)GB(order_flags, 5, 3));
-			order.SetUnloadType((OrderUnloadFlags)GB(order_flags, 2, 3));
+			order.SetLoadType(static_cast<OrderLoadType>(GB(order_flags, 5, 3)));
+			order.SetUnloadType(static_cast<OrderUnloadType>(GB(order_flags, 2, 3)));
 			order.SetStopLocation(OrderStopLocation::FarEnd);
 			break;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Order Load and Unload flags have complex logic to ensure that invalid combinations aren't used. In fact, apart from FullLoad and FullLoadAny, all mixed combinations are invalid, or at least cannot be selected in the UI.

I was going to update from arbitrary logical operations to use EnumBitSet, but instead, decided to switch things around.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Simplify logic by removing the use of bit values and treat each option as a value. It is no longer necessary to test for invalid combinations.

The enum values match the original so no savegame conversion is needed.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
