### PR TITLE
Feature: New tree life cycle algorithm

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -849,6 +849,7 @@
       <small>Note: the actually displayed set of trees depends on both type and number of trees</small>
      </li>
      <li>m5 bits 7..6: number of trees minus one</li>
+     <li>m5 bit 3: set if the tree tile is poisoned</li>
      <li>m5 bits 2..0: growth status:
       <table border="0">
        <tr>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -175,7 +175,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOO</span><span class="used" title="Tree ground">XXX</span> <span class="used" title="Tree density">XX</span> <span class="used" title="Tree counter">XXXX</span></td>
       <td class="bits"><span class="usable" title="Tree type unused bits">XX</span><span class="used" title="Tree type">XX XXXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="used" title="Number of trees on tile (+1)">XX</span><span class="free">OO O</span><span class="used" title="Tree growth">XXX</span></td>
+      <td class="bits"><span class="used" title="Number of trees on tile (+1)">XX</span><span class="free">OO</span> <span class="used" title="Poisoned">X</span><span class="used" title="Tree growth">XXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -135,8 +135,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_generate_landscape_w
 						NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_NUMBER_OF_TOWNS, STR_MAPGEN_NUMBER_OF_TOWNS_TOOLTIP), SetFill(1, 1),
 						NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_NUMBER_OF_INDUSTRIES, STR_MAPGEN_NUMBER_OF_INDUSTRIES_TOOLTIP), SetFill(1, 1),
 						NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_SEA_LEVEL, STR_MAPGEN_SEA_LEVEL_TOOLTIP), SetFill(1, 1),
-						/* Spacer due to fewer items in columns 3-4 than in 1-2. */
-						NWidget(NWID_SPACER), SetFill(1, 1),
+						NWidget(WWT_TEXT, INVALID_COLOUR), SetStringTip(STR_MAPGEN_QUANTITY_OF_TREES, STR_MAPGEN_QUANTITY_OF_TREES_TOOLTIP), SetFill(1, 1),
 					EndContainer(),
 
 					/* Widgets on the right side (global column 4). */
@@ -168,8 +167,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_generate_landscape_w
 						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_TOWN_PULLDOWN), SetToolTip(STR_MAPGEN_NUMBER_OF_TOWNS_TOOLTIP), SetFill(1, 1),
 						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_INDUSTRY_PULLDOWN), SetToolTip(STR_MAPGEN_NUMBER_OF_INDUSTRIES_TOOLTIP), SetFill(1, 1),
 						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_WATER_PULLDOWN), SetToolTip(STR_MAPGEN_SEA_LEVEL_TOOLTIP), SetFill(1, 1),
-						/* Spacer due to fewer items in columns 3-4 than in 1-2. */
-						NWidget(NWID_SPACER), SetFill(1, 1),
+						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_TREES_PULLDOWN), SetToolTip(STR_MAPGEN_QUANTITY_OF_TREES_TOOLTIP), SetFill(1, 1),
 					EndContainer(),
 				EndContainer(),
 			EndContainer(),
@@ -385,6 +383,7 @@ static DropDownList BuildTownNameDropDown()
 static const StringID _max_height[]  = {STR_TERRAIN_TYPE_VERY_FLAT, STR_TERRAIN_TYPE_FLAT, STR_TERRAIN_TYPE_HILLY, STR_TERRAIN_TYPE_MOUNTAINOUS, STR_TERRAIN_TYPE_ALPINIST, STR_TERRAIN_TYPE_CUSTOM};
 static const StringID _sea_lakes[]   = {STR_SEA_LEVEL_VERY_LOW, STR_SEA_LEVEL_LOW, STR_SEA_LEVEL_MEDIUM, STR_SEA_LEVEL_HIGH, STR_SEA_LEVEL_CUSTOM};
 static const StringID _rivers[]      = {STR_RIVERS_NONE, STR_RIVERS_FEW, STR_RIVERS_MODERATE, STR_RIVERS_LOT};
+static const StringID _trees[]       = {STR_TREES_FEW, STR_TREES_MODERATE, STR_TREES_LOT};
 static const StringID _borders[]     = {STR_MAPGEN_BORDER_RANDOMIZE, STR_MAPGEN_BORDER_MANUAL, STR_MAPGEN_BORDER_INFINITE_WATER};
 static const StringID _smoothness[]  = {STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_VERY_SMOOTH, STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_SMOOTH, STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_ROUGH, STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_VERY_ROUGH};
 static const StringID _rotation[]    = {STR_CONFIG_SETTING_HEIGHTMAP_ROTATION_COUNTER_CLOCKWISE, STR_CONFIG_SETTING_HEIGHTMAP_ROTATION_CLOCKWISE};
