### PR TITLE
Codechange: use scoped enum for PacketAdminType

### DIFF
--- a/docs/admin_network.md
+++ b/docs/admin_network.md
@@ -38,7 +38,7 @@ Last updated:    2024-03-26
   packets are dropped in favour of a new packet.
 
   This though will be reflected in the protocol version as announced in the
-  `ADMIN_PACKET_SERVER_PROTOCOL` in section 2.0).
+  `PacketAdminType::ServerProtocol` in section 2.0).
 
   A reference implementation in Java for a client connecting to the admin interface
   can be found at: [http://dev.openttdcoop.org/projects/joan](http://dev.openttdcoop.org/projects/joan)
@@ -49,18 +49,18 @@ Last updated:    2024-03-26
   Create a TCP connection to the server on port 3977. The application is
   expected to authenticate within 10 seconds.
 
-  To authenticate send either an `ADMIN_PACKET_ADMIN_JOIN` or an
-  `ADMIN_PACKET_ADMIN_JOIN_SECURE` packet.
+  To authenticate send either an `PacketAdminType::AdminJoin` or an
+  `PacketAdminType::AdminJoinSecure` packet.
 
-  The `ADMIN_PACKET_ADMIN_JOIN` packet sends the password without any
+  The `PacketAdminType::AdminJoin` packet sends the password without any
   encryption or safeguards over the connection, and as such has been disabled
   by default.
 
-  The `ADMIN_PACKET_ADMIN_JOIN_SECURE` packet initiates a key exchange
+  The `PacketAdminType::AdminJoinSecure` packet initiates a key exchange
   authentication schema which tells te server which methods the client
   supports and the server makes a choice. The server will then send an
-  `ADMIN_PACKET_SERVER_AUTH_REQUEST` packet to which the client has to respond
-  with an `ADMIN_PACKET_ADMIN_AUTH_RESPONSE` packet.
+  `PacketAdminType::ServerAuthenticationRequest` packet to which the client has to respond
+  with an `PacketAdminType::AdminAuthenticationResponse` packet.
 
   The current choices for secure authentication are authorized keys, where
   the client has a private key and the server a list of authorized public
@@ -69,41 +69,41 @@ Last updated:    2024-03-26
   The server falls back to password authentication when the client's key is
   not in the list of authorized keys.
 
-  When authentication has succeeded for either of the `JOIN` schemas, the
-  server will reply with `ADMIN_PACKET_SERVER_PROTOCOL` followed directly
-  by `ADMIN_PACKET_SERVER_WELCOME`.
+  When authentication has succeeded for either of the `AdminJoin` schemas, the
+  server will reply with `PacketAdminType::ServerProtocol` followed directly
+  by `PacketAdminType::ServerWelcome`.
 
-  `ADMIN_PACKET_SERVER_PROTOCOL` contains details about the protocol version.
+  `PacketAdminType::ServerProtocol` contains details about the protocol version.
   It is the job of your application to check this number and decide whether
   it will remain connected or not.
   Furthermore, this packet holds details on every `AdminUpdateType` and the
   supported `AdminFrequencyTypes` (bitwise representation).
 
-  `ADMIN_PACKET_SERVER_WELCOME` contains details on the server and the map,
+  `PacketAdminType::ServerWelcome` contains details on the server and the map,
   e.g. if the server is dedicated, its NetworkLanguage, size of the Map, etc.
 
-  Once you have received `ADMIN_PACKET_SERVER_WELCOME` you are connected and
+  Once you have received `PacketAdminType::ServerWelcome` you are connected and
   authorized to do your thing.
 
   The server will not provide any game related updates unless you ask for them.
   There are four packets the server will none the less send, if applicable:
 
-    - ADMIN_PACKET_SERVER_ERROR
-    - ADMIN_PACKET_SERVER_WELCOME
-    - ADMIN_PACKET_SERVER_NEWGAME
-    - ADMIN_PACKET_SERVER_SHUTDOWN
+    - PacketAdminType::ServerError
+    - PacketAdminType::ServerWelcome
+    - PacketAdminType::ServerNewGame
+    - PacketAdminType::ServerShutdown
 
-  However, `ADMIN_PACKET_SERVER_WELCOME` only after a `ADMIN_PACKET_SERVER_NEWGAME`
+  However, `PacketAdminType::ServerWelcome` only after a `PacketAdminType::ServerNewGame`
 
 
 ## 3.0) Asking for updates
 
-  Asking for updates is done with `ADMIN_PACKET_ADMIN_UPDATE_FREQUENCY`.
+  Asking for updates is done with `PacketAdminType::AdminUpdateFrequency`.
   With this packet you define which update you wish to receive at which
   frequency.
 
   Note: not every update type supports every frequency. If in doubt, you can
-  verify against the data received in `ADMIN_PACKET_SERVER_PROTOCOL`.
+  verify against the data received in `PacketAdminType::ServerProtocol`.
 
   Please note the potential gotcha in the "Certain packet information" section below
   when using the `ADMIN_UPDATE_FREQUENCY` packet.
@@ -116,43 +116,43 @@ Last updated:    2024-03-26
 
   `ADMIN_UPDATE_DATE` results in the server sending:
 
-    - ADMIN_PACKET_SERVER_DATE
+    - PacketAdminType::ServerDate
 
   `ADMIN_UPDATE_CLIENT_INFO` results in the server sending:
 
-    - ADMIN_PACKET_SERVER_CLIENT_JOIN
-    - ADMIN_PACKET_SERVER_CLIENT_INFO
-    - ADMIN_PACKET_SERVER_CLIENT_UPDATE
-    - ADMIN_PACKET_SERVER_CLIENT_QUIT
-    - ADMIN_PACKET_SERVER_CLIENT_ERROR
+    - PacketAdminType::ServerClientJoin
+    - PacketAdminType::ServerClientInfo
+    - PacketAdminType::ServerClientUpdate
+    - PacketAdminType::ServerClientQuit
+    - PacketAdminType::ServerClientError
 
   `ADMIN_UPDATE_COMPANY_INFO` results in the server sending:
 
-    - ADMIN_PACKET_SERVER_COMPANY_NEW
-    - ADMIN_PACKET_SERVER_COMPANY_INFO
-    - ADMIN_PACKET_SERVER_COMPANY_UPDATE
-    - ADMIN_PACKET_SERVER_COMPANY_REMOVE
+    - PacketAdminType::ServerCompanyNew
+    - PacketAdminType::ServerCompanyInfo
+    - PacketAdminType::ServerCompanyUpdate
+    - PacketAdminType::ServerCompanyRemove
 
   `ADMIN_UPDATE_COMPANY_ECONOMY` results in the server sending:
 
-    - ADMIN_PACKET_SERVER_COMPANY_ECONOMY
+    - PacketAdminType::ServerCompanyEconomy
 
   `ADMIN_UPDATE_COMPANY_STATS` results in the server sending:
 
-    - ADMIN_PACKET_SERVER_COMPANY_STATS
+    - PacketAdminType::ServerCompanyStatistics
 
   `ADMIN_UPDATE_CHAT` results in the server sending:
 
-    - ADMIN_PACKET_SERVER_CHAT
+    - PacketAdminType::ServerChat
 
   `ADMIN_UPDATE_CONSOLE` results in the server sending:
 
-    - ADMIN_PACKET_SERVER_CONSOLE
+    - PacketAdminType::ServerConsole
 
 
   `ADMIN_UPDATE_CMD_LOGGING` results in the server sending:
 
-    - ADMIN_PACKET_SERVER_CMD_LOGGING
+    - PacketAdminType::ServerCommandLogging
 
 ## 3.1) Polling manually
 
@@ -183,12 +183,12 @@ Last updated:    2024-03-26
 
   Rcon runs separate from the `ADMIN_UPDATE_CONSOLE` `AdminUpdateType`. Requesting
   the execution of a remote console command is done with the packet
-  `ADMIN_PACKET_ADMIN_RCON`.
+  `PacketAdminType::AdminRemoteConsoleCommand`.
 
   Note: No additional authentication is required for rcon commands.
 
-  The server will reply with one or more `ADMIN_PACKET_SERVER_RCON` packets.
-  Finally an `ADMIN_PACKET_ADMIN_RCON_END` packet will be sent. Applications
+  The server will reply with one or more `PacketAdminType::ServerRemoteConsoleCommand` packets.
+  Finally an `PacketAdminType::AdminRemoteConsoleCommandEnd` packet will be sent. Applications
   will not receive the answer twice if they have asked for the `AdminUpdateType`
   `ADMIN_UPDATE_CONSOLE`, as the result is not printed on the servers console
   (just like clients rcon commands).
@@ -199,7 +199,7 @@ Last updated:    2024-03-26
   was not sent from the admin network.
 
   Note that when content is queried or updated via rcon, the processing
-  happens asynchronously. But the `ADMIN_PACKET_ADMIN_RCON_END` packet is sent
+  happens asynchronously. But the `PacketAdminType::AdminRemoteConsoleCommandEnd` packet is sent
   already right after the content is requested as there's no immediate output.
   Thus other packages and the output of content rcon command may be sent at
   an arbitrary later time, mixing into the output of other console activity,
@@ -208,7 +208,7 @@ Last updated:    2024-03-26
 
 ## 5.0) Sending chat
 
-  Sending a `ADMIN_PACKET_ADMIN_CHAT` results in chat originating from the server.
+  Sending a `PacketAdminType::AdminChat` results in chat originating from the server.
 
   Currently four types of chat are supported:
 
@@ -233,12 +233,12 @@ Last updated:    2024-03-26
 ## 6.0) Disconnecting
 
   It is a kind thing to say good bye before leaving. Do this by sending the
-  `ADMIN_PACKET_ADMIN_QUIT` packet.
+  `PacketAdminType::AdminQuit` packet.
 
 
 ## 7.0) Certain packet information
 
-  `ADMIN_PACKET_ADMIN_UPDATE_FREQUENCY` and `ADMIN_PACKET_ADMIN_POLL`
+  `PacketAdminType::AdminUpdateFrequency` and `PacketAdminType::AdminPoll`
 
     Potential gotcha: the AdminUpdateType integer type used is a
     uint16 for `UPDATE_FREQUENCY`, and a uint8 for `POLL`.
@@ -246,21 +246,21 @@ Last updated:    2024-03-26
     It is safe to cast between the two when sending
     (i.e cast from a uint8 to a uint16).
 
-  All `ADMIN_PACKET_SERVER_*` packets have an enum value greater 100.
+  All `PacketAdminType::Server*` packets have an enum value greater 100.
 
-  `ADMIN_PACKET_SERVER_WELCOME`
+  `PacketAdminType::ServerWelcome`
 
-    Either directly follows `ADMIN_PACKET_SERVER_PROTOCOL` or is sent
+    Either directly follows `PacketAdminType::ServerProtocol` or is sent
     after a new game has been started or a map loaded, i.e. also
-    after ADMIN_PACKET_SERVER_NEWGAME.
+    after PacketAdminType::ServerNewGame.
 
-  `ADMIN_PACKET_SERVER_CLIENT_JOIN` and `ADMIN_PACKET_SERVER_COMPANY_NEW`
+  `PacketAdminType::ServerClientJoin` and `PacketAdminType::ServerCompanyNew`
 
     These packets directly follow their respective INFO packets. If you receive
     a CLIENT_JOIN / COMPANY_NEW packet without having received the INFO packet
     it may be a good idea to POLL for the specific ID.
 
-  `ADMIN_PACKET_SERVER_CMD_NAMES` and `ADMIN_PACKET_SERVER_CMD_LOGGING`
+  `PacketAdminType::ServerCommandNames` and `PacketAdminType::ServerCommandLogging`
 
     Data provided with these packets is not stable and will not be
     treated as such. Do not rely on IDs or names to be constant

--- a/src/network/core/tcp_admin.cpp
+++ b/src/network/core/tcp_admin.cpp
@@ -37,47 +37,47 @@ NetworkRecvStatus NetworkAdminSocketHandler::HandlePacket(Packet &p)
 	PacketAdminType type = static_cast<PacketAdminType>(p.Recv_uint8());
 
 	switch (type) {
-		case ADMIN_PACKET_ADMIN_JOIN:             return this->Receive_ADMIN_JOIN(p);
-		case ADMIN_PACKET_ADMIN_QUIT:             return this->Receive_ADMIN_QUIT(p);
-		case ADMIN_PACKET_ADMIN_UPDATE_FREQUENCY: return this->Receive_ADMIN_UPDATE_FREQUENCY(p);
-		case ADMIN_PACKET_ADMIN_POLL:             return this->Receive_ADMIN_POLL(p);
-		case ADMIN_PACKET_ADMIN_CHAT:             return this->Receive_ADMIN_CHAT(p);
-		case ADMIN_PACKET_ADMIN_EXTERNAL_CHAT:    return this->Receive_ADMIN_EXTERNAL_CHAT(p);
-		case ADMIN_PACKET_ADMIN_RCON:             return this->Receive_ADMIN_RCON(p);
-		case ADMIN_PACKET_ADMIN_GAMESCRIPT:       return this->Receive_ADMIN_GAMESCRIPT(p);
-		case ADMIN_PACKET_ADMIN_PING:             return this->Receive_ADMIN_PING(p);
-		case ADMIN_PACKET_ADMIN_JOIN_SECURE:      return this->Receive_ADMIN_JOIN_SECURE(p);
-		case ADMIN_PACKET_ADMIN_AUTH_RESPONSE:    return this->Receive_ADMIN_AUTH_RESPONSE(p);
+		case PacketAdminType::AdminJoin: return this->ReceiveAdminJoin(p);
+		case PacketAdminType::AdminQuit: return this->ReceiveAdminQuit(p);
+		case PacketAdminType::AdminUpdateFrequency: return this->ReceiveAdminUpdateFrequency(p);
+		case PacketAdminType::AdminPoll: return this->ReceiveAdminPoll(p);
+		case PacketAdminType::AdminChat: return this->ReceiveAdminChat(p);
+		case PacketAdminType::AdminExternalChat: return this->ReceiveAdminExternalChat(p);
+		case PacketAdminType::AdminRemoteConsoleCommand: return this->ReceiveAdminRemoteConsoleCommand(p);
+		case PacketAdminType::AdminGameScript: return this->ReceiveAdminGameScript(p);
+		case PacketAdminType::AdminPing: return this->ReceiveAdminPing(p);
+		case PacketAdminType::AdminJoinSecure: return this->ReceiveAdminJoinSecure(p);
+		case PacketAdminType::AdminAuthenticationResponse: return this->ReceiveAdminAuthenticationResponse(p);
 
-		case ADMIN_PACKET_SERVER_FULL:            return this->Receive_SERVER_FULL(p);
-		case ADMIN_PACKET_SERVER_BANNED:          return this->Receive_SERVER_BANNED(p);
-		case ADMIN_PACKET_SERVER_ERROR:           return this->Receive_SERVER_ERROR(p);
-		case ADMIN_PACKET_SERVER_PROTOCOL:        return this->Receive_SERVER_PROTOCOL(p);
-		case ADMIN_PACKET_SERVER_WELCOME:         return this->Receive_SERVER_WELCOME(p);
-		case ADMIN_PACKET_SERVER_NEWGAME:         return this->Receive_SERVER_NEWGAME(p);
-		case ADMIN_PACKET_SERVER_SHUTDOWN:        return this->Receive_SERVER_SHUTDOWN(p);
+		case PacketAdminType::ServerFull: return this->ReceiveServerFull(p);
+		case PacketAdminType::ServerBanned: return this->ReceiveServerBanned(p);
+		case PacketAdminType::ServerError: return this->ReceiveServerError(p);
+		case PacketAdminType::ServerProtocol: return this->ReceiveServerProtocol(p);
+		case PacketAdminType::ServerWelcome: return this->ReceiveServerWelcome(p);
+		case PacketAdminType::ServerNewGame: return this->ReceiveServerNewGame(p);
+		case PacketAdminType::ServerShutdown: return this->ReceiveServerShutdown(p);
 
-		case ADMIN_PACKET_SERVER_DATE:            return this->Receive_SERVER_DATE(p);
-		case ADMIN_PACKET_SERVER_CLIENT_JOIN:     return this->Receive_SERVER_CLIENT_JOIN(p);
-		case ADMIN_PACKET_SERVER_CLIENT_INFO:     return this->Receive_SERVER_CLIENT_INFO(p);
-		case ADMIN_PACKET_SERVER_CLIENT_UPDATE:   return this->Receive_SERVER_CLIENT_UPDATE(p);
-		case ADMIN_PACKET_SERVER_CLIENT_QUIT:     return this->Receive_SERVER_CLIENT_QUIT(p);
-		case ADMIN_PACKET_SERVER_CLIENT_ERROR:    return this->Receive_SERVER_CLIENT_ERROR(p);
-		case ADMIN_PACKET_SERVER_COMPANY_NEW:     return this->Receive_SERVER_COMPANY_NEW(p);
-		case ADMIN_PACKET_SERVER_COMPANY_INFO:    return this->Receive_SERVER_COMPANY_INFO(p);
-		case ADMIN_PACKET_SERVER_COMPANY_UPDATE:  return this->Receive_SERVER_COMPANY_UPDATE(p);
-		case ADMIN_PACKET_SERVER_COMPANY_REMOVE:  return this->Receive_SERVER_COMPANY_REMOVE(p);
-		case ADMIN_PACKET_SERVER_COMPANY_ECONOMY: return this->Receive_SERVER_COMPANY_ECONOMY(p);
-		case ADMIN_PACKET_SERVER_COMPANY_STATS:   return this->Receive_SERVER_COMPANY_STATS(p);
-		case ADMIN_PACKET_SERVER_CHAT:            return this->Receive_SERVER_CHAT(p);
-		case ADMIN_PACKET_SERVER_RCON:            return this->Receive_SERVER_RCON(p);
-		case ADMIN_PACKET_SERVER_CONSOLE:         return this->Receive_SERVER_CONSOLE(p);
-		case ADMIN_PACKET_SERVER_CMD_NAMES:       return this->Receive_SERVER_CMD_NAMES(p);
-		case ADMIN_PACKET_SERVER_CMD_LOGGING:     return this->Receive_SERVER_CMD_LOGGING(p);
-		case ADMIN_PACKET_SERVER_RCON_END:        return this->Receive_SERVER_RCON_END(p);
-		case ADMIN_PACKET_SERVER_PONG:            return this->Receive_SERVER_PONG(p);
-		case ADMIN_PACKET_SERVER_AUTH_REQUEST:    return this->Receive_SERVER_AUTH_REQUEST(p);
-		case ADMIN_PACKET_SERVER_ENABLE_ENCRYPTION: return this->Receive_SERVER_ENABLE_ENCRYPTION(p);
+		case PacketAdminType::ServerDate: return this->ReceiveServerDate(p);
+		case PacketAdminType::ServerClientJoin: return this->ReceiveServerClientJoin(p);
+		case PacketAdminType::ServerClientInfo: return this->ReceiveServerClientInfo(p);
+		case PacketAdminType::ServerClientUpdate: return this->ReceiveServerClientUpdate(p);
+		case PacketAdminType::ServerClientQuit: return this->ReceiveServerClientQuit(p);
+		case PacketAdminType::ServerClientError: return this->ReceiveServerClientError(p);
+		case PacketAdminType::ServerCompanyNew: return this->ReceiveServerCompanyNew(p);
+		case PacketAdminType::ServerCompanyInfo: return this->ReceiveServerCompanyInfo(p);
+		case PacketAdminType::ServerCompanyUpdate: return this->ReceiveServerCompanyUpdate(p);
+		case PacketAdminType::ServerCompanyRemove: return this->ReceiveServerCompanyRemove(p);
+		case PacketAdminType::ServerCompanyEconomy: return this->ReceiveServerCompanyEconomy(p);
+		case PacketAdminType::ServerCompanyStatistics: return this->ReceiveServerCompanyStatistics(p);
+		case PacketAdminType::ServerChat: return this->ReceiveServerChat(p);
+		case PacketAdminType::ServerRemoteConsoleCommand: return this->ReceiveServerRemoteConsoleCommand(p);
+		case PacketAdminType::ServerConsole: return this->ReceiveServerConsole(p);
+		case PacketAdminType::ServerCommandNames: return this->ReceiveServerCommandNames(p);
+		case PacketAdminType::ServerCommandLogging: return this->ReceiveServerCommandLogging(p);
+		case PacketAdminType::ServerRemoteConsoleCommandEnd: return this->ReceiveServerRemoteConsoleCommandEnd(p);
+		case PacketAdminType::ServerPong: return this->ReceiveServerPong(p);
+		case PacketAdminType::ServerAuthenticationRequest: return this->ReceiveServerAuthenticationRequest(p);
+		case PacketAdminType::ServerEnableEncryption: return this->ReceiveServerEnableEncryption(p);
 
 		default:
 			Debug(net, 0, "[tcp/admin] Received invalid packet type {} from '{}' ({})", type, this->admin_name, this->admin_version);
@@ -115,44 +115,44 @@ NetworkRecvStatus NetworkAdminSocketHandler::ReceiveInvalidPacket(PacketAdminTyp
 	return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 }
 
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_JOIN(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_JOIN); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_QUIT(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_QUIT); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_UPDATE_FREQUENCY(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_UPDATE_FREQUENCY); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_POLL(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_POLL); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_CHAT(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_CHAT); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_EXTERNAL_CHAT(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_EXTERNAL_CHAT); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_RCON(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_RCON); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_GAMESCRIPT(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_GAMESCRIPT); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_PING(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_PING); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_JOIN_SECURE(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_JOIN_SECURE); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_ADMIN_AUTH_RESPONSE(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_ADMIN_AUTH_RESPONSE); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminJoin(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminJoin); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminQuit(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminQuit); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminUpdateFrequency(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminUpdateFrequency); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminPoll(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminPoll); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminChat(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminChat); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminExternalChat(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminExternalChat); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminRemoteConsoleCommand(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminRemoteConsoleCommand); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminGameScript(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminGameScript); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminPing(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminPing); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminJoinSecure(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminJoinSecure); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveAdminAuthenticationResponse(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::AdminAuthenticationResponse); }
 
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_FULL(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_FULL); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_BANNED(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_BANNED); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_ERROR(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_ERROR); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_PROTOCOL(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_PROTOCOL); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_WELCOME(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_WELCOME); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_NEWGAME(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_NEWGAME); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_SHUTDOWN(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_SHUTDOWN); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerFull(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerFull); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerBanned(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerBanned); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerError(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerError); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerProtocol(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerProtocol); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerWelcome(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerWelcome); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerNewGame(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerNewGame); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerShutdown(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerShutdown); }
 
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_DATE(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_DATE); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_CLIENT_JOIN(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_CLIENT_JOIN); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_CLIENT_INFO(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_CLIENT_INFO); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_CLIENT_UPDATE(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_CLIENT_UPDATE); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_CLIENT_QUIT(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_CLIENT_QUIT); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_CLIENT_ERROR(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_CLIENT_ERROR); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_COMPANY_NEW(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_COMPANY_NEW); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_COMPANY_INFO(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_COMPANY_INFO); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_COMPANY_UPDATE(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_COMPANY_UPDATE); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_COMPANY_REMOVE(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_COMPANY_REMOVE); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_COMPANY_ECONOMY(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_COMPANY_ECONOMY); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_COMPANY_STATS(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_COMPANY_STATS); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_CHAT(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_CHAT); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_RCON(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_RCON); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_CONSOLE(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_CONSOLE); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_CMD_NAMES(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_CMD_NAMES); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_CMD_LOGGING(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_CMD_LOGGING); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_RCON_END(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_RCON_END); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_PONG(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_PONG); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_AUTH_REQUEST(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_AUTH_REQUEST); }
-NetworkRecvStatus NetworkAdminSocketHandler::Receive_SERVER_ENABLE_ENCRYPTION(Packet &) { return this->ReceiveInvalidPacket(ADMIN_PACKET_SERVER_ENABLE_ENCRYPTION); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerDate(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerDate); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerClientJoin(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerClientJoin); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerClientInfo(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerClientInfo); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerClientUpdate(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerClientUpdate); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerClientQuit(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerClientQuit); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerClientError(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerClientError); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerCompanyNew(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerCompanyNew); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerCompanyInfo(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerCompanyInfo); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerCompanyUpdate(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerCompanyUpdate); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerCompanyRemove(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerCompanyRemove); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerCompanyEconomy(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerCompanyEconomy); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerCompanyStatistics(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerCompanyStatistics); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerChat(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerChat); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerRemoteConsoleCommand(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerRemoteConsoleCommand); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerConsole(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerConsole); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerCommandNames(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerCommandNames); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerCommandLogging(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerCommandLogging); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerRemoteConsoleCommandEnd(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerRemoteConsoleCommandEnd); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerPong(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerPong); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerAuthenticationRequest(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerAuthenticationRequest); }
+NetworkRecvStatus NetworkAdminSocketHandler::ReceiveServerEnableEncryption(Packet &) { return this->ReceiveInvalidPacket(PacketAdminType::ServerEnableEncryption); }

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -17,53 +17,56 @@
 /**
  * Enum with types of TCP packets specific to the admin network.
  * This protocol may only be extended to ensure stability.
+ * @important The order MUST not be changed.
  */
