### PR TITLE
Codechange: [Script] Make member functions that do not change state const

### DIFF
--- a/src/script/api/script_accounting.cpp
+++ b/src/script/api/script_accounting.cpp
@@ -12,7 +12,7 @@
 
 #include "../../safeguards.h"
 
-Money ScriptAccounting::GetCosts()
+Money ScriptAccounting::GetCosts() const
 {
 	return this->GetDoCommandCosts();
 }

--- a/src/script/api/script_accounting.hpp
+++ b/src/script/api/script_accounting.hpp
@@ -48,7 +48,7 @@ public:
 	 * @note when nesting ScriptAccounting instances all instances' GetCosts
 	 *   will always return the value of the 'top' instance.
 	 */
-	Money GetCosts();
+	Money GetCosts() const;
 
 	/**
 	 * Reset the costs to zero.

--- a/src/script/api/script_event.hpp
+++ b/src/script/api/script_event.hpp
@@ -75,7 +75,7 @@ public:
 	 * Get the event-type.
 	 * @return The @c ScriptEventType.
 	 */
-	ScriptEventType GetEventType() { return this->type; }
+	ScriptEventType GetEventType() const { return this->type; }
 
 protected:
 	/**

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -30,14 +30,14 @@ bool ScriptEventEnginePreview::IsEngineValid() const
 	return e != nullptr && e->IsEnabled();
 }
 
-std::optional<std::string> ScriptEventEnginePreview::GetName()
+std::optional<std::string> ScriptEventEnginePreview::GetName() const
 {
 	if (!this->IsEngineValid()) return std::nullopt;
 
 	return ::StrMakeValid(::GetString(STR_ENGINE_NAME, this->engine), {});
 }
 
-CargoType ScriptEventEnginePreview::GetCargoType()
+CargoType ScriptEventEnginePreview::GetCargoType() const
 {
 	if (!this->IsEngineValid()) return INVALID_CARGO;
 	CargoArray cap = ::GetCapacityOfArticulatedParts(this->engine);
@@ -48,7 +48,7 @@ CargoType ScriptEventEnginePreview::GetCargoType()
 	return CargoType(std::distance(std::cbegin(cap), it));
 }
 
-int32_t ScriptEventEnginePreview::GetCapacity()
+int32_t ScriptEventEnginePreview::GetCapacity() const
 {
 	if (!this->IsEngineValid()) return -1;
 	const Engine *e = ::Engine::Get(this->engine);
@@ -70,7 +70,7 @@ int32_t ScriptEventEnginePreview::GetCapacity()
 	}
 }
 
-int32_t ScriptEventEnginePreview::GetMaxSpeed()
+int32_t ScriptEventEnginePreview::GetMaxSpeed() const
 {
 	if (!this->IsEngineValid()) return -1;
 	const Engine *e = ::Engine::Get(this->engine);
@@ -79,19 +79,19 @@ int32_t ScriptEventEnginePreview::GetMaxSpeed()
 	return max_speed;
 }
 
-Money ScriptEventEnginePreview::GetPrice()
+Money ScriptEventEnginePreview::GetPrice() const
 {
 	if (!this->IsEngineValid()) return -1;
 	return ::Engine::Get(this->engine)->GetCost();
 }
 
-Money ScriptEventEnginePreview::GetRunningCost()
+Money ScriptEventEnginePreview::GetRunningCost() const
 {
 	if (!this->IsEngineValid()) return -1;
 	return ::Engine::Get(this->engine)->GetRunningCost();
 }
 
-int32_t ScriptEventEnginePreview::GetVehicleType()
+int32_t ScriptEventEnginePreview::GetVehicleType() const
 {
 	if (!this->IsEngineValid()) return ScriptVehicle::VT_INVALID;
 	switch (::Engine::Get(this->engine)->type) {
@@ -183,7 +183,7 @@ static bool ScriptEventAdminPortReadValue(HSQUIRRELVM vm, nlohmann::json &json)
 	return true;
 }
 
-SQInteger ScriptEventAdminPort::GetObject(HSQUIRRELVM vm)
+SQInteger ScriptEventAdminPort::GetObject(HSQUIRRELVM vm) const
 {
 	auto json = nlohmann::json::parse(this->json, nullptr, false);
 

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -68,31 +68,31 @@ public:
 	 * Get the VehicleID of the crashed vehicle.
 	 * @return The crashed vehicle.
 	 */
-	VehicleID GetVehicleID() { return this->vehicle; }
+	VehicleID GetVehicleID() const { return this->vehicle; }
 
 	/**
 	 * Find the tile the vehicle crashed.
 	 * @return The crash site.
 	 */
-	TileIndex GetCrashSite() { return this->crash_site; }
+	TileIndex GetCrashSite() const { return this->crash_site; }
 
 	/**
 	 * Get the reason for crashing
 	 * @return The reason for crashing
 	 */
