### PR TITLE
Fix #14610: Do not treat aircraft with only depot orders as having valid orders

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1881,7 +1881,11 @@ uint16_t GetServiceIntervalClamped(int interval, bool ispercent)
  */
 static bool CheckForValidOrders(const Vehicle *v)
 {
-	return std::ranges::any_of(v->Orders(), [](const Order &order) { return order.IsGotoOrder(); });
+	/* Check if vehicle has any valid orders.
+	 * Function is only called for aircraft, no type check needed. */
+	return std::ranges::any_of(v->Orders(), [](const Order &order) {
+		return order.IsGotoOrder() && !order.IsType(OT_GOTO_DEPOT);
+	});
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Fixes #14610

Aircraft with only "go to nearest depot" orders could enter an undefined state.
When `CheckForValidOrders()` considered `OT_GOTO_DEPOT` as a valid order these
aircraft would not be handled by `HandleMissingAircraftOrders()`, potentially
causing them to hang or behave incorrectly.

The issue was identified and the solution suggested in the issue comments:
"ignore all 'go to nearest hangar' orders in CheckForValidOrders".


## Description


Modified `CheckForValidOrders()` to exclude OT_GOTO_DEPOT orders when checking
validity for aircraft. Aircraft with only depot orders are now treated as having
no valid orders this ensures they are properly handled by `HandleMissingAircraftOrders()`.

This implements the solution suggested in the original issue comments.



## Limitations


- Only affects aircraft (VEH_AIRCRAFT)
- Other vehicle types unchanged