-enum PacketAdminType : uint8_t {
-	ADMIN_PACKET_ADMIN_JOIN,             ///< The admin announces and authenticates itself to the server using an unsecured passwords.
-	ADMIN_PACKET_ADMIN_QUIT,             ///< The admin tells the server that it is quitting.
-	ADMIN_PACKET_ADMIN_UPDATE_FREQUENCY, ///< The admin tells the server the update frequency of a particular piece of information.
-	ADMIN_PACKET_ADMIN_POLL,             ///< The admin explicitly polls for a piece of information.
-	ADMIN_PACKET_ADMIN_CHAT,             ///< The admin sends a chat message to be distributed.
-	ADMIN_PACKET_ADMIN_RCON,             ///< The admin sends a remote console command.
-	ADMIN_PACKET_ADMIN_GAMESCRIPT,       ///< The admin sends a JSON string for the GameScript.
-	ADMIN_PACKET_ADMIN_PING,             ///< The admin sends a ping to the server, expecting a ping-reply (PONG) packet.
-	ADMIN_PACKET_ADMIN_EXTERNAL_CHAT,    ///< The admin sends a chat message from external source.
-	ADMIN_PACKET_ADMIN_JOIN_SECURE,      ///< The admin announces and starts a secure authentication handshake.
-	ADMIN_PACKET_ADMIN_AUTH_RESPONSE,    ///< The admin responds to the authentication request.
+enum class PacketAdminType : uint8_t {
+	AdminJoin, ///< The admin announces and authenticates itself to the server using an unsecured passwords.
+	AdminQuit, ///< The admin tells the server that it is quitting.
+	AdminUpdateFrequency, ///< The admin tells the server the update frequency of a particular piece of information.
+	AdminPoll, ///< The admin explicitly polls for a piece of information.
+	AdminChat, ///< The admin sends a chat message to be distributed.
+	AdminRemoteConsoleCommand, ///< The admin sends a remote console command.
+	AdminGameScript, ///< The admin sends a JSON string for the GameScript.
+	AdminPing, ///< The admin sends a ping to the server, expecting a ping-reply (PONG) packet.
+	AdminExternalChat, ///< The admin sends a chat message from external source.
+	AdminJoinSecure, ///< The admin announces and starts a secure authentication handshake.
+	AdminAuthenticationResponse, ///< The admin responds to the authentication request.
 
-	ADMIN_PACKET_SERVER_FULL = 100,      ///< The server tells the admin it cannot accept the admin.
-	ADMIN_PACKET_SERVER_BANNED,          ///< The server tells the admin it is banned.
-	ADMIN_PACKET_SERVER_ERROR,           ///< The server tells the admin an error has occurred.
-	ADMIN_PACKET_SERVER_PROTOCOL,        ///< The server tells the admin its protocol version.
-	ADMIN_PACKET_SERVER_WELCOME,         ///< The server welcomes the admin to a game.
-	ADMIN_PACKET_SERVER_NEWGAME,         ///< The server tells the admin its going to start a new game.
-	ADMIN_PACKET_SERVER_SHUTDOWN,        ///< The server tells the admin its shutting down.
+	ServerFull = 100, ///< The server tells the admin it cannot accept the admin.
+	ServerBanned, ///< The server tells the admin it is banned.
+	ServerError, ///< The server tells the admin an error has occurred.
+	ServerProtocol, ///< The server tells the admin its protocol version.
+	ServerWelcome, ///< The server welcomes the admin to a game.
+	ServerNewGame, ///< The server tells the admin its going to start a new game.
+	ServerShutdown, ///< The server tells the admin its shutting down.
 
-	ADMIN_PACKET_SERVER_DATE,            ///< The server tells the admin what the current game date is.
-	ADMIN_PACKET_SERVER_CLIENT_JOIN,     ///< The server tells the admin that a client has joined.
-	ADMIN_PACKET_SERVER_CLIENT_INFO,     ///< The server gives the admin information about a client.
-	ADMIN_PACKET_SERVER_CLIENT_UPDATE,   ///< The server gives the admin an information update on a client.
-	ADMIN_PACKET_SERVER_CLIENT_QUIT,     ///< The server tells the admin that a client quit.
-	ADMIN_PACKET_SERVER_CLIENT_ERROR,    ///< The server tells the admin that a client caused an error.
-	ADMIN_PACKET_SERVER_COMPANY_NEW,     ///< The server tells the admin that a new company has started.
-	ADMIN_PACKET_SERVER_COMPANY_INFO,    ///< The server gives the admin information about a company.
-	ADMIN_PACKET_SERVER_COMPANY_UPDATE,  ///< The server gives the admin an information update on a company.
-	ADMIN_PACKET_SERVER_COMPANY_REMOVE,  ///< The server tells the admin that a company was removed.
-	ADMIN_PACKET_SERVER_COMPANY_ECONOMY, ///< The server gives the admin some economy related company information.
-	ADMIN_PACKET_SERVER_COMPANY_STATS,   ///< The server gives the admin some statistics about a company.
-	ADMIN_PACKET_SERVER_CHAT,            ///< The server received a chat message and relays it.
-	ADMIN_PACKET_SERVER_RCON,            ///< The server's reply to a remove console command.
-	ADMIN_PACKET_SERVER_CONSOLE,         ///< The server gives the admin the data that got printed to its console.
-	ADMIN_PACKET_SERVER_CMD_NAMES,       ///< The server sends out the names of the DoCommands to the admins.
-	ADMIN_PACKET_SERVER_CMD_LOGGING_OLD, ///< Used to be the type ID of \c ADMIN_PACKET_SERVER_CMD_LOGGING in \c NETWORK_GAME_ADMIN_VERSION 1.
-	ADMIN_PACKET_SERVER_GAMESCRIPT,      ///< The server gives the admin information from the GameScript in JSON.
-	ADMIN_PACKET_SERVER_RCON_END,        ///< The server indicates that the remote console command has completed.
-	ADMIN_PACKET_SERVER_PONG,            ///< The server replies to a ping request from the admin.
-	ADMIN_PACKET_SERVER_CMD_LOGGING,     ///< The server gives the admin copies of incoming command packets.
-	ADMIN_PACKET_SERVER_AUTH_REQUEST,    ///< The server gives the admin the used authentication method and required parameters.
-	ADMIN_PACKET_SERVER_ENABLE_ENCRYPTION, ///< The server tells that authentication has completed and requests to enable encryption with the keys of the last \c ADMIN_PACKET_ADMIN_AUTH_RESPONSE.
-
-	INVALID_ADMIN_PACKET = 0xFF,         ///< An invalid marker for admin packets.
+	ServerDate, ///< The server tells the admin what the current game date is.
+	ServerClientJoin, ///< The server tells the admin that a client has joined.
+	ServerClientInfo, ///< The server gives the admin information about a client.
+	ServerClientUpdate, ///< The server gives the admin an information update on a client.
+	ServerClientQuit, ///< The server tells the admin that a client quit.
+	ServerClientError, ///< The server tells the admin that a client caused an error.
+	ServerCompanyNew, ///< The server tells the admin that a new company has started.
+	ServerCompanyInfo, ///< The server gives the admin information about a company.
+	ServerCompanyUpdate, ///< The server gives the admin an information update on a company.
+	ServerCompanyRemove, ///< The server tells the admin that a company was removed.
+	ServerCompanyEconomy, ///< The server gives the admin some economy related company information.
+	ServerCompanyStatistics, ///< The server gives the admin some statistics about a company.
+	ServerChat, ///< The server received a chat message and relays it.
+	ServerRemoteConsoleCommand, ///< The server's reply to a remote console command.
+	ServerConsole, ///< The server gives the admin the data that got printed to its console.
+	ServerCommandNames, ///< The server sends out the names of the DoCommands to the admins.
+	ServerCommandLoggingOld, ///< Used to be the type ID of \c PacketAdminType::ServerCommandLogging in \c NETWORK_GAME_ADMIN_VERSION 1.
+	ServerGameScript, ///< The server gives the admin information from the GameScript in JSON.
+	ServerRemoteConsoleCommandEnd, ///< The server indicates that the remote console command has completed.
+	ServerPong, ///< The server replies to a ping request from the admin.
+	ServerCommandLogging, ///< The server gives the admin copies of incoming command packets.
+	ServerAuthenticationRequest, ///< The server gives the admin the used authentication method and required parameters.
+	ServerEnableEncryption, ///< The server tells that authentication has completed and requests to enable encryption with the keys of the last \c PacketAdminType::AdminAuthenticationResponse.
+};
+/** Mark PacketAdminType as a PacketType. */
+template <> struct IsEnumPacketType<PacketAdminType> {
+	static constexpr bool value = true; ///< This is an enumeration of a PacketType.
 };
 
 /** Status of an admin. */
@@ -127,14 +130,14 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_JOIN(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminJoin(Packet &p);
 
 	/**
 	 * Notification to the server that this admin is quitting.
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_QUIT(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminQuit(Packet &p);
 
 	/**
 	 * Register updates to be sent at certain frequencies (as announced in the PROTOCOL packet):
@@ -143,7 +146,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_UPDATE_FREQUENCY(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminUpdateFrequency(Packet &p);
 
 	/**
 	 * Poll the server for certain updates, an invalid poll (e.g. not existent id) gets silently dropped:
@@ -154,7 +157,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_POLL(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminPoll(Packet &p);
 
 	/**
 	 * Send chat as the server:
@@ -165,7 +168,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_CHAT(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminChat(Packet &p);
 
 	/**
 	 * Send chat from the external source:
@@ -176,7 +179,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_EXTERNAL_CHAT(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminExternalChat(Packet &p);
 
 	/**
 	 * Execute a command on the servers console:
@@ -184,7 +187,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_RCON(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminRemoteConsoleCommand(Packet &p);
 
 	/**
 	 * Send a JSON string to the current active GameScript.
@@ -192,7 +195,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_GAMESCRIPT(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminGameScript(Packet &p);
 
 	/**
 	 * Ping the server, requiring the server to reply with a pong packet.
@@ -200,7 +203,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_PING(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminPing(Packet &p);
 
 	/**
 	 * Join the admin network using a secure authentication method:
@@ -209,15 +212,15 @@ protected:
 	 * uint16_t Bitmask of supported authentication methods. See \c NetworkAuthenticationMethod for the supported methods.
 	 *
 	 * The server will determine which of the authentication methods supplied by the client will be used.
-	 * When there is no supported authentication method, an \c ADMIN_PACKET_SERVER_ERROR packet will be
+	 * When there is no supported authentication method, an \c PacketAdminType::ServerError packet will be
 	 * sent with \c NetworkErrorCode::NoAuthenticationMethodAvailable as error.
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_JOIN_SECURE(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminJoinSecure(Packet &p);
 
 	/**
-	 * Admin responds to \c ADMIN_PACKET_SERVER_AUTH_REQUEST with the appropriate
+	 * Admin responds to \c PacketAdminType::ServerAuthenticationRequest with the appropriate
 	 * data given the agreed upon \c NetworkAuthenticationMethod.
 	 * With \c NETWORK_AUTH_METHOD_X25519_PAKE and \c NETWORK_AUTH_METHOD_X25519_AUTHORIZED_KEY:
 	 *   32 * uint8_t Public key of the client.
@@ -226,21 +229,21 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_ADMIN_AUTH_RESPONSE(Packet &p);
+	virtual NetworkRecvStatus ReceiveAdminAuthenticationResponse(Packet &p);
 
 	/**
 	 * The server is full (connection gets closed).
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_FULL(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerFull(Packet &p);
 
 	/**
 	 * The source IP address is banned (connection gets closed).
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_BANNED(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerBanned(Packet &p);
 
 	/**
 	 * An error was caused by this admin connection (connection gets closed).
@@ -248,7 +251,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_ERROR(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerError(Packet &p);
 
 	/**
 	 * Inform a just joined admin about the protocol specifics:
@@ -259,7 +262,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_PROTOCOL(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerProtocol(Packet &p);
 
 	/**
 	 * Welcome a connected admin to the game:
@@ -275,21 +278,21 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_WELCOME(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerWelcome(Packet &p);
 
 	/**
 	 * Notification about a newgame.
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_NEWGAME(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerNewGame(Packet &p);
 
 	/**
 	 * Notification about the server shutting down.
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_SHUTDOWN(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerShutdown(Packet &p);
 
 	/**
 	 * Send the current date of the game:
@@ -297,7 +300,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_DATE(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerDate(Packet &p);
 
 	/**
 	 * Notification of a new client:
@@ -305,7 +308,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_CLIENT_JOIN(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerClientJoin(Packet &p);
 
 	/**
 	 * Client information of a specific client:
@@ -318,7 +321,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_CLIENT_INFO(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerClientInfo(Packet &p);
 
 	/**
 	 * Client update details on a specific client (e.g. after rename or move):
@@ -328,7 +331,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_CLIENT_UPDATE(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerClientUpdate(Packet &p);
 
 	/**
 	 * Notification about a client leaving the game.
@@ -336,7 +339,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_CLIENT_QUIT(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerClientQuit(Packet &p);
 
 	/**
 	 * Notification about a client error (and thus the clients disconnection).
@@ -345,7 +348,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_CLIENT_ERROR(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerClientError(Packet &p);
 
 	/**
 	 * Notification of a new company:
@@ -353,7 +356,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_COMPANY_NEW(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerCompanyNew(Packet &p);
 
 	/**
 	 * Company information on a specific company:
@@ -367,7 +370,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_COMPANY_INFO(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerCompanyInfo(Packet &p);
 
 	/**
 	 * Company information of a specific company:
@@ -384,7 +387,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_COMPANY_UPDATE(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerCompanyUpdate(Packet &p);
 
 	/**
 	 * Notification about a removed company (e.g. due to bankruptcy).
@@ -393,7 +396,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_COMPANY_REMOVE(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerCompanyRemove(Packet &p);
 
 	/**
 	 * Economy update of a specific company:
@@ -411,7 +414,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_COMPANY_ECONOMY(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerCompanyEconomy(Packet &p);
 
 	/**
 	 * Company statistics on stations and vehicles:
@@ -429,7 +432,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_COMPANY_STATS(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerCompanyStatistics(Packet &p);
 
 	/**
 	 * Send chat from the game into the admin network:
@@ -441,7 +444,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_CHAT(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerChat(Packet &p);
 
 	/**
 	 * Result of an rcon command:
@@ -450,7 +453,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_RCON(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerRemoteConsoleCommand(Packet &p);
 
 	/**
 	 * Send what would be printed on the server's console also into the admin network.
@@ -459,7 +462,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_CONSOLE(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerConsole(Packet &p);
 
 	/**
 	 * Send DoCommand names to the bot upon request only.
@@ -478,7 +481,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_CMD_NAMES(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerCommandNames(Packet &p);
 
 	/**
 	 * Send incoming command packets to the admin network.
@@ -498,7 +501,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_CMD_LOGGING(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerCommandLogging(Packet &p);
 
 	/**
 	 * Server requests authentication challenge from the admin.
@@ -509,7 +512,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_AUTH_REQUEST(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerAuthenticationRequest(Packet &p);
 
 	/**
 	 * Indication to the client that authentication is complete and encryption has to be used from here on forward.
@@ -518,7 +521,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_ENABLE_ENCRYPTION(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerEnableEncryption(Packet &p);
 
 	/**
 	 * Send a ping-reply (pong) to the admin that sent us the ping packet.
@@ -526,7 +529,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_PONG(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerPong(Packet &p);
 
 	/**
 	 * Notify the admin connection that the rcon command has finished.
@@ -534,7 +537,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return The state the network should have.
 	 */
-	virtual NetworkRecvStatus Receive_SERVER_RCON_END(Packet &p);
+	virtual NetworkRecvStatus ReceiveServerRemoteConsoleCommandEnd(Packet &p);
 
 	NetworkRecvStatus HandlePacket(Packet &p);
 public:

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -20,11 +20,12 @@
 
 /**
  * Template for TCP listeners.
- * @param Tsocket      The class we create sockets for.
+ * @param Tsocket The class we create sockets for.
+ * @param EnumPacketType The enumeration type of the packet type.
  * @param Tfull_packet The packet type to return when we don't allow more sockets.
- * @param Tban_packet  The packet type to return when the client is banned.
+ * @param Tban_packet The packet type to return when the client is banned.
  */
-template <class Tsocket, PacketType Tfull_packet, PacketType Tban_packet>
+template <class Tsocket, typename EnumPacketType, EnumPacketType Tfull_packet, EnumPacketType Tban_packet>
 class TCPListenHandler {
 	/** List of sockets we listen on. */
 	static SocketList sockets;
@@ -177,6 +178,6 @@ public:
 };
 
 /** Instantiate the sockets. */
-template <class Tsocket, PacketType Tfull_packet, PacketType Tban_packet> SocketList TCPListenHandler<Tsocket, Tfull_packet, Tban_packet>::sockets;
+template <class Tsocket, typename EnumPacketType, EnumPacketType Tfull_packet, EnumPacketType Tban_packet> SocketList TCPListenHandler<Tsocket, EnumPacketType, Tfull_packet, Tban_packet>::sockets;
 
 #endif /* NETWORK_CORE_TCP_LISTEN_H */

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -135,7 +135,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendError(NetworkErrorCode er
 	/* Whatever the error might be, authentication (keys) must be released as soon as possible. */
 	this->authentication_handler = nullptr;
 
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_ERROR);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerError);
 
 	p->Send_uint8(to_underlying(error));
 	this->SendPacket(std::move(p));
@@ -155,7 +155,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendProtocol()
 {
 	this->status = ADMIN_STATUS_ACTIVE;
 
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_PROTOCOL);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerProtocol);
 
 	/* announce the protocol version */
 	p->Send_uint8(NETWORK_GAME_ADMIN_VERSION);
