### PR TITLE
Fix #15116: old cargo/industry sets without cargo translation table broken

### DIFF
--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -154,6 +154,7 @@ struct GRFFile {
 
 	int traininfo_vehicle_pitch = 0; ///< Vertical offset for drawing train images in depot GUI and vehicle details
 	uint traininfo_vehicle_width = 0; ///< Width (in pixels) of a 8/8 train vehicle in depot GUI and vehicle details
+	bool cargo_list_is_fallback = false; ///< Set if cargo types have been created but a cargo list has not been installed
 
 	GrfSpecFeatures grf_features{}; ///< Bitset of GrfSpecFeature the grf uses
 	PriceMultipliers price_base_multipliers{}; ///< Price base multipliers as set by the grf.

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -110,6 +110,8 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 	/* Properties which are handled as a whole */
 	switch (prop) {
 		case 0x09: // Cargo Translation Table; loading during both reservation and activation stage (in case it is selected depending on defined cargos)
+			/* Explicitly defined cargo translation table means it's no longer a fallback list. LoadTranslationTable erases any existing list. */
+			_cur_gps.grffile->cargo_list_is_fallback = false;
 			return LoadTranslationTable<CargoLabel>(first, last, buf, [](GRFFile &grf) -> std::vector<CargoLabel> & { return grf.cargo_list; }, "Cargo");
 
 		case 0x12: // Rail type translation table; loading during both reservation and activation stage (in case it is selected depending on defined railtypes)
@@ -336,6 +338,8 @@ static ChangeInfoResult GlobalVarReserveInfo(uint first, uint last, int prop, By
 	/* Properties which are handled as a whole */
 	switch (prop) {
 		case 0x09: // Cargo Translation Table; loading during both reservation and activation stage (in case it is selected depending on defined cargos)
+			/* Explicitly defined cargo translation table means it's no longer a fallback list. LoadTranslationTable erases any existing list. */
+			_cur_gps.grffile->cargo_list_is_fallback = false;
 			return LoadTranslationTable<CargoLabel>(first, last, buf, [](GRFFile &grf) -> std::vector<CargoLabel> & { return grf.cargo_list; }, "Cargo");
 
 		case 0x12: // Rail type translation table; loading during both reservation and activation stage (in case it is selected depending on defined railtypes)

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -82,7 +82,7 @@ CargoType GetCargoTranslation(uint8_t cargo, const GRFFile *grffile, bool usebit
 	/* We can't use GetCargoTranslationTable here as the usebit flag changes behaviour. */
 	/* Pre-version 7 uses the bitnum lookup from (standard in v8) instead of climate dependent in some places.. */
 	std::span<const CargoLabel> cargo_list;
-	if (grffile->grf_version < 7 && !usebit) {
+	if (grffile->grf_version < 7 && !usebit && !grffile->cargo_list_is_fallback) {
 		cargo_list = GetClimateDependentCargoTranslationTable();
 	} else if (!grffile->cargo_list.empty()) {
 		cargo_list = grffile->cargo_list;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #15116 and #15149, old cargo/industry NewGRFs that don't set up a cargo translation table are broken by the changes to translation tables since 14.1.

This results in a regression and savegames using these NewGRFs are no longer playable.

<img width="952" height="426" alt="image" src="https://github.com/user-attachments/assets/32865980-fe30-48a1-9bc3-b07d01fce3f0" />

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

## Description

When a NewGRF sets cargo labels, install a fallback table if the NewGRF does not install one to give them a better chance of working.

<img width="952" height="426" alt="image" src="https://github.com/user-attachments/assets/b7669052-4ab2-4051-82a7-489f1f29049d" />

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Not heavily tested, but the industry chain in Pikka's Basic Industries looks correct.

Won't help really old sets that don't even set labels.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