-	CrashReason GetCrashReason() { return this->crash_reason; }
+	CrashReason GetCrashReason() const { return this->crash_reason; }
 
 	/**
 	 * Get the number of victims
 	 * @return The number of victims
 	 */
-	SQInteger GetVictims() { return this->victims; }
+	SQInteger GetVictims() const { return this->victims; }
 
 	/**
 	 * Get the CompanyID of the company owning the vehicle
 	 * @return The company owning the vehicle
 	 */
-	ScriptCompany::CompanyID GetVehicleOwner() { return this->company; }
+	ScriptCompany::CompanyID GetVehicleOwner() const { return this->company; }
 
 private:
 	TileIndex crash_site;     ///< The location of the crash.
@@ -129,7 +129,7 @@ public:
 	 * Get the SubsidyID of the subsidy.
 	 * @return The subsidy id.
 	 */
-	SubsidyID GetSubsidyID() { return this->subsidy_id; }
+	SubsidyID GetSubsidyID() const { return this->subsidy_id; }
 
 private:
 	SubsidyID subsidy_id; ///< The subsidy that got offered.
@@ -162,7 +162,7 @@ public:
 	 * Get the SubsidyID of the subsidy.
 	 * @return The subsidy id.
 	 */
-	SubsidyID GetSubsidyID() { return this->subsidy_id; }
+	SubsidyID GetSubsidyID() const { return this->subsidy_id; }
 
 private:
 	SubsidyID subsidy_id; ///< The subsidy offer that expired.
@@ -195,7 +195,7 @@ public:
 	 * Get the SubsidyID of the subsidy.
 	 * @return The subsidy id.
 	 */
-	SubsidyID GetSubsidyID() { return this->subsidy_id; }
+	SubsidyID GetSubsidyID() const { return this->subsidy_id; }
 
 private:
 	SubsidyID subsidy_id; ///< The subsidy that was awarded.
@@ -228,7 +228,7 @@ public:
 	 * Get the SubsidyID of the subsidy.
 	 * @return The subsidy id.
 	 */
-	 SubsidyID GetSubsidyID() { return this->subsidy_id; }
+	 SubsidyID GetSubsidyID() const { return this->subsidy_id; }
 
 private:
 	SubsidyID subsidy_id; ///< The subsidy that expired.
@@ -263,21 +263,21 @@ public:
 	 * Get the name of the offered engine.
 	 * @return The name the engine has.
 	 */
-	std::optional<std::string> GetName();
+	std::optional<std::string> GetName() const;
 
 	/**
 	 * Get the cargo-type of the offered engine. In case it can transport multiple cargoes, it
 	 *  returns the first/main.
 	 * @return The cargo-type of the engine.
 	 */
-	CargoType GetCargoType();
+	CargoType GetCargoType() const;
 
 	/**
 	 * Get the capacity of the offered engine. In case it can transport multiple cargoes, it
 	 *  returns the first/main.
 	 * @return The capacity of the engine.
 	 */
-	int32_t GetCapacity();
+	int32_t GetCapacity() const;
 
 	/**
 	 * Get the maximum speed of the offered engine.
@@ -286,29 +286,29 @@ public:
 	 *       This is mph / 1.6, which is roughly km/h.
 	 *       To get km/h multiply this number by 1.00584.
 	 */
-	int32_t GetMaxSpeed();
+	int32_t GetMaxSpeed() const;
 
 	/**
 	 * Get the new cost of the offered engine.
 	 * @return The new cost the engine has.
 	 */
-	Money GetPrice();
+	Money GetPrice() const;
 
 	/**
 	 * Get the running cost of the offered engine.
 	 * @return The running cost of the vehicle per economy-year.
 	 * @see \ref ScriptEconomyTime
 	 */
-	Money GetRunningCost();
+	Money GetRunningCost() const;
 
 	/**
 	 * Get the type of the offered engine.
 	 * @return The type the engine has.
 	 */
 #ifdef DOXYGEN_API
-	ScriptVehicle::VehicleType GetVehicleType();
+	ScriptVehicle::VehicleType GetVehicleType() const;
 #else
-	int32_t GetVehicleType();
+	int32_t GetVehicleType() const;
 #endif /* DOXYGEN_API */
 
 	/**
@@ -355,7 +355,7 @@ public:
 	 * Get the CompanyID of the company that has been created.
 	 * @return The CompanyID of the company.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->owner; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->owner; }
 
 private:
 	ScriptCompany::CompanyID owner; ///< The new company.
@@ -389,13 +389,13 @@ public:
 	 * Get the CompanyID of the company that has been renamed.
 	 * @return The CompanyID of the company.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->company; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->company; }
 
 	/**
 	 * Get the new name of the company.
 	 * @return The new name of the company.
 	 */
-	std::optional<std::string> GetNewName() { return this->new_name; }
+	std::optional<std::string> GetNewName() const { return this->new_name; }
 
 private:
 
@@ -431,7 +431,7 @@ public:
 	 * Get the CompanyID of the company that is in trouble.
 	 * @return The CompanyID of the company in trouble.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->owner; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->owner; }
 
 private:
 	ScriptCompany::CompanyID owner; ///< The company that is in trouble.
