### PR TITLE
Codefix: wrong parameter names and partially missing parameters

### DIFF
--- a/src/aircraft_gui.cpp
+++ b/src/aircraft_gui.cpp
@@ -66,6 +66,7 @@ void DrawAircraftDetails(const Aircraft *v, const Rect &r)
  * @param v         Front vehicle
  * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
+ * @param image_type Context where the image is being drawn.
  */
 void DrawAircraftImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type)
 {

--- a/src/animated_tile_map.h
+++ b/src/animated_tile_map.h
@@ -35,6 +35,7 @@ inline AnimatedTileState GetAnimatedTileState(Tile t)
 /**
  * Set the animated state of a tile.
  * @param t The tile.
+ * @param state The new state.
  */
 inline void SetAnimatedTileState(Tile t, AnimatedTileState state)
 {

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -226,7 +226,7 @@ public:
  * Check whether there's a base set matching some information.
  * @param ci The content info to compare it to.
  * @param md5sum Should the MD5 checksum be tested as well?
- * @param s The list with sets.
+ * @param sets The span with sets.
  * @return The filename of the first file of the base set, or \c std::nullopt if there is no match.
  */
 template <class Tbase_set>

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -273,7 +273,7 @@ struct SpecializedStation : public BaseStation {
 
 	/**
 	 * Creates a new T-object in the station pool.
-	 * @param args... The arguments to the constructor.
+	 * @param args The arguments to the constructor.
 	 * @return The created object.
 	 */
 	template <typename... Targs>
@@ -285,7 +285,7 @@ struct SpecializedStation : public BaseStation {
 	/**
 	 * Creates a new T-object in the station pool.
 	 * @param index The index allocate the object at.
-	 * @param args... The arguments to the constructor.
+	 * @param args The arguments to the constructor.
 	 * @return The created object.
 	 */
 	template <typename... Targs>

--- a/src/bitmap_type.h
+++ b/src/bitmap_type.h
@@ -52,7 +52,7 @@ public:
 
 	/**
 	 * Initialize the BitmapTileArea with the specified Rect.
-	 * @param rect Rect to use.
+	 * @param r Rect to use.
 	 */
 	void Initialize(const Rect &r)
 	{

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -140,9 +140,7 @@ public:
 
 	/**
 	 * Fill a buffer with information about the blitters.
-	 * @param p The buffer to fill.
-	 * @param last The last element of the buffer.
-	 * @return p The location till where we filled the buffer.
+	 * @param output_iterator The buffer to fill.
 	 */
 	static void GetBlittersInfo(std::back_insert_iterator<std::string> &output_iterator)
 	{

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -769,6 +769,7 @@ static int DrawShipPurchaseInfo(int left, int right, int y, EngineID engine_numb
  * @param y Top of the area to draw in.
  * @param engine_number Engine to display.
  * @param refittable If set, the aircraft can be refitted.
+ * @param te Extra information about refits and capacities.
  * @return Bottom of the used area.
  */
 static int DrawAircraftPurchaseInfo(int left, int right, int y, EngineID engine_number, bool refittable, TestedEngineDetails &te)
@@ -873,6 +874,7 @@ void TestedEngineDetails::FillDefaultCapacities(const Engine *e)
  * Draw the purchase info details of a vehicle at a given location.
  * @param left,right,y location where to draw the info
  * @param engine_number the engine of which to draw the info of
+ * @param te Extra information about refits and capacities.
  * @return y after drawing all the text
  */
 int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, TestedEngineDetails &te)
@@ -962,6 +964,7 @@ static void DrawEngineBadgeColumn(const Rect &r, int column_group, const GUIBadg
  * @param selected_id what engine to highlight as selected, if any
  * @param show_count Whether to show the amount of engines or not
  * @param selected_group the group to list the engines of
+ * @param badge_classes The badges associated with the drawn engine.
  */
 void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar &sb, EngineID selected_id, bool show_count, GroupID selected_group, const GUIBadgeClasses &badge_classes)
 {

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -63,6 +63,7 @@ INSTANTIATE_POOL_METHODS(Company)
 
 /**
  * Constructor.
+ * @param index The unique pool identifier of this company.
  * @param name_1 Name of the company.
  * @param is_ai  A computer program is running for this company.
  */
@@ -833,6 +834,7 @@ static const IntervalTimer<TimerGameEconomy> _economy_companies_yearly({TimerGam
 
 /**
  * Fill the CompanyNewsInformation struct with the required data.
+ * @param title The title of the company news.
  * @param c the current company.
  * @param other the other company (use \c nullptr if not relevant).
  */
@@ -877,6 +879,7 @@ void CompanyAdminRemove(CompanyID company_id, CompanyRemoveReason reason)
  * @param flags operation to perform
  * @param cca action to perform
  * @param company_id company to perform the action on
+ * @param reason The reason why the company is being removed.
  * @param client_id ClientID
  * @return the cost of this operation or an error
  */
@@ -1418,7 +1421,7 @@ std::optional<uint> FindCompanyManagerFaceLabel(std::string_view label)
 
 /**
  * Get the face variables for a face style.
- * @param style_index Face style to get variables for.
+ * @param style Face style to get variables for.
  * @return Variables for the face style.
  */
 FaceVars GetCompanyManagerFaceVars(uint style)
@@ -1459,7 +1462,7 @@ void RandomiseCompanyManagerFace(CompanyManagerFace &cmf, Randomizer &randomizer
  * Mask company manager face bits to ensure they are all within range.
  * @note Does not update the CompanyManagerFace itself. Unused bits are cleared.
  * @param cmf The CompanyManagerFace.
- * @param style The face variables.
+ * @param vars The face variables.
  * @return The masked face bits.
  */
 uint32_t MaskCompanyManagerFaceBits(const CompanyManagerFace &cmf, FaceVars vars)

--- a/src/company_manager_face.h
+++ b/src/company_manager_face.h
@@ -86,7 +86,7 @@ struct FaceVar {
 
 	/**
 	 * Scales a company manager's face bits variable to the correct scope
-	 * @param vars The face variables of the face style.
+	 * @param val The value to scale.
 	 * @pre val < (1U << length), i.e. val has a value of 0..2^(bits used for this variable)-1
 	 * @return the scaled value
 	 */
@@ -155,6 +155,7 @@ inline uint64_t GetActiveFaceVars(const CompanyManagerFace &cmf, FaceVars vars)
  * Scales all company manager's face bits to the correct scope
  *
  * @param cmf the company manager's face to write the bits to
+ * @param vars The face variables to scale.
  */
 inline void ScaleAllCompanyManagerFaceBits(CompanyManagerFace &cmf, FaceVars vars)
 {

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -133,6 +133,7 @@ static std::string RemoveUnderscores(std::string name)
  * Register a new command to be used in the console
  * @param name name of the command that will be used
  * @param proc function that will be called upon execution of command
+ * @param hook Callback to check whether the command is allowed to run in the current context.
  */
 /* static */ void IConsole::CmdRegister(const std::string &name, IConsoleCmdProc *proc, IConsoleHook *hook)
 {
@@ -265,6 +266,7 @@ static void IConsoleAliasExec(const IConsoleAlias *alias, std::span<std::string>
  * Execute a given command passed to us. First chop it up into
  * individual tokens (separated by spaces), then execute it if possible
  * @param command_string string to be parsed and executed
+ * @param recurse_count The number of re-entrant calls to this function.
  */
 void IConsoleCmdExec(std::string_view command_string, const uint recurse_count)
 {

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -31,7 +31,7 @@ void IConsolePrint(TextColour colour_code, const std::string &string);
  * are also logged. All lines to print are added to a temporary buffer which can be
  * used as a history to print them onscreen
  * @param colour_code The colour of the command.
- * @param format_string The formatting string to tell what to do with the remaining arguments.
+ * @param format The formatting string to tell what to do with the remaining arguments.
  * @param first_arg The first argument to the format.
  * @param other_args The other arguments to the format.
  * @tparam A The type of the first argument.

--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -158,7 +158,7 @@ constexpr uint ClampU(const uint a, const uint min, const uint max)
  * For example ClampTo<uint8_t> will return a value clamped to the range of 0
  * to 255. Anything smaller will become 0, anything larger will become 255.
  *
- * @param a The 64-bit value to clamp.
+ * @param value The 64-bit value to clamp.
  * @return The 64-bit value reduced to a value within the given allowed range
  * for the return type.
  * @see Clamp(int, int, int)

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -305,6 +305,7 @@ public:
 		/**
 		 * Marks Titem as free. Its memory is released
 		 * @param p memory to free
+		 * @param size The size that was allocated during allocation.
 		 * @note the item has to be allocated in the pool!
 		 */
 		inline void operator delete(void *p, size_t size)
@@ -324,7 +325,7 @@ public:
 
 		/**
 		 * Creates a new T-object in the associated pool.
-		 * @param args... The arguments to the constructor.
+		 * @param args The arguments to the constructor.
 		 * @return The created object.
 		 */
 		template <typename T = Titem, typename... Targs>
@@ -338,7 +339,7 @@ public:
 		/**
 		 * Creates a new T-object in the associated pool.
 		 * @param index The to allocate the object at.
-		 * @param args... The arguments to the constructor.
+		 * @param args The arguments to the constructor.
 		 * @return The created object.
 		 */
 		template <typename T = Titem, typename... Targs>

--- a/src/core/random_func.hpp
+++ b/src/core/random_func.hpp
@@ -83,6 +83,7 @@ void SetRandomSeed(uint32_t seed);
  * can be returned and \a limit - 1 can be returned, but \a limit can not be
  * returned.
  * @param limit Limit for the range to be picked from.
+ * @param location Source code location where this function is called from.
  * @return A random number in [0,\a limit).
  */
 inline uint32_t RandomRange(uint32_t limit, const std::source_location location = std::source_location::current())
@@ -129,6 +130,7 @@ inline bool Chance16I(const uint32_t a, const uint32_t b, const uint32_t r)
  * @see Chance16I()
  * @param a The nominator of the fraction
  * @param b The denominator of the fraction
+ * @param location Source code location where this function is called from.
  * @return True with (a/b) probability
  */
 inline bool Chance16(const uint32_t a, const uint32_t b, const std::source_location location = std::source_location::current())
@@ -149,6 +151,7 @@ inline bool Chance16(const uint32_t a, const uint32_t b, const std::source_locat
  * @param a The numerator of the fraction
  * @param b The denominator of the fraction
  * @param r The variable to save the randomize-number from Random()
+ * @param location Source code location where this function is called from.
  * @return True in (a/b) percent
  */
 inline bool Chance16R(const uint32_t a, const uint32_t b, uint32_t &r, const std::source_location location = std::source_location::current())

--- a/src/core/string_consumer.hpp
+++ b/src/core/string_consumer.hpp
@@ -850,6 +850,7 @@ public:
 	/**
 	 * Peek and parse an integer in number 'base'.
 	 * If 'base == 0', then a prefix '0x' decides between base 16 or base 10.
+	 * @param base The base to interpret the string as.
 	 * @param clamp If the value is a valid number, but out of range for T, return the maximum representable value.
 	 *              Negative values for unsigned results are still treated as invalid.
 	 * @return Length of string match, and parsed value.
@@ -863,6 +864,7 @@ public:
 	/**
 	 * Try to read and parse an integer in number 'base', and then advance the reader.
 	 * If 'base == 0', then a prefix '0x' decides between base 16 or base 10.
+	 * @param base The base to interpret the string as.
 	 * @param clamp If the value is a valid number, but out of range for T, return the maximum representable value.
 	 *              Negative values for unsigned results are still treated as invalid.
 	 * @return Parsed value, if valid.
@@ -879,6 +881,8 @@ public:
 	/**
 	 * Read and parse an integer in number 'base', and advance the reader.
 	 * If 'base == 0', then a prefix '0x' decides between base 16 or base 10.
+	 * @param base The base to interpret the string as.
+	 * @param def The default when no valid integer could be parsed.
 	 * @param clamp If the value is a valid number, but out of range for T, return the maximum representable value.
 	 *              Negative values for unsigned results are still treated as invalid.
 	 * @return Parsed value, or 'def' if invalid.

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -36,8 +36,8 @@
 constexpr uint8_t CRASHLOG_SURVEY_VERSION = 1;
 
 /**
- * Writes the gamelog data to the buffer.
- * @param output_iterator Iterator to write the output to.
+ * Writes the gamelog data to the given JSON object.
+ * @param json The object to write to.
  */
 static void SurveyGamelog(nlohmann::json &json)
 {
@@ -49,8 +49,8 @@ static void SurveyGamelog(nlohmann::json &json)
 }
 
 /**
- * Writes up to 32 recent news messages to the buffer, with the most recent first.
- * @param output_iterator Iterator to write the output to.
+ * Writes up to 32 recent news messages to the given JSON object, with the most recent first.
+ * @param json The object to write to.
  */
 static void SurveyRecentNews(nlohmann::json &json)
 {

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -104,7 +104,8 @@ void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_itera
 
 /**
  * Internal function for outputting the debug line.
- * @param level Debug category.
+ * @param category The category/classification of the debug message.
+ * @param level The severity of the debug level; lower is more likely to be shown.
  * @param message The message to output.
  */
 void DebugPrint(std::string_view category, int level, std::string &&message)

--- a/src/depot_cmd.h
+++ b/src/depot_cmd.h
@@ -18,6 +18,6 @@ CommandCost CmdRenameDepot(DoCommandFlags flags, DepotID depot_id, const std::st
 
 DEF_CMD_TRAIT(Commands::RenameDepot, CmdRenameDepot, {}, CommandType::OtherManagement)
 
-void CcCloneVehicle(Commands cmd, const CommandCost &result, VehicleID veh_id);
+void CcCloneVehicle(Commands, const CommandCost &result, VehicleID veh_id);
 
 #endif /* DEPOT_CMD_H */

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -397,6 +397,7 @@ Dimension GetDropDownListDimension(const DropDownList &list)
  * @param button   The widget which is passed to Window::OnDropdownSelect and OnDropdownClose.
  *                 Unless you override those functions, this should be then widget index of the dropdown button.
  * @param wi_rect  Coord of the parent drop down button, used to position the dropdown menu.
+ * @param wi_colour Colour of the parent widget.
  * @param options Drop Down options for this menu.
  */
 void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, WidgetID button, Rect wi_rect, Colours wi_colour, DropDownOptions options)

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -646,6 +646,7 @@ static void ClearLastVariant(EngineID engine_id, VehicleType type)
 /**
  * Update #Engine::reliability and (if needed) update the engine GUIs.
  * @param e %Engine to update.
+ * @param new_month Whether this is called from a 'new month' context or not, i.e. whether engines should be aged.
  */
 void CalcEngineReliability(Engine *e, bool new_month)
 {
@@ -715,7 +716,7 @@ void SetYearEngineAgingStops()
 /**
  * Start/initialise one engine.
  * @param e The engine to initialise.
- * @param aging_date The date used for age calculations.
+ * @param aging_ymd The date used for age calculations.
  * @param seed Random seed.
  */
 void StartupOneEngine(Engine *e, const TimerGameCalendar::YearMonthDay &aging_ymd, uint32_t seed)

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -456,6 +456,7 @@ std::string GetEngineInfoString(EngineID engine)
  * @param y      Vertical position to use for drawing the engine.
  * @param engine Engine to draw.
  * @param pal    Palette to use for drawing.
+ * @param image_type Context where the image is being drawn.
  */
 void DrawVehicleEngine(int left, int right, int preferred_x, int y, EngineID engine, PaletteID pal, EngineImageType image_type)
 {

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -78,6 +78,7 @@ static WindowDesc _errmsg_face_desc(
  * @param x            World X position (TileVirtX) of the error location. Set both x and y to 0 to just center the message when there is no related error tile.
  * @param y            World Y position (TileVirtY) of the error location. Set both x and y to 0 to just center the message when there is no related error tile.
  * @param extra_msg    Extra error message showed in third line. Can be empty.
+ * @param company The associated company to the error message. Company::Invalid() when there is none.
  */
 ErrorMessageData::ErrorMessageData(EncodedString &&summary_msg, EncodedString &&detailed_msg, bool is_critical, int x, int y, EncodedString &&extra_msg, CompanyID company) :
 	is_critical(is_critical),
@@ -310,6 +311,7 @@ void ShowErrorMessage(EncodedString &&summary_msg, int x, int y, CommandCost &cc
  * @param x            World X position (TileVirtX) of the error location. Set both x and y to 0 to just center the message when there is no related error tile.
  * @param y            World Y position (TileVirtY) of the error location. Set both x and y to 0 to just center the message when there is no related error tile.
  * @param extra_msg    Extra error message shown in third line. Can be empty.
+ * @param company The associated company to the error message. Company::Invalid() when there is none.
  */
 void ShowErrorMessage(EncodedString &&summary_msg, EncodedString &&detailed_msg, WarningLevel wl, int x, int y, EncodedString &&extra_msg, CompanyID company)
 {

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -236,7 +236,9 @@ static std::optional<FileHandle> FioFOpenFileTar(const TarFileListEntry &entry, 
 /**
  * Opens a OpenTTD file somewhere in a personal or global directory.
  * @param filename Name of the file to open.
+ * @param mode The fopen-mode to open the file.
  * @param subdir Subdirectory to open.
+ * @param[out] filesize Optional output for the size of the file.
  * @return File handle of the opened file, or \c nullptr if the file is not available.
  */
 std::optional<FileHandle> FioFOpenFile(std::string_view filename, std::string_view mode, Subdirectory subdir, size_t *filesize)

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -247,7 +247,7 @@ public:
 			fop(fop), callback_proc(callback_proc), file_list(file_list)
 	{}
 
-	bool AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename) override;
+	bool AddFile(const std::string &filename, size_t, const std::string &) override;
 };
 
 /**
@@ -539,6 +539,7 @@ void FiosGetHeightmapList(SaveLoadOperation fop, bool show_dirs, FileList &file_
  * Callback for FiosGetTownDataList.
  * @param fop Purpose of collecting the list.
  * @param file Name of the file to check.
+ * @param ext The file extension of the file to check.
  * @return a FIOS_TYPE_JSON type of the found file, FIOS_TYPE_INVALID if not a valid JSON file, and the title of the file (if any).
  */
 static std::tuple<FiosType, std::string> FiosGetTownDataListCallback(SaveLoadOperation fop, std::string_view file, std::string_view ext)

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -225,6 +225,8 @@ public:
 	 * try to resolve the filename of the font using fontconfig, where the
 	 * format is 'font family name' or 'font family name, font style'.
 	 * @param fs The font size to load.
+	 * @param fonttype The type of font that is requested to be loaded.
+	 * @return The loaded font, or \c nullptr when none could be loaded.
 	 */
 	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
 	{

--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -37,6 +37,7 @@ static std::array<std::unordered_map<char32_t, SpriteID>, FS_END> _char_maps{}; 
 
 /**
  * Get SpriteID associated with a character.
+ * @param fs The font size of the character.
  * @param key Character to find.
  * @return SpriteID for character, or 0 if not present.
  */

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -711,6 +711,7 @@ int DrawString(int left, int right, int top, StringID str, TextColour colour, St
  * Calculates height of string (in pixels). The string is changed to a multiline string if needed.
  * @param str string to check
  * @param maxw maximum string width
+ * @param fontsize The size of the initial characters.
  * @return height of pixels of string when it is drawn
  */
 int GetStringHeight(std::string_view str, int maxw, FontSize fontsize)
@@ -759,6 +760,7 @@ Dimension GetStringMultiLineBoundingBox(StringID str, const Dimension &suggestio
  * Calculate string bounding box for multi-line strings.
  * @param str        String to check.
  * @param suggestion Suggested bounding box.
+ * @param fontsize The size of the initial characters.
  * @return Bounding box for the multi-line string, may be bigger than \a suggestion.
  */
 Dimension GetStringMultiLineBoundingBox(std::string_view str, const Dimension &suggestion, FontSize fontsize)
@@ -905,6 +907,7 @@ Dimension GetStringBoundingBox(std::string_view str, FontSize start_fontsize)
  * Get bounding box of a string.
  * Has the same restrictions as #GetStringBoundingBox(std::string_view str, FontSize start_fontsize).
  * @param strid String to examine.
+ * @param start_fontsize Fontsize to start the text with.
  * @return Width and height of the bounding box for the string in pixels.
  */
 Dimension GetStringBoundingBox(StringID strid, FontSize start_fontsize)
@@ -1058,6 +1061,7 @@ void DrawSprite(SpriteID img, PaletteID pal, int x, int y, const SubSprite *sub,
  * @param y The Y location to draw.
  * @param mode The settings for the blitter to pass.
  * @param sub Whether to only draw a sub set of the sprite.
+ * @param sprite_id The unique identifier of the sprite for NewGRF debug purposes.
  * @param zoom The zoom level at which to draw the sprites.
  * @param dst Optional parameter for a different blitting destination.
  * @tparam ZOOM_BASE The factor required to get the sub sprite information into the right size.

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -145,7 +145,7 @@ ICUParagraphLayout::ICUVisualRun::ICUVisualRun(const ICURun &run, int x) :
  * Shape a single run.
  *
  * @param buff The buffer of which a partial (depending on start/length of the run) will be shaped.
- * @param length The length of the buffer.
+ * @param buff_length The length of the buffer.
  */
 void ICURun::Shape(UChar *buff, size_t buff_length)
 {

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -556,6 +556,7 @@ static void AddVehicleToGroup(Vehicle *v, GroupID new_g)
  * @param group_id index of group
  * @param veh_id vehicle to add to a group
  * @param add_shared Add shared vehicles as well.
+ * @param vli The list of vehicles that should be added to the group (can be empty).
  * @return the cost of this operation or an error
  */
 std::tuple<CommandCost, GroupID> CmdAddVehicleGroup(DoCommandFlags flags, GroupID group_id, VehicleID veh_id, bool add_shared, const VehicleListIdentifier &vli)
@@ -713,7 +714,9 @@ CommandCost CmdSetGroupLivery(DoCommandFlags flags, GroupID group_id, bool prima
 /**
  * Set group flag for a group and its sub-groups.
  * @param g initial group.
- * @param set 1 to set or 0 to clear protection.
+ * @param flag The flag to set.
+ * @param set \c true to set or \c false to clear protection.
+ * @param children Whether to propagate the change to the children.
  */
 static void SetGroupFlag(Group *g, GroupFlag flag, bool set, bool children)
 {

--- a/src/group_cmd.h
+++ b/src/group_cmd.h
@@ -43,7 +43,7 @@ DEF_CMD_TRAIT(Commands::RemoveAllVehiclesGroup, CmdRemoveAllVehiclesGroup, {}, C
 DEF_CMD_TRAIT(Commands::SetGroupFlag, CmdSetGroupFlag, {}, CommandType::RouteManagement)
 DEF_CMD_TRAIT(Commands::SetGroupLivery, CmdSetGroupLivery, {}, CommandType::RouteManagement)
 
-void CcCreateGroup(Commands cmd, const CommandCost &result, GroupID new_group, VehicleType vt, GroupID parent_group);
-void CcAddVehicleNewGroup(Commands cmd, const CommandCost &result, GroupID new_group, GroupID, VehicleID veh_id, bool, const VehicleListIdentifier &);
+void CcCreateGroup(Commands, const CommandCost &result, GroupID new_group, VehicleType vt, GroupID);
+void CcAddVehicleNewGroup(Commands, const CommandCost &result, GroupID new_group, GroupID, VehicleID, bool, const VehicleListIdentifier &);
 
 #endif /* GROUP_CMD_H */

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -159,7 +159,7 @@ static void GuiGroupListAddChildren(GUIGroupList &list, GUIGroupListItem &item, 
 
 /**
  * Build GUI group list, a sorted hierarchical list of groups for owner and vehicle type.
- * @param dst Destination list, owned by the caller.
+ * @param list Destination list, owned by the caller.
  * @param fold Whether to handle group folding/hiding.
  * @param owner Owner of groups.
  * @param veh_type Vehicle type of groups.
@@ -334,6 +334,7 @@ private:
 	 * Draw a row in the group list.
 	 * @param r Rect to draw row in.
 	 * @param g_id Group to list.
+	 * @param level_mask Bitset with the vertical lines of the tree that need to be drawn before this group.
 	 * @param indent Indentation level.
 	 * @param protection Whether autoreplace protection is set.
 	 * @param has_children Whether the group has children and should have a fold / unfold button.
@@ -1264,6 +1265,7 @@ static inline VehicleGroupWindow *FindVehicleGroupWindow(VehicleType vt, Owner o
 
 /**
  * Opens a 'Rename group' window for newly created group.
+ * @param gid The group that got created.
  * @param veh_type Vehicle type.
  */
 static void CcCreateGroup(GroupID gid, VehicleType veh_type)

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -42,6 +42,7 @@ static constexpr size_t CHANGELOG_VERSIONS_LIMIT = 20;
  * Find the path to the game manual file.
  *
  * @param filename The filename to find.
+ * @param subdir The sub directory to search in.
  * @return std::string The path to the filename if found.
  */
 static std::optional<std::string> FindGameManualFilePath(std::string_view filename, Subdirectory subdir)

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2380,6 +2380,7 @@ static uint GetNumberOfIndustries()
  * Since there is no feedback why placement fails, there is no other option
  * than to try a few times before concluding it does not work.
  * @param type     Industry type of the desired industry.
+ * @param creation_type The circumstances the industry is created under.
  * @param try_hard Try very hard to find a place. (Used to place at least one industry per type.)
  * @return Pointer to created industry, or \c nullptr if creation failed.
  */
@@ -2396,6 +2397,7 @@ static Industry *PlaceIndustry(IndustryType type, IndustryAvailabilityCallType c
 /**
  * Try to build a industry on the map.
  * @param type IndustryType of the desired industry
+ * @param water Whether building a water or land based industry.
  * @param try_hard Try very hard to find a place. (Used to place at least one industry per type)
  */
 static void PlaceInitialIndustry(IndustryType type, bool water, bool try_hard)

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1371,7 +1371,7 @@ protected:
 
 	/**
 	 * Set accepted cargo filter for the industry list.
-	 * @param index The cargo to be set
+	 * @param cargo_type The cargo to be set
 	 */
 	void SetAcceptedCargoFilter(CargoType cargo_type)
 	{

--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -35,8 +35,8 @@ void IniItem::SetValue(std::string_view value)
 
 /**
  * Construct a new in-memory group of an Ini file.
- * @param parent the file we belong to
  * @param name   the name of the group
+ * @param type The type of group.
  */
 IniGroup::IniGroup(std::string_view name, IniGroupType type) : type(type), comment("\n")
 {

--- a/src/linkgraph/demands.cpp
+++ b/src/linkgraph/demands.cpp
@@ -95,7 +95,6 @@ class AsymmetricScaler : public Scaler {
 public:
 	/**
 	 * Nothing to do here.
-	 * @param unused.
 	 */
 	inline void AddNode(const Node &)
 	{
@@ -103,7 +102,6 @@ public:
 
 	/**
 	 * Nothing to do here.
-	 * @param unused.
 	 */
 	inline void SetDemandPerNode(uint)
 	{
@@ -112,7 +110,6 @@ public:
 	/**
 	 * Get the effective supply of one node towards another one.
 	 * @param from The supplying node.
-	 * @param unused.
 	 */
 	inline uint EffectiveSupply(const Node &from, const Node &)
 	{
@@ -166,7 +163,7 @@ inline void Scaler::SetDemands(LinkGraphJob &job, NodeID from_id, NodeID to_id, 
 /**
  * Do the actual demand calculation, called from constructor.
  * @param job Job to calculate the demands for.
- * @tparam Tscaler Scaler to be used for scaling demands.
+ * @param scaler Scaler to be used for scaling demands.
  */
 template <class Tscaler>
 void DemandCalculator::CalcDemand(LinkGraphJob &job, Tscaler scaler)

--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -162,7 +162,8 @@ NodeID LinkGraph::AddNode(const Station *st)
  * @param to Destination node of the link.
  * @param capacity Capacity of the link.
  * @param usage Usage to be added.
- * @param mode Update mode to be used.
+ * @param travel_time Travel time to be added, in ticks.
+ * @param modes Update modes to be used.
  */
 void LinkGraph::BaseNode::AddEdge(NodeID to, uint capacity, uint usage, uint32_t travel_time, EdgeUpdateModes modes)
 {
@@ -181,7 +182,8 @@ void LinkGraph::BaseNode::AddEdge(NodeID to, uint capacity, uint usage, uint32_t
  * @param to Target node.
  * @param capacity Capacity of the link.
  * @param usage Usage to be added.
- * @param mode Update mode to be used.
+ * @param travel_time Travel time to be added, in ticks.
+ * @param modes Update modes to be used.
  */
 void LinkGraph::BaseNode::UpdateEdge(NodeID to, uint capacity, uint usage, uint32_t travel_time, EdgeUpdateModes modes)
 {
@@ -212,7 +214,7 @@ void LinkGraph::BaseNode::RemoveEdge(NodeID to)
  * @param capacity Capacity to be added/updated.
  * @param usage Usage to be added.
  * @param travel_time Travel time to be added, in ticks.
- * @param mode Update mode to be applied.
+ * @param modes Update modes to be applied.
  */
 void LinkGraph::BaseEdge::Update(uint capacity, uint usage, uint32_t travel_time, EdgeUpdateModes modes)
 {

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -190,6 +190,7 @@ public:
 
 	/**
 	 * Real constructor.
+	 * @param index Unique identifier of this graph.
 	 * @param cargo Cargo the link graph is about.
 	 */
 	LinkGraph(LinkGraphID index, CargoType cargo = INVALID_CARGO) :

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -235,9 +235,11 @@ void LinkGraphOverlay::AddLinks(const Station *from, const Station *to)
  * Add information from a given pair of link stat and flow stat to the given
  * link properties. The shown usage or plan is always the maximum of all link
  * stats involved.
+ * @param new_cargo Cargo type of the new link.
  * @param new_cap Capacity of the new link.
  * @param new_usg Usage of the new link.
  * @param new_plan Planned flow for the new link.
+ * @param time Travel time of the new link.
  * @param new_shared If the new link is shared.
  * @param cargo LinkProperties to write the information to.
  */

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -119,18 +119,21 @@ public:
 
 		/**
 		 * Get the transport demand between end the points of the edge.
+		 * @param to Remote end of the edge.
 		 * @return Demand.
 		 */
 		uint DemandTo(NodeID to) const { return this->demands[to].demand; }
 
 		/**
 		 * Get the transport demand that hasn't been satisfied by flows, yet.
+		 * @param to Remote end of the edge.
 		 * @return Unsatisfied demand.
 		 */
 		uint UnsatisfiedDemandTo(NodeID to) const { return this->demands[to].unsatisfied_demand; }
 
 		/**
 		 * Satisfy some demand.
+		 * @param to Remote end of the edge.
 		 * @param demand Demand to be satisfied.
 		 */
 		void SatisfyDemandTo(NodeID to, uint demand)

--- a/src/linkgraph/mcf.cpp
+++ b/src/linkgraph/mcf.cpp
@@ -31,7 +31,7 @@ public:
 	 */
 	DistanceAnnotation(NodeID n, bool source = false) : Path(n, source) {}
 
-	bool IsBetter(const DistanceAnnotation *base, uint cap, int free_cap, uint dist) const;
+	bool IsBetter(const DistanceAnnotation *base, uint, int free_cap, uint dist) const;
 
 	/**
 	 * Return the actual value of the annotation, in this case the distance.
@@ -232,6 +232,7 @@ bool DistanceAnnotation::IsBetter(const DistanceAnnotation *base, uint,
  * Determines if an extension to the given Path with the given parameters is
  * better than this path.
  * @param base Other path.
+ * @param cap Capacity of the edge.
  * @param free_cap Capacity of the new edge to be added to base.
  * @param dist Distance of the new edge.
  * @return True if base + the new edge would be better than the path associated

--- a/src/linkgraph/mcf.h
+++ b/src/linkgraph/mcf.h
@@ -85,7 +85,7 @@ public:
 
 	/**
 	 * Run the calculation.
-	 * @param graph Component to be calculated.
+	 * @param job Component to be calculated.
 	 */
 	void Run(LinkGraphJob &job) const override { Tpass pass(job); }
 };

--- a/src/misc/getoptdata.h
+++ b/src/misc/getoptdata.h
@@ -37,7 +37,7 @@ struct GetOptData {
 
 	/**
 	 * Constructor of the data store.
-	 * @param argument The command line arguments, excluding the program name.
+	 * @param arguments The command line arguments, excluding the program name.
 	 * @param options Command line option descriptions.
 	 */
 	GetOptData(ArgumentSpan arguments, OptionSpan options) : arguments(arguments), options(options) {}

--- a/src/misc_cmd.cpp
+++ b/src/misc_cmd.cpp
@@ -120,6 +120,7 @@ CommandCost CmdDecreaseLoan(DoCommandFlags flags, LoanCommand cmd, Money amount)
 
 /**
  * Sets the max loan amount of your company. Does not respect the global loan setting.
+ * @param flags Flags whether to test or execute this command.
  * @param company the company ID.
  * @param amount the new max loan amount, will be rounded down to the multitude of LOAN_INTERVAL. If set to COMPANY_MAX_LOAN_DEFAULT reset the max loan to default(global) value.
  * @return zero cost or an error

--- a/src/misc_cmd.h
+++ b/src/misc_cmd.h
@@ -21,7 +21,7 @@ enum class LoanCommand : uint8_t {
 	Amount, ///< Loan/repay the given amount.
 };
 
-CommandCost CmdMoneyCheat(DoCommandFlags flags, Money amount);
+CommandCost CmdMoneyCheat(DoCommandFlags, Money amount);
 CommandCost CmdChangeBankBalance(DoCommandFlags flags, TileIndex tile, Money delta, CompanyID company, ExpensesType expenses_type);
 CommandCost CmdIncreaseLoan(DoCommandFlags flags, LoanCommand cmd, Money amount);
 CommandCost CmdDecreaseLoan(DoCommandFlags flags, LoanCommand cmd, Money amount);

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -570,6 +570,7 @@ TextEffectID ShowFillingPercent(int x, int y, int z, uint8_t percent, StringID s
 /**
  * Update vehicle loading indicators.
  * @param te_id   TextEffectID to be updated.
+ * @param percent Percentage of (un)loading.
  * @param string  String which is printed.
  */
 void UpdateFillingPercent(TextEffectID te_id, uint8_t percent, StringID string)

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -438,7 +438,7 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
  *
  * @param connection_string The string to parse.
  * @param default_port The default port to set port to if not in connection_string.
- * @param company Pointer to the company variable to set iff indicated.
+ * @param company_id Pointer to the company variable to set iff indicated.
  * @return A valid ServerAddress of the parsed information.
  */
 /* static */ ServerAddress ServerAddress::Parse(std::string_view connection_string, uint16_t default_port, CompanyID *company_id)

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -199,6 +199,7 @@ static void HandleIncomingNetworkGameInfoGRFConfig(GRFConfig &config, std::strin
  * Serializes the NetworkGameInfo struct to the packet.
  * @param p    the packet to write the data to.
  * @param info the NetworkGameInfo struct to serialize from.
+ * @param send_newgrf_names Whether to send the NewGRF names or not.
  */
 void SerializeNetworkGameInfo(Packet &p, const NetworkServerGameInfo &info, bool send_newgrf_names)
 {
@@ -267,6 +268,7 @@ void SerializeNetworkGameInfo(Packet &p, const NetworkServerGameInfo &info, bool
  * Deserializes the NetworkGameInfo struct from the packet.
  * @param p    the packet to read the data from.
  * @param info the NetworkGameInfo to deserialize into.
+ * @param newgrf_lookup_table Lookup table for index-mapped NewGRFs.
  */
 void DeserializeNetworkGameInfo(Packet &p, NetworkGameInfo &info, const GameInfoNewGRFLookupTable *newgrf_lookup_table)
 {

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -23,6 +23,7 @@
  * @param connection_string The address to connect to.
  * @param default_port If not indicated in connection_string, what port to use.
  * @param bind_address The local bind address to use. Defaults to letting the OS find one.
+ * @param family The IP-family to connect with.
  */
 TCPConnecter::TCPConnecter(std::string_view connection_string, uint16_t default_port, const NetworkAddress &bind_address, int family) :
 	bind_address(bind_address),

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -98,6 +98,7 @@ void ClientNetworkEmergencySave()
 /**
  * Create a new socket for the client side of the game connection.
  * @param s The socket to connect with.
+ * @param connection_string The connection string that the connection was made with.
  */
 ClientNetworkGameSocketHandler::ClientNetworkGameSocketHandler(SOCKET s, std::string_view connection_string) : NetworkGameSocketHandler(s), connection_string(connection_string)
 {
@@ -1287,7 +1288,7 @@ bool NetworkValidateOurClientName()
 
 /**
  * Send the server our name as callback from the setting.
- * @param newname The new client name.
+ * @param client_name The new client name.
  */
 void NetworkUpdateClientName(const std::string &client_name)
 {

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -696,7 +696,7 @@ class NetworkContentConnecter : public TCPConnecter {
 public:
 	/**
 	 * Initiate the connecting.
-	 * @param address The address of the server.
+	 * @param connection_string The address of the server.
 	 */
 	NetworkContentConnecter(std::string_view connection_string) : TCPConnecter(connection_string, NETWORK_CONTENT_SERVER_PORT) {}
 

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -576,6 +576,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectFailure(std::string_view toke
  * to the game server is established.
  * @param token Token of the connecter that succeeded.
  * @param sock The socket that the connecter can now use.
+ * @param address Address of the client that connected.
  */
 void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(std::string_view token, SOCKET sock, NetworkAddress &address)
 {

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1604,7 +1604,7 @@ static void NetworkAutoCleanCompanies()
 
 /**
  * Check whether a name is unique, and otherwise try to make it unique.
- * @param new_name The name to check/modify.
+ * @param name The name to check/modify.
  * @return True if an unique name was achieved.
  */
 bool NetworkMakeClientNameUnique(std::string &name)

--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -27,6 +27,8 @@ public:
 	 * Initiate the connecting.
 	 * @param stun_handler The handler for this request.
 	 * @param connection_string The address of the server.
+	 * @param token The (server) token for the STUN action.
+	 * @param family The IP-family to connect with.
 	 */
 	NetworkStunConnecter(ClientNetworkStunSocketHandler *stun_handler, std::string_view connection_string, std::string_view token, uint8_t family) :
 		TCPConnecter(connection_string, NETWORK_STUN_SERVER_PORT, NetworkAddress(), family),

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -23,6 +23,7 @@ private:
 public:
 	/**
 	 * Initiate the connecting.
+	 * @param handler Callback handler for denoting success or failure.
 	 * @param connection_string The address of the TURN server.
 	 */
 	NetworkTurnConnecter(ClientNetworkTurnSocketHandler *handler, std::string_view connection_string) : TCPConnecter(connection_string, NETWORK_TURN_SERVER_PORT), handler(handler) {}

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -28,6 +28,7 @@ struct AirportTileScopeResolver : public ScopeResolver {
 
 	/**
 	 * Constructor of the scope resolver specific for airport tiles.
+	 * @param ro Surrounding resolver.
 	 * @param ats Specification of the airport tiles.
 	 * @param tile %Tile for the callback, only valid for airporttile callbacks.
 	 * @param st Station of the airport for which the callback is run, or \c nullptr for build gui.

--- a/src/newgrf_badge_gui.cpp
+++ b/src/newgrf_badge_gui.cpp
@@ -380,7 +380,8 @@ DropDownList BuildBadgeClassConfigurationList(const GUIBadgeClasses &gui_classes
  * Toggle badge class visibility.
  * @param feature Feature being used.
  * @param class_badge Class badge.
- * @param click Dropdown click result.
+ * @param click_result Dropdown click result.
+ * @param choices Configuration of the badge filters.
  */
 static void BadgeClassToggleVisibility(GrfSpecFeature feature, Badge &class_badge, int click_result, BadgeFilterChoices &choices)
 {
@@ -460,6 +461,7 @@ static void BadgeClassMoveNext(GrfSpecFeature feature, Badge &class_badge, uint 
  * @param columns Maximum column number permitted.
  * @param result Selected dropdown item value.
  * @param click_result Dropdown click result.
+ * @param choices Configuration of the badge filters.
  * @return true iff the caller should reinitialise their widgets.
  */
 bool HandleBadgeConfigurationDropDownClick(GrfSpecFeature feature, uint columns, int result, int click_result, BadgeFilterChoices &choices)
@@ -552,7 +554,7 @@ DropDownList NWidgetBadgeFilter::GetDropDownList(PaletteID palette) const
 /**
  * Add badge drop down filter widgets.
  * @param window Window that holds the container.
- * @param container Container widget index to hold filter widgets.
+ * @param container_id Container widget index to hold filter widgets.
  * @param widget Widget index to apply to first filter.
  * @param colour Background colour of widgets.
  * @param feature GRF feature for filters.

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -145,6 +145,7 @@ void RoadVehicle::GetImage(Direction direction, EngineImageType image_type, Vehi
  * @param y Vertical position of the engine.
  * @param engine Engine to draw
  * @param pal Palette to use.
+ * @param image_type Context where the image is being drawn.
  */
 void DrawRoadVehEngine(int left, int right, int preferred_x, int y, EngineID engine, PaletteID pal, EngineImageType image_type)
 {

--- a/src/roadveh_gui.cpp
+++ b/src/roadveh_gui.cpp
@@ -108,6 +108,7 @@ void DrawRoadVehDetails(const Vehicle *v, const Rect &r)
  * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
  * @param skip      Number of pixels to skip at the front (for scrolling)
+ * @param image_type Context where the image is being drawn.
  */
 void DrawRoadVehImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip)
 {

--- a/src/ship_gui.cpp
+++ b/src/ship_gui.cpp
@@ -25,6 +25,7 @@
  * @param v         Front vehicle
  * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
+ * @param image_type Context where the image is being drawn.
  */
 void DrawShipImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type)
 {

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -92,6 +92,7 @@ static int HighlightDragPosition(int px, int max_width, int y, VehicleID selecti
  * @param v         Front vehicle
  * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
+ * @param image_type Context where the image is being drawn.
  * @param skip      Number of pixels to skip at the front (for scrolling)
  * @param drag_dest The vehicle another one is dragged over, \c VehicleID::Invalid() if none.
  */

--- a/src/tunnelbridge_cmd.h
+++ b/src/tunnelbridge_cmd.h
@@ -20,6 +20,6 @@ CommandCost CmdBuildTunnel(DoCommandFlags flags, TileIndex start_tile, Transport
 DEF_CMD_TRAIT(Commands::BuildBridge, CmdBuildBridge, CommandFlags({CommandFlag::Deity, CommandFlag::Auto, CommandFlag::NoWater}), CommandType::LandscapeConstruction)
 DEF_CMD_TRAIT(Commands::BuildTunnel, CmdBuildTunnel, CommandFlags({CommandFlag::Deity, CommandFlag::Auto}),                       CommandType::LandscapeConstruction)
 
-void CcBuildBridge(Commands cmd, const CommandCost &result, TileIndex end_tile, TileIndex tile_start, TransportType transport_type, BridgeType, uint8_t);
+void CcBuildBridge(Commands, const CommandCost &result, TileIndex end_tile, TileIndex tile_start, TransportType transport_type, BridgeType, uint8_t);
 
 #endif /* TUNNELBRIDGE_CMD_H */

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -436,6 +436,7 @@ public:
 	/**
 	 * Gets the sprite to show for the given direction
 	 * @param direction the direction the vehicle is facing
+	 * @param image_type Context where the image is being drawn.
 	 * @param[out] result Vehicle sprite sequence.
 	 */
 	virtual void GetImage([[maybe_unused]] Direction direction, [[maybe_unused]] EngineImageType image_type, [[maybe_unused]] VehicleSpriteSeq *result) const { result->Clear(); }

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1705,6 +1705,7 @@ static void DrawSmallOrderList(const OrderList *orderlist, int left, int right, 
  * @param v         Front vehicle
  * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
+ * @param image_type Context where the image is being drawn.
  * @param skip      Number of pixels to skip at the front (for scrolling)
  */
 void DrawVehicleImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip)
@@ -3511,6 +3512,7 @@ void CcBuildPrimaryVehicle(Commands, const CommandCost &result, VehicleID new_ve
 /**
  * Get the width of a vehicle (part) in pixels.
  * @param v Vehicle to get the width for.
+ * @param image_type Context where the image is being drawn.
  * @return Width of the vehicle.
  */
 int GetSingleVehicleWidth(const Vehicle *v, EngineImageType image_type)
@@ -3535,6 +3537,7 @@ int GetSingleVehicleWidth(const Vehicle *v, EngineImageType image_type)
 /**
  * Get the width of a vehicle (including all parts of the consist) in pixels.
  * @param v Vehicle to get the width for.
+ * @param image_type Context where the image is being drawn.
  * @return Width of the vehicle.
  */
 int GetVehicleWidth(const Vehicle *v, EngineImageType image_type)

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -281,6 +281,7 @@ bool Window::IsWidgetHighlighted(WidgetID widget_index) const
  * @param pt the point inside the window the mouse resides on after closure.
  * @param widget the widget (button) that the dropdown is associated with.
  * @param index the element in the dropdown that is selected.
+ * @param click_result The result of the OnClick call.
  * @param instant_close whether the dropdown was configured to close on mouse up.
  */
 void Window::OnDropdownClose(Point pt, WidgetID widget, int index, int click_result, bool instant_close)

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -688,6 +688,7 @@ public:
 	 * Event to display a custom tooltip.
 	 * @param pt     The point where the mouse is located.
 	 * @param widget The widget where the mouse is located.
+	 * @param close_cond The conditions when to close the tooltip.
 	 * @return True if the event is handled, false if it is ignored.
 	 */
 	virtual bool OnTooltip([[maybe_unused]] Point pt, [[maybe_unused]] WidgetID widget, [[maybe_unused]] TooltipCloseCondition close_cond) { return false; }


### PR DESCRIPTION
## Motivation / Problem

Loads of doxygen warnings about undocumented parameters.


## Description

Fix some documentation.

I mostly went through the ones where parameters were documented, but not all. This incidentally also triggers when doxygen parameter and function parameter names mismatch.

In the case of command callbacks, the parameter name was removed in some cases of the declaration to denote that they are not used. This also silences the doxygen warning about the parameter.


## Limitations

This is definitely not all; baby steps.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
