### PR TITLE
Codechange: remove duplicate doxygen warnings

### DIFF
--- a/.github/sort_doxygen_warnings.py
+++ b/.github/sort_doxygen_warnings.py
@@ -18,7 +18,7 @@ def main():
             continue
         # Doxygen warnings can span multiple lines, keep these lines together.
         warnings[-1] = f"{warnings[-1]}\n{line}"
-    warnings.sort()
+    warnings = sorted(set(warnings))
     with open(sys.argv[2], "w") as out:
         out.write("\n".join(warnings))
     print("Doxygen warnings sorted successfully.")


### PR DESCRIPTION
## Motivation / Problem

When going through warnings in the doxygen output, you'll often encounter the same warning. Often as in: a 2.8 MiB log will become 2.4 MiB log by this change, so roughly a ~15% reduction.

For example:
```
.../src/aircraft_cmd.cpp:$: warning: parameters of member AircraftNextAirportPos_and_Order are not documented
.../src/aircraft_cmd.cpp:$: warning: parameters of member AircraftNextAirportPos_and_Order are not documented

.../src/aircraft_gui.cpp:$: warning: The following parameter of DrawAircraftImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type) is not documented:
  parameter 'image_type'
.../src/aircraft_gui.cpp:$: warning: The following parameter of DrawAircraftImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type) is not documented:
  parameter 'image_type'

.../src/base_media_base.h:$: warning: argument 's' of command @param is not found in the argument list of TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, std::span< const std::unique_ptr< Tbase_set > > sets)
.../src/base_media_base.h:$: warning: argument 's' of command @param is not found in the argument list of TryGetBaseSetFile(const ContentInfo &ci, bool md5sum, std::span< const std::unique_ptr< Tbase_set > > sets)
```


## Description

Instead of just sorting, pass the warnings through `set` to also remove duplicates when preparing for determining the difference.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
