### PR TITLE
Add: Show additional vehicle details based on sort criteria

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -458,7 +458,7 @@ public:
 				int side = (widget == WID_RV_LEFT_MATRIX) ? 0 : 1;
 
 				/* Do the actual drawing */
-				DrawEngineList(this->window_number, r, this->engines[side], *this->vscroll[side], this->sel_engine[side], side == 0, this->sel_group, this->badge_classes);
+				DrawEngineList(this->window_number, r, this->engines[side], *this->vscroll[side], this->sel_engine[side], side == 0, this->sel_group, this->badge_classes, this->sort_criteria);
 				break;
 			}
 		}

--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -53,7 +53,7 @@ extern EngList_SortTypeFunction * const _engine_sort_functions[][11];
 /* Functions in build_vehicle_gui.cpp */
 uint GetEngineListHeight(VehicleType type);
 void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selected, WidgetID button);
-void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar &sb, EngineID selected_id, bool show_count, GroupID selected_group, const GUIBadgeClasses &badge_classes);
+void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar &sb, EngineID selected_id, bool show_count, GroupID selected_group, const GUIBadgeClasses &badge_classes, uint8_t sort_criteria);
 void GUIEngineListAddChildren(GUIEngineList &dst, const GUIEngineList &src, EngineID parent = EngineID::Invalid(), uint8_t indent = 0);
 
 #endif /* ENGINE_GUI_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4231,6 +4231,19 @@ STR_PURCHASE_INFO_AIRCRAFT_RANGE                                :{BLACK}Range: {
 STR_PURCHASE_INFO_AIRCRAFT_TYPE                                 :{BLACK}Aircraft type: {GOLD}{STRING}
 STR_PURCHASE_INFO_RAILTYPES                                     :{BLACK}Rail types: {GOLD}{RAW_STRING}
 
+# Vehicle sort details
+STR_PURCHASE_SORT_DETAILS_COST                                  :{CURRENCY_LONG}
+STR_PURCHASE_SORT_DETAILS_SPEED                                 :{VELOCITY}
+STR_PURCHASE_SORT_DETAILS_POWER                                 :{POWER}
+STR_PURCHASE_SORT_DETAILS_MAX_TE                                :{FORCE}
+STR_PURCHASE_SORT_DETAILS_INTRO_DATE                            :{NUM}
+STR_PURCHASE_SORT_DETAILS_RUNNINGCOST_YEAR                      :{CURRENCY_LONG}/year
+STR_PURCHASE_SORT_DETAILS_RUNNINGCOST_PERIOD                    :{CURRENCY_LONG}/period
+STR_PURCHASE_SORT_DETAILS_RELIABILITY                           :{COMMA}%
+STR_PURCHASE_SORT_DETAILS_POWER_VS_RUNNING_COST                 :{DECIMAL}
+STR_PURCHASE_SORT_DETAILS_AIRCRAFT_RANGE                        :{COMMA} tiles
+STR_PURCHASE_SORT_DETAILS_CAPACITY                              :{COMMA}
+
 ###length 3
 STR_CARGO_TYPE_FILTER_ALL                                       :All cargo types
 STR_CARGO_TYPE_FILTER_FREIGHT                                   :Freight


### PR DESCRIPTION
When creating vehicles and sorting the list, additional vehicle details are shown for the field being sorted by. For example, when sorting by running cost, the running cost of every vehicle is shown in the vehicle list at the top-level.

## Motivation / Problem

The problem this solves is that often when you are creating a new vehicle and sort by some criteria, you then have to click every item in the list to see how good/bad that item is with regard to what you're sorting by. Suppose you're creating a new truck, and you want to find a reliable one, so you sort by Maximum Reliability. In today's UI you have to click on each truck one at a time to find which one is 'good enough'.

My proposal fixes this problem by showing at the list-level the value that is being sorted by (whenever applicable). That way you can immediately see the drop-off in values so you can get to the item that suits your needs.

I think most users would benefit from this, especially in games with many NewGRFs that add many vehicle types.

## Description

The Build Vehicle GUI now checks if something is being sorted, and if so, gets additional details for that field, and adds them to the list.

Here's what it looks like when creating a tram and sorting by 'Maximum speed' (note that the speed of every vehicle, if applicable, is shown):

<img width="401" height="558" alt="image" src="https://github.com/user-attachments/assets/e9ebde8e-e162-4393-a373-20e6c2cd5380" />
Related discussion on TT Forums: https://www.tt-forums.net/viewtopic.php?t=92651

## What's been tested:

I've tested every scenario I can think of so far, including:

1. All vehicle categories: truck, rail, tram, water, air
1. Lots of NewGRFs that add many various vehicle types
1. Vehicle types that lack certain information (such as aircraft with no max range, or vehicles with no capacities)
1. Articulated vehicles that have multiple different capacities
1. Trains vs. wagons
1. Left-to-right languages (e.g. English) and right-to-left (RTL) languages (e.g. Hebrew)
1. Overflowing text (ensure ellipsis is shown in correct place)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
