### PR TITLE
Feature: Placing random houses from collections

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2858,6 +2858,14 @@ STR_PICKER_PREVIEW_SHRINK_TOOLTIP                               :Reduce the heig
 STR_PICKER_PREVIEW_EXPAND                                       :+
 STR_PICKER_PREVIEW_EXPAND_TOOLTIP                               :Increase the height of preview images. Ctrl+Click to increase to maximum
 
+STR_PICKER_RANDOM                                               :Random
+STR_PICKER_STATION_RANDOM_TOOLTIP                               :Place random stations from the selected collection
+STR_PICKER_WAYPOINT_RANDOM_TOOLTIP                              :Place random waypoints from the selected collection
+STR_PICKER_ROADSTOP_BUS_RANDOM_TOOLTIP                          :Place random bus stations from the selected collection
+STR_PICKER_ROADSTOP_TRUCK_RANDOM_TOOLTIP                        :Place random lorry stations from the selected collection
+STR_PICKER_OBJECT_RANDOM_TOOLTIP                                :Place random 1x1 objects from the selected collection
+STR_PICKER_HOUSE_RANDOM_TOOLTIP                                 :Place random 1x1 houses from the selected collection
+
 STR_PICKER_DEFAULT_COLLECTION                                   :Default collection
 STR_PICKER_SELECT_COLLECTION_TOOLTIP                            :Select a collection
 STR_PICKER_COLLECTION_ADD                                       :Add

--- a/src/misc/endian_buffer.hpp
+++ b/src/misc/endian_buffer.hpp
@@ -48,6 +48,21 @@ public:
 		return *this;
 	}
 
+	/**
+	 * EndianBufferReader overload for vectors.
+	 * @param vector The vector to serialize.
+	 * @return The buffer.
+	 */
+	template <typename Tvalues>
+	EndianBufferWriter &operator <<(const std::vector<Tvalues> &vector)
+	{
+		*this << static_cast<uint32_t>(vector.size());
+		for (const auto &value : vector) {
+			*this << value;
+		}
+		return *this;
+	}
+
 	EndianBufferWriter &operator <<(const std::monostate &)
 	{
 		return *this;
@@ -171,6 +186,26 @@ public:
 		return *this;
 	}
 
+	/**
+	 * EndianBufferReader overload for vectors.
+	 * @param vector The vector to deserialize.
+	 * @return The buffer.
+	 */
+	template <typename Tvalues>
+	EndianBufferReader &operator >>(std::vector<Tvalues> &vector)
+	{
+		uint32_t size;
+		Tvalues value;
+		vector = std::vector<Tvalues>{};
+		*this >> size;
+		for (uint32_t i = 0; i != size; i++) {
+			if (this->read_pos >= this->buffer.size()) break;
+			*this >> value;
+			vector.push_back(std::move(value));
+		}
+		return *this;
+	}
+
 	EndianBufferReader &operator >>(const std::monostate &)
 	{
 		return *this;
@@ -245,7 +280,10 @@ private:
 		static_assert(!std::is_const_v<T>, "Can't read into const variables");
 		static_assert(sizeof(T) <= 8, "Value can't be larger than 8 bytes");
 
-		if (read_pos + sizeof(T) > this->buffer.size()) return {};
+		if (read_pos + sizeof(T) > this->buffer.size()) {
+			this->read_pos += sizeof(T);
+			return {};
+		}
 
 		T value = static_cast<T>(this->buffer[this->read_pos++]);
 		if constexpr (sizeof(T) > 1) {

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -50,6 +50,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_OBJECT_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_OBJECT_TYPE_TOOLTIP; }
+	StringID GetRandomTooltip() const override { return STR_PICKER_OBJECT_RANDOM_TOOLTIP; }
 	StringID GetCollectionTooltip() const override { return STR_PICKER_OBJECT_COLLECTION_TOOLTIP; }
 
 	bool IsActive() const override

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -107,6 +107,8 @@ public:
 		}
 	}
 
