### PR TITLE
Fix #14938: Don't allow cacti to die off

### DIFF
--- a/src/command_func.h
+++ b/src/command_func.h
@@ -28,6 +28,7 @@
 static const CommandCost CMD_ERROR = CommandCost(INVALID_STRING_ID);
 
 void NetworkSendCommand(Commands cmd, StringID err_message, CommandCallback *callback, CompanyID company, const CommandDataBuffer &cmd_data);
+bool IsNetworkRegisteredCallback(CommandCallback *callback);
 
 bool IsValidCommand(Commands cmd);
 CommandFlags GetCommandFlags(Commands cmd);
@@ -196,6 +197,7 @@ public:
 	template <typename Tcallback>
 	static bool Post(StringID err_message, Tcallback *callback, Targs... args)
 	{
+		assert(::IsNetworkRegisteredCallback(reinterpret_cast<CommandCallback *>(reinterpret_cast<void(*)()>(callback))));
 		return InternalPost(err_message, callback, true, false, std::forward_as_tuple(args...));
 	}
 

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -81,7 +81,9 @@ static constexpr auto _callback_tuple = std::make_tuple(
 	&CcRoadStop,
 	&CcStartStopVehicle,
 	&CcGame,
-	&CcAddVehicleNewGroup
+	&CcAddVehicleNewGroup,
+	&CcMoveStationName,
+	&CcMoveWaypointName
 );
 
 #ifdef SILENCE_GCC_FUNCTION_POINTER_CAST

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -111,6 +111,16 @@ inline auto MakeCallbackTable(std::index_sequence<i...>) noexcept
 /** Type-erased table of callbacks. */
 static const auto _callback_table = MakeCallbackTable(std::make_index_sequence<_callback_tuple_size>{});
 
