### PR TITLE
Improved Water Edges

### DIFF
--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -755,6 +755,7 @@ static double perlin_coast_noise_2D(const double x, const double y, const double
  */
 static void HeightMapCoastLines(BorderFlags water_borders)
 {
+	/* Both map dimensions are powers of 2. Division by smaller powers of 2 will always result in an integer. */
 	const int smallest_size = std::min(_height_map.size_x, _height_map.size_y);
 	const int map_ratio = std::max(_height_map.size_x, _height_map.size_y) / smallest_size;
 
@@ -762,7 +763,7 @@ static void HeightMapCoastLines(BorderFlags water_borders)
 	 * reaches the limit of 64. It scales both by the shortest side and the map ratio to try and balance variation in the
 	 * coastline and the amount of water on the map.
 	 */
-	const double jagged_distance = std::min(12 + static_cast<int>(pow(smallest_size / 64, 2)) + std::min(map_ratio, 16), 64);
+	const int jagged_distance = std::min(12 + (smallest_size * smallest_size / 4096) + std::min(map_ratio, 16), 64);
 
 	/* Smoother perlin noise is used to add more depth to the coastline as the smallest edge increases in length */
 	const int smooth_distance = std::min(smallest_size / 32, 32);


### PR DESCRIPTION
## Motivation / Problem

The existing water map edges create relatively straight coastlines unless they intersect with inland seas. The limited number of water tiles can also restrict industry placement and cause them to be squeezed in where they can fit. Aside from how the edges look, long straight coastlines can remove some of the challenge of building a coastal road or railway.

<img width="2082" height="1068" alt="1024_original" src="https://github.com/user-attachments/assets/be666134-9db9-4bf3-acf8-0b6d38cb0c60" />

This was generated from seed 3176204060, with mountainous terrain, medium variety, rough smoothness, and very low sea levels. (Industries are FIRS)

## Description

The changes are little more than tweaking HeightMapCoastLines(). This is the function that sets tiles along the water edge(s) of the map to 0. The same 2D perlin noise functions are used as before and with mostly the same parameters. Margin and depth variables are used to set a water margin (i.e. no land in this area) and how far features intrude inland.

<img width="2084" height="1065" alt="image" src="https://github.com/user-attachments/assets/d0c0e129-b5e6-4ecf-991d-7efe77048d9a" />

## Limitations

- The margin and depth variables are set to different values based on map size and are not user configurable.
- I've not provided a setting to turn this off and use the original values/code.
- This doesn't interact with the sea level setting. Ideally, increasing sea level would lead to even larger coastal features, but I don't think that's readily achievable with the existing approach.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
