### PR TITLE
Change: Scale subsidy distance by town/industry density and cargo amount

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -446,10 +446,10 @@ struct GenerateLandscapeWindow : public Window {
 				if (_game_mode == GM_EDITOR) {
 					return GetString(STR_CONFIG_SETTING_OFF);
 				}
-				if (_settings_newgame.difficulty.number_towns == CUSTOM_TOWN_NUMBER_DIFFICULTY) {
+				if (_settings_newgame.difficulty.number_towns == TownDensity::Custom) {
 					return GetString(STR_NUM_CUSTOM_NUMBER, _settings_newgame.game_creation.custom_town_number);
 				}
-				return GetString(_num_towns[_settings_newgame.difficulty.number_towns]);
+				return GetString(_num_towns[to_underlying(_settings_newgame.difficulty.number_towns)]);
 
 			case WID_GL_TOWNNAME_DROPDOWN: {
 				uint gen = _settings_newgame.game_creation.town_name;
@@ -676,7 +676,7 @@ struct GenerateLandscapeWindow : public Window {
 				break;
 
 			case WID_GL_TOWN_PULLDOWN: // Number of towns
-				ShowDropDownMenu(this, _num_towns, _settings_newgame.difficulty.number_towns, WID_GL_TOWN_PULLDOWN, 0, 0);
+				ShowDropDownMenu(this, _num_towns, to_underlying(_settings_newgame.difficulty.number_towns), WID_GL_TOWN_PULLDOWN, 0, 0);
 				break;
 
 			case WID_GL_TOWNNAME_DROPDOWN: // Townname generator
@@ -887,11 +887,11 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_HEIGHTMAP_ROTATION_PULLDOWN: _settings_newgame.game_creation.heightmap_rotation = index; break;
 
 			case WID_GL_TOWN_PULLDOWN:
-				if ((uint)index == CUSTOM_TOWN_NUMBER_DIFFICULTY) {
+				if (index == to_underlying(TownDensity::Custom)) {
 					this->widget_id = widget;
 					ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.custom_town_number), STR_MAPGEN_NUMBER_OF_TOWNS, 5, this, CS_NUMERAL, {});
 				}
-				_settings_newgame.difficulty.number_towns = index;
+				_settings_newgame.difficulty.number_towns = static_cast<TownDensity>(index);
 				break;
 
 			case WID_GL_TOWNNAME_DROPDOWN: // Town names

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1708,7 +1708,7 @@ bool AfterLoadGame()
 		}
 
 		/* Same goes for number of towns, although no test is needed, just an increment */
-		_settings_game.difficulty.number_towns++;
+		_settings_game.difficulty.number_towns = static_cast<TownDensity>(to_underlying(_settings_game.difficulty.number_towns) + 1);
 	}
 
 	if (IsSavegameVersionBefore(SLV_64)) {

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -67,6 +67,16 @@ enum class IndustryDensity : uint8_t {
 	End, ///< Number of industry density settings.
 };
 
+/** Available town generation densities. */
+enum class TownDensity : uint8_t {
+	VeryLow, ///< Very low number of towns.
+	Low, ///< Low number of towns.
+	Normal, ///< Normal number of towns.
+	High, ///< High number of towns.
+
+	Custom, ///< Custom number of towns.
+};
+
 /** Possible options for the Maximum Height pulldown in the Genworld GUI. */
 enum class GenworldMaxHeight : uint8_t {
 	VeryFlat,
@@ -151,7 +161,7 @@ struct DifficultySettings {
 
 	uint8_t max_no_competitors; ///< the number of competitors (AIs)
 	uint16_t competitors_interval; ///< the interval (in minutes) between adding competitors
-	uint8_t number_towns; ///< the amount of towns
+	TownDensity number_towns; ///< the amount of towns. @see TownDensity
 	IndustryDensity industry_density; ///< The industry density. @see IndustryDensity
 	uint32_t max_loan; ///< the maximum initial loan
 	uint8_t initial_interest; ///< amount of interest (to pay over the loan)

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -182,8 +182,9 @@ static uint GetScaledMaxSubsidyDistance(SourceType source, SourceType dest)
 		}
 	}
 
-	/* Maybe scale based on industry density. */
+	/* Scale based on industries. */
 	if (source == SourceType::Industry || dest == SourceType::Industry) {
+		/* Maybe scale based on industry density. */
 		switch (_settings_game.difficulty.industry_density) {
 			case IndustryDensity::Custom:
 				/* Compare the custom result with Normal density, scaled by map size. */
@@ -205,6 +206,11 @@ static uint GetScaledMaxSubsidyDistance(SourceType source, SourceType dest)
 
 			default: break; // Normal and High are not scaled.
 		}
+
+		/* A successful industry subsidy depends on two given industries having a valid cargo to transport between them.
+		 * If there are more cargos, this is less likely, so scale the max distance to try to generate the same number of subsidies. */
+		const uint MAX_BASE_CARGO_COUNT = 10; // Tropic and Toyland each have 10 industry cargo, not counting Passengers and Mail.
+		distance = std::max(distance, distance * static_cast<uint>(_sorted_cargo_specs.size() / MAX_BASE_CARGO_COUNT));
 	}
 
 	return distance;

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -151,6 +151,66 @@ static bool CheckSubsidyDuplicate(CargoType cargo, Source src, Source dst)
 }
 
 /**
+ * Get the scaled max distance of a subsidy, based on town or industry density relative to Normal density.
+ * @param source The source type.
+ * @param dest The destination type.
+ * @return The scaled distance allowed for a subsidy from the given source to given destination.
+ */
+static uint GetScaledMaxSubsidyDistance(SourceType source, SourceType dest)
+{
+	/* Start with an unscaled distance, then find the lowest density of the source and destination types.
+	 * The source and destination types may be the same or different. */
+	uint distance = SUBSIDY_BASE_DISTANCE;
+
+	/* Maybe scale based on town density. */
+	if (source == SourceType::Town || dest == SourceType::Town) {
+		switch (_settings_game.difficulty.number_towns) {
+			case TownDensity::Custom:
+				/* Compare the custom result with Normal density, scaled by map size. */
+				distance = std::max(distance, SUBSIDY_BASE_DISTANCE * (23 / Map::ScaleBySize(static_cast<uint>(Town::GetNumItems()))));
+				break;
+
+			case TownDensity::VeryLow:
+				distance = std::max(distance, SUBSIDY_BASE_DISTANCE * 5);
+				break;
+
+			case TownDensity::Low:
+				distance = std::max(distance, SUBSIDY_BASE_DISTANCE * 2);
+				break;
+
+			default: break; // Normal and High are not scaled.
+		}
+	}
+
+	/* Maybe scale based on industry density. */
+	if (source == SourceType::Industry || dest == SourceType::Industry) {
+		switch (_settings_game.difficulty.industry_density) {
+			case IndustryDensity::Custom:
+				/* Compare the custom result with Normal density, scaled by map size. */
+				distance = std::max(distance, SUBSIDY_BASE_DISTANCE * (55 / Map::ScaleBySize(static_cast<uint>(Industry::GetNumItems()))));
+				break;
+
+			case IndustryDensity::Minimal:
+				distance = std::max(distance, SUBSIDY_BASE_DISTANCE * 10);
+				break;
+
+			case IndustryDensity::VeryLow:
+				distance = std::max(distance, SUBSIDY_BASE_DISTANCE * 5);
+				break;
+
+			case IndustryDensity::Low:
+			case IndustryDensity::FundedOnly: // We can't know the density, so we assume it's about IndustryDensity::Low.
+				distance = std::max(distance, SUBSIDY_BASE_DISTANCE * 2);
+				break;
+
+			default: break; // Normal and High are not scaled.
+		}
+	}
+
+	return distance;
+}
+
+/**
  * Checks if the source and destination of a subsidy are inside the distance limit.
  * @param src Source of cargo.
  * @param dst Destination of cargo.
@@ -161,7 +221,7 @@ static bool CheckSubsidyDistance(Source src, Source dst)
 	TileIndex tile_src = (src.type == SourceType::Town) ? Town::Get(src.ToTownID())->xy : Industry::Get(src.ToIndustryID())->location.tile;
 	TileIndex tile_dst = (dst.type == SourceType::Town) ? Town::Get(dst.ToTownID())->xy : Industry::Get(dst.ToIndustryID())->location.tile;
 
-	return (DistanceManhattan(tile_src, tile_dst) <= SUBSIDY_MAX_DISTANCE);
+	return DistanceManhattan(tile_src, tile_dst) <= GetScaledMaxSubsidyDistance(src.type, dst.type);
 }
 
 /**
@@ -252,7 +312,7 @@ bool FindSubsidyPassengerRoute()
 		return false;
 	}
 
-	if (DistanceManhattan(src->xy, dst->xy) > SUBSIDY_MAX_DISTANCE) return false;
+	if (DistanceManhattan(src->xy, dst->xy) > GetScaledMaxSubsidyDistance(SourceType::Town, SourceType::Town)) return false;
 	if (CheckSubsidyDuplicate(cargo_type, {src->index, SourceType::Town}, {dst->index, SourceType::Town})) return false;
 
 	CreateSubsidy(cargo_type, {src->index, SourceType::Town}, {dst->index, SourceType::Town});

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -52,7 +52,7 @@ static const uint SUBSIDY_OFFER_MONTHS         =  12; ///< Duration of subsidy o
 static const uint SUBSIDY_PAX_MIN_POPULATION   = 400; ///< Min. population of towns for subsidised pax route
 static const uint SUBSIDY_CARGO_MIN_POPULATION = 900; ///< Min. population of destination town for cargo route
 static const uint SUBSIDY_MAX_PCT_TRANSPORTED  =  42; ///< Subsidy will be created only for towns/industries with less % transported
-static const uint SUBSIDY_MAX_DISTANCE         =  70; ///< Max. length of subsidised route (DistanceManhattan)
+static const uint SUBSIDY_BASE_DISTANCE        =  70; ///< Max length of a subsidised route at Normal town/industry density (DistanceManhattan)
 static const uint SUBSIDY_TOWN_CARGO_RADIUS    =   6; ///< Extent of a tile area around town center when scanning for town cargo acceptance and production (6 ~= min catchment + min station / 2)
 
 #endif /* SUBSIDY_BASE_H */

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -85,10 +85,9 @@ var      = difficulty.number_towns
 type     = SLE_UINT8
 from     = SLV_97
 flags    = SettingFlag::NewgameOnly
-def      = 2
-min      = 0
-max      = 4
-interval = 1
+def      = TownDensity::Normal
+min      = TownDensity::VeryLow
+max      = TownDensity::Custom
 strval   = STR_NUM_VERY_LOW
 cat      = SC_BASIC
 

--- a/src/town.h
+++ b/src/town.h
@@ -26,7 +26,6 @@ struct BuildingCounts {
 	auto operator<=>(const BuildingCounts &) const = default;
 };
 
-static const uint CUSTOM_TOWN_NUMBER_DIFFICULTY  = 4; ///< value for custom town number in difficulty settings
 static const uint CUSTOM_TOWN_MAX_NUMBER = 5000;  ///< this is the maximum number of towns a user can specify in customisation
 
 static const uint TOWN_GROWTH_WINTER = 0xFFFFFFFE; ///< The town only needs this cargo in the winter (any amount)

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2410,10 +2410,10 @@ static Town *CreateRandomTown(uint attempts, uint32_t townnameparts, TownSize si
 uint GetDefaultTownsForMapSize()
 {
 	static const uint8_t num_initial_towns[4] = {5, 11, 23, 46};  // very low, low, normal, high
-	if (_settings_game.difficulty.number_towns == static_cast<uint>(CUSTOM_TOWN_NUMBER_DIFFICULTY)) {
+	if (_settings_game.difficulty.number_towns == TownDensity::Custom) {
 		return _settings_newgame.game_creation.custom_town_number;
 	}
-	return Map::ScaleBySize(num_initial_towns[_settings_game.difficulty.number_towns]);
+	return Map::ScaleBySize(num_initial_towns[to_underlying(_settings_game.difficulty.number_towns)]);
 }
 
 /**
@@ -2429,7 +2429,7 @@ bool GenerateTowns(TownLayout layout, std::optional<uint> number)
 	uint total;
 	if (number.has_value()) {
 		total = number.value();
-	} else if (_settings_game.difficulty.number_towns == static_cast<uint>(CUSTOM_TOWN_NUMBER_DIFFICULTY)) {
+	} else if (_settings_game.difficulty.number_towns == TownDensity::Custom) {
 		total = GetDefaultTownsForMapSize();
 	} else {
 		total = Map::ScaleByLandProportion(GetDefaultTownsForMapSize() + (Random() & 7));


### PR DESCRIPTION
## Motivation / Problem

Subsidies are currently hardcoded to a maximum of 70 tiles, Manhattan distance.

With lower town/industry densities than Normal, this often fails to generate any subsidies.

Also, a successful industry subsidy depends on two given industries having a valid cargo to transport between them.
If there are more cargos than a vanilla game, this is less likely.

## Description

* Scale the maximum distance based on the town and/or industry density, whichever is relevant to the given subsidy (maybe both).
* Scale the maximum distance based on the number of cargos in the current game, relative to the vanilla economies which have 9 or 10 industry cargos.

## Limitations

Subsidies choose a random cargo and then a random industry, so complex industry sets like FIRS Steeltown often fail to generate subsidies for industries with multiple outputs. Mostly you see single-output industries like Coal Mines or Farms. This is a separate issue for a different PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
