### PR TITLE
Change: Crash trains when trying to remove their track

### DIFF
--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -15,6 +15,7 @@
 #include "newgrf_debug.h"
 #include "newgrf_railtype.h"
 #include "train.h"
+#include "train_cmd.h"
 #include "autoslope.h"
 #include "water.h"
 #include "tunnelbridge_map.h"
@@ -669,7 +670,10 @@ CommandCost CmdRemoveSingleRail(DoCommandFlags flags, TileIndex tile, Track trac
 			}
 
 			CommandCost ret = EnsureNoTrainOnTrack(tile, track);
-			if (ret.Failed()) return ret;
+			if (ret.Failed()) {
+				if (flags.Test(DoCommandFlag::Execute)) CrashTrainsOnTrack(tile, track);
+				return ret;
+			}
 
 			present = GetTrackBits(tile);
 			if ((present & trackbit) == 0) return CommandCost(STR_ERROR_THERE_IS_NO_RAILROAD_TRACK);

--- a/src/train_cmd.h
+++ b/src/train_cmd.h
@@ -27,5 +27,6 @@ DEF_CMD_TRAIT(CMD_FORCE_TRAIN_PROCEED,     CmdForceTrainProceed,     CommandFlag
 DEF_CMD_TRAIT(CMD_REVERSE_TRAIN_DIRECTION, CmdReverseTrainDirection, CommandFlag::Location, CommandType::VehicleManagement)
 
 void CcBuildWagon(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16_t, CargoArray, TileIndex tile, EngineID, bool, CargoType, ClientID);
+void CrashTrainsOnTrack(TileIndex tile, Track track);
 
 #endif /* TRAIN_CMD_H */


### PR DESCRIPTION
## Motivation / Problem

In Locomotion, if you try to remove a track from beneath a train, the train crashes.

I rarely see train crashes in my game and wouldn't mind a bit more excitement.

## Description

Crash trains if you try to remove their track. This does not allow the track to be removed, it just blows up the train to punish you for your mistake. 😄 

## Limitations

* Sort of a silly idea.
* The comment on the code I copied says it's not multiplayer-safe. I'm not sure why, and could use help making it safe.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
