### PR TITLE
Change: Fix the UI workflow for entering the scenario editor

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1185,14 +1185,6 @@ struct CreateScenarioWindow : public Window
 				ShowDropDownList(this, BuildMapsizeDropDown(), _settings_newgame.game_creation.map_y, WID_CS_MAPSIZE_Y_PULLDOWN);
 				break;
 
-			case WID_CS_EMPTY_WORLD: // Empty world / flat world
-				StartGeneratingLandscape(GLWM_SCENARIO);
-				break;
-
-			case WID_CS_RANDOM_WORLD: // Generate
-				ShowGenerateLandscape();
-				break;
-
 			case WID_CS_START_DATE_DOWN:
 			case WID_CS_START_DATE_UP: // Year buttons
 				/* Don't allow too fast scrolling */
@@ -1225,6 +1217,22 @@ struct CreateScenarioWindow : public Window
 			case WID_CS_FLAT_LAND_HEIGHT_TEXT: // Height level text
 				this->widget_id = WID_CS_FLAT_LAND_HEIGHT_TEXT;
 				ShowQueryString(GetString(STR_JUST_INT, _settings_newgame.game_creation.se_flat_world_height), STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_QUERY_CAPT, 4, this, CS_NUMERAL, {});
+				break;
+
+			case WID_GL_AI_BUTTON: ///< AI Settings
+				ShowAIConfigWindow();
+				break;
+
+			case WID_GL_GS_BUTTON: ///< Game Script Settings
+				ShowGSConfigWindow();
+				break;
+
+			case WID_GL_NEWGRF_BUTTON: ///< NewGRF Settings
+				ShowNewGRFSettings(true, true, false, _grfconfig_newgame);
+				break;
+
+			case WID_CS_EMPTY_WORLD: // Empty world / flat world
+				StartGeneratingLandscape(GLWM_SCENARIO);
 				break;
 		}
 	}
@@ -1281,46 +1289,49 @@ static constexpr std::initializer_list<NWidgetPart> _nested_create_scenario_widg
 				NWidget(WWT_IMGBTN_2, Colours::Orange, WID_CS_TOYLAND), SetSpriteTip(SPR_SELECT_TOYLAND, STR_INTRO_TOOLTIP_TOYLAND_LANDSCAPE),
 			EndContainer(),
 
-			NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_wide, 0),
-				/* Green generation type buttons: 'Flat land' and 'Random land'. */
+			/* Labels + setting drop-downs */
+			NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_normal, 0),
+				/* Labels. */
 				NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
-					NWidget(WWT_PUSHTXTBTN, Colours::Green, WID_CS_EMPTY_WORLD), SetStringTip(STR_SE_MAPGEN_FLAT_WORLD, STR_SE_MAPGEN_FLAT_WORLD_TOOLTIP), SetFill(1, 1),
-					NWidget(WWT_PUSHTXTBTN, Colours::Green, WID_CS_RANDOM_WORLD), SetStringTip(STR_SE_MAPGEN_RANDOM_LAND, STR_TERRAFORM_TOOLTIP_GENERATE_RANDOM_LAND), SetFill(1, 1),
+					NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_MAPSIZE, STR_MAPGEN_MAPSIZE_TOOLTIP), SetFill(0, 1),
+					NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_DATE, STR_MAPGEN_DATE_TOOLTIP), SetFill(0, 1),
+					NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_SE_MAPGEN_FLAT_WORLD_HEIGHT, STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_TOOLTIP), SetFill(0, 1),
 				EndContainer(),
 
