### PR TITLE
Codechange: [Script] Reuse memory when changing values of ScriptList items

### DIFF
--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -560,9 +560,10 @@ bool ScriptList::SetValue(SQInteger item, SQInteger value)
 	this->sorter->Remove(item);
 	auto value_iter = this->values.find({value_old, item});
 	assert(value_iter != this->values.end());
-	this->values.erase(value_iter);
 	item_iter->second = value;
-	this->values.emplace(value, item);
+	auto node_handle = this->values.extract(value_iter);
+	node_handle.value().first = value;
+	this->values.insert(std::move(node_handle));
 
 	return true;
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
When updating value of a `ScriptList` item, we erase the `(old_value, item)` pair from the by value set before inserting the `(new_value, item)` pair.
This cause deallocation of the old element and allocation for the new element.
When valuating a huge list these could have a noticeable effect on performance.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Instead of erasing the old element, extract it, modify it and insert it back into the set.
This will skip the dealloc/alloc and use the already allocated memory.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Silly tests show a 26s improvement (from 155s to 129s), but I don't know if it will be as visible with normal use cases.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
