### PR TITLE
Codefix #15145, 9e9b513, f4b0ac2: Hide line numbers in doxygen warnings.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -122,7 +122,7 @@ WARN_NO_PARAMDOC       = YES
 WARN_IF_UNDOC_ENUM_VAL = YES
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$${DOXYGEN_WARN_FORMAT_LINE}: $text"
-WARN_LINE_FORMAT       = "at line $line of file $file"
+WARN_LINE_FORMAT       = "at line $${DOXYGEN_WARN_FORMAT_LINE} of file $file"
 WARN_LOGFILE           = ${DOXYGEN_WARN_FILE}
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -492,7 +492,7 @@ protected:
 	 * uint32_t  ID of the client sending the command.
 	 * uint8_t   ID of the company (0..MAX_COMPANIES-1).
 	 * uint16_t  ID of the command.
-	 * <var>   Command specific buffer with encoded parameters of variable length.
+	 * `<var>` Command specific buffer with encoded parameters of variable length.
 	 *         The content differs per command and can change without notification.
 	 * uint32_t  Frame of execution.
 	 * @param p The packet that was just received.

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -325,7 +325,7 @@ protected:
 	 * Send a DoCommand to the Server:
 	 * uint8_t   ID of the company (0..MAX_COMPANIES-1).
 	 * uint32_t  ID of the command (see command.h).
-	 * <var>   Command specific buffer with encoded parameters of variable length.
+	 * `<var>` Command specific buffer with encoded parameters of variable length.
 	 *         The content differs per command and can change without notification.
 	 * uint8_t   ID of the callback.
 	 * @param p The packet that was just received.
@@ -336,7 +336,7 @@ protected:
 	 * Sends a DoCommand to the client:
 	 * uint8_t   ID of the company (0..MAX_COMPANIES-1).
 	 * uint32_t  ID of the command (see command.h).
-	 * <var>   Command specific buffer with encoded parameters of variable length.
+	 * `<var>` Command specific buffer with encoded parameters of variable length.
 	 *         The content differs per command and can change without notification.
 	 * uint8_t   ID of the callback.
 	 * uint32_t  Frame of execution.

--- a/src/script/api/Doxyfile_AI.in
+++ b/src/script/api/Doxyfile_AI.in
@@ -122,7 +122,7 @@ WARN_NO_PARAMDOC       = YES
 WARN_IF_UNDOC_ENUM_VAL = YES
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$${DOXYGEN_WARN_FORMAT_LINE}: $text"
-WARN_LINE_FORMAT       = "at line $line of file $file"
+WARN_LINE_FORMAT       = "at line $${DOXYGEN_WARN_FORMAT_LINE} of file $file"
 WARN_LOGFILE           = ${DOXYGEN_AI_WARN_FILE}
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/src/script/api/Doxyfile_GS.in
+++ b/src/script/api/Doxyfile_GS.in
@@ -122,7 +122,7 @@ WARN_NO_PARAMDOC       = YES
 WARN_IF_UNDOC_ENUM_VAL = YES
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$${DOXYGEN_WARN_FORMAT_LINE}: $text"
-WARN_LINE_FORMAT       = "at line $line of file $file"
+WARN_LINE_FORMAT       = "at line $${DOXYGEN_WARN_FORMAT_LINE} of file $file"
 WARN_LOGFILE           = ${DOXYGEN_GS_WARN_FILE}
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -116,9 +116,8 @@ struct SettingDesc {
 
 	/**
 	 * Format the value of the setting associated with this object.
-	 * @param buf The before of the buffer to format into.
-	 * @param last The end of the buffer to format into.
 	 * @param object The object the setting is in.
+	 * @return The string representing the given value in human readable format.
 	 */
 	virtual std::string FormatValue(const void *object) const = 0;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
[#15145](https://github.com/OpenTTD/OpenTTD/pull/15145) fails the [New doxygen warnings checker](https://github.com/OpenTTD/OpenTTD/actions/runs/21263009475/job/61194968260?pr=15145#logs) workflow.

`'void CFDeleter< T >::operator()(T *p)' at line 27 of file /home/runner/work/OpenTTD/OpenTTD/src/os/macosx/macos.h`
,
`/home/cyprian/openTTD/OpenTTD_SourceCode/src/network/core/tcp_game.h:$: warning: end of comment block while expecting command </var> (Probable start '/home/cyprian/openTTD/OpenTTD_SourceCode/src/network/core/tcp_game.h' at line 339)`
and
`/home/cyprian/openTTD/OpenTTD_SourceCode/src/settings_internal.h:$: warning: argument 'buf' of command @param is not found in the argument list of IntSettingDesc::FormatValue(const void *object) const inherited from member FormatValue at line 119 in file /home/cyprian/openTTD/OpenTTD_SourceCode/src/settings_internal.h`
are shown in doxygen warnings when `-DOPTION_LINE_IN_DOXYGEN_WARNINGS=OFF` is set.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Do not show line numbers in WARN_LINE_FORMAT if `-DOPTION_LINE_IN_DOXYGEN_WARNINGS=OFF` is set.
Fix all other doxygen warnings that contain line number (there are only few of them and I don't know how to hide line number in them.):
 - Use mark down to make `<var>` not read as HTML tag by doxygen.
 - Remove docs for not existing parameters that couse "... inherited from member FormatValue ..." warnings.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
The New doxygen warnings checker fails here too because line numbers disappeared in doxygen warnings. :(

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
