### PR TITLE
Add: [NewGRF] Town number of nearby stations

### DIFF
--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -41,6 +41,9 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 		/* Town index */
 		case 0x41: return this->t->index.base();
 
+		/* Number of nearby stations */
+		case 0x43: return ClampTo<uint16_t>(this->t->stations_near.size());
+
 		/* Get a variable from the persistent storage */
 		case 0x7C: {
 			/* Check the persistent storage for the GrfID stored in register 100h. */

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -57,6 +57,9 @@ static uint32_t GetNearbyTileInformation(uint8_t parameter, TileIndex tile, bool
 		/* Additional town information: (for now just) road layout */
 		case 0x42: return to_underlying(this->t->layout);
 
+		/* Number of nearby stations */
+		case 0x43: return ClampTo<uint16_t>(this->t->stations_near.size());
+
 		/* Land info for nearby tiles. */
 		case 0x60: return GetNearbyTileInformation(parameter, this->t->xy, this->ro.grffile->grf_version >= 8);
 


### PR DESCRIPTION
## Motivation / Problem

Town-level NewGRF variables are currently somewhat limited:
A NewGRF author might want to select buildings based on player 'attention' to a town: Number of stations might be useful, a complementary measure to cargo production/transport.

## Description

Expose as `varact2` variable:
`0x43`: Number of nearby stations. 

## Limitations

None(?)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
