### PR TITLE
Codechange: remove need for new (address) PoolItem(...)

### DIFF
--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -318,26 +318,8 @@ public:
 		/** Do not use new (index) PoolItem(...), but rather PoolItem::CreateAtIndex(index, ...). */
 		inline void *operator new(size_t size, Tindex index) = delete;
 
-		/**
-		 * Allocates space for new Titem at given memory address
-		 * @param ptr where are we allocating the item?
-		 * @return pointer to allocated memory (== ptr)
-		 * @note use of this is strongly discouraged
-		 * @pre the memory must not be allocated in the Pool!
-		 */
-		inline void *operator new(size_t, void *ptr)
-		{
-			for (size_t i = 0; i < Tpool->first_unused; i++) {
-				/* Don't allow creating new objects over existing.
-				 * Even if we called the destructor and reused this memory,
-				 * we don't know whether 'size' and size of currently allocated
-				 * memory are the same (because of possible inheritance).
-				 * Use { size_t index = item->index; delete item; new (index) item; }
-				 * instead to make sure destructor is called and no memory leaks. */
-				assert(ptr != Tpool->data[i]);
-			}
-			return ptr;
-		}
+		/** Do not use new (address) PoolItem(...). */
+		inline void *operator new(size_t, void *ptr) = delete;
 
 
 		/**

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -71,6 +71,10 @@ static_assert(lengthof(_orig_rail_vehicle_info) + lengthof(_orig_road_vehicle_in
 Engine::Engine(EngineID index, VehicleType type, uint16_t local_id) : EnginePool::PoolItem<&_engine_pool>(index)
 {
 	this->type = type;
+
+	/* Called in the context of loading a savegame. The rest comes from the loader. */
+	if (type == VEH_INVALID) return;
+
 	this->grf_prop.local_id = local_id;
 	this->list_position = local_id;
 	this->preview_company = CompanyID::Invalid();

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -77,7 +77,6 @@ private:
 	std::variant<std::monostate, RailVehicleInfo, RoadVehicleInfo, ShipVehicleInfo, AircraftVehicleInfo> vehicle_info{};
 
 public:
-	Engine(EngineID index) : EnginePool::PoolItem<&_engine_pool>(index) {}
 	Engine(EngineID index, VehicleType type, uint16_t local_id);
 	bool IsEnabled() const;
 

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -43,12 +43,12 @@ static const SaveLoad _engine_desc[] = {
 
 static TypedIndexContainer<std::vector<Engine>, EngineID> _temp_engine;
 
-Engine *GetTempDataEngine(EngineID index)
+Engine *GetTempDataEngine(EngineID index, VehicleType type, uint16_t local_id)
 {
 	if (index < _temp_engine.size()) {
 		return &_temp_engine[index];
 	} else if (index == _temp_engine.size()) {
-		return &_temp_engine.emplace_back(index);
+		return &_temp_engine.emplace_back(index, type, local_id);
 	} else {
 		NOT_REACHED();
 	}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -379,10 +379,10 @@ static bool FixTTOEngines()
 	/* Load the default engine set. Many of them will be overridden later */
 	{
 		EngineID j = EngineID::Begin();
-		for (uint16_t i = 0; i < lengthof(_orig_rail_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(j, VEH_TRAIN, i);
-		for (uint16_t i = 0; i < lengthof(_orig_road_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(j, VEH_ROAD, i);
-		for (uint16_t i = 0; i < lengthof(_orig_ship_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(j, VEH_SHIP, i);
-		for (uint16_t i = 0; i < lengthof(_orig_aircraft_vehicle_info); ++i, ++j) new (GetTempDataEngine(j)) Engine(j, VEH_AIRCRAFT, i);
+		for (uint16_t i = 0; i < lengthof(_orig_rail_vehicle_info); ++i, ++j) GetTempDataEngine(j, VEH_TRAIN, i);
+		for (uint16_t i = 0; i < lengthof(_orig_road_vehicle_info); ++i, ++j) GetTempDataEngine(j, VEH_ROAD, i);
+		for (uint16_t i = 0; i < lengthof(_orig_ship_vehicle_info); ++i, ++j) GetTempDataEngine(j, VEH_SHIP, i);
+		for (uint16_t i = 0; i < lengthof(_orig_aircraft_vehicle_info); ++i, ++j) GetTempDataEngine(j, VEH_AIRCRAFT, i);
 	}
 
 	TimerGameCalendar::Date aging_date = std::min(TimerGameCalendar::date + CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR, TimerGameCalendar::ConvertYMDToDate(TimerGameCalendar::Year{2050}, 0, 1));

--- a/src/saveload/saveload_internal.h
+++ b/src/saveload/saveload_internal.h
@@ -44,7 +44,7 @@ void ConvertOldMultiheadToNew();
 void ConnectMultiheadedTrains();
 
 void ResetTempEngineData();
-Engine *GetTempDataEngine(EngineID index);
+Engine *GetTempDataEngine(EngineID index, VehicleType type = VEH_INVALID, uint16_t local_id = 0);
 void CopyTempEngineData();
 
 extern int32_t _saved_scrollpos_x;


### PR DESCRIPTION
## Motivation / Problem

We have a `new (address) PoolItem(...)` operator defined that is used in one location in oldloader_sl.cpp in conjunction with `GetTempDataEngine`. This function emplaces the engine into a vector, which already does call the constructor.

In other words, we'd be calling the constructor twice for the same engine; once with the default constructor and once with a more specific one. Why not amend the current specific one to bail out early for `VEH_INVALID` and just pass the wanted parameters to `GetTempDataEngine` so this weird `new (address) PoolItem(...)`-shenanigans isn't needed?


## Description

Remove the `new (address) PoolItem(...)` operator and 'default' constructor for `Engine`.
Bail out early in the `Engine` constructor for invalid vehicles.
Pass `VehicleType` and local_id to `GetTempDataEngine` with appropriate defaults.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
