### PR TITLE
Codefix: improve Command docs

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -88,52 +88,45 @@ inline constexpr auto MakeCommandsFromTraits(std::integer_sequence<T, i...>) noe
 }
 
 /**
- * The master command table
+ * The master command table.
  *
- * This table contains all possible CommandProc functions with
- * the flags which belongs to it. The indices are the same
- * as the value from the CMD_* enums.
+ * This contains the #CommandInfo for all possible #Commands functions.
  */
-static constexpr auto _command_proc_table = MakeCommandsFromTraits(std::make_integer_sequence<std::underlying_type_t<Commands>, to_underlying(Commands::End)>{});
+static constexpr auto _command_table = MakeCommandsFromTraits(std::make_integer_sequence<std::underlying_type_t<Commands>, to_underlying(Commands::End)>{});
 
 
 /**
- * This function range-checks a cmd.
- *
- * @param cmd The integer value of a command
- * @return true if the command is valid (and got a CommandProc function)
+ * This function range-checks a Commands. This is primarily for Commands coming from the network.
+ * @param cmd The command.
+ * @return True if the command is valid.
  */
 bool IsValidCommand(Commands cmd)
 {
-	return to_underlying(cmd) < _command_proc_table.size();
+	return to_underlying(cmd) < _command_table.size();
 }
 
 /**
- * This function mask the parameter with CMD_ID_MASK and returns
- * the flags which belongs to the given command.
- *
- * @param cmd The integer value of the command
+ * Get the command flags associated with the given command.
+ * @param cmd The command.
  * @return The flags for this command
  */
 CommandFlags GetCommandFlags(Commands cmd)
 {
 	assert(IsValidCommand(cmd));
 
-	return _command_proc_table[cmd].flags;
+	return _command_table[cmd].flags;
 }
 
 /**
- * This function mask the parameter with CMD_ID_MASK and returns
- * the name which belongs to the given command.
- *
- * @param cmd The integer value of the command
+ * Get the name of the given command.
+ * @param cmd The command.
  * @return The name for this command
  */
 std::string_view GetCommandName(Commands cmd)
 {
 	assert(IsValidCommand(cmd));
 
-	return _command_proc_table[cmd].name;
+	return _command_table[cmd].name;
 }
 
 /**
@@ -158,7 +151,7 @@ bool IsCommandAllowedWhilePaused(Commands cmd)
 	static_assert(std::size(command_type_lookup) == to_underlying(CommandType::End));
 
 	assert(IsValidCommand(cmd));
-	return _game_mode == GM_EDITOR || command_type_lookup[to_underlying(_command_proc_table[cmd].type)] <= _settings_game.construction.command_pause_level;
+	return _game_mode == GM_EDITOR || command_type_lookup[to_underlying(_command_table[cmd].type)] <= _settings_game.construction.command_pause_level;
 }
 
 /**
@@ -384,7 +377,7 @@ CommandCost CommandHelperBase::InternalExecuteProcessResult(Commands cmd, Comman
 	SubtractMoneyFromCompany(_current_company, res_exec);
 
 	/* Record if there was a command issues during pause; ignore pause/other setting related changes. */
