### PR TITLE
Cleanup: remove unneeded warning disabling macros

### DIFF
--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -28,7 +28,6 @@ static FBlitter_32bppSSE4_Anim iFBlitter_32bppSSE4_Anim;
  * @param bp further blitting parameters
  * @param zoom zoom level at which we are drawing
  */
-IGNORE_UNINITIALIZED_WARNING_START
 template <BlitterMode mode, Blitter_32bppSSE2::ReadMode read_mode, Blitter_32bppSSE2::BlockType bt_last, bool translucent, bool animated>
 GNU_TARGET("sse4.1")
 inline void Blitter_32bppSSE4_Anim::Draw(const BlitterParams *bp, ZoomLevel zoom)
@@ -373,7 +372,6 @@ next_line:
 		anim_line += this->anim_buf_pitch;
 	}
 }
-IGNORE_UNINITIALIZED_WARNING_STOP
 
 /**
  * Draws a sprite to a (screen) buffer. Calls adequate templated function.

--- a/src/blitter/32bpp_sse_func.hpp
+++ b/src/blitter/32bpp_sse_func.hpp
@@ -116,7 +116,6 @@ INTERNAL_LINKAGE inline __m128i DarkenTwoPixels(__m128i src, __m128i dst, const 
 	return _mm_packus_epi16(dstAB, dstAB);
 }
 
-IGNORE_UNINITIALIZED_WARNING_START
 GNU_TARGET(SSE_TARGET)
 INTERNAL_LINKAGE Colour ReallyAdjustBrightness(Colour colour, uint8_t brightness)
 {
@@ -147,7 +146,6 @@ INTERNAL_LINKAGE Colour ReallyAdjustBrightness(Colour colour, uint8_t brightness
 	ret = _mm_packus_epi16(ret, ret);      // PACKUSWB, saturate and pack.
 	return alpha32 | _mm_cvtsi128_si32(ret);
 }
-IGNORE_UNINITIALIZED_WARNING_STOP
 
 /** ReallyAdjustBrightness() is not called that often.
  * Inlining this function implies a far jump, which has a huge latency.
@@ -210,7 +208,6 @@ INTERNAL_LINKAGE inline __m128i AdjustBrightnessOfTwoPixels([[maybe_unused]] __m
  * @param bp further blitting parameters
  * @param zoom zoom level at which we are drawing
  */
-IGNORE_UNINITIALIZED_WARNING_START
 template <BlitterMode mode, Blitter_32bppSSE2::ReadMode read_mode, Blitter_32bppSSE2::BlockType bt_last, bool translucent>
 GNU_TARGET(SSE_TARGET)
 #if (SSE_VERSION == 2)
@@ -446,7 +443,6 @@ next_line:
 		dst_line += bp->pitch;
 	}
 }
-IGNORE_UNINITIALIZED_WARNING_STOP
 
 /**
  * Draws a sprite to a (screen) buffer. Calls adequate templated function.

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -307,25 +307,4 @@ char (&ArraySizeHelper(T (&array)[N]))[N];
 #	define MAX_PATH 260
 #endif
 
-#if defined(_MSC_VER) && !defined(_DEBUG)
-#	define IGNORE_UNINITIALIZED_WARNING_START __pragma(warning(push)) __pragma(warning(disable:4700))
-#	define IGNORE_UNINITIALIZED_WARNING_STOP __pragma(warning(pop))
-#elif defined(__GNUC__) && !defined(_DEBUG)
-#	define HELPER0(x) #x
-#	define HELPER1(x) HELPER0(GCC diagnostic ignored x)
-#	define HELPER2(y) HELPER1(#y)
-#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
-#	define IGNORE_UNINITIALIZED_WARNING_START \
-		_Pragma("GCC diagnostic push") \
-		_Pragma(HELPER2(-Wuninitialized)) \
-		_Pragma(HELPER2(-Wmaybe-uninitialized))
-#	define IGNORE_UNINITIALIZED_WARNING_STOP _Pragma("GCC diagnostic pop")
-#endif
-#endif
-
-#ifndef IGNORE_UNINITIALIZED_WARNING_START
-#	define IGNORE_UNINITIALIZED_WARNING_START
-#	define IGNORE_UNINITIALIZED_WARNING_STOP
-#endif
-
 #endif /* STDAFX_H */


### PR DESCRIPTION
## Motivation / Problem

There are some macros in stdafx.h/sse-blitters to silence some warnings. However, the current (GitHub) compilers don't seem to trigger the warnings, so we're carrying basically dead weight.


## Description

Remove the macros.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
