### PR TITLE
Codefix 97f3e5b: Restore defensive programming for _tile_type_procs.

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -66,7 +66,7 @@ extern const TileTypeProcs
  * @ingroup TileCallbackGroup
  * @see TileType
  */
-const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::End)>, TileType> _tile_type_procs = {
+const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::MaxSize)>, TileType> _tile_type_procs = {
 	&_tile_type_clear_procs, // Callback functions for TileType::Clear tiles
 	&_tile_type_rail_procs, // Callback functions for TileType::Railway tiles
 	&_tile_type_road_procs, // Callback functions for TileType::Road tiles
@@ -78,6 +78,12 @@ const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(Ti
 	&_tile_type_industry_procs, // Callback functions for TileType::Industry tiles
 	&_tile_type_tunnelbridge_procs, // Callback functions for TileType::TunnelBridge tiles
 	&_tile_type_object_procs, // Callback functions for TileType::Object tiles
+	/* Explicitly initialize invalid elements to make sure that they are nullptr. */
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
+	nullptr,
 };
 
 /** landscape slope => sprite */

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -169,7 +169,7 @@ struct TileTypeProcs {
 	CheckBuildAboveProc *check_build_above_proc;
 };
 
-extern const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::End)>, TileType> _tile_type_procs;
+extern const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::MaxSize)>, TileType> _tile_type_procs;
 
 TrackStatus GetTileTrackStatus(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side = INVALID_DIAGDIR);
 VehicleEnterTileStates VehicleEnterTile(Vehicle *v, TileIndex tile, int x, int y);

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -96,7 +96,7 @@ inline uint TilePixelHeightOutsideMap(int x, int y)
 [[debug_inline]] inline static TileType GetTileType(Tile tile)
 {
 	assert(tile < Map::Size());
-	return TileType(GB(tile.type(), 4, 4));
+	return TileType(GB(tile.type(), 4, TILE_TYPE_BITS));
 }
 
 /**
@@ -135,7 +135,7 @@ inline void SetTileType(Tile tile, TileType type)
 	 * edges of the map. If _settings_game.construction.freeform_edges is true,
 	 * the upper edges of the map are also VOID tiles. */
 	assert(IsInnerTile(tile) == (type != TileType::Void));
-	SB(tile.type(), 4, 4, to_underlying(type));
+	SB(tile.type(), 4, TILE_TYPE_BITS, to_underlying(type));
 }
 
 /**

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -36,6 +36,7 @@ static constexpr uint MAX_SNOWLINE_HEIGHT = (MAX_TILE_HEIGHT - 2); ///< Maximum 
 static constexpr uint DEF_SNOW_COVERAGE = 40;                      ///< Default snow coverage.
 static constexpr uint DEF_DESERT_COVERAGE = 50;                    ///< Default desert coverage.
 
+static constexpr size_t TILE_TYPE_BITS = 4; ///< How many bits in map array are dedicated for type of each tile.
 
 /**
  * The different types of tiles.
@@ -57,7 +58,10 @@ enum class TileType : uint8_t {
 	TunnelBridge, ///< Tunnel entry/exit and bridge heads.
 	Object, ///< Contains objects such as transmitters and owned land.
 	End, ///< End marker.
+	MaxSize = 1U << TILE_TYPE_BITS, ///< The maximum possible number of tile types to be stored in map.
 };
+
+static_assert(TileType::End <= TileType::MaxSize);
 
 /**
  * Additional infos of a tile on a tropic game.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
After 97f3e5b 5 entries in _tile_type_procs are uninitialized so on acces anything could happen.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Define constants for number of bits dedicated for storing tile type, use them when possible and explicitly define nullptrs for undefined tile types. 

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Couldn't figure out if
> Otherwise, if the element is not a reference, the element is copy-initialized from an empty initializer list.

means that implicitly defined pointers are nullptr or undefined, so defined them explicitly. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
