### PR TITLE
Codechange: Lower PNG compression level from 6 to 4

### DIFF
--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -67,6 +67,7 @@ public:
 		png_init_io(png_ptr, f);
 
 		png_set_filter(png_ptr, 0, PNG_FILTER_NONE);
+		png_set_compression_level(png_ptr, 4);
 
 		png_set_IHDR(png_ptr, info_ptr, w, h, 8, pixelformat == 8 ? PNG_COLOR_TYPE_PALETTE : PNG_COLOR_TYPE_RGB,
 			PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When trying to take fullmap screenshots on larger saves (256x256+) most of the time is spent compressing the PNG instead of rendering the image. This makes it 5x slower than the same image in BMP and larger save screenshots (4096x4096+) infeasible for a multiplayer game.


## Description

Lowering the PNG compression level from the default 6 to 4 results in 30% faster save times and only 4% larger fullmap images. 
(Tested on a 256x256 fullmap screenshot via FFMPEG for ease of configuring zlib settings)
Level 6: `utime=2.234s stime=0.062s rtime=2.278s 10,448,725 bytes`
Level 4: `utime=1.609s stime=0.031s rtime=1.641s 10,906,214 bytes`

A 512x512 fullmap screenshot went from 10s to 4s, 60% faster but 10% larger.
Files are still 10x smaller than uncompressed BMP, but now only a 2x slowdown instead of 5x for fullmap images.

## Limitations

Standard screenshots increase in size by 20%, but that's only 195KB to 225KB on 1080p.
Players can always run tools like Oxipng for greater savings in significantly less time than libpng if size is a concern.

I've been unable to compile OpenTTD to test it myself, but I previously did the same change for https://github.com/libjxl/libjxl/pull/3819 and https://github.com/Yellow-Dog-Man/FreeImage/issues/20. Note, results on those repos are for 32bpp images, while OpenTTD primarily uses 8bpp so the filesize difference is much smaller between levels.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
