### PR TITLE
Add: [NewGRF] Town road layout

### DIFF
--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -41,6 +41,9 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 		/* Town index */
 		case 0x41: return this->t->index.base();
 
+		/* Additional town information: (for now just) road layout */
+		case 0x42: return to_underlying(this->t->layout);
+
 		/* Get a variable from the persistent storage */
 		case 0x7C: {
 			/* Check the persistent storage for the GrfID stored in register 100h. */

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -54,6 +54,9 @@ static uint32_t GetNearbyTileInformation(uint8_t parameter, TileIndex tile, bool
 		/* Town index */
 		case 0x41: return this->t->index.base();
 
+		/* Additional town information: (for now just) road layout */
+		case 0x42: return to_underlying(this->t->layout);
+
 		/* Land info for nearby tiles. */
 		case 0x60: return GetNearbyTileInformation(parameter, this->t->xy, this->ro.grffile->grf_version >= 8);
 


### PR DESCRIPTION
## Motivation / Problem

Town-level NewGRF variables are currently somewhat limited:
A NewGRF author might want to select buildings based on the town road layout, eg. preferring more random selections on random road layouts, or more ordered block layout buildings for grid road layouts.

## Description

Expose as `varact2` variable:

`0x42`: Road layout, which has a value of 0 for original roads, 1 for improved roads, 2 for 2x2 grid, 3 for 3x3 grid.

## Limitations

None(?)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