@@ -477,6 +476,7 @@ struct GenerateLandscapeWindow : public Window {
 
 			case WID_GL_HEIGHTMAP_NAME_TEXT: return this->name.GetDecodedString();
 			case WID_GL_RIVER_PULLDOWN:      return GetString(_rivers[_settings_newgame.game_creation.amount_of_rivers]);
+			case WID_GL_TREES_PULLDOWN:      return GetString(_trees[_settings_newgame.game_creation.amount_of_trees]);
 			case WID_GL_SMOOTHNESS_PULLDOWN: return GetString(_smoothness[_settings_newgame.game_creation.tgen_smoothness]);
 			case WID_GL_VARIETY_PULLDOWN:    return GetString(_variety[_settings_newgame.game_creation.variety]);
 			case WID_GL_AVERAGE_HEIGHT_PULLDOWN: return GetString(_average_height[to_underlying(_settings_newgame.game_creation.average_height)]);
@@ -626,6 +626,7 @@ struct GenerateLandscapeWindow : public Window {
 				break;
 
 			case WID_GL_RIVER_PULLDOWN:      strs = _rivers; break;
+			case WID_GL_TREES_PULLDOWN:      strs = _trees; break;
 			case WID_GL_SMOOTHNESS_PULLDOWN: strs = _smoothness; break;
 			case WID_GL_AVERAGE_HEIGHT_PULLDOWN: strs = _variety; break;
 			case WID_GL_VARIETY_PULLDOWN:    strs = _variety; break;
@@ -804,6 +805,10 @@ struct GenerateLandscapeWindow : public Window {
 				ShowDropDownMenu(this, _rivers, _settings_newgame.game_creation.amount_of_rivers, WID_GL_RIVER_PULLDOWN, 0, 0);
 				break;
 
+			case WID_GL_TREES_PULLDOWN: // Amount of trees
+				ShowDropDownMenu(this, _trees, _settings_newgame.game_creation.amount_of_trees, WID_GL_TREES_PULLDOWN, 0, 0);
+				break;
+
 			case WID_GL_SMOOTHNESS_PULLDOWN: // Map smoothness
 				ShowDropDownMenu(this, _smoothness, _settings_newgame.game_creation.tgen_smoothness, WID_GL_SMOOTHNESS_PULLDOWN, 0, 0);
 				break;
@@ -874,6 +879,9 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_MAPSIZE_X_PULLDOWN:     _settings_newgame.game_creation.map_x = index; break;
 			case WID_GL_MAPSIZE_Y_PULLDOWN:     _settings_newgame.game_creation.map_y = index; break;
 			case WID_GL_RIVER_PULLDOWN:         _settings_newgame.game_creation.amount_of_rivers = index; break;
+			case WID_GL_TREES_PULLDOWN:
+				_settings_newgame.game_creation.amount_of_trees = index;
+				break;
 			case WID_GL_SMOOTHNESS_PULLDOWN:    _settings_newgame.game_creation.tgen_smoothness = index;  break;
 			case WID_GL_VARIETY_PULLDOWN:       _settings_newgame.game_creation.variety = index; break;
 			case WID_GL_AVERAGE_HEIGHT_PULLDOWN: _settings_newgame.game_creation.average_height = static_cast<GenworldAverageHeight>(index); break;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1209,6 +1209,11 @@ STR_RIVERS_MODERATE                                             :Medium
 STR_RIVERS_LOT                                                  :Many
 
 ###length 3
+STR_TREES_FEW                                                   :Few
+STR_TREES_MODERATE                                              :Medium
+STR_TREES_LOT                                                   :Many
+
+###length 3
 STR_DISASTER_NONE                                               :None
 STR_DISASTER_REDUCED                                            :Reduced
 STR_DISASTER_NORMAL                                             :Normal
@@ -1639,6 +1644,9 @@ STR_CONFIG_SETTING_VARIETY_HELPTEXT                             :Choose if the m
 
 STR_CONFIG_SETTING_RIVER_AMOUNT                                 :River amount: {STRING2}
 STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT                        :Choose how many rivers to generate
+
+STR_CONFIG_SETTING_TREE_AMOUNT                                  :Tree amount: {STRING2}
+STR_CONFIG_SETTING_TREE_AMOUNT_HELPTEXT                         :The amount of trees that will be on the map. This can be changed while the game is running, but the effect will only become visible after several in-game years.
 
 STR_CONFIG_SETTING_TREE_PLACER                                  :Tree placer algorithm: {STRING2}
 STR_CONFIG_SETTING_TREE_PLACER_HELPTEXT                         :Choose the distribution of trees on the map: 'Original' plants trees uniformly scattered, 'Improved' plants them in groups
@@ -3399,6 +3407,8 @@ STR_MAPGEN_AVERAGE_HEIGHT                                       :{BLACK}Average 
 STR_MAPGEN_SEA_LEVEL                                            :{BLACK}Sea level:
 STR_MAPGEN_SEA_LEVEL_TOOLTIP                                    :{BLACK}Select the sea level
 STR_MAPGEN_QUANTITY_OF_RIVERS                                   :{BLACK}Rivers:
+STR_MAPGEN_QUANTITY_OF_TREES                                    :{BLACK}Trees:
+STR_MAPGEN_QUANTITY_OF_TREES_TOOLTIP                            :{BLACK}Amount of trees on the map
 STR_MAPGEN_SMOOTHNESS                                           :{BLACK}Smoothness:
 STR_MAPGEN_VARIETY                                              :{BLACK}Variety distribution:
 STR_MAPGEN_GENERATE                                             :{WHITE}Generate

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3393,6 +3393,10 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_NEW_TREE_ALGORITHM)) {
+		_settings_game.game_creation.amount_of_trees = 1; // Medium
+	}
+
 	for (Company *c : Company::Iterate()) {
 		UpdateCompanyLiveries(c);
 	}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -415,6 +415,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_SIGN_TEXT_COLOURS,                  ///< 363  PR#14743 Configurable sign text colors in scenario editor.
 	SLV_BUOYS_AT_0_0,                       ///< 364  PR#14983 Allow to build buoys at (0x0).
 
+	SLV_NEW_TREE_ALGORITHM,                 ///< 364  TODO PR NUM New tree algorithm.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -848,6 +848,7 @@ SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("game_creation.snow_line_height"));
 			genworld->Add(new SettingEntry("game_creation.desert_coverage"));
 			genworld->Add(new SettingEntry("game_creation.amount_of_rivers"));
+			genworld->Add(new SettingEntry("game_creation.amount_of_trees"));
 		}
 
 		SettingsPage *environment = main->Add(new SettingsPage(STR_CONFIG_SETTING_ENVIRONMENT));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -429,6 +429,7 @@ struct GameCreationSettings {
 	uint8_t min_river_length;                 ///< the minimum river length
 	uint8_t river_route_random;               ///< the amount of randomicity for the route finding
 	uint8_t amount_of_rivers;                 ///< the amount of rivers
+	uint8_t amount_of_trees;                  ///< the amount of trees
 };
 
 /** Settings related to construction in-game */

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -353,6 +353,18 @@ strhelp  = STR_CONFIG_SETTING_RIVER_AMOUNT_HELPTEXT
 strval   = STR_RIVERS_NONE
 
 [SDT_VAR]
