### PR TITLE
Codefix: use constructor to set index of PoolItems over 'magic'/UB

### DIFF
--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -82,8 +82,7 @@ struct Aircraft final : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 
 	AircraftCache acache{};
 
-	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
-	Aircraft() : SpecializedVehicleBase() {}
+	Aircraft(VehicleID index) : SpecializedVehicleBase(index) {}
 	/** We want to 'destruct' the right class. */
 	~Aircraft() override { this->PreDestructor(); }
 

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -275,8 +275,8 @@ CommandCost CmdBuildAircraft(DoCommandFlags flags, TileIndex tile, const Engine 
 	tile = st->airport.GetHangarTile(st->airport.GetHangarNum(tile));
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Aircraft *v = new Aircraft(); // aircraft
-		Aircraft *u = new Aircraft(); // shadow
+		Aircraft *v = Aircraft::Create(); // aircraft
+		Aircraft *u = Aircraft::Create(); // shadow
 		*ret = v;
 
 		v->direction = DIR_SE;
@@ -366,7 +366,7 @@ CommandCost CmdBuildAircraft(DoCommandFlags flags, TileIndex tile, const Engine 
 
 		/* Aircraft with 3 vehicles (chopper)? */
 		if (v->subtype == AIR_HELICOPTER) {
-			Aircraft *w = new Aircraft();
+			Aircraft *w = Aircraft::Create();
 			w->engine_type = e->index;
 			w->direction = DIR_N;
 			w->owner = _current_company;

--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -82,7 +82,7 @@ uint CountArticulatedParts(EngineID engine_type, bool purchase_window)
 
 	std::unique_ptr<Vehicle> v;
 	if (!purchase_window) {
-		v = std::make_unique<Vehicle>();
+		v = std::unique_ptr<Vehicle>(Vehicle::Create());
 		v->engine_type = engine_type;
 		v->owner = _current_company;
 	}
@@ -357,7 +357,7 @@ void AddArticulatedParts(Vehicle *first)
 
 			case VEH_TRAIN: {
 				Train *front = Train::From(first);
-				Train *t = new Train();
+				Train *t = Train::Create();
 				v->SetNext(t);
 				v = t;
 
@@ -381,7 +381,7 @@ void AddArticulatedParts(Vehicle *first)
 
 			case VEH_ROAD: {
 				RoadVehicle *front = RoadVehicle::From(first);
-				RoadVehicle *rv = new RoadVehicle();
+				RoadVehicle *rv = RoadVehicle::Create();
 				v->SetNext(rv);
 				v = rv;
 

--- a/src/autoreplace.cpp
+++ b/src/autoreplace.cpp
@@ -109,7 +109,7 @@ CommandCost AddEngineReplacement(EngineRenewList *erl, EngineID old_engine, Engi
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		/* Insert before the first element */
-		*erl = new EngineRenew(old_engine, new_engine, group, replace_when_old, *erl);
+		*erl = EngineRenew::Create(old_engine, new_engine, group, replace_when_old, *erl);
 	}
 
 	return CommandCost();

--- a/src/autoreplace_base.h
+++ b/src/autoreplace_base.h
@@ -37,9 +37,9 @@ struct EngineRenew : EngineRenewPool::PoolItem<&_enginerenew_pool> {
 	GroupID group_id = GroupID::Invalid();
 	bool replace_when_old = false; ///< Do replacement only when vehicle is old.
 
-	EngineRenew() {}
-	EngineRenew(EngineID from, EngineID to, GroupID group_id, bool replace_when_old, EngineRenew *next) :
-		from(from), to(to), next(next), group_id(group_id), replace_when_old(replace_when_old) {}
+	EngineRenew(EngineRenewID index) : EngineRenewPool::PoolItem<&_enginerenew_pool>(index) {}
+	EngineRenew(EngineRenewID index, EngineID from, EngineID to, GroupID group_id, bool replace_when_old, EngineRenew *next) :
+		EngineRenewPool::PoolItem<&_enginerenew_pool>(index), from(from), to(to), next(next), group_id(group_id), replace_when_old(replace_when_old) {}
 	~EngineRenew() {}
 };
 

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -87,9 +87,10 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 
 	/**
 	 * Initialize the base station.
+	 * @param index The index of the station within the pool.
 	 * @param tile The location of the station sign
 	 */
-	BaseStation(TileIndex tile) : xy(tile) {}
+	BaseStation(StationID index, TileIndex tile) : StationPool::PoolItem<&_station_pool>(index), xy(tile) {}
 
 	virtual ~BaseStation();
 
@@ -213,10 +214,11 @@ struct SpecializedStation : public BaseStation {
 
 	/**
 	 * Set station type correctly
+	 * @param index The index within the station pool.
 	 * @param tile The base tile of the station.
 	 */
-	inline SpecializedStation(TileIndex tile) :
-			BaseStation(tile)
+	inline SpecializedStation(StationID index, TileIndex tile) :
+			BaseStation(index, tile)
 	{
 		this->facilities = EXPECTED_FACIL;
 	}

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -281,6 +281,18 @@ struct SpecializedStation : public BaseStation {
 	}
 
 	/**
+	 * Creates a new T-object in the station pool.
+	 * @param index The index allocate the object at.
+	 * @param args... The arguments to the constructor.
+	 * @return The created object.
+	 */
+	template <typename... Targs>
+	static inline T *CreateAtIndex(StationID index, Targs &&... args)
+	{
+		return BaseStation::CreateAtIndex<T>(index, std::forward<Targs&&>(args)...);
+	}
+
+	/**
 	 * Converts a BaseStation to SpecializedStation with type checking.
 	 * @param st BaseStation pointer
 	 * @return pointer to SpecializedStation

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -270,6 +270,17 @@ struct SpecializedStation : public BaseStation {
 	}
 
 	/**
+	 * Creates a new T-object in the station pool.
+	 * @param args... The arguments to the constructor.
+	 * @return The created object.
+	 */
+	template <typename... Targs>
+	static inline T *Create(Targs &&... args)
+	{
+		return BaseStation::Create<T>(std::forward<Targs&&>(args)...);
+	}
+
+	/**
 	 * Converts a BaseStation to SpecializedStation with type checking.
 	 * @param st BaseStation pointer
 	 * @return pointer to SpecializedStation

--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -23,20 +23,23 @@ INSTANTIATE_POOL_METHODS(CargoPacket)
 
 /**
  * Create a new packet for savegame loading.
+ * @param index Index into the cargo packet pool.
  */
-CargoPacket::CargoPacket()
+CargoPacket::CargoPacket(CargoPacketID index) : CargoPacketPool::PoolItem<&_cargopacket_pool>(index)
 {
 }
 
 /**
  * Creates a new cargo packet.
  *
+ * @param index Index into the cargo packet pool.
  * @param first_station Source station of the packet.
  * @param count         Number of cargo entities to put in this packet.
  * @param source        Source of the packet (for subsidies).
  * @pre count != 0
  */
-CargoPacket::CargoPacket(StationID first_station,uint16_t count, Source source) :
+CargoPacket::CargoPacket(CargoPacketID index, StationID first_station,uint16_t count, Source source) :
+		CargoPacketPool::PoolItem<&_cargopacket_pool>(index),
 		count(count),
 		source(source),
 		first_station(first_station)
@@ -47,13 +50,15 @@ CargoPacket::CargoPacket(StationID first_station,uint16_t count, Source source) 
 /**
  * Create a new cargo packet. Used for older savegames to load in their partial data.
  *
+ * @param index Index into the cargo packet pool.
  * @param count              Number of cargo entities to put in this packet.
  * @param periods_in_transit Number of cargo aging periods the cargo has been in transit.
  * @param first_station      Station the cargo was initially loaded.
  * @param source_xy          Station location the cargo was initially loaded.
  * @param feeder_share       Feeder share the packet has already accumulated.
  */
-CargoPacket::CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID first_station, TileIndex source_xy, Money feeder_share) :
+CargoPacket::CargoPacket(CargoPacketID index, uint16_t count, uint16_t periods_in_transit, StationID first_station, TileIndex source_xy, Money feeder_share) :
+		CargoPacketPool::PoolItem<&_cargopacket_pool>(index),
 		count(count),
 		periods_in_transit(periods_in_transit),
 		feeder_share(feeder_share),
@@ -66,11 +71,13 @@ CargoPacket::CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID 
 /**
  * Creates a new cargo packet. Used when loading or splitting packets.
  *
+ * @param index Index into the cargo packet pool.
  * @param count         Number of cargo entities to put in this packet.
  * @param feeder_share  Feeder share the packet has already accumulated.
  * @param original      The original packet we are splitting.
  */
-CargoPacket::CargoPacket(uint16_t count, Money feeder_share, CargoPacket &original) :
+CargoPacket::CargoPacket(CargoPacketID index, uint16_t count, Money feeder_share, CargoPacket &original) :
+		CargoPacketPool::PoolItem<&_cargopacket_pool>(index),
 		count(count),
 		periods_in_transit(original.periods_in_transit),
 		feeder_share(feeder_share),

--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -96,7 +96,7 @@ CargoPacket *CargoPacket::Split(uint new_size)
 	if (!CargoPacket::CanAllocateItem()) return nullptr;
 
 	Money fs = this->GetFeederShare(new_size);
-	CargoPacket *cp_new = new CargoPacket(new_size, fs, *this);
+	CargoPacket *cp_new = CargoPacket::Create(new_size, fs, *this);
 	this->feeder_share -= fs;
 	this->count -= new_size;
 	return cp_new;

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -73,10 +73,10 @@ public:
 	/** Maximum number of items in a single cargo packet. */
 	static const uint16_t MAX_COUNT = UINT16_MAX;
 
-	CargoPacket();
-	CargoPacket(StationID first_station, uint16_t count, Source source);
-	CargoPacket(uint16_t count, uint16_t periods_in_transit, StationID first_station, TileIndex source_xy, Money feeder_share);
-	CargoPacket(uint16_t count, Money feeder_share, CargoPacket &original);
+	CargoPacket(CargoPacketID index);
+	CargoPacket(CargoPacketID index, StationID first_station, uint16_t count, Source source);
+	CargoPacket(CargoPacketID index, uint16_t count, uint16_t periods_in_transit, StationID first_station, TileIndex source_xy, Money feeder_share);
+	CargoPacket(CargoPacketID index, uint16_t count, Money feeder_share, CargoPacket &original);
 
 	/** Destroy the packet. */
 	~CargoPacket() { }

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -125,7 +125,7 @@ struct CompanyProperties {
 };
 
 struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
-	Company(StringID name_1 = {}, bool is_ai = false);
+	Company(CompanyID index, StringID name_1 = {}, bool is_ai = false);
 	~Company();
 
 	RailTypes avail_railtypes{}; ///< Rail types available to this company.

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -608,7 +608,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid(
 		c = Company::Create(STR_SV_UNNAMED, is_ai);
 	} else {
 		if (Company::IsValidID(company)) return nullptr;
-		c = new (company) Company(STR_SV_UNNAMED, is_ai);
+		c = Company::CreateAtIndex(company, STR_SV_UNNAMED, is_ai);
 	}
 
 	c->colour = colour;

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -605,7 +605,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid(
 
 	Company *c;
 	if (company == CompanyID::Invalid()) {
-		c = new Company(STR_SV_UNNAMED, is_ai);
+		c = Company::Create(STR_SV_UNNAMED, is_ai);
 	} else {
 		if (Company::IsValidID(company)) return nullptr;
 		c = new (company) Company(STR_SV_UNNAMED, is_ai);

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -66,7 +66,7 @@ INSTANTIATE_POOL_METHODS(Company)
  * @param name_1 Name of the company.
  * @param is_ai  A computer program is running for this company.
  */
-Company::Company(StringID name_1, bool is_ai)
+Company::Company(CompanyID index, StringID name_1, bool is_ai) : CompanyPool::PoolItem<&_company_pool>(index)
 {
 	this->name_1 = name_1;
 	this->is_ai = is_ai;

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -288,16 +288,8 @@ public:
 		/** Type of the pool this item is going to be part of */
 		typedef struct Pool<Titem, Tindex, Tgrowth_step, Tpool_type, Tcache> Pool;
 
-		/**
-		 * Allocates space for new Titem
-		 * @param size size of Titem
-		 * @return pointer to allocated memory
-		 * @note can never fail (return nullptr), use CanAllocate() to check first!
-		 */
-		inline void *operator new(size_t size)
-		{
-			return Tpool->GetNew(size);
-		}
+		/** Do not use new PoolItem, but rather PoolItem::Create. */
+		inline void *operator new(size_t) = delete;
 
 		/**
 		 * Marks Titem as free. Its memory is released
@@ -346,6 +338,19 @@ public:
 			return ptr;
 		}
 
+
+		/**
+		 * Creates a new T-object in the associated pool.
+		 * @param args... The arguments to the constructor.
+		 * @return The created object.
+		 */
+		template <typename T = Titem, typename... Targs>
+		requires std::is_base_of_v<Titem, T>
+		static inline T *Create(Targs &&... args)
+		{
+			void *data = Tpool->GetNew(sizeof(T));
+			return ::new (data) T(std::forward<Targs&&>(args)...);
+		}
 
 		/** Helper functions so we can use PoolItem::Function() instead of _poolitem_pool.Function() */
 

--- a/src/depot_base.h
+++ b/src/depot_base.h
@@ -25,8 +25,7 @@ struct Depot : DepotPool::PoolItem<&_depot_pool> {
 	std::string name{};
 	TimerGameCalendar::Date build_date{}; ///< Date of construction
 
-	Depot() {}
-	Depot(TileIndex xy) : xy(xy), build_date(TimerGameCalendar::date) {}
+	Depot(DepotID index, TileIndex xy = INVALID_TILE) : DepotPool::PoolItem<&_depot_pool>(index), xy(xy), build_date(TimerGameCalendar::date) {}
 	~Depot();
 
 	static inline Depot *GetByTile(TileIndex tile)

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -569,8 +569,8 @@ static bool DisasterTick_Big_Ufo(DisasterVehicle *v)
 			delete v;
 			return false;
 		}
-		DisasterVehicle *u = new DisasterVehicle(-6 * (int)TILE_SIZE, v->y_pos, DIR_SW, ST_BIG_UFO_DESTROYER, v->index);
-		DisasterVehicle *w = new DisasterVehicle(-6 * (int)TILE_SIZE, v->y_pos, DIR_SW, ST_BIG_UFO_DESTROYER_SHADOW);
+		DisasterVehicle *u = DisasterVehicle::Create(-6 * (int)TILE_SIZE, v->y_pos, DIR_SW, ST_BIG_UFO_DESTROYER, v->index);
+		DisasterVehicle *w = DisasterVehicle::Create(-6 * (int)TILE_SIZE, v->y_pos, DIR_SW, ST_BIG_UFO_DESTROYER_SHADOW);
 		u->SetNext(w);
 	} else if (v->state == 0) {
 		int x = TileX(v->dest_tile) * TILE_SIZE;
@@ -743,9 +743,9 @@ static void Disaster_Zeppeliner_Init()
 		}
 	}
 
-	DisasterVehicle *v = new DisasterVehicle(x, 0, DIR_SE, ST_ZEPPELINER);
+	DisasterVehicle *v = DisasterVehicle::Create(x, 0, DIR_SE, ST_ZEPPELINER);
 	/* Allocate shadow */
-	DisasterVehicle *u = new DisasterVehicle(x, 0, DIR_SE, ST_ZEPPELINER_SHADOW);
+	DisasterVehicle *u = DisasterVehicle::Create(x, 0, DIR_SE, ST_ZEPPELINER_SHADOW);
 	v->SetNext(u);
 }
 
@@ -759,11 +759,11 @@ static void Disaster_Small_Ufo_Init()
 	if (!Vehicle::CanAllocateItem(2)) return;
 
 	int x = TileX(RandomTile()) * TILE_SIZE + TILE_SIZE / 2;
-	DisasterVehicle *v = new DisasterVehicle(x, 0, DIR_SE, ST_SMALL_UFO);
+	DisasterVehicle *v = DisasterVehicle::Create(x, 0, DIR_SE, ST_SMALL_UFO);
 	v->dest_tile = TileXY(Map::SizeX() / 2, Map::SizeY() / 2);
 
 	/* Allocate shadow */
-	DisasterVehicle *u = new DisasterVehicle(x, 0, DIR_SE, ST_SMALL_UFO_SHADOW);
+	DisasterVehicle *u = DisasterVehicle::Create(x, 0, DIR_SE, ST_SMALL_UFO_SHADOW);
 	v->SetNext(u);
 }
 
@@ -788,8 +788,8 @@ static void Disaster_Airplane_Init()
 	int x = (Map::SizeX() + 9) * TILE_SIZE - 1;
 	int y = TileY(found->location.tile) * TILE_SIZE + 37;
 
-	DisasterVehicle *v = new DisasterVehicle(x, y, DIR_NE, ST_AIRPLANE);
-	DisasterVehicle *u = new DisasterVehicle(x, y, DIR_NE, ST_AIRPLANE_SHADOW);
+	DisasterVehicle *v = DisasterVehicle::Create(x, y, DIR_NE, ST_AIRPLANE);
+	DisasterVehicle *u = DisasterVehicle::Create(x, y, DIR_NE, ST_AIRPLANE_SHADOW);
 	v->SetNext(u);
 }
 
@@ -813,11 +813,11 @@ static void Disaster_Helicopter_Init()
 	int x = -16 * (int)TILE_SIZE;
 	int y = TileY(found->location.tile) * TILE_SIZE + 37;
 
-	DisasterVehicle *v = new DisasterVehicle(x, y, DIR_SW, ST_HELICOPTER);
-	DisasterVehicle *u = new DisasterVehicle(x, y, DIR_SW, ST_HELICOPTER_SHADOW);
+	DisasterVehicle *v = DisasterVehicle::Create(x, y, DIR_SW, ST_HELICOPTER);
+	DisasterVehicle *u = DisasterVehicle::Create(x, y, DIR_SW, ST_HELICOPTER_SHADOW);
 	v->SetNext(u);
 
-	DisasterVehicle *w = new DisasterVehicle(x, y, DIR_SW, ST_HELICOPTER_ROTORS);
+	DisasterVehicle *w = DisasterVehicle::Create(x, y, DIR_SW, ST_HELICOPTER_ROTORS);
 	u->SetNext(w);
 }
 
@@ -831,11 +831,11 @@ static void Disaster_Big_Ufo_Init()
 	int x = TileX(RandomTile()) * TILE_SIZE + TILE_SIZE / 2;
 	int y = Map::MaxX() * TILE_SIZE - 1;
 
-	DisasterVehicle *v = new DisasterVehicle(x, y, DIR_NW, ST_BIG_UFO);
+	DisasterVehicle *v = DisasterVehicle::Create(x, y, DIR_NW, ST_BIG_UFO);
 	v->dest_tile = TileXY(Map::SizeX() / 2, Map::SizeY() / 2);
 
 	/* Allocate shadow */
-	DisasterVehicle *u = new DisasterVehicle(x, y, DIR_NW, ST_BIG_UFO_SHADOW);
+	DisasterVehicle *u = DisasterVehicle::Create(x, y, DIR_NW, ST_BIG_UFO_SHADOW);
 	v->SetNext(u);
 }
 
@@ -859,7 +859,7 @@ static void Disaster_Submarine_Init(DisasterSubType subtype)
 	}
 	if (!IsWaterTile(TileVirtXY(x, y))) return;
 