@@ -178,7 +178,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendProtocol()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendWelcome()
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_WELCOME);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerWelcome);
 
 	p->Send_string(_settings_client.network.server_name);
 	p->Send_string(GetNetworkRevisionString());
@@ -202,7 +202,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendWelcome()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendNewGame()
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_NEWGAME);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerNewGame);
 	this->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -213,7 +213,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendNewGame()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendShutdown()
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_SHUTDOWN);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerShutdown);
 	this->SendPacket(std::move(p));
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -224,7 +224,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendShutdown()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendDate()
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_DATE);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerDate);
 
 	p->Send_uint32(TimerGameCalendar::date.base());
 	this->SendPacket(std::move(p));
@@ -239,7 +239,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendDate()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientJoin(ClientID client_id)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_JOIN);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientJoin);
 
 	p->Send_uint32(client_id);
 	this->SendPacket(std::move(p));
@@ -258,7 +258,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientInfo(const NetworkC
 	/* Only send data when we're a proper client, not just someone trying to query the server. */
 	if (ci == nullptr) return NETWORK_RECV_STATUS_OKAY;
 
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_INFO);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientInfo);
 
 	p->Send_uint32(ci->client_id);
 	p->Send_string(cs == nullptr ? "" : const_cast<NetworkAddress &>(cs->client_address).GetHostname());
