### PR TITLE
Include ScriptList contents in script memory allocation total

### DIFF
--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -30,6 +30,8 @@
  */
 
 struct ScriptAllocator {
+	friend class Squirrel;
+
 private:
 	std::allocator<uint8_t> allocator;
 	size_t allocated_size = 0; ///< Sum of allocated data size
@@ -813,4 +815,15 @@ bool Squirrel::CanSuspend()
 SQInteger Squirrel::GetOpsTillSuspend()
 {
 	return this->vm->_ops_till_suspend;
+}
+
+void Squirrel::IncreaseAllocatedSize(size_t bytes)
+{
+	_squirrel_allocator->CheckAllocationAllowed(bytes);
+	_squirrel_allocator->allocated_size += bytes;
+}
+
+void Squirrel::DecreaseAllocatedSize(size_t bytes)
+{
+	_squirrel_allocator->allocated_size -= bytes;
 }

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -291,6 +291,18 @@ public:
 	 * Get number of bytes allocated by this VM.
 	 */
 	size_t GetAllocatedMemory() const noexcept;
+
+	/**
+	 * Increase number of bytes allocated in the current script allocator scope.
+	 * @param bytes Number of bytes to increase.
+	 */
+	static void IncreaseAllocatedSize(size_t bytes);
+
+	/**
+	 * Decrease number of bytes allocated in the current script allocator scope.
+	 * @param bytes Number of bytes to decrease.
+	 */
+	static void DecreaseAllocatedSize(size_t bytes);
 };
 
 


### PR DESCRIPTION
## Motivation / Problem

The contents of ScriptList instances was not charged to the owning script's memory allocation total.
Scripts could fairly trivially consume arbitrarily large quantities of memory, causing performance issues, etc.

## Description

Charge a fixed number of bytes per item to the script memory allocation total.
64 bytes is less than the actual memory cost per item (on 64 bit builds) but is a reasonable amount to charge regardless of the actual overheads.

## Limitations

This does not charge any opcodes, that can be done separately.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