@@ -467,13 +467,13 @@ public:
 	 * @return The CompanyID of the company that can be bought.
 	 * @note If the company is bought this will become invalid.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->owner; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->owner; }
 
 	/**
 	 * Get the value of the new company.
 	 * @return The value of the new company.
 	 */
-	Money GetValue() { return this->value; }
+	Money GetValue() const { return this->value; }
 
 	/**
 	 * Take over the company for this merger.
@@ -520,13 +520,13 @@ public:
 	 *  ScriptCompany::ResolveCompanyID will return COMPANY_COMPANY. It's
 	 *  only useful if you're keeping track of company's yourself.
 	 */
-	ScriptCompany::CompanyID GetOldCompanyID() { return this->old_owner; }
+	ScriptCompany::CompanyID GetOldCompanyID() const { return this->old_owner; }
 
 	/**
 	 * Get the CompanyID of the new owner.
 	 * @return The CompanyID of the new owner.
 	 */
-	ScriptCompany::CompanyID GetNewCompanyID() { return this->new_owner; }
+	ScriptCompany::CompanyID GetNewCompanyID() const { return this->new_owner; }
 
 private:
 	ScriptCompany::CompanyID old_owner; ///< The company that ended to exist.
@@ -560,7 +560,7 @@ public:
 	 * Get the CompanyID of the company that has gone bankrupt.
 	 * @return The CompanyID of the company that has gone bankrupt.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->owner; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->owner; }
 
 private:
 	ScriptCompany::CompanyID owner; ///< The company that has gone bankrupt.
@@ -593,7 +593,7 @@ public:
 	 * Get the VehicleID of the vehicle that is lost.
 	 * @return The VehicleID of the vehicle that is lost.
 	 */
-	VehicleID GetVehicleID() { return this->vehicle_id; }
+	VehicleID GetVehicleID() const { return this->vehicle_id; }
 
 private:
 	VehicleID vehicle_id; ///< The vehicle that is lost.
@@ -626,7 +626,7 @@ public:
 	 * Get the VehicleID of the vehicle that is waiting in a depot.
 	 * @return The VehicleID of the vehicle that is waiting in a depot.
 	 */
-	VehicleID GetVehicleID() { return this->vehicle_id; }
+	VehicleID GetVehicleID() const { return this->vehicle_id; }
 
 private:
 	VehicleID vehicle_id; ///< The vehicle that is waiting in the depot.
@@ -659,7 +659,7 @@ public:
 	 * Get the VehicleID of the vehicle that lost money.
 	 * @return The VehicleID of the vehicle that lost money.
 	 */
-	VehicleID GetVehicleID() { return this->vehicle_id; }
+	VehicleID GetVehicleID() const { return this->vehicle_id; }
 
 private:
 	VehicleID vehicle_id; ///< The vehicle that is unprofitable.
@@ -692,7 +692,7 @@ public:
 	 * Get the IndustryID of the new industry.
 	 * @return The IndustryID of the industry.
 	 */
-	IndustryID GetIndustryID() { return this->industry_id; }
+	IndustryID GetIndustryID() const { return this->industry_id; }
 
 private:
 	IndustryID industry_id; ///< The industry that opened.
@@ -725,7 +725,7 @@ public:
 	 * Get the IndustryID of the closing industry.
 	 * @return The IndustryID of the industry.
 	 */
-	IndustryID GetIndustryID() { return this->industry_id; }
+	IndustryID GetIndustryID() const { return this->industry_id; }
 
 private:
 	IndustryID industry_id; ///< The industry that closed.
@@ -758,7 +758,7 @@ public:
 	 * Get the EngineID of the new engine.
 	 * @return The EngineID of the new engine.
 	 */
-	EngineID GetEngineID() { return this->engine; }
+	EngineID GetEngineID() const { return this->engine; }
 
 private:
 	EngineID engine; ///< The engine that became available.
@@ -793,13 +793,13 @@ public:
 	 * Get the StationID of the visited station.
 	 * @return The StationID of the visited station.
 	 */
-	StationID GetStationID() { return this->station; }
+	StationID GetStationID() const { return this->station; }
 
 	/**
 	 * Get the VehicleID of the first vehicle.
 	 * @return The VehicleID of the first vehicle.
 	 */
-	VehicleID GetVehicleID() { return this->vehicle; }
+	VehicleID GetVehicleID() const { return this->vehicle; }
 
 private:
 	StationID station; ///< The station the vehicle arrived at.
@@ -833,7 +833,7 @@ public:
 	 * Get the StationID of the station containing the affected airport.
 	 * @return The StationID of the station containing the affected airport.
 	 */
-	StationID GetStationID() { return this->station; }
+	StationID GetStationID() const { return this->station; }
 
 private:
 	StationID station; ///< The station the zeppeliner crashed.