-	new DisasterVehicle(x, y, dir, subtype);
+	DisasterVehicle::Create(x, y, dir, subtype);
 }
 
 /* Curious submarine #1, just floats around */

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -118,14 +118,15 @@ void DisasterVehicle::UpdateImage()
 
 /**
  * Construct the disaster vehicle.
+ * @param index The index within the vehicle pool.
  * @param x         The X coordinate.
  * @param y         The Y coordinate.
  * @param direction The direction the vehicle is facing.
  * @param subtype   The sub type of vehicle.
  * @param big_ufo_destroyer_target The target for the UFO destroyer.
  */
-DisasterVehicle::DisasterVehicle(int x, int y, Direction direction, DisasterSubType subtype, VehicleID big_ufo_destroyer_target) :
-		SpecializedVehicleBase(), big_ufo_destroyer_target(big_ufo_destroyer_target)
+DisasterVehicle::DisasterVehicle(VehicleID index, int x, int y, Direction direction, DisasterSubType subtype, VehicleID big_ufo_destroyer_target) :
+		SpecializedVehicleBase(index), big_ufo_destroyer_target(big_ufo_destroyer_target)
 {
 	this->vehstatus = VehState::Unclickable;
 

--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -41,8 +41,8 @@ struct DisasterVehicle final : public SpecializedVehicle<DisasterVehicle, VEH_DI
 	uint16_t state = 0; ///< Action stage of the disaster vehicle.
 
 	/** For use by saveload. */
-	DisasterVehicle() : SpecializedVehicleBase() {}
-	DisasterVehicle(int x, int y, Direction direction, DisasterSubType subtype, VehicleID big_ufo_destroyer_target = VehicleID::Invalid());
+	DisasterVehicle(VehicleID index) : SpecializedVehicleBase(index) {}
+	DisasterVehicle(VehicleID index, int x, int y, Direction direction, DisasterSubType subtype, VehicleID big_ufo_destroyer_target = VehicleID::Invalid());
 	/** We want to 'destruct' the right class. */
 	~DisasterVehicle() override = default;
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1259,7 +1259,7 @@ void PrepareUnload(Vehicle *front_v)
 	 * limit in number of CargoPayments. Can't go wrong. */
 	static_assert(CargoPaymentPool::MAX_SIZE == VehiclePool::MAX_SIZE);
 	assert(CargoPayment::CanAllocateItem());
-	front_v->cargo_payment = new CargoPayment(front_v);
+	front_v->cargo_payment = CargoPayment::Create(front_v);
 
 	std::vector<StationID> next_station;
 	front_v->GetNextStoppingStation(next_station);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1162,9 +1162,11 @@ static void TriggerIndustryProduction(Industry *i)
 
 /**
  * Makes us a new cargo payment helper.
+ * @param index The index into the cargo payment pool
  * @param front The front of the train
  */
-CargoPayment::CargoPayment(Vehicle *front) :
+CargoPayment::CargoPayment(CargoPaymentID index, Vehicle *front) :
+	CargoPaymentPool::PoolItem<&_cargo_payment_pool>(index),
 	current_station(front->last_station_visited),
 	front(front)
 {

--- a/src/economy_base.h
+++ b/src/economy_base.h
@@ -29,9 +29,8 @@ struct CargoPayment : CargoPaymentPool::PoolItem<&_cargo_payment_pool> {
 	Money visual_profit = 0; ///< The visual profit to show
 	Money visual_transfer = 0; ///< The transfer credits to be shown
 
-	/** Constructor for pool saveload */
-	CargoPayment() {}
-	CargoPayment(Vehicle *front);
+	CargoPayment(CargoPaymentID index) : CargoPaymentPool::PoolItem<&_cargo_payment_pool>(index) {}
+	CargoPayment(CargoPaymentID index, Vehicle *front);
 	~CargoPayment();
 
 	Money PayTransfer(CargoType cargo, const CargoPacket *cp, uint count, TileIndex current_tile);

--- a/src/effectvehicle.cpp
+++ b/src/effectvehicle.cpp
@@ -567,7 +567,7 @@ EffectVehicle *CreateEffectVehicle(int x, int y, int z, EffectVehicleType type)
 {
 	if (!Vehicle::CanAllocateItem()) return nullptr;
 
-	EffectVehicle *v = new EffectVehicle();
+	EffectVehicle *v = EffectVehicle::Create();
 	v->subtype = type;
 	v->x_pos = x;
 	v->y_pos = y;

--- a/src/effectvehicle_base.h
+++ b/src/effectvehicle_base.h
@@ -25,8 +25,7 @@ struct EffectVehicle final : public SpecializedVehicle<EffectVehicle, VEH_EFFECT
 	uint16_t animation_state = 0; ///< State primarily used to change the graphics/behaviour.
 	uint8_t animation_substate = 0; ///< Sub state to time the change of the graphics/behaviour.
 
-	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
-	EffectVehicle() : SpecializedVehicleBase() {}
+	EffectVehicle(VehicleID index) : SpecializedVehicleBase(index) {}
 	/** We want to 'destruct' the right class. */
 	~EffectVehicle() override = default;
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -609,7 +609,7 @@ void SetupEngines()
 		assert(std::size(mapping) >= _engine_counts[type]);
 
 		for (const EngineIDMapping &eid : mapping) {
-			new (eid.engine) Engine(type, eid.internal_id);
+			Engine::CreateAtIndex(eid.engine, type, eid.internal_id);
 		}
 	}
 }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -68,7 +68,7 @@ const uint8_t _engine_offsets[4] = {
 
 static_assert(lengthof(_orig_rail_vehicle_info) + lengthof(_orig_road_vehicle_info) + lengthof(_orig_ship_vehicle_info) + lengthof(_orig_aircraft_vehicle_info) == lengthof(_orig_engine_info));
 
-Engine::Engine(VehicleType type, uint16_t local_id)
+Engine::Engine(EngineID index, VehicleType type, uint16_t local_id) : EnginePool::PoolItem<&_engine_pool>(index)
 {
 	this->type = type;
 	this->grf_prop.local_id = local_id;

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -77,8 +77,8 @@ private:
 	std::variant<std::monostate, RailVehicleInfo, RoadVehicleInfo, ShipVehicleInfo, AircraftVehicleInfo> vehicle_info{};
 
 public:
-	Engine() {}
-	Engine(VehicleType type, uint16_t local_id);
+	Engine(EngineID index) : EnginePool::PoolItem<&_engine_pool>(index) {}
+	Engine(EngineID index, VehicleType type, uint16_t local_id);
 	bool IsEnabled() const;
 
 	/**

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -85,7 +85,7 @@ std::tuple<CommandCost, GoalID> CmdCreateGoal(DoCommandFlags flags, CompanyID co
 	if (!Goal::IsValidGoalDestination(company, type, dest)) return { CMD_ERROR, GoalID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Goal *g = new Goal(type, dest, company, text);
+		Goal *g = Goal::Create(type, dest, company, text);
 
 		if (g->company == CompanyID::Invalid()) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);

--- a/src/goal_base.h
+++ b/src/goal_base.h
@@ -27,11 +27,8 @@ struct Goal : GoalPool::PoolItem<&_goal_pool> {
 	EncodedString progress{}; ///< Progress text of the goal.
 	bool completed = false; ///< Is the goal completed or not?
 
-	/**
-	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
-	 */
-	Goal() { }
-	Goal(GoalType type, GoalTypeID dst, CompanyID company, const EncodedString &text) : company(company), type(type), dst(dst), text(text) {}
+	Goal(GoalID index, GoalType type = GT_NONE, GoalTypeID dst = 0, CompanyID company = CompanyID::Invalid(), const EncodedString &text = {}) :
+		GoalPool::PoolItem<&_goal_pool>(index), company(company), type(type), dst(dst), text(text) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter

--- a/src/ground_vehicle.hpp
+++ b/src/ground_vehicle.hpp
@@ -87,8 +87,9 @@ struct GroundVehicle : public SpecializedVehicle<T, Type> {
 
 	/**
 	 * The constructor at SpecializedVehicle must be called.
+	 * @param index The index into the vehicle pool.
 	 */
-	GroundVehicle() : SpecializedVehicle<T, Type>() {}
+	GroundVehicle(VehicleID index) : SpecializedVehicle<T, Type>(index) {}
 
 	void PowerChanged();
 	void CargoChanged();

--- a/src/group.h
+++ b/src/group.h
@@ -85,8 +85,8 @@ struct Group : GroupPool::PoolItem<&_group_pool> {
 	GroupID parent = GroupID::Invalid(); ///< Parent group
 	uint16_t number = 0; ///< Per-company group number.
 
-	Group() {}
-	Group(CompanyID owner, VehicleType vehicle_type) : owner(owner), vehicle_type(vehicle_type) {}
+	Group(GroupID index, CompanyID owner = INVALID_OWNER, VehicleType vehicle_type = VEH_INVALID) :
+		GroupPool::PoolItem<&_group_pool>(index), owner(owner), vehicle_type(vehicle_type) {}
 };
 
 

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -349,7 +349,7 @@ std::tuple<CommandCost, GroupID> CmdCreateGroup(DoCommandFlags flags, VehicleTyp
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Group *g = new Group(_current_company, vt);
+		Group *g = Group::Create(_current_company, vt);
 
 		Company *c = Company::Get(g->owner);
 		g->number = c->freegroups.UseID(c->freegroups.NextID());

--- a/src/industry.h
+++ b/src/industry.h
@@ -135,7 +135,7 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 
 	PersistentStorage *psa = nullptr; ///< Persistent storage for NewGRF industries.
 
-	Industry(TileIndex tile = INVALID_TILE) : location(tile, 0, 0) {}
+	Industry(IndustryID index, TileIndex tile = INVALID_TILE) : IndustryPool::PoolItem<&_industry_pool>(index), location(tile, 0, 0) {}
 	~Industry();
 
 	void RecomputeProductionMultipliers();

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2043,7 +2043,7 @@ static CommandCost CreateNewIndustryHelper(TileIndex tile, IndustryType type, Do
 	if (!Industry::CanAllocateItem()) return CommandCost(STR_ERROR_TOO_MANY_INDUSTRIES);
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		*ip = new Industry(tile);
+		*ip = Industry::Create(tile);
 		if (!custom_shape_check) CheckIfCanLevelIndustryPlatform(tile, {DoCommandFlag::NoWater, DoCommandFlag::Execute}, layout);
 		DoCreateNewIndustry(*ip, tile, type, layout, layout_index, t, founder, random_initial_bits);
 	}

--- a/src/league_base.h
+++ b/src/league_base.h
@@ -37,12 +37,9 @@ struct LeagueTableElement : LeagueTableElementPool::PoolItem<&_league_table_elem
 	EncodedString score{}; ///< String representation of the score associated with the element
 	Link link{}; ///< What opens when element is clicked
 
-	/**
-	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
-	 */
-	LeagueTableElement() { }
-	LeagueTableElement(LeagueTableID table, int64_t rating, CompanyID company, const EncodedString &text, const EncodedString &score, const Link &link) :
-		table(table), rating(rating), company(company), text(text), score(score), link(link) {}
+	LeagueTableElement(LeagueTableElementID index) : LeagueTableElementPool::PoolItem<&_league_table_element_pool>(index) { }
+	LeagueTableElement(LeagueTableElementID index, LeagueTableID table, int64_t rating, CompanyID company, const EncodedString &text, const EncodedString &score, const Link &link) :
+		LeagueTableElementPool::PoolItem<&_league_table_element_pool>(index), table(table), rating(rating), company(company), text(text), score(score), link(link) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
@@ -57,11 +54,8 @@ struct LeagueTable : LeagueTablePool::PoolItem<&_league_table_pool> {
 	EncodedString header{}; ///< Text to show above the table
 	EncodedString footer{}; ///< Text to show below the table
 
-	/**
-	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
-	 */
-	LeagueTable() { }
-	LeagueTable(const EncodedString &title, const EncodedString &header, const EncodedString &footer) : title(title), header(header), footer(footer) { }
+	LeagueTable(LeagueTableID index, const EncodedString &title = {}, const EncodedString &header = {}, const EncodedString &footer = {}) :
+		LeagueTablePool::PoolItem<&_league_table_pool>(index), title(title), header(header), footer(footer) { }
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter

--- a/src/league_cmd.cpp
+++ b/src/league_cmd.cpp
@@ -60,7 +60,7 @@ std::tuple<CommandCost, LeagueTableID> CmdCreateLeagueTable(DoCommandFlags flags
 	if (title.empty()) return { CMD_ERROR, LeagueTableID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		LeagueTable *lt = new LeagueTable(title, header, footer);
+		LeagueTable *lt = LeagueTable::Create(title, header, footer);
 		return { CommandCost(), lt->index };
 	}
 
@@ -89,7 +89,7 @@ std::tuple<CommandCost, LeagueTableElementID> CmdCreateLeagueTableElement(DoComm
 	if (company != CompanyID::Invalid() && !Company::IsValidID(company)) return { CMD_ERROR, LeagueTableElementID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		LeagueTableElement *lte = new LeagueTableElement(table, rating, company, text, score, link);
+		LeagueTableElement *lte = LeagueTableElement::Create(table, rating, company, text, score, link);
 		InvalidateWindowData(WC_COMPANY_LEAGUE, table);
 		return { CommandCost(), lte->index };
 	}

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -188,13 +188,12 @@ public:
 		return val > 0 ? std::max(1U, val * target_age.base() / orig_age.base()) : 0;
 	}
 
-	/** Bare constructor, only for save/load. */
-	LinkGraph() {}
 	/**
 	 * Real constructor.
 	 * @param cargo Cargo the link graph is about.
 	 */
-	LinkGraph(CargoType cargo) : cargo(cargo), last_compression(TimerGameEconomy::date) {}
+	LinkGraph(LinkGraphID index, CargoType cargo = INVALID_CARGO) :
+		LinkGraphPool::PoolItem<&_link_graph_pool>(index), cargo(cargo), last_compression(TimerGameEconomy::date) {}
 
 	void Init(uint size);
 	void ShiftDates(TimerGameEconomy::Date interval);

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -30,9 +30,11 @@ INSTANTIATE_POOL_METHODS(LinkGraphJob)
  * Create a link graph job from a link graph. The link graph will be copied so
  * that the calculations don't interfere with the normal operations on the
  * original. The job is immediately started.
+ * @param index Index into the LinkGraphJob pool.
  * @param orig Original LinkGraph to be copied.
  */
-LinkGraphJob::LinkGraphJob(const LinkGraph &orig) :
+LinkGraphJob::LinkGraphJob(LinkGraphJobID index, const LinkGraph &orig) :
+		LinkGraphJobPool::PoolItem<&_link_graph_job_pool>(index),
 		/* Copying the link graph here also copies its index member.
 		 * This is on purpose. */
 		link_graph(orig),

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -26,7 +26,7 @@ extern LinkGraphJobPool _link_graph_job_pool;
 /**
  * Class for calculation jobs to be run on link graphs.
  */
-class LinkGraphJob : public LinkGraphJobPool::PoolItem<&_link_graph_job_pool>{
+class LinkGraphJob : public LinkGraphJobPool::PoolItem<&_link_graph_job_pool> {
 public:
 	/**
 	 * Demand between two nodes.
@@ -176,9 +176,9 @@ public:
 	 * Bare constructor, only for save/load. link_graph, join_date and actually
 	 * settings have to be brutally const-casted in order to populate them.
 	 */
-	LinkGraphJob() : settings(_settings_game.linkgraph) {}
+	LinkGraphJob(LinkGraphJobID index) : LinkGraphJobPool::PoolItem<&_link_graph_job_pool>(index), link_graph(LinkGraphID::Invalid()), settings(_settings_game.linkgraph) {}
 
-	LinkGraphJob(const LinkGraph &orig);
+	LinkGraphJob(LinkGraphJobID index, const LinkGraph &orig);
 	~LinkGraphJob();
 
 	void Init();

--- a/src/linkgraph/linkgraphschedule.cpp
+++ b/src/linkgraph/linkgraphschedule.cpp
@@ -43,7 +43,7 @@ void LinkGraphSchedule::SpawnNext()
 	assert(next == LinkGraph::Get(next->index));
 	this->schedule.pop_front();
 	if (LinkGraphJob::CanAllocateItem()) {
-		LinkGraphJob *job = new LinkGraphJob(*next);
+		LinkGraphJob *job = LinkGraphJob::Create(*next);
 		job->SpawnThread();
 		this->running.push_back(job);
 	} else {

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -568,7 +568,7 @@ NetworkAddress ParseConnectionString(std::string_view connection_string, uint16_
 	/* Register the login */
 	_network_clients_connected++;
 
-	ServerNetworkGameSocketHandler *cs = new ServerNetworkGameSocketHandler(s);
+	ServerNetworkGameSocketHandler *cs = ServerNetworkGameSocketHandler::Create(s);
 	cs->client_address = address; // Save the IP of the client
 
 	InvalidateWindowData(WC_CLIENT_LIST, 0);
@@ -836,7 +836,7 @@ static void NetworkInitGameInfo()
 
 	/* There should be always space for the server. */
 	assert(NetworkClientInfo::CanAllocateItem());
-	NetworkClientInfo *ci = new NetworkClientInfo(CLIENT_ID_SERVER);
+	NetworkClientInfo *ci = NetworkClientInfo::Create(CLIENT_ID_SERVER);
 	ci->client_playas = COMPANY_SPECTATOR;
 
 	ci->client_name = _settings_client.network.client_name;

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -115,7 +115,7 @@ ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
  */
 /* static */ void ServerNetworkAdminSocketHandler::AcceptConnection(SOCKET s, const NetworkAddress &address)
 {
-	ServerNetworkAdminSocketHandler *as = new ServerNetworkAdminSocketHandler(s);
+	ServerNetworkAdminSocketHandler *as = ServerNetworkAdminSocketHandler::Create(s);
 	as->address = address; // Save the IP of the client
 }
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -62,9 +62,11 @@ static_assert(lengthof(_admin_update_type_frequencies) == ADMIN_UPDATE_END);
 
 /**
  * Create a new socket for the server side of the admin network.
+ * @param index The index in the admin pool.
  * @param s The socket to connect with.
  */
-ServerNetworkAdminSocketHandler::ServerNetworkAdminSocketHandler(SOCKET s) : NetworkAdminSocketHandler(s)
+ServerNetworkAdminSocketHandler::ServerNetworkAdminSocketHandler(AdminID index, SOCKET s) :
+	NetworkAdminSocketPool::PoolItem<&_networkadminsocket_pool>(index), NetworkAdminSocketHandler(s)
 {
 	this->status = ADMIN_STATUS_INACTIVE;
 	this->connect_time = std::chrono::steady_clock::now();

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -47,7 +47,7 @@ public:
 	std::chrono::steady_clock::time_point connect_time{}; ///< Time of connection.
 	NetworkAddress address{}; ///< Address of the admin.
 
-	ServerNetworkAdminSocketHandler(SOCKET s);
+	ServerNetworkAdminSocketHandler(AdminID index, SOCKET s);
 	~ServerNetworkAdminSocketHandler() override;
 
 	NetworkRecvStatus SendError(NetworkErrorCode error);

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -30,9 +30,10 @@ struct NetworkClientInfo : NetworkClientInfoPool::PoolItem<&_networkclientinfo_p
 
 	/**
 	 * Create a new client.
+	 * @param index The index into the client info pool.
 	 * @param client_id The unique identifier of the client.
 	 */
-	NetworkClientInfo(ClientID client_id = INVALID_CLIENT_ID) : client_id(client_id) {}
+	NetworkClientInfo(ClientPoolID index, ClientID client_id = INVALID_CLIENT_ID) : NetworkClientInfoPool::PoolItem<&_networkclientinfo_pool>(index), client_id(client_id) {}
 	~NetworkClientInfo();
 
 	static NetworkClientInfo *GetByClientID(ClientID client_id);

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -565,7 +565,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CLIENT_INFO(Pac
 	if (!NetworkClientInfo::CanAllocateItem()) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 
 	/* We don't have this client_id yet, find an empty client_id, and put the data there */
-	ci = new NetworkClientInfo(client_id);
+	ci = NetworkClientInfo::Create(client_id);
 	ci->client_playas = playas;
 	if (client_id == _network_own_client_id) this->SetInfo(ci);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -914,7 +914,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_IDENTIFY(Packet
 	}
 
 	assert(NetworkClientInfo::CanAllocateItem());
-	NetworkClientInfo *ci = new NetworkClientInfo(this->client_id);
+	NetworkClientInfo *ci = NetworkClientInfo::Create(this->client_id);
 	this->SetInfo(ci);
 	ci->join_date = TimerGameEconomy::date;
 	ci->client_name = std::move(client_name);

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -186,9 +186,11 @@ struct PacketWriter : SaveFilter {
 
 /**
  * Create a new socket for the server side of the game connection.
+ * @param index The index into the client pool.
  * @param s The socket to connect with.
  */
-ServerNetworkGameSocketHandler::ServerNetworkGameSocketHandler(SOCKET s) : NetworkGameSocketHandler(s)
+ServerNetworkGameSocketHandler::ServerNetworkGameSocketHandler(ClientPoolID index, SOCKET s) :
+	NetworkClientSocketPool::PoolItem<&_networkclientsocket_pool>(index), NetworkGameSocketHandler(s)
 {
 	this->client_id = _network_client_id++;
 	this->receive_limit = _settings_client.network.bytes_per_frame_burst;

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -74,7 +74,7 @@ public:
 	std::shared_ptr<struct PacketWriter> savegame = nullptr; ///< Writer used to write the savegame.
 	NetworkAddress client_address{}; ///< IP-address of the client (so they can be banned)
 
-	ServerNetworkGameSocketHandler(SOCKET s);
+	ServerNetworkGameSocketHandler(ClientPoolID index, SOCKET s);
 	~ServerNetworkGameSocketHandler() override;
 
 	std::unique_ptr<Packet> ReceivePacket() override;

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -263,7 +263,7 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
 	size_t engine_pool_size = Engine::GetPoolSize();
 
 	/* ... it's not, so create a new one based off an existing engine */
-	Engine *e = new Engine(type, internal_id);
+	Engine *e = Engine::Create(type, internal_id);
 	e->grf_prop.SetGRFFile(file);
 
 	/* Reserve the engine slot */

--- a/src/newgrf/newgrf_act2.cpp
+++ b/src/newgrf/newgrf_act2.cpp
@@ -286,7 +286,7 @@ static const SpriteGroup *GetCallbackResultGroup(uint16_t value)
 
 	/* Result value is not present, so make it and add to cache. */
 	assert(CallbackResultSpriteGroup::CanAllocateItem());
-	const SpriteGroup *group = new CallbackResultSpriteGroup(value);
+	const SpriteGroup *group = CallbackResultSpriteGroup::Create(value);
 	it = _cached_callback_groups.emplace(it, value, group->index);
 	return group;
 }
@@ -330,7 +330,7 @@ static const SpriteGroup *CreateGroupFromGroupID(GrfSpecFeature feature, uint8_t
 	assert(spriteset_start + num_sprites <= _cur_gps.spriteid);
 
 	assert(ResultSpriteGroup::CanAllocateItem());
-	return new ResultSpriteGroup(spriteset_start, num_sprites);
+	return ResultSpriteGroup::Create(spriteset_start, num_sprites);
 }
 
 /* Action 0x02 */
@@ -374,7 +374,7 @@ static void NewSpriteGroup(ByteReader &buf)
 			uint8_t varsize;
 
 			assert(DeterministicSpriteGroup::CanAllocateItem());
-			DeterministicSpriteGroup *group = new DeterministicSpriteGroup();
+			DeterministicSpriteGroup *group = DeterministicSpriteGroup::Create();
 			group->nfo_line = _cur_gps.nfo_line;
 			act_group = group;
 			group->var_scope = HasBit(type, 1) ? VSG_SCOPE_PARENT : VSG_SCOPE_SELF;
@@ -494,7 +494,7 @@ static void NewSpriteGroup(ByteReader &buf)
 		case 0x84: // Relative scope
 		{
 			assert(RandomizedSpriteGroup::CanAllocateItem());
-			RandomizedSpriteGroup *group = new RandomizedSpriteGroup();
+			RandomizedSpriteGroup *group = RandomizedSpriteGroup::Create();
 			group->nfo_line = _cur_gps.nfo_line;
 			act_group = group;
 			group->var_scope = HasBit(type, 1) ? VSG_SCOPE_PARENT : VSG_SCOPE_SELF;
@@ -593,7 +593,7 @@ static void NewSpriteGroup(ByteReader &buf)
 					}
 
 					assert(RealSpriteGroup::CanAllocateItem());
-					RealSpriteGroup *group = new RealSpriteGroup();
+					RealSpriteGroup *group = RealSpriteGroup::Create();
 					group->nfo_line = _cur_gps.nfo_line;
 					act_group = group;
 
@@ -622,7 +622,7 @@ static void NewSpriteGroup(ByteReader &buf)
 					uint8_t num_building_sprites = std::max((uint8_t)1, type);
 
 					assert(TileLayoutSpriteGroup::CanAllocateItem());
-					TileLayoutSpriteGroup *group = new TileLayoutSpriteGroup();
+					TileLayoutSpriteGroup *group = TileLayoutSpriteGroup::Create();
 					group->nfo_line = _cur_gps.nfo_line;
 					act_group = group;
 
@@ -638,7 +638,7 @@ static void NewSpriteGroup(ByteReader &buf)
 					}
 
 					assert(IndustryProductionSpriteGroup::CanAllocateItem());
-					IndustryProductionSpriteGroup *group = new IndustryProductionSpriteGroup();
+					IndustryProductionSpriteGroup *group = IndustryProductionSpriteGroup::Create();
 					group->nfo_line = _cur_gps.nfo_line;
 					act_group = group;
 					group->version = type;

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -213,7 +213,7 @@ uint32_t AirportResolverObject::GetDebugID() const
 		/* Create storage on first modification. */
 		uint32_t grfid = (this->ro.grffile != nullptr) ? this->ro.grffile->grfid : 0;
 		assert(PersistentStorage::CanAllocateItem());
-		this->st->airport.psa = new PersistentStorage(grfid, GSF_AIRPORTS, this->st->airport.tile);
+		this->st->airport.psa = PersistentStorage::Create(grfid, GSF_AIRPORTS, this->st->airport.tile);
 	}
 	this->st->airport.psa->StoreValue(pos, value);
 }

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -448,7 +448,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 		/* Create storage on first modification. */
 		const IndustrySpec *indsp = GetIndustrySpec(this->industry->type);
 		assert(PersistentStorage::CanAllocateItem());
-		this->industry->psa = new PersistentStorage(indsp->grf_prop.grfid, GSF_INDUSTRIES, this->industry->location.tile);
+		this->industry->psa = PersistentStorage::Create(indsp->grf_prop.grfid, GSF_INDUSTRIES, this->industry->location.tile);
 	}
 
 	this->industry->psa->StoreValue(pos, value);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -546,8 +546,7 @@ CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, siz
 {
 	const IndustrySpec *indspec = GetIndustrySpec(type);
 
-	Industry ind;
-	ind.index = IndustryID::Invalid();
+	Industry ind(IndustryID::Invalid());
 	ind.location.tile = tile;
 	ind.location.w = 0; // important to mark the industry invalid
 	ind.type = type;

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -231,8 +231,7 @@ extern bool IsSlopeRefused(Slope current, Slope refused);
  */
 CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind_tile, const IndustryTileSpec *its, IndustryType type, IndustryGfx gfx, size_t layout_index, uint16_t initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type)
 {
-	Industry ind;
-	ind.index = IndustryID::Invalid();
+	Industry ind(IndustryID::Invalid());
 	ind.location.tile = ind_base_tile;
 	ind.location.w = 0;
 	ind.type = type;

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -46,7 +46,7 @@ extern SpriteGroupPool _spritegroup_pool;
 /* Common wrapper for all the different sprite group types */
 struct SpriteGroup : SpriteGroupPool::PoolItem<&_spritegroup_pool> {
 protected:
-	SpriteGroup() {} // Not `= default` as that resets PoolItem->index.
+	SpriteGroup(SpriteGroupID index) : SpriteGroupPool::PoolItem<&_spritegroup_pool>(index) {}
 	/** Base sprite group resolver */
 	virtual ResolverResult Resolve(ResolverObject &object) const = 0;
 
@@ -64,7 +64,7 @@ public:
  */
 template <class T>
 struct SpecializedSpriteGroup : public SpriteGroup {
-	inline SpecializedSpriteGroup() : SpriteGroup() {}
+	inline SpecializedSpriteGroup(SpriteGroupID index) : SpriteGroup(index) {}
 
 	/**
 	 * Creates a new T-object in the SpriteGroup pool.
@@ -82,7 +82,7 @@ struct SpecializedSpriteGroup : public SpriteGroup {
 /* 'Real' sprite groups contain a list of other result or callback sprite
  * groups. */
 struct RealSpriteGroup : SpecializedSpriteGroup<RealSpriteGroup> {
-	RealSpriteGroup() : SpecializedSpriteGroup<RealSpriteGroup>() {}
+	RealSpriteGroup(SpriteGroupID index) : SpecializedSpriteGroup<RealSpriteGroup>(index) {}
 
 	/* Loaded = in motion, loading = not moving
 	 * Each group contains several spritesets, for various loading stages */
@@ -177,7 +177,7 @@ struct DeterministicSpriteGroupRange {
 
 
 struct DeterministicSpriteGroup : SpecializedSpriteGroup<DeterministicSpriteGroup> {
-	DeterministicSpriteGroup() : SpecializedSpriteGroup<DeterministicSpriteGroup>() {}
+	DeterministicSpriteGroup(SpriteGroupID index) : SpecializedSpriteGroup<DeterministicSpriteGroup>(index) {}
 
 	VarSpriteGroupScope var_scope{};
 	DeterministicSpriteGroupSize size{};
@@ -199,7 +199,7 @@ enum RandomizedSpriteGroupCompareMode : uint8_t {
 };
 
 struct RandomizedSpriteGroup : SpecializedSpriteGroup<RandomizedSpriteGroup> {
-	RandomizedSpriteGroup() : SpecializedSpriteGroup<RandomizedSpriteGroup>() {}
+	RandomizedSpriteGroup(SpriteGroupID index) : SpecializedSpriteGroup<RandomizedSpriteGroup>(index) {}
 
 	VarSpriteGroupScope var_scope{};  ///< Take this object:
 
@@ -223,7 +223,7 @@ struct CallbackResultSpriteGroup : SpecializedSpriteGroup<CallbackResultSpriteGr
 	 * Creates a spritegroup representing a callback result
 	 * @param value The value that was used to represent this callback result
 	 */
-	explicit CallbackResultSpriteGroup(CallbackResult value) : SpecializedSpriteGroup<CallbackResultSpriteGroup>(), result(value) {}
+	CallbackResultSpriteGroup(SpriteGroupID index, CallbackResult value) : SpecializedSpriteGroup<CallbackResultSpriteGroup>(index), result(value) {}
 
 	CallbackResult result = 0;
 
@@ -241,7 +241,7 @@ struct ResultSpriteGroup : SpecializedSpriteGroup<ResultSpriteGroup> {
 	 * @param num_sprites The number of sprites per set.
 	 * @return A spritegroup representing the sprite number result.
 	 */
-	ResultSpriteGroup(SpriteID sprite, uint8_t num_sprites) : SpecializedSpriteGroup<ResultSpriteGroup>(), num_sprites(num_sprites), sprite(sprite) {}
+	ResultSpriteGroup(SpriteGroupID index, SpriteID sprite, uint8_t num_sprites) : SpecializedSpriteGroup<ResultSpriteGroup>(index), num_sprites(num_sprites), sprite(sprite) {}
 
 	uint8_t num_sprites = 0;
 	SpriteID sprite = 0;
@@ -254,7 +254,7 @@ protected:
  * Action 2 sprite layout for houses, industry tiles, objects and airport tiles.
  */
 struct TileLayoutSpriteGroup : SpecializedSpriteGroup<TileLayoutSpriteGroup> {
-	TileLayoutSpriteGroup() : SpecializedSpriteGroup<TileLayoutSpriteGroup>() {}
+	TileLayoutSpriteGroup(SpriteGroupID index) : SpecializedSpriteGroup<TileLayoutSpriteGroup>(index) {}
 
 	NewGRFSpriteLayout dts{};
 
@@ -265,7 +265,7 @@ protected:
 };
 
 struct IndustryProductionSpriteGroup : SpecializedSpriteGroup<IndustryProductionSpriteGroup> {
-	IndustryProductionSpriteGroup() : SpecializedSpriteGroup<IndustryProductionSpriteGroup>() {}
+	IndustryProductionSpriteGroup(SpriteGroupID index) : SpecializedSpriteGroup<IndustryProductionSpriteGroup>(index) {}
 
 	uint8_t version = 0; ///< Production callback version used, or 0xFF if marked invalid
 	uint8_t num_input = 0; ///< How many subtract_input values are valid

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -59,10 +59,30 @@ public:
 };
 
 
+/**
+ * Class defining some overloaded accessors so we don't have to cast SpriteGroups that often
+ */
+template <class T>
+struct SpecializedSpriteGroup : public SpriteGroup {
+	inline SpecializedSpriteGroup() : SpriteGroup() {}
+
+	/**
+	 * Creates a new T-object in the SpriteGroup pool.
+	 * @param args... The arguments to the constructor.
+	 * @return The created object.
+	 */
+	template <typename... Targs>
+	static inline T *Create(Targs &&... args)
+	{
+		return SpriteGroup::Create<T>(std::forward<Targs&&>(args)...);
+	}
+};
+
+
 /* 'Real' sprite groups contain a list of other result or callback sprite
  * groups. */
-struct RealSpriteGroup : SpriteGroup {
-	RealSpriteGroup() : SpriteGroup() {}
+struct RealSpriteGroup : SpecializedSpriteGroup<RealSpriteGroup> {
+	RealSpriteGroup() : SpecializedSpriteGroup<RealSpriteGroup>() {}
 
 	/* Loaded = in motion, loading = not moving
 	 * Each group contains several spritesets, for various loading stages */
@@ -156,8 +176,8 @@ struct DeterministicSpriteGroupRange {
 };
 
 
-struct DeterministicSpriteGroup : SpriteGroup {
-	DeterministicSpriteGroup() : SpriteGroup() {}
+struct DeterministicSpriteGroup : SpecializedSpriteGroup<DeterministicSpriteGroup> {
+	DeterministicSpriteGroup() : SpecializedSpriteGroup<DeterministicSpriteGroup>() {}
 
 	VarSpriteGroupScope var_scope{};
 	DeterministicSpriteGroupSize size{};
@@ -178,8 +198,8 @@ enum RandomizedSpriteGroupCompareMode : uint8_t {
 	RSG_CMP_ALL,
 };
 
-struct RandomizedSpriteGroup : SpriteGroup {
-	RandomizedSpriteGroup() : SpriteGroup() {}
+struct RandomizedSpriteGroup : SpecializedSpriteGroup<RandomizedSpriteGroup> {
+	RandomizedSpriteGroup() : SpecializedSpriteGroup<RandomizedSpriteGroup>() {}
 
 	VarSpriteGroupScope var_scope{};  ///< Take this object:
 
@@ -198,12 +218,12 @@ protected:
 
 /* This contains a callback result. A failed callback has a value of
  * CALLBACK_FAILED */
-struct CallbackResultSpriteGroup : SpriteGroup {
+struct CallbackResultSpriteGroup : SpecializedSpriteGroup<CallbackResultSpriteGroup> {
 	/**
 	 * Creates a spritegroup representing a callback result
 	 * @param value The value that was used to represent this callback result
 	 */
-	explicit CallbackResultSpriteGroup(CallbackResult value) : SpriteGroup(), result(value) {}
+	explicit CallbackResultSpriteGroup(CallbackResult value) : SpecializedSpriteGroup<CallbackResultSpriteGroup>(), result(value) {}
 
 	CallbackResult result = 0;
 
@@ -214,14 +234,14 @@ protected:
 
 /* A result sprite group returns the first SpriteID and the number of
  * sprites in the set */
-struct ResultSpriteGroup : SpriteGroup {
+struct ResultSpriteGroup : SpecializedSpriteGroup<ResultSpriteGroup> {
 	/**
 	 * Creates a spritegroup representing a sprite number result.
 	 * @param sprite The sprite number.
 	 * @param num_sprites The number of sprites per set.
 	 * @return A spritegroup representing the sprite number result.
 	 */
-	ResultSpriteGroup(SpriteID sprite, uint8_t num_sprites) : SpriteGroup(), num_sprites(num_sprites), sprite(sprite) {}
+	ResultSpriteGroup(SpriteID sprite, uint8_t num_sprites) : SpecializedSpriteGroup<ResultSpriteGroup>(), num_sprites(num_sprites), sprite(sprite) {}
 
 	uint8_t num_sprites = 0;
 	SpriteID sprite = 0;
@@ -233,8 +253,8 @@ protected:
 /**
  * Action 2 sprite layout for houses, industry tiles, objects and airport tiles.
  */
-struct TileLayoutSpriteGroup : SpriteGroup {
-	TileLayoutSpriteGroup() : SpriteGroup() {}
+struct TileLayoutSpriteGroup : SpecializedSpriteGroup<TileLayoutSpriteGroup> {
+	TileLayoutSpriteGroup() : SpecializedSpriteGroup<TileLayoutSpriteGroup>() {}
 
 	NewGRFSpriteLayout dts{};
 
@@ -244,8 +264,8 @@ protected:
 	ResolverResult Resolve(ResolverObject &) const override { return this; }
 };
 
-struct IndustryProductionSpriteGroup : SpriteGroup {
-	IndustryProductionSpriteGroup() : SpriteGroup() {}
+struct IndustryProductionSpriteGroup : SpecializedSpriteGroup<IndustryProductionSpriteGroup> {
+	IndustryProductionSpriteGroup() : SpecializedSpriteGroup<IndustryProductionSpriteGroup>() {}
 
 	uint8_t version = 0; ///< Production callback version used, or 0xFF if marked invalid
 	uint8_t num_input = 0; ///< How many subtract_input values are valid

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -197,8 +197,7 @@ extern PersistentStoragePool _persistent_storage_pool;
  * Class for pooled persistent storage of data.
  */
 struct PersistentStorage : PersistentStorageArray<int32_t, 256>, PersistentStoragePool::PoolItem<&_persistent_storage_pool> {
-	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
-	PersistentStorage(const uint32_t new_grfid, GrfSpecFeature feature, TileIndex tile)
+	PersistentStorage(PersistentStorageID index, const uint32_t new_grfid, GrfSpecFeature feature, TileIndex tile) : PersistentStoragePool::PoolItem<&_persistent_storage_pool>(index)
 	{
 		this->grfid = new_grfid;
 		this->feature = feature;

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -156,7 +156,7 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 
 	/* Create a new storage. */
 	assert(PersistentStorage::CanAllocateItem());
-	PersistentStorage *psa = new PersistentStorage(grfid, GSF_FAKE_TOWNS, this->t->xy);
+	PersistentStorage *psa = PersistentStorage::Create(grfid, GSF_FAKE_TOWNS, this->t->xy);
 	psa->StoreValue(pos, value);
 	t->psa_list.push_back(psa);
 }

--- a/src/object_base.h
+++ b/src/object_base.h
@@ -28,10 +28,9 @@ struct Object : ObjectPool::PoolItem<&_object_pool> {
 	uint8_t colour = 0; ///< Colour of the object, for display purpose
 	uint8_t view = 0; ///< The view setting for this object
 
-	/** Make sure the object isn't zeroed. */
-	Object() {}
-	Object(ObjectType type, Town *town, TileArea location, TimerGameCalendar::Date build_date, uint8_t view) :
-		type(type), town(town), location(location), build_date(build_date), view(view) {}
+	Object(ObjectID index) : ObjectPool::PoolItem<&_object_pool>(index) {}
+	Object(ObjectID index, ObjectType type, Town *town, TileArea location, TimerGameCalendar::Date build_date, uint8_t view) :
+		ObjectPool::PoolItem<&_object_pool>(index), type(type), town(town), location(location), build_date(build_date), view(view) {}
 	/** Make sure the right destructor is called as well! */
 	~Object() {}
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -90,7 +90,7 @@ void BuildObject(ObjectType type, TileIndex tile, CompanyID owner, Town *town, u
 	const ObjectSpec *spec = ObjectSpec::Get(type);
 
 	TileArea ta(tile, GB(spec->size, HasBit(view, 0) ? 4 : 0, 4), GB(spec->size, HasBit(view, 0) ? 0 : 4, 4));
-	Object *o = new Object(type, town == nullptr ? CalcClosestTownFromTile(tile) : town, ta, TimerGameCalendar::date, view);
+	Object *o = Object::Create(type, town == nullptr ? CalcClosestTownFromTile(tile) : town, ta, TimerGameCalendar::date, view);
 
 	/* If nothing owns the object, the colour will be random. Otherwise
 	 * get the colour from the company's livery settings. */

--- a/src/order_backup.cpp
+++ b/src/order_backup.cpp
@@ -57,7 +57,7 @@ void OrderBackup::DoRestore(Vehicle *v)
 	if (this->clone != nullptr) {
 		Command<CMD_CLONE_ORDER>::Do(DoCommandFlag::Execute, CO_SHARE, v->index, this->clone->index);
 	} else if (!this->orders.empty() && OrderList::CanAllocateItem()) {
-		v->orders = new OrderList(std::move(this->orders), v);
+		v->orders = OrderList::Create(std::move(this->orders), v);
 		/* Make sure buoys/oil rigs are updated in the station list. */
 		InvalidateWindowClassesData(WC_STATION_LIST, 0);
 	}
@@ -89,7 +89,7 @@ void OrderBackup::DoRestore(Vehicle *v)
 		if (ob->user == user) delete ob;
 	}
 	if (OrderBackup::CanAllocateItem()) {
-		new OrderBackup(v, user);
+		OrderBackup::Create(v, user);
 	}
 }
 

--- a/src/order_backup.cpp
+++ b/src/order_backup.cpp
@@ -30,11 +30,22 @@ INSTANTIATE_POOL_METHODS(OrderBackup)
 OrderBackup::~OrderBackup() = default;
 
 /**
+ * Create an order backup for savegame loading.
+ * @param index The index of the order backup pool.
+ */
+OrderBackup::OrderBackup(OrderBackupID index) :
+	OrderBackupPool::PoolItem<&_order_backup_pool>(index)
+{
+}
+
+/**
  * Create an order backup for the given vehicle.
+ * @param index The index of the order backup pool.
  * @param v    The vehicle to make a backup of.
  * @param user The user that is requesting the backup.
  */
-OrderBackup::OrderBackup(const Vehicle *v, uint32_t user) : user(user), tile(v->tile), group(v->group_id)
+OrderBackup::OrderBackup(OrderBackupID index, const Vehicle *v, uint32_t user) :
+	OrderBackupPool::PoolItem<&_order_backup_pool>(index), user(user), tile(v->tile), group(v->group_id)
 {
 	this->CopyConsistPropertiesFrom(v);
 

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -48,9 +48,8 @@ private:
 	void DoRestore(Vehicle *v);
 
 	friend OrderBackupPool::PoolItem<&_order_backup_pool>;
-	/** Creation for savegame restoration. */
-	OrderBackup() = default;
-	OrderBackup(const Vehicle *v, uint32_t user);
+	OrderBackup(OrderBackupID index);
+	OrderBackup(OrderBackupID index, const Vehicle *v, uint32_t user);
 
 public:
 	~OrderBackup();

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -45,11 +45,12 @@ private:
 	std::vector<Order> orders; ///< The actual orders if the vehicle was not a clone.
 	uint32_t old_order_index = 0;
 
+	void DoRestore(Vehicle *v);
+
+	friend OrderBackupPool::PoolItem<&_order_backup_pool>;
 	/** Creation for savegame restoration. */
 	OrderBackup() = default;
 	OrderBackup(const Vehicle *v, uint32_t user);
-
-	void DoRestore(Vehicle *v);
 
 public:
 	~OrderBackup();

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -290,26 +290,27 @@ private:
 
 public:
 	/** Default constructor producing an invalid order list. */
-	OrderList() {}
+	OrderList(OrderListID index) : OrderListPool::PoolItem<&_orderlist_pool>(index) {}
 
 	/**
 	 * Create an order list with the given order chain for the given vehicle.
-	 *  @param chain pointer to the first order of the order chain
-	 *  @param v any vehicle using this orderlist
+	 * @param index index of the list within the order list pool
+	 * @param chain pointer to the first order of the order chain
+	 * @param v any vehicle using this orderlist
 	 */
-	OrderList(Order &&order, Vehicle *v)
+	OrderList(OrderListID index, Order &&order, Vehicle *v) : OrderListPool::PoolItem<&_orderlist_pool>(index)
 	{
 		this->orders.emplace_back(std::move(order));
 		this->Initialize(v);
 	}
 
-	OrderList(std::vector<Order> &&orders, Vehicle *v)
+	OrderList(OrderListID index, std::vector<Order> &&orders, Vehicle *v) : OrderListPool::PoolItem<&_orderlist_pool>(index)
 	{
 		this->orders = std::move(orders);
 		this->Initialize(v);
 	}
 
-	OrderList(Vehicle *v)
+	OrderList(OrderListID index, Vehicle *v) : OrderListPool::PoolItem<&_orderlist_pool>(index)
 	{
 		this->Initialize(v);
 	}

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -847,7 +847,7 @@ void InsertOrder(Vehicle *v, Order &&new_o, VehicleOrderID sel_ord)
 {
 	/* Create new order and link in list */
 	if (v->orders == nullptr) {
-		v->orders = new OrderList(std::move(new_o), v);
+		v->orders = OrderList::Create(std::move(new_o), v);
 	} else {
 		v->orders->InsertOrderAt(std::move(new_o), sel_ord);
 	}
@@ -1604,7 +1604,7 @@ CommandCost CmdCloneOrder(DoCommandFlags flags, CloneOptions action, VehicleID v
 				}
 
 				assert(OrderList::CanAllocateItem());
-				dst->orders = new OrderList(std::move(dst_orders), dst);
+				dst->orders = OrderList::Create(std::move(dst_orders), dst);
 
 				InvalidateVehicleOrder(dst, VIWD_REMOVE_ALL_ORDERS);
 

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1008,7 +1008,7 @@ CommandCost CmdBuildTrainDepot(DoCommandFlags flags, TileIndex tile, RailType ra
 		if (rotate_existing_depot) {
 			SetRailDepotExitDirection(tile, dir);
 		} else {
-			Depot *d = new Depot(tile);
+			Depot *d = Depot::Create(tile);
 
 			MakeRailDepot(tile, _current_company, d->index, dir, railtype);
 			MakeDefaultName(d);

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1176,7 +1176,7 @@ CommandCost CmdBuildRoadDepot(DoCommandFlags flags, TileIndex tile, RoadType rt,
 		if (rotate_existing_depot) {
 			SetRoadDepotExitDirection(tile, dir);
 		} else {
-			Depot *dep = new Depot(tile);
+			Depot *dep = Depot::Create(tile);
 			MakeRoadDepot(tile, _current_company, dep->index, dir, rt);
 			MakeDefaultName(dep);
 

--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -71,7 +71,7 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 	RoadStop *next = nullptr; ///< Next stop of the given type at this station
 
 	/** Initializes a RoadStop */
-	inline RoadStop(TileIndex tile = INVALID_TILE) : xy(tile) { }
+	inline RoadStop(RoadStopID index, TileIndex tile = INVALID_TILE) : RoadStopPool::PoolItem<&_roadstop_pool>(index), xy(tile) { }
 
 	~RoadStop();
 

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -109,8 +109,7 @@ struct RoadVehicle final : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 	VehicleID disaster_vehicle = VehicleID::Invalid(); ///< NOSAVE: Disaster vehicle targetting this vehicle.
 	RoadTypes compatible_roadtypes{}; ///< NOSAVE: Roadtypes this consist is powered on.
 
-	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
-	RoadVehicle() : GroundVehicleBase() {}
+	RoadVehicle(VehicleID index) : GroundVehicleBase(index) {}
 	/** We want to 'destruct' the right class. */
 	~RoadVehicle() override { this->PreDestructor(); }
 

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -269,7 +269,7 @@ CommandCost CmdBuildRoadVehicle(DoCommandFlags flags, TileIndex tile, const Engi
 	if (flags.Test(DoCommandFlag::Execute)) {
 		const RoadVehicleInfo *rvi = &e->VehInfo<RoadVehicleInfo>();
 
-		RoadVehicle *v = new RoadVehicle();
+		RoadVehicle *v = RoadVehicle::Create();
 		*ret = v;
 		v->direction = DiagDirToDir(GetRoadDepotDirection(tile));
 		v->owner = _current_company;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -961,7 +961,7 @@ bool AfterLoadGame()
 							/* From this version on there can be multiple road stops of the
 							 * same type per station. Convert the existing stops to the new
 							 * internal data structure. */
-							RoadStop *rs = new RoadStop(t);
+							RoadStop *rs = RoadStop::Create(t);
 
 							RoadStop **head =
 								IsTruckStop(t) ? &st->truck_stops : &st->bus_stops;
@@ -2156,7 +2156,7 @@ bool AfterLoadGame()
 						SlError(STR_ERROR_TOO_MANY_OBJECTS);
 					}
 
-					Object *o = new Object();
+					Object *o = Object::Create();
 					o->location.tile = (TileIndex)t;
 					o->location.w    = size;
 					o->location.h    = size;
@@ -2251,7 +2251,7 @@ bool AfterLoadGame()
 				 * assert() in Pool::GetNew() happy by calling CanAllocateItem(). */
 				static_assert(CargoPaymentPool::MAX_SIZE == VehiclePool::MAX_SIZE);
 				assert(CargoPayment::CanAllocateItem());
-				if (v->cargo_payment == nullptr) v->cargo_payment = new CargoPayment(v);
+				if (v->cargo_payment == nullptr) v->cargo_payment = CargoPayment::Create(v);
 			}
 		}
 	}

--- a/src/saveload/autoreplace_sl.cpp
+++ b/src/saveload/autoreplace_sl.cpp
@@ -45,7 +45,7 @@ struct ERNWChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			EngineRenew *er = new (EngineRenewID(index)) EngineRenew();
+			EngineRenew *er = EngineRenew::CreateAtIndex(EngineRenewID(index));
 			SlObject(er, slt);
 
 			/* Advanced vehicle lists, ungrouped vehicles got added */

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -162,7 +162,7 @@ struct CAPAChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			CargoPacket *cp = new (CargoPacketID(index)) CargoPacket();
+			CargoPacket *cp = CargoPacket::CreateAtIndex(CargoPacketID(index));
 			SlObject(cp, slt);
 		}
 	}

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -567,7 +567,7 @@ struct PLYRChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Company *c = new (CompanyID(index)) Company();
+			Company *c = Company::CreateAtIndex(CompanyID(index));
 			SlObject(c, slt);
 			_company_colours[index] = c->colour;
 		}

--- a/src/saveload/depot_sl.cpp
+++ b/src/saveload/depot_sl.cpp
@@ -49,7 +49,7 @@ struct DEPTChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			Depot *depot = new (DepotID(index)) Depot();
+			Depot *depot = Depot::CreateAtIndex(DepotID(index));
 			SlObject(depot, slt);
 
 			/* Set the town 'pointer' so we can restore it later. */

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -108,7 +108,7 @@ struct CAPYChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			CargoPayment *cp = new (CargoPaymentID(index)) CargoPayment();
+			CargoPayment *cp = CargoPayment::CreateAtIndex(CargoPaymentID(index));
 			SlObject(cp, slt);
 		}
 	}

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -48,7 +48,7 @@ Engine *GetTempDataEngine(EngineID index)
 	if (index < _temp_engine.size()) {
 		return &_temp_engine[index];
 	} else if (index == _temp_engine.size()) {
-		return &_temp_engine.emplace_back();
+		return &_temp_engine.emplace_back(index);
 	} else {
 		NOT_REACHED();
 	}

--- a/src/saveload/goal_sl.cpp
+++ b/src/saveload/goal_sl.cpp
@@ -44,7 +44,7 @@ struct GOALChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Goal *s = new (GoalID(index)) Goal();
+			Goal *s = Goal::CreateAtIndex(GoalID(index));
 			SlObject(s, slt);
 		}
 	}

--- a/src/saveload/group_sl.cpp
+++ b/src/saveload/group_sl.cpp
@@ -50,7 +50,7 @@ struct GRPSChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			Group *g = new (GroupID(index)) Group();
+			Group *g = Group::CreateAtIndex(GroupID(index));
 			SlObject(g, slt);
 
 			if (IsSavegameVersionBefore(SLV_189)) g->parent = GroupID::Invalid();

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -260,7 +260,7 @@ struct INDYChunkHandler : ChunkHandler {
 			if (IsSavegameVersionBefore(SLV_161) && !IsSavegameVersionBefore(SLV_76)) {
 				/* Store the old persistent storage. The GRFID will be added later. */
 				assert(PersistentStorage::CanAllocateItem());
-				i->psa = new PersistentStorage(0, GSF_INVALID, TileIndex{});
+				i->psa = PersistentStorage::Create(0, GSF_INVALID, TileIndex{});
 				std::copy(std::begin(_old_ind_persistent_storage.storage), std::end(_old_ind_persistent_storage.storage), std::begin(i->psa->storage));
 			}
 			if (IsSavegameVersionBefore(SLV_EXTEND_INDUSTRY_CARGO_SLOTS)) {

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -253,7 +253,7 @@ struct INDYChunkHandler : ChunkHandler {
 		SlIndustryProduced::ResetOldStructure();
 
 		while ((index = SlIterateArray()) != -1) {
-			Industry *i = new (IndustryID(index)) Industry();
+			Industry *i = Industry::CreateAtIndex(IndustryID(index));
 			SlObject(i, slt);
 
 			/* Before savegame version 161, persistent storages were not stored in a pool. */

--- a/src/saveload/league_sl.cpp
+++ b/src/saveload/league_sl.cpp
@@ -45,7 +45,7 @@ struct LEAEChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			LeagueTableElement *lte = new (LeagueTableElementID(index)) LeagueTableElement();
+			LeagueTableElement *lte = LeagueTableElement::CreateAtIndex(LeagueTableElementID(index));
 			SlObject(lte, slt);
 		}
 	}
@@ -76,7 +76,7 @@ struct LEATChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			LeagueTable *lt = new (LeagueTableID(index)) LeagueTable();
+			LeagueTable *lt = LeagueTable::CreateAtIndex(LeagueTableID(index));
 			SlObject(lt, slt);
 		}
 	}

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -277,7 +277,7 @@ struct LGRPChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			LinkGraph *lg = new (LinkGraphID(index)) LinkGraph();
+			LinkGraph *lg = LinkGraph::CreateAtIndex(LinkGraphID(index));
 			SlObject(lg, slt);
 		}
 	}
@@ -305,7 +305,7 @@ struct LGRJChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			LinkGraphJob *lgj = new (LinkGraphJobID(index)) LinkGraphJob();
+			LinkGraphJob *lgj = LinkGraphJob::CreateAtIndex(LinkGraphJobID(index));
 			SlObject(lgj, slt);
 		}
 	}

--- a/src/saveload/object_sl.cpp
+++ b/src/saveload/object_sl.cpp
@@ -49,7 +49,7 @@ struct OBJSChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Object *o = new (ObjectID(index)) Object();
+			Object *o = Object::CreateAtIndex(ObjectID(index));
 			SlObject(o, slt);
 		}
 	}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -735,7 +735,7 @@ static bool LoadOldGood(LoadgameState &ls, int num)
 	ge->status.Set(GoodsEntry::State::Acceptance, HasBit(_waiting_acceptance, 15));
 	ge->status.Set(GoodsEntry::State::Rating, _cargo_source != 0xFF);
 	if (GB(_waiting_acceptance, 0, 12) != 0 && CargoPacket::CanAllocateItem()) {
-		ge->GetOrCreateData().cargo.Append(new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? StationID::Invalid() : StationID{_cargo_source}, INVALID_TILE, 0),
+		ge->GetOrCreateData().cargo.Append(CargoPacket::Create(GB(_waiting_acceptance, 0, 12), _cargo_periods, (_cargo_source == 0xFF) ? StationID::Invalid() : StationID{_cargo_source}, INVALID_TILE, 0),
 				StationID::Invalid());
 	}
 
@@ -1383,7 +1383,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 		if (_cargo_count != 0 && CargoPacket::CanAllocateItem()) {
 			StationID source =    (_cargo_source == 0xFF) ? StationID::Invalid() : StationID{_cargo_source};
 			TileIndex source_xy = (source != StationID::Invalid()) ? Station::Get(source)->xy : (TileIndex)0;
-			v->cargo.Append(new CargoPacket(_cargo_count, _cargo_periods, source, source_xy, 0));
+			v->cargo.Append(CargoPacket::Create(_cargo_count, _cargo_periods, source, source_xy, 0));
 		}
 	}
 

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -621,7 +621,7 @@ static const OldChunks town_chunk[] = {
 
 static bool LoadOldTown(LoadgameState &ls, int num)
 {
-	Town *t = new (TownID(num)) Town();
+	Town *t = Town::CreateAtIndex(TownID(num));
 	if (!LoadChunk(ls, t, town_chunk)) return false;
 
 	if (t->xy != 0) {
@@ -693,7 +693,7 @@ static const OldChunks depot_chunk[] = {
 
 static bool LoadOldDepot(LoadgameState &ls, int num)
 {
-	Depot *d = new (DepotID(num)) Depot();
+	Depot *d = Depot::CreateAtIndex(DepotID(num));
 	if (!LoadChunk(ls, d, depot_chunk)) return false;
 
 	if (d->xy != 0) {
@@ -781,7 +781,7 @@ static const OldChunks station_chunk[] = {
 
 static bool LoadOldStation(LoadgameState &ls, int num)
 {
-	Station *st = new (StationID(num)) Station();
+	Station *st = Station::CreateAtIndex(StationID(num));
 	_current_station_id = st->index;
 
 	if (!LoadChunk(ls, st, station_chunk)) return false;
@@ -863,7 +863,7 @@ static const OldChunks industry_chunk[] = {
 
 static bool LoadOldIndustry(LoadgameState &ls, int num)
 {
-	Industry *i = new (IndustryID(num)) Industry();
+	Industry *i = Industry::CreateAtIndex(IndustryID(num));
 	if (!LoadChunk(ls, i, industry_chunk)) return false;
 
 	if (i->location.tile != 0) {
@@ -989,7 +989,7 @@ static const OldChunks _company_chunk[] = {
 
 static bool LoadOldCompany(LoadgameState &ls, int num)
 {
-	Company *c = new (CompanyID(num)) Company();
+	Company *c = Company::CreateAtIndex(CompanyID(num));
 
 	_current_company_id = (CompanyID)num;
 
@@ -1269,14 +1269,14 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 			uint type = ReadByte(ls);
 			switch (type) {
 				default: return false;
-				case 0x00 /* VEH_INVALID  */: v = nullptr;                                        break;
-				case 0x25 /* MONORAIL     */:
-				case 0x20 /* VEH_TRAIN    */: v = new (VehicleID(_current_vehicle_id)) Train();           break;
-				case 0x21 /* VEH_ROAD     */: v = new (VehicleID(_current_vehicle_id)) RoadVehicle();     break;
-				case 0x22 /* VEH_SHIP     */: v = new (VehicleID(_current_vehicle_id)) Ship();            break;
-				case 0x23 /* VEH_AIRCRAFT */: v = new (VehicleID(_current_vehicle_id)) Aircraft();        break;
-				case 0x24 /* VEH_EFFECT   */: v = new (VehicleID(_current_vehicle_id)) EffectVehicle();   break;
-				case 0x26 /* VEH_DISASTER */: v = new (VehicleID(_current_vehicle_id)) DisasterVehicle(); break;
+				case 0x00 /* VEH_INVALID */: v = nullptr; break;
+				case 0x25 /* MONORAIL */:
+				case 0x20 /* VEH_TRAIN */: v = Train::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x21 /* VEH_ROAD */: v = RoadVehicle::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x22 /* VEH_SHIP */: v = Ship::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x23 /* VEH_AIRCRAFT */: v = Aircraft::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x24 /* VEH_EFFECT */: v = EffectVehicle::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x26 /* VEH_DISASTER */: v = DisasterVehicle::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
 			}
 
 			if (!LoadChunk(ls, v, vehicle_chunk)) return false;
@@ -1346,13 +1346,13 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 			/* Read the vehicle type and allocate the right vehicle */
 			switch (ReadByte(ls)) {
 				default: SlErrorCorrupt("Invalid vehicle type");
-				case 0x00 /* VEH_INVALID */: v = nullptr;                                        break;
-				case 0x10 /* VEH_TRAIN   */: v = new (VehicleID(_current_vehicle_id)) Train();           break;
-				case 0x11 /* VEH_ROAD    */: v = new (VehicleID(_current_vehicle_id)) RoadVehicle();     break;
-				case 0x12 /* VEH_SHIP    */: v = new (VehicleID(_current_vehicle_id)) Ship();            break;
-				case 0x13 /* VEH_AIRCRAFT*/: v = new (VehicleID(_current_vehicle_id)) Aircraft();        break;
-				case 0x14 /* VEH_EFFECT  */: v = new (VehicleID(_current_vehicle_id)) EffectVehicle();   break;
-				case 0x15 /* VEH_DISASTER*/: v = new (VehicleID(_current_vehicle_id)) DisasterVehicle(); break;
+				case 0x00 /* VEH_INVALID */: v = nullptr; break;
+				case 0x10 /* VEH_TRAIN */: v = Train::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x11 /* VEH_ROAD */: v = RoadVehicle::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x12 /* VEH_SHIP */: v = Ship::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x13 /* VEH_AIRCRAFT */: v = Aircraft::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x14 /* VEH_EFFECT */: v = EffectVehicle::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
+				case 0x15 /* VEH_DISASTER */: v = DisasterVehicle::CreateAtIndex(VehicleID(_current_vehicle_id)); break;
 			}
 
 			if (!LoadChunk(ls, v, vehicle_chunk)) return false;
@@ -1422,7 +1422,7 @@ static const OldChunks sign_chunk[] = {
 
 static bool LoadOldSign(LoadgameState &ls, int num)
 {
-	Sign *si = new (SignID(num)) Sign();
+	Sign *si = Sign::CreateAtIndex(SignID(num));
 	if (!LoadChunk(ls, si, sign_chunk)) return false;
 
 	if (_old_string_id != 0) {
@@ -1486,7 +1486,7 @@ static const OldChunks subsidy_chunk[] = {
 
 static bool LoadOldSubsidy(LoadgameState &ls, int num)
 {
-	Subsidy *s = new (SubsidyID(num)) Subsidy();
+	Subsidy *s = Subsidy::CreateAtIndex(SubsidyID(num));
 	bool ret = LoadChunk(ls, s, subsidy_chunk);
 	if (!IsValidCargoType(s->cargo_type)) delete s;
 	return ret;

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -379,10 +379,10 @@ static bool FixTTOEngines()
 	/* Load the default engine set. Many of them will be overridden later */
 	{
 		EngineID j = EngineID::Begin();
-		for (uint16_t i = 0; i < lengthof(_orig_rail_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(VEH_TRAIN, i);
-		for (uint16_t i = 0; i < lengthof(_orig_road_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(VEH_ROAD, i);
-		for (uint16_t i = 0; i < lengthof(_orig_ship_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(VEH_SHIP, i);
-		for (uint16_t i = 0; i < lengthof(_orig_aircraft_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(VEH_AIRCRAFT, i);
+		for (uint16_t i = 0; i < lengthof(_orig_rail_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(j, VEH_TRAIN, i);
+		for (uint16_t i = 0; i < lengthof(_orig_road_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(j, VEH_ROAD, i);
+		for (uint16_t i = 0; i < lengthof(_orig_ship_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(j, VEH_SHIP, i);
+		for (uint16_t i = 0; i < lengthof(_orig_aircraft_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(j, VEH_AIRCRAFT, i);
 	}
 
 	TimerGameCalendar::Date aging_date = std::min(TimerGameCalendar::date + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR, TimerGameCalendar::ConvertYMDToDate(TimerGameCalendar::Year{2050}, 0, 1));

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -269,7 +269,7 @@ struct ORDLChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			OrderList *list = new (OrderListID(index)) OrderList();
+			OrderList *list = OrderList::CreateAtIndex(OrderListID(index));
 			SlObject(list, slt);
 		}
 
@@ -346,7 +346,7 @@ struct BKORChunkHandler : ChunkHandler {
 
 		while ((index = SlIterateArray()) != -1) {
 			/* set num_orders to 0 so it's a valid OrderList */
-			OrderBackup *ob = new (OrderBackupID(index)) OrderBackup();
+			OrderBackup *ob = OrderBackup::CreateAtIndex(OrderBackupID(index));
 			SlObject(ob, slt);
 		}
 	}

--- a/src/saveload/signs_sl.cpp
+++ b/src/saveload/signs_sl.cpp
@@ -50,7 +50,7 @@ struct SIGNChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Sign *si = new (SignID(index)) Sign();
+			Sign *si = Sign::CreateAtIndex(SignID(index));
 			SlObject(si, slt);
 			/* Before version 6.1, signs didn't have owner.
 			 * Before version 83, invalid signs were determined by si->str == 0.

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -79,7 +79,7 @@ void MoveBuoysToWaypoints()
 		/* Stations and waypoints are in the same pool, so if a station
 		 * is deleted there must be place for a Waypoint. */
 		assert(Waypoint::CanAllocateItem());
-		Waypoint *wp   = new (index) Waypoint(xy);
+		Waypoint *wp   = Waypoint::CreateAtIndex(index, xy);
 		wp->town       = town;
 		wp->string_id  = train ? STR_SV_STNAME_WAYPOINT : STR_SV_STNAME_BUOY;
 		wp->name       = std::move(name);
@@ -512,7 +512,7 @@ struct STNSChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Station *st = new (StationID(index)) Station();
+			Station *st = Station::CreateAtIndex(StationID(index));
 
 			_waiting_acceptance = 0;
 			SlObject(st, slt);
@@ -714,7 +714,7 @@ struct STNNChunkHandler : ChunkHandler {
 		while ((index = SlIterateArray()) != -1) {
 			bool waypoint = static_cast<StationFacilities>(SlReadByte()).Test(StationFacility::Waypoint);
 
-			BaseStation *bst = waypoint ? (BaseStation *)new (StationID(index)) Waypoint() : new (StationID(index)) Station();
+			BaseStation *bst = waypoint ? (BaseStation *)Waypoint::CreateAtIndex(StationID(index)) : Station::CreateAtIndex(StationID(index));
 			SlObject(bst, slt);
 		}
 	}
@@ -752,7 +752,7 @@ struct ROADChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			RoadStop *rs = new (RoadStopID(index)) RoadStop(INVALID_TILE);
+			RoadStop *rs = RoadStop::CreateAtIndex(RoadStopID(index), INVALID_TILE);
 
 			SlObject(rs, slt);
 		}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -399,7 +399,7 @@ public:
 		if (IsSavegameVersionBefore(SLV_161) && !IsSavegameVersionBefore(SLV_145) && st->facilities.Test(StationFacility::Airport)) {
 			/* Store the old persistent storage. The GRFID will be added later. */
 			assert(PersistentStorage::CanAllocateItem());
-			st->airport.psa = new PersistentStorage(0, GSF_INVALID, TileIndex{});
+			st->airport.psa = PersistentStorage::Create(0, GSF_INVALID, TileIndex{});
 			std::copy(std::begin(_old_st_persistent_storage.storage), std::end(_old_st_persistent_storage.storage), std::begin(st->airport.psa->storage));
 		}
 
@@ -426,7 +426,7 @@ public:
 					assert(CargoPacket::CanAllocateItem());
 
 					/* Don't construct the packet with station here, because that'll fail with old savegames */
-					CargoPacket *cp = new CargoPacket(GB(_waiting_acceptance, 0, 12), _cargo_periods, source, TileIndex{_cargo_source_xy}, _cargo_feeder_share);
+					CargoPacket *cp = CargoPacket::Create(GB(_waiting_acceptance, 0, 12), _cargo_periods, source, TileIndex{_cargo_source_xy}, _cargo_feeder_share);
 					ge.GetOrCreateData().cargo.Append(cp, StationID::Invalid());
 					ge.status.Set(GoodsEntry::State::Rating);
 				}

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -35,7 +35,7 @@ struct PSACChunkHandler : ChunkHandler {
 
 		while ((index = SlIterateArray()) != -1) {
 			assert(PersistentStorage::CanAllocateItem());
-			PersistentStorage *ps = new (PersistentStorageID(index)) PersistentStorage(0, GSF_INVALID, TileIndex{});
+			PersistentStorage *ps = PersistentStorage::CreateAtIndex(PersistentStorageID(index), 0, GSF_INVALID, TileIndex{});
 			SlObject(ps, slt);
 		}
 	}

--- a/src/saveload/story_sl.cpp
+++ b/src/saveload/story_sl.cpp
@@ -58,7 +58,7 @@ struct STPEChunkHandler : ChunkHandler {
 		int index;
 		uint32_t max_sort_value = 0;
 		while ((index = SlIterateArray()) != -1) {
-			StoryPageElement *s = new (StoryPageElementID(index)) StoryPageElement();
+			StoryPageElement *s = StoryPageElement::CreateAtIndex(StoryPageElementID(index));
 			SlObject(s, slt);
 			if (s->sort_value > max_sort_value) {
 				max_sort_value = s->sort_value;
@@ -100,7 +100,7 @@ struct STPAChunkHandler : ChunkHandler {
 		int index;
 		uint32_t max_sort_value = 0;
 		while ((index = SlIterateArray()) != -1) {
-			StoryPage *s = new (StoryPageID(index)) StoryPage();
+			StoryPage *s = StoryPage::CreateAtIndex(StoryPageID(index));
 			SlObject(s, slt);
 			if (s->sort_value > max_sort_value) {
 				max_sort_value = s->sort_value;

--- a/src/saveload/subsidy_sl.cpp
+++ b/src/saveload/subsidy_sl.cpp
@@ -48,7 +48,7 @@ struct SUBSChunkHandler : ChunkHandler {
 
 		int index;
 		while ((index = SlIterateArray()) != -1) {
-			Subsidy *s = new (SubsidyID(index)) Subsidy();
+			Subsidy *s = Subsidy::CreateAtIndex(SubsidyID(index));
 			SlObject(s, slt);
 		}
 	}

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -348,7 +348,7 @@ struct CITYChunkHandler : ChunkHandler {
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
-			Town *t = new (TownID(index)) Town();
+			Town *t = Town::CreateAtIndex(TownID(index));
 			SlObject(t, slt);
 
 			if (IsSavegameVersionBefore(SLV_165)) {

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -1129,12 +1129,12 @@ struct VEHSChunkHandler : ChunkHandler {
 			VehicleType vtype = (VehicleType)SlReadByte();
 
 			switch (vtype) {
-				case VEH_TRAIN:    v = new (VehicleID(index)) Train();           break;
-				case VEH_ROAD:     v = new (VehicleID(index)) RoadVehicle();     break;
-				case VEH_SHIP:     v = new (VehicleID(index)) Ship();            break;
-				case VEH_AIRCRAFT: v = new (VehicleID(index)) Aircraft();        break;
-				case VEH_EFFECT:   v = new (VehicleID(index)) EffectVehicle();   break;
-				case VEH_DISASTER: v = new (VehicleID(index)) DisasterVehicle(); break;
+				case VEH_TRAIN: v = Train::CreateAtIndex(VehicleID(index)); break;
+				case VEH_ROAD: v = RoadVehicle::CreateAtIndex(VehicleID(index)); break;
+				case VEH_SHIP: v = Ship::CreateAtIndex(VehicleID(index)); break;
+				case VEH_AIRCRAFT: v = Aircraft::CreateAtIndex(VehicleID(index)); break;
+				case VEH_EFFECT: v = EffectVehicle::CreateAtIndex(VehicleID(index)); break;
+				case VEH_DISASTER: v = DisasterVehicle::CreateAtIndex(VehicleID(index)); break;
 				case VEH_INVALID: // Savegame shouldn't contain invalid vehicles
 				default: SlErrorCorrupt("Invalid vehicle type");
 			}

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -290,7 +290,7 @@ void AfterLoadVehiclesPhase1(bool part_of_load)
 						for (const OldOrderSaveLoadItem *old_order = GetOldOrder(v->old_orders); old_order != nullptr; old_order = GetOldOrder(old_order->next)) {
 							orders.push_back(std::move(old_order->order));
 						}
-						v->orders = mapping[v->old_orders] = new OrderList(std::move(orders), v);
+						v->orders = mapping[v->old_orders] = OrderList::Create(std::move(orders), v);
 					} else {
 						v->orders = mapping[v->old_orders];
 						/* For old games (case a) we must create the shared vehicle chain */
@@ -324,7 +324,7 @@ void AfterLoadVehiclesPhase1(bool part_of_load)
 
 				/* As above, allocating OrderList here is safe. */
 				assert(OrderList::CanAllocateItem());
-				v->orders = new OrderList();
+				v->orders = OrderList::Create();
 				v->orders->first_shared = v;
 				for (Vehicle *u = v; u != nullptr; u = u->next_shared) {
 					u->orders = v->orders;
@@ -1143,7 +1143,7 @@ struct VEHSChunkHandler : ChunkHandler {
 
 			if (_cargo_count != 0 && IsCompanyBuildableVehicleType(v) && CargoPacket::CanAllocateItem()) {
 				/* Don't construct the packet with station here, because that'll fail with old savegames */
-				CargoPacket *cp = new CargoPacket(_cargo_count, _cargo_periods, _cargo_source, _cargo_source_xy, _cargo_feeder_share);
+				CargoPacket *cp = CargoPacket::Create(_cargo_count, _cargo_periods, _cargo_source, _cargo_source_xy, _cargo_feeder_share);
 				v->cargo.Append(cp);
 			}
 

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -115,7 +115,7 @@ void MoveWaypointsToBaseStations()
 			SlErrorCorrupt("Waypoint with invalid tile");
 		}
 
-		Waypoint *new_wp = new Waypoint(t);
+		Waypoint *new_wp = Waypoint::Create(t);
 		new_wp->town       = wp.town;
 		new_wp->town_cn    = wp.town_cn;
 		new_wp->name       = wp.name;

--- a/src/ship.h
+++ b/src/ship.h
@@ -36,8 +36,7 @@ struct Ship final : public SpecializedVehicle<Ship, VEH_SHIP> {
 	int16_t rotation_x_pos = 0; ///< NOSAVE: X Position before rotation.
 	int16_t rotation_y_pos = 0; ///< NOSAVE: Y Position before rotation.
 
-	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
-	Ship() : SpecializedVehicleBase() {}
+	Ship(VehicleID index) : SpecializedVehicleBase(index) {}
 	/** We want to 'destruct' the right class. */
 	~Ship() override { this->PreDestructor(); }
 

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -871,7 +871,7 @@ CommandCost CmdBuildShip(DoCommandFlags flags, TileIndex tile, const Engine *e, 
 
 		const ShipVehicleInfo *svi = &e->VehInfo<ShipVehicleInfo>();
 
-		Ship *v = new Ship();
+		Ship *v = Ship::Create();
 		*ret = v;
 
 		v->owner = _current_company;

--- a/src/signs_base.h
+++ b/src/signs_base.h
@@ -27,8 +27,9 @@ struct Sign : SignPool::PoolItem<&_sign_pool> {
 	Owner owner = INVALID_OWNER; // Placed by this company. Anyone can delete them though. OWNER_NONE for gray signs from old games.
 	Colours text_colour = COLOUR_WHITE; // Colour of the sign's text. Only relevant for OWNER_DEITY.
 
-	Sign() {}
-	Sign(Owner owner, int32_t x, int32_t y, int32_t z, const std::string &name) : name(name), x(x), y(y), z(z), owner(owner) {}
+	Sign(SignID index) : SignPool::PoolItem<&_sign_pool>(index) {}
+	Sign(SignID index, Owner owner, int32_t x, int32_t y, int32_t z, const std::string &name) :
+		SignPool::PoolItem<&_sign_pool>(index), name(name), x(x), y(y), z(z), owner(owner) {}
 	~Sign();
 
 	void UpdateVirtCoord();

--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -45,7 +45,7 @@ std::tuple<CommandCost, SignID> CmdPlaceSign(DoCommandFlags flags, TileIndex til
 		int x = TileX(tile) * TILE_SIZE;
 		int y = TileY(tile) * TILE_SIZE;
 
-		Sign *si = new Sign(_game_mode == GM_EDITOR ? OWNER_DEITY : _current_company, x, y, GetSlopePixelZ(x, y), text);
+		Sign *si = Sign::Create(_game_mode == GM_EDITOR ? OWNER_DEITY : _current_company, x, y, GetSlopePixelZ(x, y), text);
 
 		si->UpdateVirtCoord();
 		InvalidateWindowData(WC_SIGN_LIST, 0, 0);

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -61,8 +61,8 @@ BaseStation::~BaseStation()
 	this->sign.MarkDirty();
 }
 
-Station::Station(TileIndex tile) :
-	SpecializedStation<Station, false>(tile),
+Station::Station(StationID index, TileIndex tile) :
+	SpecializedStation<Station, false>(index, tile),
 	bus_station(INVALID_TILE, 0, 0),
 	truck_station(INVALID_TILE, 0, 0),
 	ship_station(INVALID_TILE, 0, 0),

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -552,7 +552,7 @@ public:
 	IndustryList industries_near{}; ///< Cached list of industries near the station that can accept cargo, @see DeliverGoodsToIndustry()
 	Industry *industry = nullptr; ///< NOSAVE: Associated industry for neutral stations. (Rebuilt on load from Industry->st)
 
-	Station(TileIndex tile = INVALID_TILE);
+	Station(StationID index, TileIndex tile = INVALID_TILE);
 	~Station() override;
 
 	void AddFacility(StationFacility new_facility_bit, TileIndex facil_xy);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -701,7 +701,7 @@ static CommandCost BuildStationPart(Station **st, DoCommandFlags flags, bool reu
 		if (!Station::CanAllocateItem()) return CommandCost(STR_ERROR_TOO_MANY_STATIONS_LOADING);
 
 		if (flags.Test(DoCommandFlag::Execute)) {
-			*st = new Station(area.tile);
+			*st = Station::Create(area.tile);
 			_station_kdtree.Insert((*st)->index);
 
 			(*st)->town = ClosestTownFromTile(area.tile, UINT_MAX);
@@ -2165,7 +2165,7 @@ CommandCost CmdBuildRoadStop(DoCommandFlags flags, TileIndex tile, uint8_t width
 				st->cached_roadstop_anim_triggers.Set(roadstopspec->animation.triggers);
 			}
 
-			RoadStop *road_stop = new RoadStop(cur_tile);
+			RoadStop *road_stop = RoadStop::Create(cur_tile);
 			/* Insert into linked list of RoadStops. */
 			RoadStop **currstop = FindRoadStopSpot(is_truck_stop, st);
 			*currstop = road_stop;
@@ -4268,7 +4268,7 @@ void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint
 	if (ge1.link_graph == LinkGraphID::Invalid()) {
 		if (ge2.link_graph == LinkGraphID::Invalid()) {
 			if (LinkGraph::CanAllocateItem()) {
-				lg = new LinkGraph(cargo);
+				lg = LinkGraph::Create(cargo);
 				LinkGraphSchedule::instance.Queue(lg);
 				ge2.link_graph = lg->index;
 				ge2.node = lg->AddNode(st2);
@@ -4413,11 +4413,11 @@ static uint UpdateStationWaiting(Station *st, CargoType cargo, uint amount, Sour
 	if (amount == 0) return 0;
 
 	StationID next = ge.GetVia(st->index);
-	ge.GetOrCreateData().cargo.Append(new CargoPacket(st->index, amount, source), next);
+	ge.GetOrCreateData().cargo.Append(CargoPacket::Create(st->index, amount, source), next);
 	LinkGraph *lg = nullptr;
 	if (ge.link_graph == LinkGraphID::Invalid()) {
 		if (LinkGraph::CanAllocateItem()) {
-			lg = new LinkGraph(cargo);
+			lg = LinkGraph::Create(cargo);
 			LinkGraphSchedule::instance.Queue(lg);
 			ge.link_graph = lg->index;
 			ge.node = lg->AddNode(st);
@@ -4714,7 +4714,7 @@ void BuildOilRig(TileIndex tile)
 		return;
 	}
 
-	Station *st = new Station(tile);
+	Station *st = Station::Create(tile);
 	_station_kdtree.Insert(st->index);
 	st->town = ClosestTownFromTile(tile, UINT_MAX);
 

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -228,7 +228,7 @@ std::tuple<CommandCost, StoryPageID> CmdCreateStoryPage(DoCommandFlags flags, Co
 			_story_page_next_sort_value = 0;
 		}
 
-		StoryPage *s = new StoryPage(_story_page_next_sort_value, TimerGameCalendar::date, company, text);
+		StoryPage *s = StoryPage::Create(_story_page_next_sort_value, TimerGameCalendar::date, company, text);
 
 		InvalidateWindowClassesData(WC_STORY_BOOK, -1);
 		if (StoryPage::GetNumItems() == 1) InvalidateWindowData(WC_MAIN_TOOLBAR, 0);
@@ -272,7 +272,7 @@ std::tuple<CommandCost, StoryPageElementID> CmdCreateStoryPageElement(DoCommandF
 			_story_page_element_next_sort_value = 0;
 		}
 
-		StoryPageElement *pe = new StoryPageElement(_story_page_element_next_sort_value, type, page_id);
+		StoryPageElement *pe = StoryPageElement::Create(_story_page_element_next_sort_value, type, page_id);
 		UpdateElement(*pe, tile, reference, text);
 
 		InvalidateWindowClassesData(WC_STORY_BOOK, page_id);

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -150,12 +150,9 @@ struct StoryPageElement : StoryPageElementPool::PoolItem<&_story_page_element_po
 	uint32_t referenced_id = 0; ///< Id of referenced object (location, goal etc.)
 	EncodedString text{}; ///< Static content text of page element
 
-	/**
-	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
-	 */
-	StoryPageElement() { }
-	StoryPageElement(uint32_t sort_value, StoryPageElementType type, StoryPageID page) :
-		sort_value(sort_value), page(page), type(type) { }
+	StoryPageElement(StoryPageElementID index) : StoryPageElementPool::PoolItem<&_story_page_element_pool>(index) {}
+	StoryPageElement(StoryPageElementID index, uint32_t sort_value, StoryPageElementType type, StoryPageID page) :
+		StoryPageElementPool::PoolItem<&_story_page_element_pool>(index), sort_value(sort_value), page(page), type(type) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
@@ -171,12 +168,9 @@ struct StoryPage : StoryPagePool::PoolItem<&_story_page_pool> {
 
 	EncodedString title; ///< Title of story page
 
-	/**
-	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
-	 */
-	StoryPage() { }
-	StoryPage(uint32_t sort_value, TimerGameCalendar::Date date, CompanyID company, const EncodedString &title) :
-		sort_value(sort_value), date(date), company(company), title(title) {}
+	StoryPage(StoryPageID index) : StoryPagePool::PoolItem<&_story_page_pool>(index) {}
+	StoryPage(StoryPageID index, uint32_t sort_value, TimerGameCalendar::Date date, CompanyID company, const EncodedString &title) :
+		StoryPagePool::PoolItem<&_story_page_pool>(index), sort_value(sort_value), date(date), company(company), title(title) {}
 
 	~StoryPage();
 };

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -172,7 +172,7 @@ static bool CheckSubsidyDistance(Source src, Source dst)
  */
 void CreateSubsidy(CargoType cargo_type, Source src, Source dst)
 {
-	Subsidy *s = new Subsidy(cargo_type, src, dst, SUBSIDY_OFFER_MONTHS);
+	Subsidy *s = Subsidy::Create(cargo_type, src, dst, SUBSIDY_OFFER_MONTHS);
 
 	const CargoSpec *cs = CargoSpec::Get(s->cargo_type);
 	EncodedString headline = GetEncodedString(STR_NEWS_SERVICE_SUBSIDY_OFFERED, cs->name, s->src.GetFormat(), s->src.id, s->dst.GetFormat(), s->dst.id, _settings_game.difficulty.subsidy_duration);

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -27,11 +27,8 @@ struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
 	Source src{}; ///< Source of subsidised path
 	Source dst{}; ///< Destination of subsidised path
 
-	/**
-	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
-	 */
-	Subsidy() { }
-	Subsidy(CargoType cargo_type, Source src, Source dst, uint16_t remaining) : cargo_type(cargo_type), remaining(remaining), src(src), dst(dst) {}
+	Subsidy(SubsidyID index, CargoType cargo_type = INVALID_CARGO, Source src = {}, Source dst = {}, uint16_t remaining = 0) :
+		SubsidyPool::PoolItem<&_subsidy_pool>(index), cargo_type(cargo_type), remaining(remaining), src(src), dst(dst) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter

--- a/src/town.h
+++ b/src/town.h
@@ -156,9 +156,10 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	/**
 	 * Creates a new town.
+	 * @param index the index within the town pool
 	 * @param tile center tile of the town
 	 */
-	Town(TileIndex tile = INVALID_TILE) : xy(tile) { }
+	Town(TownID index, TileIndex tile = INVALID_TILE) : TownPool::PoolItem<&_town_pool>(index), xy(tile) { }
 
 	/** Destroy the town. */
 	~Town();

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2253,7 +2253,7 @@ std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlags flags, TileIn
 		if (random_location) {
 			t = CreateRandomTown(20, townnameparts, size, city, layout);
 		} else {
-			t = new Town(tile);
+			t = Town::Create(tile);
 			DoCreateTown(t, tile, townnameparts, size, city, layout, true);
 		}
 
@@ -2401,7 +2401,7 @@ static Town *CreateRandomTown(uint attempts, uint32_t townnameparts, TownSize si
 		} else if (TownCanBePlacedHere(tile, true).Failed()) continue;
 
 		/* Allocate a town struct */
-		Town *t = new Town(tile);
+		Town *t = Town::Create(tile);
 
 		DoCreateTown(t, tile, townnameparts, size, city, layout, false);
 

--- a/src/train.h
+++ b/src/train.h
@@ -104,8 +104,7 @@ struct Train final : public GroundVehicle<Train, VEH_TRAIN> {
 	TrackBits track{};
 	TrainForceProceeding force_proceed{};
 
-	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
-	Train() : GroundVehicleBase() {}
+	Train(VehicleID index) : GroundVehicleBase(index) {}
 	/** We want to 'destruct' the right class. */
 	~Train() override { this->PreDestructor(); }
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -641,7 +641,7 @@ static CommandCost CmdBuildRailWagon(DoCommandFlags flags, TileIndex tile, const
 	if (!IsCompatibleRail(rvi->railtypes, GetRailType(tile))) return CMD_ERROR;
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Train *v = new Train();
+		Train *v = Train::Create();
 		*ret = v;
 		v->spritenum = rvi->image_index;
 
@@ -723,7 +723,7 @@ void NormalizeTrainVehInDepot(const Train *u)
 
 static void AddRearEngineToMultiheadedTrain(Train *v)
 {
-	Train *u = new Train();
+	Train *u = Train::Create();
 	v->value >>= 1;
 	u->value = v->value;
 	u->direction = v->direction;
@@ -782,7 +782,7 @@ CommandCost CmdBuildRailVehicle(DoCommandFlags flags, TileIndex tile, const Engi
 		int x = TileX(tile) * TILE_SIZE + _vehicle_initial_x_fract[dir];
 		int y = TileY(tile) * TILE_SIZE + _vehicle_initial_y_fract[dir];
 
-		Train *v = new Train();
+		Train *v = Train::Create();
 		*ret = v;
 		v->direction = DiagDirToDir(dir);
 		v->tile = tile;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2960,7 +2960,7 @@ void Vehicle::AddToShared(Vehicle *shared_chain)
 	if (shared_chain->orders == nullptr) {
 		assert(shared_chain->previous_shared == nullptr);
 		assert(shared_chain->next_shared == nullptr);
-		this->orders = shared_chain->orders = new OrderList(shared_chain);
+		this->orders = shared_chain->orders = OrderList::Create(shared_chain);
 	}
 
 	this->next_shared     = shared_chain->next_shared;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -364,9 +364,10 @@ void VehicleLengthChanged(const Vehicle *u)
 
 /**
  * Vehicle constructor.
+ * @param index The index within the vehicle pool.
  * @param type Type of the new vehicle.
  */
-Vehicle::Vehicle(VehicleType type)
+Vehicle::Vehicle(VehicleID index, VehicleType type) : VehiclePool::PoolItem<&_vehicle_pool>(index)
 {
 	this->type               = type;
 	this->coord.left         = INVALID_COORD;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -331,7 +331,7 @@ public:
 		return 0;
 	}
 
-	Vehicle(VehicleType type = VEH_INVALID);
+	Vehicle(VehicleID index, VehicleType type = VEH_INVALID);
 
 	void PreDestructor();
 	/** We want to 'destruct' the right class. */
@@ -1018,8 +1018,9 @@ struct SpecializedVehicle : public Vehicle {
 
 	/**
 	 * Set vehicle type correctly
+	 * @param index The index into the vehicle pool.
 	 */
-	inline SpecializedVehicle() : Vehicle(Type)
+	inline SpecializedVehicle(VehicleID index) : Vehicle(index, Type)
 	{
 		this->sprite_cache.sprite_seq.count = 1;
 	}

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -1127,6 +1127,17 @@ struct SpecializedVehicle : public Vehicle {
 	}
 
 	/**
+	 * Creates a new T-object in the vehicle pool.
+	 * @param args... The arguments to the constructor.
+	 * @return The created object.
+	 */
+	template <typename... Targs>
+	static inline T *Create(Targs &&... args)
+	{
+		return Vehicle::Create<T>(std::forward<Targs&&>(args)...);
+	}
+
+	/**
 	 * Converts a Vehicle to SpecializedVehicle with type checking.
 	 * @param v Vehicle pointer
 	 * @return pointer to SpecializedVehicle

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -1138,6 +1138,18 @@ struct SpecializedVehicle : public Vehicle {
 	}
 
 	/**
+	 * Creates a new T-object in the vehicle pool.
+	 * @param index The index allocate the object at.
+	 * @param args... The arguments to the constructor.
+	 * @return The created object.
+	 */
+	template <typename... Targs>
+	static inline T *CreateAtIndex(VehicleID index, Targs &&... args)
+	{
+		return Vehicle::CreateAtIndex<T>(index, std::forward<Targs&&>(args)...);
+	}
+
+	/**
 	 * Converts a Vehicle to SpecializedVehicle with type checking.
 	 * @param v Vehicle pointer
 	 * @return pointer to SpecializedVehicle

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -145,7 +145,7 @@ CommandCost CmdBuildShipDepot(DoCommandFlags flags, TileIndex tile, Axis axis)
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Depot *depot = new Depot(tile);
+		Depot *depot = Depot::Create(tile);
 
 		uint new_water_infra = 2 * LOCK_DEPOT_TILE_FACTOR;
 		/* Update infrastructure counts after the tile clears earlier.

--- a/src/waypoint_base.h
+++ b/src/waypoint_base.h
@@ -27,9 +27,10 @@ struct Waypoint final : SpecializedStation<Waypoint, true> {
 
 	/**
 	 * Create a waypoint at the given tile.
+	 * @param index The index within the station pool.
 	 * @param tile The location of the waypoint.
 	 */
-	Waypoint(TileIndex tile = INVALID_TILE) : SpecializedStation<Waypoint, true>(tile) { }
+	Waypoint(StationID index, TileIndex tile = INVALID_TILE) : SpecializedStation<Waypoint, true>(index, tile) { }
 	~Waypoint() override;
 
 	void UpdateVirtCoord() override;

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -281,7 +281,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		if (wp == nullptr) {
-			wp = new Waypoint(start_tile);
+			wp = Waypoint::Create(start_tile);
 		} else if (!wp->IsInUse()) {
 			/* Move existing (recently deleted) waypoint to the new location */
 			wp->xy = start_tile;
@@ -401,7 +401,7 @@ CommandCost CmdBuildRoadWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		if (wp == nullptr) {
-			wp = new Waypoint(start_tile);
+			wp = Waypoint::Create(start_tile);
 			SetBit(wp->waypoint_flags, WPF_ROAD);
 		} else if (!wp->IsInUse()) {
 			/* Move existing (recently deleted) waypoint to the new location */
@@ -492,7 +492,7 @@ CommandCost CmdBuildBuoy(DoCommandFlags flags, TileIndex tile)
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		if (wp == nullptr) {
-			wp = new Waypoint(tile);
+			wp = Waypoint::Create(tile);
 		} else {
 			/* Move existing (recently deleted) buoy to the new location */
 			wp->xy = tile;


### PR DESCRIPTION
## Motivation / Problem

Primarily the foot gun of the constructor overwriting the `PoolItem`'s index if you're not careful.

Secondary would be clang-tidy/coverity warnings about leaking memory as they do not see that the pool retains the references.


## Description

First prepare things by replacing
* `new PoolItem(...` with `PoolItem::Create(...`.
* `new (index) PoolItem(...` with `PoolItem::CreateAtIndex(index, ...`.

Finally add the `index` to the constructors so the `PoolItem`'s constructor sets it, instead of the `PoolItem`'s `new`. The new `Create...` functions will inject the index into the actual constructors.

This also means that `index` can become `const`, so nothing will be able to mess with it.


## Limitations

There's no simple way to split this into smaller bits, except the individual commits.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
