### PR TITLE
Codefix: add missing tracing debug messages for Coordinator/Stun/Turn

### DIFF
--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -97,6 +97,7 @@ std::unique_ptr<ClientNetworkStunSocketHandler> ClientNetworkStunSocketHandler::
 	p->Send_string(token);
 	p->Send_uint8(family);
 
+	Debug(net, 9, "Stun::SendStun({}, {})", token, family);
 	stun_handler->SendPacket(std::move(p));
 
 	return stun_handler;

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -57,9 +57,8 @@ bool ClientNetworkTurnSocketHandler::Receive_TURN_ERROR(Packet &)
 
 bool ClientNetworkTurnSocketHandler::Receive_TURN_CONNECTED(Packet &p)
 {
-	Debug(net, 9, "Receive_TURN_CONNECTED()");
-
 	std::string hostname = p.Recv_string(NETWORK_HOSTNAME_LENGTH);
+	Debug(net, 9, "Turn::Receive_TURN_CONNECTED({})", hostname);
 
 	/* Act like we no longer have a socket, as we are handing it over to the
 	 * game handler. */
@@ -101,6 +100,7 @@ void ClientNetworkTurnSocketHandler::Connect()
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(ticket);
 
+	Debug(net, 9, "Turn::SendTurn({})", ticket);
 	turn_handler->SendPacket(std::move(p));
 
 	return turn_handler;


### PR DESCRIPTION
## Motivation / Problem

When tracing issues with connecting to a game, none of the coordinator calls get logged. This makes it hard to discern what is actually going on/wrong, and causes discussions about what does and does not happen during an attempt to make a connection.

For example, without this extra logging I cannot deduce whether there never was a request to connect direct to the IP (i.e. the server could not be directly reached by the game coordinator) or whether the direct connection from the client failed.


## Description

Add `Debug(net, 9, ...);` to all send/receive points in Coordinate/Stun/Turn. 
In one case it moves the `Debug` so more information can be logged.

I deliberately left the `invite_code_secret` out of the logs for hopefully obvious reasons.


## Limitations

None really, except that it's kinda not-done to request backports for additions. However, it would be really useful when in the next release we fix this gap in the tracing of what is going on.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
