### PR TITLE
Change: Allow entering the Scenario Editor when no roadtypes are available

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -114,7 +114,9 @@ static void _GenerateWorld()
 		IncreaseGeneratingWorldProgress(GWP_MAP_INIT);
 		/* Must start economy early because of the costs. */
 		StartupEconomy();
-		if (!CheckTownRoadTypes()) {
+
+		/* Allow a landscape to generate in the editor without towns being able to be generated (e.g. to create a heightmap) */
+		if (_game_mode != GM_EDITOR && !CheckTownRoadTypes(true)) {
 			HandleGeneratingWorldAbortion();
 			return;
 		}

--- a/src/town.h
+++ b/src/town.h
@@ -351,7 +351,7 @@ inline uint16_t TownTicksToGameTicks(uint16_t ticks)
 
 
 RoadType GetTownRoadType();
-bool CheckTownRoadTypes();
+bool CheckTownRoadTypes(bool show_error_messages = false);
 std::span<const DrawBuildingsTileStruct> GetTownDrawTileData();
 
 #endif /* TOWN_H */

--- a/src/town_cmd.h
+++ b/src/town_cmd.h
@@ -45,5 +45,6 @@ DEF_CMD_TRAIT(CMD_PLACE_HOUSE_AREA, CmdPlaceHouseArea, CommandFlags({ CommandFla
 
 CommandCallback CcFoundTown;
 void CcFoundRandomTown(Commands cmd, const CommandCost &result, Money, TownID town_id);
+TimerGameCalendar::Date GetTownRoadTypeFirstIntroductionDate();
 
 #endif /* TOWN_CMD_H */


### PR DESCRIPTION
## Description

### Allows entering the scenario editor when no roadtypes are available
<img width="1922" height="1119" alt="image" src="https://github.com/user-attachments/assets/210a6135-5ac6-4abb-b3dc-b589cb142c2f" />

This prevents unnecessary limits on entering the editor. For example, a player would have previously been unable to create a heightmap if no roadtypes were available, despite no towns being required. Further, it allows players who wish to generate towns in the editor to adjust the date within the editor, rather than having to exit to the main menu and edit it in a sub-menu.

### Displays more specific error messages when towns fail to generate
This is mostly a consequence of the above change introducting more circumstances under which towns can fail to generate; for example, the town generation buttons in the Scenario Editor can now be clicked when there are no available roadtypes. 

*Examples*
<img width="3844" height="2238" alt="image" src="https://github.com/user-attachments/assets/74313cef-62b6-4987-bb0f-08f59b12f6e5" />

A new `bool` parameter of `CheckTownRoadTypes()` enables and disables error messages being shown when the check fails. Whilst this parameter is only `true` [once](https://github.com/abi9ail/OpenTTD/commit/71d1ece48a95cc1824bcf367d70e93c614404aca#diff-ddf5e1afc5ac5b36f4d4d449cb3cb05ce2aa08907029c63e3b02a495e957fd50R119), I stopped short of rewriting the `CheckTownRoadTypes()` functionality entirely as I wasn't sure how best to go about it. I think splitting the functionality into two functions, each checking whether roadtypes are available either *now* or *ever* could work, with the potential of eliminating [some introduced repetition](https://github.com/abi9ail/OpenTTD/commit/71d1ece48a95cc1824bcf367d70e93c614404aca#diff-29a91a3072972916f6a1fb6c4c39903c936ad567d962aa6d6b1dc4615596674aR1231).

## Limitations
- `CheckTownRoadTypes()` functionality could be implemented more efficiently. 
- After loading the Scenario Editor without any roadtypes available, the Road toolbar widget remains raised (and the town generation buttons...), despite being unable to place roads. <sub>\*Could be another potential improvement, but would need to mess around with tooltips if the buttons were to be disabled.</sub>

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
