### PR TITLE
Fix #15088: When buying a new train, the refit button does not become…

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -244,6 +244,9 @@ void Train::ConsistChanged(ConsistChangeFlags allowed_changes)
 		InvalidateWindowData(WC_VEHICLE_REFIT, this->index, VIWD_CONSIST_CHANGED);
 		InvalidateWindowData(WC_VEHICLE_ORDERS, this->index, VIWD_CONSIST_CHANGED);
 		InvalidateNewGRFInspectWindow(GSF_TRAINS, this->index);
+
+		/* If the consist is changed while in a depot, the vehicle view window must be invalidated to update the availability of refitting. */
+		InvalidateWindowData(WC_VEHICLE_VIEW, this->index, VIWD_CONSIST_CHANGED);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

#15088


## Description

[A change](https://github.com/OpenTTD/OpenTTD/commit/d405e4cb09911a34f263f0de26e8126e05c4d936#diff-6da2a56e241ecab552a6e843df104639216a7714ff2d12249f39b7bd312b5be9R3086) to the way that updates for `VehicleViewWindow` widgets are triggered resulted in `WID_VV_REFIT` widgets' disabled state not being updated when consists change.

Consist changes (`Train::ConsistChanged`) now [trigger](https://github.com/abi9ail/OpenTTD/blob/b585047cbe62c00f6e1ea2a69669b86d7cb4f0d9/src/train_cmd.cpp#L250) updates for `VehicleViewWindow`s appropriately \(in line with [other vehicle windows](https://github.com/OpenTTD/OpenTTD/blob/5418a8c6f8a3f43a0cc59ab09d0f5841ff861622/src/train_cmd.cpp#L244)\) matching the expected behaviour. 

Adding a call to `UpdateButtons()` at the end of `VehicleViewWindow::OnPaint()` also seems to work, but I'm cautious of 
[updating widgets in `OnPaint()`](https://github.com/OpenTTD/OpenTTD/pull/14870).

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
