### PR TITLE
Change: Removing river tiles reduce local authority rating

### DIFF
--- a/src/town_type.h
+++ b/src/town_type.h
@@ -77,6 +77,9 @@ static constexpr int RATING_BRIBE_UP_STEP = 200;
 static constexpr int RATING_BRIBE_MAXIMUM = 800;
 static constexpr int RATING_BRIBE_DOWN_TO = -50; // XXX SHOULD BE SOMETHING LOWER?
 
+static constexpr int RATING_WATER_RIVER_DOWN_STEP = -200; ///< removing a river tile
+static constexpr int RATING_WATER_MINIMUM = RATING_MINIMUM; ///< minimum rating after removing water features near town
+
 /** Town Layouts. It needs to be 8bits, because we save and load it as such */
 enum TownLayout : uint8_t {
 	TL_BEGIN = 0,

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -40,6 +40,7 @@
 #include "water_cmd.h"
 #include "landscape_cmd.h"
 #include "pathfinder/water_regions.h"
+#include "town_type.h"
 
 #include "table/strings.h"
 
@@ -597,6 +598,15 @@ static CommandCost ClearTile_Water(TileIndex tile, DoCommandFlags flags)
 					Company::Get(owner)->infrastructure.water--;
 					DirtyCompanyInfrastructureWindows(owner);
 				}
+
+				/* Handle local authority impact */
+				if (IsRiver(tile)) {
+					if (Company::IsValidID(_current_company)) {
+						Town *town = ClosestTownFromTile(tile, _settings_game.economy.dist_local_authority);
+						if (town != nullptr) ChangeTownRating(town, RATING_WATER_RIVER_DOWN_STEP, RATING_WATER_MINIMUM, flags);
+					}
+				}
+
 				DoClearSquare(tile);
 				MarkCanalsAndRiversAroundDirty(tile);
 				ClearNeighbourNonFloodingStates(tile);


### PR DESCRIPTION
## Motivation / Problem

Local authorities don't like you removing trees, but for some reason tolerate wholesale demolition of rivers.

Rivers are a nice landscape features which are currently easy to clobber by demolition with no repercussion. Therefore, thinking about soft incentives to leave them alone.

## Description

Add a fairly harsh local authority impact for demolishing a river tile near a town. -200 selected, cf. removing a church at -230.

## Limitations

Doesn't fully protect rivers, you can still demolish them once the local authority rating reaches the minimum. I considered treating rivers like town-owned roads (they're kinda like town-owned waterways), where removal was prevented at a minimum rating, but that seemed a bit heavy handed.

Might annoy some players who like demolishing rivers, but there are already map generation options for fewer or no rivers for players who don't like them as obstacles.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
