### PR TITLE
Codechange: use scoped enum for few Packet...Types

### DIFF
--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -19,6 +19,12 @@
 typedef uint16_t PacketSize; ///< Size of the whole packet.
 typedef uint8_t  PacketType; ///< Identifier for the packet
 
+/** Trait to mark an enumeration as a PacketType. */
+template <typename enum_type>
+struct IsEnumPacketType {
+	static constexpr bool value = false; ///< True iff a PacketType.
+};
+
 /**
  * Internal entity of a packet. As everything is sent as a packet,
  * all network communication will need to call the functions that
@@ -55,6 +61,18 @@ private:
 public:
 	Packet(NetworkSocketHandler *cs, size_t limit, size_t initial_read_size = EncodedLengthOfPacketSize());
 	Packet(NetworkSocketHandler *cs, PacketType type, size_t limit = COMPAT_MTU);
+
+	/**
+	 * Creates a packet to send
+	 * @param cs    The socket handler associated with the socket we are writing to; could be \c nullptr.
+	 * @param type  The type of the packet to send.
+	 * @param limit The maximum number of bytes the packet may have. Default is COMPAT_MTU.
+	 *              Be careful of compatibility with older clients/servers when changing
+	 *              the limit as it might break things if the other side is not expecting
+	 *              much larger packets than what they support.
+	 */
+	template <typename E, typename = std::enable_if_t<IsEnumPacketType<E>::value>>
+	Packet(NetworkSocketHandler *cs, E type, size_t limit = COMPAT_MTU) : Packet(cs, to_underlying(type), limit) {}
 
 	/* Sending/writing of packets */
 	void PrepareToSend();

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -106,13 +106,13 @@ bool NetworkContentSocketHandler::HandlePacket(Packet &p)
 	PacketContentType type = static_cast<PacketContentType>(p.Recv_uint8());
 
 	switch (type) {
-		case PACKET_CONTENT_CLIENT_INFO_LIST:      return this->Receive_CLIENT_INFO_LIST(p);
-		case PACKET_CONTENT_CLIENT_INFO_ID:        return this->Receive_CLIENT_INFO_ID(p);
-		case PACKET_CONTENT_CLIENT_INFO_EXTID:     return this->Receive_CLIENT_INFO_EXTID(p);
-		case PACKET_CONTENT_CLIENT_INFO_EXTID_MD5: return this->Receive_CLIENT_INFO_EXTID_MD5(p);
-		case PACKET_CONTENT_SERVER_INFO:           return this->Receive_SERVER_INFO(p);
-		case PACKET_CONTENT_CLIENT_CONTENT:        return this->Receive_CLIENT_CONTENT(p);
-		case PACKET_CONTENT_SERVER_CONTENT:        return this->Receive_SERVER_CONTENT(p);
+		case PacketContentType::ClientInfoList: return this->ReceiveClientInfoList(p);
+		case PacketContentType::ClientInfoID: return this->ReceiveClientInfoID(p);
+		case PacketContentType::ClientInfoExternalID: return this->ReceiveClientInfoExternalID(p);
+		case PacketContentType::ClientInfoExternalIDMD5: return this->ReceiveClientInfoExternalIDMD5(p);
+		case PacketContentType::ServerInfo: return this->ReceiveServerInfo(p);
+		case PacketContentType::ClientContent: return this->ReceiveClientContent(p);
+		case PacketContentType::ServerContent: return this->ReceiveServerContent(p);
 
 		default:
 			Debug(net, 0, "[tcp/content] Received invalid packet type {}", type);
@@ -168,13 +168,13 @@ bool NetworkContentSocketHandler::ReceiveInvalidPacket(PacketContentType type)
 	return false;
 }
 