+/**
+ * Helper function to ensure that callbacks used when Posting commands are actually registered for the network calls.
+ * @param callback The callback to check.
+ * @return \c true when the callback is in the callback table, otherwise \c false.
+ */
+bool IsNetworkRegisteredCallback(CommandCallback *callback)
+{
+	return std::ranges::find(_callback_table, callback) != _callback_table.end();
+}
+
 template <typename T> struct CallbackArgsHelper;
 template <typename... Targs>
 struct CallbackArgsHelper<void(*const)(Commands, const CommandCost &, Targs...)> {

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -215,19 +215,12 @@ public:
 	{
 		if (fonttype != FontType::TrueType) return nullptr;
 
-		FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
-
 		std::string font = GetFontCacheFontName(fs);
 		if (font.empty()) return nullptr;
 
 		CFAutoRelease<CTFontDescriptorRef> font_ref;
 
-		if (settings->os_handle != nullptr) {
-			font_ref.reset(static_cast<CTFontDescriptorRef>(const_cast<void *>(settings->os_handle)));
-			CFRetain(font_ref.get()); // Increase ref count to match a later release.
-		}
-
-		if (!font_ref && MacOSVersionIsAtLeast(10, 6, 0)) {
+		if (MacOSVersionIsAtLeast(10, 6, 0)) {
 			/* Might be a font file name, try load it. */
 			font_ref.reset(LoadFontFromFile(font));
 			if (!font_ref) ShowInfo("Unable to load file '{}' for {} font, using default OS font selection instead", font, FontSizeToName(fs));

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -803,10 +803,16 @@ static void TileLoopTreesAlps(TileIndex tile)
 	MarkTileDirtyByTile(tile);
 }
 
+/*
+ * Check if trees on this tile can spread, according to biome and game settings.
+ * 
+ * In most climates, the setting that decides is to "grow and spread everywhere."
+ * If it is a tropical game, then it must be in the rainforest and have a setting allowing it to spread there.
+ */
 static bool CanPlantExtraTrees(TileIndex tile)
 {
-	return ((_settings_game.game_creation.landscape == LandscapeType::Tropic && GetTropicZone(tile) == TROPICZONE_RAINFOREST) ?
-		(_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST) :
+	return ((_settings_game.game_creation.landscape == LandscapeType::Tropic) ?
+		(GetTropicZone(tile) == TROPICZONE_RAINFOREST && (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST)) :
 		_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
 }
 

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -803,11 +803,27 @@ static void TileLoopTreesAlps(TileIndex tile)
 	MarkTileDirtyByTile(tile);
 }
 
+/**
+ * Check if trees on this tile can spread, according to biome and game settings.
+ * @param tile The tile to check.
+ * @return If trees on this tile are allowed to spread.
+ */
 static bool CanPlantExtraTrees(TileIndex tile)
 {
-	return ((_settings_game.game_creation.landscape == LandscapeType::Tropic && GetTropicZone(tile) == TROPICZONE_RAINFOREST) ?
-		(_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST) :
-		_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
+	/* Desert and rainforest trees need special handling. */
+	if (_settings_game.game_creation.landscape == LandscapeType::Tropic) {
+		switch (GetTropicZone(tile)) {
+			case TROPICZONE_DESERT:
+				/* Cacti never spread. */
+				return false;
+			case TROPICZONE_RAINFOREST:
+				return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST);
+			default:
+				return _settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL;
+		}
+	}
+
+	return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
 }
 
 static void TileLoop_Trees(TileIndex tile)

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -803,29 +803,27 @@ static void TileLoopTreesAlps(TileIndex tile)
 	MarkTileDirtyByTile(tile);
 }
 
-/*
+/**
  * Check if trees on this tile can spread, according to biome and game settings.
- * 
- * In most climates, the setting that decides is to "grow and spread everywhere."
- * If it is a tropical game, then it must be in the rainforest and have a setting allowing it to spread there.
+ * @param tile The tile to check.
+ * @return If trees on this tile are allowed to spread.
  */
 static bool CanPlantExtraTrees(TileIndex tile)
 {
-/* Desert and rainforest trees need special handling. */
-if (_settings_game.game_creation.landscape == LandscapeType::Tropic) {
-	switch (GetTropicZone(tile)) {
-		case TROPICZONE_DESERT:
-			/* Cacti never spread. */
-			return false;
-		case TROPICZONE_RAINFOREST:
-			return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST);
-		default:
-			return _settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL;
+	/* Desert and rainforest trees need special handling. */
+	if (_settings_game.game_creation.landscape == LandscapeType::Tropic) {
+		switch (GetTropicZone(tile)) {
+			case TROPICZONE_DESERT:
+				/* Cacti never spread. */
+				return false;
+			case TROPICZONE_RAINFOREST:
+				return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST);
+			default:
+				return _settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL;
+		}
 	}
-}
 
-return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
-		_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
+	return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
 }
 
 static void TileLoop_Trees(TileIndex tile)

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -803,11 +803,10 @@ static void TileLoopTreesAlps(TileIndex tile)
 	MarkTileDirtyByTile(tile);
 }
 
-/*
+/**
  * Check if trees on this tile can spread, according to biome and game settings.
- * 
- * In most climates, the setting that decides is to "grow and spread everywhere."
- * If it is a tropical game, then it must be in the rainforest and have a setting allowing it to spread there.
+ * @param tile The tile to check.
+ * @return If trees on this tile are allowed to spread.
  */
 static bool CanPlantExtraTrees(TileIndex tile)
 {

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -824,7 +824,6 @@ static bool CanPlantExtraTrees(TileIndex tile)
 	}
 
 	return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
-
 }
 
 static void TileLoop_Trees(TileIndex tile)

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -824,6 +824,7 @@ static bool CanPlantExtraTrees(TileIndex tile)
 	}
 
 	return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
+
 }
 
 static void TileLoop_Trees(TileIndex tile)

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -810,21 +810,21 @@ static void TileLoopTreesAlps(TileIndex tile)
  */
 static bool CanPlantExtraTrees(TileIndex tile)
 {
-/* Desert and rainforest trees need special handling. */
-if (_settings_game.game_creation.landscape == LandscapeType::Tropic) {
-	switch (GetTropicZone(tile)) {
-		case TROPICZONE_DESERT:
-			/* Cacti never spread. */
-			return false;
-		case TROPICZONE_RAINFOREST:
-			return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST);
-		default:
-			return _settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL;
+	/* Desert and rainforest trees need special handling. */
+	if (_settings_game.game_creation.landscape == LandscapeType::Tropic) {
+		switch (GetTropicZone(tile)) {
+			case TROPICZONE_DESERT:
+				/* Cacti never spread. */
+				return false;
+			case TROPICZONE_RAINFOREST:
+				return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST);
+			default:
+				return _settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL;
+		}
 	}
-}
 
 return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
