### PR TITLE
Fix #15014: Add tooltips to explain disabled world gen settings

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -112,10 +112,10 @@ static constexpr std::initializer_list<NWidgetPart> _nested_generate_landscape_w
 							NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_MAPSIZE_Y_PULLDOWN), SetToolTip(STR_MAPGEN_MAPSIZE_TOOLTIP), SetFill(1, 1),
 						EndContainer(),
 						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_TERRAIN_PULLDOWN), SetToolTip(STR_CONFIG_SETTING_TERRAIN_TYPE_HELPTEXT), SetFill(1, 1),
-						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_VARIETY_PULLDOWN), SetToolTip(STR_CONFIG_SETTING_VARIETY_HELPTEXT), SetFill(1, 1),
-						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_SMOOTHNESS_PULLDOWN), SetToolTip(STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_HELPTEXT), SetFill(1, 1),
+						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_VARIETY_PULLDOWN), SetFill(1, 1),
+						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_SMOOTHNESS_PULLDOWN), SetFill(1, 1),
 						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_RIVER_PULLDOWN), SetToolTip(STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT), SetFill(1, 1),
-						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_BORDERS_PULLDOWN), SetToolTip(STR_MAPGEN_BORDER_TYPE_TOOLTIP), SetFill(1, 1),
+						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_BORDERS_PULLDOWN), SetFill(1, 1),
 					EndContainer(),
 				EndContainer(),
 
@@ -500,6 +500,11 @@ struct GenerateLandscapeWindow : public Window {
 			this->SetWidgetDisabledState(WID_GL_SMOOTHNESS_PULLDOWN, original);
 			this->SetWidgetDisabledState(WID_GL_VARIETY_PULLDOWN, original);
 			this->SetWidgetDisabledState(WID_GL_BORDERS_PULLDOWN, original);
+
+			/* Set their tooltips accordingly. */
+			this->GetWidget<NWidgetCore>(WID_GL_VARIETY_PULLDOWN)->SetToolTip(original ? STR_MAPGEN_DISABLED_ORIGINAL : STR_CONFIG_SETTING_VARIETY_HELPTEXT);
+			this->GetWidget<NWidgetCore>(WID_GL_SMOOTHNESS_PULLDOWN)->SetToolTip(original ? STR_MAPGEN_DISABLED_ORIGINAL : STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_HELPTEXT);
+			this->GetWidget<NWidgetCore>(WID_GL_BORDERS_PULLDOWN)->SetToolTip(original ? STR_MAPGEN_DISABLED_ORIGINAL : STR_MAPGEN_BORDER_TYPE_TOOLTIP);
 
 			/* Water edge buttons might be disabled for a variety of reasons. */
 			this->SetWidgetsDisabledState(original || !_settings_newgame.construction.freeform_edges || _settings_newgame.game_creation.water_borders == BorderFlag::Random,

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3401,6 +3401,8 @@ STR_MAPGEN_AI_SETTINGS_TOOLTIP                                  :{BLACK}Open AI 
 STR_MAPGEN_GS_SETTINGS                                          :{BLACK}Game Script Settings
 STR_MAPGEN_GS_SETTINGS_TOOLTIP                                  :{BLACK}Open game script settings
 
+STR_MAPGEN_DISABLED_ORIGINAL                                    :Disabled when using 'Original' land generator
+
 ###length 21
 STR_MAPGEN_TOWN_NAME_ORIGINAL_ENGLISH                           :English (Original)
 STR_MAPGEN_TOWN_NAME_FRENCH                                     :French


### PR DESCRIPTION
## Motivation / Problem

#15014; When using 'Original' land generator, some fields of the world generation GUI are disabled, without explanation.

## Description

When the 'Original' landscape generator is chosen, use the tooltips of disabled fields to explain why they are disabled.

Existing checks were split between the window constructor and `OnInvalidateData()`, so I moved and refactored them slightly into `OnInvalidateData()`, as a separate commit.

Closes #15014.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
