### PR TITLE
Codefix: possible null pointer dereference

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1010,13 +1010,15 @@ struct QueryStringWindow : public Window
 
 	void Close([[maybe_unused]] int data = 0) override
 	{
-		if (this->parent->window_class == WC_STATION_VIEW) SetViewportStationRect(Station::Get(this->parent->window_number), false);
-		if (this->parent->window_class == WC_WAYPOINT_VIEW) SetViewportWaypointRect(Waypoint::Get(this->parent->window_number), false);
+		if (this->parent != nullptr) {
+			if (this->parent->window_class == WC_STATION_VIEW) SetViewportStationRect(Station::Get(this->parent->window_number), false);
+			if (this->parent->window_class == WC_WAYPOINT_VIEW) SetViewportWaypointRect(Waypoint::Get(this->parent->window_number), false);
 
-		if (!this->editbox.handled && this->parent != nullptr) {
-			Window *parent = this->parent;
-			this->parent = nullptr; // so parent doesn't try to close us again
-			parent->OnQueryTextFinished(std::nullopt);
+			if (!this->editbox.handled) {
+				Window *parent = this->parent;
+				this->parent = nullptr; // so parent doesn't try to close us again
+				parent->OnQueryTextFinished(std::nullopt);
+			}
 		}
 
 		this->Window::Close();


### PR DESCRIPTION
## Motivation / Problem

There is a `Close` that unconditionally dereferences `parent`, but later checks for `nullptr`. Arguably the latter doesn't happen often, but the check has been added for some reason.


## Description

Cover the other `parent` dereferences by the check as well.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
