### PR TITLE
Codechange: Make trees more packable in save files.

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -147,6 +147,7 @@
    <td valign=top nowrap>&nbsp;</td>
    <td>
     <ul>
+	 <li>m1 bits 6..5: Water class, always WaterClass::Invalid.</li>
      <li>m1 bits 4..0: <a href="#OwnershipInfo">owner</a> of the tile (normally <tt>10</tt>)</li>
      <li>m2: see fields</li>
      <li>m3 bits 7..5: type of hedge on NE border of the tile</li>
@@ -784,7 +785,58 @@
     <ul>
      <li>m1 bits 6..5: water class (sea or land)</li>
      <li>m1 bits 4..0: <a href="#OwnershipInfo">owner</a> (normally <tt>10</tt>)</li>
-     <li>m2 bits 8..6: ground
+     <li>m3 bits 2..0: growth status:
+      <table border="0">
+       <tr>
+        <td><tt>0</tt>..<tt>2</tt>&nbsp;</td>
+        <td>one of trees is growing&nbsp;</td>
+       </tr>
+       <tr>
+        <td><tt>3</tt>&nbsp;</td>
+        <td>all trees are fully grown&nbsp;</td>
+       </tr>
+       <tr>
+        <td><tt>4</tt>..<tt>6</tt>&nbsp;</td>
+        <td>one of trees is withering&nbsp;</td>
+       </tr>
+      </table>
+     </li>
+	 <li>m3 bits 6..3: type of trees:
+      <table>
+       <tr>
+        <td nowrap valign=top><tt>00</tt>..<tt>0B</tt>&nbsp; </td>
+        <td align=left>temperate climate trees</td>
+       </tr>
+
+       <tr>
+        <td nowrap valign=top><tt>00</tt>..<tt>07</tt>&nbsp; </td>
+        <td align=left>sub-arctic climate trees</td>
+       </tr>
+
+       <tr>
+        <td nowrap valign=top><tt>00</tt>..<tt>06</tt>&nbsp; </td>
+        <td align=left>rainforest trees</td>
+       </tr>
+
+       <tr>
+        <td nowrap valign=top><tt>07</tt> </td>
+        <td align=left>cactus plants</td>
+       </tr>
+
+       <tr>
+        <td nowrap valign=top><tt>08</tt>..<tt>0B</tt>&nbsp; </td>
+        <td align=left>sub-tropical climate, non-rainforest, non-desert trees</td>
+       </tr>
+
+       <tr>
+        <td nowrap valign=top><tt>00</tt>..<tt>08</tt>&nbsp; </td>
+        <td align=left>toyland trees</td>
+       </tr>
+      </table>
+      <small>Note: the actually displayed set of trees depends on both type and number of trees</small><br>
+	  <small>Note: on acces values are converted to global enumeration of all tree types.</small>
+     </li>
+     <li>m5 bits 4..2: ground
       <table>
 
        <tr>
@@ -813,58 +865,8 @@
        </tr>
       </table>
      </li>
