### PR TITLE
Fix 568b70e: Fjordia SlCompanyLiveries::Load crash

### DIFF
--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -456,7 +456,7 @@ public:
 
 		if (IsSavegameVersionBefore(SLV_85)) {
 			/* We want to insert some liveries somewhere in between. This means some have to be moved. */
-			std::move_backward(&c->livery[LS_FREIGHT_WAGON - 2], &c->livery[LS_END - 2], &c->livery[LS_END]);
+			std::move_backward(&c->livery[LS_FREIGHT_WAGON - 2], &c->livery[LS_END - 2], &c->livery[0] + LS_END);
 			c->livery[LS_PASSENGER_WAGON_MONORAIL] = c->livery[LS_MONORAIL];
 			c->livery[LS_PASSENGER_WAGON_MAGLEV]   = c->livery[LS_MAGLEV];
 		}


### PR DESCRIPTION
## Motivation / Problem

I've downloaded "Fjordia" scenario from Online Content menu. Clicking on Play Scenario and then on "Fjordia (v1)" entry in the file browser in Load Scenario window crashes game.

## Description

OpenTTD v15.0
```
/usr/include/c++/15.2.1/array:210: constexpr std::array<_Tp, _Nm>::value_type& std::array<_Tp, _Nm>::operator[](size_type) [with _Tp = Livery; long unsigned int _Nm = 23; reference = Livery&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Crash encountered, generating crash log...
Crash log generated.

Crash in summary:
  OpenTTD version:
    Version: 15.0
    Hash: 30cc053596e34eb1d66ecbaae861d515cf3644ac
    NewGRF ver: 1F086D64
    Content ver: 15.0

  Crash:
    Reason: Aborted

  Stacktrace:
    openttd(+0x6107ca) [0x5653e4f897ca]
    openttd(+0x7331c8) [0x5653e50ac1c8]
    openttd(+0x606393) [0x5653e4f7f393]
    openttd(_ZN8CrashLog12FillCrashLogEv+0x20e) [0x5653e50aa6de]
    openttd(_ZN8CrashLog12MakeCrashLogEv+0x83) [0x5653e50af593]
    openttd(+0x6067ce) [0x5653e4f7f7ce]
    /usr/lib/libc.so.6(+0x3e4d0) [0x7f4efbc3e4d0]
    /usr/lib/libc.so.6(+0x9890c) [0x7f4efbc9890c]
    /usr/lib/libc.so.6(gsignal+0x20) [0x7f4efbc3e3a0]
    /usr/lib/libc.so.6(abort+0x26) [0x7f4efbc2557a]
    /usr/lib/libstdc++.so.6(+0x9a41f) [0x7f4efc09a41f]
    openttd(+0x190e01) [0x5653e4b09e01]
    openttd(_Z8SlObjectPvRKSt4spanIK8SaveLoadLm18446744073709551615EE+0x8f) [0x5653e4ffd57f]
    openttd(+0x64df12) [0x5653e4fc6f12]
    openttd(+0x693575) [0x5653e500c575]
    openttd(_Z10SaveOrLoadSt17basic_string_viewIcSt11char_traitsIcEE17SaveLoadOperation16DetailedFileType12Subdirectoryb+0x336) [0x5653e500f9d6]
    openttd(+0x7851a3) [0x5653e50fe1a3]
    openttd(_Z17HandleMouseEventsv+0x1abf) [0x5653e53e34df]
    openttd(_ZN20VideoDriver_SDL_Base9PollEventEv+0xf5) [0x5653e5037135]
    openttd(_ZN11VideoDriver4TickEv+0x54c) [0x5653e503fedc]
    openttd(_ZN20VideoDriver_SDL_Base8MainLoopEv+0x3e) [0x5653e503862e]
    openttd(_Z12openttd_mainSt4spanISt17basic_string_viewIcSt11char_traitsIcEELm18446744073709551615EE+0x20fc) [0x5653e5231e8c]
    openttd(main+0x269) [0x5653e4b7a1d9]
    /usr/lib/libc.so.6(+0x27635) [0x7f4efbc27635]
    /usr/lib/libc.so.6(__libc_start_main+0x89) [0x7f4efbc276e9]
    openttd(_start+0x25) [0x5653e4c0b9c5]
```

The game crashed every time with Arch Linux openttd package and my build of master branch. However, I was unable to reproduce the crash with the official binaries.

The crash occurs at [this line](https://github.com/OpenTTD/OpenTTD/blob/0c0f55302d48069fde46169899dec5bc7208c247/src/saveload/company_sl.cpp#L459). The bug is that c->liveries is an std::array, not a C array, and calling [operator[]](https://en.cppreference.com/w/cpp/container/array/operator_at.html) with an out-of-bounds index is undefined behavior. This change fixes the crash.