### PR TITLE
Codechange: Don't read font os_handle on MacOS.

### DIFF
--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -215,19 +215,12 @@ public:
 	{
 		if (fonttype != FontType::TrueType) return nullptr;
 
-		FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
-
 		std::string font = GetFontCacheFontName(fs);
 		if (font.empty()) return nullptr;
 
 		CFAutoRelease<CTFontDescriptorRef> font_ref;
 
-		if (settings->os_handle != nullptr) {
-			font_ref.reset(static_cast<CTFontDescriptorRef>(const_cast<void *>(settings->os_handle)));
-			CFRetain(font_ref.get()); // Increase ref count to match a later release.
-		}
-
-		if (!font_ref && MacOSVersionIsAtLeast(10, 6, 0)) {
+		if (MacOSVersionIsAtLeast(10, 6, 0)) {
 			/* Might be a font file name, try load it. */
 			font_ref.reset(LoadFontFromFile(font));
 			if (!font_ref) ShowInfo("Unable to load file '{}' for {} font, using default OS font selection instead", font, FontSizeToName(fs));


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

On MacOS, a font's `os_handle` is never set during fallback detection, so there's no need to read it and treat it as if it could be.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove code that reads from `os_handle` on MacOS.

(This change was previously hidden inside the "side-by-side" changes)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
