### PR TITLE
Codefix: Clean up object area placement

### DIFF
--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -391,7 +391,7 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
  * @param start_tile start tile of area dragging
  * @param type the object type to build
  * @param view the view for the object
- * @param diagonal Whether to use the Orthogonal (0) or Diagonal (1) iterator.
+ * @param diagonal Whether to use the Diagonal or Orthogonal tile iterator.
  * @return the cost of this operation or an error
  */
 CommandCost CmdBuildObjectArea(DoCommandFlags flags, TileIndex tile, TileIndex start_tile, ObjectType type, uint8_t view, bool diagonal)

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -351,15 +351,9 @@ public:
 
 		assert(select_proc == DDSP_BUILD_OBJECT);
 
-		if (!_settings_game.construction.freeform_edges) {
-			/* When end_tile is MP_VOID, the error tile will not be visible to the
-			 * user. This happens when terraforming at the southern border. */
-			if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
-			if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
-		}
 		const ObjectSpec *spec = ObjectClass::Get(_object_gui.sel_class)->GetSpec(_object_gui.sel_type);
 		Command<CMD_BUILD_OBJECT_AREA>::Post(STR_ERROR_CAN_T_BUILD_OBJECT, CcPlaySound_CONSTRUCTION_OTHER,
-			end_tile, start_tile, spec->Index(), _object_gui.sel_view, (_ctrl_pressed ? true : false));
+			end_tile, start_tile, spec->Index(), _object_gui.sel_view, _ctrl_pressed);
 	}
 
 	void OnPlaceObjectAbort() override

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -308,7 +308,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlags flags,
  * @param flags for this command type
  * @param tile end tile of area-drag
  * @param start_tile start tile of area drag
- * @param diagonal Whether to use the Orthogonal (false) or Diagonal (true) iterator.
+ * @param diagonal Whether to use the Diagonal or Orthogonal tile iterator.
  * @param LevelMode Mode of leveling \c LevelMode.
  * @return the cost of this operation or an error
  */

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -281,7 +281,7 @@ struct TerraformToolbarWindow : Window {
 						if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
 					}
 					Command<CMD_BUILD_OBJECT_AREA>::Post(STR_ERROR_CAN_T_PURCHASE_THIS_LAND, CcPlaySound_CONSTRUCTION_RAIL,
-						end_tile, start_tile, OBJECT_OWNED_LAND, 0, (_ctrl_pressed ? true : false));
+						end_tile, start_tile, OBJECT_OWNED_LAND, 0, _ctrl_pressed);
 					break;
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

I copy-pasted some messy code into #14708. Let's fix the original code too.


## Description

Scrub-a-dub-dub, clean code in the tub.

From https://github.com/OpenTTD/OpenTTD/pull/14708#discussion_r2673678582 regarding the removed code checking non-freeform edges:
> It seems to be copied from terraforming, where you actually need to be able to 'select' just beyond the map boundary because the tiles to the south are used to determine the height of the corners.
In other word, to raise the southern most visible tile corner of the map, you actually raise the invisible/void tile just south of that. And that's why this logic makes sense there; in that case you want to show that error on the visible tile.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
