### PR TITLE
Fix #15069: World generation map edges GUI starts in an invalid state

### DIFF
--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -276,7 +276,7 @@ cat      = SC_BASIC
 var      = game_creation.water_borders
 type     = SLE_UINT8
 from     = SLV_111
-def      = 15
+def      = 16
 min      = 0
 max      = 16
 


### PR DESCRIPTION

## Motivation / Problem

#15069 

## Description

Caused due to a conflict with the default values of [`game_creation.water_borders`](https://github.com/OpenTTD/OpenTTD/blob/9e9b51369e1cab201bb690c19badeda42b517fad/src/table/settings/world_settings.ini#L279) and [`game_creation.water_border_presets`](https://github.com/OpenTTD/OpenTTD/blob/9e9b51369e1cab201bb690c19badeda42b517fad/src/table/settings/world_settings.ini#L286).

Whilst the current default of `water_border_presets` is `BorderFlagPresets::Random`, `water_borders` has a default of `15` which corresponds to the first four bits in the `BorderFlag` being enabled. This value would be expected if `water_border_presets`' default value was `BorderFlagPresets::Manual`. A default value of `16` will cause the expected behaviour, as the widgets are then [set to disabled as expected](https://github.com/OpenTTD/OpenTTD/blob/9e9b51369e1cab201bb690c19badeda42b517fad/src/genworld_gui.cpp#L520).


## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