@@ -866,7 +866,7 @@ public:
 	 * Get the StationID of the station containing the affected airport.
 	 * @return The StationID of the station containing the affected airport.
 	 */
-	StationID GetStationID() { return this->station; }
+	StationID GetStationID() const { return this->station; }
 
 private:
 	StationID station; ///< The station the zeppeliner crashed.
@@ -899,7 +899,7 @@ public:
 	 * Get the TownID of the town.
 	 * @return The TownID of the town that was created.
 	 */
-	TownID GetTownID() { return this->town; }
+	TownID GetTownID() const { return this->town; }
 
 private:
 	TownID town; ///< The town that got founded.
@@ -934,7 +934,7 @@ public:
 	 * Get the VehicleID of the aircraft whose destination is too far away.
 	 * @return The VehicleID of the aircraft whose destination is too far away.
 	 */
-	VehicleID GetVehicleID() { return this->vehicle_id; }
+	VehicleID GetVehicleID() const { return this->vehicle_id; }
 
 private:
 	VehicleID vehicle_id; ///< The vehicle aircraft whose destination is too far away.
@@ -964,13 +964,13 @@ public:
 	/**
 	 * The GetObject() wrapper from Squirrel.
 	 */
-	SQInteger GetObject(HSQUIRRELVM vm);
+	SQInteger GetObject(HSQUIRRELVM vm) const;
 #else
 	/**
 	 * Get the information that was sent to you back as Squirrel object.
 	 * @return The object.
 	 */
-	SQObject GetObject();
+	SQObject GetObject() const;
 #endif /* DOXYGEN_API */
 
 
@@ -1009,19 +1009,19 @@ public:
 	 * Get the class of the window that was clicked.
 	 * @return The clicked window class.
 	 */
-	ScriptWindow::WindowClass GetWindowClass() { return this->window; }
+	ScriptWindow::WindowClass GetWindowClass() const { return this->window; }
 
 	/**
 	 * Get the number of the window that was clicked.
 	 * @return The clicked identifying number of the widget within the class.
 	 */
-	uint32_t GetWindowNumber() { return this->number; }
+	uint32_t GetWindowNumber() const { return this->number; }
 
 	/**
 	 * Get the number of the widget that was clicked.
 	 * @return The number of the clicked widget.
 	 */
-	int GetWidgetNumber() { return this->widget; }
+	int GetWidgetNumber() const { return this->widget; }
 
 private:
 	ScriptWindow::WindowClass window; ///< Window of the click.
@@ -1062,19 +1062,19 @@ public:
 	 * Get the unique id of the question.
 	 * @return The unique id.
 	 */
-	uint16_t GetUniqueID() { return this->uniqueid; }
+	uint16_t GetUniqueID() const { return this->uniqueid; }
 
 	/**
 	 * Get the company that pressed a button.
 	 * @return The company.
 	 */
-	ScriptCompany::CompanyID GetCompany() { return this->company; }
+	ScriptCompany::CompanyID GetCompany() const { return this->company; }
 
 	/**
 	 * Get the button that got pressed.
 	 * @return The button.
 	 */
-	ScriptGoal::QuestionButton GetButton() { return this->button; }
+	ScriptGoal::QuestionButton GetButton() const { return this->button; }
 
 private:
 	uint16_t uniqueid;                   ///< The uniqueid of the question.
@@ -1112,13 +1112,13 @@ public:
 	 * Get the CompanyID of the company.
 	 * @return The CompanyID of the company involved into the event.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->company; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->company; }
 
 	/**
 	 * Get the TownID of the town.
 	 * @return The TownID of the town involved into the event.
 	 */
-	TownID GetTownID() { return this->town; }
+	TownID GetTownID() const { return this->town; }
 
 private:
 	ScriptCompany::CompanyID company; ///< The company involved into the event.
@@ -1204,13 +1204,13 @@ public:
 	 * Get the VehicleID of the vehicle that has been replaced.
 	 * @return The VehicleID of the vehicle that has been replaced. This ID is no longer valid for referencing the vehicle.
 	 */
-	VehicleID GetOldVehicleID() { return this->old_id; }
+	VehicleID GetOldVehicleID() const { return this->old_id; }
 
 	/**
 	 * Get the VehicleID of the vehicle that has been created in replacement.
 	 * @return The VehicleID of the vehicle that has been created in replacement.
 	 */
-	VehicleID GetNewVehicleID() { return this->new_id; }
+	VehicleID GetNewVehicleID() const { return this->new_id; }
 
 private:
 	VehicleID old_id; ///< The vehicle that has been replaced.
@@ -1248,19 +1248,19 @@ public:
 	 * Get the CompanyID of the player that selected a tile.
 	 * @return The ID of the company.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->company_id; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->company_id; }
 
 	/**
 	 * Get the StoryPageID of the storybook page the clicked button is located on.
 	 * @return The ID of the page in the story book the click was on.
 	 */
