### PR TITLE
Codechange: Use bitfields and unions for internall map storage.

### DIFF
--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -172,7 +172,7 @@ the array so you can quickly see what is used and what is not.
       <td>4</td>
       <td class="caption">trees</td>
       <td class="bits"><span class="free">O</span><span class="used" title="Water class">XX</span><span class="usable" title="Owner (always OWNER_NONE)">1 OOOO</span></td>
-      <td class="bits"><span class="free">OOOO OOO</span><span class="used" title="Tree ground">XXX</span> <span class="used" title="Tree density">XX</span> <span class="used" title="Tree counter">XXXX</span></td>
+      <td class="bits"><span class="free">OOOO OOO</span><span class="used" title="Tree ground">XXX</span> <span class="used" title="Tree density">XX</span> <span class="free">OOOO</span></td>
       <td class="bits"><span class="usable" title="Tree type unused bits">XX</span><span class="used" title="Tree type">XX XXXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Number of trees on tile (+1)">XX</span><span class="free">OO O</span><span class="used" title="Tree growth">XXX</span></td>

--- a/src/bridge_map.h
+++ b/src/bridge_map.h
@@ -18,12 +18,12 @@
 /**
  * Checks if this is a bridge, instead of a tunnel
  * @param t The tile to analyze
- * @pre IsTileType(t, MP_TUNNELBRIDGE)
+ * @pre IsTileType(t, TileType::TunnelBridge)
  * @return true if the structure is a bridge one
  */
 inline bool IsBridge(Tile t)
 {
-	assert(IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::TunnelBridge));
 	return HasBit(t.m5(), 7);
 }
 
