### PR TITLE
Add [NewGRF]: Nearby tile and improved cargo history variables for towns

### DIFF
--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -422,7 +422,7 @@ TileIndex GetNearbyTile(uint8_t parameter, TileIndex tile, bool signed_offsets, 
 }
 
 /**
- * Common part of station var 0x67, house var 0x62, indtile var 0x60, industry var 0x62.
+ * Common part of station var 0x67, house var 0x62, indtile var 0x60, industry var 0x62, town var 0x60.
  *
  * @param tile the tile of interest.
  * @param grf_version8 True, if we are dealing with a new NewGRF which uses GRF version >= 8.


### PR DESCRIPTION
## Motivation / Problem

Town-level NewGRF variables are currently somewhat limited. As two examples:
* A NewGRF author might want to change the appearance of buildings in an entire town based on whether it is near water, in the desert, at high elevation, etc.
* A NewGRF author might want to query production of non-standard cargos (ie. not passengers or mail) which the town produces due to a houses NewGRF.

See also: https://github.com/OpenTTD/OpenTTD/discussions/12281

## Description

Expose these as `varact2` variables taking a parameter:
* `0x60`: Land info for nearby tiles, taking a -8..7 offset in x and y as a parameter. Behaves exactly like house `0x62`, but relative to the centre of the town.
* `0x61`: Production of a cargo this month, taking a cargo translation table entry as a parameter. Behaves exactly like industry `0x6C`, but for the town.
* `0x62`: Same, but cargo transported this month.
* `0x63`: Same, but cargo production last month.
* `0x64`: Same, but cargo transported last month.

## Limitations

Doesn't expose cargo produced this and last month, but I couldn't work out how to do that, plus I think @PeterN was looking at changing the town cargo accepted history code for better graphing.

There is sensitivity about duplicating town control functions between game scripts, but I think there are good NewGRF use cases for these variables.

I don't fully know what I'm doing.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
