### PR TITLE
Codefix: Use active_tab instead of hardcoded value

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -892,7 +892,7 @@ struct GameOptionsWindow : Window {
 
 	void OnPaint() override
 	{
-		if (this->GetWidget<NWidgetStacked>(WID_GO_TAB_SELECTION)->shown_plane != 4) {
+		if (GameOptionsWindow::active_tab != WID_GO_TAB_ADVANCED) {
 			this->DrawWidgets();
 			return;
 		}


### PR DESCRIPTION
## Motivation / Problem

GameOptionsWindow::OnPaint is currently using a hardcoded plane value to determine if the displayed tab is the "Advanced" tab. While it currently works, if in the future the value for the advanced tab changes, and OnPaint is not changed accordingly this might lead to undesired behaviour.

## Description

This PR fixes the problem by using active_tab and WID_GO_TAB_ADVANCED.


## Limitations

None?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