-bool NetworkContentSocketHandler::Receive_CLIENT_INFO_LIST(Packet &) { return this->ReceiveInvalidPacket(PACKET_CONTENT_CLIENT_INFO_LIST); }
-bool NetworkContentSocketHandler::Receive_CLIENT_INFO_ID(Packet &) { return this->ReceiveInvalidPacket(PACKET_CONTENT_CLIENT_INFO_ID); }
-bool NetworkContentSocketHandler::Receive_CLIENT_INFO_EXTID(Packet &) { return this->ReceiveInvalidPacket(PACKET_CONTENT_CLIENT_INFO_EXTID); }
-bool NetworkContentSocketHandler::Receive_CLIENT_INFO_EXTID_MD5(Packet &) { return this->ReceiveInvalidPacket(PACKET_CONTENT_CLIENT_INFO_EXTID_MD5); }
-bool NetworkContentSocketHandler::Receive_SERVER_INFO(Packet &) { return this->ReceiveInvalidPacket(PACKET_CONTENT_SERVER_INFO); }
-bool NetworkContentSocketHandler::Receive_CLIENT_CONTENT(Packet &) { return this->ReceiveInvalidPacket(PACKET_CONTENT_CLIENT_CONTENT); }
-bool NetworkContentSocketHandler::Receive_SERVER_CONTENT(Packet &) { return this->ReceiveInvalidPacket(PACKET_CONTENT_SERVER_CONTENT); }
+bool NetworkContentSocketHandler::ReceiveClientInfoList(Packet &) { return this->ReceiveInvalidPacket(PacketContentType::ClientInfoList); }
+bool NetworkContentSocketHandler::ReceiveClientInfoID(Packet &) { return this->ReceiveInvalidPacket(PacketContentType::ClientInfoID); }
+bool NetworkContentSocketHandler::ReceiveClientInfoExternalID(Packet &) { return this->ReceiveInvalidPacket(PacketContentType::ClientInfoExternalID); }
+bool NetworkContentSocketHandler::ReceiveClientInfoExternalIDMD5(Packet &) { return this->ReceiveInvalidPacket(PacketContentType::ClientInfoExternalIDMD5); }
+bool NetworkContentSocketHandler::ReceiveServerInfo(Packet &) { return this->ReceiveInvalidPacket(PacketContentType::ServerInfo); }
+bool NetworkContentSocketHandler::ReceiveClientContent(Packet &) { return this->ReceiveInvalidPacket(PacketContentType::ClientContent); }
+bool NetworkContentSocketHandler::ReceiveServerContent(Packet &) { return this->ReceiveInvalidPacket(PacketContentType::ServerContent); }
 
 /**
  * Helper to get the subdirectory a #ContentInfo is located in.

--- a/src/network/core/tcp_content.h
+++ b/src/network/core/tcp_content.h
@@ -16,6 +16,24 @@
 #include "../../debug.h"
 #include "tcp_content_type.h"
 
+/**
+ * Enum with all types of TCP content packets.
+ * @important The order MUST not be changed.
+ */
+enum class PacketContentType : uint8_t {
+	ClientInfoList, ///< Queries the content server for a list of info of a given content type
+	ClientInfoID, ///< Queries the content server for information about a list of internal IDs
+	ClientInfoExternalID, ///< Queries the content server for information about a list of external IDs
+	ClientInfoExternalIDMD5, ///< Queries the content server for information about a list of external IDs and MD5
+	ServerInfo, ///< Reply of content server with information about content
+	ClientContent, ///< Request a content file given an internal ID
+	ServerContent, ///< Reply with the content of the given ID
+};
+/** Mark PacketContentType as PacketType. */
+template <> struct IsEnumPacketType<PacketContentType> {
+	static constexpr bool value = true; ///< This is an enumeration of a PacketType.
+};
+
 /** Base socket handler for all Content TCP sockets */
 class NetworkContentSocketHandler : public NetworkTCPSocketHandler {
 protected:
@@ -32,7 +50,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_CLIENT_INFO_LIST(Packet &p);
+	virtual bool ReceiveClientInfoList(Packet &p);
 
 	/**
 	 * Client requesting a list of content info:
@@ -41,7 +59,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_CLIENT_INFO_ID(Packet &p);
+	virtual bool ReceiveClientInfoID(Packet &p);
 
 	/**
 	 * Client requesting a list of content info based on an external
@@ -55,7 +73,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_CLIENT_INFO_EXTID(Packet &p);
+	virtual bool ReceiveClientInfoExternalID(Packet &p);
 
 	/**
 	 * Client requesting a list of content info based on an external
@@ -70,7 +88,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_CLIENT_INFO_EXTID_MD5(Packet &p);
+	virtual bool ReceiveClientInfoExternalIDMD5(Packet &p);
 
 	/**
 	 * Server sending list of content info:
@@ -88,7 +106,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_SERVER_INFO(Packet &p);
+	virtual bool ReceiveServerInfo(Packet &p);
 
 	/**
 	 * Client requesting the actual content:
@@ -97,7 +115,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_CLIENT_CONTENT(Packet &p);
+	virtual bool ReceiveClientContent(Packet &p);
 
 	/**
 	 * Server sending list of content info:
@@ -109,7 +127,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_SERVER_CONTENT(Packet &p);
+	virtual bool ReceiveServerContent(Packet &p);
 
 	bool HandlePacket(Packet &p);
 public:

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -33,18 +33,6 @@ enum ContentType : uint8_t {
 };
 using ContentTypes = EnumBitSet<ContentType, uint16_t, CONTENT_TYPE_END>;
 
-/** Enum with all types of TCP content packets. The order MUST not be changed **/
-enum PacketContentType : uint8_t {
-	PACKET_CONTENT_CLIENT_INFO_LIST,      ///< Queries the content server for a list of info of a given content type
-	PACKET_CONTENT_CLIENT_INFO_ID,        ///< Queries the content server for information about a list of internal IDs
-	PACKET_CONTENT_CLIENT_INFO_EXTID,     ///< Queries the content server for information about a list of external IDs
-	PACKET_CONTENT_CLIENT_INFO_EXTID_MD5, ///< Queries the content server for information about a list of external IDs and MD5
-	PACKET_CONTENT_SERVER_INFO,           ///< Reply of content server with information about content
-	PACKET_CONTENT_CLIENT_CONTENT,        ///< Request a content file given an internal ID
-	PACKET_CONTENT_SERVER_CONTENT,        ///< Reply with the content of the given ID
-	PACKET_CONTENT_END,                   ///< Must ALWAYS be on the end of this list!! (period)
-};
-
 /** Unique identifier for the content. */
 using ContentID = uint32_t;
 

--- a/src/network/core/tcp_stun.cpp
+++ b/src/network/core/tcp_stun.cpp
@@ -24,4 +24,4 @@ bool NetworkStunSocketHandler::ReceiveInvalidPacket(PacketStunType type)
 	return false;
 }
 
