### PR TITLE
Fix #15137: Roads built on steep slopes at the minimum snow level height have inconsistent snowiness

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2006,8 +2006,8 @@ static void TileLoop_Road(TileIndex tile)
 {
 	switch (_settings_game.game_creation.landscape) {
 		case LandscapeType::Arctic: {
-			/* Roads on flat foundations use the snow level of the height they are elevated to. All others use the snow level of their minimum height. */
-			int tile_z = (std::get<Slope>(GetFoundationSlope(tile)) == SLOPE_FLAT) ? GetTileMaxZ(tile) : GetTileZ(tile);
+			/* Roads on flat or elevated foundations use the snow level of the height they are elevated to. All others use the snow level of their minimum height. */
+			int tile_z = (std::get<Slope>(GetFoundationSlope(tile)) == SLOPE_FLAT || std::get<Slope>(GetFoundationSlope(tile)) & SLOPE_ELEVATED) ? GetTileMaxZ(tile) : GetTileZ(tile);
 			if (IsOnSnowOrDesert(tile) != (tile_z > GetSnowLine())) {
 				ToggleSnowOrDesert(tile);
 				MarkTileDirtyByTile(tile);


### PR DESCRIPTION
## Motivation / Problem

#15137

## Description

Maximum z-height is now used to check snowiness on tiles with elevated foundations, instead of minimum z-height.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/9a6017e1-7902-4745-82b5-a07e944ed224" />

## Limitations
N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
