### PR TITLE
Fix #12937: Allow the computer to go to sleep while the game is paused

### DIFF
--- a/src/misc_cmd.cpp
+++ b/src/misc_cmd.cpp
@@ -8,6 +8,7 @@
 /** @file misc_cmd.cpp Some misc functions that are better fitted in other files, but never got moved there... */
 
 #include "stdafx.h"
+#include "openttd.h"
 #include "command_func.h"
 #include "economy_func.h"
 #include "window_func.h"
@@ -22,6 +23,7 @@
 #include "texteff.hpp"
 #include "core/backup_type.hpp"
 #include "misc_cmd.h"
+#include "video/video_driver.hpp"
 
 #include "table/strings.h"
 
@@ -204,6 +206,9 @@ CommandCost CmdPause(DoCommandFlags flags, PauseMode mode, bool pause)
 			}
 
 			NetworkHandlePauseChange(prev_mode, mode);
+
+			/* Screensaver should always be inhibited unless we're paused. */
+			VideoDriver::GetInstance()->SetScreensaverInhibited(_pause_mode.None());
 		}
 
 		SetWindowDirty(WC_STATUS_BAR, 0);

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -754,3 +754,12 @@ void VideoDriver_SDL_Base::UnlockVideoBuffer()
 
 	this->buffer_locked = false;
 }
+
+void VideoDriver_SDL_Base::SetScreensaverInhibited(bool inhibited)
+{
+	if (inhibited) {
+		SDL_DisableScreenSaver();
+	} else {
+		SDL_EnableScreenSaver();
+	}
+}

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -43,6 +43,8 @@ public:
 
 	std::string_view GetInfoString() const override { return this->driver_info; }
 
+	void SetScreensaverInhibited(bool inhibited) override;
+
 protected:
 	struct SDL_Window *sdl_window = nullptr; ///< Main SDL window.
 	Palette local_palette{}; ///< Current palette to use for drawing.

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -187,6 +187,13 @@ public:
 	void GameLoopPause();
 
 	/**
+	 * Prevents the system from going to sleep.
+	 *
+	 * @param inhibited If true, sleep will be disabled. If false, sleep will be enabled.
+	 */
+	virtual void SetScreensaverInhibited([[maybe_unused]] bool inhibited) {}
+
+	/**
 	 * Get the currently active instance of the video driver.
 	 */
 	static VideoDriver *GetInstance()


### PR DESCRIPTION
## Motivation / Problem

As seen in #12937, there is absolutely no reason to keep the screen on while the game is paused. I agree that the screensaver should be inhibited while the user is playing or the simulation is running, so they can enjoy watching the vehicles move around, but when the game is paused all that blocking the screensaver does is unnecessarily waste power (this happened to me yesterday; apparently my computer was on all night because OpenTTD was open, but paused).

## Description

If the game is paused, the screensaver is undisabled, and when it is unpaused the screensaver is redisabled.

Fixes #14709 because I screwed that one up.

## Limitations

This only applies to SDL backends.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