@@ -280,7 +280,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientInfo(const NetworkC
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientUpdate(const NetworkClientInfo *ci)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_UPDATE);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientUpdate);
 
 	p->Send_uint32(ci->client_id);
 	p->Send_string(ci->client_name);
@@ -298,7 +298,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientUpdate(const Networ
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientQuit(ClientID client_id)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_QUIT);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientQuit);
 
 	p->Send_uint32(client_id);
 	this->SendPacket(std::move(p));
@@ -314,7 +314,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientQuit(ClientID clien
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientError(ClientID client_id, NetworkErrorCode error)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CLIENT_ERROR);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientError);
 
 	p->Send_uint32(client_id);
 	p->Send_uint8(to_underlying(error));
@@ -330,7 +330,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientError(ClientID clie
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyNew(CompanyID company_id)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_NEW);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerCompanyNew);
 	p->Send_uint8(company_id);
 
 	this->SendPacket(std::move(p));
@@ -345,7 +345,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyNew(CompanyID comp
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyInfo(const Company *c)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_INFO);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerCompanyInfo);
 
 	p->Send_uint8 (c->index);
 	p->Send_string(GetString(STR_COMPANY_NAME, c->index));
@@ -369,7 +369,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyInfo(const Company
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyUpdate(const Company *c)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_UPDATE);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerCompanyUpdate);
 
 	p->Send_uint8 (c->index);
 	p->Send_string(GetString(STR_COMPANY_NAME, c->index));
