### PR TITLE
Codefix: incorrect naming of enum class members

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -260,7 +260,7 @@ bool CrashLog::WriteScreenshot()
 void CrashLog::SendSurvey() const
 {
 	if (_game_mode == GM_NORMAL) {
-		_survey.Transmit(NetworkSurveyHandler::Reason::CRASH, true);
+		_survey.Transmit(NetworkSurveyHandler::Reason::Crash, true);
 	}
 }
 

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -403,7 +403,7 @@ void ShowSelectGameWindow()
 static void AskExitGameCallback(Window *, bool confirmed)
 {
 	if (confirmed) {
-		_survey.Transmit(NetworkSurveyHandler::Reason::EXIT, true);
+		_survey.Transmit(NetworkSurveyHandler::Reason::Exit, true);
 		_exit_game = true;
 	}
 }

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2342,7 +2342,7 @@ struct SurveyResultTextfileWindow : public TextfileWindow {
 	{
 		this->ConstructWindow();
 
-		auto result = _survey.CreatePayload(NetworkSurveyHandler::Reason::PREVIEW, true);
+		auto result = _survey.CreatePayload(NetworkSurveyHandler::Reason::Preview, true);
 		this->LoadText(result);
 		this->InvalidateData();
 	}

--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -22,10 +22,10 @@
 NetworkSurveyHandler _survey = {};
 
 NLOHMANN_JSON_SERIALIZE_ENUM(NetworkSurveyHandler::Reason, {
-	{NetworkSurveyHandler::Reason::PREVIEW, "preview"},
-	{NetworkSurveyHandler::Reason::LEAVE, "leave"},
-	{NetworkSurveyHandler::Reason::EXIT, "exit"},
-	{NetworkSurveyHandler::Reason::CRASH, "crash"},
+	{NetworkSurveyHandler::Reason::Preview, "preview"},
+	{NetworkSurveyHandler::Reason::Leave, "leave"},
+	{NetworkSurveyHandler::Reason::Exit, "exit"},
+	{NetworkSurveyHandler::Reason::Crash, "crash"},
 })
 
 /**

--- a/src/network/network_survey.h
+++ b/src/network/network_survey.h
@@ -25,10 +25,10 @@ protected:
 
 public:
 	enum class Reason : uint8_t {
-		PREVIEW, ///< User is previewing the survey result.
-		LEAVE, ///< User is leaving the game (but not exiting the application).
-		EXIT, ///< User is exiting the application.
-		CRASH, ///< Game crashed.
+		Preview, ///< User is previewing the survey result.
+		Leave, ///< User is leaving the game (but not exiting the application).
+		Exit, ///< User is exiting the application.
+		Crash, ///< Game crashed.
 	};
 
 	void Transmit(Reason reason, bool blocking = false);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -820,7 +820,7 @@ void HandleExitGameRequest()
 		_exit_game = true;
 	} else if (_settings_client.gui.autosave_on_exit) {
 		DoExitSave();
-		_survey.Transmit(NetworkSurveyHandler::Reason::EXIT, true);
+		_survey.Transmit(NetworkSurveyHandler::Reason::Exit, true);
 		_exit_game = true;
 	} else {
 		AskExitGame();
@@ -1053,7 +1053,7 @@ void SwitchToMode(SwitchMode new_mode)
 	if (new_mode != SM_SAVE_GAME) ChangeAutosaveFrequency(true);
 
 	/* Transmit the survey if we were in normal-mode and not saving. It always means we leaving the current game. */
-	if (_game_mode == GM_NORMAL && new_mode != SM_SAVE_GAME) _survey.Transmit(NetworkSurveyHandler::Reason::LEAVE);
+	if (_game_mode == GM_NORMAL && new_mode != SM_SAVE_GAME) _survey.Transmit(NetworkSurveyHandler::Reason::Leave);
 
 	/* Keep track when we last switch mode. Used for survey, to know how long someone was in a game. */
 	if (new_mode != SM_SAVE_GAME) {


### PR DESCRIPTION
## Motivation / Problem

Wrong capitalisation for enum class members.


## Description

Fix capitalisation.


## Limitations

There might be more cases, but I haven't come across them yet.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