+	void SetSelectedCollection([[maybe_unused]] const std::set<PickerItem> items) const override { return; }
+
 	void FillUsedItems(std::set<PickerItem> &items) override
 	{
 		for (const Object *o : Object::Iterate()) {

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -259,8 +259,11 @@ void PickerWindow::ConstructWindow()
 		this->callbacks.FillUsedItems(this->callbacks.used);
 
 		SetWidgetDisabledState(WID_PW_MODE_ALL, !this->callbacks.HasClassChoice());
+		this->random_hidden = !this->callbacks.IsCollectionRandomisationSupported() || !HasBit(this->callbacks.mode, PFM_SAVED);
+		this->GetWidget<NWidgetStacked>(WID_PW_TYPE_RAND_SEL)->SetDisplayedPlane(this->random_hidden ? SZSP_HORIZONTAL : 0);
 
 		this->GetWidget<NWidgetCore>(WID_PW_TYPE_ITEM)->SetToolTip(this->callbacks.GetTypeTooltip());
+		this->GetWidget<NWidgetCore>(WID_PW_TYPE_RANDOM)->SetToolTip(this->callbacks.GetRandomTooltip());
 
 		auto *matrix = this->GetWidget<NWidgetMatrix>(WID_PW_TYPE_MATRIX);
 		matrix->SetScrollbar(this->GetScrollbar(WID_PW_TYPE_SCROLL));
@@ -302,6 +305,8 @@ void PickerWindow::OnInit()
 
 	this->widget_lookup.clear();
 	this->nested_root->FillWidgetLookup(this->widget_lookup);
+
+	this->SetDisabledRandomItemButton();
 }
 
 void PickerWindow::Close(int data)
@@ -367,6 +372,23 @@ DropDownList PickerWindow::BuildCollectionDropDownList()
 		i++;
 	}
 	return list;
+}
+
+void PickerWindow::SetDisabledRandomItemButton()
+{
+	bool hidden = !this->callbacks.IsCollectionRandomisationSupported() || !HasBit(this->callbacks.mode, PFM_SAVED);
+
+	if (hidden != this->random_hidden && this->has_type_picker) {
+		this->GetWidget<NWidgetStacked>(WID_PW_TYPE_RAND_SEL)->SetDisplayedPlane(hidden ? SZSP_HORIZONTAL : 0);
+		this->random_hidden = hidden;
+		this->ReInit();
+	}
+	if (hidden) return;
+
+	if (this->GetWidget<NWidgetBase>(WID_PW_TYPE_RANDOM) == nullptr) return;
+
+	this->SetWidgetDisabledState(WID_PW_TYPE_RANDOM, this->callbacks.saved.contains(this->callbacks.sel_collection) ? !this->callbacks.IsCollectionValidForRandom(this->callbacks.saved.at(this->callbacks.sel_collection), this) : true);
+	if (this->IsWidgetDisabled(WID_PW_TYPE_RANDOM)) this->RaiseWidgetWhenLowered(WID_PW_TYPE_RANDOM);
 }
 
 void PickerWindow::DrawWidget(const Rect &r, WidgetID widget) const
@@ -450,6 +472,7 @@ void PickerWindow::DeletePickerCollectionCallback(Window *win, bool confirmed)
 		picker_window = w;
 		w->SetWidgetsDisabledState(true, WID_PW_COLEC_RENAME, WID_PW_COLEC_DELETE);
 		w->InvalidateData({PickerInvalidation::Collection, PickerInvalidation::Position});
+		w->SetDisabledRandomItemButton();
 	}
 }
 
@@ -480,6 +503,7 @@ void PickerWindow::OnClick(Point pt, WidgetID widget, int)
 				/* Enabling used or saved filters automatically enables all. */
 				SetBit(this->callbacks.mode, PFM_ALL);
 			}
+			this->SetDisabledRandomItemButton();
 			this->InvalidateData({PickerInvalidation::Class, PickerInvalidation::Type, PickerInvalidation::Position});
 			SndClickBeep();
 			break;
@@ -506,6 +530,7 @@ void PickerWindow::OnClick(Point pt, WidgetID widget, int)
 				if (this->callbacks.saved.find(this->callbacks.sel_collection) == this->callbacks.saved.end()) {
 					this->callbacks.saved[""].emplace(item);
 					this->InvalidateData({PickerInvalidation::Collection, PickerInvalidation::Class});
+					this->SetDisabledRandomItemButton();
 					this->SetDirty();
 					break;
 				}
@@ -517,6 +542,7 @@ void PickerWindow::OnClick(Point pt, WidgetID widget, int)
 					this->callbacks.saved.at(this->callbacks.sel_collection).erase(it);
 				}
 				this->InvalidateData({PickerInvalidation::Type, PickerInvalidation::Class});
