### PR TITLE
Codechange: unify behaviour of handling too short packets

### DIFF
--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -285,7 +285,8 @@ bool Packet::PrepareToRead()
 
 	bool valid = cs->receive_encryption_handler->Decrypt(std::span(&this->buffer[pos], mac_size), std::span(&this->buffer[pos + mac_size], this->buffer.size() - pos - mac_size));
 	this->pos += static_cast<PacketSize>(mac_size);
-	return valid;
+	/* Is the decryption valid *and* is the remaining data big enough to contain the packet type? */
+	return valid && this->CanReadFromPacket(EncodedLengthOfPacketType());
 }
 
 /**
@@ -294,7 +295,6 @@ bool Packet::PrepareToRead()
  */
 PacketType Packet::GetPacketType() const
 {
-	assert(this->Size() >= EncodedLengthOfPacketSize() + EncodedLengthOfPacketType());
 	size_t offset = EncodedLengthOfPacketSize();
 	if (cs != nullptr && cs->send_encryption_handler != nullptr) offset += cs->send_encryption_handler->MACSize();
 	return static_cast<PacketType>(buffer[offset]);

--- a/src/network/core/tcp_admin.cpp
+++ b/src/network/core/tcp_admin.cpp
@@ -34,13 +34,7 @@ NetworkRecvStatus NetworkAdminSocketHandler::CloseConnection(bool)
  */
 NetworkRecvStatus NetworkAdminSocketHandler::HandlePacket(Packet &p)
 {
-	PacketAdminType type = (PacketAdminType)p.Recv_uint8();
-
-	if (this->HasClientQuit()) {
-		Debug(net, 0, "[tcp/admin] Received invalid packet from '{}' ({})", this->admin_name, this->admin_version);
-		this->CloseConnection();
-		return NETWORK_RECV_STATUS_MALFORMED_PACKET;
-	}
+	PacketAdminType type = static_cast<PacketAdminType>(p.Recv_uint8());
 
 	switch (type) {
 		case ADMIN_PACKET_ADMIN_JOIN:             return this->Receive_ADMIN_JOIN(p);

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -103,9 +103,9 @@ std::optional<std::string> ContentInfo::GetTextfile(TextfileType type) const
  */
 bool NetworkContentSocketHandler::HandlePacket(Packet &p)
 {
-	PacketContentType type = (PacketContentType)p.Recv_uint8();
+	PacketContentType type = static_cast<PacketContentType>(p.Recv_uint8());
 
-	switch (this->HasClientQuit() ? PACKET_CONTENT_END : type) {
+	switch (type) {
 		case PACKET_CONTENT_CLIENT_INFO_LIST:      return this->Receive_CLIENT_INFO_LIST(p);
 		case PACKET_CONTENT_CLIENT_INFO_ID:        return this->Receive_CLIENT_INFO_ID(p);
 		case PACKET_CONTENT_CLIENT_INFO_EXTID:     return this->Receive_CLIENT_INFO_EXTID(p);
@@ -115,11 +115,7 @@ bool NetworkContentSocketHandler::HandlePacket(Packet &p)
 		case PACKET_CONTENT_SERVER_CONTENT:        return this->Receive_SERVER_CONTENT(p);
 
 		default:
-			if (this->HasClientQuit()) {
-				Debug(net, 0, "[tcp/content] Received invalid packet type {}", type);
-			} else {
-				Debug(net, 0, "[tcp/content] Received illegal packet");
-			}
+			Debug(net, 0, "[tcp/content] Received invalid packet type {}", type);
 			return false;
 	}
 }

--- a/src/network/core/tcp_coordinator.cpp
+++ b/src/network/core/tcp_coordinator.cpp
@@ -22,7 +22,7 @@
  */
 bool NetworkCoordinatorSocketHandler::HandlePacket(Packet &p)
 {
-	PacketCoordinatorType type = (PacketCoordinatorType)p.Recv_uint8();
+	PacketCoordinatorType type = static_cast<PacketCoordinatorType>(p.Recv_uint8());
 
 	switch (type) {
 		case PACKET_COORDINATOR_GC_ERROR:              return this->Receive_GC_ERROR(p);

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -58,13 +58,7 @@ NetworkRecvStatus NetworkGameSocketHandler::CloseConnection(bool)
  */
 NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet &p)
 {
-	PacketGameType type = (PacketGameType)p.Recv_uint8();
-
-	if (this->HasClientQuit()) {
-		Debug(net, 0, "[tcp/game] Received invalid packet from client {}", this->client_id);
-		this->CloseConnection();
-		return NETWORK_RECV_STATUS_MALFORMED_PACKET;
-	}
+	PacketGameType type = static_cast<PacketGameType>(p.Recv_uint8());
 
 	this->last_packet = std::chrono::steady_clock::now();
 

--- a/src/network/core/tcp_turn.cpp
+++ b/src/network/core/tcp_turn.cpp
@@ -22,7 +22,7 @@
  */
 bool NetworkTurnSocketHandler::HandlePacket(Packet &p)
 {
-	PacketTurnType type = (PacketTurnType)p.Recv_uint8();
+	PacketTurnType type = static_cast<PacketTurnType>(p.Recv_uint8());
 
 	switch (type) {
 		case PACKET_TURN_TURN_ERROR:     return this->Receive_TURN_ERROR(p);

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -156,23 +156,17 @@ void NetworkUDPSocketHandler::ReceivePackets()
  */
 void NetworkUDPSocketHandler::HandleUDPPacket(Packet &p, NetworkAddress &client_addr)
 {
-	PacketUDPType type;
-
 	/* New packet == new client, which has not quit yet */
 	this->Reopen();
 
-	type = (PacketUDPType)p.Recv_uint8();
+	PacketUDPType type = static_cast<PacketUDPType>(p.Recv_uint8());
 
-	switch (this->HasClientQuit() ? PACKET_UDP_END : type) {
+	switch (type) {
 		case PACKET_UDP_CLIENT_FIND_SERVER:   this->Receive_CLIENT_FIND_SERVER(p, client_addr);   break;
 		case PACKET_UDP_SERVER_RESPONSE:      this->Receive_SERVER_RESPONSE(p, client_addr);      break;
 
 		default:
-			if (this->HasClientQuit()) {
-				Debug(net, 0, "[udp] Received invalid packet type {} from {}", type, client_addr.GetAddressAsString());
-			} else {
-				Debug(net, 0, "[udp] Received illegal packet from {}", client_addr.GetAddressAsString());
-			}
+			Debug(net, 0, "[udp] Received invalid packet type {} from {}", type, client_addr.GetAddressAsString());
 			break;
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

While working on some enumerations, I found some code in the `HandlePacket` functions that is weird/inconsistent.

1) Some check for `HasClientQuit`, others don't.
2) Some say an invalid packet of type N was received when `HasClientQuit`, but for the illegal packet type the number is not given.

When looking into whether the `HasClientQuit` check makes sense... then yes it does by happenstance because the packet size check does not account for encryption headers, nor does `PrepareToRead` catch this. Similarly, the `assert` in `GetPacketType` is pointless when the message is encrypted as you can still read beyond the buffer.


## Description

So... make `PrepareToRead` actually check whether there are enough bytes in the (decrypted) packet to be able to read the packet type from it. This makes the `HasClientQuit` calls in `HandlePacket` pointless, so they can be removed.

Remove the assert from `GetPacketType` as it's bogus and `PrepareToRead` ensures that there is enough data in the packet.

Finally, always log the packet type when it's unknown and use `static_cast` to extract the packet type.


## Limitations

Could be seen as a fix, but the 'hole' in `PrepareToRead` was sufficiently plugged by the `HandlePacket`s; the sockets that have encryption also had `HasClientQuit` in them. So in the end nothing is actively broken.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