-	StoryPageID GetStoryPageID() { return this->page_id; }
+	StoryPageID GetStoryPageID() const { return this->page_id; }
 
 	/**
 	 * Get the StoryPageElementID of the button element that was clicked.
 	 * @return The ID of the element that was clicked.
 	 */
-	StoryPageElementID GetElementID() { return this->element_id; }
+	StoryPageElementID GetElementID() const { return this->element_id; }
 
 private:
 	ScriptCompany::CompanyID company_id;
@@ -1301,25 +1301,25 @@ public:
 	 * Get the CompanyID of the player that selected a tile.
 	 * @return The company that selected the tile.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->company_id; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->company_id; }
 
 	/**
 	 * Get the StoryPageID of the storybook page the used selection button is located on.
 	 * @return The ID of the story page selection was done from.
 	 */
-	StoryPageID GetStoryPageID() { return this->page_id; }
+	StoryPageID GetStoryPageID() const { return this->page_id; }
 
 	/**
 	 * Get the StoryPageElementID of the selection button used to select the tile.
 	 * @return The ID of the element that was used to select the tile.
 	 */
-	StoryPageElementID GetElementID() { return this->element_id; }
+	StoryPageElementID GetElementID() const { return this->element_id; }
 
 	/**
 	 * Get the TileIndex of the tile the player selected.
 	 * @return The selected tile.
 	 */
-	TileIndex GetTile() { return this->tile_index; }
+	TileIndex GetTile() const { return this->tile_index; }
 
 private:
 	ScriptCompany::CompanyID company_id;
@@ -1361,25 +1361,25 @@ public:
 	 * Get the CompanyID of the player that selected a tile.
 	 * @return The company's ID.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->company_id; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->company_id; }
 
 	/**
 	 * Get the StoryPageID of the storybook page the used selection button is located on.
 	 * @return The ID of the storybook page the selected element is on.
 	 */
-	StoryPageID GetStoryPageID() { return this->page_id; }
+	StoryPageID GetStoryPageID() const { return this->page_id; }
 
 	/**
 	 * Get the StoryPageElementID of the selection button used to select the vehicle.
 	 * @return The ID of the selected element of the story page.
 	 */
-	StoryPageElementID GetElementID() { return this->element_id; }
+	StoryPageElementID GetElementID() const { return this->element_id; }
 
 	/**
 	 * Get the VehicleID of the vehicle the player selected.
 	 * @return The ID of the vehicle.
 	 */
-	VehicleID GetVehicleID() { return this->vehicle_id; }
+	VehicleID GetVehicleID() const { return this->vehicle_id; }
 
 private:
 	ScriptCompany::CompanyID company_id;
@@ -1419,13 +1419,13 @@ public:
 	 * Get the CompanyID of the company that got its president renamed.
 	 * @return The CompanyID of the company.
 	 */
-	ScriptCompany::CompanyID GetCompanyID() { return this->company; }
+	ScriptCompany::CompanyID GetCompanyID() const { return this->company; }
 
 	/**
 	 * Get the new name of the president.
 	 * @return The new name of the president.
 	 */
-	std::optional<std::string> GetNewName() { return this->new_name; }
+	std::optional<std::string> GetNewName() const { return this->new_name; }
 
 private:
 	ScriptCompany::CompanyID company; ///< The company of the renamed president.

--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -390,7 +390,7 @@ public:
 
 
 
-bool ScriptList::SaveObject(HSQUIRRELVM vm)
+bool ScriptList::SaveObject(HSQUIRRELVM vm) const
 {
 	sq_pushstring(vm, "List");
 	sq_newarray(vm, 0);
@@ -440,7 +440,7 @@ bool ScriptList::LoadObject(HSQUIRRELVM vm)
 	return true;
 }
 
-ScriptObject *ScriptList::CloneObject()
+ScriptObject *ScriptList::CloneObject() const
 {
 	ScriptList *clone = new ScriptList();
 	clone->CopyList(this);
@@ -468,7 +468,7 @@ ScriptList::~ScriptList()
 {
 }
 
-bool ScriptList::HasItem(SQInteger item)
+bool ScriptList::HasItem(SQInteger item) const
 {
 	return this->items.count(item) == 1;
 }
@@ -523,12 +523,12 @@ SQInteger ScriptList::Next()
 	return this->sorter->Next().value_or(0);
 }
 
-bool ScriptList::IsEmpty()
+bool ScriptList::IsEmpty() const
 {
 	return this->items.empty();
 }
 
