### PR TITLE
Add: [NewGRF] Nearby tile info for towns

### DIFF
--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -422,7 +422,7 @@ TileIndex GetNearbyTile(uint8_t parameter, TileIndex tile, bool signed_offsets, 
 }
 
 /**
- * Common part of station var 0x67, house var 0x62, indtile var 0x60, industry var 0x62.
+ * Common part of station var 0x67, house var 0x62, indtile var 0x60, industry var 0x62, town var 0x60.
  *
  * @param tile the tile of interest.
  * @param grf_version8 True, if we are dealing with a new NewGRF which uses GRF version >= 8.

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -24,6 +24,19 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 	return ClampTo<uint16_t>(std::invoke(proj, it->history[period]));
 }
 
+/**
+ * Get information about a nearby tile.
+ * @param parameter Pair of coordinates from callback.
+ * @param tile TileIndex from which the callback was initiated.
+ * @param grf_version8 True, if we are dealing with a new NewGRF which uses GRF version >= 8.
+ * @return a construction of bits obeying the newgrf format.
+ */
+static uint32_t GetNearbyTileInformation(uint8_t parameter, TileIndex tile, bool grf_version8)
+{
+	tile = GetNearbyTile(parameter, tile);
+	return GetNearbyTileInformation(tile, grf_version8);
+}
+
 /* virtual */ uint32_t TownScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const
 {
 	if (this->t == nullptr) {
@@ -40,6 +53,9 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 
 		/* Town index */
 		case 0x41: return this->t->index.base();
+
+		/* Land info for nearby tiles. */
+		case 0x60: return GetNearbyTileInformation(parameter, this->t->xy, this->ro.grffile->grf_version >= 8);
 
 		/* Get a variable from the persistent storage */
 		case 0x7C: {


### PR DESCRIPTION
## Motivation / Problem

Town-level NewGRF variables are currently somewhat limited:
 A NewGRF author might want to change the appearance of buildings in an entire town based on whether it is near water, in the desert, at high elevation, etc.

See also: https://github.com/OpenTTD/OpenTTD/discussions/12281

## Description

Expose this as a `varact2` variable taking a parameter:
* `0x60`: Land info for nearby tiles, taking a -8..7 offset in x and y as a parameter. Behaves exactly like house `0x62`, but relative to the centre of the town.

## Limitations

None(?)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