+				this->SetDisabledRandomItemButton();
 				break;
 			}
 
@@ -524,9 +550,17 @@ void PickerWindow::OnClick(Point pt, WidgetID widget, int)
 				this->callbacks.SetSelectedClass(item.class_index);
 				this->callbacks.SetSelectedType(item.index);
 				this->InvalidateData(PickerInvalidation::Position);
+				this->RaiseWidgetWhenLowered(WID_PW_TYPE_RANDOM);
 			}
 			SndClickBeep();
 			CloseWindowById(WC_SELECT_STATION, 0);
+			break;
+		}
+
+		case WID_PW_TYPE_RANDOM: {
+			this->ToggleWidgetLoweredState(widget);
+			SndClickBeep();
+			this->ReInit();
 			break;
 		}
 
@@ -606,6 +640,7 @@ void PickerWindow::OnQueryTextFinished(std::optional<std::string> str)
 		this->InvalidateData({PickerInvalidation::Type, PickerInvalidation::Class});
 	}
 	this->InvalidateData({PickerInvalidation::Collection, PickerInvalidation::Position});
+	this->SetDisabledRandomItemButton();
 }
 
 void PickerWindow::OnDropdownSelect(WidgetID widget, int index, int click_result)
@@ -617,6 +652,7 @@ void PickerWindow::OnDropdownSelect(WidgetID widget, int index, int click_result
 				this->callbacks.sel_collection = *it;
 				if (this->IsWidgetLowered(WID_PW_MODE_SAVED)) this->InvalidateData({PickerInvalidation::Class, PickerInvalidation::Type, PickerInvalidation::Validate});
 				this->InvalidateData(PickerInvalidation::Position);
+				this->SetDisabledRandomItemButton();
 			}
 			SetWidgetsDisabledState(this->callbacks.sel_collection == "" ? true : false, WID_PW_COLEC_RENAME, WID_PW_COLEC_DELETE);
 
@@ -997,6 +1033,9 @@ std::unique_ptr<NWidgetBase> MakePickerTypeWidgets()
 						EndContainer(),
 					EndContainer(),
 					NWidget(NWID_VSCROLLBAR, COLOUR_DARK_GREEN, WID_PW_TYPE_SCROLL),
+				EndContainer(),
+				NWidget(NWID_SELECTION, INVALID_COLOUR, WID_PW_TYPE_RAND_SEL),
+					NWidget(WWT_TEXTBTN, COLOUR_DARK_GREEN, WID_PW_TYPE_RANDOM), SetResize(1, 0), SetStringTip(STR_PICKER_RANDOM),
 				EndContainer(),
 				NWidget(NWID_HORIZONTAL),
 					NWidget(WWT_PANEL, COLOUR_DARK_GREEN),

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -155,6 +155,23 @@ public:
 	 * @return StringID without parameters.
 	 */
 	virtual StringID GetCollectionTooltip() const = 0;
+	/**
+	 * Get the tooltip for the random item button.
+	 * @return StringID without parameters.
+	 */
+	virtual StringID GetRandomTooltip() const = 0;
+	/**
+	 * Is collection randomisation supported at all for this picker type?
+	 * @return \c true If we support randomization for the picker type.
+	 */
+	virtual bool IsCollectionRandomisationSupported() const { return false; }
+	/**
+	 * Does the collection consist of only 1x1 tiles?
+	 * @param items The collection to test.
+	 * @param w The picker window in question.
+	 * @return \c true If we can randomize the collection.
+	 */
+	virtual bool IsCollectionValidForRandom([[maybe_unused]] const std::set<PickerItem> &items, [[maybe_unused]] Window *w) { return false; }
 
 	/**
 	 * Fill a set with all items that are used by the current player.
@@ -211,6 +228,8 @@ public:
 
 	std::set<PickerItem> used; ///< Set of items used in the current game by the current company.
 	std::map<std::string, std::set<PickerItem>> saved; ///< Set of saved collections of items.
+
+	static const int MAX_RANDOM_ITEMS = 2048; ///< Maximum number of items in a randomizable collection to make sure we don't exceed packet size.
 };
 
 /** Helper for PickerCallbacks when the class system is based on NewGRFClass. */
