### PR TITLE
Fix: Company query popups do not update in multiplayer.

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -1206,6 +1206,8 @@ CommandCost CmdRenameCompany(DoCommandFlags flags, const std::string &text)
 		} else {
 			c->name = text;
 		}
+
+		InvalidateWindowClassesData(WC_COMPANY, WID_C_COMPANY_NAME);
 		MarkWholeScreenDirty();
 		CompanyAdminUpdate(c);
 
@@ -1259,7 +1261,7 @@ CommandCost CmdRenamePresident(DoCommandFlags flags, const std::string &text)
 			}
 		}
 
-		InvalidateWindowClassesData(WC_COMPANY, 1);
+		InvalidateWindowClassesData(WC_COMPANY, WID_C_PRESIDENT_NAME);
 		MarkWholeScreenDirty();
 		CompanyAdminUpdate(c);
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1070,6 +1070,16 @@ void ShowQueryString(std::string_view str, StringID caption, uint maxsize, Windo
 }
 
 /**
+ * Updates default text value of query strign window.
+ * @param str String for the default text shown in the textbox.
+ */
+void UpdateQueryStringDefault(std::string_view str)
+{
+	QueryStringWindow *w = dynamic_cast<QueryStringWindow *>(FindWindowByClass(WC_QUERY_STRING));
+	if (w != nullptr) w->editbox.orig = str;
+}
+
+/**
  * Window used for asking the user a YES/NO question.
  */
 struct QueryWindow : public Window {

--- a/src/textbuf_gui.h
+++ b/src/textbuf_gui.h
@@ -28,6 +28,7 @@ using QueryStringFlags = EnumBitSet<QueryStringFlag, uint8_t>;
 typedef void QueryCallbackProc(Window*, bool);
 
 void ShowQueryString(std::string_view str, StringID caption, uint max_len, Window *parent, CharSetFilter afilter, QueryStringFlags flags);
+void UpdateQueryStringDefault(std::string_view str);
 void ShowQuery(EncodedString &&caption, EncodedString &&message, Window *w, QueryCallbackProc *callback, bool focus = false);
 
 /** The number of 'characters' on the on-screen keyboard. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

In multiplayer if two players have the popup for changing company name open and one player change the name, the window for second player does not allow to rename company back to the previous name and throws an error on attempt to rename to the same name as player one just did (see video).

https://github.com/user-attachments/assets/ed33d4c2-54a3-4b56-9fe9-ffe78a019a60

Same issue appears with president name.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Close and show again the popup after the company/president name has changed.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
