### PR TITLE
Fix b956af63: Incorrect TileIndex used in FindNearestGoodCoastalTownSpot

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2329,7 +2329,7 @@ static TileIndex FindNearestGoodCoastalTownSpot(TileIndex tile, TownLayout layou
 {
 	for (auto coast : SpiralTileSequence(tile, 40)) {
 		/* Find nearest land tile */
-		if (!IsTileType(tile, MP_CLEAR)) continue;
+		if (!IsTileType(coast, MP_CLEAR)) continue;
 
 		TileIndex furthest = INVALID_TILE;
 		uint max_dist = 0;


### PR DESCRIPTION
## Motivation / Problem

b956af63 converts FindNearestGoodCoastalTownSpot to use SpiralTileSequence, but uses the wrong tile index for the MP_CLEAR test.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
