### PR TITLE
Codefix: remove implicit LaTeX dependency

### DIFF
--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -129,8 +129,8 @@ using WidgetLookup = std::map<WidgetID, class NWidgetBase *>;
 
 /**
  * Baseclass for nested widgets.
- * @invariant After initialization, \f$current\_x = smallest\_x + n * resize\_x, for n \geq 0\f$.
- * @invariant After initialization, \f$current\_y = smallest\_y + m * resize\_y, for m \geq 0\f$.
+ * @invariant After initialization: current_x = smallest_x + n * resize_x, for n >= 0.
+ * @invariant After initialization: current_y = smallest_y + m * resize_y, for m >= 0.
  * @ingroup NestedWidgets
  */
 class NWidgetBase {


### PR DESCRIPTION
## Motivation / Problem

Two errors when building the documentation about problems with LaTeX.

[NWidgetBase's invariant](https://docs.openttd.org/source/d5/d71/classNWidgetBase#details) contains a tiny bit of documentation that requires LaTeX to properly format. Since we do not install LaTeX when building, it basically dumps out the formula's LaTeX source code in an image.


## Description

There are two solutions:
* Install doxygen-latex (~1 GB to install)
* Replace the LaTex formula with just 'text'.

I have chosen for the latter, as it's easier to read and maintain.


## Limitations

No more pretty formulae if you have LaTeX installed while building the documentation.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