-		_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
+	
 }
 
 static void TileLoop_Trees(TileIndex tile)

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -811,8 +811,20 @@ static void TileLoopTreesAlps(TileIndex tile)
  */
 static bool CanPlantExtraTrees(TileIndex tile)
 {
-	return ((_settings_game.game_creation.landscape == LandscapeType::Tropic) ?
-		(GetTropicZone(tile) == TROPICZONE_RAINFOREST && (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST)) :
+/* Desert and rainforest trees need special handling. */
+if (_settings_game.game_creation.landscape == LandscapeType::Tropic) {
+	switch (GetTropicZone(tile)) {
+		case TROPICZONE_DESERT:
+			/* Cacti never spread. */
+			return false;
+		case TROPICZONE_RAINFOREST:
+			return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST);
+		default:
+			return _settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL;
+	}
+}
+
+return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
 		_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
 }
 

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -822,7 +822,7 @@ static bool CanPlantExtraTrees(TileIndex tile)
 				return _settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL;
 		}
 	}
-
+	
 	return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
 }
 

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -822,9 +822,8 @@ static bool CanPlantExtraTrees(TileIndex tile)
 				return _settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL;
 		}
 	}
-
-return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
 	
+	return (_settings_game.construction.extra_tree_placement == ETP_SPREAD_ALL);
 }
 
 static void TileLoop_Trees(TileIndex tile)

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2248,22 +2248,22 @@ void Vehicle::BeginLoading()
 						InvalidateVehicleOrder(this, 0);
 					} else {
 						/* Delete all implicit orders up to the station we just reached */
-						VehicleOrderID cur = this->cur_implicit_order_index;
-						auto orders = this->Orders();
-						while (!orders[cur].IsType(OT_IMPLICIT) || orders[cur].GetDestination() != this->last_station_visited) {
-							if (orders[cur].IsType(OT_IMPLICIT)) {
+						const Order *order = this->GetOrder(this->cur_implicit_order_index);
+						while (!order->IsType(OT_IMPLICIT) || order->GetDestination() != this->last_station_visited) {
+							if (order->IsType(OT_IMPLICIT)) {
 								DeleteOrder(this, this->cur_implicit_order_index);
-								/* DeleteOrder does various magic with order_indices, so resync 'order' with 'cur_implicit_order_index' */
 							} else {
 								/* Skip non-implicit orders, e.g. service-orders */
-								if (cur < this->orders->GetNext(cur)) {
-									this->cur_implicit_order_index++;
-								} else {
-									/* Wrapped around. */
-									this->cur_implicit_order_index = 0;
-								}
-								cur = this->orders->GetNext(cur);
+								++this->cur_implicit_order_index;
 							}
+							order = this->GetOrder(this->cur_implicit_order_index);
+
+							/* Wrapped around. */
+							if (order == nullptr) {
+								this->cur_implicit_order_index = 0;
+								order = this->GetOrder(this->cur_implicit_order_index);
+							}
+							assert(order != nullptr);
 						}
 					}
 				} else if (!suppress_implicit_orders &&


### PR DESCRIPTION
## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

Previously, cacti on tiles in the desert would die out completely, which is behavior reserved for when trees are allowed to spread, to make sure more can take its place. As a game progressed, the desert would become increasingly barren. This bug just affected aesthetics, but happened on (current) default tree growth settings.


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

Old logic checked climate of the save and the biome of the tile together. Now, the biome is checked after the climate is. This means that when the tile is in the desert, the check for tree spread will no longer be the same as in the forests of other climates, and instead always be false, so the code that handles tree death will know to replant the tree, like the other times that trees do not spread.

Fixes #14938.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
