### PR TITLE
Codefix: expand some macros, so doxygen actually sees what is documented

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -324,7 +324,7 @@ PREDEFINED             = WITH_ZLIB \
                          _UNICODE \
                          _GNU_SOURCE \
                          FINAL=
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = DEFINE_POOL_METHOD
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------
 # Configuration options related to external references

--- a/src/core/pool_func.hpp
+++ b/src/core/pool_func.hpp
@@ -82,6 +82,7 @@ DEFINE_POOL_METHOD(inline size_t)::FindFirstFree()
  * @param index index of item
  * @pre index < this->size
  * @pre this->Get(index) == nullptr
+ * @return The resulting allocation and pool-type index.
  */
 DEFINE_POOL_METHOD(inline AllocationResult<Tindex>)::AllocateItem(size_t size, size_t index)
 {
@@ -107,7 +108,7 @@ DEFINE_POOL_METHOD(inline AllocationResult<Tindex>)::AllocateItem(size_t size, s
 /**
  * Allocates new item
  * @param size size of item
- * @return pointer to allocated item and the index of said item.
+ * @return The resulting allocation and pool-type index.
  * @note FatalError() on failure! (no free item)
  */
 DEFINE_POOL_METHOD(AllocationResult<Tindex>)::GetNew(size_t size)
@@ -130,7 +131,7 @@ DEFINE_POOL_METHOD(AllocationResult<Tindex>)::GetNew(size_t size)
  * Allocates new item with given index
  * @param size size of item
  * @param index index of item
- * @return pointer to allocated item
+ * @return The resulting allocation and pool-type index.
  * @note SlErrorCorruptFmt() on failure! (index out of range or already used)
  */
 DEFINE_POOL_METHOD(AllocationResult<Tindex>)::GetNew(size_t size, size_t index)


### PR DESCRIPTION
## Motivation / Problem

In some places we have template instantiations, where doxygen tries to apply the documentation to the stuff between the parentheses of the macro instead of the actual function.


## Description

Let doxygen expand some macros, so it actually sees what it ought to be seeing.


## Limitations

There are probably more, I found these by looking at the logs for `@param` being defined but there not being a parameter with that name.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
