### PR TITLE
Fix #15131: Trees on partial snow tiles spread properly again.

### DIFF
--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -51,10 +51,11 @@ inline ClearGround GetClearGround(Tile t)
 }
 
 /**
- * Set the type of clear tile.
- * @param t  the tile to set the clear ground type of
+ * Checks if the clear ground is of a certain type.
+ * @param t  the tile to check the ground type of
  * @param ct the ground type
  * @pre IsTileType(t, MP_CLEAR)
+ * @return Whether the tile's clear ground type matches the provided type.
  */
 inline bool IsClearGround(Tile t, ClearGround ct)
 {

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -890,8 +890,8 @@ static void TileLoop_Trees(TileIndex tile)
 
 						if (!CanPlantTreesOnTile(tile, false)) return;
 
-						/* Don't plant trees, if ground was freshly cleared */
-						if (IsTileType(tile, MP_CLEAR) && GetClearGround(tile) == CLEAR_GRASS && GetClearDensity(tile) != 3) return;
+						/* Don't plant trees if ground was freshly cleared */
+						if (IsTileType(tile, MP_CLEAR) && IsClearGround(tile, CLEAR_ROUGH)) return;
 
 						PlantTreesOnTile(tile, treetype, 0, TreeGrowthStage::Growing1);
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #15131

## Description

Before this change the tree-spreading logic would check if a tile is CLEAR_GRASS and whether it's density is below 3 (the maximum), in order to avoid spreading trees on freshly cleared tiles. #13659 changed how "snow-coveredness" is stored in the map data. The ClearGround type of a snow-covered tile is now CLEAR_GRASS instead of CLEAR_SNOW, and as a result trees on partially covered grass tiles no longer spread.

I removed the aforementioned check altogether and tried to get trees to pop up on freshly cleared ground, but was not able to. It's not impossible but the chance is very low due to the slow pace of both tree spreading and random tree spawning. And since trees are automatically deleted when the user builds something, so they shouldn't really get in the way of the user. The old logic also only worked for grass tiles, trees could still appear on snow tiles.

The new code only checks for CLEAR_ROUGH, which means that trees will not appear in the mud left behind right after a tile is bulldozed. IMO this logic is a decent alternative that works the same for all tile types.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
