### PR TITLE
Fix: [CI] Use the latest version of GOGGalaxyPipelineBuilder to upload releases to GOG

### DIFF
--- a/.github/workflows/upload-gog.yml
+++ b/.github/workflows/upload-gog.yml
@@ -46,9 +46,8 @@ jobs:
 
     - name: Install GOG Galaxy Build Creator
       run: |
-        wget https://cdn.gog.com/open/galaxy/pipeline/build_creator/gnu-linux/GOGGalaxyBuildCreator-1.4.0.AppImage
-        7z x GOGGalaxyBuildCreator-1.4.0.AppImage
-        chmod +x ./app/GOGGalaxyPipelineBuilder
+        wget https://cdn.gog.com/open/galaxy/pipeline/10.6.7.17/gnu-linux/GOGGalaxyPipelineBuilder
+        chmod +x ./GOGGalaxyPipelineBuilder
 
     - name: Install OpenGFX
       shell: bash
@@ -145,8 +144,8 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Upload to GOG"
-          ../app/GOGGalaxyPipelineBuilder build-game --username "${{ secrets.GOG_USERNAME }}" --password "${{ secrets.GOG_PASSWORD }}" --branch Testing windows.json
-          ../app/GOGGalaxyPipelineBuilder build-game --username "${{ secrets.GOG_USERNAME }}" --password "${{ secrets.GOG_PASSWORD }}" --branch Testing macos.json
-          ../app/GOGGalaxyPipelineBuilder build-game --username "${{ secrets.GOG_USERNAME }}" --password "${{ secrets.GOG_PASSWORD }}" --branch Testing linux.json
+          ../GOGGalaxyPipelineBuilder build-game --username "${{ secrets.GOG_USERNAME }}" --password "${{ secrets.GOG_PASSWORD }}" --branch Testing windows.json
+          ../GOGGalaxyPipelineBuilder build-game --username "${{ secrets.GOG_USERNAME }}" --password "${{ secrets.GOG_PASSWORD }}" --branch Testing macos.json
+          ../GOGGalaxyPipelineBuilder build-game --username "${{ secrets.GOG_USERNAME }}" --password "${{ secrets.GOG_PASSWORD }}" --branch Testing linux.json
           echo "::endgroup::"
         )


### PR DESCRIPTION
## Motivation / Problem

The GOG release job for 15.0 failed: https://github.com/OpenTTD/OpenTTD/actions/runs/20642598043/job/59276828683

## Description

It seems we were downloading an old GOG GUI toolkit then extracting the `GOGGalaxyPipelineBuilder` from it; GOG has released `GOGGalaxyPipelineBuilder` as a separate download though which is updated much more frequently.

I manually executed the steps from the GOG workflow to release 15.0, which was successful.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