@@ -34,7 +34,7 @@ inline bool IsBridge(Tile t)
  */
 inline bool IsBridgeTile(Tile t)
 {
-	return IsTileType(t, MP_TUNNELBRIDGE) && IsBridge(t);
+	return IsTileType(t, TileType::TunnelBridge) && IsBridge(t);
 }
 
 /**
@@ -127,7 +127,7 @@ inline void SetBridgeMiddle(Tile t, Axis a)
  */
 inline void MakeBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDirection d, TransportType tt)
 {
-	SetTileType(t, MP_TUNNELBRIDGE);
+	SetTileType(t, TileType::TunnelBridge);
 	SetTileOwner(t, o);
 	SetDockingTile(t, false);
 	t.m2() = 0;

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -173,13 +173,13 @@ static Foundation GetFoundation_Clear(TileIndex, Slope)
 
 static void UpdateFences(TileIndex tile)
 {
-	assert(IsTileType(tile, MP_CLEAR) && IsClearGround(tile, CLEAR_FIELDS));
+	assert(IsTileType(tile, TileType::Clear) && IsClearGround(tile, CLEAR_FIELDS));
 	bool dirty = false;
 
 	for (DiagDirection dir = DIAGDIR_BEGIN; dir < DIAGDIR_END; dir++) {
 		if (GetFence(tile, dir) != 0) continue;
 		TileIndex neighbour = tile + TileOffsByDiagDir(dir);
-		if (IsTileType(neighbour, MP_CLEAR) && IsClearGround(neighbour, CLEAR_FIELDS)) continue;
+		if (IsTileType(neighbour, TileType::Clear) && IsClearGround(neighbour, CLEAR_FIELDS)) continue;
 		SetFence(tile, dir, 3);
 		dirty = true;
 	}
@@ -334,7 +334,7 @@ void GenerateClearTile()
 	do {
 		IncreaseGeneratingWorldProgress(GWP_ROUGH_ROCKY);
 		tile = RandomTile();
-		if (IsTileType(tile, MP_CLEAR) && !IsClearGround(tile, CLEAR_DESERT)) SetClearGroundDensity(tile, CLEAR_ROUGH, 3);
+		if (IsTileType(tile, TileType::Clear) && !IsClearGround(tile, CLEAR_DESERT)) SetClearGroundDensity(tile, CLEAR_ROUGH, 3);
 	} while (--i);
 
 	/* add rocky tiles */
@@ -344,7 +344,7 @@ void GenerateClearTile()
 		tile = RandomTileSeed(r);
 
 		IncreaseGeneratingWorldProgress(GWP_ROUGH_ROCKY);
-		if (IsTileType(tile, MP_CLEAR)) {
+		if (IsTileType(tile, TileType::Clear)) {
 			uint j = GB(r, 16, 4) + 5;
 			for (;;) {
 				TileIndex tile_new;
@@ -354,7 +354,7 @@ void GenerateClearTile()
 				do {
 					if (--j == 0) goto get_out;
 					tile_new = tile + TileOffsByDiagDir((DiagDirection)GB(Random(), 0, 2));
-				} while (!IsTileType(tile_new, MP_CLEAR));
+				} while (!IsTileType(tile_new, TileType::Clear));
 				tile = tile_new;
 			}
 get_out:;

--- a/src/clear_func.h
+++ b/src/clear_func.h
@@ -5,7 +5,7 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
  */
 
-/** @file clear_func.h Functions related to clear (MP_CLEAR) land. */
+/** @file clear_func.h Functions related to clear (TileType::Clear) land. */
 
 #ifndef CLEAR_FUNC_H
 #define CLEAR_FUNC_H

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -28,24 +28,24 @@ enum ClearGround : uint8_t {
 /**
  * Test if a tile is covered with snow.
  * @param t the tile to check
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  * @return whether the tile is covered with snow.
  */
 inline bool IsSnowTile(Tile t)
 {
-	assert(IsTileType(t, MP_CLEAR));
+	assert(IsTileType(t, TileType::Clear));
 	return HasBit(t.m3(), 4);
 }
 
 /**
  * Get the type of clear tile.
  * @param t the tile to get the clear ground type of
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  * @return the ground type
  */
 inline ClearGround GetClearGround(Tile t)
 {
-	assert(IsTileType(t, MP_CLEAR));
+	assert(IsTileType(t, TileType::Clear));
 	return static_cast<ClearGround>(GB(t.m5(), 2, 3));
 }
 
@@ -53,7 +53,7 @@ inline ClearGround GetClearGround(Tile t)
  * Set the type of clear tile.
  * @param t  the tile to set the clear ground type of
  * @param ct the ground type
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  */
 inline bool IsClearGround(Tile t, ClearGround ct)
 {
@@ -64,12 +64,12 @@ inline bool IsClearGround(Tile t, ClearGround ct)
 /**
  * Get the density of a non-field clear tile.
  * @param t the tile to get the density of
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  * @return the density
  */
 inline uint GetClearDensity(Tile t)
 {
-	assert(IsTileType(t, MP_CLEAR));
+	assert(IsTileType(t, TileType::Clear));
 	return GB(t.m5(), 0, 2);
 }
 
@@ -77,11 +77,11 @@ inline uint GetClearDensity(Tile t)
  * Increment the density of a non-field clear tile.
  * @param t the tile to increment the density of
  * @param d the amount to increment the density with
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  */
 inline void AddClearDensity(Tile t, int d)
 {
-	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
+	assert(IsTileType(t, TileType::Clear)); // XXX incomplete
 	t.m5() += d;
 }
 
@@ -89,11 +89,11 @@ inline void AddClearDensity(Tile t, int d)
  * Set the density of a non-field clear tile.
  * @param t the tile to set the density of
  * @param d the new density
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  */
 inline void SetClearDensity(Tile t, uint d)
 {
-	assert(IsTileType(t, MP_CLEAR));
+	assert(IsTileType(t, TileType::Clear));
 	SB(t.m5(), 0, 2, d);
 }
 
@@ -101,12 +101,12 @@ inline void SetClearDensity(Tile t, uint d)
 /**
  * Get the counter used to advance to the next clear density/field type.
  * @param t the tile to get the counter of
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  * @return the value of the counter
  */
 inline uint GetClearCounter(Tile t)
 {
-	assert(IsTileType(t, MP_CLEAR));
+	assert(IsTileType(t, TileType::Clear));
 	return GB(t.m5(), 5, 3);
 }
 
@@ -114,11 +114,11 @@ inline uint GetClearCounter(Tile t)
  * Increments the counter used to advance to the next clear density/field type.
  * @param t the tile to increment the counter of
  * @param c the amount to increment the counter with
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  */
 inline void AddClearCounter(Tile t, int c)
 {
-	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
+	assert(IsTileType(t, TileType::Clear)); // XXX incomplete
 	t.m5() += c << 5;
 }
 
@@ -126,11 +126,11 @@ inline void AddClearCounter(Tile t, int c)
  * Sets the counter used to advance to the next clear density/field type.
  * @param t the tile to set the counter of
  * @param c the amount to set the counter to
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  */
 inline void SetClearCounter(Tile t, uint c)
 {
-	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
+	assert(IsTileType(t, TileType::Clear)); // XXX incomplete
 	SB(t.m5(), 5, 3, c);
 }
 
@@ -140,11 +140,11 @@ inline void SetClearCounter(Tile t, uint c)
  * @param t       the tile to set the ground type and density for
  * @param type    the new ground type of the tile
  * @param density the density of the ground tile
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  */
 inline void SetClearGroundDensity(Tile t, ClearGround type, uint density)
 {
-	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
+	assert(IsTileType(t, TileType::Clear)); // XXX incomplete
 	t.m5() = 0 << 5 | type << 2 | density;
 }
 
@@ -245,7 +245,7 @@ inline void SetFence(Tile t, DiagDirection side, uint h)
  */
 inline void MakeClear(Tile t, ClearGround g, uint density)
 {
-	SetTileType(t, MP_CLEAR);
+	SetTileType(t, TileType::Clear);
 	t.m1() = 0;
 	SetTileOwner(t, OWNER_NONE);
 	t.m2() = 0;
@@ -266,7 +266,7 @@ inline void MakeClear(Tile t, ClearGround g, uint density)
  */
 inline void MakeField(Tile t, uint field_type, IndustryID industry)
 {
-	SetTileType(t, MP_CLEAR);
+	SetTileType(t, TileType::Clear);
 	t.m1() = 0;
 	SetTileOwner(t, OWNER_NONE);
 	t.m2() = industry.base();

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -34,7 +34,7 @@ enum ClearGround : uint8_t {
 inline bool IsSnowTile(Tile t)
 {
 	assert(IsTileType(t, TileType::Clear));
-	return HasBit(t.m3(), 4);
+	return t.GetTileBaseAs<TileType::Clear>().snow_presence;
 }
 
 /**
@@ -46,7 +46,7 @@ inline bool IsSnowTile(Tile t)
 inline ClearGround GetClearGround(Tile t)
 {
 	assert(IsTileType(t, TileType::Clear));
-	return static_cast<ClearGround>(GB(t.m5(), 2, 3));
+	return static_cast<ClearGround>(t.GetTileExtendedAs<TileType::Clear>().ground);
 }
 
 /**
@@ -70,7 +70,7 @@ inline bool IsClearGround(Tile t, ClearGround ct)
 inline uint GetClearDensity(Tile t)
 {
 	assert(IsTileType(t, TileType::Clear));
-	return GB(t.m5(), 0, 2);
+	return t.GetTileExtendedAs<TileType::Clear>().density;
 }
 
 /**
@@ -82,7 +82,7 @@ inline uint GetClearDensity(Tile t)
 inline void AddClearDensity(Tile t, int d)
 {
 	assert(IsTileType(t, TileType::Clear)); // XXX incomplete
-	t.m5() += d;
+	t.GetTileExtendedAs<TileType::Clear>().density += d;
 }
 
 /**
@@ -94,7 +94,7 @@ inline void AddClearDensity(Tile t, int d)
 inline void SetClearDensity(Tile t, uint d)
 {
 	assert(IsTileType(t, TileType::Clear));
-	SB(t.m5(), 0, 2, d);
+	t.GetTileExtendedAs<TileType::Clear>().density = d;
 }
 
 
@@ -107,7 +107,7 @@ inline void SetClearDensity(Tile t, uint d)
 inline uint GetClearCounter(Tile t)
 {
 	assert(IsTileType(t, TileType::Clear));
-	return GB(t.m5(), 5, 3);
+	return t.GetTileExtendedAs<TileType::Clear>().update;
 }
 
 /**
@@ -119,7 +119,7 @@ inline uint GetClearCounter(Tile t)
 inline void AddClearCounter(Tile t, int c)
 {
 	assert(IsTileType(t, TileType::Clear)); // XXX incomplete
-	t.m5() += c << 5;
+	t.GetTileExtendedAs<TileType::Clear>().update += c;
 }
 
 /**
@@ -131,7 +131,7 @@ inline void AddClearCounter(Tile t, int c)
 inline void SetClearCounter(Tile t, uint c)
 {
 	assert(IsTileType(t, TileType::Clear)); // XXX incomplete
-	SB(t.m5(), 5, 3, c);
+	t.GetTileExtendedAs<TileType::Clear>().update = c;
 }
 
 
@@ -145,7 +145,10 @@ inline void SetClearCounter(Tile t, uint c)
 inline void SetClearGroundDensity(Tile t, ClearGround type, uint density)
 {
 	assert(IsTileType(t, TileType::Clear)); // XXX incomplete
-	t.m5() = 0 << 5 | type << 2 | density;
+	auto &extended = t.GetTileExtendedAs<TileType::Clear>();
+	extended.density = density;
+	extended.ground = type;
+	extended.update = 0;
 }
 
 
@@ -158,7 +161,7 @@ inline void SetClearGroundDensity(Tile t, ClearGround type, uint density)
 inline uint GetFieldType(Tile t)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
-	return GB(t.m3(), 0, 4);
+	return t.GetTileBaseAs<TileType::Clear>().field_type;
 }
 
 /**
@@ -170,7 +173,7 @@ inline uint GetFieldType(Tile t)
 inline void SetFieldType(Tile t, uint f)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS); // XXX incomplete
-	SB(t.m3(), 0, 4, f);
+	t.GetTileBaseAs<TileType::Clear>().field_type = f;
 }
 
 /**
@@ -182,7 +185,7 @@ inline void SetFieldType(Tile t, uint f)
 inline IndustryID GetIndustryIndexOfField(Tile t)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
-	return(IndustryID) t.m2();
+	return static_cast<IndustryID>(t.GetTileExtendedAs<TileType::Clear>().farm_index);
 }
 
 /**
@@ -194,7 +197,7 @@ inline IndustryID GetIndustryIndexOfField(Tile t)
 inline void SetIndustryIndexOfField(Tile t, IndustryID i)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
-	t.m2() = i.base();
+	t.GetTileExtendedAs<TileType::Clear>().farm_index = i.base();
 }
 
 
@@ -210,10 +213,10 @@ inline uint GetFence(Tile t, DiagDirection side)
 	assert(IsClearGround(t, CLEAR_FIELDS));
 	switch (side) {
 		default: NOT_REACHED();
-		case DIAGDIR_SE: return GB(t.m4(), 2, 3);
-		case DIAGDIR_SW: return GB(t.m4(), 5, 3);
-		case DIAGDIR_NE: return GB(t.m3(), 5, 3);
-		case DIAGDIR_NW: return GB(t.m6(), 2, 3);
+		case DIAGDIR_SE: return t.GetTileBaseAs<TileType::Clear>().hedge_SE;
+		case DIAGDIR_SW: return t.GetTileBaseAs<TileType::Clear>().hedge_SW;
+		case DIAGDIR_NE: return t.GetTileBaseAs<TileType::Clear>().hedge_NE;
+		case DIAGDIR_NW: return t.GetTileExtendedAs<TileType::Clear>().hedge_NW;
 	}
 }
 
@@ -229,10 +232,10 @@ inline void SetFence(Tile t, DiagDirection side, uint h)
 	assert(IsClearGround(t, CLEAR_FIELDS));
 	switch (side) {
 		default: NOT_REACHED();
-		case DIAGDIR_SE: SB(t.m4(), 2, 3, h); break;
-		case DIAGDIR_SW: SB(t.m4(), 5, 3, h); break;
-		case DIAGDIR_NE: SB(t.m3(), 5, 3, h); break;
-		case DIAGDIR_NW: SB(t.m6(), 2, 3, h); break;
+		case DIAGDIR_SE: t.GetTileBaseAs<TileType::Clear>().hedge_SE = h; break;
+		case DIAGDIR_SW: t.GetTileBaseAs<TileType::Clear>().hedge_SW = h; break;
+		case DIAGDIR_NE: t.GetTileBaseAs<TileType::Clear>().hedge_NE = h; break;
+		case DIAGDIR_NW: t.GetTileExtendedAs<TileType::Clear>().hedge_NW = h; break;
 	}
 }
 
@@ -246,15 +249,9 @@ inline void SetFence(Tile t, DiagDirection side, uint h)
 inline void MakeClear(Tile t, ClearGround g, uint density)
 {
 	SetTileType(t, TileType::Clear);
-	t.m1() = 0;
+	t.ResetData();
 	SetTileOwner(t, OWNER_NONE);
-	t.m2() = 0;
-	t.m3() = 0;
-	t.m4() = 0 << 5 | 0 << 2;
-	SetClearGroundDensity(t, g, density); // Sets m5
-	t.m6() = 0;
-	t.m7() = 0;
-	t.m8() = 0;
+	SetClearGroundDensity(t, g, density);
 }
 
 
@@ -266,16 +263,9 @@ inline void MakeClear(Tile t, ClearGround g, uint density)
  */
 inline void MakeField(Tile t, uint field_type, IndustryID industry)
 {
-	SetTileType(t, TileType::Clear);
-	t.m1() = 0;
-	SetTileOwner(t, OWNER_NONE);
-	t.m2() = industry.base();
-	t.m3() = field_type;
-	t.m4() = 0 << 5 | 0 << 2;
-	SetClearGroundDensity(t, CLEAR_FIELDS, 3);
-	SB(t.m6(), 2, 6, 0);
-	t.m7() = 0;
-	t.m8() = 0;
+	MakeClear(t, CLEAR_FIELDS, 3);
+	SetIndustryIndexOfField(t, industry);
+	SetFieldType(t, field_type);
 }
 
 /**
@@ -287,7 +277,7 @@ inline void MakeField(Tile t, uint field_type, IndustryID industry)
 inline void MakeSnow(Tile t, uint density = 0)
 {
 	assert(!IsSnowTile(t));
-	SetBit(t.m3(), 4);
+	t.GetTileBaseAs<TileType::Clear>().snow_presence = true;
 	if (GetClearGround(t) == CLEAR_FIELDS) {
 		SetClearGroundDensity(t, CLEAR_GRASS, density);
 	} else {
@@ -303,7 +293,7 @@ inline void MakeSnow(Tile t, uint density = 0)
 inline void ClearSnow(Tile t)
 {
 	assert(IsSnowTile(t));
-	ClrBit(t.m3(), 4);
+	t.GetTileBaseAs<TileType::Clear>().snow_presence = false;
 	SetClearDensity(t, 3);
 }
 

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -393,7 +393,7 @@ enum class DoCommandFlag : uint8_t {
 	Bankrupt, ///< company bankrupts, skip money check, skip vehicle on tile check in some cases
 	AutoReplace, ///< autoreplace/autorenew is in progress, this shall disable vehicle limits when building, and ignore certain restrictions when undoing things (like vehicle attach callback)
 	NoCargoCapacityCheck, ///< when autoreplace/autorenew is in progress, this shall prevent truncating the amount of cargo in the vehicle to prevent testing the command to remove cargo
-	AllTiles, ///< allow this command also on MP_VOID tiles
+	AllTiles, ///< allow this command also on TileType::Void tiles
 	NoModifyTownRating, ///< do not change town rating
 	ForceClearTile, ///< do not only remove the object on the tile, but also clear any water left on it
 };
@@ -409,7 +409,7 @@ enum class CommandFlag : uint8_t {
 	Spectator, ///< the command may be initiated by a spectator
 	Offline, ///< the command cannot be executed in a multiplayer game; single-player only
 	Auto, ///< set the DoCommandFlag::Auto flag on this command
-	AllTiles, ///< allow this command also on MP_VOID tiles
+	AllTiles, ///< allow this command also on TileType::Void tiles
 	NoTest, ///< the command's output may differ between test and execute due to town rating changes etc.
 	NoWater, ///< set the DoCommandFlag::NoWater flag on this command
 	ClientID, ///< set p2 with the ClientID of the sending client.

--- a/src/depot_map.h
+++ b/src/depot_map.h
@@ -79,10 +79,10 @@ inline VehicleType GetDepotVehicleType(Tile t)
 {
 	switch (GetTileType(t)) {
 		default: NOT_REACHED();
-		case MP_RAILWAY: return VEH_TRAIN;
-		case MP_ROAD:    return VEH_ROAD;
-		case MP_WATER:   return VEH_SHIP;
-		case MP_STATION: return VEH_AIRCRAFT;
+		case TileType::Railway: return VEH_TRAIN;
+		case TileType::Road:    return VEH_ROAD;
+		case TileType::Water:   return VEH_SHIP;
+		case TileType::Station: return VEH_AIRCRAFT;
 	}
 }
 

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -61,7 +61,7 @@ static void DisasterClearSquare(TileIndex tile)
 	if (EnsureNoVehicleOnGround(tile).Failed()) return;
 
 	switch (GetTileType(tile)) {
-		case MP_RAILWAY:
+		case TileType::Railway:
 			if (Company::IsHumanID(GetTileOwner(tile)) && !IsRailDepot(tile)) {
 				Backup<CompanyID> cur_company(_current_company, OWNER_WATER);
 				Command<CMD_LANDSCAPE_CLEAR>::Do(DoCommandFlag::Execute, tile);
@@ -72,15 +72,15 @@ static void DisasterClearSquare(TileIndex tile)
 			}
 			break;
 
-		case MP_HOUSE: {
+		case TileType::House: {
 			Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 			Command<CMD_LANDSCAPE_CLEAR>::Do(DoCommandFlag::Execute, tile);
 			cur_company.Restore();
 			break;
 		}
 
-		case MP_TREES:
-		case MP_CLEAR:
+		case TileType::Trees:
+		case TileType::Clear:
 			DoClearSquare(tile);
 			break;
 
@@ -479,7 +479,7 @@ static bool DisasterTick_Aircraft(DisasterVehicle *v, uint16_t image_override, b
 		if ((uint)x > Map::MaxX() * TILE_SIZE - 1) return true;
 
 		TileIndex tile = TileVirtXY(x, y);
-		if (!IsTileType(tile, MP_INDUSTRY)) return true;
+		if (!IsTileType(tile, TileType::Industry)) return true;
 
 		IndustryID ind = GetIndustryIndex(tile);
 		v->dest_tile = TileIndex{ind.base()};

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -484,7 +484,7 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 			 * Similar with crossings - it is needed to bar crossings that weren't before
 			 * because of different owner of crossing and approaching train */
 			for (const auto tile : Map::Iterate()) {
-				if (IsTileType(tile, MP_RAILWAY) && IsTileOwner(tile, new_owner) && HasSignals(tile)) {
+				if (IsTileType(tile, TileType::Railway) && IsTileOwner(tile, new_owner) && HasSignals(tile)) {
 					TrackBits tracks = GetTrackBits(tile);
 					do { // there may be two tracks with signals for TRACK_BIT_HORZ and TRACK_BIT_VERT
 						Track track = RemoveFirstTrack(&tracks);
@@ -1626,7 +1626,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 	/* We have not waited enough time till the next round of loading/unloading */
 	if (front->load_unload_ticks != 0) return;
 
-	if (front->type == VEH_TRAIN && (!IsTileType(front->tile, MP_STATION) || GetStationIndex(front->tile) != st->index)) {
+	if (front->type == VEH_TRAIN && (!IsTileType(front->tile, TileType::Station) || GetStationIndex(front->tile) != st->index)) {
 		/* The train reversed in the station. Take the "easy" way
 		 * out and let the train just leave as it always did. */
 		front->vehicle_flags.Set(VehicleFlag::LoadingFinished);

--- a/src/effectvehicle.cpp
+++ b/src/effectvehicle.cpp
@@ -49,7 +49,7 @@ static bool ChimneySmokeTick(EffectVehicle *v)
 		v->progress--;
 	} else {
 		TileIndex tile = TileVirtXY(v->x_pos, v->y_pos);
-		if (!IsTileType(tile, MP_INDUSTRY)) {
+		if (!IsTileType(tile, TileType::Industry)) {
 			delete v;
 			return false;
 		}
@@ -511,7 +511,7 @@ static bool BubbleTick(EffectVehicle *v)
 		if (_settings_client.sound.ambient) SndPlayVehicleFx(SND_31_BUBBLE_GENERATOR_SUCCESS, v);
 
 		tile = TileVirtXY(v->x_pos, v->y_pos);
-		if (IsTileType(tile, MP_INDUSTRY) && GetIndustryGfx(tile) == GFX_BUBBLE_CATCHER) AddAnimatedTile(tile);
+		if (IsTileType(tile, TileType::Industry) && GetIndustryGfx(tile) == GFX_BUBBLE_CATCHER) AddAnimatedTile(tile);
 	}
 
 	v->animation_state = anim_state;

--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -86,7 +86,7 @@ static inline TileLocationGroup GetTileLocationGroup(TileIndex t)
 static TrackBits GetRailTrackBitsUniversal(TileIndex t, DiagDirections *override)
 {
 	switch (GetTileType(t)) {
-		case MP_RAILWAY:
+		case TileType::Railway:
 			if (!HasRailCatenary(GetRailType(t))) return TRACK_BIT_NONE;
 			switch (GetRailTileType(t)) {
 				case RailTileType::Normal: case RailTileType::Signals:
@@ -96,7 +96,7 @@ static TrackBits GetRailTrackBitsUniversal(TileIndex t, DiagDirections *override
 			}
 			break;
 
-		case MP_TUNNELBRIDGE:
+		case TileType::TunnelBridge:
 			if (GetTunnelBridgeTransportType(t) != TRANSPORT_RAIL) return TRACK_BIT_NONE;
 			if (!HasRailCatenary(GetRailType(t))) return TRACK_BIT_NONE;
 			if (override != nullptr && (IsTunnel(t) || GetTunnelBridgeLength(t, GetOtherBridgeEnd(t)) > 0)) {
@@ -104,12 +104,12 @@ static TrackBits GetRailTrackBitsUniversal(TileIndex t, DiagDirections *override
 			}
 			return DiagDirToDiagTrackBits(GetTunnelBridgeDirection(t));
 
-		case MP_ROAD:
+		case TileType::Road:
 			if (!IsLevelCrossing(t)) return TRACK_BIT_NONE;
 			if (!HasRailCatenary(GetRailType(t))) return TRACK_BIT_NONE;
 			return GetCrossingRailBits(t);
 
-		case MP_STATION:
+		case TileType::Station:
 			if (!HasStationRail(t)) return TRACK_BIT_NONE;
 			if (!HasRailCatenary(GetRailType(t))) return TRACK_BIT_NONE;
 			return TrackToTrackBits(GetRailStationTrack(t));
@@ -198,7 +198,7 @@ static inline SpriteID GetPylonBase(TileIndex tile, TileContext context = TCX_NO
  */
 static void AdjustTileh(TileIndex tile, Slope *tileh)
 {
-	if (IsTileType(tile, MP_TUNNELBRIDGE)) {
+	if (IsTileType(tile, TileType::TunnelBridge)) {
 		if (IsTunnel(tile)) {
 			*tileh = SLOPE_STEEP; // XXX - Hack to make tunnel entrances to always have a pylon
 		} else if (*tileh != SLOPE_FLAT) {
@@ -366,10 +366,10 @@ static void DrawRailCatenaryRailway(const TileInfo *ti)
 		Foundation foundation = FOUNDATION_NONE;
 
 		/* Station and road crossings are always "flat", so adjust the tileh accordingly */
-		if (IsTileType(neighbour, MP_STATION) || IsTileType(neighbour, MP_ROAD)) tileh[TS_NEIGHBOUR] = SLOPE_FLAT;
+		if (IsTileType(neighbour, TileType::Station) || IsTileType(neighbour, TileType::Road)) tileh[TS_NEIGHBOUR] = SLOPE_FLAT;
 
 		/* Read the foundations if they are present, and adjust the tileh */
-		if (track_config[TS_NEIGHBOUR] != TRACK_BIT_NONE && IsTileType(neighbour, MP_RAILWAY) && HasRailCatenary(GetRailType(neighbour))) foundation = GetRailFoundation(tileh[TS_NEIGHBOUR], track_config[TS_NEIGHBOUR]);
+		if (track_config[TS_NEIGHBOUR] != TRACK_BIT_NONE && IsTileType(neighbour, TileType::Railway) && HasRailCatenary(GetRailType(neighbour))) foundation = GetRailFoundation(tileh[TS_NEIGHBOUR], track_config[TS_NEIGHBOUR]);
 		if (IsBridgeTile(neighbour)) {
 			foundation = GetBridgeFoundation(tileh[TS_NEIGHBOUR], DiagDirToAxis(GetTunnelBridgeDirection(neighbour)));
 		}
@@ -550,7 +550,7 @@ void DrawRailCatenaryOnBridge(const TileInfo *ti)
 void DrawRailCatenary(const TileInfo *ti)
 {
 	switch (GetTileType(ti->tile)) {
-		case MP_RAILWAY:
+		case TileType::Railway:
 			if (IsRailDepot(ti->tile)) {
 				const SortableSpriteStruct &sss = _rail_catenary_sprite_data_depot[GetRailDepotDirection(ti->tile)];
 
@@ -562,9 +562,9 @@ void DrawRailCatenary(const TileInfo *ti)
 			}
 			break;
 
-		case MP_TUNNELBRIDGE:
-		case MP_ROAD:
-		case MP_STATION:
+		case TileType::TunnelBridge:
+		case TileType::Road:
+		case TileType::Station:
 			break;
 
 		default: return;

--- a/src/industry.h
+++ b/src/industry.h
@@ -147,7 +147,7 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	 */
 	inline bool TileBelongsToIndustry(TileIndex tile) const
 	{
-		return IsTileType(tile, MP_INDUSTRY) && GetIndustryIndex(tile) == this->index;
+		return IsTileType(tile, TileType::Industry) && GetIndustryIndex(tile) == this->index;
 	}
 
 	/**
@@ -245,7 +245,7 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	/**
 	 * Get the industry of the given tile
 	 * @param tile the tile to get the industry from
-	 * @pre IsTileType(t, MP_INDUSTRY)
+	 * @pre IsTileType(t, TileType::Industry)
 	 * @return the industry
 	 */
 	static inline Industry *GetByTile(TileIndex tile)

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -619,7 +619,7 @@ public:
 
 		/* Clear farmland. */
 		for (const auto tile : Map::Iterate()) {
-			if (IsTileType(tile, MP_CLEAR) && GetClearGround(tile) == CLEAR_FIELDS) {
+			if (IsTileType(tile, TileType::Clear) && GetClearGround(tile) == CLEAR_FIELDS) {
 				MakeClear(tile, CLEAR_GRASS, 3);
 			}
 		}

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -75,7 +75,7 @@ inline IndustryID GetIndustryIndex(Tile t)
 inline bool IsIndustryCompleted(Tile t)
 {
 	assert(IsTileType(t, TileType::Industry));
-	return HasBit(t.m1(), 7);
+	return t.GetTileExtendedAs<TileType::Industry>().completed;
 }
 
 IndustryType GetIndustryType(Tile tile);
@@ -88,7 +88,7 @@ IndustryType GetIndustryType(Tile tile);
 inline void SetIndustryCompleted(Tile tile)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	SetBit(tile.m1(), 7);
+	tile.GetTileExtendedAs<TileType::Industry>().completed = 1;
 }
 
 /**
@@ -125,7 +125,7 @@ inline void SetIndustryConstructionStage(Tile tile, uint8_t value)
 inline IndustryGfx GetCleanIndustryGfx(Tile t)
 {
 	assert(IsTileType(t, TileType::Industry));
-	return t.m5() | (GB(t.m6(), 2, 1) << 8);
+	return t.GetTileExtendedAs<TileType::Industry>().graphics;
 }
 
 /**
@@ -149,8 +149,7 @@ inline IndustryGfx GetIndustryGfx(Tile t)
 inline void SetIndustryGfx(Tile t, IndustryGfx gfx)
 {
 	assert(IsTileType(t, TileType::Industry));
-	t.m5() = GB(gfx, 0, 8);
-	SB(t.m6(), 2, 1, GB(gfx, 8, 1));
+	t.GetTileExtendedAs<TileType::Industry>().graphics = gfx;
 }
 
 /**
@@ -191,7 +190,6 @@ inline void ResetIndustryConstructionStage(Tile tile)
 	extended.construction_counter = 0;
 	extended.construction_stage = 0;
 	extended.completed = 0;
-	SB(tile.m1(), 7, 1, 0);
 }
 
 /**

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -63,7 +63,7 @@ enum IndustryGraphics : uint8_t {
 inline IndustryID GetIndustryIndex(Tile t)
 {
 	assert(IsTileType(t, TileType::Industry));
-	return static_cast<IndustryID>(t.m2());
+	return static_cast<IndustryID>(t.GetTileExtendedAs<TileType::Industry>().index);
 }
 
 /**
@@ -100,7 +100,7 @@ inline void SetIndustryCompleted(Tile tile)
 inline uint8_t GetIndustryConstructionStage(Tile tile)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	return IsIndustryCompleted(tile) ? (uint8_t)INDUSTRY_COMPLETED : GB(tile.m1(), 0, 2);
+	return IsIndustryCompleted(tile) ? uint8_t(INDUSTRY_COMPLETED) : tile.GetTileExtendedAs<TileType::Industry>().construction_stage;
 }
 
 /**
@@ -112,7 +112,7 @@ inline uint8_t GetIndustryConstructionStage(Tile tile)
 inline void SetIndustryConstructionStage(Tile tile, uint8_t value)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	SB(tile.m1(), 0, 2, value);
+	tile.GetTileExtendedAs<TileType::Industry>().construction_stage = value;
 }
 
 /**
@@ -162,7 +162,7 @@ inline void SetIndustryGfx(Tile t, IndustryGfx gfx)
 inline uint8_t GetIndustryConstructionCounter(Tile tile)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	return GB(tile.m1(), 2, 2);
+	return tile.GetTileExtendedAs<TileType::Industry>().construction_counter;
 }
 
 /**
@@ -174,7 +174,7 @@ inline uint8_t GetIndustryConstructionCounter(Tile tile)
 inline void SetIndustryConstructionCounter(Tile tile, uint8_t value)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	SB(tile.m1(), 2, 2, value);
+	tile.GetTileExtendedAs<TileType::Industry>().construction_counter = value;
 }
 
 /**
@@ -187,7 +187,10 @@ inline void SetIndustryConstructionCounter(Tile tile, uint8_t value)
 inline void ResetIndustryConstructionStage(Tile tile)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	SB(tile.m1(), 0, 4, 0);
+	auto &extended = tile.GetTileExtendedAs<TileType::Industry>();
+	extended.construction_counter = 0;
+	extended.construction_stage = 0;
+	extended.completed = 0;
 	SB(tile.m1(), 7, 1, 0);
 }
 
@@ -199,7 +202,7 @@ inline void ResetIndustryConstructionStage(Tile tile)
 inline uint8_t GetIndustryAnimationLoop(Tile tile)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	return tile.m4();
+	return tile.GetTileBaseAs<TileType::Industry>().animation_loop;
 }
 
 /**
@@ -211,7 +214,7 @@ inline uint8_t GetIndustryAnimationLoop(Tile tile)
 inline void SetIndustryAnimationLoop(Tile tile, uint8_t count)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	tile.m4() = count;
+	tile.GetTileBaseAs<TileType::Industry>().animation_loop = count;
 }
 
 /**
@@ -224,7 +227,7 @@ inline void SetIndustryAnimationLoop(Tile tile, uint8_t count)
 inline uint8_t GetIndustryRandomBits(Tile tile)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	return tile.m3();
+	return tile.GetTileBaseAs<TileType::Industry>().random_bits;
 }
 
 /**
@@ -237,7 +240,7 @@ inline uint8_t GetIndustryRandomBits(Tile tile)
 inline void SetIndustryRandomBits(Tile tile, uint8_t bits)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	tile.m3() = bits;
+	tile.GetTileBaseAs<TileType::Industry>().random_bits = bits;
 }
 
 /**
@@ -250,7 +253,7 @@ inline void SetIndustryRandomBits(Tile tile, uint8_t bits)
 inline IndustryRandomTriggers GetIndustryRandomTriggers(Tile tile)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	return static_cast<IndustryRandomTriggers>(GB(tile.m6(), 3, 3));
+	return static_cast<IndustryRandomTriggers>(tile.GetTileExtendedAs<TileType::Industry>().random_triggers);
 }
 
 
@@ -264,7 +267,7 @@ inline IndustryRandomTriggers GetIndustryRandomTriggers(Tile tile)
 inline void SetIndustryRandomTriggers(Tile tile, IndustryRandomTriggers triggers)
 {
 	assert(IsTileType(tile, TileType::Industry));
-	SB(tile.m6(), 3, 3, triggers.base());
+	tile.GetTileExtendedAs<TileType::Industry>().random_triggers = triggers.base();
 }
 
 /**
@@ -278,16 +281,12 @@ inline void SetIndustryRandomTriggers(Tile tile, IndustryRandomTriggers triggers
 inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8_t random, WaterClass wc)
 {
 	SetTileType(t, TileType::Industry);
-	t.m1() = 0;
-	t.m2() = index.base();
-	SetIndustryRandomBits(t, random); // m3
-	t.m4() = 0;
-	SetIndustryGfx(t, gfx); // m5, part of m6
-	SetIndustryRandomTriggers(t, {}); // rest of m6
+	t.ResetData();
+	t.GetTileExtendedAs<TileType::Industry>().index = index.base();
+	SetIndustryRandomBits(t, random);
+	SetIndustryGfx(t, gfx);
+	SetIndustryRandomTriggers(t, {});
 	SetWaterClass(t, wc);
-	SB(t.m6(), 6, 2, 0);
-	t.m7() = 0;
-	t.m8() = 0;
 }
 
 #endif /* INDUSTRY_MAP_H */

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -57,24 +57,24 @@ enum IndustryGraphics : uint8_t {
 /**
  * Get the industry ID of the given tile
  * @param t the tile to get the industry ID from
- * @pre IsTileType(t, MP_INDUSTRY)
+ * @pre IsTileType(t, TileType::Industry)
  * @return the industry ID
  */
 inline IndustryID GetIndustryIndex(Tile t)
 {
-	assert(IsTileType(t, MP_INDUSTRY));
+	assert(IsTileType(t, TileType::Industry));
 	return static_cast<IndustryID>(t.m2());
 }
 
 /**
  * Is this industry tile fully built?
  * @param t the tile to analyze
- * @pre IsTileType(t, MP_INDUSTRY)
+ * @pre IsTileType(t, TileType::Industry)
  * @return true if and only if the industry tile is fully built
  */
 inline bool IsIndustryCompleted(Tile t)
 {
-	assert(IsTileType(t, MP_INDUSTRY));
+	assert(IsTileType(t, TileType::Industry));
 	return HasBit(t.m1(), 7);
 }
 
@@ -83,23 +83,23 @@ IndustryType GetIndustryType(Tile tile);
 /**
  * Set if the industry that owns the tile as under construction or not
  * @param tile the tile to query
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  */
 inline void SetIndustryCompleted(Tile tile)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	SetBit(tile.m1(), 7);
 }
 
 /**
  * Returns the industry construction stage of the specified tile
  * @param tile the tile to query
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  * @return the construction stage
  */
 inline uint8_t GetIndustryConstructionStage(Tile tile)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	return IsIndustryCompleted(tile) ? (uint8_t)INDUSTRY_COMPLETED : GB(tile.m1(), 0, 2);
 }
 
@@ -107,11 +107,11 @@ inline uint8_t GetIndustryConstructionStage(Tile tile)
  * Sets the industry construction stage of the specified tile
  * @param tile the tile to query
  * @param value the new construction stage
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  */
 inline void SetIndustryConstructionStage(Tile tile, uint8_t value)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	SB(tile.m1(), 0, 2, value);
 }
 
@@ -119,36 +119,36 @@ inline void SetIndustryConstructionStage(Tile tile, uint8_t value)
  * Get the industry graphics ID for the given industry tile as
  * stored in the without translation.
  * @param t the tile to get the gfx for
- * @pre IsTileType(t, MP_INDUSTRY)
+ * @pre IsTileType(t, TileType::Industry)
  * @return the gfx ID
  */
 inline IndustryGfx GetCleanIndustryGfx(Tile t)
 {
-	assert(IsTileType(t, MP_INDUSTRY));
+	assert(IsTileType(t, TileType::Industry));
 	return t.m5() | (GB(t.m6(), 2, 1) << 8);
 }
 
 /**
  * Get the industry graphics ID for the given industry tile
  * @param t the tile to get the gfx for
- * @pre IsTileType(t, MP_INDUSTRY)
+ * @pre IsTileType(t, TileType::Industry)
  * @return the gfx ID
  */
 inline IndustryGfx GetIndustryGfx(Tile t)
 {
-	assert(IsTileType(t, MP_INDUSTRY));
+	assert(IsTileType(t, TileType::Industry));
 	return GetTranslatedIndustryTileID(GetCleanIndustryGfx(t));
 }
 
 /**
  * Set the industry graphics ID for the given industry tile
  * @param t   the tile to set the gfx for
- * @pre IsTileType(t, MP_INDUSTRY)
+ * @pre IsTileType(t, TileType::Industry)
  * @param gfx the graphics ID
  */
 inline void SetIndustryGfx(Tile t, IndustryGfx gfx)
 {
-	assert(IsTileType(t, MP_INDUSTRY));
+	assert(IsTileType(t, TileType::Industry));
 	t.m5() = GB(gfx, 0, 8);
 	SB(t.m6(), 2, 1, GB(gfx, 8, 1));
 }
@@ -156,12 +156,12 @@ inline void SetIndustryGfx(Tile t, IndustryGfx gfx)
 /**
  * Returns this industry tile's construction counter value
  * @param tile the tile to query
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  * @return the construction counter
  */
 inline uint8_t GetIndustryConstructionCounter(Tile tile)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	return GB(tile.m1(), 2, 2);
 }
 
@@ -169,11 +169,11 @@ inline uint8_t GetIndustryConstructionCounter(Tile tile)
  * Sets this industry tile's construction counter value
  * @param tile the tile to query
  * @param value the new value for the construction counter
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  */
 inline void SetIndustryConstructionCounter(Tile tile, uint8_t value)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	SB(tile.m1(), 2, 2, value);
 }
 
@@ -182,11 +182,11 @@ inline void SetIndustryConstructionCounter(Tile tile, uint8_t value)
  * as well as the completion bit.
  * In fact, it is the same as restarting construction from the ground up.
  * @param tile the tile to query
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  */
 inline void ResetIndustryConstructionStage(Tile tile)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	SB(tile.m1(), 0, 4, 0);
 	SB(tile.m1(), 7, 1, 0);
 }
@@ -194,11 +194,11 @@ inline void ResetIndustryConstructionStage(Tile tile)
 /**
  * Get the animation loop number
  * @param tile the tile to get the animation loop number of
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  */
 inline uint8_t GetIndustryAnimationLoop(Tile tile)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	return tile.m4();
 }
 
@@ -206,11 +206,11 @@ inline uint8_t GetIndustryAnimationLoop(Tile tile)
  * Set the animation loop number
  * @param tile the tile to set the animation loop number of
  * @param count the new animation frame number
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  */
 inline void SetIndustryAnimationLoop(Tile tile, uint8_t count)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	tile.m4() = count;
 }
 
@@ -218,12 +218,12 @@ inline void SetIndustryAnimationLoop(Tile tile, uint8_t count)
  * Get the random bits for this tile.
  * Used for grf callbacks
  * @param tile the tile to query
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  * @return requested bits
  */
 inline uint8_t GetIndustryRandomBits(Tile tile)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	return tile.m3();
 }
 
@@ -232,11 +232,11 @@ inline uint8_t GetIndustryRandomBits(Tile tile)
  * Used for grf callbacks
  * @param tile the tile to query
  * @param bits the random bits
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  */
 inline void SetIndustryRandomBits(Tile tile, uint8_t bits)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	tile.m3() = bits;
 }
 
@@ -244,12 +244,12 @@ inline void SetIndustryRandomBits(Tile tile, uint8_t bits)
  * Get the activated triggers bits for this industry tile
  * Used for grf callbacks
  * @param tile the tile to query
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  * @return requested triggers
  */
 inline IndustryRandomTriggers GetIndustryRandomTriggers(Tile tile)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	return static_cast<IndustryRandomTriggers>(GB(tile.m6(), 3, 3));
 }
 
@@ -259,11 +259,11 @@ inline IndustryRandomTriggers GetIndustryRandomTriggers(Tile tile)
  * Used for grf callbacks
  * @param tile the tile to query
  * @param triggers the triggers to set
- * @pre IsTileType(tile, MP_INDUSTRY)
+ * @pre IsTileType(tile, TileType::Industry)
  */
 inline void SetIndustryRandomTriggers(Tile tile, IndustryRandomTriggers triggers)
 {
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	SB(tile.m6(), 3, 3, triggers.base());
 }
 
@@ -277,7 +277,7 @@ inline void SetIndustryRandomTriggers(Tile tile, IndustryRandomTriggers triggers
  */
 inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8_t random, WaterClass wc)
 {
-	SetTileType(t, MP_INDUSTRY);
+	SetTileType(t, TileType::Industry);
 	t.m1() = 0;
 	t.m2() = index.base();
 	SetIndustryRandomBits(t, random); // m3

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -66,18 +66,18 @@ extern const TileTypeProcs
  * @ingroup TileCallbackGroup
  * @see TileType
  */
-const TileTypeProcs * const _tile_type_procs[16] = {
-	&_tile_type_clear_procs,        ///< Callback functions for MP_CLEAR tiles
-	&_tile_type_rail_procs,         ///< Callback functions for MP_RAILWAY tiles
-	&_tile_type_road_procs,         ///< Callback functions for MP_ROAD tiles
-	&_tile_type_town_procs,         ///< Callback functions for MP_HOUSE tiles
-	&_tile_type_trees_procs,        ///< Callback functions for MP_TREES tiles
-	&_tile_type_station_procs,      ///< Callback functions for MP_STATION tiles
-	&_tile_type_water_procs,        ///< Callback functions for MP_WATER tiles
-	&_tile_type_void_procs,         ///< Callback functions for MP_VOID tiles
-	&_tile_type_industry_procs,     ///< Callback functions for MP_INDUSTRY tiles
-	&_tile_type_tunnelbridge_procs, ///< Callback functions for MP_TUNNELBRIDGE tiles
-	&_tile_type_object_procs,       ///< Callback functions for MP_OBJECT tiles
+const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::End)>, TileType> _tile_type_procs = {
+	&_tile_type_clear_procs, // Callback functions for TileType::Clear tiles
+	&_tile_type_rail_procs, // Callback functions for TileType::Railway tiles
+	&_tile_type_road_procs, // Callback functions for TileType::Road tiles
+	&_tile_type_town_procs, // Callback functions for TileType::House tiles
+	&_tile_type_trees_procs, // Callback functions for TileType::Trees tiles
+	&_tile_type_station_procs, // Callback functions for TileType::Station tiles
+	&_tile_type_water_procs, // Callback functions for TileType::Water tiles
+	&_tile_type_void_procs, // Callback functions for TileType::Void tiles
+	&_tile_type_industry_procs, // Callback functions for TileType::Industry tiles
+	&_tile_type_tunnelbridge_procs, // Callback functions for TileType::TunnelBridge tiles
+	&_tile_type_object_procs, // Callback functions for TileType::Object tiles
 };
 
 /** landscape slope => sprite */
@@ -324,7 +324,7 @@ int GetSlopePixelZOutsideMap(int x, int y)
 	if (IsInsideBS(x, 0, Map::SizeX() * TILE_SIZE) && IsInsideBS(y, 0, Map::SizeY() * TILE_SIZE)) {
 		return GetSlopePixelZ(x, y, false);
 	} else {
-		return _tile_type_procs[MP_VOID]->get_slope_z_proc(INVALID_TILE, x, y, false);
+		return _tile_type_procs[TileType::Void]->get_slope_z_proc(INVALID_TILE, x, y, false);
 	}
 }
 
@@ -986,7 +986,7 @@ static void CreateDesertOrRainForest(uint desert_tropic_line)
 
 		auto allows_desert = [tile, desert_tropic_line](auto &offset) {
 			TileIndex t = AddTileIndexDiffCWrap(tile, offset);
-			return t == INVALID_TILE || (TileHeight(t) < desert_tropic_line && !IsTileType(t, MP_WATER));
+			return t == INVALID_TILE || (TileHeight(t) < desert_tropic_line && !IsTileType(t, TileType::Water));
 		};
 		if (std::all_of(std::begin(_make_desert_or_rainforest_data), std::end(_make_desert_or_rainforest_data), allows_desert)) {
 			SetTropicZone(tile, TROPICZONE_DESERT);
@@ -1006,7 +1006,7 @@ static void CreateDesertOrRainForest(uint desert_tropic_line)
 
 		auto allows_rainforest = [tile](auto &offset) {
 			TileIndex t = AddTileIndexDiffCWrap(tile, offset);
-			return t == INVALID_TILE || !IsTileType(t, MP_CLEAR) || !IsClearGround(t, CLEAR_DESERT);
+			return t == INVALID_TILE || !IsTileType(t, TileType::Clear) || !IsClearGround(t, CLEAR_DESERT);
 		};
 		if (std::all_of(std::begin(_make_desert_or_rainforest_data), std::end(_make_desert_or_rainforest_data), allows_rainforest)) {
 			SetTropicZone(tile, TROPICZONE_RAINFOREST);
@@ -1120,7 +1120,7 @@ static void MakeWetlands(TileIndex centre, uint height, uint river_length)
 		if (Chance16(1, 3)) {
 			/* This tile is water. */
 			MakeRiverAndModifyDesertZoneAround(tile);
-		} else if (IsTileType(tile, MP_CLEAR)) {
+		} else if (IsTileType(tile, TileType::Clear)) {
 			/* This tile is ground, which we always make rough. */
 			SetClearGroundDensity(tile, CLEAR_ROUGH, 3);
 			/* Maybe place trees? */

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -25,7 +25,7 @@
 
 /* static */ uint Map::initial_land_count; ///< Initial number of land tiles on the map.
 
-/* static */ std::unique_ptr<Tile::BaseTile[]> Tile::base_tiles; ///< Base tiles of the map
+/* static */ std::unique_ptr<Tile::TileBase[]> Tile::base_tiles; ///< Base tiles of the map
 /* static */ std::unique_ptr<Tile::TileExtended[]> Tile::extended_tiles; ///< Extended tiles of the map
 
 
@@ -54,7 +54,7 @@
 	Map::size = size_x * size_y;
 	Map::tile_mask = Map::size - 1;
 
-	Tile::base_tiles = std::make_unique<Tile::BaseTile[]>(Map::size);
+	Tile::base_tiles = std::make_unique<Tile::TileBase[]>(Map::size);
 	Tile::extended_tiles = std::make_unique<Tile::TileExtended[]>(Map::size);
 
 	AllocateWaterRegions();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -277,7 +277,7 @@ uint GetClosestWaterDistance(TileIndex tile, bool water)
 
 			/* each side of this square has length 'dist' */
 			for (uint a = 0; a < dist; a++) {
-				/* MP_VOID tiles are not checked (interval is [min; max) for IsInsideMM())*/
+				/* TileType::Void tiles are not checked (interval is [min; max) for IsInsideMM())*/
 				if (IsInsideMM(x, min_xy, max_x) && IsInsideMM(y, min_xy, max_y)) {
 					TileIndex t = TileXY(x, y);
 					if (HasTileWaterGround(t) == water) return dist;
@@ -291,7 +291,7 @@ uint GetClosestWaterDistance(TileIndex tile, bool water)
 	if (!water) {
 		/* no land found - is this a water-only map? */
 		for (const auto t : Map::Iterate()) {
-			if (!IsTileType(t, MP_VOID) && !IsTileType(t, MP_WATER)) return 0x1FF;
+			if (!IsTileType(t, TileType::Void) && !IsTileType(t, TileType::Water)) return 0x1FF;
 		}
 	}
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -25,7 +25,7 @@
 
 /* static */ uint Map::initial_land_count; ///< Initial number of land tiles on the map.
 
-/* static */ std::unique_ptr<Tile::TileBase[]> Tile::base_tiles; ///< Base tiles of the map
+/* static */ std::unique_ptr<Tile::BaseTile[]> Tile::base_tiles; ///< Base tiles of the map
 /* static */ std::unique_ptr<Tile::TileExtended[]> Tile::extended_tiles; ///< Extended tiles of the map
 
 
@@ -54,7 +54,7 @@
 	Map::size = size_x * size_y;
 	Map::tile_mask = Map::size - 1;
 
-	Tile::base_tiles = std::make_unique<Tile::TileBase[]>(Map::size);
+	Tile::base_tiles = std::make_unique<Tile::BaseTile[]>(Map::size);
 	Tile::extended_tiles = std::make_unique<Tile::TileExtended[]>(Map::size);
 
 	AllocateWaterRegions();

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -55,6 +55,12 @@ private:
 		uint8_t random_bits = 0; ///< Canal/river random bits.
 	};
 
+	/** Storage for TileType::Industry tile base. */
+	struct IndustryTileBase : TileBaseCommon {
+		uint8_t random_bits = 0; ///< NewGRF random bits.
+		uint8_t animation_loop = 0; ///< The state of the animation loop.
+	};
+
 	/** Data that is stored per tile in old save games. Also used OldTileExtended for this. */
 	struct OldTileBase {
 		uint8_t type = 0; ///< The type (bits 4..7), bridges (2..3), rainforest/desert (0..1).
@@ -72,6 +78,7 @@ private:
 		TileBaseCommon common; ///< Common storage for all tile bases.
 		ClearTileBase clear; ///< Storage for tiles with: grass, snow, sand etc.
 		WaterTileBase water; ///< Storage for tiles with: canal, river, sea, shore etc.
+		IndustryTileBase industry; ///< Storage for tiles with parts of industries.
 		OldTileBase old; ///< Used to preserve compatibility with older save games.
 
 		/** Construct empty tile base storage. */
@@ -128,6 +135,28 @@ private:
 		uint16_t index = 0; ///< Depot index on the poll.
 	};
 
+	/**
+	 * Storage for TileType::Industry tile extended.
+	 * @note Does not inherit from TileExtendedCommon, but contains water_class from it.
+	 */
+	struct IndustryTileExtended {
+		uint16_t construction_stage : 2 = 0; ///< Stage of construction, incremented when the construction counter wraps around the meaning is different for some animated tiles which are never under construction.
+		uint16_t construction_counter : 2 = 0; ///< For buildings under construction incremented on every periodic tile processing.
+		uint16_t completed : 1 = 0; ///< Whether the industry is completed or under construction.
+		uint16_t water_class : 2 = 0; ///< The type of water that is below industry. WaterClass::Invalid used for industry tiles on land.
+		uint16_t graphics : 9 = 0; ///< Which sprite should be drawn for this industry tile.
+		uint16_t index = 0; ///< Industry index on the poll.
+		uint8_t animation_state : 2 = 0; ///< Animated tile state.
+	private:
+		[[maybe_unused]] uint8_t bit_offset_1 : 1 = 0; ///< Unused. @note Prevents save conversion.
+	public:
+		uint8_t random_triggers : 3 = 0; ///< NewGRF random triggers.
+	private:
+		[[maybe_unused]] uint8_t bit_offset_2 : 2 = 0; ///< Unused. @note Prevents save conversion.
+	public:
+		uint8_t animation_frame = 0; ///< The frame of animation.
+	};
+
 	/** Data that is stored per tile in old save games. Also used OldTileBase for this. */
 	struct OldTileExtended {
 		uint8_t m1 = 0; ///< Primarily used for ownership information
@@ -148,6 +177,7 @@ private:
 		ClearTileExtended clear; ///< Storage for tiles with: grass, snow, sand etc.
 		WaterTileExtended water; ///< Storage for tiles with water except ship depot.
 		ShipDepotTileExtended ship_depot; ///< Storage for ship depot.
+		IndustryTileExtended industry; ///< Storage for tiles with parts of industries.
 		OldTileExtended old; ///< Used to preserve compatibility with older save games.
 
 		/** Construct empty tile extended storage. */
@@ -236,6 +266,8 @@ public:
 			return base_tiles[this->tile.base()].clear;
 		} else if constexpr (Type == TileType::Water) {
 			return base_tiles[this->tile.base()].water;
+		} else if constexpr (Type == TileType::Industry) {
+			return base_tiles[this->tile.base()].industry;
 		}
 	}
 
@@ -254,6 +286,8 @@ public:
 			return extended_tiles[this->tile.base()].clear;
 		} else if constexpr (Type == TileType::Water) {
 			return extended_tiles[this->tile.base()].water;
+		} else if constexpr (Type == TileType::Industry) {
+			return extended_tiles[this->tile.base()].industry;
 		}
 	}
 

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -61,6 +61,11 @@ private:
 		uint8_t animation_loop = 0; ///< The state of the animation loop.
 	};
 
+	/** Storage for TileType::Object tile base. */
+	struct ObjectTileBase : TileBaseCommon {
+		uint8_t random_bits = 0; ///< NewGRF random bits.
+	};
+
 	/** Data that is stored per tile in old save games. Also used OldTileExtended for this. */
 	struct OldTileBase {
 		uint8_t type = 0; ///< The type (bits 4..7), bridges (2..3), rainforest/desert (0..1).
@@ -79,6 +84,7 @@ private:
 		ClearTileBase clear; ///< Storage for tiles with: grass, snow, sand etc.
 		WaterTileBase water; ///< Storage for tiles with: canal, river, sea, shore etc.
 		IndustryTileBase industry; ///< Storage for tiles with parts of industries.
+		ObjectTileBase object; ///< Storage for tiles with object e.g. transmitters, lighthouses, owned land.
 		OldTileBase old; ///< Used to preserve compatibility with older save games.
 
 		/** Construct empty tile base storage. */
@@ -157,6 +163,15 @@ private:
 		uint8_t animation_frame = 0; ///< The frame of animation.
 	};
 
+	/** Storage for TileType::Object tile extended. */
+	struct ObjectTileExtended : TileExtendedCommon {
+		uint8_t index_high_bits = 0; ///< High bits of object index on the poll.
+		uint16_t index_low_bits = 0; ///< Low bits of object index on the poll.
+		uint8_t animation_state : 2 = 0; ///< Animated tile state.
+		/* 6 bit offset is auto added by the compiler, because animation_counter can't fit into those 6 bits. */
+		uint8_t animation_counter = 0; ///< The state of the animation.
+	};
+
 	/** Data that is stored per tile in old save games. Also used OldTileBase for this. */
 	struct OldTileExtended {
 		uint8_t m1 = 0; ///< Primarily used for ownership information
@@ -178,6 +193,7 @@ private:
 		WaterTileExtended water; ///< Storage for tiles with water except ship depot.
 		ShipDepotTileExtended ship_depot; ///< Storage for ship depot.
 		IndustryTileExtended industry; ///< Storage for tiles with parts of industries.
+		ObjectTileExtended object; ///< Storage for tiles with object e.g. transmitters, lighthouses, owned land.
 		OldTileExtended old; ///< Used to preserve compatibility with older save games.
 
 		/** Construct empty tile extended storage. */
@@ -268,6 +284,8 @@ public:
 			return base_tiles[this->tile.base()].water;
 		} else if constexpr (Type == TileType::Industry) {
 			return base_tiles[this->tile.base()].industry;
+		} else if constexpr (Type == TileType::Object) {
+			return base_tiles[this->tile.base()].object;
 		}
 	}
 
@@ -288,6 +306,8 @@ public:
 			return extended_tiles[this->tile.base()].water;
 		} else if constexpr (Type == TileType::Industry) {
 			return extended_tiles[this->tile.base()].industry;
+		} else if constexpr (Type == TileType::Object) {
+			return extended_tiles[this->tile.base()].object;
 		}
 	}
 

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -66,6 +66,15 @@ private:
 		uint8_t animation_loop = 0; ///< The state of the animation loop.
 	};
 
+	/** Storage for TileType::TunnelBridge tile base. */
+	struct TunnelBridgeTileBase : TileBaseCommon {
+	private:
+		[[maybe_unused]] uint8_t bit_offset : 4 = 0; ///< Unused. @note Prevents save conversion.
+	public:
+		uint8_t tram_owner : 4 = 0; ///< The owner of the tram track.
+		uint8_t road_type : 6 = 0; ///< The type of road.
+	};
+
 	/** Storage for TileType::Object tile base. */
 	struct ObjectTileBase : TileBaseCommon {
 		uint8_t random_bits = 0; ///< NewGRF random bits.
@@ -90,6 +99,7 @@ private:
 		TreesTileBase trees; ///< Storage for tiles with trees.
 		WaterTileBase water; ///< Storage for tiles with: canal, river, sea, shore etc.
 		IndustryTileBase industry; ///< Storage for tiles with parts of industries.
+		TunnelBridgeTileBase tunnel_bridge; ///< Storage for tiles with tunnel exit or bridge head.
 		ObjectTileBase object; ///< Storage for tiles with object e.g. transmitters, lighthouses, owned land.
 		OldTileBase old; ///< Used to preserve compatibility with older save games.
 
@@ -183,6 +193,28 @@ private:
 		uint8_t animation_frame = 0; ///< The frame of animation.
 	};
 
+	/** Storage for TileType::TunnelBridge tile extended. */
+	struct TunnelBridgeTileExtended : TileExtendedCommon {
+		uint8_t direction : 2 = 0; ///< The direction onto the bridge / out of the tunnel.
+		uint8_t transport_type : 2 = 0; ///< What kind of vehicles can enter the bridge / tunnel.
+		uint8_t pbs_reservation : 1 = 0; ///< The pbs reservation state for railway.
+	private:
+		[[maybe_unused]] uint8_t bit_offset_1 : 2 = 0; ///< Unused. @note Prevents save conversion.
+	public:
+		uint8_t is_bridge : 1 = 0; ///< Whether it is a bridge or a tunnel.
+	private:
+		[[maybe_unused]] uint16_t bit_offset_2 = 0; ///< Unused. @note Prevents save conversion.
+		[[maybe_unused]] uint8_t bit_offset_3 : 2 = 0; ///< Unused. @note These bits are reserved for animated tile state.
+	public:
+		uint8_t bridge_type : 4 = 0; ///< The type of bridge. Unused for tunnels.
+		/* 2 bit offset is auto added by the compiler, because road_owner can't fit into those 2 bits. */
+		uint8_t road_owner : 5 = 0; ///< The owner of the road.
+		uint8_t snow_desert_presence : 1 = 0; ///< If set it is surrounded by snow or sand depending on the biome.
+		/* 2 bit offset is auto added by the compiler, because road_owner can't fit into those 2 bits. */
+		uint16_t rail_type : 6 = 0; ///< The track type for railway.
+		uint16_t tram_type : 6 = 0; ///< The type of tram track.
+	};
+
 	/** Storage for TileType::Object tile extended. */
 	struct ObjectTileExtended : TileExtendedCommon {
 		uint8_t index_high_bits = 0; ///< High bits of object index on the poll.
@@ -214,6 +246,7 @@ private:
 		WaterTileExtended water; ///< Storage for tiles with water except ship depot.
 		ShipDepotTileExtended ship_depot; ///< Storage for ship depot.
 		IndustryTileExtended industry; ///< Storage for tiles with parts of industries.
+		TunnelBridgeTileExtended tunnel_bridge; ///< Storage for tiles with tunnel exits or bridge heads.
 		ObjectTileExtended object; ///< Storage for tiles with object e.g. transmitters, lighthouses, owned land.
 		OldTileExtended old; ///< Used to preserve compatibility with older save games.
 
@@ -307,6 +340,8 @@ public:
 			return base_tiles[this->tile.base()].water;
 		} else if constexpr (Type == TileType::Industry) {
 			return base_tiles[this->tile.base()].industry;
+		} else if constexpr (Type == TileType::TunnelBridge) {
+			return base_tiles[this->tile.base()].tunnel_bridge;
 		} else if constexpr (Type == TileType::Object) {
 			return base_tiles[this->tile.base()].object;
 		}
@@ -331,6 +366,8 @@ public:
 			return extended_tiles[this->tile.base()].water;
 		} else if constexpr (Type == TileType::Industry) {
 			return extended_tiles[this->tile.base()].industry;
+		} else if constexpr (Type == TileType::TunnelBridge) {
+			return extended_tiles[this->tile.base()].tunnel_bridge;
 		} else if constexpr (Type == TileType::Object) {
 			return extended_tiles[this->tile.base()].object;
 		}

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -81,6 +81,7 @@ private:
 
 	/** Common tile extended for all animated tiles. */
 	struct TileExtendedAnimatedCommon : TileExtendedCommon {
+		friend class Tile;
 	private:
 		/** Unused. Needs to be splited into two parts, because some compilers (like MSVC) can't fill bits from uint32_t with other types. @note Prevents save conversion. */
 		[[maybe_unused]] uint8_t bit_offset_1 = 0;
@@ -314,6 +315,8 @@ public:
 	{
 		return extended_tiles[this->tile.base()].old.m8;
 	}
+
+	void RunUnitTest();
 };
 
 /**

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -48,6 +48,11 @@ private:
 		uint8_t hedge_SW : 3 = 0; ///< Type of hedge on SW border.
 	};
 
+	/** Storage for TileType::Trees tile base. */
+	struct TreesTileBase : TileBaseCommon {
+		uint8_t tree_type = 0; ///< The type of trees.
+	};
+
 	/** Storage for TileType::Water tile base. */
 	struct WaterTileBase : TileBaseCommon {
 		uint8_t flood : 1 = 0; ///< Non-flooding state.
@@ -82,6 +87,7 @@ private:
 		uint32_t base; ///< Bare access to all bits, useful for saving, loading and constructing map array.
 		TileBaseCommon common; ///< Common storage for all tile bases.
 		ClearTileBase clear; ///< Storage for tiles with: grass, snow, sand etc.
+		TreesTileBase trees; ///< Storage for tiles with trees.
 		WaterTileBase water; ///< Storage for tiles with: canal, river, sea, shore etc.
 		IndustryTileBase industry; ///< Storage for tiles with parts of industries.
 		ObjectTileBase object; ///< Storage for tiles with object e.g. transmitters, lighthouses, owned land.
@@ -121,6 +127,20 @@ private:
 		[[maybe_unused]] uint8_t bit_offset : 2 = 0; ///< Unused. @note These bits are reserved for animated tile state.
 	public:
 		uint8_t hedge_NW : 3 = 0; ///< Type of hedge on NW border.
+	};
+
+	/** Storage for TileType::Trees tile extended. */
+	struct TreesTileExtended : TileExtendedCommon {
+		uint8_t growth : 3 = 0; ///< The trees growth status.
+	private:
+		[[maybe_unused]] uint8_t bit_offset_1 : 3 = 0; ///< Unused. @note Prevents save conversion.
+	public:
+		uint8_t quantity : 2 = 0; ///< The number of trees minus one.
+	private:
+		[[maybe_unused]] uint16_t bit_offset_2 : 4 = 0; ///< Unused, previously tree counter. @note Prevents save conversion.
+	public:
+		uint16_t density : 2 = 0; ///< The density of the ground under trees.
+		uint16_t ground : 3 = 0; ///< The ground under trees.
 	};
 
 	/** Storage for TileType::Water tile extended. */
@@ -190,6 +210,7 @@ private:
 		uint64_t base; ///< Bare access to all bits, useful for saving, loading and constructing map array.
 		TileExtendedAnimatedCommon common; ///< Common storage for all tile extends.
 		ClearTileExtended clear; ///< Storage for tiles with: grass, snow, sand etc.
+		TreesTileExtended trees; ///< Storage for tiles with trees.
 		WaterTileExtended water; ///< Storage for tiles with water except ship depot.
 		ShipDepotTileExtended ship_depot; ///< Storage for ship depot.
 		IndustryTileExtended industry; ///< Storage for tiles with parts of industries.
@@ -280,6 +301,8 @@ public:
 			return base_tiles[this->tile.base()].common;
 		} else if constexpr (Type == TileType::Clear) {
 			return base_tiles[this->tile.base()].clear;
+		} else if constexpr (Type == TileType::Trees) {
+			return base_tiles[this->tile.base()].trees;
 		} else if constexpr (Type == TileType::Water) {
 			return base_tiles[this->tile.base()].water;
 		} else if constexpr (Type == TileType::Industry) {
@@ -302,6 +325,8 @@ public:
 			return extended_tiles[this->tile.base()].common;
 		} else if constexpr (Type == TileType::Clear) {
 			return extended_tiles[this->tile.base()].clear;
+		} else if constexpr (Type == TileType::Trees) {
+			return extended_tiles[this->tile.base()].trees;
 		} else if constexpr (Type == TileType::Water) {
 			return extended_tiles[this->tile.base()].water;
 		} else if constexpr (Type == TileType::Industry) {

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -343,7 +343,7 @@ public:
 	}
 
 	/**
-	 * Gets the maximum X coordinate within the map, including MP_VOID
+	 * Gets the maximum X coordinate within the map, including TileType::Void
 	 * @return the maximum X coordinate
 	 */
 	[[debug_inline]] inline static uint MaxX()
@@ -352,7 +352,7 @@ public:
 	}
 
 	/**
-	 * Gets the maximum Y coordinate within the map, including MP_VOID
+	 * Gets the maximum Y coordinate within the map, including TileType::Void
 	 * @return the maximum Y coordinate
 	 */
 	static inline uint MaxY()

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -112,7 +112,7 @@ StationGfx GetTranslatedAirportTileID(StationGfx gfx)
 static uint32_t GetNearbyAirportTileInformation(uint8_t parameter, TileIndex tile, StationID index, bool grf_version8)
 {
 	if (parameter != 0) tile = GetNearbyTile(parameter, tile); // only perform if it is required
-	bool is_same_airport = (IsTileType(tile, MP_STATION) && IsAirport(tile) && GetStationIndex(tile) == index);
+	bool is_same_airport = (IsTileType(tile, TileType::Station) && IsAirport(tile) && GetStationIndex(tile) == index);
 
 	return GetNearbyTileInformation(tile, grf_version8) | (is_same_airport ? 1 : 0) << 8;
 }

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -55,7 +55,7 @@ struct CanalResolverObject : public ResolverObject {
 /* virtual */ uint32_t CanalScopeResolver::GetRandomBits() const
 {
 	/* Return random bits only for water tiles, not station tiles */
-	return IsTileType(this->tile, MP_WATER) ? GetWaterTileRandomBits(this->tile) : 0;
+	return IsTileType(this->tile, TileType::Water) ? GetWaterTileRandomBits(this->tile) : 0;
 }
 
 /* virtual */ uint32_t CanalScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const
@@ -65,7 +65,7 @@ struct CanalResolverObject : public ResolverObject {
 		case 0x80: {
 			int z = GetTileZ(this->tile);
 			/* Return consistent height within locks */
-			if (IsTileType(this->tile, MP_WATER) && IsLock(this->tile) && GetLockPart(this->tile) == LockPart::Upper) z--;
+			if (IsTileType(this->tile, TileType::Water) && IsLock(this->tile) && GetLockPart(this->tile) == LockPart::Upper) z--;
 			return z;
 		}
 
@@ -96,7 +96,7 @@ struct CanalResolverObject : public ResolverObject {
 		}
 
 		/* Random data for river or canal tiles, otherwise zero */
-		case 0x83: return IsTileType(this->tile, MP_WATER) ? GetWaterTileRandomBits(this->tile) : 0;
+		case 0x83: return IsTileType(this->tile, TileType::Water) ? GetWaterTileRandomBits(this->tile) : 0;
 	}
 
 	Debug(grf, 1, "Unhandled canal variable 0x{:02X}", variable);

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -337,13 +337,13 @@ uint32_t GetTerrainType(TileIndex tile, TileContext context)
 		case LandscapeType::Arctic: {
 			bool has_snow;
 			switch (GetTileType(tile)) {
-				case MP_CLEAR:
+				case TileType::Clear:
 					/* During map generation the snowstate may not be valid yet, as the tileloop may not have run yet. */
 					if (_generating_world) goto genworld;
 					has_snow = IsSnowTile(tile) && GetClearDensity(tile) >= 2;
 					break;
 
-				case MP_RAILWAY: {
+				case TileType::Railway: {
 					/* During map generation the snowstate may not be valid yet, as the tileloop may not have run yet. */
 					if (_generating_world) goto genworld; // we do not care about foundations here
 					RailGroundType ground = GetRailGroundType(tile);
@@ -351,13 +351,13 @@ uint32_t GetTerrainType(TileIndex tile, TileContext context)
 					break;
 				}
 
-				case MP_ROAD:
+				case TileType::Road:
 					/* During map generation the snowstate may not be valid yet, as the tileloop may not have run yet. */
 					if (_generating_world) goto genworld; // we do not care about foundations here
 					has_snow = IsOnSnowOrDesert(tile);
 					break;
 
-				case MP_TREES: {
+				case TileType::Trees: {
 					/* During map generation the snowstate may not be valid yet, as the tileloop may not have run yet. */
 					if (_generating_world) goto genworld;
 					TreeGround ground = GetTreeGround(tile);
@@ -365,7 +365,7 @@ uint32_t GetTerrainType(TileIndex tile, TileContext context)
 					break;
 				}
 
-				case MP_TUNNELBRIDGE:
+				case TileType::TunnelBridge:
 					if (context == TCX_ON_BRIDGE) {
 						has_snow = (GetBridgeHeight(tile) > GetSnowLine());
 					} else {
@@ -375,16 +375,16 @@ uint32_t GetTerrainType(TileIndex tile, TileContext context)
 					}
 					break;
 
-				case MP_STATION:
-				case MP_HOUSE:
-				case MP_INDUSTRY:
-				case MP_OBJECT:
+				case TileType::Station:
+				case TileType::House:
+				case TileType::Industry:
+				case TileType::Object:
 					/* These tiles usually have a levelling foundation. So use max Z */
 					has_snow = (GetTileMaxZ(tile) > GetSnowLine());
 					break;
 
-				case MP_VOID:
-				case MP_WATER:
+				case TileType::Void:
+				case TileType::Water:
 				genworld:
 					has_snow = (GetTileZ(tile) > GetSnowLine());
 					break;
@@ -433,16 +433,16 @@ uint32_t GetNearbyTileInformation(TileIndex tile, bool grf_version8)
 	TileType tile_type = GetTileType(tile);
 
 	/* Fake tile type for trees on shore */
-	if (IsTileType(tile, MP_TREES) && GetTreeGround(tile) == TREE_GROUND_SHORE) tile_type = MP_WATER;
+	if (IsTileType(tile, TileType::Trees) && GetTreeGround(tile) == TREE_GROUND_SHORE) tile_type = TileType::Water;
 
 	/* Fake tile type for road waypoints */
-	if (IsRoadWaypointTile(tile)) tile_type = MP_ROAD;
+	if (IsRoadWaypointTile(tile)) tile_type = TileType::Road;
 
 	auto [tileh, z] = GetTilePixelSlope(tile);
 	/* Return 0 if the tile is a land tile */
-	uint8_t terrain_type = (HasTileWaterClass(tile) ? (to_underlying(GetWaterClass(tile)) + 1) & 3 : 0) << 5 | GetTerrainType(tile) << 2 | (tile_type == MP_WATER ? 1 : 0) << 1;
+	uint8_t terrain_type = (HasTileWaterClass(tile) ? (to_underlying(GetWaterClass(tile)) + 1) & 3 : 0) << 5 | GetTerrainType(tile) << 2 | (tile_type == TileType::Water ? 1 : 0) << 1;
 	if (grf_version8) z /= TILE_HEIGHT;
-	return tile_type << 24 | ClampTo<uint8_t>(z) << 16 | terrain_type << 8 | tileh;
+	return to_underlying(tile_type) << 24 | ClampTo<uint8_t>(z) << 16 | terrain_type << 8 | tileh;
 }
 
 /**

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -761,13 +761,13 @@ GrfSpecFeature GetGrfSpecFeature(TileIndex tile)
 {
 	switch (GetTileType(tile)) {
 		default:              return GSF_INVALID;
-		case MP_RAILWAY:      return GSF_RAILTYPES;
-		case MP_ROAD:         return IsLevelCrossing(tile) ? GSF_RAILTYPES : GSF_ROADTYPES;
-		case MP_HOUSE:        return GSF_HOUSES;
-		case MP_INDUSTRY:     return GSF_INDUSTRYTILES;
-		case MP_OBJECT:       return GSF_OBJECTS;
+		case TileType::Railway:      return GSF_RAILTYPES;
+		case TileType::Road:         return IsLevelCrossing(tile) ? GSF_RAILTYPES : GSF_ROADTYPES;
+		case TileType::House:        return GSF_HOUSES;
+		case TileType::Industry:     return GSF_INDUSTRYTILES;
+		case TileType::Object:       return GSF_OBJECTS;
 
-		case MP_STATION:
+		case TileType::Station:
 			switch (GetStationType(tile)) {
 				case StationType::Rail:    return GSF_STATIONS;
 				case StationType::Airport: return GSF_AIRPORTTILES;

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -237,7 +237,7 @@ std::pair<const GRFFile *, uint16_t> GetAiPurchaseCallbackResult(GrfSpecFeature 
  */
 void AmbientSoundEffectCallback(TileIndex tile)
 {
-	assert(IsTileType(tile, MP_CLEAR) || IsTileType(tile, MP_TREES) || IsTileType(tile, MP_WATER));
+	assert(IsTileType(tile, TileType::Clear) || IsTileType(tile, TileType::Trees) || IsTileType(tile, TileType::Water));
 
 	/* Only run every 1/200-th time. */
 	uint32_t r; // Save for later
@@ -247,8 +247,8 @@ void AmbientSoundEffectCallback(TileIndex tile)
 	GenericResolverObject object(false, CBID_SOUNDS_AMBIENT_EFFECT);
 	object.generic_scope.feature = GSF_SOUNDFX;
 
-	uint32_t param1_v7 = GetTileType(tile) << 28 | Clamp(TileHeight(tile), 0, 15) << 24 | GB(r, 16, 8) << 16 | GetTerrainType(tile);
-	uint32_t param1_v8 = GetTileType(tile) << 24 | GetTileZ(tile) << 16 | GB(r, 16, 8) << 8 | (HasTileWaterClass(tile) ? to_underlying(GetWaterClass(tile)) : 0) << 3 | GetTerrainType(tile);
+	uint32_t param1_v7 = to_underlying(GetTileType(tile)) << 28 | Clamp(TileHeight(tile), 0, 15) << 24 | GB(r, 16, 8) << 16 | GetTerrainType(tile);
+	uint32_t param1_v8 = to_underlying(GetTileType(tile)) << 24 | GetTileZ(tile) << 16 | GB(r, 16, 8) << 8 | (HasTileWaterClass(tile) ? to_underlying(GetWaterClass(tile)) : 0) << 3 | GetTerrainType(tile);
 
 	/* Run callback. */
 	auto callback = GetGenericCallbackResult(GSF_SOUNDFX, object, param1_v7, param1_v8);

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -112,7 +112,7 @@ HouseResolverObject::HouseResolverObject(HouseID house_id, TileIndex tile, Town 
 	town_scope(*this, town, not_yet_constructed) // Don't access StorePSA if house is not yet constructed.
 {
 	/* Tile must be valid and a house tile, unless not yet constructed in which case it may also be INVALID_TILE. */
-	assert((IsValidTile(tile) && (not_yet_constructed || IsTileType(tile, MP_HOUSE))) || (not_yet_constructed && tile == INVALID_TILE));
+	assert((IsValidTile(tile) && (not_yet_constructed || IsTileType(tile, TileType::House))) || (not_yet_constructed && tile == INVALID_TILE));
 
 	this->root_spritegroup = HouseSpec::Get(house_id)->grf_prop.GetSpriteGroup(!not_yet_constructed);
 }
@@ -277,7 +277,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 	const auto start_north_tile = start_tile + GetHouseNorthPart(start_house); // modifies 'start_house'!
 
 	for (auto tile : SpiralTileSequence(start_tile, 2 * searchradius + 1)) {
-		if (!IsTileType(tile, MP_HOUSE)) continue;
+		if (!IsTileType(tile, TileType::House)) continue;
 		HouseID house = GetHouseType(tile);
 		const HouseSpec *hs = HouseSpec::Get(house);
 		if (!hs->grf_prop.HasGrfFile()) continue; // must be one from a grf file
@@ -339,10 +339,10 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 
 	switch (variable) {
 		/* Construction stage. */
-		case 0x40: return (IsTileType(this->tile, MP_HOUSE) ? GetHouseBuildingStage(this->tile) : 0) | TileHash2Bit(TileX(this->tile), TileY(this->tile)) << 2;
+		case 0x40: return (IsTileType(this->tile, TileType::House) ? GetHouseBuildingStage(this->tile) : 0) | TileHash2Bit(TileX(this->tile), TileY(this->tile)) << 2;
 
 		/* Building age. */
-		case 0x41: return IsTileType(this->tile, MP_HOUSE) ? GetHouseAge(this->tile).base() : 0;
+		case 0x41: return IsTileType(this->tile, TileType::House) ? GetHouseAge(this->tile).base() : 0;
 
 		/* Town zone */
 		case 0x42: return to_underlying(GetTownRadiusGroup(this->town, this->tile));
@@ -357,7 +357,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 		case 0x45: return _generating_world ? 1 : 0;
 
 		/* Current animation frame. */
-		case 0x46: return IsTileType(this->tile, MP_HOUSE) ? GetAnimationFrame(this->tile) : 0;
+		case 0x46: return IsTileType(this->tile, TileType::House) ? GetAnimationFrame(this->tile) : 0;
 
 		/* Position of the house */
 		case 0x47: return TileY(this->tile) << 16 | TileX(this->tile);
@@ -380,7 +380,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 		/* Current animation frame of nearby house tiles */
 		case 0x63: {
 			TileIndex testtile = GetNearbyTile(parameter, this->tile);
-			return IsTileType(testtile, MP_HOUSE) ? GetAnimationFrame(testtile) : 0;
+			return IsTileType(testtile, TileType::House) ? GetAnimationFrame(testtile) : 0;
 		}
 
 		/* Cargo acceptance history of nearby stations */
@@ -413,7 +413,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 		/* Class and ID of nearby house tile */
 		case 0x66: {
 			TileIndex testtile = GetNearbyTile(parameter, this->tile);
-			if (!IsTileType(testtile, MP_HOUSE)) return 0xFFFFFFFF;
+			if (!IsTileType(testtile, TileType::House)) return 0xFFFFFFFF;
 			HouseID nearby_house_id = GetHouseType(testtile);
 			HouseSpec *hs = HouseSpec::Get(nearby_house_id);
 			/* Information about the grf local classid if the house has a class */
@@ -436,7 +436,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 		/* GRFID of nearby house tile */
 		case 0x67: {
 			TileIndex testtile = GetNearbyTile(parameter, this->tile);
-			if (!IsTileType(testtile, MP_HOUSE)) return 0xFFFFFFFF;
+			if (!IsTileType(testtile, TileType::House)) return 0xFFFFFFFF;
 			HouseID house_id = GetHouseType(testtile);
 			if (house_id < NEW_HOUSE_OFFSET) return 0;
 			/* Checking the grffile information via HouseSpec doesn't work
@@ -662,7 +662,7 @@ bool NewHouseTileLoop(TileIndex tile)
 static void DoTriggerHouseRandomisation(TileIndex tile, HouseRandomTrigger trigger, uint8_t base_random, bool first)
 {
 	/* We can't trigger a non-existent building... */
-	assert(IsTileType(tile, MP_HOUSE));
+	assert(IsTileType(tile, TileType::House));
 
 	HouseID hid = GetHouseType(tile);
 	HouseSpec *hs = HouseSpec::Get(hid);
@@ -731,11 +731,11 @@ static void DoTriggerHouseAnimation_WatchedCargoAccepted(TileIndex tile, TileInd
  * Run watched cargo accepted callback for a house.
  * @param tile House tile.
  * @param trigger_cargoes Triggering cargo types.
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  */
 void TriggerHouseAnimation_WatchedCargoAccepted(TileIndex tile, CargoTypes trigger_cargoes)
 {
-	assert(IsTileType(tile, MP_HOUSE));
+	assert(IsTileType(tile, TileType::House));
 	HouseID id = GetHouseType(tile);
 	const HouseSpec *hs = HouseSpec::Get(id);
 

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -35,7 +35,7 @@
 uint32_t GetNearbyIndustryTileInformation(uint8_t parameter, TileIndex tile, IndustryID index, bool signed_offsets, bool grf_version8)
 {
 	if (parameter != 0) tile = GetNearbyTile(parameter, tile, signed_offsets); // only perform if it is required
-	bool is_same_industry = (IsTileType(tile, MP_INDUSTRY) && GetIndustryIndex(tile) == index);
+	bool is_same_industry = (IsTileType(tile, TileType::Industry) && GetIndustryIndex(tile) == index);
 
 	return GetNearbyTileInformation(tile, grf_version8) | (is_same_industry ? 1 : 0) << 8;
 }
@@ -63,7 +63,7 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 {
 	switch (variable) {
 		/* Construction state of the tile: a value between 0 and 3 */
-		case 0x40: return (IsTileType(this->tile, MP_INDUSTRY)) ? GetIndustryConstructionStage(this->tile) : 0;
+		case 0x40: return (IsTileType(this->tile, TileType::Industry)) ? GetIndustryConstructionStage(this->tile) : 0;
 
 		/* Terrain type */
 		case 0x41: return GetTerrainType(this->tile);
@@ -75,7 +75,7 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 		case 0x43: return GetRelativePosition(this->tile, this->industry->location.tile);
 
 		/* Animation frame. Like house variable 46 but can contain anything 0..FF. */
-		case 0x44: return IsTileType(this->tile, MP_INDUSTRY) ? GetAnimationFrame(this->tile) : 0;
+		case 0x44: return IsTileType(this->tile, TileType::Industry) ? GetAnimationFrame(this->tile) : 0;
 
 		/* Land info of nearby tiles */
 		case 0x60: return GetNearbyIndustryTileInformation(parameter, this->tile,
@@ -84,7 +84,7 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 		/* Animation stage of nearby tiles */
 		case 0x61: {
 			TileIndex tile = GetNearbyTile(parameter, this->tile);
-			if (IsTileType(tile, MP_INDUSTRY) && Industry::GetByTile(tile) == this->industry) {
+			if (IsTileType(tile, TileType::Industry) && Industry::GetByTile(tile) == this->industry) {
 				return GetAnimationFrame(tile);
 			}
 			return UINT_MAX;
@@ -105,7 +105,7 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 /* virtual */ uint32_t IndustryTileScopeResolver::GetRandomBits() const
 {
 	assert(this->industry != nullptr && IsValidTile(this->tile));
-	assert(this->industry->index == IndustryID::Invalid() || IsTileType(this->tile, MP_INDUSTRY));
+	assert(this->industry->index == IndustryID::Invalid() || IsTileType(this->tile, TileType::Industry));
 
 	return (this->industry->index != IndustryID::Invalid()) ? GetIndustryRandomBits(this->tile) : 0;
 }
@@ -113,7 +113,7 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 /* virtual */ uint32_t IndustryTileScopeResolver::GetRandomTriggers() const
 {
 	assert(this->industry != nullptr && IsValidTile(this->tile));
-	assert(this->industry->index == IndustryID::Invalid() || IsTileType(this->tile, MP_INDUSTRY));
+	assert(this->industry->index == IndustryID::Invalid() || IsTileType(this->tile, TileType::Industry));
 	if (this->industry->index == IndustryID::Invalid()) return 0;
 	return GetIndustryRandomTriggers(this->tile).base();
 }
@@ -182,7 +182,7 @@ static void IndustryDrawTileLayout(const TileInfo *ti, const DrawTileSpriteSpan 
 uint16_t GetIndustryTileCallback(CallbackID callback, uint32_t param1, uint32_t param2, IndustryGfx gfx_id, Industry *industry, TileIndex tile, std::span<int32_t> regs100)
 {
 	assert(industry != nullptr && IsValidTile(tile));
-	assert(industry->index == IndustryID::Invalid() || IsTileType(tile, MP_INDUSTRY));
+	assert(industry->index == IndustryID::Invalid() || IsTileType(tile, TileType::Industry));
 
 	IndustryTileResolverObject object(gfx_id, tile, industry, callback, param1, param2);
 	return object.ResolveCallback(regs100);
@@ -322,7 +322,7 @@ bool TriggerIndustryAnimation(const Industry *ind, IndustryAnimationTrigger iat)
  */
 static void DoTriggerIndustryTileRandomisation(TileIndex tile, IndustryRandomTrigger trigger, Industry *ind, uint32_t &reseed_industry)
 {
-	assert(IsValidTile(tile) && IsTileType(tile, MP_INDUSTRY));
+	assert(IsValidTile(tile) && IsTileType(tile, TileType::Industry));
 
 	IndustryGfx gfx = GetIndustryGfx(tile);
 	const IndustryTileSpec *itspec = GetIndustryTileSpec(gfx);

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -158,7 +158,7 @@ template class NewGRFClass<ObjectSpec, ObjectClassID, OBJECT_CLASS_MAX>;
 
 /* virtual */ uint32_t ObjectScopeResolver::GetRandomBits() const
 {
-	return IsValidTile(this->tile) && IsTileType(this->tile, MP_OBJECT) ? GetObjectRandomBits(this->tile) : 0;
+	return IsValidTile(this->tile) && IsTileType(this->tile, TileType::Object) ? GetObjectRandomBits(this->tile) : 0;
 }
 
 /**
@@ -169,7 +169,7 @@ template class NewGRFClass<ObjectSpec, ObjectClassID, OBJECT_CLASS_MAX>;
  */
 static uint32_t GetObjectIDAtOffset(TileIndex tile, uint32_t cur_grfid)
 {
-	if (!IsTileType(tile, MP_OBJECT)) {
+	if (!IsTileType(tile, TileType::Object)) {
 		return 0xFFFF;
 	}
 
@@ -199,7 +199,7 @@ static uint32_t GetObjectIDAtOffset(TileIndex tile, uint32_t cur_grfid)
 static uint32_t GetNearbyObjectTileInformation(uint8_t parameter, TileIndex tile, ObjectID index, bool grf_version8)
 {
 	if (parameter != 0) tile = GetNearbyTile(parameter, tile); // only perform if it is required
-	bool is_same_object = (IsTileType(tile, MP_OBJECT) && GetObjectIndex(tile) == index);
+	bool is_same_object = (IsTileType(tile, TileType::Object) && GetObjectIndex(tile) == index);
 
 	return GetNearbyTileInformation(tile, grf_version8) | (is_same_object ? 1 : 0) << 8;
 }
@@ -349,7 +349,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 		/* Get random tile bits at offset param */
 		case 0x61: {
 			TileIndex tile = GetNearbyTile(parameter, this->tile);
-			return (IsTileType(tile, MP_OBJECT) && Object::GetByTile(tile) == this->obj) ? GetObjectRandomBits(tile) : 0;
+			return (IsTileType(tile, TileType::Object) && Object::GetByTile(tile) == this->obj) ? GetObjectRandomBits(tile) : 0;
 		}
 
 		/* Land info of nearby tiles */
@@ -358,7 +358,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 		/* Animation counter of nearby tile */
 		case 0x63: {
 			TileIndex tile = GetNearbyTile(parameter, this->tile);
-			return (IsTileType(tile, MP_OBJECT) && Object::GetByTile(tile) == this->obj) ? GetAnimationFrame(tile) : 0;
+			return (IsTileType(tile, TileType::Object) && Object::GetByTile(tile) == this->obj) ? GetAnimationFrame(tile) : 0;
 		}
 
 		/* Count of object, distance of closest instance */

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -212,23 +212,23 @@ void ConvertRailTypes()
 
 	for (const auto t : Map::Iterate()) {
 		switch (GetTileType(t)) {
-			case MP_RAILWAY:
+			case TileType::Railway:
 				SetRailType(t, railtype_conversion_map[GetRailType(t)]);
 				break;
 
-			case MP_ROAD:
+			case TileType::Road:
 				if (IsLevelCrossing(t)) {
 					SetRailType(t, railtype_conversion_map[GetRailType(t)]);
 				}
 				break;
 
-			case MP_STATION:
+			case TileType::Station:
 				if (HasStationRail(t)) {
 					SetRailType(t, railtype_conversion_map[GetRailType(t)]);
 				}
 				break;
 
-			case MP_TUNNELBRIDGE:
+			case TileType::TunnelBridge:
 				if (GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL) {
 					SetRailType(t, railtype_conversion_map[GetRailType(t)]);
 				}

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -241,19 +241,19 @@ void ConvertRoadTypes()
 
 	for (TileIndex t : Map::Iterate()) {
 		switch (GetTileType(t)) {
-			case MP_ROAD:
+			case TileType::Road:
 				if (RoadType rt = GetRoadTypeRoad(t); rt != INVALID_ROADTYPE) SetRoadTypeRoad(t, roadtype_conversion_map[rt]);
 				if (RoadType rt = GetRoadTypeTram(t); rt != INVALID_ROADTYPE) SetRoadTypeTram(t, roadtype_conversion_map[rt]);
 				break;
 
-			case MP_STATION:
+			case TileType::Station:
 				if (IsAnyRoadStop(t)) {
 					if (RoadType rt = GetRoadTypeRoad(t); rt != INVALID_ROADTYPE) SetRoadTypeRoad(t, roadtype_conversion_map[rt]);
 					if (RoadType rt = GetRoadTypeTram(t); rt != INVALID_ROADTYPE) SetRoadTypeTram(t, roadtype_conversion_map[rt]);
 				}
 				break;
 
-			case MP_TUNNELBRIDGE:
+			case TileType::TunnelBridge:
 				if (GetTunnelBridgeTransportType(t) == TRANSPORT_ROAD) {
 					if (RoadType rt = GetRoadTypeRoad(t); rt != INVALID_ROADTYPE) SetRoadTypeRoad(t, roadtype_conversion_map[rt]);
 					if (RoadType rt = GetRoadTypeTram(t); rt != INVALID_ROADTYPE) SetRoadTypeTram(t, roadtype_conversion_map[rt]);

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -167,7 +167,7 @@ static TileIndex FindRailStationEnd(TileIndex tile, TileIndexDiff delta, bool ch
 	for (;;) {
 		TileIndex new_tile = TileAdd(tile, delta);
 
-		if (!IsTileType(new_tile, MP_STATION) || GetStationIndex(new_tile) != sid) break;
+		if (!IsTileType(new_tile, TileType::Station) || GetStationIndex(new_tile) != sid) break;
 		if (!HasStationRail(new_tile)) break;
 		if (check_type && GetCustomStationSpecIndex(new_tile) != orig_type) break;
 		if (check_axis && GetRailStationAxis(new_tile) != orig_axis) break;
@@ -222,7 +222,7 @@ static uint32_t GetRailContinuationInfo(TileIndex tile)
 
 			/* With tunnels and bridges the tile has tracks, but they are not necessarily connected
 			 * with the next tile because the ramp is not going in the right direction. */
-			if (IsTileType(neighbour_tile, MP_TUNNELBRIDGE) && GetTunnelBridgeDirection(neighbour_tile) != *diagdir) {
+			if (IsTileType(neighbour_tile, TileType::TunnelBridge) && GetTunnelBridgeDirection(neighbour_tile) != *diagdir) {
 				continue;
 			}
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -60,12 +60,12 @@ INSTANTIATE_POOL_METHODS(Object)
 /**
  * Gets the ObjectType of the given object tile
  * @param t the tile to get the type from.
- * @pre IsTileType(t, MP_OBJECT)
+ * @pre IsTileType(t, TileType::Object)
  * @return the type.
  */
 ObjectType GetObjectType(Tile t)
 {
-	assert(IsTileType(t, MP_OBJECT));
+	assert(IsTileType(t, TileType::Object));
 	return Object::GetByTile(t)->type;
 }
 
@@ -265,7 +265,7 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 
 				/* When relocating HQ, allow it to be relocated (partial) on itself. */
 				if (!(type == OBJECT_HQ &&
-						IsTileType(t, MP_OBJECT) &&
+						IsTileType(t, TileType::Object) &&
 						IsTileOwner(t, _current_company) &&
 						IsObjectType(t, OBJECT_HQ))) {
 					cost.AddCost(Command<CMD_LANDSCAPE_CLEAR>::Do(DoCommandFlags{flags}.Reset(DoCommandFlag::Execute), t));
@@ -329,7 +329,7 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 			break;
 
 		case OBJECT_OWNED_LAND:
-			if (IsTileType(tile, MP_OBJECT) &&
+			if (IsTileType(tile, TileType::Object) &&
 					IsTileOwner(tile, _current_company) &&
 					IsObjectType(tile, OBJECT_OWNED_LAND)) {
 				return CommandCost(STR_ERROR_YOU_ALREADY_OWN_IT);
@@ -769,11 +769,11 @@ static bool TryBuildLightHouse()
 	}
 
 	/* Only build lighthouses at tiles where the border is sea. */
-	if (!IsTileType(tile, MP_WATER) || GetWaterClass(tile) != WaterClass::Sea) return false;
+	if (!IsTileType(tile, TileType::Water) || GetWaterClass(tile) != WaterClass::Sea) return false;
 
 	for (int j = 0; j < 19; j++) {
 		int h;
-		if (IsTileType(tile, MP_CLEAR) && IsTileFlat(tile, &h) && h <= 2 && !IsBridgeAbove(tile)) {
+		if (IsTileType(tile, TileType::Clear) && IsTileFlat(tile, &h) && h <= 2 && !IsBridgeAbove(tile)) {
 			for (auto t : SpiralTileSequence(tile, 9)) {
 				if (IsObjectTypeTile(t, OBJECT_LIGHTHOUSE)) return false;
 			}
@@ -795,7 +795,7 @@ static bool TryBuildTransmitter()
 {
 	TileIndex tile = RandomTile();
 	int h;
-	if (IsTileType(tile, MP_CLEAR) && IsTileFlat(tile, &h) && h >= 4 && !IsBridgeAbove(tile)) {
+	if (IsTileType(tile, TileType::Clear) && IsTileFlat(tile, &h) && h >= 4 && !IsBridgeAbove(tile)) {
 		for (auto t : SpiralTileSequence(tile, 9)) {
 			if (IsObjectTypeTile(t, OBJECT_TRANSMITTER)) return false;
 		}
@@ -814,12 +814,12 @@ void GenerateObjects()
 	uint num_water_tiles = 0;
 	if (_settings_game.construction.freeform_edges) {
 		for (uint x = 0; x < Map::MaxX(); x++) {
-			if (IsTileType(TileXY(x, 1), MP_WATER)) num_water_tiles++;
-			if (IsTileType(TileXY(x, Map::MaxY() - 1), MP_WATER)) num_water_tiles++;
+			if (IsTileType(TileXY(x, 1), TileType::Water)) num_water_tiles++;
+			if (IsTileType(TileXY(x, Map::MaxY() - 1), TileType::Water)) num_water_tiles++;
 		}
 		for (uint y = 1; y < Map::MaxY() - 1; y++) {
-			if (IsTileType(TileXY(1, y), MP_WATER)) num_water_tiles++;
-			if (IsTileType(TileXY(Map::MaxX() - 1, y), MP_WATER)) num_water_tiles++;
+			if (IsTileType(TileXY(1, y), TileType::Water)) num_water_tiles++;
+			if (IsTileType(TileXY(Map::MaxX() - 1, y), TileType::Water)) num_water_tiles++;
 		}
 	}
 
@@ -834,7 +834,7 @@ void GenerateObjects()
 		/* Scale by map size */
 		if (spec.flags.Test(ObjectFlag::ScaleByWater) && _settings_game.construction.freeform_edges) {
 			/* Scale the amount of lighthouses with the amount of land at the borders.
-			 * The -6 is because the top borders are MP_VOID (-2) and all corners
+			 * The -6 is because the top borders are TileType::Void (-2) and all corners
 			 * are counted twice (-4). */
 			amount = Map::ScaleBySize1D(amount * num_water_tiles) / (2 * Map::MaxY() + 2 * Map::MaxX() - 6);
 		} else if (spec.flags.Test(ObjectFlag::ScaleByWater)) {

--- a/src/object_map.h
+++ b/src/object_map.h
@@ -19,7 +19,7 @@ ObjectType GetObjectType(Tile t);
  * Check whether the object on a tile is of a specific type.
  * @param t Tile to test.
  * @param type Type to test.
- * @pre IsTileType(t, MP_OBJECT)
+ * @pre IsTileType(t, TileType::Object)
  * @return True if type matches.
  */
 inline bool IsObjectType(Tile t, ObjectType type)
@@ -35,30 +35,30 @@ inline bool IsObjectType(Tile t, ObjectType type)
  */
 inline bool IsObjectTypeTile(Tile t, ObjectType type)
 {
-	return IsTileType(t, MP_OBJECT) && GetObjectType(t) == type;
+	return IsTileType(t, TileType::Object) && GetObjectType(t) == type;
 }
 
 /**
  * Get the index of which object this tile is attached to.
  * @param t the tile
- * @pre IsTileType(t, MP_OBJECT)
+ * @pre IsTileType(t, TileType::Object)
  * @return The ObjectID of the object.
  */
 inline ObjectID GetObjectIndex(Tile t)
 {
-	assert(IsTileType(t, MP_OBJECT));
+	assert(IsTileType(t, TileType::Object));
 	return ObjectID(t.m2() | t.m5() << 16);
 }
 
 /**
  * Get the random bits of this tile.
  * @param t The tile to get the bits for.
- * @pre IsTileType(t, MP_OBJECT)
+ * @pre IsTileType(t, TileType::Object)
  * @return The random bits.
  */
 inline uint8_t GetObjectRandomBits(Tile t)
 {
-	assert(IsTileType(t, MP_OBJECT));
+	assert(IsTileType(t, TileType::Object));
 	return t.m3();
 }
 
@@ -73,7 +73,7 @@ inline uint8_t GetObjectRandomBits(Tile t)
  */
 inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, uint8_t random)
 {
-	SetTileType(t, MP_OBJECT);
+	SetTileType(t, TileType::Object);
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
 	t.m2() = index.base();

--- a/src/object_map.h
+++ b/src/object_map.h
@@ -47,7 +47,8 @@ inline bool IsObjectTypeTile(Tile t, ObjectType type)
 inline ObjectID GetObjectIndex(Tile t)
 {
 	assert(IsTileType(t, TileType::Object));
-	return ObjectID(t.m2() | t.m5() << 16);
+	auto &extended = t.GetTileExtendedAs<TileType::Object>();
+	return ObjectID(extended.index_low_bits | extended.index_high_bits << 16);
 }
 
 /**
@@ -59,7 +60,7 @@ inline ObjectID GetObjectIndex(Tile t)
 inline uint8_t GetObjectRandomBits(Tile t)
 {
 	assert(IsTileType(t, TileType::Object));
-	return t.m3();
+	return t.GetTileBaseAs<TileType::Object>().random_bits;
 }
 
 
@@ -74,15 +75,13 @@ inline uint8_t GetObjectRandomBits(Tile t)
 inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, uint8_t random)
 {
 	SetTileType(t, TileType::Object);
+	t.ResetData();
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
-	t.m2() = index.base();
-	t.m3() = random;
-	t.m4() = 0;
-	t.m5() = index.base() >> 16;
-	SB(t.m6(), 2, 6, 0);
-	t.m7() = 0;
-	t.m8() = 0;
+	auto &extended = t.GetTileExtendedAs<TileType::Object>();
+	extended.index_low_bits = index.base();
+	extended.index_high_bits = index.base() >> 16;
+	t.GetTileBaseAs<TileType::Object>().random_bits = random;
 }
 
 #endif /* OBJECT_MAP_H */

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -2105,7 +2105,7 @@ bool ProcessOrders(Vehicle *v)
 
 	/* Check if we've reached a 'via' destination. */
 	if (((v->current_order.IsType(OT_GOTO_STATION) && v->current_order.GetNonStopType().Test(OrderNonStopFlag::NoDestination)) || v->current_order.IsType(OT_GOTO_WAYPOINT)) &&
-			IsTileType(v->tile, MP_STATION) &&
+			IsTileType(v->tile, TileType::Station) &&
 			v->current_order.GetDestination() == GetStationIndex(v->tile)) {
 		v->DeleteUnreachedImplicitOrders();
 		/* We set the last visited station here because we do not want

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -407,10 +407,10 @@ static Order GetOrderCmdFromTile(const Vehicle *v, TileIndex tile)
 	}
 
 	/* check for station or industry with neutral station */
-	if (IsTileType(tile, MP_STATION) || IsTileType(tile, MP_INDUSTRY)) {
+	if (IsTileType(tile, TileType::Station) || IsTileType(tile, TileType::Industry)) {
 		const Station *st = nullptr;
 
-		if (IsTileType(tile, MP_STATION)) {
+		if (IsTileType(tile, TileType::Station)) {
 			st = Station::GetByTile(tile);
 		} else {
 			const Industry *in = Industry::GetByTile(tile);

--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -207,7 +207,7 @@ protected:
 		this->tiles_skipped = 0;
 
 		/* extra handling for tunnels and bridges in our direction */
-		if (IsTileType(this->old_tile, MP_TUNNELBRIDGE)) {
+		if (IsTileType(this->old_tile, TileType::TunnelBridge)) {
 			DiagDirection enterdir = GetTunnelBridgeDirection(this->old_tile);
 			if (enterdir == this->exitdir) {
 				/* we are entering the tunnel / bridge */
@@ -351,7 +351,7 @@ protected:
 		}
 
 		/* tunnel holes and bridge ramps can be entered only from proper direction */
-		if (IsTileType(this->new_tile, MP_TUNNELBRIDGE)) {
+		if (IsTileType(this->new_tile, TileType::TunnelBridge)) {
 			if (IsTunnel(this->new_tile)) {
 				if (!this->is_tunnel) {
 					DiagDirection tunnel_enterdir = GetTunnelBridgeDirection(this->new_tile);

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -35,7 +35,7 @@ protected:
 		TileType    tile_type;
 		RailType    rail_type;
 
-		TILE() : tile(INVALID_TILE), td(INVALID_TRACKDIR), tile_type(MP_VOID), rail_type(INVALID_RAILTYPE) { }
+		TILE() : tile(INVALID_TILE), td(INVALID_TRACKDIR), tile_type(TileType::Void), rail_type(INVALID_RAILTYPE) { }
 
 		TILE(TileIndex tile, Trackdir td) : tile(tile), td(td), tile_type(GetTileType(tile)), rail_type(GetTileRailType(tile)) { }
 	};
@@ -128,7 +128,7 @@ public:
 		if (IsDiagonalTrackdir(trackdir)) {
 			cost += YAPF_TILE_LENGTH;
 			switch (GetTileType(tile)) {
-				case MP_ROAD:
+				case TileType::Road:
 					/* Increase the cost for level crossings */
 					if (IsLevelCrossing(tile)) {
 						cost += Yapf().PfGetSettings().rail_crossing_penalty;
@@ -175,7 +175,7 @@ public:
 	{
 		int cost = 0;
 		/* if there is one-way signal in the opposite direction, then it is not our way */
-		if (IsTileType(tile, MP_RAILWAY)) {
+		if (IsTileType(tile, TileType::Railway)) {
 			bool has_signal_against = HasSignalOnTrackdir(tile, ReverseTrackdir(trackdir));
 			bool has_signal_along = HasSignalOnTrackdir(tile, trackdir);
 			if (has_signal_against && !has_signal_along && IsOnewaySignal(tile, TrackdirToTrack(trackdir))) {
@@ -400,7 +400,7 @@ no_entry_cost: // jump here at the beginning if the node has no parent (it is th
 				/* We will end in this pass (depot is possible target) */
 				end_segment_reason.Set(EndSegmentReason::Depot);
 
-			} else if (cur.tile_type == MP_STATION && IsRailWaypoint(cur.tile)) {
+			} else if (cur.tile_type == TileType::Station && IsRailWaypoint(cur.tile)) {
 				if (v->current_order.IsType(OT_GOTO_WAYPOINT) &&
 						GetStationIndex(cur.tile) == v->current_order.GetDestination() &&
 						!Waypoint::Get(v->current_order.GetDestination().ToStationID())->IsSingleTile()) {
@@ -453,7 +453,7 @@ no_entry_cost: // jump here at the beginning if the node has no parent (it is th
 				/* We will end in this pass (station is possible target) */
 				end_segment_reason.Set(EndSegmentReason::Station);
 
-			} else if (TrackFollower::DoTrackMasking() && cur.tile_type == MP_RAILWAY) {
+			} else if (TrackFollower::DoTrackMasking() && cur.tile_type == TileType::Railway) {
 				/* Searching for a safe tile? */
 				if (HasSignalOnTrackdir(cur.tile, cur.td) && !IsPbsSignal(GetSignalType(cur.tile, TrackdirToTrack(cur.td)))) {
 					end_segment_reason.Set(EndSegmentReason::SafeTile);
@@ -510,7 +510,7 @@ no_entry_cost: // jump here at the beginning if the node has no parent (it is th
 			/* Gather the next tile/trackdir/tile_type/rail_type. */
 			TILE next(follower_local.new_tile, (Trackdir)FindFirstBit(follower_local.new_td_bits));
 
-			if (TrackFollower::DoTrackMasking() && IsTileType(next.tile, MP_RAILWAY)) {
+			if (TrackFollower::DoTrackMasking() && IsTileType(next.tile, TileType::Railway)) {
 				if (HasSignalOnTrackdir(next.tile, next.td) && IsPbsSignal(GetSignalType(next.tile, TrackdirToTrack(next.td)))) {
 					/* Possible safe tile. */
 					end_segment_reason.Set(EndSegmentReason::SafeTile);
@@ -537,7 +537,7 @@ no_entry_cost: // jump here at the beginning if the node has no parent (it is th
 			if (segment_cost > MAX_SEGMENT_COST) {
 				/* Potentially in the infinite loop (or only very long segment?). We should
 				 * not force it to finish prematurely unless we are on a regular tile. */
-				if (IsTileType(follower->new_tile, MP_RAILWAY)) {
+				if (IsTileType(follower->new_tile, TileType::Railway)) {
 					end_segment_reason.Set(EndSegmentReason::SegmentTooLong);
 					break;
 				}

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -61,14 +61,14 @@ protected:
 		if (IsDiagonalTrackdir(trackdir)) {
 			cost += YAPF_TILE_LENGTH;
 			switch (GetTileType(tile)) {
-				case MP_ROAD:
+				case TileType::Road:
 					/* Increase the cost for level crossings */
 					if (IsLevelCrossing(tile)) {
 						cost += Yapf().PfGetSettings().road_crossing_penalty;
 					}
 					break;
 
-				case MP_STATION: {
+				case TileType::Station: {
 					if (IsRoadWaypoint(tile)) break;
 
 					const RoadStop *rs = RoadStop::GetByTile(tile, GetRoadStopType(tile));
@@ -278,7 +278,7 @@ public:
 	inline bool PfDetectDestinationTile(TileIndex tile, Trackdir trackdir)
 	{
 		if (this->dest_station != StationID::Invalid()) {
-			return IsTileType(tile, MP_STATION) &&
+			return IsTileType(tile, TileType::Station) &&
 				GetStationIndex(tile) == this->dest_station &&
 				(this->station_type == GetStationType(tile)) &&
 				(this->non_artic || IsDriveThroughStopTile(tile));

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -389,7 +389,7 @@ public:
 		if (speed_frac > 0) c += YAPF_TILE_LENGTH * (1 + follower->tiles_skipped) * speed_frac / (256 - speed_frac);
 
 		/* Lock penalty. */
-		if (IsTileType(n.GetTile(), MP_WATER) && IsLock(n.GetTile()) && GetLockPart(n.GetTile()) == LockPart::Middle) {
+		if (IsTileType(n.GetTile(), TileType::Water) && IsLock(n.GetTile()) && GetLockPart(n.GetTile()) == LockPart::Middle) {
 			const uint canal_speed = svi->ApplyWaterClassSpeedFrac(svi->max_speed, false);
 			/* Cost is proportional to the vehicle's speed as the vehicle stops in the lock. */
 			c += (TILE_HEIGHT * YAPF_TILE_LENGTH * canal_speed) / 128;

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -24,20 +24,20 @@
 TrackBits GetReservedTrackbits(TileIndex t)
 {
 	switch (GetTileType(t)) {
-		case MP_RAILWAY:
+		case TileType::Railway:
 			if (IsRailDepot(t)) return GetDepotReservationTrackBits(t);
 			if (IsPlainRail(t)) return GetRailReservationTrackBits(t);
 			break;
 
-		case MP_ROAD:
+		case TileType::Road:
 			if (IsLevelCrossing(t)) return GetCrossingReservationTrackBits(t);
 			break;
 
-		case MP_STATION:
+		case TileType::Station:
 			if (HasStationRail(t)) return GetStationReservationTrackBits(t);
 			break;
 
-		case MP_TUNNELBRIDGE:
+		case TileType::TunnelBridge:
 			if (GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL) return GetTunnelBridgeReservationTrackBits(t);
 			break;
 
@@ -91,7 +91,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 	}
 
 	switch (GetTileType(tile)) {
-		case MP_RAILWAY:
+		case TileType::Railway:
 			if (IsPlainRail(tile)) return TryReserveTrack(tile, t);
 			if (IsRailDepot(tile)) {
 				if (!HasDepotReservation(tile)) {
@@ -102,7 +102,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 			}
 			break;
 
-		case MP_ROAD:
+		case TileType::Road:
 			if (IsLevelCrossing(tile) && !HasCrossingReservation(tile)) {
 				SetCrossingReservation(tile, true);
 				UpdateLevelCrossing(tile, false);
@@ -110,7 +110,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 			}
 			break;
 
-		case MP_STATION:
+		case TileType::Station:
 			if (HasStationRail(tile) && !HasStationReservation(tile)) {
 				SetRailStationReservation(tile, true);
 				if (trigger_stations) {
@@ -123,7 +123,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 			}
 			break;
 
-		case MP_TUNNELBRIDGE:
+		case TileType::TunnelBridge:
 			if (GetTunnelBridgeTransportType(tile) == TRANSPORT_RAIL && !GetTunnelBridgeReservationTrackBits(tile)) {
 				SetTunnelBridgeReservation(tile, true);
 				return true;
@@ -154,7 +154,7 @@ void UnreserveRailTrack(TileIndex tile, Track t)
 	}
 
 	switch (GetTileType(tile)) {
-		case MP_RAILWAY:
+		case TileType::Railway:
 			if (IsRailDepot(tile)) {
 				SetDepotReservation(tile, false);
 				MarkTileDirtyByTile(tile);
@@ -163,21 +163,21 @@ void UnreserveRailTrack(TileIndex tile, Track t)
 			if (IsPlainRail(tile)) UnreserveTrack(tile, t);
 			break;
 
-		case MP_ROAD:
+		case TileType::Road:
 			if (IsLevelCrossing(tile)) {
 				SetCrossingReservation(tile, false);
 				UpdateLevelCrossing(tile);
 			}
 			break;
 
-		case MP_STATION:
+		case TileType::Station:
 			if (HasStationRail(tile)) {
 				SetRailStationReservation(tile, false);
 				MarkTileDirtyByTile(tile);
 			}
 			break;
 
-		case MP_TUNNELBRIDGE:
+		case TileType::TunnelBridge:
 			if (GetTunnelBridgeTransportType(tile) == TRANSPORT_RAIL) SetTunnelBridgeReservation(tile, false);
 			break;
 
@@ -246,7 +246,7 @@ static PBSTileInfo FollowReservation(Owner o, RailTypes rts, TileIndex tile, Tra
 		/* Depot tile? Can't continue. */
 		if (IsRailDepotTile(tile)) break;
 		/* Non-pbs signal? Reservation can't continue. */
-		if (IsTileType(tile, MP_RAILWAY) && HasSignalOnTrackdir(tile, trackdir) && !IsPbsSignal(GetSignalType(tile, TrackdirToTrack(trackdir)))) break;
+		if (IsTileType(tile, TileType::Railway) && HasSignalOnTrackdir(tile, trackdir) && !IsPbsSignal(GetSignalType(tile, TrackdirToTrack(trackdir)))) break;
 	}
 
 	return PBSTileInfo(tile, trackdir, false);
@@ -312,7 +312,7 @@ PBSTileInfo FollowTrainReservation(const Train *v, Vehicle **train_on_res)
 				if (ftoti.best != nullptr) *train_on_res = ftoti.best->First();
 			}
 		}
-		if (*train_on_res == nullptr && IsTileType(ftoti.res.tile, MP_TUNNELBRIDGE)) {
+		if (*train_on_res == nullptr && IsTileType(ftoti.res.tile, TileType::TunnelBridge)) {
 			/* The target tile is a bridge/tunnel, also check the other end tile. */
 			CheckTrainsOnTrack(ftoti, GetOtherTunnelBridgeEnd(ftoti.res.tile));
 			if (ftoti.best != nullptr) *train_on_res = ftoti.best->First();
@@ -359,7 +359,7 @@ Train *GetTrainForReservation(TileIndex tile, Track track)
 		}
 
 		/* Special case for bridges/tunnels: check the other end as well. */
-		if (IsTileType(ftoti.res.tile, MP_TUNNELBRIDGE)) {
+		if (IsTileType(ftoti.res.tile, TileType::TunnelBridge)) {
 			CheckTrainsOnTrack(ftoti, GetOtherTunnelBridgeEnd(ftoti.res.tile));
 			if (ftoti.best != nullptr) return ftoti.best;
 		}
@@ -382,7 +382,7 @@ bool IsSafeWaitingPosition(const Train *v, TileIndex tile, Trackdir trackdir, bo
 {
 	if (IsRailDepotTile(tile)) return true;
 
-	if (IsTileType(tile, MP_RAILWAY)) {
+	if (IsTileType(tile, TileType::Railway)) {
 		/* For non-pbs signals, stop on the signal tile. */
 		if (HasSignalOnTrackdir(tile, trackdir) && !IsPbsSignal(GetSignalType(tile, TrackdirToTrack(trackdir)))) return true;
 	}
@@ -406,7 +406,7 @@ bool IsSafeWaitingPosition(const Train *v, TileIndex tile, Trackdir trackdir, bo
 		/* PBS signal on next trackdir? Safe position. */
 		if (HasPbsSignalOnTrackdir(ft.new_tile, td)) return true;
 		/* One-way PBS signal against us? Safe if end-of-line is allowed. */
-		if (IsTileType(ft.new_tile, MP_RAILWAY) && HasSignalOnTrackdir(ft.new_tile, ReverseTrackdir(td)) &&
+		if (IsTileType(ft.new_tile, TileType::Railway) && HasSignalOnTrackdir(ft.new_tile, ReverseTrackdir(td)) &&
 				GetSignalType(ft.new_tile, TrackdirToTrack(td)) == SIGTYPE_PBS_ONEWAY) {
 			return include_line_end;
 		}
@@ -434,7 +434,7 @@ bool IsWaitingPositionFree(const Train *v, TileIndex tile, Trackdir trackdir, bo
 
 	/* Not reserved and depot or not a pbs signal -> free. */
 	if (IsRailDepotTile(tile)) return true;
-	if (IsTileType(tile, MP_RAILWAY) && HasSignalOnTrackdir(tile, trackdir) && !IsPbsSignal(GetSignalType(tile, track))) return true;
+	if (IsTileType(tile, TileType::Railway) && HasSignalOnTrackdir(tile, trackdir) && !IsPbsSignal(GetSignalType(tile, track))) return true;
 
 	/* Check the next tile, it has to be free as well. Do not filter for compatible railtypes
 	 * to make sure we never accidentally join up reservations. */

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -37,19 +37,19 @@ RailType RailTypeInfo::Index() const
 RailType GetTileRailType(Tile tile)
 {
 	switch (GetTileType(tile)) {
-		case MP_RAILWAY:
+		case TileType::Railway:
 			return GetRailType(tile);
 
-		case MP_ROAD:
+		case TileType::Road:
 			/* rail/road crossing */
 			if (IsLevelCrossing(tile)) return GetRailType(tile);
 			break;
 
-		case MP_STATION:
+		case TileType::Station:
 			if (HasStationRail(tile)) return GetRailType(tile);
 			break;
 
-		case MP_TUNNELBRIDGE:
+		case TileType::TunnelBridge:
 			if (GetTunnelBridgeTransportType(tile) == TRANSPORT_RAIL) return GetRailType(tile);
 			break;
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -149,7 +149,7 @@ void CcRailDepot(Commands, const CommandCost &result, TileIndex tile, RailType, 
 
 	tile += TileOffsByDiagDir(dir);
 
-	if (IsTileType(tile, MP_RAILWAY)) {
+	if (IsTileType(tile, TileType::Railway)) {
 		PlaceExtraDepotRail(tile, _place_depot_extra_dir[dir], _place_depot_extra_track[dir]);
 
 		/* Don't place the rail straight out of the depot of there is another depot across from it. */
@@ -1948,8 +1948,8 @@ static void SetDefaultRailGui()
 			/* Find the most used rail type */
 			std::array<uint, RAILTYPE_END> count{};
 			for (const auto t : Map::Iterate()) {
-				if (IsTileType(t, MP_RAILWAY) || IsLevelCrossingTile(t) || HasStationTileRail(t) ||
-						(IsTileType(t, MP_TUNNELBRIDGE) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL)) {
+				if (IsTileType(t, TileType::Railway) || IsLevelCrossingTile(t) || HasStationTileRail(t) ||
+						(IsTileType(t, TileType::TunnelBridge) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL)) {
 					count[GetRailType(t)]++;
 				}
 			}

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -30,12 +30,12 @@ enum class RailTileType : uint8_t {
  * Returns the RailTileType (normal with or without signals,
  * waypoint or depot).
  * @param t the tile to get the information from
- * @pre IsTileType(t, MP_RAILWAY)
+ * @pre IsTileType(t, TileType::Railway)
  * @return the RailTileType
  */
 [[debug_inline]] inline static RailTileType GetRailTileType(Tile t)
 {
-	assert(IsTileType(t, MP_RAILWAY));
+	assert(IsTileType(t, TileType::Railway));
 	return static_cast<RailTileType>(GB(t.m5(), 6, 2));
 }
 
@@ -43,7 +43,7 @@ enum class RailTileType : uint8_t {
  * Returns whether this is plain rails, with or without signals. Iow, if this
  * tiles RailTileType is RailTileType::Normal or RailTileType::Signals.
  * @param t the tile to get the information from
- * @pre IsTileType(t, MP_RAILWAY)
+ * @pre IsTileType(t, TileType::Railway)
  * @return true if and only if the tile is normal rail (with or without signals)
  */
 [[debug_inline]] inline static bool IsPlainRail(Tile t)
@@ -59,14 +59,14 @@ enum class RailTileType : uint8_t {
  */
 [[debug_inline]] inline static bool IsPlainRailTile(Tile t)
 {
-	return IsTileType(t, MP_RAILWAY) && IsPlainRail(t);
+	return IsTileType(t, TileType::Railway) && IsPlainRail(t);
 }
 
 
 /**
  * Checks if a rail tile has signals.
  * @param t the tile to get the information from
- * @pre IsTileType(t, MP_RAILWAY)
+ * @pre IsTileType(t, TileType::Railway)
  * @return true if and only if the tile has signals
  */
 inline bool HasSignals(Tile t)
@@ -89,7 +89,7 @@ inline void SetHasSignals(Tile tile, bool signals)
 /**
  * Is this rail tile a rail depot?
  * @param t the tile to get the information from
- * @pre IsTileType(t, MP_RAILWAY)
+ * @pre IsTileType(t, TileType::Railway)
  * @return true if and only if the tile is a rail depot
  */
 [[debug_inline]] inline static bool IsRailDepot(Tile t)
@@ -104,7 +104,7 @@ inline void SetHasSignals(Tile tile, bool signals)
  */
 [[debug_inline]] inline static bool IsRailDepotTile(Tile t)
 {
-	return IsTileType(t, MP_RAILWAY) && IsRailDepot(t);
+	return IsTileType(t, TileType::Railway) && IsRailDepot(t);
 }
 
 /**
@@ -461,7 +461,7 @@ inline void SetSignalStateByTrackdir(Tile tile, Trackdir trackdir, SignalState s
  */
 inline bool HasPbsSignalOnTrackdir(Tile tile, Trackdir td)
 {
-	return IsTileType(tile, MP_RAILWAY) && HasSignalOnTrackdir(tile, td) &&
+	return IsTileType(tile, TileType::Railway) && HasSignalOnTrackdir(tile, td) &&
 			IsPbsSignal(GetSignalType(tile, TrackdirToTrack(td)));
 }
 
@@ -473,7 +473,7 @@ inline bool HasPbsSignalOnTrackdir(Tile tile, Trackdir td)
  */
 inline bool HasOnewaySignalBlockingTrackdir(Tile tile, Trackdir td)
 {
-	return IsTileType(tile, MP_RAILWAY) && HasSignalOnTrackdir(tile, ReverseTrackdir(td)) &&
+	return IsTileType(tile, TileType::Railway) && HasSignalOnTrackdir(tile, ReverseTrackdir(td)) &&
 			!HasSignalOnTrackdir(tile, td) && IsOnewaySignal(tile, TrackdirToTrack(td));
 }
 
@@ -517,7 +517,7 @@ inline bool IsSnowRailGround(Tile t)
 
 inline void MakeRailNormal(Tile t, Owner o, TrackBits b, RailType r)
 {
-	SetTileType(t, MP_RAILWAY);
+	SetTileType(t, TileType::Railway);
 	SetTileOwner(t, o);
 	SetDockingTile(t, false);
 	t.m2() = 0;
@@ -550,7 +550,7 @@ inline void SetRailDepotExitDirection(Tile tile, DiagDirection dir)
  */
 inline void MakeRailDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirection dir, RailType rail_type)
 {
-	SetTileType(tile, MP_RAILWAY);
+	SetTileType(tile, TileType::Railway);
 	SetTileOwner(tile, owner);
 	SetDockingTile(tile, false);
 	tile.m2() = depot_id.base();

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -44,7 +44,7 @@ RoadType RoadTypeInfo::Index() const
  */
 static bool IsPossibleCrossing(const TileIndex tile, Axis ax)
 {
-	return (IsTileType(tile, MP_RAILWAY) &&
+	return (IsTileType(tile, TileType::Railway) &&
 		GetRailTileType(tile) == RailTileType::Normal &&
 		GetTrackBits(tile) == (ax == AXIS_X ? TRACK_BIT_Y : TRACK_BIT_X) &&
 		std::get<0>(GetFoundationSlope(tile)) == SLOPE_FLAT);
@@ -73,14 +73,14 @@ RoadBits CleanUpRoadBits(const TileIndex tile, RoadBits org_rb)
 			if (IsValidTile(neighbour_tile)) {
 				switch (GetTileType(neighbour_tile)) {
 					/* Always connective ones */
-					case MP_CLEAR: case MP_TREES:
+					case TileType::Clear: case TileType::Trees:
 						connective = true;
 						break;
 
 					/* The conditionally connective ones */
-					case MP_TUNNELBRIDGE:
-					case MP_STATION:
-					case MP_ROAD:
+					case TileType::TunnelBridge:
+					case TileType::Station:
+					case TileType::Road:
 						if (IsNormalRoadTile(neighbour_tile)) {
 							/* Always connective */
 							connective = true;
@@ -92,11 +92,11 @@ RoadBits CleanUpRoadBits(const TileIndex tile, RoadBits org_rb)
 						}
 						break;
 
-					case MP_RAILWAY:
+					case TileType::Railway:
 						connective = IsPossibleCrossing(neighbour_tile, DiagDirToAxis(dir));
 						break;
 
-					case MP_WATER:
+					case TileType::Water:
 						/* Check for real water tile */
 						connective = !IsWater(neighbour_tile);
 						break;

--- a/src/road_map.cpp
+++ b/src/road_map.cpp
@@ -21,13 +21,13 @@
 bool MayHaveRoad(Tile t)
 {
 	switch (GetTileType(t)) {
-		case MP_ROAD:
+		case TileType::Road:
 			return true;
 
-		case MP_STATION:
+		case TileType::Station:
 			return IsAnyRoadStop(t);
 
-		case MP_TUNNELBRIDGE:
+		case TileType::TunnelBridge:
 			return GetTunnelBridgeTransportType(t) == TRANSPORT_ROAD;
 
 		default:
@@ -56,7 +56,7 @@ RoadBits GetAnyRoadBits(Tile tile, RoadTramType rtt, bool straight_tunnel_bridge
 	if (!MayHaveRoad(tile) || !HasTileRoadType(tile, rtt)) return ROAD_NONE;
 
 	switch (GetTileType(tile)) {
-		case MP_ROAD:
+		case TileType::Road:
 			switch (GetRoadTileType(tile)) {
 				default:
 				case RoadTileType::Normal:   return GetRoadBits(tile, rtt);
@@ -64,12 +64,12 @@ RoadBits GetAnyRoadBits(Tile tile, RoadTramType rtt, bool straight_tunnel_bridge
 				case RoadTileType::Depot:    return DiagDirToRoadBits(GetRoadDepotDirection(tile));
 			}
 
-		case MP_STATION:
+		case TileType::Station:
 			assert(IsAnyRoadStopTile(tile)); // ensured by MayHaveRoad
 			if (IsDriveThroughStopTile(tile)) return AxisToRoadBits(GetDriveThroughStopAxis(tile));
 			return DiagDirToRoadBits(GetBayRoadStopDir(tile));
 
-		case MP_TUNNELBRIDGE:
+		case TileType::TunnelBridge:
 			assert(GetTunnelBridgeTransportType(tile) == TRANSPORT_ROAD); // ensured by MayHaveRoad
 			return straight_tunnel_bridge_entrance ?
 					AxisToRoadBits(DiagDirToAxis(GetTunnelBridgeDirection(tile))) :

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -30,19 +30,19 @@ bool MayHaveRoad(Tile t);
 /**
  * Get the type of the road tile.
  * @param t Tile to query.
- * @pre IsTileType(t, MP_ROAD)
+ * @pre IsTileType(t, TileType::Road)
  * @return The road tile type.
  */
 [[debug_inline]] inline static RoadTileType GetRoadTileType(Tile t)
 {
-	assert(IsTileType(t, MP_ROAD));
+	assert(IsTileType(t, TileType::Road));
 	return static_cast<RoadTileType>(GB(t.m5(), 6, 2));
 }
 
 /**
  * Return whether a tile is a normal road.
  * @param t Tile to query.
- * @pre IsTileType(t, MP_ROAD)
+ * @pre IsTileType(t, TileType::Road)
  * @return True if normal road.
  */
 [[debug_inline]] inline static bool IsNormalRoad(Tile t)
@@ -57,13 +57,13 @@ bool MayHaveRoad(Tile t);
  */
 [[debug_inline]] inline static bool IsNormalRoadTile(Tile t)
 {
-	return IsTileType(t, MP_ROAD) && IsNormalRoad(t);
+	return IsTileType(t, TileType::Road) && IsNormalRoad(t);
 }
 
 /**
  * Return whether a tile is a level crossing.
  * @param t Tile to query.
- * @pre IsTileType(t, MP_ROAD)
+ * @pre IsTileType(t, TileType::Road)
  * @return True if level crossing.
  */
 inline bool IsLevelCrossing(Tile t)
@@ -78,13 +78,13 @@ inline bool IsLevelCrossing(Tile t)
  */
 inline bool IsLevelCrossingTile(Tile t)
 {
-	return IsTileType(t, MP_ROAD) && IsLevelCrossing(t);
+	return IsTileType(t, TileType::Road) && IsLevelCrossing(t);
 }
 
 /**
  * Return whether a tile is a road depot.
  * @param t Tile to query.
- * @pre IsTileType(t, MP_ROAD)
+ * @pre IsTileType(t, TileType::Road)
  * @return True if road depot.
  */
 [[debug_inline]] inline static bool IsRoadDepot(Tile t)
@@ -99,7 +99,7 @@ inline bool IsLevelCrossingTile(Tile t)
  */
 [[debug_inline]] inline static bool IsRoadDepotTile(Tile t)
 {
-	return IsTileType(t, MP_ROAD) && IsRoadDepot(t);
+	return IsTileType(t, TileType::Road) && IsRoadDepot(t);
 }
 
 /**
@@ -258,7 +258,7 @@ inline bool IsRoadOwner(Tile t, RoadTramType rtt, Owner o)
 /**
  * Checks if given tile has town owned road
  * @param t tile to check
- * @pre IsTileType(t, MP_ROAD)
+ * @pre IsTileType(t, TileType::Road)
  * @return true iff tile has road and the road is owned by a town
  */
 inline bool HasTownOwnedRoad(Tile t)
@@ -619,7 +619,7 @@ inline void SetRoadTypes(Tile t, RoadType road_rt, RoadType tram_rt)
  */
 inline void MakeRoadNormal(Tile t, RoadBits bits, RoadType road_rt, RoadType tram_rt, TownID town, Owner road, Owner tram)
 {
-	SetTileType(t, MP_ROAD);
+	SetTileType(t, TileType::Road);
 	SetTileOwner(t, road);
 	t.m2() = town.base();
 	t.m3() = (tram_rt != INVALID_ROADTYPE ? bits : 0);
@@ -645,7 +645,7 @@ inline void MakeRoadNormal(Tile t, RoadBits bits, RoadType road_rt, RoadType tra
  */
 inline void MakeRoadCrossing(Tile t, Owner road, Owner tram, Owner rail, Axis roaddir, RailType rat, RoadType road_rt, RoadType tram_rt, TownID town)
 {
-	SetTileType(t, MP_ROAD);
+	SetTileType(t, TileType::Road);
 	SetTileOwner(t, rail);
 	t.m2() = town.base();
 	t.m3() = 0;
@@ -679,7 +679,7 @@ inline void SetRoadDepotExitDirection(Tile tile, DiagDirection dir)
  */
 inline void MakeRoadDepot(Tile tile, Owner owner, DepotID depot_id, DiagDirection dir, RoadType rt)
 {
-	SetTileType(tile, MP_ROAD);
+	SetTileType(tile, TileType::Road);
 	SetTileOwner(tile, owner);
 	tile.m2() = depot_id.base();
 	tile.m3() = 0;

--- a/src/roadstop.cpp
+++ b/src/roadstop.cpp
@@ -291,7 +291,7 @@ void RoadStop::Entry::Enter(const RoadVehicle *rv)
  */
 /* static */ bool RoadStop::IsDriveThroughRoadStopContinuation(TileIndex rs, TileIndex next)
 {
-	return IsTileType(next, MP_STATION) &&
+	return IsTileType(next, TileType::Station) &&
 			GetStationIndex(next) == GetStationIndex(rs) &&
 			GetStationType(next) == GetStationType(rs) &&
 			IsDriveThroughStopTile(next) &&

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -380,7 +380,7 @@ CommandCost CmdTurnRoadVeh(DoCommandFlags flags, VehicleID veh_id)
 
 	if (IsNormalRoadTile(v->tile) && GetDisallowedRoadDirections(v->tile) != DRD_NONE) return CMD_ERROR;
 
-	if (IsTileType(v->tile, MP_TUNNELBRIDGE) && DirToDiagDir(v->direction) == GetTunnelBridgeDirection(v->tile)) return CMD_ERROR;
+	if (IsTileType(v->tile, TileType::TunnelBridge) && DirToDiagDir(v->direction) == GetTunnelBridgeDirection(v->tile)) return CMD_ERROR;
 
 	if (flags.Test(DoCommandFlag::Execute)) {
 		v->reverse_ctr = 180;
@@ -815,7 +815,7 @@ static void RoadVehCheckOvertake(RoadVehicle *v, RoadVehicle *u)
 	if (RoadTypeIsTram(v->roadtype)) return;
 
 	/* Don't overtake in stations */
-	if (IsTileType(v->tile, MP_STATION) || IsTileType(u->tile, MP_STATION)) return;
+	if (IsTileType(v->tile, TileType::Station) || IsTileType(u->tile, TileType::Station)) return;
 
 	/* For now, articulated road vehicles can't overtake anything. */
 	if (v->HasArticulatedPart()) return;
@@ -896,12 +896,12 @@ static Trackdir RoadFindPathToDest(RoadVehicle *v, TileIndex tile, DiagDirection
 	TrackdirBits red_signals = TrackStatusToRedSignals(ts); // crossing
 	TrackdirBits trackdirs = TrackStatusToTrackdirBits(ts);
 
-	if (IsTileType(tile, MP_ROAD)) {
+	if (IsTileType(tile, TileType::Road)) {
 		if (IsRoadDepot(tile) && (!IsTileOwner(tile, v->owner) || GetRoadDepotDirection(tile) == enterdir)) {
 			/* Road depot owned by another company or with the wrong orientation */
 			trackdirs = TRACKDIR_BIT_NONE;
 		}
-	} else if (IsTileType(tile, MP_STATION) && IsBayRoadStopTile(tile)) {
+	} else if (IsTileType(tile, TileType::Station) && IsBayRoadStopTile(tile)) {
 		/* Standard road stop (drive-through stops are treated as normal road) */
 
 		if (!IsTileOwner(tile, v->owner) || GetBayRoadStopDir(tile) == enterdir || v->HasArticulatedPart()) {
@@ -1067,7 +1067,7 @@ static Trackdir FollowPreviousRoadVehicle(const RoadVehicle *v, const RoadVehicl
 	if (prev_state == RVSB_WORMHOLE || prev_state == RVSB_IN_DEPOT) {
 		DiagDirection diag_dir = INVALID_DIAGDIR;
 
-		if (IsTileType(tile, MP_TUNNELBRIDGE)) {
+		if (IsTileType(tile, TileType::TunnelBridge)) {
 			diag_dir = GetTunnelBridgeDirection(tile);
 		} else if (IsRoadDepotTile(tile)) {
 			diag_dir = ReverseDiagDir(GetRoadDepotDirection(tile));
@@ -1141,7 +1141,7 @@ static bool CanBuildTramTrackOnTile(CompanyID c, TileIndex t, RoadType rt, RoadB
 bool IndividualRoadVehicleController(RoadVehicle *v, const RoadVehicle *prev)
 {
 	if (v->overtaking != 0)  {
-		if (IsTileType(v->tile, MP_STATION)) {
+		if (IsTileType(v->tile, TileType::Station)) {
 			/* Force us to be not overtaking! */
 			v->overtaking = 0;
 		} else if (++v->overtaking_ctr >= RV_OVERTAKE_TIMEOUT) {
@@ -1171,7 +1171,7 @@ bool IndividualRoadVehicleController(RoadVehicle *v, const RoadVehicle *prev)
 			}
 		}
 
-		if (IsTileType(gp.new_tile, MP_TUNNELBRIDGE) && VehicleEnterTile(v, gp.new_tile, gp.x, gp.y).Test(VehicleEnterTileState::EnteredWormhole)) {
+		if (IsTileType(gp.new_tile, TileType::TunnelBridge) && VehicleEnterTile(v, gp.new_tile, gp.x, gp.y).Test(VehicleEnterTileState::EnteredWormhole)) {
 			/* Vehicle has just entered a bridge or tunnel */
 			v->x_pos = gp.x;
 			v->y_pos = gp.y;
@@ -1293,7 +1293,7 @@ again:
 
 		auto vets = VehicleEnterTile(v, tile, x, y);
 		if (vets.Test(VehicleEnterTileState::CannotEnter)) {
-			if (!IsTileType(tile, MP_TUNNELBRIDGE)) {
+			if (!IsTileType(tile, TileType::TunnelBridge)) {
 				v->cur_speed = 0;
 				return false;
 			}
@@ -1302,7 +1302,7 @@ again:
 			goto again;
 		}
 
-		if (IsInsideMM(v->state, RVSB_IN_ROAD_STOP, RVSB_IN_DT_ROAD_STOP_END) && IsTileType(v->tile, MP_STATION)) {
+		if (IsInsideMM(v->state, RVSB_IN_ROAD_STOP, RVSB_IN_DT_ROAD_STOP_END) && IsTileType(v->tile, TileType::Station)) {
 			if (IsReversingRoadTrackdir(dir) && IsInsideMM(v->state, RVSB_IN_ROAD_STOP, RVSB_IN_ROAD_STOP_END)) {
 				/* New direction is trying to turn vehicle around.
 				 * We can't turn at the exit of a road stop so wait.*/

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -932,6 +932,15 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_SIMPLIFY_INDUSTRY_GRAPHICS)) {
+		for (auto t : Map::Iterate()) {
+			if (IsTileType(t, TileType::Industry)) {
+				t.GetTileExtendedAs<TileType::Industry>().completed = HasBit(t.m1(), 7);
+				SetIndustryGfx(t, t.m5() | (GB(t.m6(), 2, 1) << 8));
+			}
+		}
+	}
+
 	for (const auto t : Map::Iterate()) {
 		switch (GetTileType(t)) {
 			case TileType::Station: {

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -138,7 +138,7 @@ void AfterLoadCompanyStats()
 	Company *c;
 	for (const auto tile : Map::Iterate()) {
 		switch (GetTileType(tile)) {
-			case MP_RAILWAY:
+			case TileType::Railway:
 				c = Company::GetIfValid(GetTileOwner(tile));
 				if (c != nullptr) {
 					uint pieces = 1;
@@ -153,7 +153,7 @@ void AfterLoadCompanyStats()
 				}
 				break;
 
-			case MP_ROAD: {
+			case TileType::Road: {
 				if (IsLevelCrossing(tile)) {
 					c = Company::GetIfValid(GetTileOwner(tile));
 					if (c != nullptr) c->infrastructure.rail[GetRailType(tile)] += LEVELCROSSING_TRACKBIT_FACTOR;
@@ -170,7 +170,7 @@ void AfterLoadCompanyStats()
 				break;
 			}
 
-			case MP_STATION:
+			case TileType::Station:
 				c = Company::GetIfValid(GetTileOwner(tile));
 				if (c != nullptr && GetStationType(tile) != StationType::Airport && !IsBuoy(tile)) c->infrastructure.station++;
 
@@ -205,7 +205,7 @@ void AfterLoadCompanyStats()
 				}
 				break;
 
-			case MP_WATER:
+			case TileType::Water:
 				if (IsShipDepot(tile) || IsLock(tile)) {
 					c = Company::GetIfValid(GetTileOwner(tile));
 					if (c != nullptr) {
@@ -219,14 +219,14 @@ void AfterLoadCompanyStats()
 				}
 				[[fallthrough]];
 
-			case MP_OBJECT:
+			case TileType::Object:
 				if (GetWaterClass(tile) == WaterClass::Canal) {
 					c = Company::GetIfValid(GetTileOwner(tile));
 					if (c != nullptr) c->infrastructure.water++;
 				}
 				break;
 
-			case MP_TUNNELBRIDGE: {
+			case TileType::TunnelBridge: {
 				/* Only count the tunnel/bridge if we're on the northern end tile. */
 				TileIndex other_end = GetOtherTunnelBridgeEnd(tile);
 				if (tile < other_end) {

--- a/src/saveload/object_sl.cpp
+++ b/src/saveload/object_sl.cpp
@@ -58,7 +58,7 @@ struct OBJSChunkHandler : ChunkHandler {
 	{
 		for (Object *o : Object::Iterate()) {
 			SlObject(o, _object_desc);
-			if (IsSavegameVersionBefore(SLV_148) && !IsTileType(o->location.tile, MP_OBJECT)) {
+			if (IsSavegameVersionBefore(SLV_148) && !IsTileType(o->location.tile, TileType::Object)) {
 				/* Due to a small bug stale objects could remain. */
 				delete o;
 			}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -53,7 +53,7 @@ static void FixTTDMapArray()
 {
 	for (auto tile : Map::Iterate()) {
 		switch (GetTileType(tile)) {
-			case MP_STATION:
+			case TileType::Station:
 				tile.m4() = 0; // We do not understand this TTDP station mapping (yet)
 				switch (tile.m5()) {
 					/* We have drive through stops at a totally different place */
@@ -65,7 +65,7 @@ static void FixTTDMapArray()
 				}
 				break;
 
-			case MP_RAILWAY:
+			case TileType::Railway:
 				/* We save presignals different from TTDPatch, convert them */
 				if (GB(tile.m5(), 6, 2) == 1) { // RailTileType::Signals
 					/* This byte is always zero in TTD for this type of tile */
@@ -78,10 +78,10 @@ static void FixTTDMapArray()
 				tile.m4() &= 0xF; // Only keep the lower four bits; upper four is PBS
 				break;
 
-			case MP_WATER:
+			case TileType::Water:
 				/* if water class == 3, make river there */
 				if (GB(tile.m3(), 0, 2) == 3) {
-					SetTileType(tile, MP_WATER);
+					SetTileType(tile, TileType::Water);
 					SetTileOwner(tile, OWNER_WATER);
 					tile.m2() = 0;
 					tile.m3() = 2; // WaterClass::River
@@ -184,7 +184,7 @@ void FixOldVehicles(LoadgameState &ls)
 			if (rv->state != RVSB_IN_DEPOT && rv->state != RVSB_WORMHOLE) {
 				ClrBit(rv->state, 2);
 				Tile tile(rv->tile);
-				if (IsTileType(tile, MP_STATION) && tile.m5() >= 168) {
+				if (IsTileType(tile, TileType::Station) && tile.m5() >= 168) {
 					/* Update the vehicle's road state to show we're in a drive through road stop. */
 					SetBit(rv->state, RVS_IN_DT_ROAD_STOP);
 				}
@@ -211,20 +211,20 @@ static bool FixTTOMapArray()
 {
 	for (auto tile : Map::Iterate()) {
 		TileType tt = GetTileType(tile);
-		if (tt == 11) {
+		if (to_underlying(tt) == 11) {
 			/* TTO has a different way of storing monorail.
 			 * Instead of using bits in m3 it uses a different tile type. */
 			tile.m3() = 1; // rail type = monorail (in TTD)
-			SetTileType(tile, MP_RAILWAY);
+			SetTileType(tile, TileType::Railway);
 			tile.m2() = 1; // set monorail ground to RailGroundType::Grass
-			tt = MP_RAILWAY;
+			tt = TileType::Railway;
 		}
 
 		switch (tt) {
-			case MP_CLEAR:
+			case TileType::Clear:
 				break;
 
-			case MP_RAILWAY:
+			case TileType::Railway:
 				switch (GB(tile.m5(), 6, 2)) {
 					case 0: // RailTileType::Normal
 						break;
@@ -243,7 +243,7 @@ static bool FixTTOMapArray()
 				}
 				break;
 
-			case MP_ROAD: // road (depot) or level crossing
+			case TileType::Road: // road (depot) or level crossing
 				switch (GB(tile.m5(), 4, 4)) {
 					case 0: // RoadTileType::Normal
 						if (tile.m2() == 4) tile.m2() = 5; // 'small trees' -> Roadside::Trees
@@ -258,32 +258,32 @@ static bool FixTTOMapArray()
 				}
 				break;
 
-			case MP_HOUSE:
+			case TileType::House:
 				tile.m3() = tile.m2() & 0xC0;    // construction stage
 				tile.m2() &= 0x3F;               // building type
 				if (tile.m2() >= 5) tile.m2()++; // skip "large office block on snow"
 				break;
 
-			case MP_TREES:
+			case TileType::Trees:
 				tile.m3() = GB(tile.m5(), 3, 3); // type of trees
 				tile.m5() &= 0xC7;               // number of trees and growth status
 				break;
 
-			case MP_STATION:
+			case TileType::Station:
 				tile.m3() = (tile.m5() >= 0x08 && tile.m5() <= 0x0F) ? 1 : 0; // monorail -> 1, others 0 (rail, road, airport, dock)
 				if (tile.m5() >= 8) tile.m5() -= 8; // shift for monorail
 				if (tile.m5() >= 0x42) tile.m5()++; // skip heliport
 				break;
 
-			case MP_WATER:
+			case TileType::Water:
 				tile.m3() = tile.m2() = 0;
 				break;
 
-			case MP_VOID:
+			case TileType::Void:
 				tile.m2() = tile.m3() = tile.m5() = 0;
 				break;
 
-			case MP_INDUSTRY:
+			case TileType::Industry:
 				tile.m3() = 0;
 				switch (tile.m5()) {
 					case 0x24: // farm silo
@@ -299,7 +299,7 @@ static bool FixTTOMapArray()
 				}
 				break;
 
-			case MP_TUNNELBRIDGE:
+			case TileType::TunnelBridge:
 				if (HasBit(tile.m5(), 7)) { // bridge
 					uint8_t m5 = tile.m5();
 					tile.m5() = m5 & 0xE1; // copy bits 7..5, 1
@@ -319,7 +319,7 @@ static bool FixTTOMapArray()
 				}
 				break;
 
-			case MP_OBJECT:
+			case TileType::Object:
 				tile.m2() = 0;
 				tile.m3() = 0;
 				break;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -415,6 +415,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_SIGN_TEXT_COLOURS,                  ///< 363  PR#14743 Configurable sign text colors in scenario editor.
 	SLV_BUOYS_AT_0_0,                       ///< 364  PR#14983 Allow to build buoys at (0x0).
 
+	SLV_SIMPLIFY_INDUSTRY_GRAPHICS,         ///< 365  Use 9 adjacent bits instead of m5 and m6[2] to store industry graphics.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -93,7 +93,7 @@ void MoveBuoysToWaypoints()
 			/* When we make a rail waypoint of the station, convert the map as well. */
 			for (TileIndex t : train_st) {
 				Tile tile(t);
-				if (!IsTileType(tile, MP_STATION) || GetStationIndex(tile) != index) continue;
+				if (!IsTileType(tile, TileType::Station) || GetStationIndex(tile) != index) continue;
 
 				SB(tile.m6(), 3, 3, to_underlying(StationType::RailWaypoint));
 				wp->rect.BeforeAddTile(t, StationRect::ADD_FORCE);

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -37,7 +37,7 @@ void RebuildTownCaches()
 	}
 
 	for (const auto t : Map::Iterate()) {
-		if (!IsTileType(t, MP_HOUSE)) continue;
+		if (!IsTileType(t, TileType::House)) continue;
 
 		HouseID house_id = GetHouseType(t);
 		Town *town = Town::GetByTile(t);
@@ -65,7 +65,7 @@ void RebuildTownCaches()
 void UpdateHousesAndTowns()
 {
 	for (const auto t : Map::Iterate()) {
-		if (!IsTileType(t, MP_HOUSE)) continue;
+		if (!IsTileType(t, TileType::House)) continue;
 
 		HouseID house_id = GetCleanHouseType(t);
 		if (!HouseSpec::Get(house_id)->enabled && house_id >= NEW_HOUSE_OFFSET) {
@@ -78,7 +78,7 @@ void UpdateHousesAndTowns()
 
 	/* Check for cases when a NewGRF has set a wrong house substitute type. */
 	for (const TileIndex &t : Map::Iterate()) {
-		if (!IsTileType(t, MP_HOUSE)) continue;
+		if (!IsTileType(t, TileType::House)) continue;
 
 		HouseID house_type = GetCleanHouseType(t);
 		TileIndex north_tile = t + GetHouseNorthPart(house_type); // modifies 'house_type'!
@@ -87,23 +87,23 @@ void UpdateHousesAndTowns()
 			bool valid_house = true;
 			if (hs->building_flags.Test(BuildingFlag::Size2x1)) {
 				TileIndex tile = t + TileDiffXY(1, 0);
-				if (!IsTileType(tile, MP_HOUSE) || GetCleanHouseType(tile) != house_type + 1) valid_house = false;
+				if (!IsTileType(tile, TileType::House) || GetCleanHouseType(tile) != house_type + 1) valid_house = false;
 			} else if (hs->building_flags.Test(BuildingFlag::Size1x2)) {
 				TileIndex tile = t + TileDiffXY(0, 1);
-				if (!IsTileType(tile, MP_HOUSE) || GetCleanHouseType(tile) != house_type + 1) valid_house = false;
+				if (!IsTileType(tile, TileType::House) || GetCleanHouseType(tile) != house_type + 1) valid_house = false;
 			} else if (hs->building_flags.Test(BuildingFlag::Size2x2)) {
 				TileIndex tile = t + TileDiffXY(0, 1);
-				if (!IsTileType(tile, MP_HOUSE) || GetCleanHouseType(tile) != house_type + 1) valid_house = false;
+				if (!IsTileType(tile, TileType::House) || GetCleanHouseType(tile) != house_type + 1) valid_house = false;
 				tile = t + TileDiffXY(1, 0);
-				if (!IsTileType(tile, MP_HOUSE) || GetCleanHouseType(tile) != house_type + 2) valid_house = false;
+				if (!IsTileType(tile, TileType::House) || GetCleanHouseType(tile) != house_type + 2) valid_house = false;
 				tile = t + TileDiffXY(1, 1);
-				if (!IsTileType(tile, MP_HOUSE) || GetCleanHouseType(tile) != house_type + 3) valid_house = false;
+				if (!IsTileType(tile, TileType::House) || GetCleanHouseType(tile) != house_type + 3) valid_house = false;
 			}
 			/* If not all tiles of this house are present remove the house.
 			 * The other tiles will get removed later in this loop because
 			 * their north tile is not the correct type anymore. */
 			if (!valid_house) DoClearSquare(t);
-		} else if (!IsTileType(north_tile, MP_HOUSE) || GetCleanHouseType(north_tile) != house_type) {
+		} else if (!IsTileType(north_tile, TileType::House) || GetCleanHouseType(north_tile) != house_type) {
 			/* This tile should be part of a multi-tile building but the
 			 * north tile of this house isn't on the map. */
 			DoClearSquare(t);

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -100,11 +100,11 @@ void MoveWaypointsToBaseStations()
 		TileIndex t = wp.xy;
 		/* Sometimes waypoint (sign) locations became disconnected from their actual location in
 		 * the map array. If this is the case, try to locate the actual location in the map array */
-		if (!IsTileType(t, MP_RAILWAY) || GetRailTileType(t) != RailTileType{2} /* RAIL_TILE_WAYPOINT */ || Tile(t).m2() != wp.index) {
+		if (!IsTileType(t, TileType::Railway) || GetRailTileType(t) != RailTileType{2} /* RAIL_TILE_WAYPOINT */ || Tile(t).m2() != wp.index) {
 			Debug(sl, 0, "Found waypoint tile {} with invalid position", t);
 			t = INVALID_TILE;
 			for (auto tile : Map::Iterate()) {
-				if (IsTileType(tile, MP_RAILWAY) && GetRailTileType(tile) == RailTileType{2} /* RAIL_TILE_WAYPOINT */ && tile.m2() == wp.index) {
+				if (IsTileType(tile, TileType::Railway) && GetRailTileType(tile) == RailTileType{2} /* RAIL_TILE_WAYPOINT */ && tile.m2() == wp.index) {
 					t = TileIndex(tile);
 					Debug(sl, 0, "Found actual waypoint position at {}", TileIndex(tile));
 					break;

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -39,14 +39,14 @@
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_STATION) && ::IsHangar(tile);
+	return ::IsTileType(tile, TileType::Station) && ::IsHangar(tile);
 }
 
 /* static */ bool ScriptAirport::IsAirportTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_STATION) && ::IsAirport(tile);
+	return ::IsTileType(tile, TileType::Station) && ::IsAirport(tile);
 }
 
 /* static */ SQInteger ScriptAirport::GetAirportWidth(AirportType type)
@@ -93,7 +93,7 @@
 {
 	EnforceDeityOrCompanyModeValid(-1);
 	if (!::IsValidTile(tile)) return -1;
-	if (!::IsTileType(tile, MP_STATION)) return -1;
+	if (!::IsTileType(tile, TileType::Station)) return -1;
 
 	const Station *st = ::Station::GetByTile(tile);
 	if (st->owner != ScriptObject::GetCompany() && ScriptCompanyMode::IsValid()) return -1;
@@ -106,7 +106,7 @@
 {
 	EnforceDeityOrCompanyModeValid(INVALID_TILE);
 	if (!::IsValidTile(tile)) return INVALID_TILE;
-	if (!::IsTileType(tile, MP_STATION)) return INVALID_TILE;
+	if (!::IsTileType(tile, TileType::Station)) return INVALID_TILE;
 	if (GetNumHangars(tile) < 1) return INVALID_TILE;
 
 	const Station *st = ::Station::GetByTile(tile);

--- a/src/script/api/script_depotlist.cpp
+++ b/src/script/api/script_depotlist.cpp
@@ -21,9 +21,9 @@ ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 	switch (transport_type) {
 		default: return;
 
-		case ScriptTile::TRANSPORT_ROAD:  tile_type = ::MP_ROAD; break;
-		case ScriptTile::TRANSPORT_RAIL:  tile_type = ::MP_RAILWAY; break;
-		case ScriptTile::TRANSPORT_WATER: tile_type = ::MP_WATER; break;
+		case ScriptTile::TRANSPORT_ROAD:  tile_type = ::TileType::Road; break;
+		case ScriptTile::TRANSPORT_RAIL:  tile_type = ::TileType::Railway; break;
+		case ScriptTile::TRANSPORT_WATER: tile_type = ::TileType::Water; break;
 
 		case ScriptTile::TRANSPORT_AIR: {
 			/* Hangars are not seen as real depots by the depot code. */

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -38,7 +38,7 @@
 
 /* static */ IndustryID ScriptIndustry::GetIndustryID(TileIndex tile)
 {
-	if (!::IsValidTile(tile) || !::IsTileType(tile, MP_INDUSTRY)) return IndustryID::Invalid();
+	if (!::IsValidTile(tile) || !::IsTileType(tile, TileType::Industry)) return IndustryID::Invalid();
 	return ::GetIndustryIndex(tile);
 }
 
@@ -182,7 +182,7 @@
 
 	const Industry *ind = ::Industry::Get(industry_id);
 	for (TileIndex tile_cur : ind->location) {
-		if (IsTileType(tile_cur, MP_STATION) && IsOilRig(tile_cur)) {
+		if (IsTileType(tile_cur, TileType::Station) && IsOilRig(tile_cur)) {
 			return tile_cur;
 		}
 	}
@@ -204,7 +204,7 @@
 
 	const Industry *ind = ::Industry::Get(industry_id);
 	for (TileIndex tile_cur : ind->location) {
-		if (IsTileType(tile_cur, MP_STATION) && IsOilRig(tile_cur)) {
+		if (IsTileType(tile_cur, TileType::Station) && IsOilRig(tile_cur)) {
 			return tile_cur;
 		}
 	}

--- a/src/script/api/script_marine.cpp
+++ b/src/script/api/script_marine.cpp
@@ -25,35 +25,35 @@
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_WATER) && ::GetWaterTileType(tile) == WaterTileType::Depot;
+	return ::IsTileType(tile, TileType::Water) && ::GetWaterTileType(tile) == WaterTileType::Depot;
 }
 
 /* static */ bool ScriptMarine::IsDockTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_STATION) && ::IsDock(tile);
+	return ::IsTileType(tile, TileType::Station) && ::IsDock(tile);
 }
 
 /* static */ bool ScriptMarine::IsBuoyTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_STATION) && ::IsBuoy(tile);
+	return ::IsTileType(tile, TileType::Station) && ::IsBuoy(tile);
 }
 
 /* static */ bool ScriptMarine::IsLockTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_WATER) && ::GetWaterTileType(tile) == WaterTileType::Lock;
+	return ::IsTileType(tile, TileType::Water) && ::GetWaterTileType(tile) == WaterTileType::Lock;
 }
 
 /* static */ bool ScriptMarine::IsCanalTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_WATER) && ::IsCanal(tile);
+	return ::IsTileType(tile, TileType::Water) && ::IsCanal(tile);
 }
 
 /* static */ bool ScriptMarine::AreWaterTilesConnected(TileIndex t1, TileIndex t2)

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -34,14 +34,14 @@ static OrderType GetOrderTypeByTile(TileIndex t)
 
 	switch (::GetTileType(t)) {
 		default: break;
-		case MP_STATION:
+		case TileType::Station:
 			if (IsBuoy(t) || IsRailWaypoint(t) || IsRoadWaypoint(t)) return OT_GOTO_WAYPOINT;
 			if (IsHangar(t)) return OT_GOTO_DEPOT;
 			return OT_GOTO_STATION;
 
-		case MP_WATER:   if (::IsShipDepot(t)) return OT_GOTO_DEPOT; break;
-		case MP_ROAD:    if (::GetRoadTileType(t) == RoadTileType::Depot) return OT_GOTO_DEPOT; break;
-		case MP_RAILWAY:
+		case TileType::Water:   if (::IsShipDepot(t)) return OT_GOTO_DEPOT; break;
+		case TileType::Road:    if (::GetRoadTileType(t) == RoadTileType::Depot) return OT_GOTO_DEPOT; break;
+		case TileType::Railway:
 			if (IsRailDepot(t)) return OT_GOTO_DEPOT;
 			break;
 	}
@@ -266,7 +266,7 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 				}
 			} else if (st->ship_station.tile != INVALID_TILE) {
 				for (TileIndex t : st->ship_station) {
-					if (IsTileType(t, MP_STATION) && (IsDock(t) || IsOilRig(t)) && GetStationIndex(t) == st->index) return t;
+					if (IsTileType(t, TileType::Station) && (IsDock(t) || IsOilRig(t)) && GetStationIndex(t) == st->index) return t;
 				}
 			} else if (st->bus_stops != nullptr) {
 				return st->bus_stops->xy;
@@ -499,10 +499,10 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 				/* Check explicitly if the order is to a station (for aircraft) or
 				 * to a depot (other vehicle types). */
 				if (::Vehicle::Get(vehicle_id)->type == VEH_AIRCRAFT) {
-					if (!::IsTileType(destination, MP_STATION)) return false;
+					if (!::IsTileType(destination, TileType::Station)) return false;
 					order.MakeGoToDepot(::GetStationIndex(destination), odtf, onsf, odaf);
 				} else {
-					if (::IsTileType(destination, MP_STATION)) return false;
+					if (::IsTileType(destination, TileType::Station)) return false;
 					order.MakeGoToDepot(::GetDepotIndex(destination), odtf, onsf, odaf);
 				}
 			}

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -35,7 +35,7 @@
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_RAILWAY) && !::IsRailDepot(tile)) ||
+	return (::IsTileType(tile, TileType::Railway) && !::IsRailDepot(tile)) ||
 			(::HasStationTileRail(tile) && !::IsStationTileBlocked(tile)) || ::IsLevelCrossingTile(tile);
 }
 
@@ -412,7 +412,7 @@ static const ScriptRailSignalData _possible_trackdirs[5][NUM_TRACK_DIRECTIONS] =
 /* static */ ScriptRail::SignalType ScriptRail::GetSignalType(TileIndex tile, TileIndex front)
 {
 	if (ScriptMap::DistanceManhattan(tile, front) != 1) return SIGNALTYPE_NONE;
-	if (!::IsTileType(tile, MP_RAILWAY) || !::HasSignals(tile)) return SIGNALTYPE_NONE;
+	if (!::IsTileType(tile, TileType::Railway) || !::HasSignals(tile)) return SIGNALTYPE_NONE;
 
 	int data_index = 2 + (::TileX(front) - ::TileX(tile)) + 2 * (::TileY(front) - ::TileY(tile));
 

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -37,7 +37,7 @@
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_ROAD) && ::GetRoadTileType(tile) != RoadTileType::Depot) ||
+	return (::IsTileType(tile, TileType::Road) && ::GetRoadTileType(tile) != RoadTileType::Depot) ||
 			IsDriveThroughRoadStationTile(tile);
 }
 
@@ -46,7 +46,7 @@
 	if (!::IsValidTile(tile)) return false;
 	if (!IsRoadTypeAvailable(GetCurrentRoadType())) return false;
 
-	return ::IsTileType(tile, MP_ROAD) && ::GetRoadTileType(tile) == RoadTileType::Depot &&
+	return ::IsTileType(tile, TileType::Road) && ::GetRoadTileType(tile) == RoadTileType::Depot &&
 			::GetPresentRoadTypes(tile).Test(::RoadType(GetCurrentRoadType()));
 }
 
@@ -467,10 +467,10 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 	if (!::GetPresentRoadTypes(neighbour_tile).Test(rt)) return false;
 
 	switch (::GetTileType(neighbour_tile)) {
-		case MP_ROAD:
+		case TileType::Road:
 			return (::GetRoadTileType(neighbour_tile) != RoadTileType::Depot);
 
-		case MP_STATION:
+		case TileType::Station:
 			if (::IsDriveThroughStopTile(neighbour_tile)) {
 				return ::DiagDirToAxis(neighbour) == ::GetDriveThroughStopAxis(neighbour_tile);
 			}
@@ -625,7 +625,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 {
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
-	EnforcePrecondition(false, IsTileType(tile, MP_ROAD))
+	EnforcePrecondition(false, IsTileType(tile, TileType::Road))
 	EnforcePrecondition(false, GetRoadTileType(tile) == RoadTileType::Depot);
 
 	return ScriptObject::Command<CMD_LANDSCAPE_CLEAR>::Do(tile);
@@ -635,7 +635,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 {
 	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
-	EnforcePrecondition(false, IsTileType(tile, MP_STATION));
+	EnforcePrecondition(false, IsTileType(tile, TileType::Station));
 	EnforcePrecondition(false, IsStationRoadStop(tile));
 
 	return ScriptObject::Command<CMD_REMOVE_ROAD_STOP>::Do(tile, 1, 1, GetRoadStopType(tile), false);

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -28,7 +28,7 @@
 
 /* static */ StationID ScriptStation::GetStationID(TileIndex tile)
 {
-	if (!::IsValidTile(tile) || !::IsTileType(tile, MP_STATION)) return StationID::Invalid();
+	if (!::IsValidTile(tile) || !::IsTileType(tile, TileType::Station)) return StationID::Invalid();
 	return ::GetStationIndex(tile);
 }
 

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -30,10 +30,10 @@
 
 	switch (::GetTileType(tile)) {
 		default: return false;
-		case MP_CLEAR: return true;
-		case MP_TREES: return true;
-		case MP_WATER: return IsCoast(tile);
-		case MP_ROAD:
+		case TileType::Clear: return true;
+		case TileType::Trees: return true;
+		case TileType::Water: return IsCoast(tile);
+		case TileType::Road:
 			/* Tram bits aren't considered buildable */
 			if (::GetRoadTypeTram(tile) != INVALID_ROADTYPE) return false;
 			/* Depots and crossings aren't considered buildable */
@@ -66,36 +66,36 @@
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_WATER) && ::IsSea(tile);
+	return ::IsTileType(tile, TileType::Water) && ::IsSea(tile);
 }
 
 /* static */ bool ScriptTile::IsRiverTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_WATER) && ::IsRiver(tile);
+	return ::IsTileType(tile, TileType::Water) && ::IsRiver(tile);
 }
 
 /* static */ bool ScriptTile::IsWaterTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_WATER) && !::IsCoast(tile);
+	return ::IsTileType(tile, TileType::Water) && !::IsCoast(tile);
 }
 
 /* static */ bool ScriptTile::IsCoastTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_WATER) && ::IsCoast(tile)) ||
-		(::IsTileType(tile, MP_TREES) && ::GetTreeGround(tile) == TREE_GROUND_SHORE);
+	return (::IsTileType(tile, TileType::Water) && ::IsCoast(tile)) ||
+		(::IsTileType(tile, TileType::Trees) && ::GetTreeGround(tile) == TREE_GROUND_SHORE);
 }
 
 /* static */ bool ScriptTile::IsStationTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_STATION);
+	return ::IsTileType(tile, TileType::Station);
 }
 
 /* static */ bool ScriptTile::IsSteepSlope(Slope slope)
@@ -116,49 +116,49 @@
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_TREES);
+	return ::IsTileType(tile, TileType::Trees);
 }
 
 /* static */ bool ScriptTile::IsFarmTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_CLEAR) && ::IsClearGround(tile, CLEAR_FIELDS));
+	return (::IsTileType(tile, TileType::Clear) && ::IsClearGround(tile, CLEAR_FIELDS));
 }
 
 /* static */ bool ScriptTile::IsRockTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_CLEAR) && ::GetClearGround(tile) == ::CLEAR_ROCKS);
+	return (::IsTileType(tile, TileType::Clear) && ::GetClearGround(tile) == ::CLEAR_ROCKS);
 }
 
 /* static */ bool ScriptTile::IsRoughTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_CLEAR) && ::GetClearGround(tile) == ::CLEAR_ROUGH);
+	return (::IsTileType(tile, TileType::Clear) && ::GetClearGround(tile) == ::CLEAR_ROUGH);
 }
 
 /* static */ bool ScriptTile::IsSnowTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_CLEAR) && ::IsSnowTile(tile));
+	return (::IsTileType(tile, TileType::Clear) && ::IsSnowTile(tile));
 }
 
 /* static */ bool ScriptTile::IsDesertTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return (::IsTileType(tile, MP_CLEAR) && ::IsClearGround(tile, CLEAR_DESERT));
+	return (::IsTileType(tile, TileType::Clear) && ::IsClearGround(tile, CLEAR_DESERT));
 }
 
 /* static */ bool ScriptTile::IsHouseTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;
 
-	return ::IsTileType(tile, MP_HOUSE);
+	return ::IsTileType(tile, TileType::House);
 }
 
 /* static */ ScriptTile::TerrainType ScriptTile::GetTerrainType(TileIndex tile)
@@ -213,8 +213,8 @@
 /* static */ ScriptCompany::CompanyID ScriptTile::GetOwner(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return ScriptCompany::COMPANY_INVALID;
-	if (::IsTileType(tile, MP_HOUSE)) return ScriptCompany::COMPANY_INVALID;
-	if (::IsTileType(tile, MP_INDUSTRY)) return ScriptCompany::COMPANY_INVALID;
+	if (::IsTileType(tile, TileType::House)) return ScriptCompany::COMPANY_INVALID;
+	if (::IsTileType(tile, TileType::Industry)) return ScriptCompany::COMPANY_INVALID;
 
 	return ScriptCompany::ResolveCompanyID(ScriptCompany::ToScriptCompanyID(::GetTileOwner(tile)));
 }

--- a/src/script/api/script_tilelist.cpp
+++ b/src/script/api/script_tilelist.cpp
@@ -109,7 +109,7 @@ void ScriptTileList::RemoveTile(TileIndex tile)
 static void FillIndustryCatchment(const Industry *i, SQInteger radius, BitmapTileArea &bta)
 {
 	for (TileIndex cur_tile : i->location) {
-		if (!::IsTileType(cur_tile, MP_INDUSTRY) || ::GetIndustryIndex(cur_tile) != i->index) continue;
+		if (!::IsTileType(cur_tile, TileType::Industry) || ::GetIndustryIndex(cur_tile) != i->index) continue;
 
 		int tx = TileX(cur_tile);
 		int ty = TileY(cur_tile);
@@ -119,7 +119,7 @@ static void FillIndustryCatchment(const Industry *i, SQInteger radius, BitmapTil
 				if (tx + x < 0 || tx + x > (int)Map::MaxX()) continue;
 				TileIndex tile = TileXY(tx + x, ty + y);
 				if (!IsValidTile(tile)) continue;
-				if (::IsTileType(tile, MP_INDUSTRY) && ::GetIndustryIndex(tile) == i->index) continue;
+				if (::IsTileType(tile, TileType::Industry) && ::GetIndustryIndex(tile) == i->index) continue;
 				bta.SetTile(tile);
 			}
 		}
@@ -194,7 +194,7 @@ ScriptTileList_StationType::ScriptTileList_StationType(StationID station_id, Scr
 
 	TileArea ta(::TileXY(rect->left, rect->top), rect->Width(), rect->Height());
 	for (TileIndex cur_tile : ta) {
-		if (!::IsTileType(cur_tile, MP_STATION)) continue;
+		if (!::IsTileType(cur_tile, TileType::Station)) continue;
 		if (::GetStationIndex(cur_tile) != station_id) continue;
 		if (!station_types.Test(::GetStationType(cur_tile))) continue;
 		this->AddTile(cur_tile);

--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -93,25 +93,25 @@ ScriptVehicleList_Depot::ScriptVehicleList_Depot(TileIndex tile)
 	VehicleType type;
 
 	switch (GetTileType(tile)) {
-		case MP_STATION: // Aircraft
+		case TileType::Station: // Aircraft
 			if (!IsAirport(tile)) return;
 			type = VEH_AIRCRAFT;
 			dest = GetStationIndex(tile);
 			break;
 
-		case MP_RAILWAY:
+		case TileType::Railway:
 			if (!IsRailDepot(tile)) return;
 			type = VEH_TRAIN;
 			dest = GetDepotIndex(tile);
 			break;
 
-		case MP_ROAD:
+		case TileType::Road:
 			if (!IsRoadDepot(tile)) return;
 			type = VEH_ROAD;
 			dest = GetDepotIndex(tile);
 			break;
 
-		case MP_WATER:
+		case TileType::Water:
 			if (!IsShipDepot(tile)) return;
 			type = VEH_SHIP;
 			dest = GetDepotIndex(tile);

--- a/src/script/api/script_waypoint.cpp
+++ b/src/script/api/script_waypoint.cpp
@@ -24,7 +24,7 @@
 
 /* static */ StationID ScriptWaypoint::GetWaypointID(TileIndex tile)
 {
-	if (!::IsValidTile(tile) || !::IsTileType(tile, MP_STATION) || ::Waypoint::GetByTile(tile) == nullptr) return StationID::Invalid();
+	if (!::IsValidTile(tile) || !::IsTileType(tile, TileType::Station) || ::Waypoint::GetByTile(tile) == nullptr) return StationID::Invalid();
 	return ::GetStationIndex(tile);
 }
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -475,7 +475,7 @@ static bool CheckFreeformEdges(int32_t &new_value)
 			}
 		}
 		for (uint i = 1; i < Map::MaxX(); i++) {
-			if (!IsTileType(TileXY(i, Map::MaxY() - 1), MP_WATER) || TileHeight(TileXY(1, Map::MaxY())) != 0) {
+			if (!IsTileType(TileXY(i, Map::MaxY() - 1), TileType::Water) || TileHeight(TileXY(1, Map::MaxY())) != 0) {
 				ShowErrorMessage(GetEncodedString(STR_CONFIG_SETTING_EDGES_NOT_WATER), {}, WL_ERROR);
 				return false;
 			}
@@ -487,7 +487,7 @@ static bool CheckFreeformEdges(int32_t &new_value)
 			}
 		}
 		for (uint i = 1; i < Map::MaxY(); i++) {
-			if (!IsTileType(TileXY(Map::MaxX() - 1, i), MP_WATER) || TileHeight(TileXY(Map::MaxX(), i)) != 0) {
+			if (!IsTileType(TileXY(Map::MaxX() - 1, i), TileType::Water) || TileHeight(TileXY(Map::MaxX(), i)) != 0) {
 				ShowErrorMessage(GetEncodedString(STR_CONFIG_SETTING_EDGES_NOT_WATER), {}, WL_ERROR);
 				return false;
 			}
@@ -507,11 +507,11 @@ static void UpdateFreeformEdges(int32_t new_value)
 		/* Make tiles at the border water again. */
 		for (uint i = 0; i < Map::MaxX(); i++) {
 			SetTileHeight(TileXY(i, 0), 0);
-			SetTileType(TileXY(i, 0), MP_WATER);
+			SetTileType(TileXY(i, 0), TileType::Water);
 		}
 		for (uint i = 0; i < Map::MaxY(); i++) {
 			SetTileHeight(TileXY(0, i), 0);
-			SetTileType(TileXY(0, i), MP_WATER);
+			SetTileType(TileXY(0, i), TileType::Water);
 		}
 	}
 	MarkWholeScreenDirty();

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -53,11 +53,11 @@ constexpr int MAX_SHIP_DEPOT_SEARCH_DISTANCE = 80;
 WaterClass GetEffectiveWaterClass(TileIndex tile)
 {
 	if (HasTileWaterClass(tile)) return GetWaterClass(tile);
-	if (IsTileType(tile, MP_TUNNELBRIDGE)) {
+	if (IsTileType(tile, TileType::TunnelBridge)) {
 		assert(GetTunnelBridgeTransportType(tile) == TRANSPORT_WATER);
 		return WaterClass::Canal;
 	}
-	if (IsTileType(tile, MP_RAILWAY)) {
+	if (IsTileType(tile, TileType::Railway)) {
 		assert(GetRailGroundType(tile) == RailGroundType::HalfTileWater);
 		return WaterClass::Sea;
 	}
@@ -566,7 +566,7 @@ static const ShipSubcoordData _ship_subcoord[DIAGDIR_END][TRACK_END] = {
 static int ShipTestUpDownOnLock(const Ship *v)
 {
 	/* Suitable tile? */
-	if (!IsTileType(v->tile, MP_WATER) || !IsLock(v->tile) || GetLockPart(v->tile) != LockPart::Middle) return 0;
+	if (!IsTileType(v->tile, TileType::Water) || !IsLock(v->tile) || GetLockPart(v->tile) != LockPart::Middle) return 0;
 
 	/* Must be at the centre of the lock */
 	if ((v->x_pos & 0xF) != 8 || (v->y_pos & 0xF) != 8) return 0;
@@ -622,11 +622,11 @@ bool IsShipDestinationTile(TileIndex tile, StationID station)
 		TileIndex t = tile + TileOffsByDiagDir(d);
 		if (!IsValidTile(t)) continue;
 		if (IsDockTile(t) && GetStationIndex(t) == station && IsDockWaterPart(t)) return true;
-		if (IsTileType(t, MP_INDUSTRY)) {
+		if (IsTileType(t, TileType::Industry)) {
 			const Industry *i = Industry::GetByTile(t);
 			if (i->neutral_station != nullptr && i->neutral_station->index == station) return true;
 		}
-		if (IsTileType(t, MP_STATION) && IsOilRig(t) && GetStationIndex(t) == station) return true;
+		if (IsTileType(t, TileType::Station) && IsOilRig(t) && GetStationIndex(t) == station) return true;
 	}
 	return false;
 }
@@ -814,7 +814,7 @@ static void ShipController(Ship *v)
 			}
 		} else {
 			/* On a bridge */
-			if (!IsTileType(gp.new_tile, MP_TUNNELBRIDGE) || !VehicleEnterTile(v, gp.new_tile, gp.x, gp.y).Test(VehicleEnterTileState::EnteredWormhole)) {
+			if (!IsTileType(gp.new_tile, TileType::TunnelBridge) || !VehicleEnterTile(v, gp.new_tile, gp.x, gp.y).Test(VehicleEnterTileState::EnteredWormhole)) {
 				v->x_pos = gp.x;
 				v->y_pos = gp.y;
 				v->UpdatePosition();

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -275,7 +275,7 @@ static SigFlags ExploreSegment(Owner owner)
 		DiagDirection exitdir = enterdir == INVALID_DIAGDIR ? INVALID_DIAGDIR : ReverseDiagDir(enterdir); // expected new exit direction (for straight line)
 
 		switch (GetTileType(tile)) {
-			case MP_RAILWAY: {
+			case TileType::Railway: {
 				if (GetTileOwner(tile) != owner) continue; // do not propagate signals on others' tiles (remove for tracksharing)
 
 				if (IsRailDepot(tile)) {
@@ -352,7 +352,7 @@ static SigFlags ExploreSegment(Owner owner)
 				continue; // continue the while() loop
 				}
 
-			case MP_STATION:
+			case TileType::Station:
 				if (!HasStationRail(tile)) continue;
 				if (GetTileOwner(tile) != owner) continue;
 				if (DiagDirToAxis(enterdir) != GetRailStationAxis(tile)) continue; // different axis
@@ -362,7 +362,7 @@ static SigFlags ExploreSegment(Owner owner)
 				tile += TileOffsByDiagDir(exitdir);
 				break;
 
-			case MP_ROAD:
+			case TileType::Road:
 				if (!IsLevelCrossing(tile)) continue;
 				if (GetTileOwner(tile) != owner) continue;
 				if (DiagDirToAxis(enterdir) == GetCrossingRoadAxis(tile)) continue; // different axis
@@ -371,7 +371,7 @@ static SigFlags ExploreSegment(Owner owner)
 				tile += TileOffsByDiagDir(exitdir);
 				break;
 
-			case MP_TUNNELBRIDGE: {
+			case TileType::TunnelBridge: {
 				if (GetTileOwner(tile) != owner) continue;
 				if (GetTunnelBridgeTransportType(tile) != TRANSPORT_RAIL) continue;
 				DiagDirection dir = GetTunnelBridgeDirection(tile);
@@ -490,13 +490,13 @@ static SigSegState UpdateSignalsInBuffer(Owner owner)
 		assert(_tbuset.IsEmpty());
 		assert(_tbdset.IsEmpty());
 
-		/* After updating signal, data stored are always MP_RAILWAY with signals.
+		/* After updating signal, data stored are always TileType::Railway with signals.
 		 * Other situations happen when data are from outside functions -
 		 * modification of railbits (including both rail building and removal),
 		 * train entering/leaving block, train leaving depot...
 		 */
 		switch (GetTileType(tile)) {
-			case MP_TUNNELBRIDGE:
+			case TileType::TunnelBridge:
 				/* 'optimization assert' - do not try to update signals when it is not needed */
 				assert(GetTunnelBridgeTransportType(tile) == TRANSPORT_RAIL);
 				assert(dir == INVALID_DIAGDIR || dir == ReverseDiagDir(GetTunnelBridgeDirection(tile)));
@@ -504,7 +504,7 @@ static SigSegState UpdateSignalsInBuffer(Owner owner)
 				_tbdset.Add(GetOtherTunnelBridgeEnd(tile), INVALID_DIAGDIR);
 				break;
 
-			case MP_RAILWAY:
+			case TileType::Railway:
 				if (IsRailDepot(tile)) {
 					/* 'optimization assert' do not try to update signals in other cases */
 					assert(dir == INVALID_DIAGDIR || dir == GetRailDepotDirection(tile));
@@ -513,8 +513,8 @@ static SigSegState UpdateSignalsInBuffer(Owner owner)
 				}
 				[[fallthrough]];
 
-			case MP_STATION:
-			case MP_ROAD:
+			case TileType::Station:
+			case TileType::Road:
 				if ((TrackStatusToTrackBits(GetTileTrackStatus(tile, TRANSPORT_RAIL, 0)) & _enterdir_to_trackbits[dir]) != TRACK_BIT_NONE) {
 					/* only add to set when there is some 'interesting' track */
 					_tbdset.Add(tile, dir);

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -29,6 +29,7 @@
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 #include "smallmap_gui.h"
+#include "core/enum_type.hpp"
 
 #include "widgets/smallmap_widget.h"
 
@@ -372,50 +373,50 @@ static inline uint32_t ApplyMask(uint32_t colour, const AndOr *mask)
 
 
 /** Colour masks for "Contour" and "Routes" modes. */
-static const AndOr _smallmap_contours_andor[] = {
-	{MKCOLOUR_0000               , MKCOLOUR_FFFF}, // MP_CLEAR
-	{MKCOLOUR_0XX0(PC_GREY      ), MKCOLOUR_F00F}, // MP_RAILWAY
-	{MKCOLOUR_0XX0(PC_BLACK     ), MKCOLOUR_F00F}, // MP_ROAD
-	{MKCOLOUR_0XX0(PC_DARK_RED  ), MKCOLOUR_F00F}, // MP_HOUSE
-	{MKCOLOUR_0000               , MKCOLOUR_FFFF}, // MP_TREES
-	{MKCOLOUR_XXXX(PC_LIGHT_BLUE), MKCOLOUR_0000}, // MP_STATION
-	{MKCOLOUR_XXXX(PC_WATER     ), MKCOLOUR_0000}, // MP_WATER
-	{MKCOLOUR_0000               , MKCOLOUR_FFFF}, // MP_VOID
-	{MKCOLOUR_XXXX(PC_DARK_RED  ), MKCOLOUR_0000}, // MP_INDUSTRY
-	{MKCOLOUR_0000               , MKCOLOUR_FFFF}, // MP_TUNNELBRIDGE
-	{MKCOLOUR_0XX0(PC_DARK_RED  ), MKCOLOUR_F00F}, // MP_OBJECT
-	{MKCOLOUR_0XX0(PC_GREY      ), MKCOLOUR_F00F},
+static const EnumClassIndexContainer<std::array<AndOr, to_underlying(TileType::End) + 1>, TileType> _smallmap_contours_andor = {
+	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::Clear
+	AndOr(MKCOLOUR_0XX0(PC_GREY), MKCOLOUR_F00F), // TileType::Railway
+	AndOr(MKCOLOUR_0XX0(PC_BLACK), MKCOLOUR_F00F), // TileType::Road
+	AndOr(MKCOLOUR_0XX0(PC_DARK_RED), MKCOLOUR_F00F), // TileType::House
+	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::Trees
+	AndOr(MKCOLOUR_XXXX(PC_LIGHT_BLUE), MKCOLOUR_0000), // TileType::Station
+	AndOr(MKCOLOUR_XXXX(PC_WATER), MKCOLOUR_0000), // TileType::Water
+	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::Void
+	AndOr(MKCOLOUR_XXXX(PC_DARK_RED), MKCOLOUR_0000), // TileType::Industry
+	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::TunnelBridge
+	AndOr(MKCOLOUR_0XX0(PC_DARK_RED), MKCOLOUR_F00F), // TileType::Object
+	AndOr(MKCOLOUR_0XX0(PC_GREY), MKCOLOUR_F00F),
 };
 
 /** Colour masks for "Vehicles", "Industry", and "Vegetation" modes. */
-static const AndOr _smallmap_vehicles_andor[] = {
-	{MKCOLOUR_0000               , MKCOLOUR_FFFF}, // MP_CLEAR
-	{MKCOLOUR_0XX0(PC_BLACK     ), MKCOLOUR_F00F}, // MP_RAILWAY
-	{MKCOLOUR_0XX0(PC_BLACK     ), MKCOLOUR_F00F}, // MP_ROAD
-	{MKCOLOUR_0XX0(PC_DARK_RED  ), MKCOLOUR_F00F}, // MP_HOUSE
-	{MKCOLOUR_0000               , MKCOLOUR_FFFF}, // MP_TREES
-	{MKCOLOUR_0XX0(PC_BLACK     ), MKCOLOUR_F00F}, // MP_STATION
-	{MKCOLOUR_XXXX(PC_WATER     ), MKCOLOUR_0000}, // MP_WATER
-	{MKCOLOUR_0000               , MKCOLOUR_FFFF}, // MP_VOID
-	{MKCOLOUR_XXXX(PC_DARK_RED  ), MKCOLOUR_0000}, // MP_INDUSTRY
-	{MKCOLOUR_0000               , MKCOLOUR_FFFF}, // MP_TUNNELBRIDGE
-	{MKCOLOUR_0XX0(PC_DARK_RED  ), MKCOLOUR_F00F}, // MP_OBJECT
-	{MKCOLOUR_0XX0(PC_BLACK     ), MKCOLOUR_F00F},
+static const EnumClassIndexContainer<std::array<AndOr, to_underlying(TileType::End) + 1>, TileType> _smallmap_vehicles_andor = {
+	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::Clear
+	AndOr(MKCOLOUR_0XX0(PC_BLACK), MKCOLOUR_F00F), // TileType::Railway
+	AndOr(MKCOLOUR_0XX0(PC_BLACK), MKCOLOUR_F00F), // TileType::Road
+	AndOr(MKCOLOUR_0XX0(PC_DARK_RED), MKCOLOUR_F00F), // TileType::House
+	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::Trees
+	AndOr(MKCOLOUR_0XX0(PC_BLACK), MKCOLOUR_F00F), // TileType::Station
+	AndOr(MKCOLOUR_XXXX(PC_WATER), MKCOLOUR_0000), // TileType::Water
+	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::Void
+	AndOr(MKCOLOUR_XXXX(PC_DARK_RED), MKCOLOUR_0000), // TileType::Industry
+	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::TunnelBridge
+	AndOr(MKCOLOUR_0XX0(PC_DARK_RED), MKCOLOUR_F00F), // TileType::Object
+	AndOr(MKCOLOUR_0XX0(PC_BLACK), MKCOLOUR_F00F),
 };
 
 /** Mapping of tile type to importance of the tile (higher number means more interesting to show). */
-static const uint8_t _tiletype_importance[] = {
-	2, // MP_CLEAR
-	8, // MP_RAILWAY
-	7, // MP_ROAD
-	5, // MP_HOUSE
-	2, // MP_TREES
-	9, // MP_STATION
-	2, // MP_WATER
-	1, // MP_VOID
-	6, // MP_INDUSTRY
-	8, // MP_TUNNELBRIDGE
-	2, // MP_OBJECT
+static const EnumClassIndexContainer<std::array<uint8_t, to_underlying(TileType::End) + 1>, TileType> _tiletype_importance = {
+	2, // TileType::Clear
+	8, // TileType::Railway
+	7, // TileType::Road
+	5, // TileType::House
+	2, // TileType::Trees
+	9, // TileType::Station
+	2, // TileType::Water
+	1, // TileType::Void
+	6, // TileType::Industry
+	8, // TileType::TunnelBridge
+	2, // TileType::Object
 	0,
 };
 
@@ -468,7 +469,7 @@ static inline uint32_t GetSmallMapIndustriesPixels(TileIndex tile, TileType t)
 static inline uint32_t GetSmallMapRoutesPixels(TileIndex tile, TileType t)
 {
 	switch (t) {
-		case MP_STATION:
+		case TileType::Station:
 			switch (GetStationType(tile)) {
 				case StationType::Rail:    return MKCOLOUR_XXXX(PC_VERY_DARK_BROWN);
 				case StationType::Airport: return MKCOLOUR_XXXX(PC_RED);
@@ -478,7 +479,7 @@ static inline uint32_t GetSmallMapRoutesPixels(TileIndex tile, TileType t)
 				default:              return MKCOLOUR_FFFF;
 			}
 
-		case MP_RAILWAY: {
+		case TileType::Railway: {
 			AndOr andor = {
 				MKCOLOUR_0XX0(GetRailTypeInfo(GetRailType(tile))->map_colour),
 				_smallmap_contours_andor[t].mand
@@ -488,7 +489,7 @@ static inline uint32_t GetSmallMapRoutesPixels(TileIndex tile, TileType t)
 			return ApplyMask(cs->default_colour, &andor);
 		}
 
-		case MP_ROAD: {
+		case TileType::Road: {
 			const RoadTypeInfo *rti = nullptr;
 			if (GetRoadTypeRoad(tile) != INVALID_ROADTYPE) {
 				rti = GetRoadTypeInfo(GetRoadTypeRoad(tile));
@@ -547,7 +548,7 @@ static const uint32_t _vegetation_clear_bits[] = {
 static inline uint32_t GetSmallMapVegetationPixels(TileIndex tile, TileType t)
 {
 	switch (t) {
-		case MP_CLEAR:
+		case TileType::Clear:
 			if (IsSnowTile(tile)) return MKCOLOUR_XXXX(PC_LIGHT_BLUE);
 			if (IsClearGround(tile, CLEAR_GRASS)) {
 				if (GetClearDensity(tile) < 3) return MKCOLOUR_XXXX(PC_BARE_LAND);
@@ -555,10 +556,10 @@ static inline uint32_t GetSmallMapVegetationPixels(TileIndex tile, TileType t)
 			}
 			return _vegetation_clear_bits[GetClearGround(tile)];
 
-		case MP_INDUSTRY:
+		case TileType::Industry:
 			return IsTileForestIndustry(tile) ? MKCOLOUR_XXXX(PC_GREEN) : MKCOLOUR_XXXX(PC_DARK_RED);
 
-		case MP_TREES:
+		case TileType::Trees:
 			if (GetTreeGround(tile) == TREE_GROUND_SNOW_DESERT || GetTreeGround(tile) == TREE_GROUND_ROUGH_SNOW) {
 				return (_settings_game.game_creation.landscape == LandscapeType::Arctic) ? MKCOLOUR_XYYX(PC_LIGHT_BLUE, PC_TREES) : MKCOLOUR_XYYX(PC_ORANGE, PC_TREES);
 			}
@@ -583,10 +584,10 @@ uint32_t GetSmallMapOwnerPixels(TileIndex tile, TileType t, IncludeHeightmap inc
 	Owner o;
 
 	switch (t) {
-		case MP_VOID:     return MKCOLOUR_XXXX(PC_BLACK);
-		case MP_INDUSTRY: return MKCOLOUR_XXXX(PC_DARK_GREY);
-		case MP_HOUSE:    return MKCOLOUR_XXXX(PC_DARK_RED);
-		case MP_ROAD:
+		case TileType::Void:     return MKCOLOUR_XXXX(PC_BLACK);
+		case TileType::Industry: return MKCOLOUR_XXXX(PC_DARK_GREY);
+		case TileType::House:    return MKCOLOUR_XXXX(PC_DARK_RED);
+		case TileType::Road:
 			o = GetRoadOwner(tile, HasRoadTypeRoad(tile) ? RTT_ROAD : RTT_TRAM);
 			break;
 
@@ -596,7 +597,7 @@ uint32_t GetSmallMapOwnerPixels(TileIndex tile, TileType t, IncludeHeightmap inc
 	}
 
 	if ((o < MAX_COMPANIES && !_legend_land_owners[_company_to_list_pos[o]].show_on_map) || o == OWNER_NONE || o == OWNER_WATER) {
-		if (t == MP_WATER) return MKCOLOUR_XXXX(PC_WATER);
+		if (t == TileType::Water) return MKCOLOUR_XXXX(PC_WATER);
 		const SmallMapColourScheme *cs = &_heightmap_schemes[_settings_client.gui.smallmap_land_colour];
 		return ((include_heightmap == IncludeHeightmap::IfEnabled && _smallmap_show_heightmap) || include_heightmap == IncludeHeightmap::Always)
 			? cs->height_colours[TileHeight(tile)] : cs->default_colour;
@@ -930,7 +931,7 @@ protected:
 			} else {
 				ta = TileArea(TileXY(xc, yc), this->zoom, this->zoom);
 			}
-			ta.ClampToMap(); // Clamp to map boundaries (may contain MP_VOID tiles!).
+			ta.ClampToMap(); // Clamp to map boundaries (may contain TileType::Void tiles!).
 
 			uint32_t val = this->GetTileColours(ta);
 			uint8_t *val8 = (uint8_t *)&val;
@@ -1323,24 +1324,24 @@ protected:
 	{
 		int importance = 0;
 		TileIndex tile = INVALID_TILE; // Position of the most important tile.
-		TileType et = MP_VOID;         // Effective tile type at that position.
+		TileType et = TileType::Void;         // Effective tile type at that position.
 
 		for (TileIndex ti : ta) {
 			TileType ttype = GetTileType(ti);
 
 			switch (ttype) {
-				case MP_TUNNELBRIDGE: {
+				case TileType::TunnelBridge: {
 					TransportType tt = GetTunnelBridgeTransportType(ti);
 
 					switch (tt) {
-						case TRANSPORT_RAIL: ttype = MP_RAILWAY; break;
-						case TRANSPORT_ROAD: ttype = MP_ROAD;    break;
-						default:             ttype = MP_WATER;   break;
+						case TRANSPORT_RAIL: ttype = TileType::Railway; break;
+						case TRANSPORT_ROAD: ttype = TileType::Road;    break;
+						default:             ttype = TileType::Water;   break;
 					}
 					break;
 				}
 
-				case MP_INDUSTRY:
+				case TileType::Industry:
 					/* Special handling of industries while in "Industries" smallmap view. */
 					if (this->map_type == SMT_INDUSTRY) {
 						/* If industry is allowed to be seen, use its colour on the map.
@@ -1354,7 +1355,7 @@ protected:
 							}
 						}
 						/* Otherwise make it disappear */
-						ttype = IsTileOnWater(ti) ? MP_WATER : MP_CLEAR;
+						ttype = IsTileOnWater(ti) ? TileType::Water : TileType::Clear;
 					}
 					break;
 

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -305,12 +305,12 @@ void Station::MarkTilesDirty(bool cargo_change) const
  * Get the catchment size of an individual station tile.
  * @param tile Station tile to get catchment size of.
  * @param st Associated station of station tile.
- * @pre IsTileType(tile, MP_STATION)
+ * @pre IsTileType(tile, TileType::Station)
  * @return The catchment size of the station tile.
  */
 static uint GetTileCatchmentRadius(TileIndex tile, const Station *st)
 {
-	assert(IsTileType(tile, MP_STATION));
+	assert(IsTileType(tile, TileType::Station));
 
 	if (_settings_game.station.modified_catchment) {
 		switch (GetStationType(tile)) {
@@ -431,9 +431,9 @@ void Station::RemoveFromAllNearbyLists()
 
 	for (const auto &tile : this->catchment_tiles) {
 		TileType type = GetTileType(tile);
-		if (type == MP_HOUSE) {
+		if (type == TileType::House) {
 			towns.insert(GetTownIndex(tile));
-		} else if (type == MP_INDUSTRY) {
+		} else if (type == TileType::Industry) {
 			industries.insert(GetIndustryIndex(tile));
 		}
 	}
@@ -453,7 +453,7 @@ bool Station::CatchmentCoversTown(TownID t) const
 {
 	BitmapTileIterator it(this->catchment_tiles);
 	for (TileIndex tile = it; tile != INVALID_TILE; tile = ++it) {
-		if (IsTileType(tile, MP_HOUSE) && GetTownIndex(tile) == t) return true;
+		if (IsTileType(tile, TileType::House) && GetTownIndex(tile) == t) return true;
 	}
 	return false;
 }
@@ -477,7 +477,7 @@ void Station::RecomputeCatchment(bool no_clear_nearby_lists)
 		/* Station is associated with an industry, so we only need to deliver to that industry. */
 		this->catchment_tiles.Initialize(this->industry->location);
 		for (TileIndex tile : this->industry->location) {
-			if (IsTileType(tile, MP_INDUSTRY) && GetIndustryIndex(tile) == this->industry->index) {
+			if (IsTileType(tile, TileType::Industry) && GetIndustryIndex(tile) == this->industry->index) {
 				this->catchment_tiles.SetTile(tile);
 			}
 		}
@@ -496,7 +496,7 @@ void Station::RecomputeCatchment(bool no_clear_nearby_lists)
 	/* Loop finding all station tiles */
 	TileArea ta(TileXY(this->rect.left, this->rect.top), TileXY(this->rect.right, this->rect.bottom));
 	for (TileIndex tile : ta) {
-		if (!IsTileType(tile, MP_STATION) || GetStationIndex(tile) != this->index) continue;
+		if (!IsTileType(tile, TileType::Station) || GetStationIndex(tile) != this->index) continue;
 
 		uint r = GetTileCatchmentRadius(tile, this);
 		if (r == CA_NONE) continue;
@@ -509,11 +509,11 @@ void Station::RecomputeCatchment(bool no_clear_nearby_lists)
 	/* Search catchment tiles for towns and industries */
 	BitmapTileIterator it(this->catchment_tiles);
 	for (TileIndex tile = it; tile != INVALID_TILE; tile = ++it) {
-		if (IsTileType(tile, MP_HOUSE)) {
+		if (IsTileType(tile, TileType::House)) {
 			Town *t = Town::GetByTile(tile);
 			t->stations_near.insert(this);
 		}
-		if (IsTileType(tile, MP_INDUSTRY)) {
+		if (IsTileType(tile, TileType::Industry)) {
 			Industry *i = Industry::GetByTile(tile);
 
 			/* Ignore industry if it has a neutral station. It already can't be this station. */
@@ -630,7 +630,7 @@ CommandCost StationRect::BeforeAddRect(TileIndex tile, int w, int h, StationRect
 {
 	TileArea ta(TileXY(left_a, top_a), TileXY(right_a, bottom_a));
 	for (TileIndex tile : ta) {
-		if (IsTileType(tile, MP_STATION) && GetStationIndex(tile) == st_id) return true;
+		if (IsTileType(tile, TileType::Station) && GetStationIndex(tile) == st_id) return true;
 	}
 
 	return false;

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -655,7 +655,7 @@ void ForAllStationsAroundTiles(const TileArea &ta, Func func)
 	uint max_c = _settings_game.station.modified_catchment ? MAX_CATCHMENT : CA_UNMODIFIED;
 	TileArea ta_ext = TileArea(ta).Expand(max_c);
 	for (TileIndex tile : ta_ext) {
-		if (!IsTileType(tile, MP_STATION)) continue;
+		if (!IsTileType(tile, TileType::Station)) continue;
 		seen_stations.insert(GetStationIndex(tile));
 	}
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -91,12 +91,12 @@
 /**
  * Check whether the given tile is a hangar.
  * @param t the tile to of whether it is a hangar.
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return true if and only if the tile is a hangar.
  */
 bool IsHangar(Tile t)
 {
-	assert(IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::Station));
 
 	/* If the tile isn't an airport there's no chance it's a hangar. */
 	if (!IsAirport(t)) return false;
@@ -127,7 +127,7 @@ CommandCost GetStationAround(TileArea ta, StationID closest_station, CompanyID c
 
 	/* check around to see if there are any stations there owned by the company */
 	for (TileIndex tile_cur : ta) {
-		if (IsTileType(tile_cur, MP_STATION)) {
+		if (IsTileType(tile_cur, TileType::Station)) {
 			StationID t = GetStationIndex(tile_cur);
 			if (!T::IsValidID(t) || T::Get(t)->owner != company || !filter(T::Get(t))) continue;
 			if (closest_station == StationID::Invalid()) {
@@ -176,7 +176,7 @@ static int CountMapSquareAround(TileIndex tile, CMSAMatcher cmp)
 static bool CMSAMine(TileIndex tile)
 {
 	/* No industry */
-	if (!IsTileType(tile, MP_INDUSTRY)) return false;
+	if (!IsTileType(tile, TileType::Industry)) return false;
 
 	const Industry *ind = Industry::GetByTile(tile);
 
@@ -202,7 +202,7 @@ static bool CMSAMine(TileIndex tile)
  */
 static bool CMSAWater(TileIndex tile)
 {
-	return IsTileType(tile, MP_WATER) && IsWater(tile);
+	return IsTileType(tile, TileType::Water) && IsWater(tile);
 }
 
 /**
@@ -212,7 +212,7 @@ static bool CMSAWater(TileIndex tile)
  */
 static bool CMSATree(TileIndex tile)
 {
-	return IsTileType(tile, MP_TREES);
+	return IsTileType(tile, TileType::Trees);
 }
 
 enum StationNaming : uint8_t {
@@ -271,7 +271,7 @@ static StringID GenerateStationName(Station *st, TileIndex tile, StationNaming n
 	}
 
 	for (auto indtile : SpiralTileSequence(tile, 7)) {
-		if (!IsTileType(indtile, MP_INDUSTRY)) continue;
+		if (!IsTileType(indtile, TileType::Industry)) continue;
 
 		/* If the station name is undefined it means that it doesn't name a station */
 		IndustryType indtype = GetIndustryType(indtile);
@@ -539,7 +539,7 @@ CargoArray GetProductionAroundTiles(TileIndex north_tile, int w, int h, int rad)
 	/* Loop over all tiles to get the produced cargo of
 	 * everything except industries */
 	for (TileIndex tile : ta) {
-		if (IsTileType(tile, MP_INDUSTRY)) industries.insert(GetIndustryIndex(tile));
+		if (IsTileType(tile, TileType::Industry)) industries.insert(GetIndustryIndex(tile));
 		AddProducedCargo(tile, produced);
 	}
 
@@ -577,7 +577,7 @@ CargoArray GetAcceptanceAroundTiles(TileIndex center_tile, int w, int h, int rad
 
 	for (TileIndex tile : ta) {
 		/* Ignore industry if it has a neutral station. */
-		if (!_settings_game.station.serve_neutral_industries && IsTileType(tile, MP_INDUSTRY) && Industry::GetByTile(tile)->neutral_station != nullptr) continue;
+		if (!_settings_game.station.serve_neutral_industries && IsTileType(tile, TileType::Industry) && Industry::GetByTile(tile)->neutral_station != nullptr) continue;
 
 		AddAcceptedCargo(tile, acceptance, always_accepted);
 	}
@@ -1011,7 +1011,7 @@ static CommandCost CheckFlatLandRailStation(TileIndex tile_cur, TileIndex north_
 	/* if station is set, then we have special handling to allow building on top of already existing stations.
 	 * so station points to StationID::Invalid() if we can build on any station.
 	 * Or it points to a station if we're only allowed to build on exactly that station. */
-	if (station != nullptr && IsTileType(tile_cur, MP_STATION)) {
+	if (station != nullptr && IsTileType(tile_cur, TileType::Station)) {
 		if (!IsRailStation(tile_cur)) {
 			return ClearTile_Station(tile_cur, DoCommandFlag::Auto); // get error message
 		} else {
@@ -1087,7 +1087,7 @@ static CommandCost CheckFlatLandRoadStop(TileIndex cur_tile, int &allowed_z, con
 	/* If station is set, then we have special handling to allow building on top of already existing stations.
 	 * Station points to StationID::Invalid() if we can build on any station.
 	 * Or it points to a station if we're only allowed to build on exactly that station. */
-	if (station != nullptr && IsTileType(cur_tile, MP_STATION)) {
+	if (station != nullptr && IsTileType(cur_tile, TileType::Station)) {
 		if (!IsAnyRoadStop(cur_tile)) {
 			return ClearTile_Station(cur_tile, DoCommandFlag::Auto); // Get error message.
 		} else {
@@ -2040,7 +2040,7 @@ CommandCost CalculateRoadStopCost(TileArea tile_area, DoCommandFlags flags, bool
 		CommandCost ret = CheckFlatLandRoadStop(cur_tile, allowed_z, roadstopspec, flags, invalid_dirs, is_drive_through, station_type, axis, est, rt);
 		if (ret.Failed()) return ret;
 
-		bool is_preexisting_roadstop = IsTileType(cur_tile, MP_STATION) && IsAnyRoadStop(cur_tile);
+		bool is_preexisting_roadstop = IsTileType(cur_tile, TileType::Station) && IsAnyRoadStop(cur_tile);
 
 		/* Only add costs if a stop doesn't already exist in the location */
 		if (!is_preexisting_roadstop) {
@@ -2155,7 +2155,7 @@ CommandCost CmdBuildRoadStop(DoCommandFlags flags, TileIndex tile, uint8_t width
 			Owner road_owner = road_rt != INVALID_ROADTYPE ? GetRoadOwner(cur_tile, RTT_ROAD) : _current_company;
 			Owner tram_owner = tram_rt != INVALID_ROADTYPE ? GetRoadOwner(cur_tile, RTT_TRAM) : _current_company;
 
-			if (IsTileType(cur_tile, MP_STATION) && IsStationRoadStop(cur_tile)) {
+			if (IsTileType(cur_tile, TileType::Station) && IsStationRoadStop(cur_tile)) {
 				RemoveRoadStop(cur_tile, flags, *specindex);
 			}
 
@@ -2425,7 +2425,7 @@ static CommandCost RemoveGenericRoadStop(DoCommandFlags flags, const TileArea &r
 
 	for (TileIndex cur_tile : roadstop_area) {
 		/* Make sure the specified tile is a road stop of the correct type */
-		if (!IsTileType(cur_tile, MP_STATION) || !IsAnyRoadStop(cur_tile) || IsRoadWaypoint(cur_tile) != road_waypoint) continue;
+		if (!IsTileType(cur_tile, TileType::Station) || !IsAnyRoadStop(cur_tile) || IsRoadWaypoint(cur_tile) != road_waypoint) continue;
 
 		/* Save information on to-be-restored roads before the stop is removed. */
 		RoadBits road_bits = ROAD_NONE;
@@ -2933,7 +2933,7 @@ CommandCost CmdBuildDock(DoCommandFlags flags, TileIndex tile, StationID station
 	if (add_cost) cost.AddCost(ret.GetCost());
 
 	tile_cur += TileOffsByDiagDir(direction);
-	if (!IsTileType(tile_cur, MP_WATER) || !IsTileFlat(tile_cur)) {
+	if (!IsTileType(tile_cur, TileType::Water) || !IsTileFlat(tile_cur)) {
 		return CommandCost(STR_ERROR_SITE_UNSUITABLE);
 	}
 
@@ -2983,10 +2983,10 @@ void RemoveDockingTile(TileIndex t)
 		TileIndex tile = t + TileOffsByDiagDir(d);
 		if (!IsValidTile(tile)) continue;
 
-		if (IsTileType(tile, MP_STATION)) {
+		if (IsTileType(tile, TileType::Station)) {
 			Station *st = Station::GetByTile(tile);
 			if (st != nullptr) UpdateStationDockingTiles(st);
-		} else if (IsTileType(tile, MP_INDUSTRY)) {
+		} else if (IsTileType(tile, TileType::Industry)) {
 			Station *neutral = Industry::GetByTile(tile)->neutral_station;
 			if (neutral != nullptr) UpdateStationDockingTiles(neutral);
 		}
@@ -3903,7 +3903,7 @@ void TriggerWatchedCargoCallbacks(Station *st)
 	/* Loop over all houses in the catchment. */
 	BitmapTileIterator it(st->catchment_tiles);
 	for (TileIndex tile = it; tile != INVALID_TILE; tile = ++it) {
-		if (IsTileType(tile, MP_HOUSE)) {
+		if (IsTileType(tile, TileType::House)) {
 			TriggerHouseAnimation_WatchedCargoAccepted(tile, cargoes);
 		}
 	}
@@ -4559,7 +4559,7 @@ static void AddNearbyStationsByCatchment(TileIndex tile, StationList &stations, 
 const StationList &StationFinder::GetStations()
 {
 	if (this->tile != INVALID_TILE) {
-		if (IsTileType(this->tile, MP_HOUSE)) {
+		if (IsTileType(this->tile, TileType::House)) {
 			/* Town nearby stations need to be filtered per tile. */
 			assert(this->w == 1 && this->h == 1);
 			AddNearbyStationsByCatchment(this->tile, this->stations, Town::GetByTile(this->tile)->stations_near);
@@ -4720,7 +4720,7 @@ void BuildOilRig(TileIndex tile)
 
 	st->string_id = GenerateStationName(st, tile, STATIONNAMING_OILRIG);
 
-	assert(IsTileType(tile, MP_INDUSTRY));
+	assert(IsTileType(tile, TileType::Industry));
 	/* Mark industry as associated both ways */
 	st->industry = Industry::GetByTile(tile);
 	st->industry->neutral_station = st;
@@ -4845,7 +4845,7 @@ static void ChangeTileOwner_Station(TileIndex tile, Owner old_owner, Owner new_o
 			} else {
 				Command<CMD_REMOVE_ROAD_STOP>::Do({DoCommandFlag::Execute, DoCommandFlag::Bankrupt}, tile, 1, 1, (GetStationType(tile) == StationType::Truck) ? RoadStopType::Truck : RoadStopType::Bus, false);
 			}
-			assert(IsTileType(tile, MP_ROAD));
+			assert(IsTileType(tile, TileType::Road));
 			/* Change owner of tile and all roadtypes */
 			ChangeTileOwner(tile, old_owner, new_owner);
 		} else {
@@ -4853,7 +4853,7 @@ static void ChangeTileOwner_Station(TileIndex tile, Owner old_owner, Owner new_o
 			/* Set tile owner of water under (now removed) buoy and dock to OWNER_NONE.
 			 * Update owner of buoy if it was not removed (was in orders).
 			 * Do not update when owned by OWNER_WATER (sea and rivers). */
-			if ((IsTileType(tile, MP_WATER) || IsBuoyTile(tile)) && IsTileOwner(tile, old_owner)) SetTileOwner(tile, OWNER_NONE);
+			if ((IsTileType(tile, TileType::Water) || IsBuoyTile(tile)) && IsTileOwner(tile, old_owner)) SetTileOwner(tile, OWNER_NONE);
 		}
 	}
 }

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -63,8 +63,8 @@ struct GenericWaypointTypeFilter
 	static bool IsAcceptableWaypointTile(TileIndex tile) { return IsTileType(tile, TILE_TYPE); }
 	static constexpr bool IsWaypoint() { return true; }
 };
-using RailWaypointTypeFilter = GenericWaypointTypeFilter<false, MP_RAILWAY>;
-using RoadWaypointTypeFilter = GenericWaypointTypeFilter<true, MP_ROAD>;
+using RailWaypointTypeFilter = GenericWaypointTypeFilter<false, TileType::Railway>;
+using RoadWaypointTypeFilter = GenericWaypointTypeFilter<true, TileType::Road>;
 
 /**
  * Calculates and draws the accepted or supplied cargo around the selected tile(s)
@@ -117,7 +117,7 @@ void FindStationsAroundSelection()
 	TileArea location(TileVirtXY(_thd.pos.x, _thd.pos.y), _thd.size.x / TILE_SIZE - 1, _thd.size.y / TILE_SIZE - 1);
 
 	/* If the current tile is already a station, then it must be the nearest station. */
-	if (IsTileType(location.tile, MP_STATION) && GetTileOwner(location.tile) == _local_company) {
+	if (IsTileType(location.tile, TileType::Station) && GetTileOwner(location.tile) == _local_company) {
 		typename T::StationType *st = T::StationType::GetByTile(location.tile);
 		if (st != nullptr && T::IsValidBaseStation(st)) {
 			SetViewportCatchmentSpecializedStation<typename T::StationType>(st, true);
@@ -137,7 +137,7 @@ void FindStationsAroundSelection()
 
 	/* Direct loop instead of ForAllStationsAroundTiles as we are not interested in catchment area */
 	for (TileIndex tile : ta) {
-		if (IsTileType(tile, MP_STATION) && GetTileOwner(tile) == _local_company) {
+		if (IsTileType(tile, TileType::Station) && GetTileOwner(tile) == _local_company) {
 			typename T::StationType *st = T::StationType::GetByTile(tile);
 			if (st == nullptr || !T::IsValidBaseStation(st)) continue;
 			if (adjacent != nullptr && st != adjacent) {
@@ -2207,7 +2207,7 @@ static void AddNearbyStation(TileIndex tile, TileArea *ctx)
 	}
 
 	/* Check if own station and if we stay within station spread */
-	if (!IsTileType(tile, MP_STATION)) return;
+	if (!IsTileType(tile, TileType::Station)) return;
 
 	StationID sid = GetStationIndex(tile);
 

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -22,12 +22,12 @@ typedef uint8_t StationGfx; ///< Index of station graphics. @see _station_displa
 /**
  * Get StationID from a tile
  * @param t Tile to query station ID from
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return Station ID of the station at \a t
  */
 inline StationID GetStationIndex(Tile t)
 {
-	assert(IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::Station));
 	return (StationID)t.m2();
 }
 
@@ -38,12 +38,12 @@ static const int GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET =  4; ///< The offset for the
 /**
  * Get the station type of this tile
  * @param t the tile to query
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return the station type
  */
 inline StationType GetStationType(Tile t)
 {
-	assert(IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::Station));
 	return (StationType)GB(t.m6(), 3, 4);
 }
 
@@ -62,12 +62,12 @@ inline RoadStopType GetRoadStopType(Tile t)
 /**
  * Get the station graphics of this tile
  * @param t the tile to query
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return the station graphics
  */
 inline StationGfx GetStationGfx(Tile t)
 {
-	assert(IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::Station));
 	return t.m5();
 }
 
@@ -75,18 +75,18 @@ inline StationGfx GetStationGfx(Tile t)
  * Set the station graphics of this tile
  * @param t the tile to update
  * @param gfx the new graphics
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  */
 inline void SetStationGfx(Tile t, StationGfx gfx)
 {
-	assert(IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::Station));
 	t.m5() = gfx;
 }
 
 /**
  * Is this station tile a rail station?
  * @param t the tile to get the information from
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return true if and only if the tile is a rail station
  */
 inline bool IsRailStation(Tile t)
@@ -101,13 +101,13 @@ inline bool IsRailStation(Tile t)
  */
 inline bool IsRailStationTile(Tile t)
 {
-	return IsTileType(t, MP_STATION) && IsRailStation(t);
+	return IsTileType(t, TileType::Station) && IsRailStation(t);
 }
 
 /**
  * Is this station tile a rail waypoint?
  * @param t the tile to get the information from
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return true if and only if the tile is a rail waypoint
  */
 inline bool IsRailWaypoint(Tile t)
@@ -122,14 +122,14 @@ inline bool IsRailWaypoint(Tile t)
  */
 inline bool IsRailWaypointTile(Tile t)
 {
-	return IsTileType(t, MP_STATION) && IsRailWaypoint(t);
+	return IsTileType(t, TileType::Station) && IsRailWaypoint(t);
 }
 
 /**
  * Has this station tile a rail? In other words, is this station
  * tile a rail station or rail waypoint?
  * @param t the tile to check
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return true if and only if the tile has rail
  */
 inline bool HasStationRail(Tile t)
@@ -145,13 +145,13 @@ inline bool HasStationRail(Tile t)
  */
 inline bool HasStationTileRail(Tile t)
 {
-	return IsTileType(t, MP_STATION) && HasStationRail(t);
+	return IsTileType(t, TileType::Station) && HasStationRail(t);
 }
 
 /**
  * Is this station tile an airport?
  * @param t the tile to get the information from
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return true if and only if the tile is an airport
  */
 inline bool IsAirport(Tile t)
@@ -166,7 +166,7 @@ inline bool IsAirport(Tile t)
  */
 inline bool IsAirportTile(Tile t)
 {
-	return IsTileType(t, MP_STATION) && IsAirport(t);
+	return IsTileType(t, TileType::Station) && IsAirport(t);
 }
 
 bool IsHangar(Tile t);
@@ -174,7 +174,7 @@ bool IsHangar(Tile t);
 /**
  * Is the station at \a t a truck stop?
  * @param t Tile to check
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return \c true if station is a truck stop, \c false otherwise
  */
 inline bool IsTruckStop(Tile t)
@@ -185,7 +185,7 @@ inline bool IsTruckStop(Tile t)
 /**
  * Is the station at \a t a bus stop?
  * @param t Tile to check
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return \c true if station is a bus stop, \c false otherwise
  */
 inline bool IsBusStop(Tile t)
@@ -196,7 +196,7 @@ inline bool IsBusStop(Tile t)
 /**
  * Is the station at \a t a road waypoint?
  * @param t Tile to check
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return \c true if station is a road waypoint, \c false otherwise
  */
 inline bool IsRoadWaypoint(Tile t)
@@ -211,18 +211,18 @@ inline bool IsRoadWaypoint(Tile t)
  */
 inline bool IsRoadWaypointTile(Tile t)
 {
-	return IsTileType(t, MP_STATION) && IsRoadWaypoint(t);
+	return IsTileType(t, TileType::Station) && IsRoadWaypoint(t);
 }
 
 /**
  * Is the station at \a t a road station?
  * @param t Tile to check
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return \c true if station at the tile is a bus stop or a truck stop, \c false otherwise
  */
 inline bool IsStationRoadStop(Tile t)
 {
-	assert(IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::Station));
 	return IsTruckStop(t) || IsBusStop(t);
 }
 
@@ -233,18 +233,18 @@ inline bool IsStationRoadStop(Tile t)
  */
 inline bool IsStationRoadStopTile(Tile t)
 {
-	return IsTileType(t, MP_STATION) && IsStationRoadStop(t);
+	return IsTileType(t, TileType::Station) && IsStationRoadStop(t);
 }
 
 /**
  * Is the station at \a t a road station?
  * @param t Tile to check
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return \c true if station at the tile is a bus stop, truck stop or road waypoint, \c false otherwise
  */
 inline bool IsAnyRoadStop(Tile t)
 {
-	assert(IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::Station));
 	return IsTruckStop(t) || IsBusStop(t) || IsRoadWaypoint(t);
 }
 
@@ -255,7 +255,7 @@ inline bool IsAnyRoadStop(Tile t)
  */
 inline bool IsAnyRoadStopTile(Tile t)
 {
-	return IsTileType(t, MP_STATION) && IsAnyRoadStop(t);
+	return IsTileType(t, TileType::Station) && IsAnyRoadStop(t);
 }
 
 /**
@@ -362,7 +362,7 @@ inline Axis GetDriveThroughStopAxis(Tile t)
 /**
  * Is tile \a t part of an oilrig?
  * @param t Tile to check
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return \c true if the tile is an oilrig tile
  */
 inline bool IsOilRig(Tile t)
@@ -373,7 +373,7 @@ inline bool IsOilRig(Tile t)
 /**
  * Is tile \a t a dock tile?
  * @param t Tile to check
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return \c true if the tile is a dock
  */
 inline bool IsDock(Tile t)
@@ -388,13 +388,13 @@ inline bool IsDock(Tile t)
  */
 inline bool IsDockTile(Tile t)
 {
-	return IsTileType(t, MP_STATION) && GetStationType(t) == StationType::Dock;
+	return IsTileType(t, TileType::Station) && GetStationType(t) == StationType::Dock;
 }
 
 /**
  * Is tile \a t a buoy tile?
  * @param t Tile to check
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return \c true if the tile is a buoy
  */
 inline bool IsBuoy(Tile t)
@@ -409,7 +409,7 @@ inline bool IsBuoy(Tile t)
  */
 inline bool IsBuoyTile(Tile t)
 {
-	return IsTileType(t, MP_STATION) && IsBuoy(t);
+	return IsTileType(t, TileType::Station) && IsBuoy(t);
 }
 
 /**
@@ -419,7 +419,7 @@ inline bool IsBuoyTile(Tile t)
  */
 inline bool IsHangarTile(Tile t)
 {
-	return IsTileType(t, MP_STATION) && IsHangar(t);
+	return IsTileType(t, TileType::Station) && IsHangar(t);
 }
 
 /**
@@ -685,23 +685,23 @@ inline uint GetCustomRoadStopSpecIndex(Tile t)
  * Set the random bits for a station tile.
  * @param t Tile to set random bits for.
  * @param random_bits The random bits.
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  */
 inline void SetStationTileRandomBits(Tile t, uint8_t random_bits)
 {
-	assert(IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::Station));
 	SB(t.m3(), 4, 4, random_bits);
 }
 
 /**
  * Get the random bits of a station tile.
  * @param t Tile to query
- * @pre IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::Station)
  * @return The random bits for this station tile.
  */
 inline uint8_t GetStationTileRandomBits(Tile t)
 {
-	assert(IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::Station));
 	return GB(t.m3(), 4, 4);
 }
 
@@ -716,7 +716,7 @@ inline uint8_t GetStationTileRandomBits(Tile t)
  */
 inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, uint8_t section, WaterClass wc = WaterClass::Invalid)
 {
-	SetTileType(t, MP_STATION);
+	SetTileType(t, TileType::Station);
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
 	SetDockingTile(t, false);

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -279,7 +279,7 @@ bool FindSubsidyTownCargoRoute()
 	CargoArray town_cargo_produced{};
 	TileArea ta = TileArea(src_town->xy, 1, 1).Expand(SUBSIDY_TOWN_CARGO_RADIUS);
 	for (TileIndex tile : ta) {
-		if (IsTileType(tile, MP_HOUSE)) {
+		if (IsTileType(tile, TileType::House)) {
 			AddProducedCargo(tile, town_cargo_produced);
 		}
 	}
@@ -380,7 +380,7 @@ bool FindSubsidyCargoDestination(CargoType cargo_type, Source src)
 			CargoArray town_cargo_accepted{};
 			TileArea ta = TileArea(dst_town->xy, 1, 1).Expand(SUBSIDY_TOWN_CARGO_RADIUS);
 			for (TileIndex tile : ta) {
-				if (IsTileType(tile, MP_HOUSE)) {
+				if (IsTileType(tile, TileType::House)) {
 					AddAcceptedCargo(tile, town_cargo_accepted, nullptr);
 				}
 			}
@@ -530,7 +530,7 @@ bool CheckSubsidised(CargoType cargo_type, CompanyID company, Source src, const 
 
 			BitmapTileIterator it(st->catchment_tiles);
 			for (TileIndex tile = it; tile != INVALID_TILE; tile = ++it) {
-				if (!IsTileType(tile, MP_HOUSE)) continue;
+				if (!IsTileType(tile, TileType::House)) continue;
 				const Town *t = Town::GetByTile(tile);
 				if (t->cache.part_of_subsidy.Test(PartOfSubsidy::Destination)) include(towns_near, t);
 			}

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -138,7 +138,7 @@ static std::tuple<CommandCost, TileIndex> TerraformTileHeight(TerraformerState *
 	for (DiagDirection dir = DIAGDIR_BEGIN; dir < DIAGDIR_END; dir++) {
 		TileIndex neighbour_tile = AddTileIndexDiffCWrap(tile, TileIndexDiffCByDiagDir(dir));
 
-		/* Not using IsValidTile as we want to also change MP_VOID tiles, which IsValidTile excludes. */
+		/* Not using IsValidTile as we want to also change TileType::Void tiles, which IsValidTile excludes. */
 		if (neighbour_tile == INVALID_TILE) continue;
 
 		/* Get TileHeight of neighboured tile as of current terraform progress */
@@ -207,9 +207,9 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlags flags,
 	for (int pass = 0; pass < 2; pass++) {
 		for (const auto &t : ts.dirty_tiles) {
 			assert(t < Map::Size());
-			/* MP_VOID tiles can be terraformed but as tunnels and bridges
+			/* TileType::Void tiles can be terraformed but as tunnels and bridges
 			 * cannot go under / over these tiles they don't need checking. */
-			if (IsTileType(t, MP_VOID)) continue;
+			if (IsTileType(t, TileType::Void)) continue;
 
 			/* Find new heights of tile corners */
 			int z_N = TerraformGetHeightOfTile(&ts, t + TileDiffXY(0, 0));

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -82,11 +82,11 @@ static void GenerateRockyArea(TileIndex end, TileIndex start)
 
 	for (TileIndex tile : ta) {
 		switch (GetTileType(tile)) {
-			case MP_TREES:
+			case TileType::Trees:
 				if (GetTreeGround(tile) == TREE_GROUND_SHORE) continue;
 				[[fallthrough]];
 
-			case MP_CLEAR:
+			case TileType::Clear:
 				MakeClear(tile, CLEAR_ROCKS, 3);
 				break;
 
@@ -112,7 +112,7 @@ static void GenerateRockyArea(TileIndex end, TileIndex start)
 bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_tile, TileIndex end_tile)
 {
 	if (!_settings_game.construction.freeform_edges) {
-		/* When end_tile is MP_VOID, the error tile will not be visible to the
+		/* When end_tile is TileType::Void, the error tile will not be visible to the
 		 * user. This happens when terraforming at the southern border. */
 		if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
 		if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
@@ -275,7 +275,7 @@ struct TerraformToolbarWindow : Window {
 					break;
 				case DDSP_BUILD_OBJECT:
 					if (!_settings_game.construction.freeform_edges) {
-						/* When end_tile is MP_VOID, the error tile will not be visible to the
+						/* When end_tile is TileType::Void, the error tile will not be visible to the
 						 * user. This happens when terraforming at the southern border. */
 						if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
 						if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_test_files(
     flatset_type.cpp
     history_func.cpp
     landscape_partial_pixel_z.cpp
+	map_storage.cpp
     math_func.cpp
     mock_environment.h
     mock_fontcache.h

--- a/src/tests/map_storage.cpp
+++ b/src/tests/map_storage.cpp
@@ -1,0 +1,65 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file map_storage.cpp Consistency tests for members of map_func.h. */
+
+#include "../stdafx.h"
+
+#include "../3rdparty/catch2/catch.hpp"
+
+#include "../map_func.h"
+
+#include "../safeguards.h"
+
+/** Unique data that will allow to distinguish parts of map storage from each other. */
+static constexpr uint64_t BASE_VALUE = 0b0000000011111110000000111111000000111110000011110000111000110010; // Needs to be 64 bits.
+
+/** Function that performs unit test of internall low level storage. */
+void Tile::RunUnitTest()
+{
+	TileBase &base = base_tiles[this->tile.base()];
+	TileExtended &extended = extended_tiles[this->tile.base()];
+
+	base.base = uint32_t(BASE_VALUE);
+	extended.base = BASE_VALUE;
+
+	/* Test common base. */
+	CHECK(base.common.tropic_zone == GB(BASE_VALUE, 0, 2));
+	CHECK(base.common.bridge_above == GB(BASE_VALUE, 2, 2));
+	CHECK(base.common.type == GB(BASE_VALUE, 4, 4));
+	CHECK(base.common.height == GB(BASE_VALUE, 8, 8));
+
+	/* Test common extended. */
+	CHECK(extended.common.owner == GB(BASE_VALUE, 0, 5));
+	CHECK(extended.common.water_class == GB(BASE_VALUE, 5, 2));
+	CHECK(extended.common.ship_docking == GB(BASE_VALUE, 7, 1));
+	CHECK(extended.common.bit_offset_1 == GB(BASE_VALUE, 8, 8));
+	CHECK(extended.common.bit_offset_2 == GB(BASE_VALUE, 16, 16));
+	CHECK(extended.common.animation_state == GB(BASE_VALUE, 32, 2));
+
+	/* Test old base. */
+	CHECK(this->type() == GB(BASE_VALUE, 0, 8));
+	CHECK(this->height() == GB(BASE_VALUE, 8, 8));
+	CHECK(this->m3() == GB(BASE_VALUE, 16, 8));
+	CHECK(this->m4() == GB(BASE_VALUE, 24, 8));
+
+	/* Test old extended. */
+	CHECK(this->m1() == GB(BASE_VALUE, 0, 8));
+	CHECK(this->m5() == GB(BASE_VALUE, 8, 8));
+	CHECK(this->m2() == GB(BASE_VALUE, 16, 16));
+	CHECK(this->m6() == GB(BASE_VALUE, 32, 8));
+	CHECK(this->m7() == GB(BASE_VALUE, 40, 8));
+	CHECK(this->m8() == GB(BASE_VALUE, 48, 16));
+}
+
+/** Tests if internall structs and unions of Tile class are consistent. */
+TEST_CASE("Map storage test.")
+{
+	Map::Allocate(MIN_MAP_SIZE, MIN_MAP_SIZE);
+	Tile t(TileIndex{});
+	t.RunUnitTest();
+}

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -10,6 +10,7 @@
 #ifndef TILE_CMD_H
 #define TILE_CMD_H
 
+#include "core/enum_type.hpp"
 #include "core/geometry_type.hpp"
 #include "command_type.h"
 #include "vehicle_type.h"
@@ -168,7 +169,7 @@ struct TileTypeProcs {
 	CheckBuildAboveProc *check_build_above_proc;
 };
 
-extern const TileTypeProcs * const _tile_type_procs[16];
+extern const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::End)>, TileType> _tile_type_procs;
 
 TrackStatus GetTileTrackStatus(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side = INVALID_DIAGDIR);
 VehicleEnterTileStates VehicleEnterTile(Vehicle *v, TileIndex tile, int x, int y);

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -96,7 +96,7 @@ inline uint TilePixelHeightOutsideMap(int x, int y)
 [[debug_inline]] inline static TileType GetTileType(Tile tile)
 {
 	assert(tile < Map::Size());
-	return (TileType)GB(tile.type(), 4, 4);
+	return TileType(GB(tile.type(), 4, 4));
 }
 
 /**
@@ -120,13 +120,13 @@ inline bool IsInnerTile(Tile tile)
  * Set the type of a tile
  *
  * This functions sets the type of a tile. If the type
- * MP_VOID is selected the tile must be at the south-west or
+ * TileType::Void is selected the tile must be at the south-west or
  * south-east edges of the map and vice versa.
  *
  * @param tile The tile to save the new type
  * @param type The type to save
  * @pre tile < Map::Size()
- * @pre type MP_VOID <=> tile is on the south-east or south-west edge.
+ * @pre type TileType::Void <=> tile is on the south-east or south-west edge.
  */
 inline void SetTileType(Tile tile, TileType type)
 {
@@ -134,8 +134,8 @@ inline void SetTileType(Tile tile, TileType type)
 	/* VOID tiles (and no others) are exactly allowed at the lower left and right
 	 * edges of the map. If _settings_game.construction.freeform_edges is true,
 	 * the upper edges of the map are also VOID tiles. */
-	assert(IsInnerTile(tile) == (type != MP_VOID));
-	SB(tile.type(), 4, 4, type);
+	assert(IsInnerTile(tile) == (type != TileType::Void));
+	SB(tile.type(), 4, 4, to_underlying(type));
 }
 
 /**
@@ -156,30 +156,30 @@ inline void SetTileType(Tile tile, TileType type)
  * Checks if a tile is valid
  *
  * @param tile The tile to check
- * @return True if the tile is on the map and not one of MP_VOID.
+ * @return True if the tile is on the map and not one of TileType::Void.
  */
 inline bool IsValidTile(Tile tile)
 {
-	return tile < Map::Size() && !IsTileType(tile, MP_VOID);
+	return tile < Map::Size() && !IsTileType(tile, TileType::Void);
 }
 
 /**
  * Returns the owner of a tile
  *
  * This function returns the owner of a tile. This cannot used
- * for tiles which type is one of MP_HOUSE, MP_VOID and MP_INDUSTRY
+ * for tiles which type is one of TileType::House, TileType::Void and TileType::Industry
  * as no company owned any of these buildings.
  *
  * @param tile The tile to check
  * @return The owner of the tile
  * @pre IsValidTile(tile)
- * @pre The type of the tile must not be MP_HOUSE and MP_INDUSTRY
+ * @pre The type of the tile must not be TileType::House and TileType::Industry
  */
 inline Owner GetTileOwner(Tile tile)
 {
 	assert(IsValidTile(tile));
-	assert(!IsTileType(tile, MP_HOUSE));
-	assert(!IsTileType(tile, MP_INDUSTRY));
+	assert(!IsTileType(tile, TileType::House));
+	assert(!IsTileType(tile, TileType::Industry));
 
 	return (Owner)GB(tile.m1(), 0, 5);
 }
@@ -188,18 +188,18 @@ inline Owner GetTileOwner(Tile tile)
  * Sets the owner of a tile
  *
  * This function sets the owner status of a tile. Note that you cannot
- * set a owner for tiles of type MP_HOUSE, MP_VOID and MP_INDUSTRY.
+ * set a owner for tiles of type TileType::House, TileType::Void and TileType::Industry.
  *
  * @param tile The tile to change the owner status.
  * @param owner The new owner.
  * @pre IsValidTile(tile)
- * @pre The type of the tile must not be MP_HOUSE and MP_INDUSTRY
+ * @pre The type of the tile must not be TileType::House and TileType::Industry
  */
 inline void SetTileOwner(Tile tile, Owner owner)
 {
 	assert(IsValidTile(tile));
-	assert(!IsTileType(tile, MP_HOUSE));
-	assert(!IsTileType(tile, MP_INDUSTRY));
+	assert(!IsTileType(tile, TileType::House));
+	assert(!IsTileType(tile, TileType::Industry));
 
 	SB(tile.m1(), 0, 5, owner.base());
 }
@@ -225,7 +225,7 @@ inline bool IsTileOwner(Tile tile, Owner owner)
 inline void SetTropicZone(Tile tile, TropicZone type)
 {
 	assert(tile < Map::Size());
-	assert(!IsTileType(tile, MP_VOID) || type == TROPICZONE_NORMAL);
+	assert(!IsTileType(tile, TileType::Void) || type == TROPICZONE_NORMAL);
 	SB(tile.type(), 0, 2, type);
 }
 
@@ -244,12 +244,12 @@ inline TropicZone GetTropicZone(Tile tile)
 /**
  * Get the current animation frame
  * @param t the tile
- * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::House) || IsTileType(t, TileType::Object) || IsTileType(t, TileType::Industry) || IsTileType(t, TileType::Station)
  * @return frame number
  */
 inline uint8_t GetAnimationFrame(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::House) || IsTileType(t, TileType::Object) || IsTileType(t, TileType::Industry) || IsTileType(t, TileType::Station));
 	return t.m7();
 }
 
@@ -257,11 +257,11 @@ inline uint8_t GetAnimationFrame(Tile t)
  * Set a new animation frame
  * @param t the tile
  * @param frame the new frame number
- * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_STATION)
+ * @pre IsTileType(t, TileType::House) || IsTileType(t, TileType::Object) || IsTileType(t, TileType::Industry) || IsTileType(t, TileType::Station)
  */
 inline void SetAnimationFrame(Tile t, uint8_t frame)
 {
-	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_STATION));
+	assert(IsTileType(t, TileType::House) || IsTileType(t, TileType::Object) || IsTileType(t, TileType::Industry) || IsTileType(t, TileType::Station));
 	t.m7() = frame;
 }
 

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -42,20 +42,21 @@ static constexpr uint DEF_DESERT_COVERAGE = 50;                    ///< Default 
  *
  * Each tile belongs to one type, according whatever is build on it.
  *
- * @note A railway with a crossing street is marked as MP_ROAD.
+ * @note A railway with a crossing street is marked as TileType::Road.
  */
-enum TileType : uint8_t {
-	MP_CLEAR,               ///< A tile without any structures, i.e. grass, rocks, farm fields etc.
-	MP_RAILWAY,             ///< A railway
-	MP_ROAD,                ///< A tile with road (or tram tracks)
-	MP_HOUSE,               ///< A house by a town
-	MP_TREES,               ///< Tile got trees
-	MP_STATION,             ///< A tile of a station
-	MP_WATER,               ///< Water tile
-	MP_VOID,                ///< Invisible tiles at the SW and SE border
-	MP_INDUSTRY,            ///< Part of an industry
-	MP_TUNNELBRIDGE,        ///< Tunnel entry/exit and bridge heads
-	MP_OBJECT,              ///< Contains objects such as transmitters and owned land
+enum class TileType : uint8_t {
+	Clear, ///< A tile without any structures, i.e. grass, rocks, farm fields etc.
+	Railway, ///< A tile with railway.
+	Road, ///< A tile with road and/or tram tracks.
+	House, ///< A house by a town.
+	Trees, ///< Tile with one or more trees.
+	Station, ///< A tile of a station or airport.
+	Water, ///< Water tile.
+	Void, ///< Invisible tiles at the SW and SE border.
+	Industry, ///< Part of an industry.
+	TunnelBridge, ///< Tunnel entry/exit and bridge heads.
+	Object, ///< Contains objects such as transmitters and owned land.
+	End, ///< End marker.
 };
 
 /**

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -57,6 +57,7 @@ enum class TileType : uint8_t {
 	TunnelBridge, ///< Tunnel entry/exit and bridge heads.
 	Object, ///< Contains objects such as transmitters and owned land.
 	End, ///< End marker.
+	Invalid = 0xFF, ///< Invalid marker.
 };
 
 /**

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -17,12 +17,12 @@
 /**
  * Get the index of which town this house/street is attached to.
  * @param t the tile
- * @pre IsTileType(t, MP_HOUSE) or IsTileType(t, MP_ROAD) but not a road depot
+ * @pre IsTileType(t, TileType::House) or IsTileType(t, TileType::Road) but not a road depot
  * @return TownID
  */
 inline TownID GetTownIndex(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
+	assert(IsTileType(t, TileType::House) || (IsTileType(t, TileType::Road) && !IsRoadDepot(t)));
 	return static_cast<TownID>(t.m2());
 }
 
@@ -30,11 +30,11 @@ inline TownID GetTownIndex(Tile t)
  * Set the town index for a road or house tile.
  * @param t the tile
  * @param index the index of the town
- * @pre IsTileType(t, MP_HOUSE) or IsTileType(t, MP_ROAD) but not a road depot
+ * @pre IsTileType(t, TileType::House) or IsTileType(t, TileType::Road) but not a road depot
  */
 inline void SetTownIndex(Tile t, TownID index)
 {
-	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
+	assert(IsTileType(t, TileType::House) || (IsTileType(t, TileType::Road) && !IsRoadDepot(t)));
 	t.m2() = index.base();
 }
 
@@ -42,19 +42,19 @@ inline void SetTownIndex(Tile t, TownID index)
  * Get the type of this house, which is an index into the house spec array
  * without doing any NewGRF related translations.
  * @param t the tile
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  * @return house type
  */
 inline HouseID GetCleanHouseType(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	return GB(t.m8(), 0, 12);
 }
 
 /**
  * Get the type of this house, which is an index into the house spec array
  * @param t the tile
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  * @return house type
  */
 inline HouseID GetHouseType(Tile t)
@@ -66,11 +66,11 @@ inline HouseID GetHouseType(Tile t)
  * Set the house type.
  * @param t the tile
  * @param house_id the new house type
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  */
 inline void SetHouseType(Tile t, HouseID house_id)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	SB(t.m8(), 0, 12, house_id);
 }
 
@@ -81,7 +81,7 @@ inline void SetHouseType(Tile t, HouseID house_id)
  */
 inline bool IsHouseProtected(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	return HasBit(t.m3(), 5);
 }
 
@@ -92,7 +92,7 @@ inline bool IsHouseProtected(Tile t)
  */
 inline void SetHouseProtected(Tile t, bool house_protected)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	SB(t.m3(), 5, 1, house_protected ? 1 : 0);
 }
 
@@ -166,7 +166,7 @@ inline void SetLiftPosition(Tile t, uint8_t pos)
  */
 inline bool IsHouseCompleted(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	return HasBit(t.m3(), 7);
 }
 
@@ -177,7 +177,7 @@ inline bool IsHouseCompleted(Tile t)
  */
 inline void SetHouseCompleted(Tile t, bool status)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	SB(t.m3(), 7, 1, !!status);
 }
 
@@ -199,24 +199,24 @@ inline void SetHouseCompleted(Tile t, bool status)
  * fool the system by returning the TOWN_HOUSE_COMPLETE (3),
  * thus showing a beautiful complete house.
  * @param t the tile of the house to get the building stage of
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  * @return the building stage of the house
  */
 inline uint8_t GetHouseBuildingStage(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	return IsHouseCompleted(t) ? (uint8_t)TOWN_HOUSE_COMPLETED : GB(t.m5(), 3, 2);
 }
 
 /**
  * Gets the construction stage of a house
  * @param t the tile of the house to get the construction stage of
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  * @return the construction stage of the house
  */
 inline uint8_t GetHouseConstructionTick(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	return IsHouseCompleted(t) ? 0 : GB(t.m5(), 0, 3);
 }
 
@@ -225,11 +225,11 @@ inline uint8_t GetHouseConstructionTick(Tile t)
  * It is working with the whole counter + stage 5 bits, making it
  * easier to work:  the wraparound is automatic.
  * @param t the tile of the house to increment the construction stage of
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  */
 inline void IncHouseConstructionTick(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	AB(t.m5(), 0, 5, 1);
 
 	if (GB(t.m5(), 3, 2) == TOWN_HOUSE_COMPLETED) {
@@ -243,34 +243,34 @@ inline void IncHouseConstructionTick(Tile t)
  * Sets the age of the house to zero.
  * Needs to be called after the house is completed. During construction stages the map space is used otherwise.
  * @param t the tile of this house
- * @pre IsTileType(t, MP_HOUSE) && IsHouseCompleted(t)
+ * @pre IsTileType(t, TileType::House) && IsHouseCompleted(t)
  */
 inline void ResetHouseAge(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE) && IsHouseCompleted(t));
+	assert(IsTileType(t, TileType::House) && IsHouseCompleted(t));
 	t.m5() = 0;
 }
 
 /**
  * Increments the age of the house.
  * @param t the tile of this house
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  */
 inline void IncrementHouseAge(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	if (IsHouseCompleted(t) && t.m5() < 0xFF) t.m5()++;
 }
 
 /**
  * Get the age of the house
  * @param t the tile of this house
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  * @return year
  */
 inline TimerGameCalendar::Year GetHouseAge(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	return TimerGameCalendar::Year{IsHouseCompleted(t) ? t.m5() : 0};
 }
 
@@ -279,11 +279,11 @@ inline TimerGameCalendar::Year GetHouseAge(Tile t)
  * This is required for newgrf house
  * @param t      the tile of this house
  * @param random the new random bits
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  */
 inline void SetHouseRandomBits(Tile t, uint8_t random)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	t.m1() = random;
 }
 
@@ -291,12 +291,12 @@ inline void SetHouseRandomBits(Tile t, uint8_t random)
  * Get the random bits for this house.
  * This is required for newgrf house
  * @param t the tile of this house
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  * @return random bits
  */
 inline uint8_t GetHouseRandomBits(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	return t.m1();
 }
 
@@ -305,11 +305,11 @@ inline uint8_t GetHouseRandomBits(Tile t)
  * This is required for newgrf house
  * @param t        the tile of this house
  * @param triggers the activated triggers
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  */
 inline void SetHouseRandomTriggers(Tile t, HouseRandomTriggers triggers)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	SB(t.m3(), 0, 5, triggers.base());
 }
 
@@ -317,24 +317,24 @@ inline void SetHouseRandomTriggers(Tile t, HouseRandomTriggers triggers)
  * Get the already activated triggers bits for this house.
  * This is required for newgrf house
  * @param t the tile of this house
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  * @return triggers
  */
 inline HouseRandomTriggers GetHouseRandomTriggers(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	return static_cast<HouseRandomTriggers>(GB(t.m3(), 0, 5));
 }
 
 /**
  * Get the amount of time remaining before the tile loop processes this tile.
  * @param t the house tile
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  * @return time remaining
  */
 inline uint8_t GetHouseProcessingTime(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	return GB(t.m6(), 2, 6);
 }
 
@@ -342,22 +342,22 @@ inline uint8_t GetHouseProcessingTime(Tile t)
  * Set the amount of time remaining before the tile loop processes this tile.
  * @param t the house tile
  * @param time the time to be set
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  */
 inline void SetHouseProcessingTime(Tile t, uint8_t time)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	SB(t.m6(), 2, 6, time);
 }
 
 /**
  * Decrease the amount of time remaining before the tile loop processes this tile.
  * @param t the house tile
- * @pre IsTileType(t, MP_HOUSE)
+ * @pre IsTileType(t, TileType::House)
  */
 inline void DecHouseProcessingTime(Tile t)
 {
-	assert(IsTileType(t, MP_HOUSE));
+	assert(IsTileType(t, TileType::House));
 	t.m6() -= 1 << 2;
 }
 
@@ -370,13 +370,13 @@ inline void DecHouseProcessingTime(Tile t)
  * @param type of house.  Index into house specs array
  * @param random_bits required for newgrf houses
  * @param house_protected Whether the house is protected from the town upgrading it.
- * @pre IsTileType(t, MP_CLEAR)
+ * @pre IsTileType(t, TileType::Clear)
  */
 inline void MakeHouseTile(Tile t, TownID tid, uint8_t counter, uint8_t stage, HouseID type, uint8_t random_bits, bool house_protected)
 {
-	assert(IsTileType(t, MP_CLEAR));
+	assert(IsTileType(t, TileType::Clear));
 
-	SetTileType(t, MP_HOUSE);
+	SetTileType(t, TileType::House);
 	t.m1() = random_bits;
 	t.m2() = tid.base();
 	t.m3() = 0;

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -82,11 +82,11 @@ enum class TreeGrowthStage : uint8_t {
  *
  * @param t The tile to get the treetype from
  * @return The treetype of the given tile with trees
- * @pre Tile t must be of type MP_TREES
+ * @pre Tile t must be of type TileType::Trees
  */
 inline TreeType GetTreeType(Tile t)
 {
-	assert(IsTileType(t, MP_TREES));
+	assert(IsTileType(t, TileType::Trees));
 	return (TreeType)t.m3();
 }
 
@@ -97,11 +97,11 @@ inline TreeType GetTreeType(Tile t)
  *
  * @param t The tile to get the groundtype from
  * @return The groundtype of the tile
- * @pre Tile must be of type MP_TREES
+ * @pre Tile must be of type TileType::Trees
  */
 inline TreeGround GetTreeGround(Tile t)
 {
-	assert(IsTileType(t, MP_TREES));
+	assert(IsTileType(t, TileType::Trees));
 	return (TreeGround)GB(t.m2(), 6, 3);
 }
 
@@ -121,12 +121,12 @@ inline TreeGround GetTreeGround(Tile t)
  * "get the tree density of a tile" but "get the density of a tile which got trees".
  *
  * @param t The tile to get the 'density'
- * @pre Tile must be of type MP_TREES
+ * @pre Tile must be of type TileType::Trees
  * @see GetTreeCount
  */
 inline uint GetTreeDensity(Tile t)
 {
-	assert(IsTileType(t, MP_TREES));
+	assert(IsTileType(t, TileType::Trees));
 	return GB(t.m2(), 4, 2);
 }
 
@@ -139,11 +139,11 @@ inline uint GetTreeDensity(Tile t)
  * @param t The tile to set the density and ground type
  * @param g The ground type to save
  * @param d The density to save with
- * @pre Tile must be of type MP_TREES
+ * @pre Tile must be of type TileType::Trees
  */
 inline void SetTreeGroundDensity(Tile t, TreeGround g, uint d)
 {
-	assert(IsTileType(t, MP_TREES)); // XXX incomplete
+	assert(IsTileType(t, TileType::Trees)); // XXX incomplete
 	SB(t.m2(), 4, 2, d);
 	SB(t.m2(), 6, 3, g);
 	SetWaterClass(t, g == TREE_GROUND_SHORE ? WaterClass::Sea : WaterClass::Invalid);
@@ -154,15 +154,15 @@ inline void SetTreeGroundDensity(Tile t, TreeGround g, uint d)
  *
  * This function returns the number of trees of a tile (1-4).
  * The tile must be contains at least one tree or be more specific: it must be
- * of type MP_TREES.
+ * of type TileType::Trees.
  *
  * @param t The index to get the number of trees
  * @return The number of trees (1-4)
- * @pre Tile must be of type MP_TREES
+ * @pre Tile must be of type TileType::Trees
  */
 inline uint GetTreeCount(Tile t)
 {
-	assert(IsTileType(t, MP_TREES));
+	assert(IsTileType(t, TileType::Trees));
 	return GB(t.m5(), 6, 2) + 1;
 }
 
@@ -175,11 +175,11 @@ inline uint GetTreeCount(Tile t)
  *
  * @param t The tile to change the tree amount
  * @param c The value to add (or reduce) on the tree-count value
- * @pre Tile must be of type MP_TREES
+ * @pre Tile must be of type TileType::Trees
  */
 inline void AddTreeCount(Tile t, int c)
 {
-	assert(IsTileType(t, MP_TREES)); // XXX incomplete
+	assert(IsTileType(t, TileType::Trees)); // XXX incomplete
 	t.m5() += c << 6;
 }
 
@@ -190,11 +190,11 @@ inline void AddTreeCount(Tile t, int c)
  *
  * @param t The tile to get the tree growth stage
  * @return The tree growth stage
- * @pre Tile must be of type MP_TREES
+ * @pre Tile must be of type TileType::Trees
  */
 inline TreeGrowthStage GetTreeGrowth(Tile t)
 {
-	assert(IsTileType(t, MP_TREES));
+	assert(IsTileType(t, TileType::Trees));
 	return static_cast<TreeGrowthStage>(GB(t.m5(), 0, 3));
 }
 
@@ -205,11 +205,11 @@ inline TreeGrowthStage GetTreeGrowth(Tile t)
  *
  * @param t The tile to add the value on
  * @param a The value to add on the tree growth stage
- * @pre Tile must be of type MP_TREES
+ * @pre Tile must be of type TileType::Trees
  */
 inline void AddTreeGrowth(Tile t, int a)
 {
-	assert(IsTileType(t, MP_TREES)); // XXX incomplete
+	assert(IsTileType(t, TileType::Trees)); // XXX incomplete
 	t.m5() += a;
 }
 
@@ -221,11 +221,11 @@ inline void AddTreeGrowth(Tile t, int a)
  *
  * @param t The tile to change the tree growth stage
  * @param g The new value
- * @pre Tile must be of type MP_TREES
+ * @pre Tile must be of type TileType::Trees
  */
 inline void SetTreeGrowth(Tile t, TreeGrowthStage g)
 {
-	assert(IsTileType(t, MP_TREES)); // XXX incomplete
+	assert(IsTileType(t, TileType::Trees)); // XXX incomplete
 	SB(t.m5(), 0, 3, to_underlying(g));
 }
 
@@ -243,7 +243,7 @@ inline void SetTreeGrowth(Tile t, TreeGrowthStage g)
  */
 inline void MakeTree(Tile t, TreeType type, uint count, TreeGrowthStage growth, TreeGround ground, uint density)
 {
-	SetTileType(t, MP_TREES);
+	SetTileType(t, TileType::Trees);
 	SetTileOwner(t, OWNER_NONE);
 	SetWaterClass(t, ground == TREE_GROUND_SHORE ? WaterClass::Sea : WaterClass::Invalid);
 	t.m2() = ground << 6 | density << 4 | 0;

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -87,7 +87,7 @@ enum class TreeGrowthStage : uint8_t {
 inline TreeType GetTreeType(Tile t)
 {
 	assert(IsTileType(t, TileType::Trees));
-	return (TreeType)t.m3();
+	return TreeType(t.GetTileBaseAs<TileType::Trees>().tree_type);
 }
 
 /**
@@ -102,7 +102,7 @@ inline TreeType GetTreeType(Tile t)
 inline TreeGround GetTreeGround(Tile t)
 {
 	assert(IsTileType(t, TileType::Trees));
-	return (TreeGround)GB(t.m2(), 6, 3);
+	return TreeGround(t.GetTileExtendedAs<TileType::Trees>().ground);
 }
 
 /**
@@ -127,7 +127,7 @@ inline TreeGround GetTreeGround(Tile t)
 inline uint GetTreeDensity(Tile t)
 {
 	assert(IsTileType(t, TileType::Trees));
-	return GB(t.m2(), 4, 2);
+	return t.GetTileExtendedAs<TileType::Trees>().density;
 }
 
 /**
@@ -144,8 +144,9 @@ inline uint GetTreeDensity(Tile t)
 inline void SetTreeGroundDensity(Tile t, TreeGround g, uint d)
 {
 	assert(IsTileType(t, TileType::Trees)); // XXX incomplete
-	SB(t.m2(), 4, 2, d);
-	SB(t.m2(), 6, 3, g);
+	auto &extended = t.GetTileExtendedAs<TileType::Trees>();
+	extended.density = d;
+	extended.ground = g;
 	SetWaterClass(t, g == TREE_GROUND_SHORE ? WaterClass::Sea : WaterClass::Invalid);
 }
 
@@ -163,7 +164,7 @@ inline void SetTreeGroundDensity(Tile t, TreeGround g, uint d)
 inline uint GetTreeCount(Tile t)
 {
 	assert(IsTileType(t, TileType::Trees));
-	return GB(t.m5(), 6, 2) + 1;
+	return t.GetTileExtendedAs<TileType::Trees>().quantity + 1;
 }
 
 /**
@@ -180,7 +181,7 @@ inline uint GetTreeCount(Tile t)
 inline void AddTreeCount(Tile t, int c)
 {
 	assert(IsTileType(t, TileType::Trees)); // XXX incomplete
-	t.m5() += c << 6;
+	t.GetTileExtendedAs<TileType::Trees>().quantity += c ;
 }
 
 /**
@@ -195,7 +196,7 @@ inline void AddTreeCount(Tile t, int c)
 inline TreeGrowthStage GetTreeGrowth(Tile t)
 {
 	assert(IsTileType(t, TileType::Trees));
-	return static_cast<TreeGrowthStage>(GB(t.m5(), 0, 3));
+	return static_cast<TreeGrowthStage>(t.GetTileExtendedAs<TileType::Trees>().growth);
 }
 
 /**
@@ -210,7 +211,7 @@ inline TreeGrowthStage GetTreeGrowth(Tile t)
 inline void AddTreeGrowth(Tile t, int a)
 {
 	assert(IsTileType(t, TileType::Trees)); // XXX incomplete
-	t.m5() += a;
+	t.GetTileExtendedAs<TileType::Trees>().growth += a;
 }
 
 /**
@@ -226,7 +227,7 @@ inline void AddTreeGrowth(Tile t, int a)
 inline void SetTreeGrowth(Tile t, TreeGrowthStage g)
 {
 	assert(IsTileType(t, TileType::Trees)); // XXX incomplete
-	SB(t.m5(), 0, 3, to_underlying(g));
+	t.GetTileExtendedAs<TileType::Trees>().growth = to_underlying(g);
 }
 
 /**
@@ -244,15 +245,15 @@ inline void SetTreeGrowth(Tile t, TreeGrowthStage g)
 inline void MakeTree(Tile t, TreeType type, uint count, TreeGrowthStage growth, TreeGround ground, uint density)
 {
 	SetTileType(t, TileType::Trees);
+	t.ResetData();
 	SetTileOwner(t, OWNER_NONE);
 	SetWaterClass(t, ground == TREE_GROUND_SHORE ? WaterClass::Sea : WaterClass::Invalid);
-	t.m2() = ground << 6 | density << 4 | 0;
-	t.m3() = type;
-	t.m4() = 0 << 5 | 0 << 2;
-	t.m5() = count << 6 | to_underlying(growth);
-	SB(t.m6(), 2, 6, 0);
-	t.m7() = 0;
-	t.m8() = 0;
+	t.GetTileBaseAs<TileType::Trees>().tree_type = type;
+	auto &extended = t.GetTileExtendedAs<TileType::Trees>();
+	extended.ground = ground;
+	extended.density = density;
+	extended.quantity = count;
+	extended.growth = to_underlying(growth);
 }
 
 #endif /* TREE_MAP_H */

--- a/src/tunnel_map.h
+++ b/src/tunnel_map.h
@@ -23,7 +23,7 @@
 inline bool IsTunnel(Tile t)
 {
 	assert(IsTileType(t, TileType::TunnelBridge));
-	return !HasBit(t.m5(), 7);
+	return !t.GetTileExtendedAs<TileType::TunnelBridge>().is_bridge;
 }
 
 /**
@@ -50,14 +50,11 @@ bool IsTunnelInWayDir(TileIndex tile, int z, DiagDirection dir);
 inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType road_rt, RoadType tram_rt)
 {
 	SetTileType(t, TileType::TunnelBridge);
+	t.ResetData();
 	SetTileOwner(t, o);
-	t.m2() = 0;
-	t.m3() = 0;
-	t.m4() = 0;
-	t.m5() = TRANSPORT_ROAD << 2 | d;
-	SB(t.m6(), 2, 6, 0);
-	t.m7() = 0;
-	t.m8() = 0;
+	auto &extended = t.GetTileExtendedAs<TileType::TunnelBridge>();
+	extended.transport_type = TRANSPORT_ROAD;
+	extended.direction = d;
 	SetRoadOwner(t, RTT_ROAD, o);
 	if (o != OWNER_TOWN) SetRoadOwner(t, RTT_TRAM, o);
 	SetRoadTypes(t, road_rt, tram_rt);
@@ -73,14 +70,11 @@ inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType road_rt, R
 inline void MakeRailTunnel(Tile t, Owner o, DiagDirection d, RailType r)
 {
 	SetTileType(t, TileType::TunnelBridge);
+	t.ResetData();
 	SetTileOwner(t, o);
-	t.m2() = 0;
-	t.m3() = 0;
-	t.m4() = 0;
-	t.m5() = TRANSPORT_RAIL << 2 | d;
-	SB(t.m6(), 2, 6, 0);
-	t.m7() = 0;
-	t.m8() = 0;
+	auto &extended = t.GetTileExtendedAs<TileType::TunnelBridge>();
+	extended.transport_type = TRANSPORT_RAIL;
+	extended.direction = d;
 	SetRailType(t, r);
 }
 

--- a/src/tunnel_map.h
+++ b/src/tunnel_map.h
@@ -17,12 +17,12 @@
 /**
  * Is this a tunnel (entrance)?
  * @param t the tile that might be a tunnel
- * @pre IsTileType(t, MP_TUNNELBRIDGE)
+ * @pre IsTileType(t, TileType::TunnelBridge)
  * @return true if and only if this tile is a tunnel (entrance)
  */
 inline bool IsTunnel(Tile t)
 {
-	assert(IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::TunnelBridge));
 	return !HasBit(t.m5(), 7);
 }
 
@@ -33,7 +33,7 @@ inline bool IsTunnel(Tile t)
  */
 inline bool IsTunnelTile(Tile t)
 {
-	return IsTileType(t, MP_TUNNELBRIDGE) && IsTunnel(t);
+	return IsTileType(t, TileType::TunnelBridge) && IsTunnel(t);
 }
 
 TileIndex GetOtherTunnelEnd(TileIndex);
@@ -49,7 +49,7 @@ bool IsTunnelInWayDir(TileIndex tile, int z, DiagDirection dir);
  */
 inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType road_rt, RoadType tram_rt)
 {
-	SetTileType(t, MP_TUNNELBRIDGE);
+	SetTileType(t, TileType::TunnelBridge);
 	SetTileOwner(t, o);
 	t.m2() = 0;
 	t.m3() = 0;
@@ -72,7 +72,7 @@ inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType road_rt, R
  */
 inline void MakeRailTunnel(Tile t, Owner o, DiagDirection d, RailType r)
 {
-	SetTileType(t, MP_TUNNELBRIDGE);
+	SetTileType(t, TileType::TunnelBridge);
 	SetTileOwner(t, o);
 	t.m2() = 0;
 	t.m3() = 0;

--- a/src/tunnelbridge_map.h
+++ b/src/tunnelbridge_map.h
@@ -20,12 +20,12 @@
  * Tunnel: Get the direction facing into the tunnel
  * Bridge: Get the direction pointing onto the bridge
  * @param t The tile to analyze
- * @pre IsTileType(t, MP_TUNNELBRIDGE)
+ * @pre IsTileType(t, TileType::TunnelBridge)
  * @return the above mentioned direction
  */
 inline DiagDirection GetTunnelBridgeDirection(Tile t)
 {
-	assert(IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::TunnelBridge));
 	return (DiagDirection)GB(t.m5(), 0, 2);
 }
 
@@ -33,12 +33,12 @@ inline DiagDirection GetTunnelBridgeDirection(Tile t)
  * Tunnel: Get the transport type of the tunnel (road or rail)
  * Bridge: Get the transport type of the bridge's ramp
  * @param t The tile to analyze
- * @pre IsTileType(t, MP_TUNNELBRIDGE)
+ * @pre IsTileType(t, TileType::TunnelBridge)
  * @return the transport type in the tunnel/bridge
  */
 inline TransportType GetTunnelBridgeTransportType(Tile t)
 {
-	assert(IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::TunnelBridge));
 	return (TransportType)GB(t.m5(), 2, 2);
 }
 
@@ -46,12 +46,12 @@ inline TransportType GetTunnelBridgeTransportType(Tile t)
  * Tunnel: Is this tunnel entrance in a snowy or desert area?
  * Bridge: Does the bridge ramp lie in a snow or desert area?
  * @param t The tile to analyze
- * @pre IsTileType(t, MP_TUNNELBRIDGE)
+ * @pre IsTileType(t, TileType::TunnelBridge)
  * @return true if and only if the tile is in a snowy/desert area
  */
 inline bool HasTunnelBridgeSnowOrDesert(Tile t)
 {
-	assert(IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::TunnelBridge));
 	return HasBit(t.m7(), 5);
 }
 
@@ -61,56 +61,56 @@ inline bool HasTunnelBridgeSnowOrDesert(Tile t)
  * @param t the tunnel entrance / bridge ramp tile
  * @param snow_or_desert is the entrance/ramp in snow or desert (true), when
  *                       not in snow and not in desert false
- * @pre IsTileType(t, MP_TUNNELBRIDGE)
+ * @pre IsTileType(t, TileType::TunnelBridge)
  */
 inline void SetTunnelBridgeSnowOrDesert(Tile t, bool snow_or_desert)
 {
-	assert(IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::TunnelBridge));
 	SB(t.m7(), 5, 1, snow_or_desert);
 }
 
 /**
  * Determines type of the wormhole and returns its other end
  * @param t one end
- * @pre IsTileType(t, MP_TUNNELBRIDGE)
+ * @pre IsTileType(t, TileType::TunnelBridge)
  * @return other end
  */
 inline TileIndex GetOtherTunnelBridgeEnd(Tile t)
 {
-	assert(IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::TunnelBridge));
 	return IsTunnel(t) ? GetOtherTunnelEnd(t) : GetOtherBridgeEnd(t);
 }
 
 
 /**
  * Get the reservation state of the rail tunnel/bridge
- * @pre IsTileType(t, MP_TUNNELBRIDGE) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL
+ * @pre IsTileType(t, TileType::TunnelBridge) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL
  * @param t the tile
  * @return reservation state
  */
 inline bool HasTunnelBridgeReservation(Tile t)
 {
-	assert(IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::TunnelBridge));
 	assert(GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL);
 	return HasBit(t.m5(), 4);
 }
 
 /**
  * Set the reservation state of the rail tunnel/bridge
- * @pre IsTileType(t, MP_TUNNELBRIDGE) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL
+ * @pre IsTileType(t, TileType::TunnelBridge) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL
  * @param t the tile
  * @param b the reservation state
  */
 inline void SetTunnelBridgeReservation(Tile t, bool b)
 {
-	assert(IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::TunnelBridge));
 	assert(GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL);
 	AssignBit(t.m5(), 4, b);
 }
 
 /**
  * Get the reserved track bits for a rail tunnel/bridge
- * @pre IsTileType(t, MP_TUNNELBRIDGE) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL
+ * @pre IsTileType(t, TileType::TunnelBridge) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL
  * @param t the tile
  * @return reserved track bits
  */

--- a/src/tunnelbridge_map.h
+++ b/src/tunnelbridge_map.h
@@ -26,7 +26,7 @@
 inline DiagDirection GetTunnelBridgeDirection(Tile t)
 {
 	assert(IsTileType(t, TileType::TunnelBridge));
-	return (DiagDirection)GB(t.m5(), 0, 2);
+	return DiagDirection(t.GetTileExtendedAs<TileType::TunnelBridge>().direction);
 }
 
 /**
@@ -39,7 +39,7 @@ inline DiagDirection GetTunnelBridgeDirection(Tile t)
 inline TransportType GetTunnelBridgeTransportType(Tile t)
 {
 	assert(IsTileType(t, TileType::TunnelBridge));
-	return (TransportType)GB(t.m5(), 2, 2);
+	return TransportType(t.GetTileExtendedAs<TileType::TunnelBridge>().transport_type);
 }
 
 /**
@@ -52,7 +52,7 @@ inline TransportType GetTunnelBridgeTransportType(Tile t)
 inline bool HasTunnelBridgeSnowOrDesert(Tile t)
 {
 	assert(IsTileType(t, TileType::TunnelBridge));
-	return HasBit(t.m7(), 5);
+	return t.GetTileExtendedAs<TileType::TunnelBridge>().snow_desert_presence;
 }
 
 /**
@@ -66,7 +66,7 @@ inline bool HasTunnelBridgeSnowOrDesert(Tile t)
 inline void SetTunnelBridgeSnowOrDesert(Tile t, bool snow_or_desert)
 {
 	assert(IsTileType(t, TileType::TunnelBridge));
-	SB(t.m7(), 5, 1, snow_or_desert);
+	t.GetTileExtendedAs<TileType::TunnelBridge>().snow_desert_presence = snow_or_desert;
 }
 
 /**
@@ -92,7 +92,7 @@ inline bool HasTunnelBridgeReservation(Tile t)
 {
 	assert(IsTileType(t, TileType::TunnelBridge));
 	assert(GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL);
-	return HasBit(t.m5(), 4);
+	return t.GetTileExtendedAs<TileType::TunnelBridge>().pbs_reservation;
 }
 
 /**
@@ -105,7 +105,7 @@ inline void SetTunnelBridgeReservation(Tile t, bool b)
 {
 	assert(IsTileType(t, TileType::TunnelBridge));
 	assert(GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL);
-	AssignBit(t.m5(), 4, b);
+	t.GetTileExtendedAs<TileType::TunnelBridge>().pbs_reservation = b;
 }
 
 /**

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2190,11 +2190,11 @@ void Vehicle::DeleteUnreachedImplicitOrders()
 
 /**
  * Prepare everything to begin the loading when arriving at a station.
- * @pre IsTileType(this->tile, MP_STATION) || this->type == VEH_SHIP.
+ * @pre IsTileType(this->tile, TileType::Station) || this->type == VEH_SHIP.
  */
 void Vehicle::BeginLoading()
 {
-	assert(IsTileType(this->tile, MP_STATION) || this->type == VEH_SHIP);
+	assert(IsTileType(this->tile, TileType::Station) || this->type == VEH_SHIP);
 
 	TimerGameTick::Ticks travel_time = TimerGameTick::counter - this->last_loading_tick;
 	if (this->current_order.IsType(OT_GOTO_STATION) &&
@@ -2375,7 +2375,7 @@ void Vehicle::LeaveStation()
 
 	if (this->type == VEH_TRAIN && !this->vehstatus.Test(VehState::Crashed)) {
 		/* Trigger station animation (trains only) */
-		if (IsTileType(this->tile, MP_STATION)) {
+		if (IsTileType(this->tile, TileType::Station)) {
 			TriggerStationRandomisation(st, this->tile, StationRandomTrigger::VehicleDeparts);
 			TriggerStationAnimation(st, this->tile, StationAnimationTrigger::VehicleDeparts);
 		}

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1022,28 +1022,28 @@ const Town *_viewport_highlight_town; ///< Currently selected town for coverage 
 static TileHighlightType GetTileHighlightType(TileIndex t)
 {
 	if (_viewport_highlight_station != nullptr) {
-		if (IsTileType(t, MP_STATION) && GetStationIndex(t) == _viewport_highlight_station->index) return THT_WHITE;
+		if (IsTileType(t, TileType::Station) && GetStationIndex(t) == _viewport_highlight_station->index) return THT_WHITE;
 		if (_viewport_highlight_station->TileIsInCatchment(t)) return THT_BLUE;
 	}
 
 	if (_viewport_highlight_station_rect != nullptr) {
-		if (IsTileType(t, MP_STATION) && GetStationIndex(t) == _viewport_highlight_station_rect->index) return THT_WHITE;
+		if (IsTileType(t, TileType::Station) && GetStationIndex(t) == _viewport_highlight_station_rect->index) return THT_WHITE;
 		const StationRect *r = &_viewport_highlight_station_rect->rect;
 		if (r->PtInExtendedRect(TileX(t), TileY(t))) return THT_BLUE;
 	}
 
 	if (_viewport_highlight_waypoint != nullptr) {
-		if (IsTileType(t, MP_STATION) && GetStationIndex(t) == _viewport_highlight_waypoint->index) return THT_BLUE;
+		if (IsTileType(t, TileType::Station) && GetStationIndex(t) == _viewport_highlight_waypoint->index) return THT_BLUE;
 	}
 
 	if (_viewport_highlight_waypoint_rect != nullptr) {
-		if (IsTileType(t, MP_STATION) && GetStationIndex(t) == _viewport_highlight_waypoint_rect->index) return THT_WHITE;
+		if (IsTileType(t, TileType::Station) && GetStationIndex(t) == _viewport_highlight_waypoint_rect->index) return THT_WHITE;
 		const StationRect *r = &_viewport_highlight_waypoint_rect->rect;
 		if (r->PtInExtendedRect(TileX(t), TileY(t))) return THT_BLUE;
 	}
 
 	if (_viewport_highlight_town != nullptr) {
-		if (IsTileType(t, MP_HOUSE)) {
+		if (IsTileType(t, TileType::House)) {
 			if (GetTownIndex(t) == _viewport_highlight_town->index) {
 				TileHighlightType type = THT_RED;
 				for (const Station *st : _viewport_highlight_town->stations_near) {
@@ -1052,7 +1052,7 @@ static TileHighlightType GetTileHighlightType(TileIndex t)
 				}
 				return type;
 			}
-		} else if (IsTileType(t, MP_STATION)) {
+		} else if (IsTileType(t, TileType::Station)) {
 			for (const Station *st : _viewport_highlight_town->stations_near) {
 				if (st->owner != _current_company) continue;
 				if (GetStationIndex(t) == st->index) return THT_WHITE;
@@ -1090,7 +1090,7 @@ static void HighlightTownLocalAuthorityTiles(const TileInfo *ti)
 	if (_town_local_authority_kdtree.Count() == 0) return;
 
 	/* Tile belongs to town regardless of distance from town. */
-	if (GetTileType(ti->tile) == MP_HOUSE) {
+	if (GetTileType(ti->tile) == TileType::House) {
 		if (!Town::GetByTile(ti->tile)->show_zone) return;
 
 		DrawTileSelectionRect(ti, PALETTE_CRASH);
@@ -1261,10 +1261,10 @@ static void ViewportAddLandscape()
 				tile_type = GetTileType(_cur_ti.tile);
 			} else {
 				_cur_ti.tile = INVALID_TILE;
-				tile_type = MP_VOID;
+				tile_type = TileType::Void;
 			}
 
-			if (tile_type != MP_VOID) {
+			if (tile_type != TileType::Void) {
 				/* We are inside the map => paint landscape. */
 				std::tie(_cur_ti.tileh, _cur_ti.z) = GetTilePixelSlope(_cur_ti.tile);
 			} else {
@@ -1284,7 +1284,7 @@ static void ViewportAddLandscape()
 			int min_visible_height = viewport_y - (_vd.dpi.top + _vd.dpi.height);
 			bool tile_visible = min_visible_height <= 0;
 
-			if (tile_type != MP_VOID) {
+			if (tile_type != TileType::Void) {
 				/* Is tile with buildings visible? */
 				if (min_visible_height < MAX_TILE_EXTENT_TOP) tile_visible = true;
 

--- a/src/void_map.h
+++ b/src/void_map.h
@@ -18,7 +18,7 @@
  */
 inline void MakeVoid(Tile t)
 {
-	SetTileType(t, MP_VOID);
+	SetTileType(t, TileType::Void);
 	SetTileHeight(t, 0);
 	t.m1() = 0;
 	t.m2() = 0;

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -79,7 +79,7 @@ bool IsPossibleDockingTile(Tile t);
  */
 inline WaterTileType GetWaterTileType(Tile t)
 {
-	assert(IsTileType(t, MP_WATER));
+	assert(IsTileType(t, TileType::Water));
 	return static_cast<WaterTileType>(GB(t.m5(), WBL_TYPE_BEGIN, WBL_TYPE_COUNT));
 }
 
@@ -90,7 +90,7 @@ inline WaterTileType GetWaterTileType(Tile t)
  */
 inline void SetWaterTileType(Tile t, WaterTileType type)
 {
-	assert(IsTileType(t, MP_WATER));
+	assert(IsTileType(t, TileType::Water));
 	SB(t.m5(), WBL_TYPE_BEGIN, WBL_TYPE_COUNT, to_underlying(type));
 }
 
@@ -102,13 +102,13 @@ inline void SetWaterTileType(Tile t, WaterTileType type)
  */
 inline bool HasTileWaterClass(Tile t)
 {
-	return IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_TREES);
+	return IsTileType(t, TileType::Water) || IsTileType(t, TileType::Station) || IsTileType(t, TileType::Industry) || IsTileType(t, TileType::Object) || IsTileType(t, TileType::Trees);
 }
 
 /**
  * Get the water class at a tile.
  * @param t Water tile to query.
- * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT)
+ * @pre IsTileType(t, TileType::Water) || IsTileType(t, TileType::Station) || IsTileType(t, TileType::Industry) || IsTileType(t, TileType::Object)
  * @return Water class at the tile.
  */
 inline WaterClass GetWaterClass(Tile t)
@@ -121,7 +121,7 @@ inline WaterClass GetWaterClass(Tile t)
  * Set the water class at a tile.
  * @param t  Water tile to change.
  * @param wc New water class.
- * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT)
+ * @pre IsTileType(t, TileType::Water) || IsTileType(t, TileType::Station) || IsTileType(t, TileType::Industry) || IsTileType(t, TileType::Object)
  */
 inline void SetWaterClass(Tile t, WaterClass wc)
 {
@@ -132,7 +132,7 @@ inline void SetWaterClass(Tile t, WaterClass wc)
 /**
  * Tests if the tile was built on water.
  * @param t the tile to check
- * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT)
+ * @pre IsTileType(t, TileType::Water) || IsTileType(t, TileType::Station) || IsTileType(t, TileType::Industry) || IsTileType(t, TileType::Object)
  * @return true iff on water
  */
 inline bool IsTileOnWater(Tile t)
@@ -144,7 +144,7 @@ inline bool IsTileOnWater(Tile t)
  * Is it a plain water tile?
  * @param t Water tile to query.
  * @return \c true if any type of clear water like ocean, river, or canal.
- * @pre IsTileType(t, MP_WATER)
+ * @pre IsTileType(t, TileType::Water)
  */
 inline bool IsWater(Tile t)
 {
@@ -155,7 +155,7 @@ inline bool IsWater(Tile t)
  * Is it a sea water tile?
  * @param t Water tile to query.
  * @return \c true if it is a sea water tile.
- * @pre IsTileType(t, MP_WATER)
+ * @pre IsTileType(t, TileType::Water)
  */
 inline bool IsSea(Tile t)
 {
@@ -166,7 +166,7 @@ inline bool IsSea(Tile t)
  * Is it a canal tile?
  * @param t Water tile to query.
  * @return \c true if it is a canal tile.
- * @pre IsTileType(t, MP_WATER)
+ * @pre IsTileType(t, TileType::Water)
  */
 inline bool IsCanal(Tile t)
 {
@@ -177,7 +177,7 @@ inline bool IsCanal(Tile t)
  * Is it a river water tile?
  * @param t Water tile to query.
  * @return \c true if it is a river water tile.
- * @pre IsTileType(t, MP_WATER)
+ * @pre IsTileType(t, TileType::Water)
  */
 inline bool IsRiver(Tile t)
 {
@@ -191,14 +191,14 @@ inline bool IsRiver(Tile t)
  */
 inline bool IsWaterTile(Tile t)
 {
-	return IsTileType(t, MP_WATER) && IsWater(t);
+	return IsTileType(t, TileType::Water) && IsWater(t);
 }
 
 /**
  * Is it a coast tile?
  * @param t Water tile to query.
  * @return \c true if it is a sea water tile.
- * @pre IsTileType(t, MP_WATER)
+ * @pre IsTileType(t, TileType::Water)
  */
 inline bool IsCoast(Tile t)
 {
@@ -212,14 +212,14 @@ inline bool IsCoast(Tile t)
  */
 inline bool IsCoastTile(Tile t)
 {
-	return (IsTileType(t, MP_WATER) && IsCoast(t)) || (IsTileType(t, MP_TREES) && GetWaterClass(t) != WaterClass::Invalid);
+	return (IsTileType(t, TileType::Water) && IsCoast(t)) || (IsTileType(t, TileType::Trees) && GetWaterClass(t) != WaterClass::Invalid);
 }
 
 /**
  * Is it a water tile with a ship depot on it?
  * @param t Water tile to query.
  * @return \c true if it is a ship depot tile.
- * @pre IsTileType(t, MP_WATER)
+ * @pre IsTileType(t, TileType::Water)
  */
 inline bool IsShipDepot(Tile t)
 {
@@ -233,7 +233,7 @@ inline bool IsShipDepot(Tile t)
  */
 inline bool IsShipDepotTile(Tile t)
 {
-	return IsTileType(t, MP_WATER) && IsShipDepot(t);
+	return IsTileType(t, TileType::Water) && IsShipDepot(t);
 }
 
 /**
@@ -300,7 +300,7 @@ inline TileIndex GetShipDepotNorthTile(Tile t)
  * Is there a lock on a given water tile?
  * @param t Water tile to query.
  * @return \c true if it is a water lock tile.
- * @pre IsTileType(t, MP_WATER)
+ * @pre IsTileType(t, TileType::Water)
  */
 inline bool IsLock(Tile t)
 {
@@ -311,7 +311,7 @@ inline bool IsLock(Tile t)
  * Get the direction of the water lock.
  * @param t Water tile to query.
  * @return Direction of the lock.
- * @pre IsTileType(t, MP_WATER) && IsLock(t)
+ * @pre IsTileType(t, TileType::Water) && IsLock(t)
  */
 inline DiagDirection GetLockDirection(Tile t)
 {
@@ -323,7 +323,7 @@ inline DiagDirection GetLockDirection(Tile t)
  * Get the part of a lock.
  * @param t Water tile to query.
  * @return The part.
- * @pre IsTileType(t, MP_WATER) && IsLock(t)
+ * @pre IsTileType(t, TileType::Water) && IsLock(t)
  */
 inline LockPart GetLockPart(Tile t)
 {
@@ -335,11 +335,11 @@ inline LockPart GetLockPart(Tile t)
  * Get the random bits of the water tile.
  * @param t Water tile to query.
  * @return Random bits of the tile.
- * @pre IsTileType(t, MP_WATER)
+ * @pre IsTileType(t, TileType::Water)
  */
 inline uint8_t GetWaterTileRandomBits(Tile t)
 {
-	assert(IsTileType(t, MP_WATER));
+	assert(IsTileType(t, TileType::Water));
 	return t.m4();
 }
 
@@ -362,7 +362,7 @@ inline bool HasTileWaterGround(Tile t)
  */
 inline void SetDockingTile(Tile t, bool b)
 {
-	assert(IsTileType(t, MP_WATER) || IsTileType(t, MP_RAILWAY) || IsTileType(t, MP_STATION) || IsTileType(t, MP_TUNNELBRIDGE));
+	assert(IsTileType(t, TileType::Water) || IsTileType(t, TileType::Railway) || IsTileType(t, TileType::Station) || IsTileType(t, TileType::TunnelBridge));
 	AssignBit(t.m1(), 7, b);
 }
 
@@ -372,7 +372,7 @@ inline void SetDockingTile(Tile t, bool b)
  */
 inline bool IsDockingTile(Tile t)
 {
-	return (IsTileType(t, MP_WATER) || IsTileType(t, MP_RAILWAY) || IsTileType(t, MP_STATION) || IsTileType(t, MP_TUNNELBRIDGE)) && HasBit(t.m1(), 7);
+	return (IsTileType(t, TileType::Water) || IsTileType(t, TileType::Railway) || IsTileType(t, TileType::Station) || IsTileType(t, TileType::TunnelBridge)) && HasBit(t.m1(), 7);
 }
 
 
@@ -382,7 +382,7 @@ inline bool IsDockingTile(Tile t)
  */
 inline void MakeShore(Tile t)
 {
-	SetTileType(t, MP_WATER);
+	SetTileType(t, TileType::Water);
 	SetTileOwner(t, OWNER_WATER);
 	SetWaterClass(t, WaterClass::Sea);
 	SetDockingTile(t, false);
@@ -405,7 +405,7 @@ inline void MakeShore(Tile t)
  */
 inline void MakeWater(Tile t, Owner o, WaterClass wc, uint8_t random_bits)
 {
-	SetTileType(t, MP_WATER);
+	SetTileType(t, TileType::Water);
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
 	SetDockingTile(t, false);
@@ -461,7 +461,7 @@ inline void MakeCanal(Tile t, Owner o, uint8_t random_bits)
  */
 inline void MakeShipDepot(Tile t, Owner o, DepotID did, DepotPart part, Axis a, WaterClass original_water_class)
 {
-	SetTileType(t, MP_WATER);
+	SetTileType(t, TileType::Water);
 	SetTileOwner(t, o);
 	SetWaterClass(t, original_water_class);
 	SetDockingTile(t, false);
@@ -486,7 +486,7 @@ inline void MakeShipDepot(Tile t, Owner o, DepotID did, DepotPart part, Axis a, 
  */
 inline void MakeLockTile(Tile t, Owner o, LockPart part, DiagDirection dir, WaterClass original_water_class)
 {
-	SetTileType(t, MP_WATER);
+	SetTileType(t, TileType::Water);
 	SetTileOwner(t, o);
 	SetWaterClass(t, original_water_class);
 	SetDockingTile(t, false);
@@ -529,7 +529,7 @@ inline void MakeLock(Tile t, Owner o, DiagDirection d, WaterClass wc_lower, Wate
  */
 inline void SetNonFloodingWaterTile(Tile t, bool b)
 {
-	assert(IsTileType(t, MP_WATER));
+	assert(IsTileType(t, TileType::Water));
 	AssignBit(t.m3(), 0, b);
 }
 /**
@@ -538,7 +538,7 @@ inline void SetNonFloodingWaterTile(Tile t, bool b)
  */
 inline bool IsNonFloodingWaterTile(Tile t)
 {
-	assert(IsTileType(t, MP_WATER));
+	assert(IsTileType(t, TileType::Water));
 	return HasBit(t.m3(), 0);
 }
 

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -109,7 +109,7 @@ Axis GetAxisForNewRailWaypoint(TileIndex tile)
 	if (IsRailWaypointTile(tile)) return GetRailStationAxis(tile);
 
 	/* Non-plain rail type, no valid axis for waypoints. */
-	if (!IsTileType(tile, MP_RAILWAY) || GetRailTileType(tile) != RailTileType::Normal) return INVALID_AXIS;
+	if (!IsTileType(tile, TileType::Railway) || GetRailTileType(tile) != RailTileType::Normal) return INVALID_AXIS;
 
 	switch (GetTrackBits(tile)) {
 		case TRACK_BIT_X: return AXIS_X;
@@ -154,7 +154,7 @@ static CommandCost IsValidTileForWaypoint(TileIndex tile, Axis axis, StationID *
 	/* if waypoint is set, then we have special handling to allow building on top of already existing waypoints.
 	 * so waypoint points to StationID::Invalid() if we can build on any waypoint.
 	 * Or it points to a waypoint if we're only allowed to build on exactly that waypoint. */
-	if (waypoint != nullptr && IsTileType(tile, MP_STATION)) {
+	if (waypoint != nullptr && IsTileType(tile, TileType::Station)) {
 		if (!IsRailWaypoint(tile)) {
 			return ClearTile_Station(tile, DoCommandFlag::Auto); // get error message
 		} else {
@@ -305,7 +305,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 		for (auto [i, it, tile] = std::make_tuple(0, stl.begin(), start_tile); i < count; ++i, ++it, tile += offset) {
 			uint8_t old_specindex = HasStationTileRail(tile) ? GetCustomStationSpecIndex(tile) : 0;
 			if (!HasStationTileRail(tile)) c->infrastructure.station++;
-			bool reserved = IsTileType(tile, MP_RAILWAY) ?
+			bool reserved = IsTileType(tile, TileType::Railway) ?
 					HasBit(GetRailReservationTrackBits(tile), AxisToTrack(axis)) :
 					HasStationReservation(tile);
 			MakeRailWaypoint(tile, wp->owner, wp->index, axis, *it, GetRailType(tile));


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
I wanted to do such change for [14671](https://github.com/OpenTTD/OpenTTD/discussions/14671) but I was not sure if it will be accepted.

Binary for solution with bitsets is shorter than for curent solution with GB and SB.

I have also tested the performance of those two solutions with the following codes.
Test A:
```cpp
#include <cstdint>

typedef unsigned int uint;

template <typename T>
inline constexpr static uint GB(const T x, const uint8_t s, const uint8_t n)
{
	return (x >> s) & (((T)1U << n) - 1);
}

template <typename T, typename U>
constexpr T SB(T &x, const uint8_t s, const uint8_t n, const U d)
{
	x &= (T)(~((((T)1U << n) - 1) << s));
	x |= (T)(d << s);
	return x;
}

static uint16_t A = 36;

uint8_t a_get() {
    return GB(A, 2, 4);
}

void a_set(uint8_t what) {
    SB(A, 2, 4, what);
}

int main() {
    for (int i = 0; i < (1 << 19); ++i) {
        a_set(a_get() + 1);
        a_set(a_get() * a_get());
    }
}
```
Test B:
```cpp
#include <cstdint>

typedef unsigned int uint;

struct mem {
   	uint8_t a : 2;
    uint8_t b : 4;
   	uint8_t c : 2;
};

static_assert(sizeof(mem) == 1);

union u {
    uint8_t bare;
    mem splited;

    u(uint8_t in) {
        this->bare = in;
    }
};

static u B(36);

uint8_t b_get() {
    return B.splited.b;
}

void b_set(uint8_t what) {
    B.splited.b = what;
}

int main() {
    for (int i = 0; i < (1 << 19); ++i) {
        b_set(b_get() + 1);
        b_set(b_get() * b_get());
    }
}
```
And results:
```console
cyprian@blade:~/tmp$ hyperfine --warmup=100 ./a.out ./b.out
Benchmark 1: ./a.out
  Time (mean ± σ):      10.0 ms ±   0.3 ms    [User: 9.5 ms, System: 0.5 ms]
  Range (min … max):     9.4 ms …  11.3 ms    280 runs
 
Benchmark 2: ./b.out
  Time (mean ± σ):       6.3 ms ±   0.2 ms    [User: 6.0 ms, System: 0.4 ms]
  Range (min … max):     5.9 ms …   7.2 ms    421 runs
 
Summary
  './b.out' ran
    1.60 ± 0.07 times faster than './a.out'
```

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Instead of spliting storage for one tile into m1, m2, m3, m4, m5, m6, m7 and m8 split it accordingly for each tile type to data that it stores, specifying how many bits each value uses. The combine all tile type specific storages into one object with `union`. To acces those members from *_map.h files, use template function that is inlined and its output is evaluated during compile, so effectively only one line from this function is inlined. Use template specification to overload those function for accesing subtype specific storage e.g. storage for ship depot or road stops as they store diffrent informations than other things using the same `TileType`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
 - Contains [#15138](https://github.com/OpenTTD/OpenTTD/pull/15138).
 - Due to c standard specification the way how bits are aligned in structures is compiler specific.
 I have included the test (tests/map_storage.cpp) to check if bits are aligned correctly, but as you can see in the comments some things had to be done strangely just to make windows version (compiled by MSVC) pass this test. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