@@ -307,6 +326,7 @@ public:
 	bool has_class_picker = false; ///< Set if this window has a class picker 'component'.
 	bool has_type_picker = false; ///< Set if this window has a type picker 'component'.
 	bool has_collection_picker = false; ///< Set if this window has a collection picker 'component'.
+	bool random_hidden = true; ///< Should we be hiding the randomization button?
 	int preview_height = 0; ///< Height of preview images.
 	std::set<std::string> inactive; ///< Set of collections with inactive items.
 
@@ -316,6 +336,7 @@ public:
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, const Dimension &padding, Dimension &fill, Dimension &resize) override;
 	std::string GetWidgetString(WidgetID widget, StringID stringid) const override;
 	DropDownList BuildCollectionDropDownList();
+	void SetDisabledRandomItemButton(); ///< Set if the 'random' button should be hidden, disabled, or toggleable.
 	void DrawWidget(const Rect &r, WidgetID widget) const override;
 	void OnDropdownSelect(WidgetID widget, int index, int click_result) override;
 	void OnResize() override;

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -161,6 +161,11 @@ public:
 	 */
 	virtual StringID GetRandomTooltip() const = 0;
 	/**
+	 * Set the selected collection.
+	 * @param items the collection to set for placement.
+	 */
+	virtual void SetSelectedCollection([[maybe_unused]] const std::set<PickerItem> items) const = 0;
+	/**
 	 * Is collection randomisation supported at all for this picker type?
 	 * @return \c true If we support randomization for the picker type.
 	 */
@@ -219,6 +224,7 @@ public:
 
 	const std::string ini_group; ///< Ini Group for saving favourites.
 	uint8_t mode = 0; ///< Bitmask of \c PickerFilterModes.
+	bool place_collection = false;       ///< Are we placing a collection?
 	bool rename_collection = false;      ///< Are we renaming a collection?
 	std::string sel_collection;          ///< Currently selected collection of saved items.
 	std::string edit_collection;         ///< Collection to rename or delete.

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1069,6 +1069,8 @@ public:
 		}
 	}
 
+	void SetSelectedCollection([[maybe_unused]] const std::set<PickerItem> items) const override { return; }
+
 	void FillUsedItems(std::set<PickerItem> &items) override
 	{
 		bool default_added = false;
@@ -1888,6 +1890,8 @@ public:
 	{
 		DrawWaypointSprite(x, y, this->GetClassIndex(cls_id), id, _cur_railtype);
 	}
+
+	void SetSelectedCollection([[maybe_unused]] const std::set<PickerItem> items) const override { return; }
 
 	void FillUsedItems(std::set<PickerItem> &items) override
 	{

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1012,6 +1012,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_STATION_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_STATION_TYPE_TOOLTIP; }
+	StringID GetRandomTooltip() const override { return STR_PICKER_STATION_RANDOM_TOOLTIP; }
 	StringID GetCollectionTooltip() const override { return STR_PICKER_STATION_COLLECTION_TOOLTIP; }
 
 	bool IsActive() const override
@@ -1832,6 +1833,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_WAYPOINT_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_WAYPOINT_TYPE_TOOLTIP; }
+	StringID GetRandomTooltip() const override { return STR_PICKER_WAYPOINT_RANDOM_TOOLTIP; }
 	StringID GetCollectionTooltip() const override { return STR_PICKER_WAYPOINT_COLLECTION_TOOLTIP; }
 
 	bool IsActive() const override

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1322,6 +1322,8 @@ public:
 		}
 	}
 
+	void SetSelectedCollection([[maybe_unused]] const std::set<PickerItem> items) const override { return; }
+
 	void FillUsedItems(std::set<PickerItem> &items) override
 	{
 		for (const Station *st : Station::Iterate()) {
@@ -1747,6 +1749,8 @@ public:
 			DrawRoadStopTile(x, y, _cur_roadtype, spec, StationType::RoadWaypoint, RSV_DRIVE_THROUGH_X);
 		}
 	}
