### PR TITLE
Codechange: make aircraft vehicle flags enum-class and EnumBitSet

### DIFF
--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -33,17 +33,18 @@ enum AircraftSubType : uint8_t {
 };
 
 /** Flags for air vehicles; shared with disaster vehicles. */
-enum AirVehicleFlags : uint8_t {
-	VAF_DEST_TOO_FAR             = 0, ///< Next destination is too far away.
+enum class VehicleAirFlag : uint8_t {
+	DestinationTooFar = 0, ///< Next destination is too far away.
 
 	/* The next two flags are to prevent stair climbing of the aircraft. The idea is that the aircraft
 	 * will ascend or descend multiple flight levels at a time instead of following the contours of the
 	 * landscape at a fixed altitude. This only has effect when there are more than 15 height levels. */
-	VAF_IN_MAX_HEIGHT_CORRECTION = 1, ///< The vehicle is currently lowering its altitude because it hit the upper bound.
-	VAF_IN_MIN_HEIGHT_CORRECTION = 2, ///< The vehicle is currently raising its altitude because it hit the lower bound.
+	InMaximumHeightCorrection = 1, ///< The vehicle is currently lowering its altitude because it hit the upper bound.
+	InMinimumHeightCorrection = 2, ///< The vehicle is currently raising its altitude because it hit the lower bound.
 
-	VAF_HELI_DIRECT_DESCENT      = 3, ///< The helicopter is descending directly at its destination (helipad or in front of hangar)
+	HelicopterDirectDescent = 3, ///< The helicopter is descending directly at its destination (helipad or in front of hangar)
 };
+using VehicleAirFlags = EnumBitSet<VehicleAirFlag, uint8_t>;
 
 static const int ROTOR_Z_OFFSET         = 5;    ///< Z Offset between helicopter- and rotorsprite.
 
@@ -78,7 +79,7 @@ struct Aircraft final : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 	Direction last_direction = INVALID_DIR;
 	uint8_t number_consecutive_turns = 0; ///< Protection to prevent the aircraft of making a lot of turns in order to reach a specific point.
 	uint8_t turn_counter = 0; ///< Ticks between each turn to prevent > 45 degree turns.
-	uint8_t flags = 0; ///< Aircraft flags. @see AirVehicleFlags
+	VehicleAirFlags flags{}; ///< Aircraft flags. @see VehicleAirFlags
 
 	AircraftCache acache{};
 

--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -11,6 +11,7 @@
 #define DISASTER_VEHICLE_H
 
 #include "vehicle_base.h"
+#include "aircraft.h"
 
 /** Different sub types of disaster vehicles. */
 enum DisasterSubType : uint8_t {
@@ -37,7 +38,7 @@ enum DisasterSubType : uint8_t {
 struct DisasterVehicle final : public SpecializedVehicle<DisasterVehicle, VEH_DISASTER> {
 	SpriteID image_override{}; ///< Override for the default disaster vehicle sprite.
 	VehicleID big_ufo_destroyer_target = VehicleID::Invalid(); ///< The big UFO that this destroyer is supposed to bomb.
-	uint8_t flags = 0; ///< Flags about the state of the vehicle, @see AirVehicleFlags
+	VehicleAirFlags flags{}; ///< Flags about the state of the vehicle, @see VehicleAirFlags
 	uint16_t state = 0; ///< Action stage of the disaster vehicle.
 
 	/** For use by saveload. */

--- a/src/train.h
+++ b/src/train.h
@@ -22,7 +22,7 @@
 struct Train;
 
 /** Rail vehicle flags. */
-enum VehicleRailFlag : uint8_t {
+enum class VehicleRailFlag : uint8_t {
 	Reversing = 0, ///< Train is slowing down to reverse.
 	PoweredWagon = 3, ///< Wagon is powered.
 	Flipped = 4, ///< Reverse the visible direction of the vehicle.

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -598,7 +598,7 @@ CommandCost CmdStartStopVehicle(DoCommandFlags flags, VehicleID veh_id, bool eva
 			Aircraft *a = Aircraft::From(v);
 			/* cannot stop airplane when in flight, or when taking off / landing */
 			if (a->state >= STARTTAKEOFF && a->state < TERM7) return CommandCost(STR_ERROR_AIRCRAFT_IS_IN_FLIGHT);
-			if (HasBit(a->flags, VAF_HELI_DIRECT_DESCENT)) return CommandCost(STR_ERROR_AIRCRAFT_IS_IN_FLIGHT);
+			if (a->flags.Test(VehicleAirFlag::HelicopterDirectDescent)) return CommandCost(STR_ERROR_AIRCRAFT_IS_IN_FLIGHT);
 			break;
 		}
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3145,7 +3145,7 @@ public:
 
 		if (v->type == VEH_TRAIN && Train::From(v)->flags.Test(VehicleRailFlag::Stuck) && !v->current_order.IsType(OT_LOADING)) return GetString(STR_VEHICLE_STATUS_TRAIN_STUCK);
 
-		if (v->type == VEH_AIRCRAFT && HasBit(Aircraft::From(v)->flags, VAF_DEST_TOO_FAR) && !v->current_order.IsType(OT_LOADING)) return GetString(STR_VEHICLE_STATUS_AIRCRAFT_TOO_FAR);
+		if (v->type == VEH_AIRCRAFT && Aircraft::From(v)->flags.Test(VehicleAirFlag::DestinationTooFar) && !v->current_order.IsType(OT_LOADING)) return GetString(STR_VEHICLE_STATUS_AIRCRAFT_TOO_FAR);
 
 		/* Vehicle is in a "normal" state, show current order. */
 		if (mouse_over_start_stop) {


### PR DESCRIPTION
## Motivation / Problem

Our goal to use `enum class` and `EnumBitSet` where applicable.


## Description

While doing this change I noticed `enum VehicleRailFlags` being `enum class`-ed without actually adding the `class`, so I'm sneaking that in. Especially as I'm also renaming `AirVehicleFlags` to `VehicleAirFlags` for consistency.

Make `VehicleAirFlag` an `enum class` with the appropriate member renames, and introduce `VehicleAirFlags` as `EnumBitSet` and use that instead of `uint8_t` where applicable (aircraft and disaster vehicles).


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
