### PR TITLE
Fix #15026: Remove incorrect info from base sounds tooltip

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1115,7 +1115,7 @@ STR_GAME_OPTIONS_BASE_GRF_TOOLTIP                               :Select the base
 STR_GAME_OPTIONS_BASE_GRF_DESCRIPTION_TOOLTIP                   :Additional information about the base graphics set
 
 STR_GAME_OPTIONS_BASE_SFX                                       :Base sounds set
-STR_GAME_OPTIONS_BASE_SFX_TOOLTIP                               :Select the base sounds set to use (cannot be changed in-game, only from the main menu)
+STR_GAME_OPTIONS_BASE_SFX_TOOLTIP                               :Select the base sounds set to use
 STR_GAME_OPTIONS_BASE_SFX_DESCRIPTION_TOOLTIP                   :Additional information about the base sounds set
 
 STR_GAME_OPTIONS_BASE_MUSIC                                     :Base music set


### PR DESCRIPTION
## Motivation / Problem

Per #15026, the tooltip for the Options > Sounds dropdown to select the base sounds is "Select the base sounds set to use (cannot be changed in-game, only from the main menu)".

This is incorrect, as it is possible to change in-game.

## Description

Remove the incorrect information in parentheses.

Fixes #15026.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