-	if (_pause_mode.Any() && _command_proc_table[cmd].type != CommandType::ServerSetting) _pause_mode.Set(PauseMode::CommandDuringPause);
+	if (_pause_mode.Any() && _command_table[cmd].type != CommandType::ServerSetting) _pause_mode.Set(PauseMode::CommandDuringPause);
 
 	/* update signals if needed */
 	UpdateSignalsInBuffer();

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -269,7 +269,7 @@ void CommandHelperBase::LogCommandExecution(Commands cmd, StringID err_message, 
  * @param[in,out] cur_company Backup of current company at start of command execution.
  * @return True if test run can go ahead, false on error.
  */
-bool CommandHelperBase::InternalExecutePrepTest(CommandFlags cmd_flags, TileIndex, Backup<CompanyID> &cur_company)
+bool CommandHelperBase::InternalExecutePrepTest(CommandFlags cmd_flags, Backup<CompanyID> &cur_company)
 {
 	/* Always execute server and spectator commands as spectator */
 	bool exec_as_spectator = cmd_flags.Any({CommandFlag::Spectator, CommandFlag::Server});

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -250,7 +250,13 @@ void CommandHelperBase::InternalPostResult(CommandCost &res, TileIndex tile, boo
 	}
 }
 
-/** Helper to make a desync log for a command. */
+/**
+ * Helper to make a desync log for a command.
+ * @param cmd The executed command.
+ * @param err_message The error messages of the command.
+ * @param args The encoded arguments of the command.
+ * @param failed Whether the command failed.
+ */
 void CommandHelperBase::LogCommandExecution(Commands cmd, StringID err_message, const CommandDataBuffer &args, bool failed)
 {
 	Debug(desync, 1, "{}: {:08x}; {:02x}; {:02x}; {:08x}; {:08x}; {} ({})", failed ? "cmdf" : "cmd", (uint32_t)TimerGameEconomy::date.base(), TimerGameEconomy::date_fract, _current_company, cmd, err_message, FormatArrayAsHex(args), GetCommandName(cmd));
@@ -326,7 +332,7 @@ std::tuple<bool, bool, bool> CommandHelperBase::InternalExecuteValidateTestAndPr
  * @param cmd Command that was executed.
  * @param cmd_flags Command flags.
  * @param res_test Command result of test run.
- * @param tes_exec Command result of real run.
+ * @param res_exec Command result of real run.
  * @param extra_cash Additional cash required for successful command execution.
  * @param tile Tile of command execution.
  * @param[in,out] cur_company Backup of current company at start of command execution.

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -89,7 +89,7 @@ protected:
 	static void InternalDoAfter(CommandCost &res, DoCommandFlags flags, bool top_level, bool test);
 	static std::tuple<bool, bool, bool> InternalPostBefore(Commands cmd, CommandFlags flags, TileIndex tile, StringID err_message, bool network_command);
 	static void InternalPostResult(CommandCost &res, TileIndex tile, bool estimate_only, bool only_sending, StringID err_message, bool my_cmd);
-	static bool InternalExecutePrepTest(CommandFlags cmd_flags, TileIndex tile, Backup<CompanyID> &cur_company);
+	static bool InternalExecutePrepTest(CommandFlags cmd_flags, Backup<CompanyID> &cur_company);
 	static std::tuple<bool, bool, bool> InternalExecuteValidateTestAndPrepExec(CommandCost &res, CommandFlags cmd_flags, bool estimate_only, bool network_command, Backup<CompanyID> &cur_company);
 	static CommandCost InternalExecuteProcessResult(Commands cmd, CommandFlags cmd_flags, const CommandCost &res_test, const CommandCost &res_exec, Money extra_cash, TileIndex tile, Backup<CompanyID> &cur_company);
 	static void LogCommandExecution(Commands cmd, StringID err_message, const CommandDataBuffer &args, bool failed);
@@ -365,7 +365,7 @@ protected:
 		}
 
 		Backup<CompanyID> cur_company(_current_company);
-		if (!InternalExecutePrepTest(cmd_flags, tile, cur_company)) {
+		if (!InternalExecutePrepTest(cmd_flags, cur_company)) {
 			cur_company.Trash();
 			return MakeResult(CMD_ERROR);
 		}

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -216,7 +216,6 @@ public:
 
 	/**
 	 * Prepare a command to be send over the network
-	 * @param cmd The command to execute (a CMD_* value)
 	 * @param err_message Message prefix to show on error
 	 * @param company The company that wants to send the command
 	 * @param args Parameters for the command
@@ -459,6 +458,7 @@ struct CommandHelper<Tcmd, Tret(*)(DoCommandFlags, Targs...), false> : CommandHe
 	 * commands that don't take a TileIndex by themselves.
 	 * @param err_message Message prefix to show on error
 	 * @param callback A callback function to call after the command is finished
+	 * @param location Tile location for user feedback.
 	 * @param args Parameters for the command
 	 * @return \c true if the command succeeded, else \c false.
 	 */

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -125,7 +125,7 @@ private:
 
 public:
 	/**
-	 * This function executes a given command with the parameters from the #CommandProc parameter list.
+	 * This function executes a given command.
 	 * Depending on the flags parameter it executes or tests a command.
 	 *
 	 * @note This function is to be called from the StateGameLoop or from within the execution of a Command.
@@ -134,7 +134,6 @@ public:
 	 *
 	 * @param flags Flags for the command and how to execute the command
 	 * @param args Parameters for the command
-	 * @see CommandProc
 	 * @return the cost
 	 */
 	static Tret Do(DoCommandFlags flags, Targs... args)

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -484,30 +484,24 @@ typedef std::vector<uint8_t> CommandDataBuffer;
 /**
  * Define a callback function for the client, after the command is finished.
  *
- * Functions of this type are called after the command is finished. The parameters
- * are from the #CommandProc callback type. The boolean parameter indicates if the
- * command succeeded or failed.
+ * Functions of this type are called after the command is finished.
  *
  * @param cmd The command that was executed
  * @param result The result of the executed command
  * @param tile The tile of the command action
- * @see CommandProc
  */
 typedef void CommandCallback(Commands cmd, const CommandCost &result, TileIndex tile);
 
 /**
  * Define a callback function for the client, after the command is finished.
  *
- * Functions of this type are called after the command is finished. The parameters
- * are from the #CommandProc callback type. The boolean parameter indicates if the
- * command succeeded or failed.
+ * Functions of this type are called after the command is finished.
  *
  * @param cmd The command that was executed
  * @param result The result of the executed command
  * @param tile The tile of the command action
  * @param data Additional data of the command
  * @param result_data Additional returned data from the command
- * @see CommandProc
  */
 typedef void CommandCallbackData(Commands cmd, const CommandCost &result, const CommandDataBuffer &data, CommandDataBuffer result_data);
 

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -38,6 +38,8 @@ public:
 
 	/**
 	 * Creates a command return value with one, or optionally two, error message strings.
+	 * @param msg The error message.
+	 * @param extra_msg Optional secondary error message.
 	 */
 	explicit CommandCost(StringID msg, StringID extra_msg = INVALID_STRING_ID) : cost(0), message(msg), expense_type(INVALID_EXPENSES), success(false), extra_message(extra_msg) {}
 
@@ -57,6 +59,7 @@ public:
 	/**
 	 * Set the 'owner' (the originator) of this error message. This is used to show a company owner's face if you
 	 * attempt an action on something owned by other company.
+	 * @param owner The owner.
 	 */
 	inline void SetErrorOwner(Owner owner)
 	{
@@ -85,6 +88,7 @@ public:
 
 	/**
 	 * Get the originator owner for this error.
+	 * @return The owner.
 	 */
 	inline CompanyID GetErrorOwner() const
 	{
@@ -499,7 +503,6 @@ typedef void CommandCallback(Commands cmd, const CommandCost &result, TileIndex 
  *
  * @param cmd The command that was executed
  * @param result The result of the executed command
- * @param tile The tile of the command action
  * @param data Additional data of the command
  * @param result_data Additional returned data from the command
  */


### PR DESCRIPTION
## Motivation / Problem

Doxygen warnings.


## Description

Take out some low hanging fruits in the realm of Commands:
* Referencing non-existent CommandProc type; includes rename of `_command_proc_table` to `_command_table` as it does not actually contain any procedure/function.
* Add parameters where only parameters are missing.
* Remove parameters where they don't exist in the function.

## Limitations

There are plenty more doxygen warnings, but... small steps.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
