### PR TITLE
Fix: disable_elrails handling with engines that use both RAIL and ELRL

### DIFF
--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -586,7 +586,7 @@ void UpdateDisableElrailSettingState(bool disable, bool update_vehicles)
 		/* update railtype of engines intended to use elrail */
 		if (rv_info->intended_railtypes.Test(RAILTYPE_ELECTRIC)) {
 			rv_info->railtypes.Set(RAILTYPE_ELECTRIC, !disable);
-			rv_info->railtypes.Set(RAILTYPE_RAIL, disable);
+			rv_info->railtypes.Set(RAILTYPE_RAIL, disable || rv_info->intended_railtypes.Test(RAILTYPE_RAIL));
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Incorrect handling of _settings_game.vehicle.disable_elrails handling with rail engines that use both RAIL and ELRL (via train property 0x34).

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