@@ -391,7 +391,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyUpdate(const Compa
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyRemove(CompanyID company_id, AdminCompanyRemoveReason acrr)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_REMOVE);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerCompanyRemove);
 
 	p->Send_uint8(company_id);
 	p->Send_uint8(acrr);
@@ -411,7 +411,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyEconomy()
 		/* Get the income. */
 		Money income = -std::reduce(std::begin(company->yearly_expenses[0]), std::end(company->yearly_expenses[0]));
 
-		auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_ECONOMY);
+		auto p = std::make_unique<Packet>(this, PacketAdminType::ServerCompanyEconomy);
 
 		p->Send_uint8(company->index);
 
@@ -446,7 +446,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyStats()
 
 	/* Go through all the companies. */
 	for (const Company *company : Company::Iterate()) {
-		auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_COMPANY_STATS);
+		auto p = std::make_unique<Packet>(this, PacketAdminType::ServerCompanyStatistics);
 
 		/* Send the information. */
 		p->Send_uint8(company->index);
@@ -470,7 +470,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyStats()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendChat(NetworkAction action, NetworkChatDestinationType desttype, ClientID client_id, std::string_view msg, int64_t data)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CHAT);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerChat);
 
 	p->Send_uint8(to_underlying(action));
 	p->Send_uint8(to_underlying(desttype));
