### PR TITLE
Codechange: use scoped enums for timer enumerations, rename one enum

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -580,7 +580,7 @@ public:
 		CheckRedrawStationCoverage(this);
 	}
 
-	const IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::Trigger::Year, TimerGameCalendar::Priority::None}, [this](auto) {
 		this->InvalidateData();
 	}};
 };

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -634,7 +634,7 @@ struct CheatWindow : Window {
 		this->SetDirty();
 	}
 
-	const IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::MONTH, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::Trigger::Month, TimerGameCalendar::Priority::None}, [this](auto) {
 		this->SetDirty();
 	}};
 };

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -657,7 +657,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid(
 }
 
 /** Start a new competitor company if possible. */
-TimeoutTimer<TimerGameTick> _new_competitor_timeout({ TimerGameTick::Priority::COMPETITOR_TIMEOUT, 0 }, []() {
+TimeoutTimer<TimerGameTick> _new_competitor_timeout({ TimerGameTick::Priority::CompetitorTimeout, 0 }, []() {
 	if (_game_mode == GM_MENU || !AI::CanStartNew()) return;
 	if (_networking && Company::GetNumItems() >= _settings_client.network.max_companies) return;
 	if (_settings_game.difficulty.competitors_interval == 0) return;
@@ -800,7 +800,7 @@ void OnTick_Companies()
 		/* Randomize a bit when the AI is actually going to start; ranges from 87.5% .. 112.5% of indicated value. */
 		timeout += ScriptObject::GetRandomizer(OWNER_NONE).Next(timeout / 4) - timeout / 8;
 
-		_new_competitor_timeout.Reset({ TimerGameTick::Priority::COMPETITOR_TIMEOUT, static_cast<uint>(std::max(1, timeout)) });
+		_new_competitor_timeout.Reset({ TimerGameTick::Priority::CompetitorTimeout, static_cast<uint>(std::max(1, timeout)) });
 	}
 
 	_cur_company_tick_index = (_cur_company_tick_index + 1) % MAX_COMPANIES;
@@ -810,7 +810,7 @@ void OnTick_Companies()
  * A year has passed, update the economic data of all companies, and perhaps show the
  * financial overview window of the local company.
  */
-static const IntervalTimer<TimerGameEconomy> _economy_companies_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::COMPANY}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_companies_yearly({TimerGameEconomy::Trigger::Year, TimerGameEconomy::Priority::Company}, [](auto)
 {
 	/* Copy statistics */
 	for (Company *c : Company::Iterate()) {

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -61,7 +61,7 @@ static uint _script_current_depth; ///< Depth of scripts running (used to abort 
 static std::string _scheduled_monthly_script; ///< Script scheduled to execute by the 'schedule' console command (empty if no script is scheduled).
 
 /** Timer that runs every month of game time for the 'schedule' console command. */
-static const IntervalTimer<TimerGameCalendar> _scheduled_monthly_timer = {{TimerGameCalendar::MONTH, TimerGameCalendar::Priority::NONE}, [](auto) {
+static const IntervalTimer<TimerGameCalendar> _scheduled_monthly_timer = {{TimerGameCalendar::Trigger::Month, TimerGameCalendar::Priority::None}, [](auto) {
 	if (_scheduled_monthly_script.empty()) {
 		return;
 	}

--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -144,7 +144,7 @@ uint64_t GetMaskOfAllowedCurrencies()
 /**
  * Verify if the currency chosen by the user is about to be converted to Euro
  */
-static const IntervalTimer<TimerGameCalendar> _check_switch_to_euro({TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _check_switch_to_euro({TimerGameCalendar::Trigger::Year, TimerGameCalendar::Priority::None}, [](auto)
 {
 	if (_currency_specs[_settings_game.locale.currency].to_euro != CF_NOEURO &&
 			_currency_specs[_settings_game.locale.currency].to_euro != CF_ISEURO &&

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -945,7 +945,7 @@ static void ResetDisasterDelay()
 	_disaster_delay = GB(Random(), 0, 9) + 730;
 }
 
-static const IntervalTimer<TimerGameEconomy> _economy_disaster_daily({TimerGameEconomy::DAY, TimerGameEconomy::Priority::DISASTER}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_disaster_daily({TimerGameEconomy::Trigger::Day, TimerGameEconomy::Priority::Disaster}, [](auto)
 {
 	if (--_disaster_delay != 0) return;
 

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -477,7 +477,7 @@ public:
 		CheckRedrawStationCoverage(this);
 	}
 
-	const IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::Trigger::Year, TimerGameCalendar::Priority::None}, [this](auto) {
 		this->InvalidateData();
 	}};
 };

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1958,7 +1958,7 @@ void LoadUnloadStation(Station *st)
 /**
  * Every calendar month update of inflation.
  */
-static const IntervalTimer<TimerGameCalendar> _calendar_inflation_monthly({TimerGameCalendar::MONTH, TimerGameCalendar::Priority::COMPANY}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _calendar_inflation_monthly({TimerGameCalendar::Trigger::Month, TimerGameCalendar::Priority::Company}, [](auto)
 {
 	if (_settings_game.economy.inflation) {
 		AddInflation();
@@ -1969,7 +1969,7 @@ static const IntervalTimer<TimerGameCalendar> _calendar_inflation_monthly({Timer
 /**
  * Every economy month update of company economic data, plus economy fluctuations.
  */
-static const IntervalTimer<TimerGameEconomy> _economy_companies_monthly({ TimerGameEconomy::MONTH, TimerGameEconomy::Priority::COMPANY }, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_companies_monthly({ TimerGameEconomy::Trigger::Month, TimerGameEconomy::Priority::Company }, [](auto)
 {
 	CompaniesGenStatistics();
 	CompaniesPayInterest();

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -962,7 +962,7 @@ static bool IsVehicleTypeDisabled(VehicleType type, bool ai)
 }
 
 /** Daily check to offer an exclusive engine preview to the companies. */
-static const IntervalTimer<TimerGameCalendar> _calendar_engines_daily({TimerGameCalendar::DAY, TimerGameCalendar::Priority::ENGINE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _calendar_engines_daily({TimerGameCalendar::Trigger::Day, TimerGameCalendar::Priority::Engine}, [](auto)
 {
 	for (Company *c : Company::Iterate()) {
 		c->avail_railtypes = AddDateIntroducedRailTypes(c->avail_railtypes, TimerGameCalendar::date);
@@ -1187,7 +1187,7 @@ void CalendarEnginesMonthlyLoop()
 	}
 }
 
-static const IntervalTimer<TimerGameCalendar> _calendar_engines_monthly({TimerGameCalendar::MONTH, TimerGameCalendar::Priority::ENGINE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _calendar_engines_monthly({TimerGameCalendar::Trigger::Month, TimerGameCalendar::Priority::Engine}, [](auto)
 {
 	CalendarEnginesMonthlyLoop();
 });

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -260,7 +260,7 @@ void ShowEndGameChart()
 	new EndGameWindow(_endgame_desc);
 }
 
-static const IntervalTimer<TimerGameCalendar> _check_end_game({TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _check_end_game({TimerGameCalendar::Trigger::Year, TimerGameCalendar::Priority::None}, [](auto)
 {
 	/* 0 = never */
 	if (_settings_game.game_creation.ending_year == 0) return;

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -3083,7 +3083,7 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
  * For small maps, it implies that less than one change per month is required, while on bigger maps,
  * it would be way more. The daily loop handles those changes.
  */
-static const IntervalTimer<TimerGameEconomy> _economy_industries_daily({TimerGameEconomy::DAY, TimerGameEconomy::Priority::INDUSTRY}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_industries_daily({TimerGameEconomy::Trigger::Day, TimerGameEconomy::Priority::Industry}, [](auto)
 {
 	_economy.industry_daily_change_counter += _economy.industry_daily_increment;
 
@@ -3125,7 +3125,7 @@ static const IntervalTimer<TimerGameEconomy> _economy_industries_daily({TimerGam
 	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, IDIWD_PRODUCTION_CHANGE);
 });
 
-static const IntervalTimer<TimerGameEconomy> _economy_industries_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::INDUSTRY}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_industries_monthly({TimerGameEconomy::Trigger::Month, TimerGameEconomy::Priority::Industry}, [](auto)
 {
 	Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1831,7 +1831,7 @@ static void NetworkRestartMap()
 }
 
 /** Timer to restart a network server automatically based on real-time hours played. Initialized at zero to disable until settings are loaded. */
-static IntervalTimer<TimerGameRealtime> _network_restart_map_timer({std::chrono::hours::zero(), TimerGameRealtime::UNPAUSED}, [](auto)
+static IntervalTimer<TimerGameRealtime> _network_restart_map_timer({std::chrono::hours::zero(), TimerGameRealtime::Trigger::Unpaused}, [](auto)
 {
 	if (!_network_server) return;
 
@@ -1850,7 +1850,7 @@ void ChangeNetworkRestartTime(bool reset)
 {
 	if (!_network_server) return;
 
-	_network_restart_map_timer.SetInterval({ std::chrono::hours(_settings_client.network.restart_hours), TimerGameRealtime::UNPAUSED }, reset);
+	_network_restart_map_timer.SetInterval({ std::chrono::hours(_settings_client.network.restart_hours), TimerGameRealtime::Trigger::Unpaused }, reset);
 }
 
 /** Check if we want to restart the map based on the year. */
@@ -1866,14 +1866,14 @@ static void NetworkCheckRestartMapYear()
 }
 
 /** Calendar yearly "callback". Called whenever the calendar year changes. */
-static const IntervalTimer<TimerGameCalendar> _calendar_network_yearly({ TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE }, [](auto) {
+static const IntervalTimer<TimerGameCalendar> _calendar_network_yearly({ TimerGameCalendar::Trigger::Year, TimerGameCalendar::Priority::None }, [](auto) {
 	if (!_network_server) return;
 
 	NetworkCheckRestartMapYear();
 });
 
 /** Economy yearly "callback". Called whenever the economy year changes. */
-static const IntervalTimer<TimerGameEconomy> _economy_network_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_network_yearly({TimerGameEconomy::Trigger::Year, TimerGameEconomy::Priority::None}, [](auto)
 {
 	if (!_network_server) return;
 
@@ -1881,7 +1881,7 @@ static const IntervalTimer<TimerGameEconomy> _economy_network_yearly({TimerGameE
 });
 
 /** Quarterly "callback". Called whenever the economy quarter changes. */
-static const IntervalTimer<TimerGameEconomy> _network_quarterly({TimerGameEconomy::QUARTER, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _network_quarterly({TimerGameEconomy::Trigger::Quarter, TimerGameEconomy::Priority::None}, [](auto)
 {
 	if (!_network_server) return;
 
@@ -1890,7 +1890,7 @@ static const IntervalTimer<TimerGameEconomy> _network_quarterly({TimerGameEconom
 });
 
 /** Economy monthly "callback". Called whenever the economy month changes. */
-static const IntervalTimer<TimerGameEconomy> _network_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _network_monthly({TimerGameEconomy::Trigger::Month, TimerGameEconomy::Priority::None}, [](auto)
 {
 	if (!_network_server) return;
 
@@ -1899,7 +1899,7 @@ static const IntervalTimer<TimerGameEconomy> _network_monthly({TimerGameEconomy:
 });
 
 /** Economy weekly "callback". Called whenever the economy week changes. */
-static const IntervalTimer<TimerGameEconomy> _network_weekly({TimerGameEconomy::WEEK, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _network_weekly({TimerGameEconomy::Trigger::Week, TimerGameEconomy::Priority::None}, [](auto)
 {
 	if (!_network_server) return;
 
@@ -1907,7 +1907,7 @@ static const IntervalTimer<TimerGameEconomy> _network_weekly({TimerGameEconomy::
 });
 
 /** Daily "callback". Called whenever the economy date changes. */
-static const IntervalTimer<TimerGameEconomy> _economy_network_daily({TimerGameEconomy::DAY, TimerGameEconomy::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_network_daily({TimerGameEconomy::Trigger::Day, TimerGameEconomy::Priority::None}, [](auto)
 {
 	if (!_network_server) return;
 

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -177,7 +177,7 @@ std::string NewGRFProfiler::GetOutputFilename() const
 /**
  * Check whether profiling is active and should be finished.
  */
-static TimeoutTimer<TimerGameTick> _profiling_finish_timeout({ TimerGameTick::Priority::NONE, 0 }, []()
+static TimeoutTimer<TimerGameTick> _profiling_finish_timeout({ TimerGameTick::Priority::None, 0 }, []()
 {
 	NewGRFProfiler::FinishAll();
 });
@@ -187,7 +187,7 @@ static TimeoutTimer<TimerGameTick> _profiling_finish_timeout({ TimerGameTick::Pr
  */
 /* static */ void NewGRFProfiler::StartTimer(uint64_t ticks)
 {
-	_profiling_finish_timeout.Reset({ TimerGameTick::Priority::NONE, static_cast<uint>(ticks) });
+	_profiling_finish_timeout.Reset({ TimerGameTick::Priority::None, static_cast<uint>(ticks) });
 }
 
 /**

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1258,10 +1258,10 @@ void StateGameLoop()
 
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 		AnimateAnimatedTiles();
-		if (TimerManager<TimerGameCalendar>::Elapsed(1)) {
+		if (TimerManager<TimerGameCalendar>::Elapsed({})) {
 			RunVehicleCalendarDayProc();
 		}
-		TimerManager<TimerGameEconomy>::Elapsed(1);
+		TimerManager<TimerGameEconomy>::Elapsed({});
 		TimerManager<TimerGameTick>::Elapsed(1);
 		RunTileLoop();
 		CallVehicleTicks();
@@ -1286,7 +1286,7 @@ void StateGameLoop()
 }
 
 /** Interval for regular autosaves. Initialized at zero to disable till settings are loaded. */
-static IntervalTimer<TimerGameRealtime> _autosave_interval({std::chrono::milliseconds::zero(), TimerGameRealtime::AUTOSAVE}, [](auto)
+static IntervalTimer<TimerGameRealtime> _autosave_interval({std::chrono::milliseconds::zero(), TimerGameRealtime::Trigger::Autosave}, [](auto)
 {
 	/* We reset the command-during-pause mode here, so we don't continue
 	 * to make auto-saves when nothing more is changing. */
@@ -1313,7 +1313,7 @@ static IntervalTimer<TimerGameRealtime> _autosave_interval({std::chrono::millise
  */
 void ChangeAutosaveFrequency(bool reset)
 {
-	_autosave_interval.SetInterval({std::chrono::minutes(_settings_client.gui.autosave_interval), TimerGameRealtime::AUTOSAVE}, reset);
+	_autosave_interval.SetInterval({std::chrono::minutes(_settings_client.gui.autosave_interval), TimerGameRealtime::Trigger::Autosave}, reset);
 }
 
 /**

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -235,7 +235,7 @@ private:
 	std::pair<WidgetID, WidgetID> badge_filters{};
 	BadgeFilterChoices badge_filter_choices{};
 
-	const IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> yearly_interval = {{TimerGameCalendar::Trigger::Year, TimerGameCalendar::Priority::None}, [this](auto) {
 		this->SetDirty();
 	}};
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2001,7 +2001,7 @@ void ResetSignalVariant(int32_t)
 	}
 }
 
-static const IntervalTimer<TimerGameCalendar> _check_reset_signal({TimerGameCalendar::YEAR, TimerGameCalendar::Priority::NONE}, [](auto)
+static const IntervalTimer<TimerGameCalendar> _check_reset_signal({TimerGameCalendar::Trigger::Year, TimerGameCalendar::Priority::None}, [](auto)
 {
 	if (TimerGameCalendar::year != _settings_client.gui.semaphore_build_before) return;
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4367,7 +4367,7 @@ void OnTick_Station()
 }
 
 /** Economy monthly loop for stations. */
-static const IntervalTimer<TimerGameEconomy> _economy_stations_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::STATION}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_stations_monthly({TimerGameEconomy::Trigger::Month, TimerGameEconomy::Priority::Station}, [](auto)
 {
 	for (Station *st : Station::Iterate()) {
 		for (GoodsEntry &ge : st->goods) {

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -205,7 +205,7 @@ struct StatusBarWindow : Window {
 		this->SetWidgetDirty(WID_S_MIDDLE);
 	}};
 
-	const IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::Trigger::Day, TimerGameCalendar::Priority::None}, [this](auto) {
 		this->SetWidgetDirty(WID_S_LEFT);
 	}};
 };

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -422,7 +422,7 @@ bool FindSubsidyCargoDestination(CargoType cargo_type, Source src)
 }
 
 /** Perform the economy monthly update of open subsidies, and try to create a new one. */
-static const IntervalTimer<TimerGameEconomy> _economy_subsidies_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::SUBSIDY}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_subsidies_monthly({TimerGameEconomy::Trigger::Month, TimerGameEconomy::Priority::Subsidy}, [](auto)
 {
 	bool modified = false;
 

--- a/src/timer/timer_game_calendar.cpp
+++ b/src/timer/timer_game_calendar.cpp
@@ -91,10 +91,8 @@ void TimeoutTimer<TimerGameCalendar>::Elapsed(TimerGameCalendar::TElapsed trigge
 }
 
 template <>
-bool TimerManager<TimerGameCalendar>::Elapsed([[maybe_unused]] TimerGameCalendar::TElapsed delta)
+bool TimerManager<TimerGameCalendar>::Elapsed(TimerGameCalendar::TElapsed)
 {
-	assert(delta == 1);
-
 	if (_game_mode == GM_MENU) return false;
 
 	/* If calendar day progress is frozen, don't try to advance time. */
@@ -137,18 +135,18 @@ bool TimerManager<TimerGameCalendar>::Elapsed([[maybe_unused]] TimerGameCalendar
 	auto timers = TimerManager<TimerGameCalendar>::GetTimers();
 
 	for (auto timer : timers) {
-		timer->Elapsed(TimerGameCalendar::DAY);
+		timer->Elapsed(TimerGameCalendar::Trigger::Day);
 	}
 
 	if (new_month) {
 		for (auto timer : timers) {
-			timer->Elapsed(TimerGameCalendar::MONTH);
+			timer->Elapsed(TimerGameCalendar::Trigger::Month);
 		}
 	}
 
 	if (new_year) {
 		for (auto timer : timers) {
-			timer->Elapsed(TimerGameCalendar::YEAR);
+			timer->Elapsed(TimerGameCalendar::Trigger::Year);
 		}
 	}
 
@@ -166,7 +164,7 @@ bool TimerManager<TimerGameCalendar>::Elapsed([[maybe_unused]] TimerGameCalendar
 template <>
 void TimerManager<TimerGameCalendar>::Validate(TimerGameCalendar::TPeriod period)
 {
-	if (period.priority == TimerGameCalendar::Priority::NONE) return;
+	if (period.priority == TimerGameCalendar::Priority::None) return;
 
 	/* Validate we didn't make a developer error and scheduled more than one
 	 * entry on the same priority/trigger. There can only be one timer on

--- a/src/timer/timer_game_common.h
+++ b/src/timer/timer_game_common.h
@@ -23,7 +23,7 @@
  * Other than that, make sure you only set one callback per priority.
  *
  * For example:
- *   IntervalTimer<TimerGameCalendar>({TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [](uint count) {});
+ *   IntervalTimer<TimerGameCalendar>({TimerGameCalendar::Trigger::Day, TimerGameCalendar::Priority::None}, [](uint count) {});
  *
  * @note Callbacks are executed in the game-thread.
  */
@@ -94,27 +94,30 @@ public:
 		return Date{(365 * year_as_int) + number_of_leap_years};
 	}
 
-	enum Trigger : uint8_t {
-		DAY,
-		WEEK,
-		MONTH,
-		QUARTER,
-		YEAR,
+	/** Trigger reasons for the timer based triggers. */
+	enum class Trigger : uint8_t {
+		Day, ///< Triggeres daily.
+		Week, ///< Triggers every Tuesday.
+		Month, ///< Triggered at the first of the month.
+		Quarter, ///< Triggered every first of January, April, July and October.
+		Year, ///< Triggered every first of January.
 	};
 
-	enum Priority : uint8_t {
-		NONE, ///< These timers can be executed in any order; there is no Random() in them, so order is not relevant.
+	/** Different levels of priority to run the timers in. */
+	enum class Priority : uint8_t {
+		None, ///< These timers can be executed in any order; there is no Random() in them, so order is not relevant.
 
 		/* All other may have a Random() call in them, so order is important.
 		 * For safety, you can only setup a single timer on a single priority. */
-		COMPANY,
-		DISASTER,
-		ENGINE,
-		INDUSTRY,
-		STATION,
-		SUBSIDY,
-		TOWN,
-		VEHICLE,
+
+		Company, ///< Changes to companies.
+		Disaster, ///< Running disaster logic.
+		Engine, ///< Running engine availability updates.
+		Industry, ///< Running industry production changes.
+		Station, ///< Processing of goods statistics.
+		Subsidy, ///< Creating new subsidies.
+		Town, ///< Town growth and rating management.
+		Vehicle, ///< Income and profit warnings.
 	};
 
 	struct TPeriod {
@@ -136,7 +139,7 @@ public:
 		}
 	};
 
-	using TElapsed = uint;
+	using TElapsed = Trigger;
 	struct TStorage {};
 };
 

--- a/src/timer/timer_game_economy.cpp
+++ b/src/timer/timer_game_economy.cpp
@@ -119,10 +119,8 @@ void TimeoutTimer<TimerGameEconomy>::Elapsed(TimerGameEconomy::TElapsed trigger)
 }
 
 template <>
-bool TimerManager<TimerGameEconomy>::Elapsed([[maybe_unused]] TimerGameEconomy::TElapsed delta)
+bool TimerManager<TimerGameEconomy>::Elapsed(TimerGameEconomy::TElapsed)
 {
-	assert(delta == 1);
-
 	if (_game_mode == GM_MENU) return false;
 
 	TimerGameEconomy::date_fract++;
@@ -149,30 +147,30 @@ bool TimerManager<TimerGameEconomy>::Elapsed([[maybe_unused]] TimerGameEconomy::
 	auto timers = TimerManager<TimerGameEconomy>::GetTimers();
 
 	for (auto timer : timers) {
-		timer->Elapsed(TimerGameEconomy::DAY);
+		timer->Elapsed(TimerGameEconomy::Trigger::Day);
 	}
 
 	if ((TimerGameEconomy::date.base() % 7) == 3) {
 		for (auto timer : timers) {
-			timer->Elapsed(TimerGameEconomy::WEEK);
+			timer->Elapsed(TimerGameEconomy::Trigger::Week);
 		}
 	}
 
 	if (new_month) {
 		for (auto timer : timers) {
-			timer->Elapsed(TimerGameEconomy::MONTH);
+			timer->Elapsed(TimerGameEconomy::Trigger::Month);
 		}
 
 		if ((TimerGameEconomy::month % 3) == 0) {
 			for (auto timer : timers) {
-				timer->Elapsed(TimerGameEconomy::QUARTER);
+				timer->Elapsed(TimerGameEconomy::Trigger::Quarter);
 			}
 		}
 	}
 
 	if (new_year) {
 		for (auto timer : timers) {
-			timer->Elapsed(TimerGameEconomy::YEAR);
+			timer->Elapsed(TimerGameEconomy::Trigger::Year);
 		}
 	}
 
@@ -194,7 +192,7 @@ bool TimerManager<TimerGameEconomy>::Elapsed([[maybe_unused]] TimerGameEconomy::
 template <>
 void TimerManager<TimerGameEconomy>::Validate(TimerGameEconomy::TPeriod period)
 {
-	if (period.priority == TimerGameEconomy::Priority::NONE) return;
+	if (period.priority == TimerGameEconomy::Priority::None) return;
 
 	/* Validate we didn't make a developer error and scheduled more than one
 	 * entry on the same priority/trigger. There can only be one timer on

--- a/src/timer/timer_game_realtime.cpp
+++ b/src/timer/timer_game_realtime.cpp
@@ -18,8 +18,8 @@ template <>
 void IntervalTimer<TimerGameRealtime>::Elapsed(TimerGameRealtime::TElapsed delta)
 {
 	if (this->period.period == std::chrono::milliseconds::zero()) return;
-	if (this->period.flag == TimerGameRealtime::PeriodFlags::AUTOSAVE && _pause_mode.Any() && !_pause_mode.Test(PauseMode::CommandDuringPause)) return;
-	if (this->period.flag == TimerGameRealtime::PeriodFlags::UNPAUSED && _pause_mode.Any()) return;
+	if (this->period.trigger == TimerGameRealtime::Trigger::Autosave && _pause_mode.Any() && !_pause_mode.Test(PauseMode::CommandDuringPause)) return;
+	if (this->period.trigger == TimerGameRealtime::Trigger::Unpaused && _pause_mode.Any()) return;
 
 	this->storage.elapsed += delta;
 
@@ -39,8 +39,8 @@ void TimeoutTimer<TimerGameRealtime>::Elapsed(TimerGameRealtime::TElapsed delta)
 {
 	if (this->fired) return;
 	if (this->period.period == std::chrono::milliseconds::zero()) return;
-	if (this->period.flag == TimerGameRealtime::PeriodFlags::AUTOSAVE && _pause_mode.Any() && _pause_mode.Test(PauseMode::CommandDuringPause)) return;
-	if (this->period.flag == TimerGameRealtime::PeriodFlags::UNPAUSED && _pause_mode.Any()) return;
+	if (this->period.trigger == TimerGameRealtime::Trigger::Autosave && _pause_mode.Any() && _pause_mode.Test(PauseMode::CommandDuringPause)) return;
+	if (this->period.trigger == TimerGameRealtime::Trigger::Unpaused && _pause_mode.Any()) return;
 
 	this->storage.elapsed += delta;
 

--- a/src/timer/timer_game_realtime.h
+++ b/src/timer/timer_game_realtime.h
@@ -16,9 +16,9 @@
  * Timer that represents real time for game-related purposes.
  *
  * For pausing, there are several modes:
- * - Continue to tick during pause (PeriodFlags::ALWAYS).
- * - Stop ticking when paused (PeriodFlags::UNPAUSED).
- * - Only tick when unpaused or when there was a Command executed recently (recently: since last autosave) (PeriodFlags::AUTOSAVE).
+ * - Continue to tick during pause (Trigger::Always).
+ * - Stop ticking when paused (Trigger::Unpaused).
+ * - Only tick when unpaused or when there was a Command executed recently (recently: since last autosave) (Trigger::Autosave).
  *
  * @note The lowest possible interval is 1ms, although realistic the lowest
  * interval is 27ms. This timer is only updated when the game-thread makes
@@ -27,27 +27,28 @@
  */
 class TimerGameRealtime {
 public:
-	enum PeriodFlags : uint8_t {
-		ALWAYS, ///< Always run, even when paused.
-		UNPAUSED, ///< Only run when not paused.
-		AUTOSAVE, ///< Only run when not paused or there was a Command executed recently.
+	/** When is the timer supposed to be run. */
+	enum class Trigger : uint8_t {
+		Always, ///< Always run, even when paused.
+		Unpaused, ///< Only run when not paused.
+		Autosave, ///< Only run when not paused or there was a Command executed recently.
 	};
 
 	struct TPeriod {
 		std::chrono::milliseconds period;
-		PeriodFlags flag;
+		Trigger trigger;
 
-		TPeriod(std::chrono::milliseconds period, PeriodFlags flag) : period(period), flag(flag) {}
+		TPeriod(std::chrono::milliseconds period, Trigger trigger) : period(period), trigger(trigger) {}
 
 		bool operator < (const TPeriod &other) const
 		{
-			if (this->flag != other.flag) return this->flag < other.flag;
+			if (this->trigger != other.trigger) return this->trigger < other.trigger;
 			return this->period < other.period;
 		}
 
 		bool operator == (const TPeriod &other) const
 		{
-			return this->flag == other.flag && this->period == other.period;
+			return this->trigger == other.trigger && this->period == other.period;
 		}
 	};
 	using TElapsed = std::chrono::milliseconds;

--- a/src/timer/timer_game_tick.cpp
+++ b/src/timer/timer_game_tick.cpp
@@ -63,7 +63,7 @@ bool TimerManager<TimerGameTick>::Elapsed(TimerGameTick::TElapsed delta)
 template <>
 void TimerManager<TimerGameTick>::Validate(TimerGameTick::TPeriod period)
 {
-	if (period.priority == TimerGameTick::Priority::NONE) return;
+	if (period.priority == TimerGameTick::Priority::None) return;
 
 	/* Validate we didn't make a developer error and scheduled more than one
 	 * entry on the same priority. There can only be one timer on

--- a/src/timer/timer_game_tick.h
+++ b/src/timer/timer_game_tick.h
@@ -24,12 +24,14 @@ public:
 	using Ticks = int32_t; ///< The type to store ticks in
 	using TickCounter = uint64_t; ///< The type that the tick counter is stored in
 
-	enum Priority : uint8_t {
-		NONE, ///< These timers can be executed in any order; the order is not relevant.
+	/** Different levels of priority to run the timers in. */
+	enum class Priority : uint8_t {
+		None, ///< These timers can be executed in any order; the order is not relevant.
 
 		/* For all other priorities, the order is important.
 		 * For safety, you can only setup a single timer on a single priority. */
-		COMPETITOR_TIMEOUT,
+
+		CompetitorTimeout, ///< Considering starting a new competitor/AI.
 	};
 
 	struct TPeriod {

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -789,7 +789,7 @@ struct TimetableWindow : Window {
 	/**
 	 * In real-time mode, the timetable GUI shows relative times and needs to be redrawn every second.
 	 */
-	const IntervalTimer<TimerGameTick> redraw_interval = { { TimerGameTick::Priority::NONE, Ticks::TICKS_PER_SECOND }, [this](auto) {
+	const IntervalTimer<TimerGameTick> redraw_interval = { { TimerGameTick::Priority::None, Ticks::TICKS_PER_SECOND }, [this](auto) {
 		if (_settings_client.gui.timetable_mode == TimetableMode::Seconds) {
 			this->SetDirty();
 		}

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -4166,7 +4166,7 @@ Town::SuppliedHistory SumHistory(std::span<const Town::SuppliedHistory> history)
 	return {.production = ClampTo<uint16_t>(production / count), .transported = ClampTo<uint16_t>(transported / count)};
 }
 
-static const IntervalTimer<TimerGameEconomy> _economy_towns_monthly({TimerGameEconomy::MONTH, TimerGameEconomy::Priority::TOWN}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_towns_monthly({TimerGameEconomy::Trigger::Month, TimerGameEconomy::Priority::Town}, [](auto)
 {
 	for (Town *t : Town::Iterate()) {
 		/* Check for active town actions and decrement their counters. */
@@ -4195,7 +4195,7 @@ static const IntervalTimer<TimerGameEconomy> _economy_towns_monthly({TimerGameEc
 	}
 });
 
-static const IntervalTimer<TimerGameEconomy> _economy_towns_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::TOWN}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_towns_yearly({TimerGameEconomy::Trigger::Year, TimerGameEconomy::Priority::Town}, [](auto)
 {
 	/* Increment house ages */
 	for (const auto t : Map::Iterate()) {

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -605,7 +605,7 @@ public:
 		Command<CMD_RENAME_TOWN>::Post(STR_ERROR_CAN_T_RENAME_TOWN, static_cast<TownID>(this->window_number), *str);
 	}
 
-	const IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [this](auto) {
+	const IntervalTimer<TimerGameCalendar> daily_interval = {{TimerGameCalendar::Trigger::Day, TimerGameCalendar::Priority::None}, [this](auto) {
 		/* Refresh after possible snowline change */
 		this->SetDirty();
 	}};

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3019,7 +3019,7 @@ void Vehicle::RemoveFromShared()
 	this->previous_shared = nullptr;
 }
 
-static const IntervalTimer<TimerGameEconomy> _economy_vehicles_yearly({TimerGameEconomy::YEAR, TimerGameEconomy::Priority::VEHICLE}, [](auto)
+static const IntervalTimer<TimerGameEconomy> _economy_vehicles_yearly({TimerGameEconomy::Trigger::Year, TimerGameEconomy::Priority::Vehicle}, [](auto)
 {
 	for (Vehicle *v : Vehicle::Iterate()) {
 		if (v->IsPrimaryVehicle()) {


### PR DESCRIPTION
## Motivation / Problem

Using scoped enums to make it less likely to use the wrong enumeration due to the type-unsafeness of non-scoped enums.


## Description

Make the enumerations in the timers scoped. `Priority` was already sort-of faking it by using the scope when used, however it wasn't enforced.

The `PeriodFlags` was renamed to `Trigger` because it's basically a filter on when it triggers, but not at all used as a bit mask.

The `TElapsed` type is a bit weird. In game economy/calendar timers its consumers want the trigger, but the elapsed 'time' the timer manager is provided with is always `1`. With an assert to ensure that.
Can't really use `Trigger::Day` because the timer manager is called every tick, but adding a tick to the trigger might make people believe that it'd be usable as a trigger, which it isn't. So now it passes `{}` as a token of "don't care", and the timer manager doesn't check for the value. That way `TElapsed` can become the trigger and prevent a lot of `to_underlying` calls.


## Limitations

See previous section.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
