### PR TITLE
Change: Fetch OpenGFX2 for CI workflows

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -78,15 +78,15 @@ jobs:
         mkdir -p ~/.local/share/openttd/baseset
         cd ~/.local/share/openttd/baseset
 
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::group::Download OpenGFX2"
+        curl -L https://cdn.openttd.org/opengfx2_classic-releases/0.8/opengfx2_classic-0.8-all.zip -o opengfx2-all.zip
         echo "::endgroup::"
 
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
+        echo "::group::Unpack OpenGFX2"
+        unzip opengfx2-all.zip
         echo "::endgroup::"
 
-        rm -f opengfx-all.zip
+        rm -f opengfx2-all.zip
 
     - name: Install GCC problem matcher
       uses: ammaraskar/gcc-problem-matcher@master

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -45,15 +45,15 @@ jobs:
         mkdir -p ~/Documents/OpenTTD/baseset
         cd ~/Documents/OpenTTD/baseset
 
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::group::Download OpenGFX2"
+        curl -L https://cdn.openttd.org/opengfx2_classic-releases/0.8/opengfx2_classic-0.8-all.zip -o opengfx2-all.zip
         echo "::endgroup::"
 
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
+        echo "::group::Unpack OpenGFX2"
+        unzip opengfx2-all.zip
         echo "::endgroup::"
 
-        rm -f opengfx-all.zip
+        rm -f opengfx2-all.zip
 
     - name: Install GCC problem matcher
       uses: ammaraskar/gcc-problem-matcher@master

--- a/.github/workflows/ci-mingw.yml
+++ b/.github/workflows/ci-mingw.yml
@@ -47,15 +47,15 @@ jobs:
         mkdir -p "C:/Users/Public/Documents/OpenTTD/baseset"
         cd "C:/Users/Public/Documents/OpenTTD/baseset"
 
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::group::Download OpenGFX2"
+        curl -L https://cdn.openttd.org/opengfx2_classic-releases/0.8/opengfx2_classic-0.8-all.zip -o opengfx2-all.zip
         echo "::endgroup::"
 
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
+        echo "::group::Unpack OpenGFX2"
+        unzip opengfx2-all.zip
         echo "::endgroup::"
 
-        rm -f opengfx-all.zip
+        rm -f opengfx2-all.zip
 
     - name: Install GCC problem matcher
       uses: ammaraskar/gcc-problem-matcher@master

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,15 +31,15 @@ jobs:
         mkdir -p "C:/Users/Public/Documents/OpenTTD/baseset"
         cd "C:/Users/Public/Documents/OpenTTD/baseset"
 
-        echo "::group::Download OpenGFX"
-        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::group::Download OpenGFX2"
+        curl -L https://cdn.openttd.org/opengfx2_classic-releases/0.8/opengfx2_classic-0.8-all.zip -o opengfx2-all.zip
         echo "::endgroup::"
 
-        echo "::group::Unpack OpenGFX"
-        unzip opengfx-all.zip
+        echo "::group::Unpack OpenGFX2"
+        unzip opengfx2-all.zip
         echo "::endgroup::"
 
-        rm -f opengfx-all.zip
+        rm -f opengfx2-all.zip
 
     - name: Install MSVC problem matcher
       uses: ammaraskar/msvc-problem-matcher@master


### PR DESCRIPTION
## Motivation / Problem

[As per discussions here](https://github.com/OpenTTD/OpenTTD/issues/13747), we'd like to use OpenGFX2 as the default base graphics, so it probably makes sense to update all the CI workflows to match.

## Description

Update the workflows to fetch OpenGFX2 from the CDN.

It seems that the workflows haven't been consistently updated for a while, several were still fetching OpenGFX 6.0 instead of 7.1. Synchronise all to fetch OpenGFX2 Classic.

## Limitations

OpenGFX2 is ~3x larger, due to the extra zoom GUI sprites and base set parameter-controlled graphical alternates, so more bandwidth usage if that's an issue?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
