### PR TITLE
Fix 92e895a: don't force proceed crashed trains

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2149,7 +2149,7 @@ CommandCost CmdReverseTrainDirection(DoCommandFlags flags, VehicleID veh_id, boo
  */
 static TrainForceProceeding DetermineNextTrainForceProceeding(const Train *t)
 {
-	if (t->force_proceed == TFP_SIGNAL) return TFP_NONE;
+	if (t->vehstatus.Test(VehState::Crashed) || t->force_proceed == TFP_SIGNAL) return TFP_NONE;
 	if (!t->flags.Test(VehicleRailFlag::Stuck)) return t->IsChainInDepot() ? TFP_STUCK : TFP_SIGNAL;
 
 	TileIndex next_tile = TileAddByDiagDir(t->tile, TrackdirToExitdir(t->GetVehicleTrackdir()));


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Because of #14724 when train is stuck and the train is forced to proceed the TrackdirToExitdir is called.
The exitdir does not really make sense for crashed down trains.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Set force_proceed to TFP_NONE if train has crashed.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
I might have interpreted the crash message wrong.
```bash
openttd: /home/cyprian/openTTD/OpenTTD_SourceCode/src/pathfinder/yapf/../../track_func.h:441: DiagDirection TrackdirToExitdir(Trackdir): Assertion `IsValidTrackdirForRoadVehicle(trackdir)' failed.

Thread 1 "openttd" received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
44	./nptl/pthread_kill.c: Nie ma takiego pliku ani katalogu.
(gdb) backtrace
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x00007ffff72aaf4f in __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  0x00007ffff725bfb2 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007ffff7246472 in __GI_abort () at ./stdlib/abort.c:79
#4  0x00007ffff7246395 in __assert_fail_base (fmt=0x7ffff73bba90 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x55555779d620 "IsValidTrackdirForRoadVehicle(trackdir)", 
    file=file@entry=0x55555779d448 "/home/cyprian/openTTD/OpenTTD_SourceCode/src/pathfinder/yapf/../../track_func.h", line=line@entry=441, function=function@entry=0x55555779d6d8 "DiagDirection TrackdirToExitdir(Trackdir)")
    at ./assert/assert.c:94
#5  0x00007ffff7254ec2 in __GI___assert_fail (assertion=0x55555779d620 "IsValidTrackdirForRoadVehicle(trackdir)", file=0x55555779d448 "/home/cyprian/openTTD/OpenTTD_SourceCode/src/pathfinder/yapf/../../track_func.h", line=441, 
    function=0x55555779d6d8 "DiagDirection TrackdirToExitdir(Trackdir)") at ./assert/assert.c:103
#6  0x0000555556cf7d2a in TrackdirToExitdir (trackdir=INVALID_TRACKDIR) at /home/cyprian/openTTD/OpenTTD_SourceCode/src/pathfinder/yapf/../../track_func.h:441
#7  0x00005555574c8394 in DetermineNextTrainForceProceeding (t=0x7fffa0421b20) at /home/cyprian/openTTD/OpenTTD_SourceCode/src/train_cmd.cpp:2155
#8  0x00005555574c862e in CmdForceTrainProceed (flags=..., veh_id=...) at /home/cyprian/openTTD/OpenTTD_SourceCode/src/train_cmd.cpp:2179
^C
#9  0x0000555556880f7e in std::__invoke_impl<CommandCost, CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned int, VehicleIDTag, 1044480u, 1048575u>), EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned int, VehicleIDTag, 1044480u, 1048575u> > (
    __f=@0x5555574c8547: {CommandCost (EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned int, VehicleIDTag, 1044480, 1048575>)} 0x5555574c8547 <CmdForceTrainProceed(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned int, VehicleIDTag, 1044480u, 1048575u>)>) at /usr/include/c++/12/bits/invoke.h:61
#10 0x000055555687f3fc in std::__invoke<CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned int, VehicleIDTag, 1044480u, 1048575u>), EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned int, VehicleIDTag, 1044480u, 1048575u> > (__fn=<error reading variable: Cannot access memory at address 0x5555574c8547>) at /usr/include/c++/12/bits/invoke.h:97
#11 0x000055555687c049 in std::__apply_impl<CommandCost (&)(EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned int, VehicleIDTag, 1044480u, 1048575u>), std::tuple<EnumBitSet<DoCommandFlag, unsigned short, (DoCommandFlag)16>, PoolID<unsigned int, VehicleIDTag, 1044480u, 1048575u> >, 0ul, 1ul> (__f=<error reading variable: Cannot access memory at address 0x7fffffffce40>, __t=...) at /usr/include/c++/12/tuple:1853
Backtrace stopped: Cannot access memory at address 0x7fffffffce68
```

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
