### PR TITLE
Fix: Station view window fold/unfold not refreshing scrollbar

### DIFF
--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -1949,6 +1949,7 @@ struct StationViewWindow : public Window {
 			}
 		}
 		this->SetWidgetDirty(WID_SV_WAITING);
+		this->SetWidgetDirty(WID_SV_SCROLLBAR);
 	}
 
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override


### PR DESCRIPTION
## Motivation / Problem

Folding/unfolding items in the station view window cargo panel changes the length of the panel contents but does not trigger redrawing of the associated scrollbar. So the visual state of the scrollbar does not immediately reflect the actual scrollbar state.

## Description

Fox the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