+
+	void SetSelectedCollection([[maybe_unused]] const std::set<PickerItem> items) const override { return; }
 
 	void FillUsedItems(std::set<PickerItem> &items) override
 	{

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1249,6 +1249,7 @@ public:
 
 	StringID GetClassTooltip() const override;
 	StringID GetTypeTooltip() const override;
+	StringID GetRandomTooltip() const override;
 	StringID GetCollectionTooltip() const override;
 
 	bool IsActive() const override
@@ -1340,10 +1341,12 @@ public:
 
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Bus>::GetClassTooltip() const { return STR_PICKER_ROADSTOP_BUS_CLASS_TOOLTIP; }
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Bus>::GetTypeTooltip() const { return STR_PICKER_ROADSTOP_BUS_TYPE_TOOLTIP; }
+template <> StringID RoadStopPickerCallbacks<RoadStopType::Bus>::GetRandomTooltip() const { return STR_PICKER_ROADSTOP_BUS_RANDOM_TOOLTIP; }
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Bus>::GetCollectionTooltip() const { return STR_PICKER_ROADSTOP_BUS_COLLECTION_TOOLTIP; }
 
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Truck>::GetClassTooltip() const { return STR_PICKER_ROADSTOP_TRUCK_CLASS_TOOLTIP; }
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Truck>::GetTypeTooltip() const { return STR_PICKER_ROADSTOP_TRUCK_TYPE_TOOLTIP; }
+template <> StringID RoadStopPickerCallbacks<RoadStopType::Truck>::GetRandomTooltip() const { return STR_PICKER_ROADSTOP_TRUCK_RANDOM_TOOLTIP; }
 template <> StringID RoadStopPickerCallbacks<RoadStopType::Truck>::GetCollectionTooltip() const { return STR_PICKER_ROADSTOP_TRUCK_COLLECTION_TOOLTIP; }
 
 static RoadStopPickerCallbacks<RoadStopType::Bus> _bus_callback_instance("fav_passenger_roadstops");
@@ -1684,6 +1687,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_WAYPOINT_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_WAYPOINT_TYPE_TOOLTIP; }
+	StringID GetRandomTooltip() const override { return STR_PICKER_WAYPOINT_RANDOM_TOOLTIP; }
 	StringID GetCollectionTooltip() const override { return STR_PICKER_WAYPOINT_COLLECTION_TOOLTIP; }
 
 	bool IsActive() const override

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3015,13 +3015,13 @@ CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, b
  * @param flags Type of operation.
  * @param tile End tile of area dragging.
  * @param start_tile Start tile of area dragging.
- * @param house The HouseID of the house spec.
+ * @param houses Vector of the HouseIDs of the house specs.
  * @param is_protected Whether the house is protected from the town upgrading it.
  * @param replace Whether we can replace existing houses.
  * @param diagonal Whether to use the Diagonal or Orthogonal tile iterator.
  * @return Empty cost or an error.
  */
