### PR TITLE
Codefix: remove @param documentation for parameters that don't exist anymore

### DIFF
--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -133,7 +133,6 @@ void CargoPacket::Reduce(uint count)
 
 /**
  * Invalidates (sets source_id to INVALID_SOURCE) all cargo packets from given source.
- * @param src_type Type of source.
  * @param src Index of source.
  */
 /* static */ void CargoPacket::InvalidateAllFrom(Source src)

--- a/src/core/multimap.hpp
+++ b/src/core/multimap.hpp
@@ -141,7 +141,6 @@ public:
 	/**
 	 * Postfix increment operator. Same as prefix increment, but return the
 	 * previous state.
-	 * @param dummy param to mark postfix.
 	 * @return This iterator before incrementing.
 	 */
 	Self operator++(int)
@@ -172,7 +171,6 @@ public:
 	/**
 	 * Postfix decrement operator. Same as prefix decrement, but return the
 	 * previous state.
-	 * @param dummy param to mark postfix.
 	 * @return This iterator before decrementing.
 	 */
 	Self operator--(int)

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -101,7 +101,6 @@ void Gamelog::Reset()
 /**
  * Adds the GRF ID, checksum and filename if found to the output iterator
  * @param output_iterator The iterator to add the GRF info to.
- * @param last The end of the buffer
  * @param grfid GRF ID
  * @param md5sum array of md5sum to print, if known
  * @param gc GrfConfig, if known

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -359,7 +359,6 @@ class BuildIndustryWindow : public Window {
 	 *
 	 * @param cargolist    Array of CargoType to display
 	 * @param cargo_suffix Array of suffixes to attach to each cargo
-	 * @param cargolistlen Length of arrays
 	 * @param prefixstr    String to use for the first item
 	 * @return A formatted raw string
 	 */

--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -16,7 +16,6 @@
 
 /**
  * Construct a new in-memory item of an Ini file.
- * @param parent the group we belong to
  * @param name   the name of the item
  */
 IniItem::IniItem(std::string_view name)

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -83,7 +83,6 @@ public:
 	 * The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
 	[[debug_inline]] inline uint8_t &type()
@@ -95,7 +94,6 @@ public:
 	 * The height of the northern corner
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the height for.
 	 * @return reference to the byte holding the height.
 	 */
 	[[debug_inline]] inline uint8_t &height()
@@ -107,7 +105,6 @@ public:
 	 * Primarily used for ownership information
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
 	[[debug_inline]] inline uint8_t &m1()
@@ -119,7 +116,6 @@ public:
 	 * Primarily used for indices to towns, industries and stations
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the data for.
 	 * @return reference to the uint16_t holding the data.
 	 */
 	[[debug_inline]] inline uint16_t &m2()
@@ -131,7 +127,6 @@ public:
 	 * General purpose
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
 	[[debug_inline]] inline uint8_t &m3()
@@ -143,7 +138,6 @@ public:
 	 * General purpose
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
 	[[debug_inline]] inline uint8_t &m4()
@@ -155,7 +149,6 @@ public:
 	 * General purpose
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
 	[[debug_inline]] inline uint8_t &m5()
@@ -167,7 +160,6 @@ public:
 	 * General purpose
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
 	[[debug_inline]] inline uint8_t &m6()
@@ -179,7 +171,6 @@ public:
 	 * Primarily used for newgrf support
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the data for.
 	 * @return reference to the byte holding the data.
 	 */
 	[[debug_inline]] inline uint8_t &m7()
@@ -191,7 +182,6 @@ public:
 	 * General purpose
 	 *
 	 * Look at docs/landscape.html for the exact meaning of the data.
-	 * @param tile The tile to get the data for.
 	 * @return reference to the uint16_t holding the data.
 	 */
 	[[debug_inline]] inline uint16_t &m8()

--- a/src/misc/history_func.hpp
+++ b/src/misc/history_func.hpp
@@ -75,7 +75,6 @@ T GetAndResetAccumulatedAverage(Taccrued &total)
  * @param valid_history Mask of valid history records.
  * @param hr History range to get.
  * @param age Age of data to get.
- * @param cur_month Current economy month.
  * @param[out] result Extracted historical data.
  * @return True iff the data for this history range and age is valid.
  */