-     <li>m2 bits 5..4: ground density</li>
-     <li>m3 bits 7..0: type of trees:
-      <table>
-       <tr>
-        <td nowrap valign=top><tt>00</tt>..<tt>0B</tt>&nbsp; </td>
-        <td align=left>temperate climate trees</td>
-       </tr>
-
-       <tr>
-        <td nowrap valign=top><tt>0C</tt>..<tt>13</tt>&nbsp; </td>
-        <td align=left>sub-arctic climate trees</td>
-       </tr>
-
-       <tr>
-        <td nowrap valign=top><tt>14</tt>..<tt>1A</tt>&nbsp; </td>
-        <td align=left>rainforest trees</td>
-       </tr>
-
-       <tr>
-        <td nowrap valign=top><tt>1B</tt> </td>
-        <td align=left>cactus plants</td>
-       </tr>
-
-       <tr>
-        <td nowrap valign=top><tt>1C</tt>..<tt>1F</tt>&nbsp; </td>
-        <td align=left>sub-tropical climate, non-rainforest, non-desert trees</td>
-       </tr>
-
-       <tr>
-        <td nowrap valign=top><tt>20</tt>..<tt>28</tt>&nbsp; </td>
-        <td align=left>toyland trees</td>
-       </tr>
-      </table>
-      <small>Note: the actually displayed set of trees depends on both type and number of trees</small>
-     </li>
-     <li>m5 bits 7..6: number of trees minus one</li>
-     <li>m5 bits 2..0: growth status:
-      <table border="0">
-       <tr>
-        <td><tt>0</tt>..<tt>2</tt>&nbsp;</td>
-        <td>one of trees is growing&nbsp;</td>
-       </tr>
-       <tr>
-        <td><tt>3</tt>&nbsp;</td>
-        <td>all trees are fully grown&nbsp;</td>
-       </tr>
-       <tr>
-        <td><tt>4</tt>..<tt>6</tt>&nbsp;</td>
-        <td>one of trees is withering&nbsp;</td>
-       </tr>
-      </table>
-     </li>
+     <li>m5 bits 1..0: ground density</li>
+	 <li>m6 bits 3..2: number of trees minus one</li>
     </ul>
    </td>
   </tr>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -81,7 +81,7 @@ the array so you can quickly see what is used and what is not.
       <td class="caption">ground</td>
       <td class="bits" rowspan=29><span class="used" title="Tile type">XXXX</span> <span class="used" title="Presence and direction of bridge above">XX</span> <span class="used" title="Tropic Zone: only meaningful in tropic climate. It contains the definition of the available zones">XX</span></td>
       <td class="bits" rowspan=29><span class="used" title="Tile height">XXXX XXXX</span></td>
-      <td class="bits" rowspan=2><span class="free">OOO</span><span class="usable" title="Owner (always OWNER_NONE)">1 OOOO</span></td>
+      <td class="bits" rowspan=2><span class="free">O</span><span class="usable" title="Water class (always WaterClass::Invalid)">11</span><span class="usable" title="Owner (always OWNER_NONE)">1 OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Type of hedge on NE border">XXX</span> <span class="used" title="Snow presence">X</span><span class="free">OOOO</span></td>
       <td class="bits" rowspan=2><span class="used" title="Type of hedge on SW border">XXX</span> <span class="used" title="Type of hedge on SE border">XXX</span><span class="free">OO</span></td>
@@ -172,11 +172,11 @@ the array so you can quickly see what is used and what is not.
       <td>4</td>
       <td class="caption">trees</td>
       <td class="bits"><span class="free">O</span><span class="used" title="Water class">XX</span><span class="usable" title="Owner (always OWNER_NONE)">1 OOOO</span></td>
-      <td class="bits"><span class="free">OOOO OOO</span><span class="used" title="Tree ground">XXX</span> <span class="used" title="Tree density">XX</span> <span class="free">OOOO</span></td>
-      <td class="bits"><span class="usable" title="Tree type unused bits">XX</span><span class="used" title="Tree type">XX XXXX</span></td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits"><span class="free">O</span><span class="used" title="Tree type">XXXX</span> <span class="used" title="Tree growth">XXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="used" title="Number of trees on tile (+1)">XX</span><span class="free">OO O</span><span class="used" title="Tree growth">XXX</span></td>
-      <td class="bits"><span class="free">OOOO OOOO</span></td>
+	  <td class="bits"><span class="free">OOO</span><span class="used" title="Tree ground">XXX</span> <span class="used" title="Tree density">XX</span></td>
+      <td class="bits"><span class="free">OOOO</span> <span class="used" title="Number of trees on tile (+1)">XX</span><span class="free">OO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -172,7 +172,7 @@ the array so you can quickly see what is used and what is not.
       <td>4</td>
       <td class="caption">trees</td>
       <td class="bits"><span class="free">O</span><span class="used" title="Water class">XX</span><span class="usable" title="Owner (always OWNER_NONE)">1 OOOO</span></td>
