### PR TITLE
Add: [Script] GetAllocatedMemory and GetPeakAllocatedMemory to ScriptController

### DIFF
--- a/src/script/api/ai/ai_controller.sq.hpp
+++ b/src/script/api/ai/ai_controller.sq.hpp
@@ -18,6 +18,8 @@ void SQAIController_Register(Squirrel &engine)
 
 	SQAIController.DefSQStaticMethod(engine, &ScriptController::GetTick,           "GetTick",           ".");
 	SQAIController.DefSQStaticMethod(engine, &ScriptController::GetOpsTillSuspend, "GetOpsTillSuspend", ".");
+	SQAIController.DefSQStaticMethod(engine, &ScriptController::GetPeakAllocatedMemory, "GetPeakAllocatedMemory", ".");
+	SQAIController.DefSQStaticMethod(engine, &ScriptController::GetAllocatedMemory, "GetAllocatedMemory", ".");
 	SQAIController.DefSQStaticMethod(engine, &ScriptController::SetCommandDelay,   "SetCommandDelay",   ".i");
 	SQAIController.DefSQStaticMethod(engine, &ScriptController::Sleep,             "Sleep",             ".i");
 	SQAIController.DefSQStaticMethod(engine, &ScriptController::Break,             "Break",             ".s");

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -19,6 +19,10 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li AIController::GetPeakAllocatedMemory
+ * \li AIController::GetAllocatedMemory
+ *
  * \b 15.0
  *
  * API additions:

--- a/src/script/api/game/game_controller.sq.hpp
+++ b/src/script/api/game/game_controller.sq.hpp
@@ -18,6 +18,8 @@ void SQGSController_Register(Squirrel &engine)
 
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::GetTick,           "GetTick",           ".");
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::GetOpsTillSuspend, "GetOpsTillSuspend", ".");
+	SQGSController.DefSQStaticMethod(engine, &ScriptController::GetPeakAllocatedMemory, "GetPeakAllocatedMemory", ".");
+	SQGSController.DefSQStaticMethod(engine, &ScriptController::GetAllocatedMemory, "GetAllocatedMemory", ".");
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::SetCommandDelay,   "SetCommandDelay",   ".i");
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::Sleep,             "Sleep",             ".i");
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::Break,             "Break",             ".s");

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -19,6 +19,10 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li GSController::GetPeakAllocatedMemory
+ * \li GSController::GetAllocatedMemory
+ *
  * \b 15.0
  *
  * API additions:

--- a/src/script/api/script_controller.cpp
+++ b/src/script/api/script_controller.cpp
@@ -84,6 +84,16 @@ ScriptController::ScriptController(::CompanyID company) :
 	return ScriptObject::GetActiveInstance().GetOpsTillSuspend();
 }
 
+/* static */ SQInteger ScriptController::GetPeakAllocatedMemory()
+{
+	return ScriptObject::GetActiveInstance().GetPeakAllocatedMemory();
+}
+
+/* static */ SQInteger ScriptController::GetAllocatedMemory()
+{
+	return ScriptObject::GetActiveInstance().GetAllocatedMemory();
+}
+
 /* static */ void ScriptController::DecreaseOps(int amount)
 {
 	Squirrel &engine = *ScriptObject::GetActiveInstance().engine;

--- a/src/script/api/script_controller.hpp
+++ b/src/script/api/script_controller.hpp
@@ -121,6 +121,20 @@ public:
 	static int GetOpsTillSuspend();
 
 	/**
+	 * Get the peak amount of memory allocated by the script in bytes
+	 * @return The peak amount of memory allocated.
+	 * @api all
+	 */
+	static SQInteger GetPeakAllocatedMemory();
+
+	/**
+	 * Get the current amount of memory allocated by the script in bytes
+	 * @return The current amount of memory allocated.
+	 * @api all
+	 */
+	static SQInteger GetAllocatedMemory();
+
+	/**
 	 * Remove \c amount ops from the number of ops till suspend.
 	 * @api none
 	 */

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -847,6 +847,12 @@ size_t ScriptInstance::GetAllocatedMemory() const
 	return this->engine->GetAllocatedMemory();
 }
 
+size_t ScriptInstance::GetPeakAllocatedMemory() const
+{
+	assert(this->engine != nullptr);
+	return this->engine->GetPeakAllocatedMemory();
+}
+
 void ScriptInstance::ReleaseSQObject(HSQOBJECT *obj)
 {
 	if (!this->in_shutdown) this->engine->ReleaseObject(obj);

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -244,6 +244,8 @@ public:
 
 	size_t GetAllocatedMemory() const;
 
+	size_t GetPeakAllocatedMemory() const;
+
 	/**
 	 * Indicate whether this instance is currently being destroyed.
 	 */

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -293,6 +293,11 @@ public:
 	size_t GetAllocatedMemory() const noexcept;
 
 	/**
+	 * Get the peak number of bytes allocated by this VM.
+	 */
+	size_t GetPeakAllocatedMemory() const noexcept;
+
+	/**
 	 * Increase number of bytes allocated in the current script allocator scope.
 	 * @param bytes Number of bytes to increase.
 	 */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
I am interested in knowing what my scripts current and peak memory usage are.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Allows AIs and GS to get their current and peak memory usage via API methods.

`ScriptController::GetPeakAllocatedMemory`
`ScriptController::GetAllocatedMemory`

Updates squirrel allocator to track peak allocated memory.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
None, I hope.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
