### PR TITLE
Codechange: [Script] Reduce code duplication for list sorters

### DIFF
--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -19,9 +19,15 @@
  */
 class ScriptListSorter {
 protected:
-	ScriptList *list;       ///< The list that's being sorted.
-	bool has_no_more_items; ///< Whether we have more items to iterate over.
-	std::optional<SQInteger> item_next{}; ///< The next item we will show, or std::nullopt if there are no more items to iterate over.
+	const ScriptList *list; ///< The list that's being sorted.
+	bool has_no_more_items = true; ///< Whether we have more items to iterate over.
+	std::optional<SQInteger> item_next = std::nullopt; ///< The next item we will show, or std::nullopt if there are no more items to iterate over.
+
+	/**
+	 * Create a new sorter.
+	 * @param list The list to sort.
+	 */
+	ScriptListSorter(const ScriptList *list) : list(list) {}
 
 	/**
 	 * Actually try to find the next item.
@@ -64,7 +70,7 @@ public:
 	/**
 	 * See if the sorter has reached the end.
 	 */
-	bool IsEnd()
+	bool IsEnd() const
 	{
 		return this->list->items.empty() || this->has_no_more_items;
 	}
@@ -77,19 +83,16 @@ public:
 		if (this->IsEnd()) return;
 
 		/* If we remove the 'next' item, skip to the next */
-		if (item == this->item_next) {
-			this->FindNext();
-			return;
-		}
+		if (item == this->item_next) this->FindNext();
 	}
 
 	/**
 	 * Attach the sorter to a new list. This assumes the content of the old list has been moved to
 	 * the new list, too, so that we don't have to invalidate any iterators. Note that std::swap
 	 * doesn't invalidate iterators on lists and maps, so that should be safe.
-	 * @param target New list to attach to.
+	 * @param new_list New list to attach to.
 	 */
-	void Retarget(ScriptList *new_list)
+	void Retarget(const ScriptList *new_list)
 	{
 		this->list = new_list;
 	}
@@ -100,18 +103,14 @@ public:
  */
 class ScriptListSorterValueAscending : public ScriptListSorter {
 private:
-	ScriptList::ScriptListSet::iterator value_iter; ///< The iterator over the value/item pairs in the set.
+	ScriptList::ScriptListSet::const_iterator value_iter; ///< The iterator over the value/item pairs in the set.
 
 public:
 	/**
 	 * Create a new sorter.
 	 * @param list The list to sort.
 	 */
-	ScriptListSorterValueAscending(ScriptList *list)
-	{
-		this->list = list;
-		this->End();
-	}
+	ScriptListSorterValueAscending(const ScriptList *list) : ScriptListSorter(list) {}
 
 	std::optional<SQInteger> Begin() override
 	{
@@ -149,18 +148,14 @@ private:
 	/* Note: We cannot use reverse_iterator.
 	 *       The iterators must only be invalidated when the element they are pointing to is removed.
 	 *       This only holds for forward iterators. */
-	ScriptList::ScriptListSet::iterator value_iter; ///< The iterator over the value/item pairs in the set.
+	ScriptList::ScriptListSet::const_iterator value_iter; ///< The iterator over the value/item pairs in the set.
 
 public:
 	/**
 	 * Create a new sorter.
 	 * @param list The list to sort.
 	 */
-	ScriptListSorterValueDescending(ScriptList *list)
-	{
-		this->list = list;
-		this->End();
-	}
+	ScriptListSorterValueDescending(const ScriptList *list) : ScriptListSorter(list) {}
 
 	std::optional<SQInteger> Begin() override
 	{
@@ -201,18 +196,14 @@ public:
  */
 class ScriptListSorterItemAscending : public ScriptListSorter {
 private:
-	ScriptList::ScriptListMap::iterator item_iter; ///< The iterator over the items in the map.
+	ScriptList::ScriptListMap::const_iterator item_iter; ///< The iterator over the items in the map.
 
 public:
 	/**
 	 * Create a new sorter.
 	 * @param list The list to sort.
 	 */
-	ScriptListSorterItemAscending(ScriptList *list)
-	{
-		this->list = list;
-		this->End();
-	}
+	ScriptListSorterItemAscending(const ScriptList *list) : ScriptListSorter(list) {}
 
 	std::optional<SQInteger> Begin() override
 	{
@@ -250,18 +241,14 @@ private:
 	/* Note: We cannot use reverse_iterator.
 	 *       The iterators must only be invalidated when the element they are pointing to is removed.
 	 *       This only holds for forward iterators. */
-	ScriptList::ScriptListMap::iterator item_iter; ///< The iterator over the items in the map.
+	ScriptList::ScriptListMap::const_iterator item_iter; ///< The iterator over the items in the map.
 
 public:
 	/**
 	 * Create a new sorter.
 	 * @param list The list to sort.
 	 */
-	ScriptListSorterItemDescending(ScriptList *list)
-	{
-		this->list = list;
-		this->End();
-	}
+	ScriptListSorterItemDescending(const ScriptList *list) : ScriptListSorter(list) {}
 
 	std::optional<SQInteger> Begin() override
 	{


### PR DESCRIPTION
## Motivation / Problem

The script's list sorters duplicate some code amongst the different implementation. Move these to the super class.

## Description

* Move functions in the sub classes that are identical to the super class.
* Add `const` where applicable.


## Limitations

None.

Well... there used to be a lot of template shenanigans, but that was significantly slower so I've removed those bits.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