-bool NetworkStunSocketHandler::Receive_SERCLI_STUN(Packet &) { return this->ReceiveInvalidPacket(PACKET_STUN_SERCLI_STUN); }
+bool NetworkStunSocketHandler::ReceiveClientStun(Packet &) { return this->ReceiveInvalidPacket(PacketStunType::ClientStun); }

--- a/src/network/core/tcp_stun.h
+++ b/src/network/core/tcp_stun.h
@@ -14,10 +14,16 @@
 #include "tcp.h"
 #include "packet.h"
 
-/** Enum with all types of TCP STUN packets. The order MUST not be changed. **/
-enum PacketStunType : uint8_t {
-	PACKET_STUN_SERCLI_STUN,  ///< Send a STUN request to the STUN server.
-	PACKET_STUN_END,          ///< Must ALWAYS be on the end of this list!! (period)
+/**
+ * Enum with all types of TCP STUN packets.
+ * @important The order MUST not be changed.
+ */
+enum class PacketStunType : uint8_t {
+	ClientStun, ///< Send a STUN request to the STUN server.
+};
+/** Mark PacketStunType as PacketType. */
+template <> struct IsEnumPacketType<PacketStunType> {
+	static constexpr bool value = true; ///< This is an enumeration of a PacketType.
 };
 
 /** Base socket handler for all STUN TCP sockets. */
@@ -37,7 +43,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_SERCLI_STUN(Packet &p);
+	virtual bool ReceiveClientStun(Packet &p);
 
 public:
 	/**

--- a/src/network/core/tcp_turn.cpp
+++ b/src/network/core/tcp_turn.cpp
@@ -25,9 +25,9 @@ bool NetworkTurnSocketHandler::HandlePacket(Packet &p)
 	PacketTurnType type = static_cast<PacketTurnType>(p.Recv_uint8());
 
 	switch (type) {
-		case PACKET_TURN_TURN_ERROR:     return this->Receive_TURN_ERROR(p);
-		case PACKET_TURN_SERCLI_CONNECT: return this->Receive_SERCLI_CONNECT(p);
-		case PACKET_TURN_TURN_CONNECTED: return this->Receive_TURN_CONNECTED(p);
+		case PacketTurnType::ServerError: return this->ReceiveServerError(p);
+		case PacketTurnType::ClientConnect: return this->ReceiveClientConnect(p);
+		case PacketTurnType::ServerConnected: return this->ReceiveServerConnected(p);
 
 		default:
 			Debug(net, 0, "[tcp/turn] Received invalid packet type {}", type);
@@ -63,6 +63,6 @@ bool NetworkTurnSocketHandler::ReceiveInvalidPacket(PacketTurnType type)
 	return false;
 }
 
-bool NetworkTurnSocketHandler::Receive_TURN_ERROR(Packet &) { return this->ReceiveInvalidPacket(PACKET_TURN_TURN_ERROR); }
-bool NetworkTurnSocketHandler::Receive_SERCLI_CONNECT(Packet &) { return this->ReceiveInvalidPacket(PACKET_TURN_SERCLI_CONNECT); }
-bool NetworkTurnSocketHandler::Receive_TURN_CONNECTED(Packet &) { return this->ReceiveInvalidPacket(PACKET_TURN_TURN_CONNECTED); }
+bool NetworkTurnSocketHandler::ReceiveServerError(Packet &) { return this->ReceiveInvalidPacket(PacketTurnType::ServerError); }
+bool NetworkTurnSocketHandler::ReceiveClientConnect(Packet &) { return this->ReceiveInvalidPacket(PacketTurnType::ClientConnect); }
+bool NetworkTurnSocketHandler::ReceiveServerConnected(Packet &) { return this->ReceiveInvalidPacket(PacketTurnType::ServerConnected); }

--- a/src/network/core/tcp_turn.h
+++ b/src/network/core/tcp_turn.h
@@ -15,12 +15,18 @@
 #include "packet.h"
 #include "network_game_info.h"
 
-/** Enum with all types of TCP TURN packets. The order MUST not be changed. **/
-enum PacketTurnType : uint8_t {
-	PACKET_TURN_TURN_ERROR,     ///< TURN server is unable to relay.
-	PACKET_TURN_SERCLI_CONNECT, ///< Client or server is connecting to the TURN server.
-	PACKET_TURN_TURN_CONNECTED, ///< TURN server indicates the socket is now being relayed.
-	PACKET_TURN_END,            ///< Must ALWAYS be on the end of this list!! (period)
+/**
+ * Enum with all types of TCP TURN packets.
+ * @important The order MUST not be changed.
+ */
+enum class PacketTurnType : uint8_t {
+	ServerError, ///< TURN server is unable to relay.
+	ClientConnect, ///< Client (or OpenTTD server) is connecting to the TURN server.
+	ServerConnected, ///< TURN server indicates the socket is now being relayed.
+};
+/** Mark PacketTurnType as PacketType. */
+template <> struct IsEnumPacketType<PacketTurnType> {
+	static constexpr bool value = true; ///< This is an enumeration of a PacketType.
 };
 
 /** Base socket handler for all TURN TCP sockets. */
@@ -36,10 +42,10 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_TURN_ERROR(Packet &p);
+	virtual bool ReceiveServerError(Packet &p);
 
 	/**
-	 * Client or servers wants to connect to the TURN server (on request by
+	 * Client (or OpenTTD server) wants to connect to the TURN server (on request by
 	 * the Game Coordinator).
 	 *
 	 *  uint8_t   Game Coordinator protocol version.
@@ -48,10 +54,10 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_SERCLI_CONNECT(Packet &p);
+	virtual bool ReceiveClientConnect(Packet &p);
 
 	/**
-	 * TURN server has connected client and server together and will now relay
+	 * TURN server has connected client and OpenTTD server together and will now relay
 	 * all packets to each other. No further TURN packets should be send over
 	 * this socket, and the socket should be handed over to the game protocol.
 	 *
@@ -60,7 +66,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_TURN_CONNECTED(Packet &p);
+	virtual bool ReceiveServerConnected(Packet &p);
 
 	bool HandlePacket(Packet &p);
 public:

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -162,8 +162,8 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet &p, NetworkAddress &client_
 	PacketUDPType type = static_cast<PacketUDPType>(p.Recv_uint8());
 
 	switch (type) {
-		case PACKET_UDP_CLIENT_FIND_SERVER:   this->Receive_CLIENT_FIND_SERVER(p, client_addr);   break;
-		case PACKET_UDP_SERVER_RESPONSE:      this->Receive_SERVER_RESPONSE(p, client_addr);      break;
+		case PacketUDPType::ClientFindServer: this->ReceiveClientFindServer(p, client_addr); break;
+		case PacketUDPType::ServerResponse: this->ReceiveServerResponse(p, client_addr); break;
 
 		default:
 			Debug(net, 0, "[udp] Received invalid packet type {} from {}", type, client_addr.GetAddressAsString());
@@ -181,5 +181,5 @@ void NetworkUDPSocketHandler::ReceiveInvalidPacket(PacketUDPType type, NetworkAd
 	Debug(net, 0, "[udp] Received packet type {} on wrong port from {}", type, client_addr.GetAddressAsString());
 }
 
-void NetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet &, NetworkAddress &client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_CLIENT_FIND_SERVER, client_addr); }
-void NetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet &, NetworkAddress &client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_SERVER_RESPONSE, client_addr); }
+void NetworkUDPSocketHandler::ReceiveClientFindServer(Packet &, NetworkAddress &client_addr) { this->ReceiveInvalidPacket(PacketUDPType::ClientFindServer, client_addr); }
+void NetworkUDPSocketHandler::ReceiveServerResponse(Packet &, NetworkAddress &client_addr) { this->ReceiveInvalidPacket(PacketUDPType::ServerResponse, client_addr); }

--- a/src/network/core/udp.h
+++ b/src/network/core/udp.h
@@ -13,11 +13,17 @@
 #include "address.h"
 #include "packet.h"
 
-/** Enum with all types of UDP packets. The order MUST not be changed **/
-enum PacketUDPType : uint8_t {
-	PACKET_UDP_CLIENT_FIND_SERVER,   ///< Queries a game server for game information
-	PACKET_UDP_SERVER_RESPONSE,      ///< Reply of the game server with game information
-	PACKET_UDP_END,                  ///< Must ALWAYS be on the end of this list!! (period)
+/**
+ * Enum with all types of UDP packets.
+ * @important The order MUST not be changed.
+ */
+enum class PacketUDPType : uint8_t {
+	ClientFindServer, ///< Queries a game server for game information
+	ServerResponse, ///< Reply of the game server with game information
+};
+/** Mark PacketUDPType as PacketType. */
+template <> struct IsEnumPacketType<PacketUDPType> {
+	static constexpr bool value = true; ///< This is an enumeration of a PacketType.
 };
 
 /** Base socket handler for all UDP sockets */
@@ -35,14 +41,14 @@ protected:
 	 * @param p           The received packet.
 	 * @param client_addr The origin of the packet.
 	 */
-	virtual void Receive_CLIENT_FIND_SERVER(Packet &p, NetworkAddress &client_addr);
+	virtual void ReceiveClientFindServer(Packet &p, NetworkAddress &client_addr);
 
 	/**
 	 * Response to a query letting the client know we are here.
 	 * @param p           The received packet.
 	 * @param client_addr The origin of the packet.
 	 */
-	virtual void Receive_SERVER_RESPONSE(Packet &p, NetworkAddress &client_addr);
+	virtual void ReceiveServerResponse(Packet &p, NetworkAddress &client_addr);
 
 	void HandleUDPPacket(Packet &p, NetworkAddress &client_addr);
 public:

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -79,8 +79,8 @@ protected:
 
 	friend class NetworkContentConnecter;
 
-	bool Receive_SERVER_INFO(Packet &p) override;
-	bool Receive_SERVER_CONTENT(Packet &p) override;
+	bool ReceiveServerInfo(Packet &p) override;
+	bool ReceiveServerContent(Packet &p) override;
 
 	ContentInfo *GetContent(ContentID cid) const;
 	void DownloadContentInfo(ContentID cid);

--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<ClientNetworkStunSocketHandler> ClientNetworkStunSocketHandler::
 
 	stun_handler->Connect(token, family);
 
-	auto p = std::make_unique<Packet>(stun_handler.get(), PACKET_STUN_SERCLI_STUN);
+	auto p = std::make_unique<Packet>(stun_handler.get(), PacketStunType::ClientStun);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(token);
 	p->Send_uint8(family);

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -47,19 +47,19 @@ public:
 	}
 };
 
-bool ClientNetworkTurnSocketHandler::Receive_TURN_ERROR(Packet &)
+bool ClientNetworkTurnSocketHandler::ReceiveServerError(Packet &)
 {
-	Debug(net, 9, "Receive_TURN_ERROR()");
+	Debug(net, 9, "ReceiveServerError()");
 
 	this->ConnectFailure();
 
 	return false;
 }
 
-bool ClientNetworkTurnSocketHandler::Receive_TURN_CONNECTED(Packet &p)
+bool ClientNetworkTurnSocketHandler::ReceiveServerConnected(Packet &p)
 {
 	std::string hostname = p.Recv_string(NETWORK_HOSTNAME_LENGTH);
-	Debug(net, 9, "Turn::Receive_TURN_CONNECTED({})", hostname);
+	Debug(net, 9, "Turn::ReceiveServerConnected({})", hostname);
 
 	/* Act like we no longer have a socket, as we are handing it over to the
 	 * game handler. */
@@ -97,7 +97,7 @@ void ClientNetworkTurnSocketHandler::Connect()
 {
 	auto turn_handler = std::make_unique<ClientNetworkTurnSocketHandler>(token, tracking_number, connection_string);
 
-	auto p = std::make_unique<Packet>(turn_handler.get(), PACKET_TURN_SERCLI_CONNECT);
+	auto p = std::make_unique<Packet>(turn_handler.get(), PacketTurnType::ClientConnect);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(ticket);
 

--- a/src/network/network_turn.h
+++ b/src/network/network_turn.h
@@ -20,8 +20,8 @@ private:
 	std::string connection_string; ///< The connection string of the TURN server we are connecting to.
 
 protected:
-	bool Receive_TURN_ERROR(Packet &p) override;
-	bool Receive_TURN_CONNECTED(Packet &p) override;
+	bool ReceiveServerError(Packet &p) override;
+	bool ReceiveServerConnected(Packet &p) override;
 
 public:
 	std::shared_ptr<TCPConnecter> connecter{}; ///< Connecter instance.

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -52,7 +52,7 @@ static UDPSocket _udp_server("Server"); ///< udp server socket
 /** Helper class for handling all server side communication. */
 class ServerNetworkUDPSocketHandler : public NetworkUDPSocketHandler {
 protected:
-	void Receive_CLIENT_FIND_SERVER(Packet &p, NetworkAddress &client_addr) override;
+	void ReceiveClientFindServer(Packet &p, NetworkAddress &client_addr) override;
 public:
 	/**
 	 * Create the socket.
@@ -62,9 +62,9 @@ public:
 	~ServerNetworkUDPSocketHandler() override = default;
 };
 
-void ServerNetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet &, NetworkAddress &client_addr)
+void ServerNetworkUDPSocketHandler::ReceiveClientFindServer(Packet &, NetworkAddress &client_addr)
 {
-	Packet packet(this, PACKET_UDP_SERVER_RESPONSE);
+	Packet packet(this, PacketUDPType::ServerResponse);
 	this->SendPacket(packet, client_addr);
 
 	Debug(net, 7, "Queried from {}", client_addr.GetHostname());
@@ -75,12 +75,12 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet &, Network
 /** Helper class for handling all client side communication. */
 class ClientNetworkUDPSocketHandler : public NetworkUDPSocketHandler {
 protected:
-	void Receive_SERVER_RESPONSE(Packet &p, NetworkAddress &client_addr) override;
+	void ReceiveServerResponse(Packet &p, NetworkAddress &client_addr) override;
 public:
 	~ClientNetworkUDPSocketHandler() override = default;
 };
 
-void ClientNetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet &, NetworkAddress &client_addr)
+void ClientNetworkUDPSocketHandler::ReceiveServerResponse(Packet &, NetworkAddress &client_addr)
 {
 	Debug(net, 3, "Server response from {}", client_addr.GetAddressAsString());
 
@@ -96,7 +96,7 @@ static void NetworkUDPBroadCast(NetworkUDPSocketHandler &socket)
 	for (NetworkAddress &addr : _broadcast_list) {
 		Debug(net, 5, "Broadcasting to {}", addr.GetHostname());
 
-		Packet p(&socket, PACKET_UDP_CLIENT_FIND_SERVER);
+		Packet p(&socket, PacketUDPType::ClientFindServer);
 		socket.SendPacket(p, addr, true, true);
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

Working on replacing non-scoped enumerations with scoped ones.


## Description

Introduce a trait so the `Packet` constructor can also  be called with specific scoped enumerations.

Perform conversion on:
* PacketContentType (moved to not have to indirectly include packet.h in code outside network).
* PacketStunType
* PacketTurnType
* PacketUDPType

Also rename the `Receive_XXX` functions appropriately.


## Limitations

Contains #15118, which unifies some handling and by proxy removes the need to have an `END` marker in all of these types.

Does not contain PacketAdminType, PacketCoordinatorType and PacketGameType due to the number of elements in them and making this PR about 5 times larger. Lets keep things relatively  small when reviewing.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