-				/* Labels + setting drop-downs */
-				NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_normal, 0),
-					/* Labels. */
-					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
-						NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_MAPSIZE, STR_MAPGEN_MAPSIZE_TOOLTIP), SetFill(0, 1),
-						NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_DATE, STR_MAPGEN_DATE_TOOLTIP), SetFill(0, 1),
-						NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_SE_MAPGEN_FLAT_WORLD_HEIGHT, STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_TOOLTIP), SetFill(0, 1),
+				NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
+					/* Map size. */
+					NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_normal, 0),
+						NWidget(WWT_DROPDOWN, Colours::Orange, WID_CS_MAPSIZE_X_PULLDOWN), SetToolTip(STR_MAPGEN_MAPSIZE_TOOLTIP), SetFill(1, 1),
+						NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_BY), SetFill(0, 1), SetAlignment(SA_CENTER),
+						NWidget(WWT_DROPDOWN, Colours::Orange, WID_CS_MAPSIZE_Y_PULLDOWN), SetToolTip(STR_MAPGEN_MAPSIZE_TOOLTIP), SetFill(1, 1),
 					EndContainer(),
 
-					NWidget(NWID_VERTICAL, NWidContainerFlag::EqualSize), SetPIP(0, WidgetDimensions::unscaled.vsep_sparse, 0),
-						/* Map size. */
-						NWidget(NWID_HORIZONTAL), SetPIP(0, WidgetDimensions::unscaled.hsep_normal, 0),
-							NWidget(WWT_DROPDOWN, Colours::Orange, WID_CS_MAPSIZE_X_PULLDOWN), SetToolTip(STR_MAPGEN_MAPSIZE_TOOLTIP), SetFill(1, 1),
-							NWidget(WWT_TEXT, Colours::Invalid), SetStringTip(STR_MAPGEN_BY), SetFill(0, 1), SetAlignment(SA_CENTER),
-							NWidget(WWT_DROPDOWN, Colours::Orange, WID_CS_MAPSIZE_Y_PULLDOWN), SetToolTip(STR_MAPGEN_MAPSIZE_TOOLTIP), SetFill(1, 1),
-						EndContainer(),
+					/* Date. */
+					NWidget(NWID_HORIZONTAL),
+						NWidget(WWT_IMGBTN, Colours::Orange, WID_CS_START_DATE_DOWN), SetFill(0, 1), SetSpriteTip(SPR_ARROW_DOWN, STR_SCENEDIT_TOOLBAR_MOVE_THE_STARTING_DATE_BACKWARD_TOOLTIP), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
+						NWidget(WWT_PUSHTXTBTN, Colours::Orange, WID_CS_START_DATE_TEXT),  SetFill(1, 1), SetToolTip(STR_MAPGEN_DATE_TOOLTIP),
+						NWidget(WWT_IMGBTN, Colours::Orange, WID_CS_START_DATE_UP), SetFill(0, 1), SetSpriteTip(SPR_ARROW_UP, STR_SCENEDIT_TOOLBAR_MOVE_THE_STARTING_DATE_FORWARD_TOOLTIP), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
+					EndContainer(),
 
-						/* Date. */
-						NWidget(NWID_HORIZONTAL),
-							NWidget(WWT_IMGBTN, Colours::Orange, WID_CS_START_DATE_DOWN), SetFill(0, 1), SetSpriteTip(SPR_ARROW_DOWN, STR_SCENEDIT_TOOLBAR_MOVE_THE_STARTING_DATE_BACKWARD_TOOLTIP), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
-							NWidget(WWT_PUSHTXTBTN, Colours::Orange, WID_CS_START_DATE_TEXT),  SetFill(1, 1), SetToolTip(STR_MAPGEN_DATE_TOOLTIP),
-							NWidget(WWT_IMGBTN, Colours::Orange, WID_CS_START_DATE_UP), SetFill(0, 1), SetSpriteTip(SPR_ARROW_UP, STR_SCENEDIT_TOOLBAR_MOVE_THE_STARTING_DATE_FORWARD_TOOLTIP), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
-						EndContainer(),
-
-						/* Flat map height. */
-						NWidget(NWID_HORIZONTAL),
-							NWidget(WWT_IMGBTN, Colours::Orange, WID_CS_FLAT_LAND_HEIGHT_DOWN), SetFill(0, 1), SetSpriteTip(SPR_ARROW_DOWN, STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_DOWN_TOOLTIP), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
-							NWidget(WWT_PUSHTXTBTN, Colours::Orange, WID_CS_FLAT_LAND_HEIGHT_TEXT),  SetFill(1, 1), SetToolTip(STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_TOOLTIP),
-							NWidget(WWT_IMGBTN, Colours::Orange, WID_CS_FLAT_LAND_HEIGHT_UP), SetFill(0, 1), SetSpriteTip(SPR_ARROW_UP, STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_UP_TOOLTIP), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
-						EndContainer(),
+					/* Flat map height. */
+					NWidget(NWID_HORIZONTAL),
+						NWidget(WWT_IMGBTN, Colours::Orange, WID_CS_FLAT_LAND_HEIGHT_DOWN), SetFill(0, 1), SetSpriteTip(SPR_ARROW_DOWN, STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_DOWN_TOOLTIP), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
+						NWidget(WWT_PUSHTXTBTN, Colours::Orange, WID_CS_FLAT_LAND_HEIGHT_TEXT),  SetFill(1, 1), SetToolTip(STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_TOOLTIP),
+						NWidget(WWT_IMGBTN, Colours::Orange, WID_CS_FLAT_LAND_HEIGHT_UP), SetFill(0, 1), SetSpriteTip(SPR_ARROW_UP, STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_UP_TOOLTIP), SetAspect(WidgetDimensions::ASPECT_UP_DOWN_BUTTON),
 					EndContainer(),
 				EndContainer(),
 			EndContainer(),
