### PR TITLE
Fix 317dc71: MacOS version detection was broken

### DIFF
--- a/src/os/macosx/macos.h
+++ b/src/os/macosx/macos.h
@@ -13,7 +13,7 @@
 /** Helper function displaying a message the best possible way. */
 void ShowMacDialog(std::string_view title, std::string_view message, std::string_view button_label);
 
-void GetMacOSVersion(int *return_major, int *return_minor, int *return_bugfix);
+std::tuple<int, int, int> GetMacOSVersion();
 
 bool IsMonospaceFont(CFStringRef name);
 

--- a/src/os/macosx/macos.h
+++ b/src/os/macosx/macos.h
@@ -15,25 +15,6 @@ void ShowMacDialog(std::string_view title, std::string_view message, std::string
 
 void GetMacOSVersion(int *return_major, int *return_minor, int *return_bugfix);
 
-/**
- * Check if we are at least running on the specified version of Mac OS.
- * @param major major version of the os. This would be 10 in the case of 10.4.11.
- * @param minor minor version of the os. This would be 4 in the case of 10.4.11.
- * @param bugfix bugfix version of the os. This would be 11 in the case of 10.4.11.
- * @return true if the running os is at least what we asked, false otherwise.
- */
-inline bool MacOSVersionIsAtLeast(long major, long minor, long bugfix)
-{
-	int version_major, version_minor, version_bugfix;
-	GetMacOSVersion(&version_major, &version_minor, &version_bugfix);
-
-	if (version_major < major) return false;
-	if (version_major == major && version_minor < minor) return false;
-	if (version_major == major && version_minor == minor && version_bugfix < bugfix) return false;
-
-	return true;
-}
-
 bool IsMonospaceFont(CFStringRef name);
 
 void MacOSSetThreadName(const std::string &name);

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -26,29 +26,13 @@ static NSAutoreleasePool *_ottd_autorelease_pool;
 #endif
 
 /**
- * Get the version of the MacOS we are running under. Code adopted
- * from http://www.cocoadev.com/index.pl?DeterminingOSVersion
- * @param return_major major version of the os. This would be 10 in the case of 10.4.11
- * @param return_minor minor version of the os. This would be 4 in the case of 10.4.11
- * @param return_bugfix bugfix version of the os. This would be 11 in the case of 10.4.11
- * A return value of -1 indicates that something went wrong and we don't know.
+ * Get the version of the MacOS we are running under.
+ * @return Tuple with major, minor and patch of the MacOS version.
  */
-void GetMacOSVersion(int *return_major, int *return_minor, int *return_bugfix)
+std::tuple<int, int, int> GetMacOSVersion()
 {
-	*return_major = -1;
-	*return_minor = -1;
-	*return_bugfix = -1;
-
-	if ([[ NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion) ]) {
-		IMP sel = [ [ NSProcessInfo processInfo] methodForSelector:@selector(operatingSystemVersion) ];
-		NSOperatingSystemVersion ver = ((NSOperatingSystemVersion (*)(id, SEL))sel)([ NSProcessInfo processInfo], @selector(operatingSystemVersion));
-
-		*return_major = (int)ver.majorVersion;
-		*return_minor = (int)ver.minorVersion;
-		*return_bugfix = (int)ver.patchVersion;
-
-		return;
-	}
+	NSOperatingSystemVersion ver = [ [ NSProcessInfo processInfo ] operatingSystemVersion ];
+	return { static_cast<int>(ver.majorVersion), static_cast<int>(ver.minorVersion), static_cast<int>(ver.patchVersion) };
 }
 
 #ifdef WITH_COCOA

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -193,9 +193,7 @@ bool IsMonospaceFont(CFStringRef name)
  */
 void MacOSSetThreadName(const std::string &name)
 {
-	if (MacOSVersionIsAtLeast(10, 6, 0)) {
-		pthread_setname_np(name.c_str());
-	}
+	pthread_setname_np(name.c_str());
 
 	NSThread *cur = [ NSThread currentThread ];
 	if (cur != nil && [ cur respondsToSelector:@selector(setName:) ]) {

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -124,8 +124,6 @@ static const CTRunDelegateCallbacks _sprite_font_callback = {
 
 /* static */ std::unique_ptr<ParagraphLayouter> CoreTextParagraphLayoutFactory::GetParagraphLayout(CharType *buff, CharType *buff_end, FontMap &font_mapping)
 {
-	if (!MacOSVersionIsAtLeast(10, 5, 0)) return nullptr;
-
 	/* Can't layout an empty string. */
 	ptrdiff_t length = buff_end - buff;
 	if (length == 0) return nullptr;
@@ -276,8 +274,6 @@ void MacOSResetScriptCache(FontSize size)
 /** Register an external font file with the CoreText system. */
 void MacOSRegisterExternalFont(std::string_view file_path)
 {
-	if (!MacOSVersionIsAtLeast(10, 6, 0)) return;
-
 	CFAutoRelease<CFStringRef> path(CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(file_path.data()), file_path.size(), kCFStringEncodingUTF8, false));
 	CFAutoRelease<CFURLRef> url(CFURLCreateWithFileSystemPath(kCFAllocatorDefault, path.get(), kCFURLPOSIXPathStyle, false));
 
@@ -287,8 +283,6 @@ void MacOSRegisterExternalFont(std::string_view file_path)
 /** Store current language locale as a CoreFoundation locale. */
 void MacOSSetCurrentLocaleName(std::string_view iso_code)
 {
-	if (!MacOSVersionIsAtLeast(10, 5, 0)) return;
-
 	CFAutoRelease<CFStringRef> iso(CFStringCreateWithBytes(kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(iso_code.data()), iso_code.size(), kCFStringEncodingUTF8, false));
 	_osx_locale.reset(CFLocaleCreate(kCFAllocatorDefault, iso.get()));
 }
@@ -302,9 +296,6 @@ void MacOSSetCurrentLocaleName(std::string_view iso_code)
  */
 int MacOSStringCompare(std::string_view s1, std::string_view s2)
 {
-	static const bool supported = MacOSVersionIsAtLeast(10, 5, 0);
-	if (!supported) return 0;
-
 	CFStringCompareFlags flags = kCFCompareCaseInsensitive | kCFCompareNumerically | kCFCompareLocalized | kCFCompareWidthInsensitive | kCFCompareForcedOrdering;
 
 	CFAutoRelease<CFStringRef> cf1(CFStringCreateWithBytes(kCFAllocatorDefault, (const UInt8 *)s1.data(), s1.size(), kCFStringEncodingUTF8, false));
@@ -326,9 +317,6 @@ int MacOSStringCompare(std::string_view s1, std::string_view s2)
  */
 int MacOSStringContains(std::string_view str, std::string_view value, bool case_insensitive)
 {
-	static const bool supported = MacOSVersionIsAtLeast(10, 5, 0);
-	if (!supported) return -1;
-
 	CFStringCompareFlags flags = kCFCompareLocalized | kCFCompareWidthInsensitive;
 	if (case_insensitive) flags |= kCFCompareCaseInsensitive;
 
@@ -447,7 +435,5 @@ int MacOSStringContains(std::string_view str, std::string_view value, bool case_
 
 /* static */ std::unique_ptr<StringIterator> OSXStringIterator::Create()
 {
-	if (!MacOSVersionIsAtLeast(10, 5, 0)) return nullptr;
-
 	return std::make_unique<OSXStringIterator>();
 }

--- a/src/os/macosx/survey_osx.cpp
+++ b/src/os/macosx/survey_osx.cpp
@@ -20,13 +20,12 @@
 
 void SurveyOS(nlohmann::json &json)
 {
-	int ver_maj, ver_min, ver_bug;
-	GetMacOSVersion(&ver_maj, &ver_min, &ver_bug);
+	auto [ver_major, ver_minor, ver_patch] = GetMacOSVersion();
 
 	const NXArchInfo *arch = NXGetLocalArchInfo();
 
 	json["os"] = "MacOS";
-	json["release"] = fmt::format("{}.{}.{}", ver_maj, ver_min, ver_bug);
+	json["release"] = fmt::format("{}.{}.{}", ver_major, ver_minor, ver_patch);
 	json["machine"] = arch != nullptr ? arch->description : "unknown";
 	json["min_ver"] = MAC_OS_X_VERSION_MIN_REQUIRED;
 	json["max_ver"] = MAC_OS_X_VERSION_MAX_ALLOWED;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -550,6 +550,9 @@ void VideoDriver_Cocoa::MainLoopReal()
 
 @end
 
+/** Register the cocoa video driver. */
+static FVideoDriver_CocoaQuartz iFVideoDriver_CocoaQuartz;
+
 /**
  * Clear buffer to opaque black.
  * @param buffer Pointer to the buffer.

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -103,8 +103,6 @@ void VideoDriver_Cocoa::Stop()
  */
 std::optional<std::string_view> VideoDriver_Cocoa::Initialize()
 {
-	if (!MacOSVersionIsAtLeast(10, 7, 0)) return "The Cocoa video driver requires Mac OS X 10.7 or later.";
-
 	if (_cocoa_video_started) return "Already started";
 	_cocoa_video_started = true;
 
@@ -237,18 +235,16 @@ std::vector<int> VideoDriver_Cocoa::GetListOfMonitorRefreshRates()
 {
 	std::vector<int> rates{};
 
-	if (MacOSVersionIsAtLeast(10, 6, 0)) {
-		std::array<CGDirectDisplayID, 16> displays;
+	std::array<CGDirectDisplayID, 16> displays;
 
-		uint32_t count = 0;
-		CGGetActiveDisplayList(displays.size(), displays.data(), &count);
+	uint32_t count = 0;
+	CGGetActiveDisplayList(displays.size(), displays.data(), &count);
 
-		for (uint32_t i = 0; i < count; i++) {
-			CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displays[i]);
-			int rate = (int)CGDisplayModeGetRefreshRate(mode);
-			if (rate > 0) rates.push_back(rate);
-			CGDisplayModeRelease(mode);
-		}
+	for (uint32_t i = 0; i < count; i++) {
+		CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displays[i]);
+		int rate = static_cast<int>(CGDisplayModeGetRefreshRate(mode));
+		if (rate > 0) rates.push_back(rate);
+		CGDisplayModeRelease(mode);
 	}
 
 	return rates;

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -310,10 +310,8 @@ static void setupWindowMenu()
 	[ menuItem setSubmenu:windowMenu ];
 	[ [ NSApp mainMenu ] addItem:menuItem ];
 
-	if (MacOSVersionIsAtLeast(10, 7, 0)) {
-		/* The OS will change the name of this menu item automatically */
-		[ windowMenu addItemWithTitle:@"Fullscreen" action:@selector(toggleFullScreen:) keyEquivalent:@"^f" ];
-	}
+	/* The OS will change the name of this menu item automatically */
+	[ windowMenu addItemWithTitle:@"Fullscreen" action:@selector(toggleFullScreen:) keyEquivalent:@"^f" ];
 
 	/* Tell the application object that this is now the window menu */
 	[ NSApp setWindowsMenu:windowMenu ];


### PR DESCRIPTION
## Motivation / Problem

Complaints that MacOS builds did not have a functioning video card driver any more.


## Description

Remove all unneeded `MacOSVersionIsAtLeast` calls, since we don't support anything near the currently used functions.

Also further simplify `GetMacOSVersion` to just unconditionally use `[ NSProcessInfo processInfo ] operatingSystemVersion`.


## Limitations

Completely untested. 

Actual cocoa not being loaded is 'fixed' by just not checking any more, so cocoa working is no test for the version detection being fixed. That must be done by previewing the survey results.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
