### PR TITLE
Codechange: cleanup old defines for unsupported versions of MacOS

### DIFF
--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -23,10 +23,6 @@
 
 #include "../safeguards.h"
 
-#if !defined(HAVE_OSX_1011_SDK)
-#define kMusicSequenceFile_AnyType 0
-#endif
-
 static FMusicDriver_Cocoa iFMusicDriver_Cocoa;
 
 

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -31,16 +31,6 @@
  */
 
 
-#if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_10)
-typedef struct {
-	NSInteger majorVersion;
-	NSInteger minorVersion;
-	NSInteger patchVersion;
-} OTTDOperatingSystemVersion;
-
-#define NSOperatingSystemVersion OTTDOperatingSystemVersion
-#endif
-
 #ifdef WITH_COCOA
 static NSAutoreleasePool *_ottd_autorelease_pool;
 #endif
@@ -69,28 +59,6 @@ void GetMacOSVersion(int *return_major, int *return_minor, int *return_bugfix)
 
 		return;
 	}
-
-#if (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_10)
-#ifdef __clang__
-#	pragma clang diagnostic push
-#	pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-	SInt32 systemVersion, version_major, version_minor, version_bugfix;
-	if (Gestalt(gestaltSystemVersion, &systemVersion) == noErr) {
-		if (systemVersion >= 0x1040) {
-			if (Gestalt(gestaltSystemVersionMajor,  &version_major) == noErr) *return_major = (int)version_major;
-			if (Gestalt(gestaltSystemVersionMinor,  &version_minor) == noErr) *return_minor = (int)version_minor;
-			if (Gestalt(gestaltSystemVersionBugFix, &version_bugfix) == noErr) *return_bugfix = (int)version_bugfix;
-		} else {
-			*return_major = (int)(GB(systemVersion, 12, 4) * 10 + GB(systemVersion, 8, 4));
-			*return_minor = (int)GB(systemVersion, 4, 4);
-			*return_bugfix = (int)GB(systemVersion, 0, 4);
-		}
-	}
-#ifdef __clang__
-#	pragma clang diagnostic pop
-#endif
-#endif
 }
 
 #ifdef WITH_COCOA

--- a/src/os/macosx/osx_stdafx.h
+++ b/src/os/macosx/osx_stdafx.h
@@ -13,64 +13,6 @@
 
 #include <AvailabilityMacros.h>
 
-/* We assume if these macros are defined, the SDK is also at least this version or later. */
-#ifdef MAC_OS_X_VERSION_10_7
-#define HAVE_OSX_107_SDK
-#endif
-
-#ifdef MAC_OS_X_VERSION_10_9
-#define HAVE_OSX_109_SDK
-#endif
-
-#ifdef MAC_OS_X_VERSION_10_11
-#define HAVE_OSX_1011_SDK
-#endif
-
-#ifdef MAC_OS_X_VERSION_10_12
-#define HAVE_OSX_1012_SDK
-#endif
-
-#ifdef MAC_OS_X_VERSION_10_15
-#define HAVE_OSX_1015_SDK
-#endif
-
-/* It would seem that to ensure backward compatibility we have to ensure that we have defined MAC_OS_X_VERSION_10_x everywhere */
-#ifndef MAC_OS_X_VERSION_10_3
-#define MAC_OS_X_VERSION_10_3 1030
-#endif
-
-#ifndef MAC_OS_X_VERSION_10_4
-#define MAC_OS_X_VERSION_10_4 1040
-#endif
-
-#ifndef MAC_OS_X_VERSION_10_5
-#define MAC_OS_X_VERSION_10_5 1050
-#endif
-
-#ifndef MAC_OS_X_VERSION_10_6
-#define MAC_OS_X_VERSION_10_6 1060
-#endif
-
-#ifndef MAC_OS_X_VERSION_10_7
-#define MAC_OS_X_VERSION_10_7 1070
-#endif
-
-#ifndef MAC_OS_X_VERSION_10_8
-#define MAC_OS_X_VERSION_10_8 1080
-#endif
-
-#ifndef MAC_OS_X_VERSION_10_9
-#define MAC_OS_X_VERSION_10_9 1090
-#endif
-
-#ifndef MAC_OS_X_VERSION_10_10
-#define MAC_OS_X_VERSION_10_10 101000
-#endif
-
-#ifndef MAC_OS_X_VERSION_10_11
-#define MAC_OS_X_VERSION_10_11 101100
-#endif
-
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
 
@@ -132,9 +74,7 @@ typedef float CGFloat;
 #endif /* __LP64__ */
 #endif /* CGFLOAT_DEFINED */
 
-/* OS X SDK versions >= 10.5 have a non-const iconv. */
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
-#	define HAVE_NON_CONST_ICONV
-#endif
+/* OS X has a non-const iconv. */
+#define HAVE_NON_CONST_ICONV
 
 #endif /* MACOS_STDAFX_H */

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -21,34 +21,6 @@
 #include "../../safeguards.h"
 
 
