### PR TITLE
Fix #14626: House Selection interface not large enough to show all av…

### DIFF
--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1643,12 +1643,16 @@ static CargoTypes GetProducedCargoOfHouse(const HouseSpec *hs)
 }
 
 struct BuildHouseWindow : public PickerWindow {
+private:
+	uint coverage_height = 0; ///< Height of the coverage texts.
+public:
 	std::string house_info{};
 	static inline bool house_protected;
 	static inline bool replace;
 
 	BuildHouseWindow(WindowDesc &desc, Window *parent) : PickerWindow(desc, parent, 0, HousePickerCallbacks::instance)
 	{
+		this->coverage_height = 2 * GetCharacterHeight(FS_NORMAL) + WidgetDimensions::scaled.vsep_normal;
 		HousePickerCallbacks::instance.SetClimateMask();
 		this->ConstructWindow();
 	}
@@ -1795,6 +1799,25 @@ struct BuildHouseWindow : public PickerWindow {
 		this->SetWidgetDisabledState(WID_BH_PROTECT_TOGGLE, hasflag);
 	}
 
+	void OnPaint() override
+	{
+		this->DrawWidgets();
+
+		if (this->IsShaded()) return;
+		/* House Information, including 'Accepts' and 'Supplies' texts. */
+		Rect r = this->GetWidget<NWidgetBase>(WID_BH_INFO)->GetCurrentRect();
+		const int bottom = r.bottom;
+		r.bottom = INT_MAX; // Allow overflow as we want to know the required height.
+		r.top = DrawStringMultiLine(r, this->house_info) + WidgetDimensions::scaled.vsep_normal;
+		/* Resize background if the window is too small.
+		 * Never make the window smaller to avoid oscillating if the size change affects the acceptance.
+		 * (This is the case, if making the window bigger moves the mouse into the window.) */
+		if (r.top > bottom) {
+			this->coverage_height += r.top - bottom;
+			ReInit();
+		}
+	}
+
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
 	{
 		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
@@ -1820,6 +1843,19 @@ struct BuildHouseWindow : public PickerWindow {
 		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
 		Command<CMD_PLACE_HOUSE_AREA>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER,
 			end_tile, start_tile, spec->Index(), BuildHouseWindow::house_protected, BuildHouseWindow::replace, _ctrl_pressed);
+	}
+
+	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override
+	{
+		switch (widget) {
+			case WID_BH_INFO:
+				size.height = this->coverage_height;
+				break;
+
+			default:
+				this->PickerWindow::UpdateWidgetSize(widget, size, padding, fill, resize);
+				break;
+		}
 	}
 
 	const IntervalTimer<TimerWindow> view_refresh_interval = {std::chrono::milliseconds(2500), [this](auto) {


### PR DESCRIPTION
## Motivation / Problem

#14626

## Description

The `BuildRailStationWindow` and `BuildRoadStationWindow` [approach](https://github.com/abi9ail/OpenTTD/blob/198f9b6041d6fbfc9674e55c830b8dc84edb0b79/src/rail_gui.cpp#L1164) to adjusting window sizes to fit cargo acceptance strings has been replicated within `HousePickerWindow`s.

Cargo acceptance strings will no longer be unintentionally clipped, as the windows will be automatically resized.


## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
