### PR TITLE
Codefix: various parameter/type related fixes 

### DIFF
--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -423,7 +423,7 @@ void AddArticulatedParts(Vehicle *first)
 		if (flip_image) v->spritenum++;
 
 		if (v->type == VEH_TRAIN) {
-			auto prob = TestVehicleBuildProbability(v, v->engine_type, BuildProbabilityType::Reversed);
+			auto prob = TestVehicleBuildProbability(v, BuildProbabilityType::Reversed);
 			if (prob.has_value()) Train::From(v)->flags.Set(VehicleRailFlag::Flipped, prob.value());
 		}
 		v->UpdatePosition();

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -374,8 +374,8 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 	/* Try to reverse the vehicle, but do not care if it fails as the new type might not be reversible */
 	if (new_veh->type == VEH_TRAIN && Train::From(old_veh)->flags.Test(VehicleRailFlag::Flipped)) {
 		/* Only copy the reverse state if neither old or new vehicle implements reverse-on-build probability callback. */
-		if (!TestVehicleBuildProbability(old_veh, old_veh->engine_type, BuildProbabilityType::Reversed).has_value() &&
-			!TestVehicleBuildProbability(new_veh, new_veh->engine_type, BuildProbabilityType::Reversed).has_value()) {
+		if (!TestVehicleBuildProbability(old_veh, BuildProbabilityType::Reversed).has_value() &&
+			!TestVehicleBuildProbability(new_veh, BuildProbabilityType::Reversed).has_value()) {
 			Command<Commands::ReverseTrainDirection>::Do(DoCommandFlag::Execute, new_veh->index, true);
 		}
 	}

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1248,9 +1248,9 @@ int GetEngineProperty(EngineID engine, PropertyID property, int orig_value, cons
  * @param type Build probability type to test for.
  * @returns True or false depending on the probability result, or std::nullopt if the callback failed.
  */
-std::optional<bool> TestVehicleBuildProbability(Vehicle *v, EngineID engine, BuildProbabilityType type)
+std::optional<bool> TestVehicleBuildProbability(Vehicle *v, BuildProbabilityType type)
 {
-	uint16_t p = GetVehicleCallback(CBID_VEHICLE_BUILD_PROBABILITY, to_underlying(type), 0, engine, v);
+	uint16_t p = GetVehicleCallback(CBID_VEHICLE_BUILD_PROBABILITY, to_underlying(type), 0, v->engine_type, v);
 	if (p == CALLBACK_FAILED) return std::nullopt;
 
 	const uint16_t PROBABILITY_RANGE = 100;

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -106,7 +106,7 @@ enum class BuildProbabilityType : uint8_t {
 	Reversed = 0, ///< Change the rail vehicle should be reversed when purchased.
 };
 
-std::optional<bool> TestVehicleBuildProbability(Vehicle *v, EngineID engine, BuildProbabilityType type);
+std::optional<bool> TestVehicleBuildProbability(Vehicle *v, BuildProbabilityType type);
 
 void TriggerVehicleRandomisation(Vehicle *veh, VehicleRandomTrigger trigger);
 

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -436,11 +436,10 @@ static inline uint32_t GetSmallMapContoursPixels(TileIndex tile, TileType t)
 /**
  * Return the colour a tile would be displayed with in the small map in mode "Vehicles".
  *
- * @param tile The tile of which we would like to get the colour.
  * @param t    Effective tile type of the tile (see #SmallMapWindow::GetTileColours).
  * @return The colour of tile in the small map in mode "Vehicles"
  */
-static inline uint32_t GetSmallMapVehiclesPixels(TileIndex, TileType t)
+static inline uint32_t GetSmallMapVehiclesPixels(TileType t)
 {
 	const SmallMapColourScheme *cs = &_heightmap_schemes[_settings_client.gui.smallmap_land_colour];
 	return ApplyMask(cs->default_colour, &_smallmap_vehicles_andor[t]);
@@ -1375,7 +1374,7 @@ protected:
 				return GetSmallMapContoursPixels(tile, et);
 
 			case SMT_VEHICLES:
-				return GetSmallMapVehiclesPixels(tile, et);
+				return GetSmallMapVehiclesPixels(et);
 
 			case SMT_INDUSTRY:
 				return GetSmallMapIndustriesPixels(tile, et);

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2424,12 +2424,9 @@ static WindowDesc _select_station_desc(
 
 /**
  * Check whether we need to show the station selection window.
- * @param cmd Command to build the station.
- * @param ta Tile area of the to-be-built station
- * @tparam T the station filter type
+ * @param proc Callback to check whether we can build.
  * @return whether we need to show the station selection window.
  */
-template <class T>
 static bool StationJoinerNeeded(const StationPickerCmdProc &proc)
 {
 	/* Only show selection if distant join is enabled in the settings */
@@ -2460,7 +2457,7 @@ static bool StationJoinerNeeded(const StationPickerCmdProc &proc)
 template <class T>
 void ShowSelectBaseStationIfNeeded(TileArea ta, StationPickerCmdProc&& proc)
 {
-	if (StationJoinerNeeded<T>(proc)) {
+	if (StationJoinerNeeded(proc)) {
 		if (!_settings_client.gui.persistent_buildingtools) ResetObjectToPlace();
 		FindStationsNearby<T>(ta, false);
 		new SelectStationWindow<T>(_select_station_desc, ta, std::move(proc));

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -686,7 +686,7 @@ static CommandCost CmdBuildRailWagon(DoCommandFlags flags, TileIndex tile, const
 
 		v->group_id = DEFAULT_GROUP;
 
-		auto prob = TestVehicleBuildProbability(v, v->engine_type, BuildProbabilityType::Reversed);
+		auto prob = TestVehicleBuildProbability(v, BuildProbabilityType::Reversed);
 		if (prob.has_value()) v->flags.Set(VehicleRailFlag::Flipped, prob.value());
 		AddArticulatedParts(v);
 
@@ -753,7 +753,7 @@ static void AddRearEngineToMultiheadedTrain(Train *v)
 	v->SetMultiheaded();
 	u->SetMultiheaded();
 	v->SetNext(u);
-	auto prob = TestVehicleBuildProbability(u, u->engine_type, BuildProbabilityType::Reversed);
+	auto prob = TestVehicleBuildProbability(u, BuildProbabilityType::Reversed);
 	if (prob.has_value()) u->flags.Set(VehicleRailFlag::Flipped, prob.value());
 	u->UpdatePosition();
 
@@ -827,7 +827,7 @@ CommandCost CmdBuildRailVehicle(DoCommandFlags flags, TileIndex tile, const Engi
 		v->SetFrontEngine();
 		v->SetEngine();
 
-		auto prob = TestVehicleBuildProbability(v, v->engine_type, BuildProbabilityType::Reversed);
+		auto prob = TestVehicleBuildProbability(v, BuildProbabilityType::Reversed);
 		if (prob.has_value()) v->flags.Set(VehicleRailFlag::Flipped, prob.value());
 		v->UpdatePosition();
 

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -898,8 +898,8 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlags flags, TileInd
 
 			if (v->type == VEH_TRAIN && Train::From(v)->flags.Test(VehicleRailFlag::Flipped)) {
 				/* Only copy the reverse state if neither old or new vehicle implements reverse-on-build probability callback. */
-				if (!TestVehicleBuildProbability(v, v->engine_type, BuildProbabilityType::Reversed).has_value() &&
-					!TestVehicleBuildProbability(w, w->engine_type, BuildProbabilityType::Reversed).has_value()) {
+				if (!TestVehicleBuildProbability(v, BuildProbabilityType::Reversed).has_value() &&
+					!TestVehicleBuildProbability(w, BuildProbabilityType::Reversed).has_value()) {
 					Train::From(w)->flags.Set(VehicleRailFlag::Flipped);
 				}
 			}

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -116,7 +116,7 @@ struct BaseVehicleListWindow : public Window {
 	void UpdateVehicleGroupBy(GroupBy group_by);
 	void SortVehicleList();
 	void BuildVehicleList();
-	void SetCargoFilter(uint8_t index);
+	void SetCargoFilter(CargoType cargo_type);
 	void SetCargoFilterArray();
 	void FilterVehicleList();
 	StringID GetCargoFilterLabel(CargoType cargo_type) const;


### PR DESCRIPTION
## Motivation / Problem

Warnings of doxygen about parameters not being documented, or being documented by not existing.

In these cases leading to a different result than just plain amending the documentation.


## Description

* All calls to `TestVehicleBuildProbability` use `v, v->engine_type`, so why have the engine type as a separate (undocumented) parameter? Just remove the parameter.
* Type difference between declaration and definition; amend declaration.
* Function is templated, when nothing in the function uses templates; remove template.
* Parameter is documented, but not actually used; remove the parameter.


## Limitations

Solves just a small part of the doxygen warnings.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
