### PR TITLE
Cleanup: remove unneeded define

### DIFF
--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -21,10 +21,6 @@
 #undef Rect
 #undef Point
 
-#ifndef __clang__
-#define __bridge
-#endif
-
 /*
  * This file contains objective C
  * Apple uses objective C instead of plain C to interact with OS specific/native functions


### PR DESCRIPTION
## Motivation / Problem

`__bridge` is defined in macos.mm but not in cocoa_v.mm. It is however used in both.

The define was added to fix some compiler warnings a long time ago. Current compilers don't need it.


## Description

Remove the unneeded define.


## Limitations

No idea which non-clang compiler would be used for Apple. I'd suspect AppleClang to be clang as well for the define.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
