### PR TITLE
Add: [NewGRF] Town production and transport by cargo ID

### DIFF
--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -11,6 +11,7 @@
 #include "debug.h"
 #include "town.h"
 #include "newgrf_town.h"
+#include "newgrf_cargo.h"
 #include "timer/timer_game_tick.h"
 
 #include "safeguards.h"
@@ -22,6 +23,26 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 	if (it == std::end(t->supplied)) return 0;
 
 	return ClampTo<uint16_t>(std::invoke(proj, it->history[period]));
+}
+
+/**
+ * Get cargo history for a town via cargo translation table.
+ * @param t Town to query.
+ * @param parameter Cargo ID from callback.
+ * @param grffile GRF file to use for cargo translation.
+ * @param period Period to query.
+ * @param proj Projection to apply on the history data.
+ * @return The cargo quantity for the given period and projection, or 0 if invalid.
+ */
+static uint32_t TownHistoryHelperCargoID(const Town *t, uint32_t parameter, const GRFFile *grffile, uint period, auto proj)
+{
+	CargoType cargo = GetCargoTranslation(parameter, grffile);
+	if (!IsValidCargoType(cargo)) return 0;
+
+	auto it = t->GetCargoSupplied(cargo);
+	if (it == std::end(t->supplied)) return 0;
+
+	return ClampTo<uint32_t>(std::invoke(proj, it->history[period]));
 }
 
 /* virtual */ uint32_t TownScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const
@@ -40,6 +61,12 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 
 		/* Town index */
 		case 0x41: return this->t->index.base();
+
+		/* Recent cargo production and transport, by cargo label */
+		case 0x61: return TownHistoryHelperCargoID(this->t, parameter, this->ro.grffile, THIS_MONTH, &Town::SuppliedHistory::production);
+		case 0x62: return TownHistoryHelperCargoID(this->t, parameter, this->ro.grffile, THIS_MONTH, &Town::SuppliedHistory::transported);
+		case 0x63: return TownHistoryHelperCargoID(this->t, parameter, this->ro.grffile, LAST_MONTH, &Town::SuppliedHistory::production);
+		case 0x64: return TownHistoryHelperCargoID(this->t, parameter, this->ro.grffile, LAST_MONTH, &Town::SuppliedHistory::transported);
 
 		/* Get a variable from the persistent storage */
 		case 0x7C: {

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -11,17 +11,66 @@
 #include "debug.h"
 #include "town.h"
 #include "newgrf_town.h"
+#include "newgrf_cargo.h"
 #include "timer/timer_game_tick.h"
 
 #include "safeguards.h"
 
 template <typename Tproj>
-static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, Tproj proj)
+/**
+ * Get cargo production/transport history for a town via cargo label.
+ * @param t Town to query.
+ * @param label Cargo label from callback.
+ * @param period Period to query.
+ * @param proj Projection to apply on the history data.
+ * @return The cargo quantity for the given period and projection, or 0 if invalid.
+ */
+static uint16_t TownProductionHistoryHelper(const Town *t, CargoLabel label, uint period, Tproj proj)
 {
 	auto it = t->GetCargoSupplied(GetCargoTypeByLabel(label));
 	if (it == std::end(t->supplied)) return 0;
 
 	return ClampTo<uint16_t>(std::invoke(proj, it->history[period]));
+}
+
+/**
+ * Get cargo production/transport history for a town via cargo translation table.
+ * @param t Town to query.
+ * @param parameter Cargo ID from callback.
+ * @param grffile GRF file to use for cargo translation.
+ * @param period Period to query.
+ * @param proj Projection to apply on the history data.
+ * @return The cargo quantity for the given period and projection, or 0 if invalid.
+ */
+static uint32_t TownProductionHistoryHelperCargoID(const Town *t, uint32_t parameter, const GRFFile *grffile, uint period, auto proj)
+{
+	CargoType cargo = GetCargoTranslation(parameter, grffile);
+	if (!IsValidCargoType(cargo)) return 0;
+
+	auto it = t->GetCargoSupplied(cargo);
+	if (it == std::end(t->supplied)) return 0;
+
+	return ClampTo<uint32_t>(std::invoke(proj, it->history[period]));
+}
+
+/**
+ * Get cargo acceptance history for a town via cargo translation table.
+ * @param t Town to query.
+ * @param parameter Cargo ID from callback.
+ * @param grffile GRF file to use for cargo translation.
+ * @param period Period to query.
+ * @param proj Projection to apply on the history data.
+ * @return The cargo quantity for the given period and projection, or 0 if invalid.
+ */
+static uint32_t TownAcceptanceHistoryHelperCargoID(const Town *t, uint32_t parameter, const GRFFile *grffile, uint period, auto proj)
+{
+	CargoType cargo = GetCargoTranslation(parameter, grffile);
+	if (!IsValidCargoType(cargo)) return 0;
+
+	auto it = t->GetCargoAccepted(cargo);
+	if (it == std::end(t->accepted)) return 0;
+
+	return ClampTo<uint32_t>(std::invoke(proj, it->history[period]));
 }
 
 /**
@@ -57,8 +106,21 @@ static uint32_t GetNearbyTileInformation(uint8_t parameter, TileIndex tile, bool
 		/* Additional town information: (for now just) road layout */
 		case 0x42: return to_underlying(this->t->layout);
 