@@ -489,7 +489,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendChat(NetworkAction action
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRconEnd(std::string_view command)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_RCON_END);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerRemoteConsoleCommandEnd);
 
 	p->Send_string(command);
 	this->SendPacket(std::move(p));
@@ -505,7 +505,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRconEnd(std::string_view 
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRcon(uint16_t colour, std::string_view result)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_RCON);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerRemoteConsoleCommand);
 
 	p->Send_uint16(colour);
 	p->Send_string(result);
@@ -514,7 +514,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendRcon(uint16_t colour, std
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_RCON(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminRemoteConsoleCommand(Packet &p)
 {
 	if (this->status <= ADMIN_STATUS_AUTHENTICATE) return this->SendError(NetworkErrorCode::NotExpected);
 
@@ -528,7 +528,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_RCON(Packet &p)
 	return this->SendRconEnd(command);
 }
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_GAMESCRIPT(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminGameScript(Packet &p)
 {
 	if (this->status <= ADMIN_STATUS_AUTHENTICATE) return this->SendError(NetworkErrorCode::NotExpected);
 
@@ -540,7 +540,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_GAMESCRIPT(Pack
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_PING(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminPing(Packet &p)
 {
 	if (this->status <= ADMIN_STATUS_AUTHENTICATE) return this->SendError(NetworkErrorCode::NotExpected);
 
@@ -565,7 +565,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendConsole(std::string_view 
 	 * smaller than COMPAT_MTU. */
 	if (origin.size() + string.size() + 2 + 3 >= COMPAT_MTU) return NETWORK_RECV_STATUS_OKAY;
 
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CONSOLE);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerConsole);
 
 	p->Send_string(origin);
 	p->Send_string(string);
@@ -581,7 +581,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendConsole(std::string_view 
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendGameScript(std::string_view json)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_GAMESCRIPT);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerGameScript);
 
 	p->Send_string(json);
 	this->SendPacket(std::move(p));
@@ -596,7 +596,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendGameScript(std::string_vi
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendPong(uint32_t d1)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_PONG);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerPong);
 
 	p->Send_uint32(d1);
 	this->SendPacket(std::move(p));
@@ -610,7 +610,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendPong(uint32_t d1)
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdNames()
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CMD_NAMES);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerCommandNames);
 
 	for (uint16_t i = 0; i < to_underlying(Commands::End); i++) {
 		std::string_view cmdname = GetCommandName(static_cast<Commands>(i));
@@ -622,7 +622,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdNames()
 			p->Send_bool(false);
 			this->SendPacket(std::move(p));
 
-			p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CMD_NAMES);
+			p = std::make_unique<Packet>(this, PacketAdminType::ServerCommandNames);
 		}
 
 		p->Send_bool(true);
@@ -645,7 +645,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdNames()
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdLogging(ClientID client_id, const CommandPacket &cp)
 {
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CMD_LOGGING);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerCommandLogging);
 
 	p->Send_uint32(client_id);
 	p->Send_uint8 (cp.company);
