### PR TITLE
Fix #15166: Foundations missing when adjacent to NewGRF objects without foundation

### DIFF
--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -449,7 +449,7 @@ static void DrawTile_Object(TileInfo *ti)
 	/* Fall back for when the object doesn't exist anymore. */
 	if (!spec->IsEnabled()) type = OBJECT_TRANSMITTER;
 
-	if (!spec->flags.Test(ObjectFlag::HasNoFoundation)) DrawFoundation(ti, GetFoundation_Object(ti->tile, ti->tileh));
+	DrawFoundation(ti, GetFoundation_Object(ti->tile, ti->tileh));
 
 	if (type < NEW_OBJECT_OFFSET) {
 		const DrawTileSprites *dts = nullptr;
@@ -502,7 +502,8 @@ static int GetSlopePixelZ_Object(TileIndex tile, uint x, uint y, bool)
 
 static Foundation GetFoundation_Object(TileIndex tile, Slope tileh)
 {
-	return IsObjectType(tile, OBJECT_OWNED_LAND) ? FOUNDATION_NONE : FlatteningFoundation(tileh);
+	const ObjectSpec *spec = ObjectSpec::Get(GetObjectType(tile));
+	return spec->IsEnabled() && spec->flags.Test(ObjectFlag::HasNoFoundation) ? FOUNDATION_NONE : FlatteningFoundation(tileh);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Fixes #15166.


## Description

When introducing NewGRF objects the fact whether an object should be drawn with foundation was completely handled in the drawing routine. However, neighbouring tiles need to know whether the object is on a foundation, because it needs to draw their northern foundation when their northern neighbour is not on a foundation.

Solution is simple: move the logic whether a tile has a foundation or not into `GetFoundation_Object`, which is already used for drawing the tile. This means drawing the object and the neighbours have the same information about the existence of foundations around.


## Limitations

Obvious limitation is that there (likely) is some NewGRF that depends on this bug existing.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