+
+			/* AI, GS, and NewGRF settings */
+			NWidget(NWID_HORIZONTAL, NWidContainerFlag::EqualSize),
+				NWidget(WWT_PUSHTXTBTN, Colours::Orange, WID_GL_AI_BUTTON), SetMinimalTextLines(2, 0), SetStringTip(STR_MAPGEN_AI_SETTINGS, STR_MAPGEN_AI_SETTINGS_TOOLTIP), SetFill(1, 0),
+				NWidget(WWT_PUSHTXTBTN, Colours::Orange, WID_GL_GS_BUTTON), SetMinimalTextLines(2, 0), SetStringTip(STR_MAPGEN_GS_SETTINGS, STR_MAPGEN_GS_SETTINGS_TOOLTIP), SetFill(1, 0),
+				NWidget(WWT_PUSHTXTBTN, Colours::Orange, WID_GL_NEWGRF_BUTTON), SetMinimalTextLines(2, 0), SetStringTip(STR_MAPGEN_NEWGRF_SETTINGS, STR_MAPGEN_NEWGRF_SETTINGS_TOOLTIP), SetFill(1, 0),
+			EndContainer(),
+
+			/* Green enter scenario editor button. */
+			NWidget(WWT_PUSHTXTBTN, Colours::Green, WID_CS_EMPTY_WORLD), SetMinimalTextLines(2, 0), SetStringTip(STR_SE_MAPGEN_FLAT_WORLD, STR_SE_MAPGEN_FLAT_WORLD_TOOLTIP), SetFill(1, 1),
+
 		EndContainer(),
 	EndContainer(),
 };

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -316,7 +316,7 @@ struct SelectGameWindow : public Window {
 				break;
 			case WID_SGI_EDIT_SCENARIO:
 				_is_network_server = false;
-				StartScenarioEditor();
+				ShowCreateScenario();
 				break;
 
 			case WID_SGI_PLAY_NETWORK:

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3496,10 +3496,9 @@ STR_MAPGEN_DESERT_COVERAGE_QUERY_CAPT                           :{WHITE}Desert c
 STR_MAPGEN_START_DATE_QUERY_CAPT                                :{WHITE}Change starting year
 
 # SE Map generation
-STR_SE_MAPGEN_CAPTION                                           :{WHITE}Scenario Type
-STR_SE_MAPGEN_FLAT_WORLD                                        :{WHITE}Flat land
-STR_SE_MAPGEN_FLAT_WORLD_TOOLTIP                                :{BLACK}Generate a flat land
-STR_SE_MAPGEN_RANDOM_LAND                                       :{WHITE}Random land
+STR_SE_MAPGEN_CAPTION                                           :{WHITE}New Scenario
+STR_SE_MAPGEN_FLAT_WORLD                                        :{WHITE}Generate empty world
+STR_SE_MAPGEN_FLAT_WORLD_TOOLTIP                                :{BLACK}Generate an empty flat land new scenario
 STR_SE_MAPGEN_FLAT_WORLD_HEIGHT                                 :{BLACK}Height of flat land:
 STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_TOOLTIP                         :{BLACK}Choose the height of the land above sea level
 STR_SE_MAPGEN_FLAT_WORLD_HEIGHT_DOWN_TOOLTIP                    :{BLACK}Move the height of flat land one down

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -423,7 +423,7 @@ STR_SCENEDIT_TOOLBAR_MOVE_THE_STARTING_DATE_BACKWARD_TOOLTIP    :{BLACK}Move the
 STR_SCENEDIT_TOOLBAR_MOVE_THE_STARTING_DATE_FORWARD_TOOLTIP     :{BLACK}Move the starting date forward 1 year
 STR_SCENEDIT_TOOLBAR_SET_DATE_TOOLTIP                           :{BLACK}Click to enter the starting year
 STR_SCENEDIT_TOOLBAR_DISPLAY_MAP_TOWN_DIRECTORY_TOOLTIP         :{BLACK}Open map, extra viewport, sign list, or town or industry directory
-STR_SCENEDIT_TOOLBAR_LANDSCAPE_GENERATION_TOOLTIP               :{BLACK}Open landscaping menu or generate a new world
+STR_SCENEDIT_TOOLBAR_LANDSCAPE_GENERATION_TOOLTIP               :{BLACK}Open landscaping menu, reset or generate a new world
 STR_SCENEDIT_TOOLBAR_TOWN_GENERATION_TOOLTIP                    :{BLACK}Build or generate towns
 STR_SCENEDIT_TOOLBAR_INDUSTRY_GENERATION_TOOLTIP                :{BLACK}Build or generate industries
 STR_SCENEDIT_TOOLBAR_ROAD_CONSTRUCTION_TOOLTIP                  :{BLACK}Build road infrastructure
@@ -433,9 +433,10 @@ STR_SCENEDIT_TOOLBAR_PLACE_SIGN_TOOLTIP                         :{BLACK}Place si
 STR_SCENEDIT_TOOLBAR_PLACE_OBJECT_TOOLTIP                       :{BLACK}Place object. Ctrl+Click+Drag to select the area diagonally. Also press Shift to show cost estimate only
 
 # Scenario editor file menu
-###length 7
+###length 8
 STR_SCENEDIT_FILE_MENU_SAVE_SCENARIO                            :Save scenario
 STR_SCENEDIT_FILE_MENU_LOAD_SCENARIO                            :Load scenario
+STR_SCENEDIT_FILE_MENU_NEW_SCENARIO                             :New scenario
 STR_SCENEDIT_FILE_MENU_SAVE_HEIGHTMAP                           :Save heightmap
 STR_SCENEDIT_FILE_MENU_LOAD_HEIGHTMAP                           :Load heightmap
 STR_SCENEDIT_FILE_MENU_QUIT_EDITOR                              :Abandon scenario editor
@@ -3092,7 +3093,7 @@ STR_TERRAFORM_TOOLTIP_DEFINE_DESERT_AREA                        :{BLACK}Define d
 STR_TERRAFORM_TOOLTIP_INCREASE_SIZE_OF_LAND_AREA                :{BLACK}Increase area of land to lower/raise
 STR_TERRAFORM_TOOLTIP_DECREASE_SIZE_OF_LAND_AREA                :{BLACK}Decrease area of land to lower/raise
 STR_TERRAFORM_TOOLTIP_GENERATE_RANDOM_LAND                      :{BLACK}Generate random land
-STR_TERRAFORM_SE_NEW_WORLD                                      :{BLACK}Create new scenario
+STR_TERRAFORM_SE_GENERATE_RANDOM_LAND                           :{BLACK}Generate random landscape
 STR_TERRAFORM_RESET_LANDSCAPE                                   :{BLACK}Reset landscape
 STR_TERRAFORM_RESET_LANDSCAPE_TOOLTIP                           :{BLACK}Remove all company-owned property from the map
 

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -491,8 +491,8 @@ static constexpr std::initializer_list<NWidgetPart> _nested_scen_edit_land_gen_w
 			NWidget(NWID_SPACER), SetMinimalSize(2, 0),
 		EndContainer(),
 		NWidget(NWID_SPACER), SetMinimalSize(0, 6),
-		NWidget(WWT_TEXTBTN, Colours::Grey, WID_ETT_NEW_SCENARIO), SetMinimalSize(160, 12),
-								SetFill(1, 0), SetStringTip(STR_TERRAFORM_SE_NEW_WORLD, STR_TERRAFORM_TOOLTIP_GENERATE_RANDOM_LAND), SetPadding(0, 2, 0, 2),
+		NWidget(WWT_TEXTBTN, Colours::Grey, WID_ETT_RANDOM_LANDSCAPE), SetMinimalSize(160, 12),
+								SetFill(1, 0), SetStringTip(STR_TERRAFORM_SE_GENERATE_RANDOM_LAND, STR_TERRAFORM_TOOLTIP_GENERATE_RANDOM_LAND), SetPadding(0, 2, 0, 2),
 		NWidget(WWT_TEXTBTN, Colours::Grey, WID_ETT_RESET_LANDSCAPE), SetMinimalSize(160, 12),
 								SetFill(1, 0), SetStringTip(STR_TERRAFORM_RESET_LANDSCAPE, STR_TERRAFORM_RESET_LANDSCAPE_TOOLTIP), SetPadding(1, 2, 2, 2),
 	EndContainer(),
@@ -629,9 +629,9 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 				break;
 			}
 