@@ -662,7 +662,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdLogging(ClientID clien
  * Receiving functions
  ************/
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_JOIN(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminJoin(Packet &p)
 {
 	if (this->status != ADMIN_STATUS_INACTIVE) return this->SendError(NetworkErrorCode::NotExpected);
 
@@ -691,13 +691,13 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_JOIN(Packet &p)
 	return this->SendProtocol();
 }
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_QUIT(Packet &)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminQuit(Packet &)
 {
 	/* The admin is leaving nothing else to do */
 	return this->CloseConnection();
 }
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_UPDATE_FREQUENCY(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminUpdateFrequency(Packet &p)
 {
 	if (this->status <= ADMIN_STATUS_AUTHENTICATE) return this->SendError(NetworkErrorCode::NotExpected);
 
@@ -717,7 +717,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_UPDATE_FREQUENC
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_POLL(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminPoll(Packet &p)
 {
 	if (this->status <= ADMIN_STATUS_AUTHENTICATE) return this->SendError(NetworkErrorCode::NotExpected);
 
@@ -783,7 +783,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_POLL(Packet &p)
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_CHAT(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminChat(Packet &p)
 {
 	if (this->status <= ADMIN_STATUS_AUTHENTICATE) return this->SendError(NetworkErrorCode::NotExpected);
 
@@ -809,7 +809,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_CHAT(Packet &p)
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_EXTERNAL_CHAT(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminExternalChat(Packet &p)
 {
 	if (this->status <= ADMIN_STATUS_AUTHENTICATE) return this->SendError(NetworkErrorCode::NotExpected);
 
@@ -832,7 +832,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_EXTERNAL_CHAT(P
  * Secure authentication send and receive methods.
  */
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_JOIN_SECURE(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminJoinSecure(Packet &p)
 {
 	if (this->status != ADMIN_STATUS_INACTIVE) return this->SendError(NetworkErrorCode::NotExpected);
 
@@ -867,7 +867,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendAuthRequest()
 
 	Debug(net, 6, "[admin] '{}' ({}) authenticating using {}", this->admin_name, this->admin_version, this->authentication_handler->GetName());
 
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_AUTH_REQUEST);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerAuthenticationRequest);
 	this->authentication_handler->SendRequest(*p);
 
 	this->SendPacket(std::move(p));
@@ -883,14 +883,14 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendEnableEncryption()
 {
 	if (this->status != ADMIN_STATUS_AUTHENTICATE) return this->SendError(NetworkErrorCode::NotExpected);
 
-	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_ENABLE_ENCRYPTION);
+	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerEnableEncryption);
 	this->authentication_handler->SendEnableEncryption(*p);
 	this->SendPacket(std::move(p));
 
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
-NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_AUTH_RESPONSE(Packet &p)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminAuthenticationResponse(Packet &p)
 {
 	if (this->status != ADMIN_STATUS_AUTHENTICATE) return this->SendError(NetworkErrorCode::NotExpected);
 

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -23,7 +23,7 @@ using NetworkAdminSocketPool = Pool<ServerNetworkAdminSocketHandler, AdminID, 2,
 extern NetworkAdminSocketPool _networkadminsocket_pool;
 
 /** Class for handling the server side of the game connection. */
-class ServerNetworkAdminSocketHandler : public NetworkAdminSocketPool::PoolItem<&_networkadminsocket_pool>, public NetworkAdminSocketHandler, public TCPListenHandler<ServerNetworkAdminSocketHandler, ADMIN_PACKET_SERVER_FULL, ADMIN_PACKET_SERVER_BANNED> {
+class ServerNetworkAdminSocketHandler : public NetworkAdminSocketPool::PoolItem<&_networkadminsocket_pool>, public NetworkAdminSocketHandler, public TCPListenHandler<ServerNetworkAdminSocketHandler, PacketAdminType, ADMIN_PACKET_SERVER_FULL, ADMIN_PACKET_SERVER_BANNED> {
 private:
 	std::unique_ptr<NetworkAuthenticationServerHandler> authentication_handler = nullptr; ///< The handler for the authentication.
 protected:

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -23,21 +23,21 @@ using NetworkAdminSocketPool = Pool<ServerNetworkAdminSocketHandler, AdminID, 2,
 extern NetworkAdminSocketPool _networkadminsocket_pool;
 
 /** Class for handling the server side of the game connection. */
-class ServerNetworkAdminSocketHandler : public NetworkAdminSocketPool::PoolItem<&_networkadminsocket_pool>, public NetworkAdminSocketHandler, public TCPListenHandler<ServerNetworkAdminSocketHandler, PacketAdminType, ADMIN_PACKET_SERVER_FULL, ADMIN_PACKET_SERVER_BANNED> {
+class ServerNetworkAdminSocketHandler : public NetworkAdminSocketPool::PoolItem<&_networkadminsocket_pool>, public NetworkAdminSocketHandler, public TCPListenHandler<ServerNetworkAdminSocketHandler, PacketAdminType, PacketAdminType::ServerFull, PacketAdminType::ServerBanned> {
 private:
 	std::unique_ptr<NetworkAuthenticationServerHandler> authentication_handler = nullptr; ///< The handler for the authentication.
 protected:
-	NetworkRecvStatus Receive_ADMIN_JOIN(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_QUIT(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_UPDATE_FREQUENCY(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_POLL(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_CHAT(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_EXTERNAL_CHAT(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_RCON(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_GAMESCRIPT(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_PING(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_JOIN_SECURE(Packet &p) override;
-	NetworkRecvStatus Receive_ADMIN_AUTH_RESPONSE(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminJoin(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminQuit(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminUpdateFrequency(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminPoll(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminChat(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminExternalChat(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminRemoteConsoleCommand(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminGameScript(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminPing(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminJoinSecure(Packet &p) override;
+	NetworkRecvStatus ReceiveAdminAuthenticationResponse(Packet &p) override;
 
 	NetworkRecvStatus SendProtocol();
 	NetworkRecvStatus SendPong(uint32_t d1);

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -56,7 +56,7 @@ NetworkClientSocketPool _networkclientsocket_pool{"NetworkClientSocket"};
 INSTANTIATE_POOL_METHODS(NetworkClientSocket)
 
 /** Instantiate the listen sockets. */
-template SocketList TCPListenHandler<ServerNetworkGameSocketHandler, PACKET_SERVER_FULL, PACKET_SERVER_BANNED>::sockets;
+template SocketList TCPListenHandler<ServerNetworkGameSocketHandler, PacketGameType, PACKET_SERVER_FULL, PACKET_SERVER_BANNED>::sockets;
 
 static NetworkAuthenticationDefaultPasswordProvider _password_provider{_settings_client.network.server_password}; ///< Provides the password validation for the game's password.
 static NetworkAuthenticationDefaultAuthorizedKeyHandler _authorized_key_handler{_settings_client.network.server_authorized_keys}; ///< Provides the authorized key handling for the game authentication.

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -21,7 +21,7 @@ using NetworkClientSocketPool = Pool<NetworkClientSocket, ClientPoolID, 8, PoolT
 extern NetworkClientSocketPool _networkclientsocket_pool;
 
 /** Class for handling the server side of the game connection. */
-class ServerNetworkGameSocketHandler : public NetworkClientSocketPool::PoolItem<&_networkclientsocket_pool>, public NetworkGameSocketHandler, public TCPListenHandler<ServerNetworkGameSocketHandler, PACKET_SERVER_FULL, PACKET_SERVER_BANNED> {
+class ServerNetworkGameSocketHandler : public NetworkClientSocketPool::PoolItem<&_networkclientsocket_pool>, public NetworkGameSocketHandler, public TCPListenHandler<ServerNetworkGameSocketHandler, PacketGameType, PACKET_SERVER_FULL, PACKET_SERVER_BANNED> {
 protected:
 	std::unique_ptr<class NetworkAuthenticationServerHandler> authentication_handler = nullptr; ///< The handler for the authentication.
 	std::string peer_public_key{}; ///< The public key of our client.


### PR DESCRIPTION
## Motivation / Problem

Using scoped enums to get rid of noise/conflicts in the global namespace.
In this particular case the `PacketAdminType`.


## Description

Introduce a trait so the Packet constructor can also be called with specific scoped enumerations.

Make the `TCPListener` template use the actual enumeration type, instead of the 'typedef' `uint8_t`.

Convert `PacketAdminType` to a scope enumeration and rename the Receive_XXX functions appropriately.


## Limitations

Contains #15118, which unifies some handling and by proxy removes the need to have an END marker in all of these types. The Packet trait change is also contained in #15119; it's the same commit so it ought not to conflict.

Does not contain another PacketTypes due to the number of elements in them and making this PR about 3 times larger. Lets keep things relatively small when reviewing.

External libraries might be using the old names in their code, but the mapping is fairly straight forward, so it's only a mild inconvenience at worst. There is no need to change the enumeration names in those external libraries.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