-bool ScriptList::IsEnd()
+bool ScriptList::IsEnd() const
 {
 	if (!this->initialized) {
 		Debug(script, 0, "IsEnd() is invalid as Begin() is never called");
@@ -537,12 +537,12 @@ bool ScriptList::IsEnd()
 	return this->sorter->IsEnd();
 }
 
-SQInteger ScriptList::Count()
+SQInteger ScriptList::Count() const
 {
 	return this->items.size();
 }
 
-SQInteger ScriptList::GetValue(SQInteger item)
+SQInteger ScriptList::GetValue(SQInteger item) const
 {
 	auto item_iter = this->items.find(item);
 	return item_iter == this->items.end() ? 0 : item_iter->second;
@@ -758,7 +758,7 @@ void ScriptList::KeepList(ScriptList *list)
 	this->RemoveItems([&](const SQInteger &k, const SQInteger &) { return !list->HasItem(k); });
 }
 
-SQInteger ScriptList::_get(HSQUIRRELVM vm)
+SQInteger ScriptList::_get(HSQUIRRELVM vm) const
 {
 	if (sq_gettype(vm, 2) != OT_INTEGER) return SQ_ERROR;
 

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -144,9 +144,9 @@ protected:
 		ScriptList::FillList<T>(vm, list, [](const T *) { return true; });
 	}
 
-	virtual bool SaveObject(HSQUIRRELVM vm) override;
+	virtual bool SaveObject(HSQUIRRELVM vm) const override;
 	virtual bool LoadObject(HSQUIRRELVM vm) override;
-	virtual ScriptObject *CloneObject() override;
+	virtual ScriptObject *CloneObject() const override;
 
 	/**
 	 * Copy the content of a list.
@@ -202,7 +202,7 @@ public:
 	 * @param item the item to check for.
 	 * @return true if the item is in the list.
 	 */
-	bool HasItem(SQInteger item);
+	bool HasItem(SQInteger item) const;
 
 	/**
 	 * Go to the beginning of the list and return the item. To get the value use list.GetValue(list.Begin()).
@@ -222,27 +222,27 @@ public:
 	 * Check if a list is empty.
 	 * @return true if the list is empty.
 	 */
-	bool IsEmpty();
+	bool IsEmpty() const;
 
 	/**
 	 * Check if there is a element left. In other words, if this is false,
 	 * the last call to Begin() or Next() returned a valid item.
 	 * @return true if the current item is beyond end-of-list.
 	 */
-	bool IsEnd();
+	bool IsEnd() const;
 
 	/**
 	 * Returns the amount of items in the list.
 	 * @return amount of items in the list.
 	 */
-	SQInteger Count();
+	SQInteger Count() const;
 
 	/**
 	 * Get the value that belongs to this item.
 	 * @param item the item to get the value from
 	 * @return the value that belongs to this item.
 	 */
-	SQInteger GetValue(SQInteger item);
+	SQInteger GetValue(SQInteger item) const;
 
 	/**
 	 * Set a value of an item directly.
@@ -371,7 +371,7 @@ public:
 	/**
 	 * Used for 'foreach()' and [] get from Squirrel.
 	 */
-	SQInteger _get(HSQUIRRELVM vm);
+	SQInteger _get(HSQUIRRELVM vm) const;
 
 	/**
 	 * Used for [] set from Squirrel.

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -96,7 +96,7 @@ protected:
 	 *  - the data for the object (any supported types)
 	 * @return True iff saving this type is supported.
 	 */
-	virtual bool SaveObject(HSQUIRRELVM) { return false; }
+	virtual bool SaveObject(HSQUIRRELVM) const { return false; }
 
 	/**
 	 * Load this object.
@@ -109,7 +109,7 @@ protected:
 	 * Clone an object.
 	 * @return The clone if cloning this type is supported, nullptr otherwise.
 	 */
-	virtual ScriptObject *CloneObject() { return nullptr; }
+	virtual ScriptObject *CloneObject() const { return nullptr; }
 
 public:
 	/**

--- a/src/script/api/script_priorityqueue.cpp
+++ b/src/script/api/script_priorityqueue.cpp
@@ -66,7 +66,7 @@ SQInteger ScriptPriorityQueue::Pop(HSQUIRRELVM vm)
 	return ret;
 }
 
-SQInteger ScriptPriorityQueue::Peek(HSQUIRRELVM vm)
+SQInteger ScriptPriorityQueue::Peek(HSQUIRRELVM vm) const
 {
 	if (this->IsEmpty()) {
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_FAILED);
@@ -77,7 +77,7 @@ SQInteger ScriptPriorityQueue::Peek(HSQUIRRELVM vm)
 	return SQConvert::Return<HSQOBJECT>::Set(vm, this->queue.front().second);
 }
 
-SQInteger ScriptPriorityQueue::Exists(HSQUIRRELVM vm)
+SQInteger ScriptPriorityQueue::Exists(HSQUIRRELVM vm) const
 {
 	HSQOBJECT item;
 	sq_resetobject(&item);
@@ -95,12 +95,12 @@ SQInteger ScriptPriorityQueue::Clear(HSQUIRRELVM vm)
 	return 0;
 }
 
-bool ScriptPriorityQueue::IsEmpty()
+bool ScriptPriorityQueue::IsEmpty() const
 {
 	return this->queue.empty();
 }
 
-SQInteger ScriptPriorityQueue::Count()
+SQInteger ScriptPriorityQueue::Count() const
 {
 	return (SQInteger)this->queue.size();
 }

--- a/src/script/api/script_priorityqueue.hpp
+++ b/src/script/api/script_priorityqueue.hpp
@@ -73,8 +73,8 @@ public:
 #else
 	SQInteger Insert(HSQUIRRELVM vm);
 	SQInteger Pop(HSQUIRRELVM vm);
-	SQInteger Peek(HSQUIRRELVM vm);
-	SQInteger Exists(HSQUIRRELVM vm);
+	SQInteger Peek(HSQUIRRELVM vm) const;
+	SQInteger Exists(HSQUIRRELVM vm) const;
 	SQInteger Clear(HSQUIRRELVM vm);
 #endif /* DOXYGEN_API */
 
@@ -82,13 +82,13 @@ public:
 	 * Check if the queue is empty.
 	 * @return true if the queue is empty.
 	 */
-	bool IsEmpty();
+	bool IsEmpty() const;
 
 	/**
 	 * Returns the amount of items in the queue.
 	 * @return amount of items in the queue.
 	 */
-	SQInteger Count();
+	SQInteger Count() const;
 };
 
 #endif /* SCRIPT_PRIORITYQUEUE_HPP */

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -21,7 +21,7 @@
 
 #include "../../safeguards.h"
 