-			case WID_ETT_NEW_SCENARIO: // gen random land
+			case WID_ETT_RANDOM_LANDSCAPE: // gen random land
 				this->HandleButtonClick(widget);
-				ShowCreateScenario();
+				ShowGenerateLandscape();
 				break;
 
 			case WID_ETT_RESET_LANDSCAPE: // Reset landscape

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -62,6 +62,7 @@
 #include "timer/timer_game_calendar.h"
 #include "help_gui.h"
 #include "core/string_consumer.hpp"
+#include "genworld.h"
 
 #include "widgets/toolbar_widget.h"
 
@@ -352,6 +353,7 @@ static CallBackFunction MenuClickSettings(int index)
 enum class SaveLoadEditorMenuEntries : uint8_t {
 	SaveScenario = 0, ///< Save the scenario.
 	LoadScenario, ///< Load a scenario.
+	NewScenario, ///< Create new scenario configuring climate, size, etc.
 	SaveHeightmap, ///< Save the heightmap.
 	LoadHeightmap, ///< Load a heightmap.
 	ExitToMainMenu, ///< Exit to main menu.
@@ -390,8 +392,9 @@ static CallBackFunction ToolbarSaveClick(Window *w)
 static CallBackFunction ToolbarScenSaveOrLoad(Window *w)
 {
 	PopupMainToolbarMenu(w, WID_TE_SAVE, {STR_SCENEDIT_FILE_MENU_SAVE_SCENARIO, STR_SCENEDIT_FILE_MENU_LOAD_SCENARIO,
-			STR_SCENEDIT_FILE_MENU_SAVE_HEIGHTMAP, STR_SCENEDIT_FILE_MENU_LOAD_HEIGHTMAP,
-			STR_SCENEDIT_FILE_MENU_QUIT_EDITOR, STR_NULL, STR_SCENEDIT_FILE_MENU_QUIT});
+			STR_SCENEDIT_FILE_MENU_NEW_SCENARIO, STR_SCENEDIT_FILE_MENU_SAVE_HEIGHTMAP,
+			STR_SCENEDIT_FILE_MENU_LOAD_HEIGHTMAP, STR_SCENEDIT_FILE_MENU_QUIT_EDITOR, STR_NULL,
+			STR_SCENEDIT_FILE_MENU_QUIT});
 	return CallBackFunction::None;
 }
 
