### PR TITLE
Codefix: initialise all fields of FileScanner

### DIFF
--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -36,7 +36,7 @@ extern std::vector<Searchpath> _valid_searchpaths;
 /** Helper for scanning for files with a given name */
 class FileScanner {
 protected:
-	Subdirectory subdir; ///< The current sub directory we are searching through
+	Subdirectory subdir{}; ///< The current sub directory we are searching through
 public:
 	/** Destruct the proper one... */
 	virtual ~FileScanner() = default;


### PR DESCRIPTION
## Motivation / Problem

clang-tidy warnings:

openttd/src/fios.cpp:247:54: warning: 1 uninitialized field at the end of the constructor call [clang-analyzer-optin.cplusplus.UninitializedObject]

openttd/src/newgrf_config.cpp:491:3: warning: 1 uninitialized field at the end of the constructor call [clang-analyzer-optin.cplusplus.UninitializedObject]

In both cases due to `FileScanner` not initialising `subdir`.


## Description

Default initialise `subdir`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