-/* CTRunDelegateCreate is supported since MacOS X 10.5, but was only included in the SDKs starting with the 10.9 SDK. */
-#ifndef HAVE_OSX_109_SDK
-extern "C" {
-	typedef const struct __CTRunDelegate * CTRunDelegateRef;
-
-	typedef void (*CTRunDelegateDeallocateCallback) (void *refCon);
-	typedef CGFloat (*CTRunDelegateGetAscentCallback) (void *refCon);
-	typedef CGFloat (*CTRunDelegateGetDescentCallback) (void *refCon);
-	typedef CGFloat (*CTRunDelegateGetWidthCallback) (void *refCon);
-	typedef struct {
-		CFIndex                         version;
-		CTRunDelegateDeallocateCallback dealloc;
-		CTRunDelegateGetAscentCallback  getAscent;
-		CTRunDelegateGetDescentCallback getDescent;
-		CTRunDelegateGetWidthCallback   getWidth;
-	} CTRunDelegateCallbacks;
-
-	enum : int32_t {
-		kCTRunDelegateVersion1 = 1,
-		kCTRunDelegateCurrentVersion = kCTRunDelegateVersion1
-	};
-
-	extern const CFStringRef kCTRunDelegateAttributeName AVAILABLE_MAC_OS_X_VERSION_10_5_AND_LATER;
-
-	CTRunDelegateRef CTRunDelegateCreate(const CTRunDelegateCallbacks *callbacks, void *refCon) AVAILABLE_MAC_OS_X_VERSION_10_5_AND_LATER;
-}
-#endif /* HAVE_OSX_109_SDK */
-
 /** Cached current locale. */
 static CFAutoRelease<CFLocaleRef> _osx_locale;
 /** CoreText cache for font information, cleared when OTTD changes fonts. */

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -45,17 +45,6 @@
 #import <sys/param.h> /* for MAXPATHLEN */
 #import <sys/time.h> /* gettimeofday */
 
-/* The 10.12 SDK added new names for some enum constants and
- * deprecated the old ones. As there's no functional change in any
- * way, just use a define for older SDKs to the old names. */
-#ifndef HAVE_OSX_1012_SDK
-#	define NSEventModifierFlagCommand NSCommandKeyMask
-#	define NSEventModifierFlagControl NSControlKeyMask
-#	define NSEventModifierFlagOption NSAlternateKeyMask
-#	define NSEventModifierFlagShift NSShiftKeyMask
-#	define NSEventModifierFlagCapsLock NSAlphaShiftKeyMask
-#endif
-
 /**
  * Important notice regarding all modifications!!!!!!!
  * There are certain limitations because the file is objective C++.
@@ -375,11 +364,7 @@ bool VideoDriver_Cocoa::MakeWindow(int width, int height)
 	NSRect contentRect = NSMakeRect(0, 0, width, height);
 
 	/* Create main window. */
-#ifdef HAVE_OSX_1012_SDK
 	unsigned int style = NSWindowStyleMaskTitled | NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskClosable;