@@ -407,6 +410,7 @@ static CallBackFunction MenuClickSaveLoad(int index = 0)
 		switch (SaveLoadEditorMenuEntries(index)) {
 			case SaveLoadEditorMenuEntries::SaveScenario: ShowSaveLoadDialog(AbstractFileType::Scenario, SaveLoadOperation::Save); break;
 			case SaveLoadEditorMenuEntries::LoadScenario: ShowSaveLoadDialog(AbstractFileType::Scenario, SaveLoadOperation::Load); break;
+			case SaveLoadEditorMenuEntries::NewScenario: ShowCreateScenario(); break;
 			case SaveLoadEditorMenuEntries::SaveHeightmap: ShowSaveLoadDialog(AbstractFileType::Heightmap, SaveLoadOperation::Save); break;
 			case SaveLoadEditorMenuEntries::LoadHeightmap: ShowSaveLoadDialog(AbstractFileType::Heightmap, SaveLoadOperation::Load); break;
 			case SaveLoadEditorMenuEntries::ExitToMainMenu: AskExitToGameMenu(); break;

--- a/src/widgets/terraform_widget.h
+++ b/src/widgets/terraform_widget.h
@@ -40,7 +40,7 @@ enum EditorTerraformToolbarWidgets : WidgetID {
 	WID_ETT_BUTTONS_END,                         ///< End of pushable buttons.
 	WID_ETT_INCREASE_SIZE = WID_ETT_BUTTONS_END, ///< Upwards arrow button to increase terraforming size.
 	WID_ETT_DECREASE_SIZE,                       ///< Downwards arrow button to decrease terraforming size.
-	WID_ETT_NEW_SCENARIO,                        ///< Button for generating a new scenario.
+	WID_ETT_RANDOM_LANDSCAPE,                    ///< Button for generating a random landscape.
 	WID_ETT_RESET_LANDSCAPE,                     ///< Button for removing all company-owned property.
 };
 


### PR DESCRIPTION
## Motivation / Problem

Entering and configuring the map and addon settings for the scenario editor is convoluted and confusing. It'd be simpler to enter the scenario editor via a window like the world generation window for setting up a new game. That'd give an opportunity to set climate, map size, NewGRFs, etc. Then, once in the scenario editor, make sure the landscape tools allow easy access to generating a random landscape if wanted.

## Description

Two commits, doing two (mostly) separate changes.

First commit: Change the existing new scenario window to appear when the scenario editor button in the main menu is clicked on. Rearrange it so that it only generates an empty flat world, and adds options to configure various add-ons, like the world generation window.

<img width="1900" height="1181" alt="image" src="https://github.com/user-attachments/assets/9eacfa9b-ed11-4601-8e2f-9a67f8b0c04d" />

Second commit: Rearrange tools in the scenario editor to make a bit more sense. There are two linked changes, because the old land generation window behaved quite oddly.

First, move making a new scenario to the save toolbar button:

<img width="1900" height="1181" alt="image" src="https://github.com/user-attachments/assets/c77811a1-0c9b-4663-8c41-8f76506dd48e" />

Second, change the generate random landscape button take you directly to new landscape generation, it didn't before(!). This also lets you (re-)configure climate, map size, etc.

<img width="1900" height="1181" alt="image" src="https://github.com/user-attachments/assets/f6634e10-effd-47a4-9a86-a318f08d37f5" />

Fixes #15203

## Limitations

Might be nice to enter the scenario editor via a landscape generation option, instead of always going into a flat map. I looked into that, but the behaviour of the world generation window is not defined by target game state, but is instead defined by current game state (menu -> game, editor -> editor), so more involved to alter. Could be a future enhancement?

Best UI consistency would possibly be to define climate, map size and add-ons only when using new scenario, and lock these when generating a random landscape in the scenario editor. But, might be too confusing when players expect the world generation window to behave in a certain way.

The right place for tools in the scenario editor is less obvious. Landscape generation probably makes more sense as a toolbar dropdown option rather than part of the terrain editing window. Might be better to move load/save heightmap from scenario editor save button to the landscape button. But, probably the next step?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