--- a/src/network/core/tcp_content.h
+++ b/src/network/core/tcp_content.h
@@ -115,8 +115,7 @@ protected:
 public:
 	/**
 	 * Create a new cs socket handler for a given cs
-	 * @param s  the socket we are connected with
-	 * @param address IP etc. of the client
+	 * @param s The socket we are connected with.
 	 */
 	NetworkContentSocketHandler(SOCKET s = INVALID_SOCKET) :
 		NetworkTCPSocketHandler(s)

--- a/src/network/core/tcp_stun.h
+++ b/src/network/core/tcp_stun.h
@@ -42,8 +42,7 @@ protected:
 public:
 	/**
 	 * Create a new cs socket handler for a given cs.
-	 * @param s  the socket we are connected with.
-	 * @param address IP etc. of the client.
+	 * @param s The socket we are connected with.
 	 */
 	NetworkStunSocketHandler(SOCKET s = INVALID_SOCKET) : NetworkTCPSocketHandler(s) {}
 };

--- a/src/network/core/tcp_turn.h
+++ b/src/network/core/tcp_turn.h
@@ -66,8 +66,7 @@ protected:
 public:
 	/**
 	 * Create a new cs socket handler for a given cs.
-	 * @param s  the socket we are connected with.
-	 * @param address IP etc. of the client.
+	 * @param s The socket we are connected with.
 	 */
 	NetworkTurnSocketHandler(SOCKET s = INVALID_SOCKET) : NetworkTCPSocketHandler(s) {}
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -323,7 +323,6 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendNewGRFsOk()
 
 /**
  * Set the game password as requested.
- * @param password The game password.
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendAuthResponse()
 {

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -212,7 +212,6 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentType type)
 
 /**
  * Request the content list for a given number of content IDs.
- * @param count The number of IDs to request.
  * @param content_ids The unique identifiers of the content to request information about.
  */
 void ClientNetworkContentSocketHandler::RequestContentList(std::span<const ContentID> content_ids)

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -2100,8 +2100,6 @@ bool NetworkCompanyHasClients(CompanyID company)
 
 /**
  * Get the name of the client, if the user did not send it yet, Client ID is used.
- * @param client_name The variable to write the name to.
- * @param last        The pointer to the last element of the destination buffer
  */
 std::string ServerNetworkGameSocketHandler::GetClientName() const
 {

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -121,7 +121,6 @@ const Tspec *NewGRFClass<Tspec, Tindex, Tmax>::GetSpec(uint index) const
  * Retrieve a spec by GRF location.
  * @param grfid    GRF ID of spec.
  * @param local_id Index within GRF file of spec.
- * @param index    Pointer to return the index of the spec in its class. If nullptr then not used.
  * @return The spec.
  */
 template <typename Tspec, typename Tindex, Tindex Tmax>

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -28,7 +28,6 @@ std::vector<NewGRFProfiler> _newgrf_profilers;
 /**
  * Create profiler object and begin profiling session.
  * @param grffile   The GRF file to collect profiling data on
- * @param end_date  Game date to end profiling on
  */
 NewGRFProfiler::NewGRFProfiler(const GRFFile *grffile) : grffile(grffile)
 {

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -274,7 +274,6 @@ uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t para
  * Draw representation of a road stop tile for GUI purposes.
  * @param x position x of image.
  * @param y position y of image.
- * @param image an int offset for the sprite.
  * @param roadtype the RoadType of the underlying road.
  * @param spec the RoadStop's spec.
  * @return true of the tile was drawn (allows for fallback to default graphics)

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -796,8 +796,8 @@ void DeallocateSpecFromStation(BaseStation *st, uint8_t specindex)
  * @param y Position y of image.
  * @param axis Axis.
  * @param railtype Rail type.
- * @param sclass, station Type of station.
- * @param station station ID
+ * @param sclass Class of station.
+ * @param station Station ID with the class.
  * @return True if the tile was drawn (allows for fallback to default graphic)
  */
 bool DrawStationTile(int x, int y, RailType railtype, Axis axis, StationClassID sclass, uint station)

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -857,8 +857,9 @@ static std::list<NewsItem>::iterator DeleteNewsItem(std::list<NewsItem>::iterato
 
 /**
  * Create a new newsitem to be shown.
- * @param string_id String to display.
+ * @param headline The headline of the news.
  * @param type      The type of news.
+ * @param style Manner of styling the news.
  * @param flags     Flags related to how to display the news.
  * @param ref1      Reference 1 to some object: Used for a possible viewport, scrolling after clicking on the news, and for deleting the news when the object is deleted.
  * @param ref2      Reference 2 to some object: Used for scrolling after clicking on the news, and for deleting the news when the object is deleted.
@@ -887,8 +888,9 @@ std::string NewsItem::GetStatusText() const
 
 /**
  * Add a new newsitem to be shown.
- * @param string String to display
+ * @param headline The headline of the news.
  * @param type news category
+ * @param style Manner of styling the news.
  * @param flags display flags for the news
  * @param ref1     Reference 1 to some object: Used for a possible viewport, scrolling after clicking on the news, and for deleting the news when the object is deleted.
  * @param ref2     Reference 2 to some object: Used for scrolling after clicking on the news, and for deleting the news when the object is deleted.
@@ -935,10 +937,9 @@ uint32_t SerialiseNewsReference(const NewsReference &reference)
 /**
  * Create a new custom news item.
  * @param flags type of operation
- * @aram type NewsType of the message.
- * @param reftype1 NewsReferenceType of first reference.
+ * @param type NewsType of the message.
  * @param company Company this news message is for.
- * @param reference_id First reference of the news message.
+ * @param reference First reference of the news message.
  * @param text The text of the news message.
  * @return the cost of this operation or an error
  */

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -247,7 +247,6 @@ void Order::AssignOrder(const Order &other)
 
 /**
  * Recomputes everything.
- * @param chain first order in the chain
  * @param v one of vehicle that is using this orderlist
  */
 void OrderList::Initialize(Vehicle *v)
@@ -1454,7 +1453,6 @@ CommandCost CmdModifyOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
  * Check if an aircraft has enough range for an order list.
  * @param v_new Aircraft to check.
  * @param v_order Vehicle currently holding the order list.
- * @param first First order in the source order list.
  * @return True if the aircraft has enough range for the orders, false otherwise.
  */
 static bool CheckAircraftOrderDistance(const Aircraft *v_new, const Vehicle *v_order)

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -351,7 +351,6 @@ std::string FS2OTTD(std::wstring_view name)
  * Convert from OpenTTD's encoding to a wide string.
  * OpenTTD internal encoding is UTF8.
  * @param name valid string that will be converted (UTF8)
- * @param console_cp convert to the console encoding instead of the normal system encoding.
  * @return converted string; if failed string is of zero-length
  */
 std::wstring OTTD2FS(std::string_view name)

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -168,7 +168,6 @@ bool ValParamRoadType(RoadType roadtype)
 
 /**
  * Add the road types that are to be introduced at the given date.
- * @param rt      Roadtype
  * @param current The currently available roadtypes.
  * @param date    The date for the introduction comparisons.
  * @return The road types that should be available when date

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -3344,7 +3344,6 @@ SaveOrLoadResult SaveOrLoad(std::string_view filename, SaveLoadOperation fop, De
 /**
  * Create an autosave or netsave.
  * @param counter A reference to the counter variable to be used for rotating the file name.
- * @param netsave Indicates if this is a regular autosave or a netsave.
  */
 void DoAutoOrNetsave(FiosNumberedSaveName &counter)
 {

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -221,7 +221,6 @@ public:
 	/**
 	 * DoCommand callback function for all commands executed by scripts.
 	 * @param result The result of the command.
-	 * @param tile The tile on which the command was executed.
 	 * @param data Command data as given to DoCommandPInternal.
 	 * @param result_data Extra data return from the command.
 	 * @param cmd cmd as given to DoCommandPInternal.

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -674,7 +674,6 @@ static std::tuple<int32_t, uint32_t> GetMinutesPerYearRange(const IntSettingDesc
 
 /**
  * Pre-callback check when trying to change the timetable mode. This is locked to Seconds when using wallclock units.
- * @param Unused.
  * @return True if we allow changing the timetable mode.
  */
 static bool CanChangeTimetableMode(int32_t &)

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -44,8 +44,7 @@ public:
 
 	/**
 	 * Add text to the output buffer.
-	 * @param text   Text to store.
-	 * @param length Length of the text in bytes.
+	 * @param text Text to store.
 	 * @return Number of bytes actually stored.
 	 */
 	size_t Add(std::string_view text)

--- a/src/slider.cpp
+++ b/src/slider.cpp
@@ -88,7 +88,7 @@ void DrawSliderWidget(Rect r, Colours wedge_colour, Colours handle_colour, TextC
  * @param min_value Minimum value of slider
  * @param max_value Maximum value of slider
  * @param nmarks Number of marks displayed. Value will be rounded to nearest mark.
- * @param value[in,out] Value to modify
+ * @param[in,out] value Value to modify
  * @return       True if the value setting was modified
  */
 bool ClickSliderWidget(Rect r, Point pt, int min_value, int max_value, int nmarks, int &value)

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -608,7 +608,6 @@ void ReadGRFSpriteOffsets(SpriteFile &file)
  * @param load_index Global sprite index.
  * @param file GRF to load from.
  * @param file_sprite_id Sprite number in the GRF.
- * @param container_version Container version of the GRF.
  * @return True if a valid sprite was loaded, false on any error.
  */
 bool LoadNextSprite(SpriteID load_index, SpriteFile &file, uint file_sprite_id)

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -566,7 +566,6 @@ CargoArray GetProductionAroundTiles(TileIndex north_tile, int w, int h, int rad)
  * @param h Y extent of area
  * @param rad Search radius in addition to given area
  * @param always_accepted bitmask of cargo accepted by houses and headquarters; can be nullptr
- * @param ind Industry associated with neutral station (e.g. oil rig) or nullptr
  */
 CargoArray GetAcceptanceAroundTiles(TileIndex center_tile, int w, int h, int rad, CargoTypes *always_accepted)
 {

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -265,7 +265,7 @@ char (&ArraySizeHelper(T (&array)[N]))[N];
  * Unlike sizeof this function returns the number of elements
  * of the given type.
  *
- * @param x The pointer to the first element of the array
+ * @param array The pointer to the first element of the array
  * @return The number of elements
  */
 #define lengthof(array) (sizeof(ArraySizeHelper(array)))

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -86,7 +86,6 @@ void StringData::FreeTranslation()
 
 /**
  * Add a newly created LangString.
- * @param s  The name of the string.
  * @param ls The string to add.
  */
 void StringData::Add(std::shared_ptr<LangString> ls)

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -1089,7 +1089,6 @@ enum IndustryTypes : uint8_t {
 /**
  * Writes the properties of an industry into the IndustrySpec struct.
  * @param tbl  tile table
- * @param sndc number of sounds
  * @param snd  sounds table
  * @param d    cost multiplier
  * @param pc   prospecting chance

--- a/src/tile_map.cpp
+++ b/src/tile_map.cpp
@@ -72,7 +72,6 @@ std::tuple<Slope, int> GetTileSlopeZ(TileIndex tile)
  *
  * @param x X coordinate of the tile to compute slope of, may be outside the map.
  * @param y Y coordinate of the tile to compute slope of, may be outside the map.
- * @param h If not \c nullptr, pointer to storage of z height.
  * @return Slope of the tile, except for the HALFTILE part, and the z height of the tile.
  */
 std::tuple<Slope, int> GetTilePixelSlopeOutsideMap(int x, int y)

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -908,7 +908,7 @@ static void ClearPixelBuffer(size_t len, T data)
  * @param w New width of the window.
  * @param h New height of the window.
  * @param force Recreate resources even if size didn't change.
- * @param False if nothing had to be done, true otherwise.
+ * @return \c false if nothing had to be done, \c true otherwise.
  */
 bool OpenGLBackend::Resize(int w, int h, bool force)
 {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1793,7 +1793,6 @@ static Point LocalGetWindowPlacement(const WindowDesc &desc, int16_t sm_width, i
  * Perform the first part of the initialization of a nested widget tree.
  * Construct a nested widget tree in #nested_root, and optionally fill the #widget_lookup array to provide quick access to the uninitialized widgets.
  * This is mainly useful for setting very basic properties.
- * @param fill_nested Fill the #widget_lookup (enabling is expensive!).
  * @note Filling the nested array requires an additional traversal through the nested widget tree, and is best performed by #FinishInitNested rather than here.
  */
 void Window::CreateNestedTree()


### PR DESCRIPTION
## Motivation / Problem

Over time parameters have been removed, but their documentation hasn't.


## Description

Remove a whole slew of them, including some minor related things like:
* moving the in/out parameter marking to the right place.
* convert `@param` into `@return` when applicable.


## Limitations

There are some more remaining, but their solution isn't as trivial as these.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