+		/* Number of nearby stations */
+		case 0x43: return ClampTo<uint16_t>(this->t->stations_near.size());
+
 		/* Land info for nearby tiles. */
 		case 0x60: return GetNearbyTileInformation(parameter, this->t->xy, this->ro.grffile->grf_version >= 8);
+
+		/* Recent cargo production and transport, by cargo label */
+		case 0x61: return TownProductionHistoryHelperCargoID(this->t, parameter, this->ro.grffile, THIS_MONTH, &Town::SuppliedHistory::production);
+		case 0x62: return TownProductionHistoryHelperCargoID(this->t, parameter, this->ro.grffile, THIS_MONTH, &Town::SuppliedHistory::transported);
+		case 0x63: return TownProductionHistoryHelperCargoID(this->t, parameter, this->ro.grffile, LAST_MONTH, &Town::SuppliedHistory::production);
+		case 0x64: return TownProductionHistoryHelperCargoID(this->t, parameter, this->ro.grffile, LAST_MONTH, &Town::SuppliedHistory::transported);
+
+		/* Recent cargo acceptance, by cargo label */
+		case 0x65: return TownAcceptanceHistoryHelperCargoID(this->t, parameter, this->ro.grffile, THIS_MONTH, &Town::AcceptedHistory::accepted);
+		case 0x66: return TownAcceptanceHistoryHelperCargoID(this->t, parameter, this->ro.grffile, LAST_MONTH, &Town::AcceptedHistory::accepted);
 
 		/* Get a variable from the persistent storage */
 		case 0x7C: {
@@ -114,22 +176,22 @@ static uint32_t GetNearbyTileInformation(uint8_t parameter, TileIndex tile, bool
 		case 0xB2: return this->t->statues.base();
 		case 0xB6: return ClampTo<uint16_t>(this->t->cache.num_houses);
 		case 0xB9: return this->t->growth_rate / Ticks::TOWN_GROWTH_TICKS;
-		case 0xBA: return TownHistoryHelper(this->t, CT_PASSENGERS, THIS_MONTH, &Town::SuppliedHistory::production);
-		case 0xBB: return TownHistoryHelper(this->t, CT_PASSENGERS, THIS_MONTH, &Town::SuppliedHistory::production) >> 8;
-		case 0xBC: return TownHistoryHelper(this->t, CT_MAIL, THIS_MONTH, &Town::SuppliedHistory::production);
-		case 0xBD: return TownHistoryHelper(this->t, CT_MAIL, THIS_MONTH, &Town::SuppliedHistory::production) >> 8;
-		case 0xBE: return TownHistoryHelper(this->t, CT_PASSENGERS, THIS_MONTH, &Town::SuppliedHistory::transported);
-		case 0xBF: return TownHistoryHelper(this->t, CT_PASSENGERS, THIS_MONTH, &Town::SuppliedHistory::transported) >> 8;
-		case 0xC0: return TownHistoryHelper(this->t, CT_MAIL, THIS_MONTH, &Town::SuppliedHistory::transported);
-		case 0xC1: return TownHistoryHelper(this->t, CT_MAIL, THIS_MONTH, &Town::SuppliedHistory::transported) >> 8;
-		case 0xC2: return TownHistoryHelper(this->t, CT_PASSENGERS, LAST_MONTH, &Town::SuppliedHistory::production);
-		case 0xC3: return TownHistoryHelper(this->t, CT_PASSENGERS, LAST_MONTH, &Town::SuppliedHistory::production) >> 8;
-		case 0xC4: return TownHistoryHelper(this->t, CT_MAIL, LAST_MONTH, &Town::SuppliedHistory::production);
-		case 0xC5: return TownHistoryHelper(this->t, CT_MAIL, LAST_MONTH, &Town::SuppliedHistory::production) >> 8;
-		case 0xC6: return TownHistoryHelper(this->t, CT_PASSENGERS, LAST_MONTH, &Town::SuppliedHistory::transported);
-		case 0xC7: return TownHistoryHelper(this->t, CT_PASSENGERS, LAST_MONTH, &Town::SuppliedHistory::transported) >> 8;
-		case 0xC8: return TownHistoryHelper(this->t, CT_MAIL, LAST_MONTH, &Town::SuppliedHistory::transported);
-		case 0xC9: return TownHistoryHelper(this->t, CT_MAIL, LAST_MONTH, &Town::SuppliedHistory::transported) >> 8;
+		case 0xBA: return TownProductionHistoryHelper(this->t, CT_PASSENGERS, THIS_MONTH, &Town::SuppliedHistory::production);
+		case 0xBB: return TownProductionHistoryHelper(this->t, CT_PASSENGERS, THIS_MONTH, &Town::SuppliedHistory::production) >> 8;
+		case 0xBC: return TownProductionHistoryHelper(this->t, CT_MAIL, THIS_MONTH, &Town::SuppliedHistory::production);
+		case 0xBD: return TownProductionHistoryHelper(this->t, CT_MAIL, THIS_MONTH, &Town::SuppliedHistory::production) >> 8;
+		case 0xBE: return TownProductionHistoryHelper(this->t, CT_PASSENGERS, THIS_MONTH, &Town::SuppliedHistory::transported);
+		case 0xBF: return TownProductionHistoryHelper(this->t, CT_PASSENGERS, THIS_MONTH, &Town::SuppliedHistory::transported) >> 8;
+		case 0xC0: return TownProductionHistoryHelper(this->t, CT_MAIL, THIS_MONTH, &Town::SuppliedHistory::transported);
+		case 0xC1: return TownProductionHistoryHelper(this->t, CT_MAIL, THIS_MONTH, &Town::SuppliedHistory::transported) >> 8;
+		case 0xC2: return TownProductionHistoryHelper(this->t, CT_PASSENGERS, LAST_MONTH, &Town::SuppliedHistory::production);
+		case 0xC3: return TownProductionHistoryHelper(this->t, CT_PASSENGERS, LAST_MONTH, &Town::SuppliedHistory::production) >> 8;
+		case 0xC4: return TownProductionHistoryHelper(this->t, CT_MAIL, LAST_MONTH, &Town::SuppliedHistory::production);
+		case 0xC5: return TownProductionHistoryHelper(this->t, CT_MAIL, LAST_MONTH, &Town::SuppliedHistory::production) >> 8;
+		case 0xC6: return TownProductionHistoryHelper(this->t, CT_PASSENGERS, LAST_MONTH, &Town::SuppliedHistory::transported);
+		case 0xC7: return TownProductionHistoryHelper(this->t, CT_PASSENGERS, LAST_MONTH, &Town::SuppliedHistory::transported) >> 8;
+		case 0xC8: return TownProductionHistoryHelper(this->t, CT_MAIL, LAST_MONTH, &Town::SuppliedHistory::transported);
+		case 0xC9: return TownProductionHistoryHelper(this->t, CT_MAIL, LAST_MONTH, &Town::SuppliedHistory::transported) >> 8;
 		case 0xCA: return this->t->GetPercentTransported(GetCargoTypeByLabel(CT_PASSENGERS));
 		case 0xCB: return this->t->GetPercentTransported(GetCargoTypeByLabel(CT_MAIL));
 		case 0xCC: return this->t->received[TownAcceptanceEffect::Food].new_act;


### PR DESCRIPTION
## Motivation / Problem

Town-level NewGRF variables are currently somewhat limited:
A NewGRF author might want to query production of non-standard cargos (ie. not passengers or mail) which the town produces due to a houses NewGRF.

See also: https://github.com/OpenTTD/OpenTTD/discussions/12281

## Description

Expose as `varact2` variables taking a parameter:
* `0x61`: Production of a cargo this month, taking a cargo translation table entry as a parameter. Behaves exactly like industry `0x6C`, but for the town.
* `0x62`: Same, but cargo transported this month.
* `0x63`: Same, but cargo production last month.
* `0x64`: Same, but cargo transported last month.

Edit: Now also exposes cargo acceptance:
* `0x65`: Same, but cargo accepted this month.
* `0x66`: Same, but cargo accepted last month.

## Limitations

~~Doesn't expose cargo produced this and last month, but I couldn't work out how to do that, plus I think @PeterN was looking at changing the town cargo accepted history code for better graphing.~~ Edit: Now supported.

There is sensitivity about duplicating town control functions between game scripts, but I think there are good NewGRF use cases for these variables.

I don't fully know what I'm doing.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
