### PR TITLE
Codechange: remove unused parameter and unneeded heap allocation

### DIFF
--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -69,27 +69,19 @@ bool IsArticulatedEngine(EngineID engine_type)
 /**
  * Count the number of articulated parts of an engine.
  * @param engine_type The engine to get the number of parts of.
- * @param purchase_window Whether we are in the scope of the purchase window or not, i.e. whether we cannot allocate vehicles.
  * @return The number of parts.
  */
-uint CountArticulatedParts(EngineID engine_type, bool purchase_window)
+uint CountArticulatedParts(EngineID engine_type)
 {
 	if (!EngInfo(engine_type)->callback_mask.Test(VehicleCallbackMask::ArticEngine)) return 0;
 
-	/* If we can't allocate a vehicle now, we can't allocate it in the command
-	 * either, so it doesn't matter how many articulated parts there are. */
-	if (!Vehicle::CanAllocateItem()) return 0;
-
-	std::unique_ptr<Vehicle> v;
-	if (!purchase_window) {
-		v = std::unique_ptr<Vehicle>(Vehicle::Create());
-		v->engine_type = engine_type;
-		v->owner = _current_company;
-	}
+	Vehicle v(VehicleID::Invalid());
+	v.engine_type = engine_type;
+	v.owner = _current_company;
 
 	uint i;
 	for (i = 1; i < MAX_ARTICULATED_PARTS; i++) {
-		if (GetNextArticulatedPart(i, engine_type, v.get()) == EngineID::Invalid()) break;
+		if (GetNextArticulatedPart(i, engine_type, &v) == EngineID::Invalid()) break;
 	}
 
 	return i - 1;

--- a/src/articulated_vehicles.h
+++ b/src/articulated_vehicles.h
@@ -13,7 +13,7 @@
 #include "vehicle_type.h"
 #include "engine_type.h"
 
-uint CountArticulatedParts(EngineID engine_type, bool purchase_window);
+uint CountArticulatedParts(EngineID engine_type);
 CargoArray GetCapacityOfArticulatedParts(EngineID engine);
 CargoTypes GetCargoTypesOfArticulatedParts(EngineID engine);
 void AddArticulatedParts(Vehicle *first);

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -122,8 +122,8 @@ std::tuple<CommandCost, VehicleID, uint, uint16_t, CargoArray> CmdBuildVehicle(D
 	/* Check whether the number of vehicles we need to build can be built according to pool space. */
 	uint num_vehicles;
 	switch (type) {
-		case VEH_TRAIN:    num_vehicles = (e->VehInfo<RailVehicleInfo>().railveh_type == RAILVEH_MULTIHEAD ? 2 : 1) + CountArticulatedParts(eid, false); break;
-		case VEH_ROAD:     num_vehicles = 1 + CountArticulatedParts(eid, false); break;
+		case VEH_TRAIN:    num_vehicles = (e->VehInfo<RailVehicleInfo>().railveh_type == RAILVEH_MULTIHEAD ? 2 : 1) + CountArticulatedParts(eid); break;
+		case VEH_ROAD:     num_vehicles = 1 + CountArticulatedParts(eid); break;
 		case VEH_SHIP:     num_vehicles = 1; break;
 		case VEH_AIRCRAFT: num_vehicles = e->VehInfo<AircraftVehicleInfo>().subtype & AIR_CTOL ? 2 : 3; break;
 		default: NOT_REACHED(); // Safe due to IsDepotTile()


### PR DESCRIPTION
## Motivation / Problem

Wondered why a vehicle needs to be allocated onto the heap, but then found out it's called with the same parameter each time. So, it could just as easily be allocated onto the stack, making the whole thing simpler.


## Description

Remove the unused parameter, and allocate to the stack instead with an invalid `VehicleID`.


## Limitations

I really hope there's no NewGRF that is using the VehicleID for something when checking how many articulated parts there ought to be. But then, with multiple parts the IDs of checking and creating would not even match up either.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