-CommandCost CmdPlaceHouseArea(DoCommandFlags flags, TileIndex tile, TileIndex start_tile, HouseID house, bool is_protected, bool replace, bool diagonal)
+CommandCost CmdPlaceHouseArea(DoCommandFlags flags, TileIndex tile, TileIndex start_tile, std::vector<HouseID> houses, bool is_protected, bool replace, bool diagonal)
 {
 	if (start_tile >= Map::Size()) return CMD_ERROR;
 
@@ -3029,12 +3029,15 @@ CommandCost CmdPlaceHouseArea(DoCommandFlags flags, TileIndex tile, TileIndex st
 
 	if (Town::GetNumItems() == 0) return CommandCost(STR_ERROR_MUST_FOUND_TOWN_FIRST);
 
-	if (static_cast<size_t>(house) >= HouseSpec::Specs().size()) return CMD_ERROR;
-	const HouseSpec *hs = HouseSpec::Get(house);
-	if (!hs->enabled) return CMD_ERROR;
+	if (std::any_of(houses.begin(), houses.end(), [](HouseID house) { return static_cast<size_t>(house) >= HouseSpec::Specs().size(); })) return CMD_ERROR;
 
-	/* Only allow placing an area of 1x1 houses. */
-	if (!hs->building_flags.Test(BuildingFlag::Size1x1)) return CMD_ERROR;
+	for (const HouseID &house : houses) {
+		const HouseSpec *hs = HouseSpec::Get(house);
+		if (!hs->enabled) return CMD_ERROR;
+
+		/* Only allow placing an area of 1x1 houses. */
+		if (!hs->building_flags.Test(BuildingFlag::Size1x1)) return CMD_ERROR;
+	}
 
 	/* Use the built object limit to rate limit house placement. */
 	const Company *c = Company::GetIfValid(_current_company);
@@ -3043,9 +3046,15 @@ CommandCost CmdPlaceHouseArea(DoCommandFlags flags, TileIndex tile, TileIndex st
 	CommandCost last_error = CMD_ERROR;
 	bool had_success = false;
 
+	SavedRandomSeeds saved_seeds;
+	SaveRandomSeeds(&saved_seeds);
+
+	if (!flags.Test(DoCommandFlag::Execute)) RestoreRandomSeeds(saved_seeds);
+
 	std::unique_ptr<TileIterator> iter = TileIterator::Create(tile, start_tile, diagonal);
 	for (; *iter != INVALID_TILE; ++(*iter)) {
 		TileIndex t = *iter;
+		const HouseID house = houses.at(RandomRange(static_cast<uint32_t>(houses.size())));
 		CommandCost ret = Command<Commands::PlaceHouse>::Do(DoCommandFlags{flags}.Reset(DoCommandFlag::Execute), t, house, is_protected, replace);
 
 		/* If we've reached the limit, stop building (or testing). */

--- a/src/town_cmd.h
+++ b/src/town_cmd.h
@@ -11,6 +11,7 @@
 #define TOWN_CMD_H
 
 #include "command_type.h"
+#include "command_func.h"
 #include "company_type.h"
 #include "town.h"
 #include "town_type.h"
@@ -28,7 +29,7 @@ CommandCost CmdTownSetText(DoCommandFlags flags, TownID town_id, const EncodedSt
 CommandCost CmdExpandTown(DoCommandFlags flags, TownID town_id, uint32_t grow_amount, TownExpandModes modes);
 CommandCost CmdDeleteTown(DoCommandFlags flags, TownID town_id);
 CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, bool house_protected, bool replace);
-CommandCost CmdPlaceHouseArea(DoCommandFlags flags, TileIndex tile, TileIndex start_tile, HouseID house, bool is_protected, bool replace, bool diagonal);
+CommandCost CmdPlaceHouseArea(DoCommandFlags flags, TileIndex tile, TileIndex start_tile, std::vector<HouseID> houses, bool is_protected, bool replace, bool diagonal);
 
 DEF_CMD_TRAIT(Commands::FoundTown, CmdFoundTown, CommandFlags({CommandFlag::Deity, CommandFlag::NoTest}), CommandType::LandscapeConstruction) // founding random town can fail only in exec run
 DEF_CMD_TRAIT(Commands::RenameTown, CmdRenameTown, CommandFlags({CommandFlag::Deity, CommandFlag::Server}), CommandType::OtherManagement)

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1834,7 +1834,7 @@ struct BuildHouseWindow : public PickerWindow {
 	{
 		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
 
-		if (spec->building_flags.Test(BuildingFlag::Size1x1)) {
+		if (spec->building_flags.Test(BuildingFlag::Size1x1) || this->callbacks.place_collection) {
 			VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_PLACE_HOUSE);
 		} else {
 			Command<Commands::PlaceHouse>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER, tile, spec->Index(), BuildHouseWindow::house_protected, BuildHouseWindow::replace);
@@ -1852,9 +1852,18 @@ struct BuildHouseWindow : public PickerWindow {
 
 		assert(select_proc == DDSP_PLACE_HOUSE);
 
-		const HouseSpec *spec = HouseSpec::Get(HousePickerCallbacks::sel_type);
+		std::vector<HouseID> house_ids;
+		if (this->callbacks.place_collection) {
+			house_ids.reserve(HousePickerCallbacks::sel_collection.size());
+			for (const int &type : HousePickerCallbacks::sel_collection) {
+				house_ids.emplace_back(HouseSpec::Get(type)->Index());
+			}
+		} else {
+			house_ids.reserve(1);
+			house_ids.emplace_back(HouseSpec::Get(HousePickerCallbacks::sel_type)->Index());
+		}
 		Command<Commands::PlaceHouseArea>::Post(STR_ERROR_CAN_T_BUILD_HOUSE, CcPlaySound_CONSTRUCTION_OTHER,
-			end_tile, start_tile, spec->Index(), BuildHouseWindow::house_protected, BuildHouseWindow::replace, _ctrl_pressed);
+			end_tile, start_tile, house_ids, BuildHouseWindow::house_protected, BuildHouseWindow::replace, _ctrl_pressed);
 	}
 
 	const IntervalTimer<TimerWindow> view_refresh_interval = {std::chrono::milliseconds(2500), [this](auto) {

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1492,6 +1492,7 @@ public:
 
 	StringID GetClassTooltip() const override { return STR_PICKER_HOUSE_CLASS_TOOLTIP; }
 	StringID GetTypeTooltip() const override { return STR_PICKER_HOUSE_TYPE_TOOLTIP; }
+	StringID GetRandomTooltip() const override { return STR_PICKER_HOUSE_RANDOM_TOOLTIP; }
 	StringID GetCollectionTooltip() const override { return STR_PICKER_HOUSE_COLLECTION_TOOLTIP; }
 	bool IsActive() const override { return true; }
 
@@ -1568,6 +1569,21 @@ public:
 	void DrawType(int x, int y, int, int id) const override
 	{
 		DrawHouseInGUI(x, y, id, HousePickerCallbacks::sel_view);
+	}
+
+	bool IsCollectionRandomisationSupported() const override { return true; }
+
+	bool IsCollectionValidForRandom(const std::set<PickerItem> &items, [[maybe_unused]] Window *w) override
+	{
+		if (items.size() >= MAX_RANDOM_ITEMS) return false;
+
+		for (const PickerItem &item : items) {
+			if (item.index == -1) continue;
+			const HouseSpec *hs = HouseSpec::Get(item.index);
+			if (hs == nullptr) continue;
+			if (!hs->building_flags.Test(BuildingFlag::Size1x1)) return false;
+		}
+		return true;
 	}
 
 	void FillUsedItems(std::set<PickerItem> &items) override

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1477,6 +1477,7 @@ public:
 	static inline int sel_class; ///< Currently selected 'class'.
 	static inline int sel_type; ///< Currently selected HouseID.
 	static inline int sel_view; ///< Currently selected 'view'. This is not controllable as its based on random data.
+	static inline std::vector<int> sel_collection; ///< Currently selected collection.
 
 	/* Houses do not have classes like NewGRFClass. We'll make up fake classes based on town zone
 	 * availability instead. */
@@ -1569,6 +1570,15 @@ public:
 	void DrawType(int x, int y, int, int id) const override
 	{
 		DrawHouseInGUI(x, y, id, HousePickerCallbacks::sel_view);
+	}
+
+	void SetSelectedCollection(std::set<PickerItem> items) const override
+	{
+		sel_collection.clear();
+		sel_collection.reserve(items.size());
+		for (const PickerItem &item : items) {
+			if (item.class_index != -1 && item.index != -1) sel_collection.emplace_back(item.index);
+		}
 	}
 
 	bool IsCollectionRandomisationSupported() const override { return true; }

--- a/src/widgets/picker_widget.h
+++ b/src/widgets/picker_widget.h
@@ -34,6 +34,8 @@ enum PickerClassWindowWidgets : WidgetID {
 	WID_PW_TYPE_MATRIX, ///< Matrix with items.
 	WID_PW_TYPE_ITEM, ///< A single item.
 	WID_PW_TYPE_SCROLL, ///< Scrollbar for the matrix.
+	WID_PW_TYPE_RAND_SEL, ///< Selector for random item button, which can be hidden.
+	WID_PW_TYPE_RANDOM, ///< Random item button.
 	WID_PW_TYPE_NAME, ///< Name of selected item.
 	WID_PW_TYPE_RESIZE, ///< Type resize handle.
 	WID_PW_CONFIGURE_BADGES, ///< Button to configure badges.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
When using the house placer, you usually want to be placing a variety of houses instead of just the same one over and over again. Currently this is very tedious, let's change that.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Adds a button to the type picker that is only visible if saved items are selected and the picker supports randomization. If the currently selected collection is valid for randomization, the feature can be used and a random house or area of houses can be placed.
[house_randomizer.webm](https://github.com/user-attachments/assets/31abd2ab-4e84-4fac-87ae-a4a1147e940e)
Also includes a new endian buffer overload for vectors from #15201

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

- Only 1x1 houses can be randomized, doing larger sizes would require a lot of math I don't feel cut out for.
- I have plans to add this to all the picker windows but those are for other PRs. This PR does add tooltips for each one however.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