-      <td class="bits"><span class="free">OOOO OOO</span><span class="used" title="Tree ground">XXX</span> <span class="used" title="Tree density">XX</span> <span class="used" title="Tree counter">XXXX</span></td>
+      <td class="bits"><span class="free">OOOO OOO</span><span class="used" title="Tree ground">XXX</span> <span class="used" title="Tree density">XX</span> <span class="free">OOOO</span></td>
       <td class="bits"><span class="usable" title="Tree type unused bits">XX</span><span class="used" title="Tree type">XX XXXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Number of trees on tile (+1)">XX</span><span class="free">OO O</span><span class="used" title="Tree growth">XXX</span></td>

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -246,7 +246,7 @@ inline void SetFence(Tile t, DiagDirection side, uint h)
 inline void MakeClear(Tile t, ClearGround g, uint density)
 {
 	SetTileType(t, MP_CLEAR);
-	t.m1() = 0;
+	t.m1() = to_underlying(WaterClass::Invalid) << 5; // Using SetWaterClass() would trigger an assert.
 	SetTileOwner(t, OWNER_NONE);
 	t.m2() = 0;
 	t.m3() = 0;
@@ -267,7 +267,7 @@ inline void MakeClear(Tile t, ClearGround g, uint density)
 inline void MakeField(Tile t, uint field_type, IndustryID industry)
 {
 	SetTileType(t, MP_CLEAR);
-	t.m1() = 0;
+	t.m1() = to_underlying(WaterClass::Invalid) << 5; // Using SetWaterClass() would trigger an assert.
 	SetTileOwner(t, OWNER_NONE);
 	t.m2() = industry.base();
 	t.m3() = field_type;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -415,6 +415,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_SIGN_TEXT_COLOURS,                  ///< 363  PR#14743 Configurable sign text colors in scenario editor.
 	SLV_BUOYS_AT_0_0,                       ///< 364  PR#14983 Allow to build buoys at (0x0).
 
+	SLV_BETTER_TREES_STORAGE,               ///< 365  PR#15155 Make trees more packable in save files.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
The same save with trees takes about 30% more space than without them.
@ldpl plans to remove trees in citymania. _(That's my motivation, not a problem.)_

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Map is saved in 8 parts. Each part contains one of 8 chunks for every tile. If in one part chunks for multiple tiles contain similar data then the packing algorithm can pack them. So if tree tiles store in a chunk similar value to the clear tiles, then the save file can be packed more.

Clear tiles store density, ground type and counter in m5, those values are the same for all grass tiles in the full state (density = 3). Tree tiles stored those values in m2, as they are the same this PR moves them to m5.

Secondly data that was stored in m5 for trees is move to m3 as it is more likely to have diffrent values for clear tiles than m4 or m6 because it contains snow presence and field state.

Tree type that was stored in all 8 bits of m3 but values for one type of landscape can be stored in only 4 bits therefore as m3 now has only 3 bits left, store there the 3 lowes bits of the tree type and the 4th bit store in m5[7] because if it is 0 then the value of m5 match clear tiles and if it is 1 then the this bit could be packed with 2 bits of density wich also are 1.

Last but not least set bits in clear tiles that trees use to store water class to WaterClass::Invalid as that value is used for trees on land.

## Results
### Test 1
Master no trees: 14.1 kB
Master trees: 24.0 kB
PR no trees: 14.1 kB
PR trees: 20.3 kB

[Test1.zip](https://github.com/user-attachments/files/24826310/Test1.zip)

### Test 2
Master no trees: 16.3 kB
Master trees: 24.2 kB
PR no trees: 16.4 kB
PR trees: 21.8 kB

[Test2.zip](https://github.com/user-attachments/files/24826312/Test2.zip)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Contains [#15143](https://github.com/OpenTTD/OpenTTD/pull/15143).
Conflicts with [#15138](https://github.com/OpenTTD/OpenTTD/pull/15138) and [#15140](https://github.com/OpenTTD/OpenTTD/pull/15140)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
