### PR TITLE
Fix #14677: desync due to using newgame time settings to validate savegame time settings

### DIFF
--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -670,7 +670,7 @@ static void ChangeMinutesPerYear(int32_t new_value)
 static std::tuple<int32_t, uint32_t> GetMinutesPerYearRange(const IntSettingDesc &)
 {
 	/* Allow a non-default value only if using Wallclock timekeeping units. */
-	if (_settings_newgame.economy.timekeeping_units == TKU_WALLCLOCK) return { CalendarTime::FROZEN_MINUTES_PER_YEAR, CalendarTime::MAX_MINUTES_PER_YEAR };
+	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) return { CalendarTime::FROZEN_MINUTES_PER_YEAR, CalendarTime::MAX_MINUTES_PER_YEAR };
 
 	return { CalendarTime::DEF_MINUTES_PER_YEAR, CalendarTime::DEF_MINUTES_PER_YEAR };
 }


### PR DESCRIPTION
## Motivation / Problem

Desync, fixes #14677.


## Description

When validating game settings during game load, simply do not use the 'new game' settings but those from the actual game.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