-#else
-	unsigned int style = NSTitledWindowMask | NSResizableWindowMask | NSMiniaturizableWindowMask | NSClosableWindowMask;
-#endif
 	this->window = [ [ OTTD_CocoaWindow alloc ] initWithContentRect:contentRect styleMask:style backing:NSBackingStoreBuffered defer:NO driver:this ];
 	if (this->window == nil) {
 		Debug(driver, 0, "Could not create the Cocoa window.");
@@ -449,11 +434,7 @@ bool VideoDriver_Cocoa::MakeWindow(int width, int height)
  */
 bool VideoDriver_Cocoa::PollEvent()
 {
-#ifdef HAVE_OSX_1012_SDK
 	NSEventMask mask = NSEventMaskAny;
-#else
-	NSEventMask mask = NSAnyEventMask;
-#endif
 	NSEvent *event = [ NSApp nextEventMatchingMask:mask untilDate:[ NSDate distantPast ] inMode:NSDefaultRunLoopMode dequeue:YES ];
 
 	if (event == nil) return false;

--- a/src/video/cocoa/cocoa_wnd.h
+++ b/src/video/cocoa/cocoa_wnd.h
@@ -12,10 +12,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-#ifdef MAC_OS_X_VERSION_10_12_2
-#	define HAVE_TOUCHBAR_SUPPORT
-#endif
-
 class VideoDriver_Cocoa;
 
 /* Right Mouse Button Emulation enum */
@@ -34,9 +30,7 @@ extern NSString *OTTDMainLaunchGameEngine;
 
 /** Subclass of NSWindow to cater our special needs */
 @interface OTTD_CocoaWindow : NSWindow
-#ifdef HAVE_TOUCHBAR_SUPPORT
 	<NSTouchBarDelegate>
-#endif
 
 - (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag driver:(VideoDriver_Cocoa *)drv;
 

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -43,17 +43,6 @@
 /* Table data for key mapping. */
 #include "cocoa_keys.h"
 
-/* The 10.12 SDK added new names for some enum constants and
- * deprecated the old ones. As there's no functional change in any
- * way, just use a define for older SDKs to the old names. */
-#ifndef HAVE_OSX_1012_SDK
-#	define NSEventModifierFlagCommand NSCommandKeyMask
-#	define NSEventModifierFlagControl NSControlKeyMask
-#	define NSEventModifierFlagOption NSAlternateKeyMask
-#	define NSEventModifierFlagShift NSShiftKeyMask
-#	define NSEventModifierFlagCapsLock NSAlphaShiftKeyMask
-#endif
-
 /**
  * Important notice regarding all modifications!!!!!!!
  * There are certain limitations because the file is objective C++.
@@ -62,7 +51,6 @@
  * Read http://developer.apple.com/releasenotes/Cocoa/Objective-C++.html for more information.
  */
 
-#ifdef HAVE_TOUCHBAR_SUPPORT
 struct TouchBarButton {
 	NSTouchBarItemIdentifier key;
 	SpriteID                 sprite;
@@ -82,8 +70,6 @@ static const std::array<TouchBarButton, 9> _touchbar_buttons{{
 	{ @"openttd.build_docks",   SPR_IMG_BUILDWATER,  MTHK_BUILD_DOCKS,   @"Docks" },
 	{ @"openttd.build_airport", SPR_IMG_BUILDAIR,    MTHK_BUILD_AIRPORT, @"Airport" }
 }};
-
-#endif
 
 bool _allow_hidpi_window = true; // Referenced from table/misc_settings.ini
 
@@ -199,11 +185,7 @@ static NSImage *NSImageFromSprite(SpriteID sprite_id, ZoomLevel zoom)
 	[ NSApp stop:self ];
 
 	/* Send an empty event to return from the run loop. Without that, application is stuck waiting for an event. */
-#ifdef HAVE_OSX_1012_SDK
 	NSEventType type = NSEventTypeApplicationDefined;
-#else
-	NSEventType type = NSApplicationDefined;
-#endif
 	NSEvent *event = [ NSEvent otherEventWithType:type location:NSMakePoint(0, 0) modifierFlags:0 timestamp:0.0 windowNumber:0 context:nil subtype:0 data1:0 data2:0 ];
 	[ NSApp postEvent:event atStart:YES ];
 }
@@ -410,11 +392,7 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 
 	@autoreleasepool {
 		NSAlert *alert = [ [ NSAlert alloc ] init ];
-#ifdef HAVE_OSX_1012_SDK
 		[ alert setAlertStyle: NSAlertStyleCritical ];
-#else
-		[ alert setAlertStyle: NSCriticalAlertStyle ];
-#endif
 		[ alert setMessageText:[ [ NSString alloc ] initWithBytes:title.data() length:title.size() encoding:NSUTF8StringEncoding ] ];
 		[ alert setInformativeText:[ [ NSString alloc ] initWithBytes:message.data() length:message.size() encoding:NSUTF8StringEncoding ] ];
 		[ alert addButtonWithTitle: [ [ NSString alloc ] initWithBytes:buttonLabel.data() length:buttonLabel.size() encoding:NSUTF8StringEncoding ] ];
@@ -483,8 +461,6 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	driver->AllocateBackingStore();
 }
 
-#ifdef HAVE_TOUCHBAR_SUPPORT
-
 - (void)touchBarButtonAction:(id)sender
 {
 	NSButton *btn = (NSButton *)sender;
@@ -526,11 +502,8 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	return tb_item;
 }
 
-#endif /* HAVE_TOUCHBAR_SUPPORT */
-
 - (void)refreshSystemSprites
 {
-#ifdef HAVE_TOUCHBAR_SUPPORT
 	if (!self->touchbar_created || ![ self respondsToSelector:@selector(touchBar) ] || self.touchBar == nil) return;
 
 	/* Re-create button images from OTTD sprites. */
@@ -557,7 +530,6 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 			button.imagePosition = NSNoImage;
 		}
 	}
-#endif /* HAVE_TOUCHBAR_SUPPORT */
 }
 
 @end


### PR DESCRIPTION
## Motivation / Problem

We are carrying a lot of defines around in the MacOS code for old versions. The 'newest' of these old versions is 10.12.

The oldest GitHub runner has SDK 13. The current latest has 15. Between 10.12 and 13 there is 10.13, 10.14, 10.15, 11 and 12.

Apple's support for 10.12 ended in 2019.


## Description

Remove a lot of old cruft.


## Limitations

Someone with a really old SDK cannot build OpenTTD any more. Though do we really care? On our website we're stating 10.14+ for the built binaries.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