+var      = game_creation.amount_of_trees
+type     = SLE_UINT8
+from     = SLV_NEW_TREE_ALGORITHM
+flags    = SettingFlag::GuiDropdown
+def      = 1
+min      = 0
+max      = 2
+str      = STR_CONFIG_SETTING_TREE_AMOUNT
+strhelp  = STR_CONFIG_SETTING_TREE_AMOUNT_HELPTEXT
+strval   = STR_TREES_FEW
+
+[SDT_VAR]
 var      = construction.map_height_limit
 type     = SLE_UINT8
 from     = SLV_194

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -230,6 +230,28 @@ inline void SetTreeGrowth(Tile t, TreeGrowthStage g)
 }
 
 /**
+ * Returns whether a tree tile is poisoned
+ * @param tile The tile to check
+ * @return True if poisoned, false otherwise
+ */
+inline bool IsTreeTilePoisoned(Tile tile)
+{
+	assert(GetTileType(tile) == MP_TREES);
+	return HasBit(tile.m5(), 3);
+}
+
+/**
+ * Sets whether a tree tile is poisoned
+ * @param tile The tile to apply to value to
+ * @param poisoned Whether the tile will be poisoned or not.
+ */
+inline void SetTreeTilePoisoned(Tile tile, bool poisoned)
+{
+	assert(GetTileType(tile) == MP_TREES);
+	AssignBit(tile.m5(), 3, poisoned);
+}
+
+/**
  * Make a tree-tile.
  *
  * This functions change the tile to a tile with trees and all information which belongs to it.

--- a/src/widgets/genworld_widget.h
+++ b/src/widgets/genworld_widget.h
@@ -51,6 +51,7 @@ enum GenerateLandscapeWidgets : WidgetID {
 	WID_GL_MAX_HEIGHT_PULLDOWN,         ///< Dropdown 'Maximum height'.
 	WID_GL_WATER_PULLDOWN,              ///< Dropdown 'Sea level'.
 	WID_GL_RIVER_PULLDOWN,              ///< Dropdown 'Rivers'.
+	WID_GL_TREES_PULLDOWN,              ///< Dropdown 'Trees'.
 	WID_GL_SMOOTHNESS_PULLDOWN,         ///< Dropdown 'Smoothness'.
 	WID_GL_VARIETY_PULLDOWN,            ///< Dropdown 'Variety distribution'.
 	WID_GL_AVERAGE_HEIGHT_PULLDOWN,     ///< Dropdown 'Average height'.


### PR DESCRIPTION
## Motivation / Problem

The tree generation algorithms produce nice results, especially after the recent work done in #13515, but eventually trees take over the entire map. Individual trees do die but eventually that spot just gets filled in with new trees. The user can't control the amount of trees, although there is a setting to stop tree growth, but this breaks certain industries.

## Description

DISCLAIMER: this work is still somewhat rough, hence the draft status. It's functional but needs further refinement. Feel free to try it out, feedback is very welcome.

The approach I took is loosely based on the Forest-fire model: https://en.wikipedia.org/wiki/Forest-fire_model. I got the inspiration for this from a Veritasium video, and specifically this section: https://www.youtube.com/watch?v=HBluLfX2F_k&t=1136s.

In order to keep the tree growth under control I've introduced so-called "tree poisoning events". Think of it as a lightning strike burning down the forest, except that the forest will disappear in slow motion. Every time the tile loop visits a tree tile there's a small chance such an event is triggered. When it does it spreads out to all adjacent tree tiles, marking them as poisoned (there's a limit to the amount of tiles, and a small percentage survives). Trees on poisoned tiles slowly die one by one until all of the trees are gone, leaving a clearing. Poisoned trees will be drawn in grey when CTRL is held (a debug feature, this will be removed eventually).

The beauty of this system is that it's self-balancing and independent of the map size. More tree tiles means a poisoning event is more likely to happen, and with a higher tree density it is likely to spread to more tiles. If there are many trees there will be many poisoning events with a big impact. If there are few trees there will be few poisoning events, allowing trees to grow and spead. Tree growth and tree death will find an equilibrium, balancing the amount of trees versus clear ground.

I removed all of the tree generation logic, and instead we just run the new tree growth/death algorithm for a while during map generation. This way the amount of trees and their general appearance (amount of clumping, etc) stay constant during the course of the game.

The amount of trees can be configured in the map generation window. It can also be changed during a game, but it does take a few in-game years to take effect.

# Visuals

Here's a video of a heavily fast forwarded game with amount of trees set to _many_:
https://github.com/user-attachments/assets/0d22788a-5e67-45cf-94e1-523cad4ddb6a

Here's a map after 50 years in openttd 14.1:
<img width="2016" height="1021" alt="trees_old" src="https://github.com/user-attachments/assets/fa1c5f2c-bda6-4c4b-b2e6-5fb72cf2eef1" />

And here's the same map after 50 years with amount of trees set to _medium_:
<img width="2043" height="1013" alt="trees_new" src="https://github.com/user-attachments/assets/0f06630a-818a-4d4f-a9ce-3b393f47a267" />


## Limitations

- Tree tile updates now happen 4 times faster. I wanted the tree life cycle to be a bit more dynamic, but maybe this is a bit too much.
- Tree growth in the scenario editor was already a bit funky, but got really messed up in this PR. I need to look into this.
- Right now existing savegames all default to medium tree growth. This means savegames with lots of trees will see many of them disappear after some in-game years.
- Running the algorithm during map generation takes a bit more time, especially on larger maps with the tree amount set to many.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