-EncodedString RawText::GetEncodedText()
+EncodedString RawText::GetEncodedText() const
 {
 	return ::GetEncodedString(STR_JUST_RAW_STRING, this->text);
 }
@@ -184,7 +184,7 @@ void ScriptText::SetPadParameterCount(HSQUIRRELVM vm)
 	sq_settop(vm, top);
 }
 
-EncodedString ScriptText::GetEncodedText()
+EncodedString ScriptText::GetEncodedText() const
 {
 	ScriptTextList seen_texts;
 	ParamList params;
@@ -196,12 +196,12 @@ EncodedString ScriptText::GetEncodedText()
 	return ::EncodedString{std::move(result)};
 }
 
-void ScriptText::_FillParamList(ParamList &params, ScriptTextList &seen_texts)
+void ScriptText::_FillParamList(ParamList &params, ScriptTextList &seen_texts) const
 {
 	if (std::ranges::find(seen_texts, this) != seen_texts.end()) throw Script_FatalError(fmt::format("{}: Circular reference detected", GetGameStringName(this->string)));
 	seen_texts.push_back(this);
 
-	for (int idx = 0; Param &p : this->param) {
+	for (int idx = 0; const Param &p : this->param) {
 		params.emplace_back(this->string, idx, &p);
 		++idx;
 		if (!std::holds_alternative<ScriptTextRef>(p)) continue;
@@ -255,7 +255,7 @@ void ScriptText::ParamCheck::Encode(StringBuilder &builder, std::string_view cmd
 	this->used = true;
 }
 
-void ScriptText::_GetEncodedText(StringBuilder &builder, int &param_count, ParamSpan args, bool first)
+void ScriptText::_GetEncodedText(StringBuilder &builder, int &param_count, ParamSpan args, bool first) const
 {
 	const std::string &name = GetGameStringName(this->string);
 
@@ -302,7 +302,7 @@ void ScriptText::_GetEncodedText(StringBuilder &builder, int &param_count, Param
 						continue;
 					}
 					int count = 0;
-					ScriptTextRef &ref = std::get<ScriptTextRef>(*p.param);
+					const ScriptTextRef &ref = std::get<ScriptTextRef>(*p.param);
 					ref->_GetEncodedText(builder, count, args.subspan(idx), false);
 					if (++count != cur_param.consumes) {
 						ScriptLog::Warning(fmt::format("{}({}): {{{}}} expects {} to be consumed, but {} consumes {}", name, param_count + 1, cur_param.cmd, cur_param.consumes - 1, GetGameStringName(ref->string), count - 1));
@@ -332,7 +332,7 @@ void ScriptText::_GetEncodedText(StringBuilder &builder, int &param_count, Param
 	}
 }
 
-const std::string Text::GetDecodedText()
+std::string Text::GetDecodedText() const
 {
 	return this->GetEncodedText().GetDecodedString();
 }

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -27,14 +27,14 @@ public:
 	 * @return A string.
 	 * @api -all
 	 */
-	virtual EncodedString GetEncodedText() = 0;
+	virtual EncodedString GetEncodedText() const = 0;
 
 	/**
 	 * Convert a #ScriptText into a decoded normal string.
 	 * @return A string.
 	 * @api -all
 	 */
-	const std::string GetDecodedText();
+	std::string GetDecodedText() const;
 };
 
 /**
@@ -45,7 +45,7 @@ class RawText : public Text {
 public:
 	RawText(const std::string &text) : text(text) {}
 
-	EncodedString GetEncodedText() override;
+	EncodedString GetEncodedText() const override;
 private:
 	const std::string text;
 };
@@ -124,7 +124,7 @@ public:
 	/**
 	 * @api -all
 	 */
-	EncodedString GetEncodedText() override;
+	EncodedString GetEncodedText() const override;
 
 	/**
 	 * @api -all
@@ -133,17 +133,17 @@ public:
 
 private:
 	using ScriptTextRef = ScriptObjectRef<ScriptText>;
-	using ScriptTextList = std::vector<ScriptText *>;
+	using ScriptTextList = std::vector<const ScriptText *>;
 	using Param = std::variant<std::monostate, SQInteger, std::string, ScriptTextRef>;
 
 	struct ParamCheck {
 		StringIndexInTab owner;
 		int idx;
-		Param *param;
+		const Param *param;
 		bool used = false;
 		std::string_view cmd;
 
-		ParamCheck(StringIndexInTab owner, int idx, Param *param) : owner(owner), idx(idx), param(param) {}
+		ParamCheck(StringIndexInTab owner, int idx, const Param *param) : owner(owner), idx(idx), param(param) {}
 
 		void Encode(StringBuilder &output, std::string_view cmd);
 	};
@@ -163,7 +163,7 @@ private:
 	 * @param params The list of parameters to fill.
 	 * @param seen_texts The list of seen ScriptText.
 	 */
-	void _FillParamList(ParamList &params, ScriptTextList &seen_texts);
+	void _FillParamList(ParamList &params, ScriptTextList &seen_texts) const;
 
 	/**
 	 * Internal function for recursive calling this function over multiple
@@ -173,7 +173,7 @@ private:
 	 * @param args The parameters to be consumed.
 	 * @param first Whether it's the first call in the recursion.
 	 */
-	void _GetEncodedText(StringBuilder &output, int &param_count, ParamSpan args, bool first);
+	void _GetEncodedText(StringBuilder &output, int &param_count, ParamSpan args, bool first) const;
 
 	/**
 	 * Set a parameter, where the value is the first item on the stack.

--- a/src/script/api/script_tilelist.cpp
+++ b/src/script/api/script_tilelist.cpp
@@ -15,7 +15,7 @@
 
 #include "../../safeguards.h"
 
-bool ScriptTileList::SaveObject(HSQUIRRELVM vm)
+bool ScriptTileList::SaveObject(HSQUIRRELVM vm) const
 {
 	sq_pushstring(vm, "TileList");
 	if (!ScriptList::SaveObject(vm)) return false;
@@ -23,7 +23,7 @@ bool ScriptTileList::SaveObject(HSQUIRRELVM vm)
 	return true;
 }
 
-ScriptObject *ScriptTileList::CloneObject()
+ScriptObject *ScriptTileList::CloneObject() const
 {
 	ScriptTileList *clone = new ScriptTileList();
 	clone->CopyList(this);

--- a/src/script/api/script_tilelist.hpp
+++ b/src/script/api/script_tilelist.hpp
@@ -21,8 +21,8 @@
  */
 class ScriptTileList : public ScriptList {
 protected:
-	virtual bool SaveObject(HSQUIRRELVM) override;
-	virtual ScriptObject *CloneObject() override;
+	virtual bool SaveObject(HSQUIRRELVM) const override;
+	virtual ScriptObject *CloneObject() const override;
 public:
 	/**
 	 * Adds the rectangle between tile_from and tile_to to the to-be-evaluated tiles.

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -182,7 +182,7 @@ namespace SQConvert {
 	 */
 	template <class Tcls, typename Tretval, typename... Targs>
 	struct HelperT<Tretval(Tcls:: *)(Targs...)> {
-		static int SQCall(Tcls *instance, Tretval(Tcls:: *func)(Targs...), HSQUIRRELVM vm)
+		static int SQCall(Tcls *instance, auto func, HSQUIRRELVM vm)
 		{
 			return SQCall(instance, func, vm, std::index_sequence_for<Targs...>{});
 		}
@@ -194,7 +194,7 @@ namespace SQConvert {
 
 	private:
 		template <size_t... i>
-		static int SQCall(Tcls *instance, Tretval(Tcls:: *func)(Targs...), [[maybe_unused]] HSQUIRRELVM vm, std::index_sequence<i...>)
+		static int SQCall(Tcls *instance, auto func, [[maybe_unused]] HSQUIRRELVM vm, std::index_sequence<i...>)
 		{
 			if constexpr (std::is_void_v<Tretval>) {
 				(instance->*func)(
@@ -219,6 +219,12 @@ namespace SQConvert {
 			return inst;
 		}
 	};
+
+	/**
+	 * The real C++ caller for const methods.
+	 */
+	template <class Tcls, typename Tretval, typename... Targs>
+	struct HelperT<Tretval(Tcls:: *)(Targs...) const> : HelperT<Tretval(Tcls:: *)(Targs...)> {};
 
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

We should make class member functions `const` that don't change their state. It shows the intent that things are not going to be changed.


## Description

Add a `const` to member functions of the script API, and update the Squirrel helper to support them.


## Limitations

There's probably a lot outside of the script API, and there are parameters that should get a `const` treatment. But this is already big enough for a single PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
