### PR TITLE
Change: Currency: update turkish lira value and symbol

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -52,7 +52,7 @@ static const std::array<CurrencySpec, CURRENCY_END> origin_currency_specs = {{
 	{   50, "", CF_NOEURO,                     "",         NBSP "p",       "RUR", 1, STR_GAME_OPTIONS_CURRENCY_RUR    }, ///< russian rouble
 	{  479, "", TimerGameCalendar::Year{2007}, "",         NBSP "SIT",     "SIT", 1, STR_GAME_OPTIONS_CURRENCY_SIT    }, ///< slovenian tolar
 	{   13, "", CF_NOEURO,                     "",         NBSP "Kr",      "SEK", 1, STR_GAME_OPTIONS_CURRENCY_SEK    }, ///< swedish krona
-	{    3, "", CF_NOEURO,                     "",         NBSP "TL",      "TRY", 1, STR_GAME_OPTIONS_CURRENCY_TRY    }, ///< turkish lira
+	{    3, "", CF_NOEURO,                     "\u20ba",   "",             "TRY", 0, STR_GAME_OPTIONS_CURRENCY_TRY    }, ///< turkish lira
 	{   60, "", TimerGameCalendar::Year{2009}, "",         NBSP "Sk",      "SKK", 1, STR_GAME_OPTIONS_CURRENCY_SKK    }, ///< slovak koruna
 	{    4, "", CF_NOEURO,                     "R$" NBSP,  "",             "BRL", 0, STR_GAME_OPTIONS_CURRENCY_BRL    }, ///< brazil real
 	{   31, "", TimerGameCalendar::Year{2011}, "",         NBSP "EEK",     "EEK", 1, STR_GAME_OPTIONS_CURRENCY_EEK    }, ///< estonian krooni


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Turkish lira value and writing is not up to date.

## Description

Turkish lira has devalued over time and is now 1/50 of €. Also it has a symbol (₺).

The Central Bank of the Republic of Türkiye [suggests](https://www.tcmb.gov.tr/wps/wcm/connect/TR/TCMB+TR/Main+Menu/Banka+Hakkinda/Sikca+Sorulan+Sorular/TL+Simgesi/) that the symbol should be written to the left of the number without a space.

Translation from the central bank web site:

> The abbreviation for the Turkish Lira is "TL", and the symbol for the Turkish Lira is "₺". Depending on the context, either the symbol or the abbreviation can be used to represent the Turkish Lira, but not simultaneously. While it is preferable to write the Turkish Lira (or its abbreviation, TL) clearly in texts and official correspondence, the use of the symbol is recommended in graphs, tables, etc.
> 
> In line with international practice, the symbol is placed to the left of the number (monetary amount) and without a space.
> 
