### PR TITLE
Codefix: wrong parameter names and partially missing parameters #2

### DIFF
--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -103,6 +103,7 @@ void ResetHouses()
  * @param not_yet_constructed House is still under construction.
  * @param initial_random_bits Random bits during construction checks.
  * @param watched_cargo_triggers Cargo types that triggered the watched cargo callback.
+ * @param view The house's 'view'.
  */
 HouseResolverObject::HouseResolverObject(HouseID house_id, TileIndex tile, Town *town,
 		CallbackID callback, uint32_t param1, uint32_t param2,

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -35,6 +35,7 @@ struct HouseScopeResolver : public ScopeResolver {
 	 * @param not_yet_constructed House is still under construction.
 	 * @param initial_random_bits Random bits during construction checks.
 	 * @param watched_cargo_triggers Cargo types that triggered the watched cargo callback.
+	 * @param view The house's 'view'.
 	 */
 	HouseScopeResolver(ResolverObject &ro, HouseID house_id, TileIndex tile, Town *town,
 			bool not_yet_constructed, uint8_t initial_random_bits, CargoTypes watched_cargo_triggers, int view)

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -571,6 +571,7 @@ CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, siz
  * Check with callback #CBID_INDUSTRY_PROBABILITY whether the industry can be built.
  * @param type Industry type to check.
  * @param creation_type Reason to construct a new industry.
+ * @param default_prob The default probability if the NewGRF doesn't override it.
  * @return If the industry has no callback or allows building, \c true is returned. Otherwise, \c false is returned.
  */
 uint32_t GetIndustryProbabilityCallback(IndustryType type, IndustryAvailabilityCallType creation_type, uint32_t default_prob)

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -377,6 +377,7 @@ unhandled:
 /**
  * Constructor of the object resolver.
  * @param obj Object being resolved.
+ * @param spec Specifiction of the object's type.
  * @param tile %Tile of the object.
  * @param view View of the object.
  * @param callback Callback ID.

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -118,6 +118,7 @@ struct ObjectScopeResolver : public ScopeResolver {
 	 * Constructor of an object scope resolver.
 	 * @param ro Surrounding resolver.
 	 * @param obj Object being resolved.
+	 * @param spec The specification of the object type.
 	 * @param tile %Tile of the object.
 	 * @param view View of the object.
 	 */

--- a/src/newgrf_railtype.h
+++ b/src/newgrf_railtype.h
@@ -23,6 +23,7 @@ struct RailTypeScopeResolver : public ScopeResolver {
 	/**
 	 * Constructor of the railtype scope resolvers.
 	 * @param ro Surrounding resolver.
+	 * @param rti Specification of the rail type.
 	 * @param tile %Tile containing the track. For track on a bridge this is the southern bridgehead.
 	 * @param context Are we resolving sprites for the upper halftile, or on a bridge?
 	 */

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -277,6 +277,8 @@ uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t para
  * @param image an int offset for the sprite.
  * @param roadtype the RoadType of the underlying road.
  * @param spec the RoadStop's spec.
+ * @param type The type of station.
+ * @param view The road stop's view.
  * @return true of the tile was drawn (allows for fallback to default graphics)
  */
 void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec, StationType type, int view)

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -142,7 +142,7 @@ RoadTypeResolverObject::RoadTypeResolverObject(const RoadTypeInfo *rti, TileInde
  * @param rti The road type data (spec).
  * @param tile The tile to get the sprite for.
  * @param rtsg The type of sprite to draw.
- * @param content Where are we drawing the tile?
+ * @param context Where are we drawing the tile?
  * @param [out] num_results If not nullptr, return the number of sprites in the spriteset.
  * @return The sprite to draw.
  */

--- a/src/newgrf_sound.cpp
+++ b/src/newgrf_sound.cpp
@@ -78,6 +78,7 @@ size_t GetSoundPoolAllocatedMemory()
 /**
  * Extract meta data from a NewGRF sound.
  * @param sound Sound to load.
+ * @param sound_id Identifier of the sound to load.
  * @return True if a valid sound was loaded.
  */
 bool LoadNewGRFSound(SoundEntry &sound, SoundID sound_id)

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -68,7 +68,7 @@ struct SpecializedSpriteGroup : public SpriteGroup {
 
 	/**
 	 * Creates a new T-object in the SpriteGroup pool.
-	 * @param args... The arguments to the constructor.
+	 * @param args The arguments to the constructor.
 	 * @return The created object.
 	 */
 	template <typename... Targs>
@@ -221,6 +221,7 @@ protected:
 struct CallbackResultSpriteGroup : SpecializedSpriteGroup<CallbackResultSpriteGroup> {
 	/**
 	 * Creates a spritegroup representing a callback result
+	 * @param index Unique (pool) identifier of the SpriteGroup.
 	 * @param value The value that was used to represent this callback result
 	 */
 	CallbackResultSpriteGroup(SpriteGroupID index, CallbackResult value) : SpecializedSpriteGroup<CallbackResultSpriteGroup>(index), result(value) {}
@@ -237,6 +238,7 @@ protected:
 struct ResultSpriteGroup : SpecializedSpriteGroup<ResultSpriteGroup> {
 	/**
 	 * Creates a spritegroup representing a sprite number result.
+	 * @param index Unique (pool) identifier of the SpriteGroup.
 	 * @param sprite The sprite number.
 	 * @param num_sprites The number of sprites per set.
 	 * @return A spritegroup representing the sprite number result.

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -934,6 +934,7 @@ static void MakeNewEditorWorld()
  * a previous correct state. In the menu for example load the intro game again.
  * @param filename file to be loaded
  * @param fop mode of loading, always SLO_LOAD
+ * @param dft Type of file that is going to be loaded.
  * @param newgm switch to this mode of loading fails due to some unknown error
  * @param subdir default directory to look for filename, set to 0 if not needed
  * @param lf Load filter to use, if nullptr: use filename + subdir.

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -293,9 +293,9 @@ public:
 	OrderList(OrderListID index) : OrderListPool::PoolItem<&_orderlist_pool>(index) {}
 
 	/**
-	 * Create an order list with the given order chain for the given vehicle.
+	 * Create an order list with the order for the given vehicle.
 	 * @param index index of the list within the order list pool
-	 * @param chain pointer to the first order of the order chain
+	 * @param order Rvalue reference to the order.
 	 * @param v any vehicle using this orderlist
 	 */
 	OrderList(OrderListID index, Order &&order, Vehicle *v) : OrderListPool::PoolItem<&_orderlist_pool>(index)
@@ -357,7 +357,7 @@ public:
 	/**
 	 * Get the order after the given one or the first one, if the given one is the
 	 * last one.
-	 * @param curr Order to find the next one for.
+	 * @param cur Order to find the next one for.
 	 * @return Next order.
 	 */
 	inline VehicleOrderID GetNext(VehicleOrderID cur) const

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -353,6 +353,7 @@ VehicleOrderID OrderList::GetNextDecisionNode(VehicleOrderID next, uint hops) co
 
 /**
  * Recursively determine the next deterministic station to stop at.
+ * @param next_station The next stations that we have already seen, and might be adding to.
  * @param v The vehicle we're looking at.
  * @param first Order to start searching at or INVALID_VEH_ORDER_ID to start at cur_implicit_order_index + 1.
  * @param hops Number of orders we have already looked at.
@@ -411,7 +412,7 @@ void OrderList::GetNextStoppingStation(std::vector<StationID> &next_station, con
 
 /**
  * Insert a new order into the order chain.
- * @param new_order is the order to insert into the chain.
+ * @param order Rvalue reference of the order to insert into the chain.
  * @param index is the position where the order is supposed to be inserted.
  */
 void OrderList::InsertOrderAt(Order &&order, VehicleOrderID index)

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -205,6 +205,7 @@ public:
 	 * If a CoreText font description is present, e.g. from the automatic font
 	 * fallback search, use it. Otherwise, try to resolve it by font name.
 	 * @param fs The font size to load.
+	 * @param fonttype The type of font that is being loaded.
 	 */
 	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
 	{

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -270,11 +270,12 @@ public:
 	Win32FontCacheFactory() : FontCacheFactory("win32", "Win32 font loader") {}
 
 	/**
-	* Loads the GDI font.
-	* If a GDI font description is present, e.g. from the automatic font
-	* fallback search, use it. Otherwise, try to resolve it by font name.
-	* @param fs The font size to load.
-	*/
+	 * Loads the GDI font.
+	 * If a GDI font description is present, e.g. from the automatic font
+	 * fallback search, use it. Otherwise, try to resolve it by font name.
+	 * @param fs The font size to load.
+	 * @param fonttype The type of font that is being loaded.
+	 */
 	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
 	{
 		if (fonttype != FontType::TrueType) return nullptr;

--- a/src/palette.cpp
+++ b/src/palette.cpp
@@ -121,7 +121,7 @@ static uint8_t FindNearestColourIndex(uint8_t r, uint8_t g, uint8_t b)
 
 /**
  * Find nearest company colour palette index for a brightness level.
- * @param pixel Pixel to find.
+ * @param b Pixel-colour to find.
  * @returns palette index of nearest colour.
  */
 static uint8_t FindNearestColourReshadeIndex(uint8_t b)

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -337,7 +337,7 @@ void InvalidateWaterRegion(TileIndex tile)
  * accessible from one particular side of the starting patch.
  * @param water_region_patch Water patch within the water region to start searching from
  * @param side Side of the water region to look for neighbouring patches of water
- * @param callback The function that will be called for each neighbour that is found
+ * @param func The function that will be called for each neighbour that is found
  */
 static inline void VisitAdjacentWaterRegionPatchNeighbours(const WaterRegionPatchDesc &water_region_patch, DiagDirection side, VisitWaterRegionPatchCallback &func)
 {

--- a/src/pathfinder/yapf/yapf.h
+++ b/src/pathfinder/yapf/yapf.h
@@ -22,6 +22,7 @@
  * @param v        the ship that needs to find a path
  * @param tile     the tile to find the path from (should be next tile the ship is about to enter)
  * @param path_found [out] Whether a path has been found (true) or has been guessed (false)
+ * @param path_cache Cache of a previously chosen path.
  * @return         the best trackdir for next turn or INVALID_TRACK if the path could not be found
  */
 Track YapfShipChooseTrack(const Ship *v, TileIndex tile, bool &path_found, ShipPathCache &path_cache);
@@ -41,6 +42,7 @@ bool YapfShipCheckReverse(const Ship *v, Trackdir *trackdir);
  * @param enterdir  diagonal direction which the RV will enter this new tile from
  * @param trackdirs available trackdirs on the new tile (to choose from)
  * @param path_found [out] Whether a path has been found (true) or has been guessed (false)
+ * @param path_cache Cache of a previously chosen path.
  * @return          the best trackdir for next turn or INVALID_TRACKDIR if the path could not be found
  */
 Trackdir YapfRoadVehicleChooseTrack(const RoadVehicle *v, TileIndex tile, DiagDirection enterdir, TrackdirBits trackdirs, bool &path_found, RoadVehPathCache &path_cache);

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1933,7 +1933,7 @@ static const FenceOffset _fence_offsets[] = {
 /**
  * Draw a track fence.
  * @param ti Tile drawing information.
- * @param base_image First fence sprite.
+ * @param psid First fence sprite and palette.
  * @param num_sprites Number of fence sprites.
  * @param rfo Fence to draw.
  */
@@ -1990,6 +1990,7 @@ static void DrawTrackFence_SW(const TileInfo *ti, const PalSpriteID &psid, uint 
  * Draw track fences.
  * @param ti Tile drawing information.
  * @param rti Rail type information.
+ * @param pal The palette to apply while drawing.
  */
 static void DrawTrackDetails(const TileInfo *ti, const RailTypeInfo *rti, PaletteID pal)
 {

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1498,6 +1498,7 @@ private:
 
 	/**
 	 * Draw dynamic a signal-sprite in a button in the signal GUI
+	 * @param r The rectangle to draw the sprite in.
 	 * @param image        the sprite to draw
 	 */
 	void DrawSignalSprite(const Rect &r, SpriteID image) const

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -117,7 +117,7 @@ RoadBits CleanUpRoadBits(const TileIndex tile, RoadBits org_rb)
 /**
  * Finds out, whether given company has a given RoadType available for construction.
  * @param company ID of company
- * @param roadtypet RoadType to test
+ * @param roadtype RoadType to test
  * @return true if company has the requested RoadType available
  */
 bool HasRoadTypeAvail(const CompanyID company, RoadType roadtype)
@@ -147,6 +147,7 @@ bool HasRoadTypeAvail(const CompanyID company, RoadType roadtype)
 /**
  * Test if any buildable RoadType is available for a company.
  * @param company the company in question
+ * @param rtt Whether to check for road or tram types.
  * @return true if company has any RoadTypes available
  */
 bool HasAnyRoadTypesAvail(CompanyID company, RoadTramType rtt)

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -244,7 +244,7 @@ static Foundation GetRoadFoundation(Slope tileh, RoadBits bits);
  * @param tile      the tile to remove the road from
  * @param remove    the roadbits that are going to be removed
  * @param owner     the actual owner of the roadbits of the tile
- * @param rt        the road type to remove the bits from
+ * @param rtt The road type to remove the bits from.
  * @param flags     command flags
  * @param town_check Shall the town rating checked/affected
  * @return A succeeded command when it is allowed to remove the road bits, a failed command otherwise.
@@ -308,7 +308,7 @@ CommandCost CheckAllowRemoveRoad(TileIndex tile, RoadBits remove, Owner owner, R
  * @param tile tile where to remove road from
  * @param flags operation to perform
  * @param pieces roadbits to remove
- * @param rt roadtype to remove
+ * @param rtt Road type to remove.
  * @param town_check should we check if the town allows removal?
  */
 static CommandCost RemoveRoad(TileIndex tile, DoCommandFlags flags, RoadBits pieces, RoadTramType rtt, bool town_check)
@@ -1496,6 +1496,7 @@ static void DrawRoadDetail(SpriteID img, const TileInfo *ti, int8_t dx, int8_t d
 /**
  * Draw road underlay and overlay sprites.
  * @param ti TileInfo
+ * @param pal The palette to apply to the overlays.
  * @param road_rti Road road type information
  * @param tram_rti Tram road type information
  * @param road_offset Road sprite offset (based on road bits)
@@ -2455,6 +2456,7 @@ static void ConvertRoadTypeOwner(TileIndex tile, uint num_pieces, Owner owner, R
  * @param tile end tile of road conversion drag
  * @param area_start start tile of drag
  * @param to_type new roadtype to convert to.
+ * @param diagonal Whether a diagonal or orthogonal area is to be converted.
  * @return the cost of this operation or an error
  */
 CommandCost CmdConvertRoad(DoCommandFlags flags, TileIndex tile, TileIndex area_start, RoadType to_type, bool diagonal)

--- a/src/road_cmd.h
+++ b/src/road_cmd.h
@@ -36,6 +36,6 @@ DEF_CMD_TRAIT(Commands::ConvertRoad, CmdConvertRoad, {}, CommandType::LandscapeC
 CommandCallback CcPlaySound_CONSTRUCTION_OTHER;
 CommandCallback CcBuildRoadTunnel;
 void CcRoadDepot(Commands cmd, const CommandCost &result, TileIndex tile, RoadType rt, DiagDirection dir);
-void CcRoadStop(Commands cmd, const CommandCost &result, TileIndex tile, uint8_t width, uint8_t length, RoadStopType, bool is_drive_through, DiagDirection dir, RoadType, RoadStopClassID spec_class, uint16_t spec_index, StationID, bool);
+void CcRoadStop(Commands, const CommandCost &result, TileIndex tile, uint8_t width, uint8_t length, RoadStopType, bool is_drive_through, DiagDirection dir, RoadType, RoadStopClassID spec_class, uint16_t spec_index, StationID, bool);
 
 #endif /* ROAD_CMD_H */

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -121,6 +121,7 @@ void CcPlaySound_CONSTRUCTION_OTHER(Commands, const CommandCost &result, TileInd
 /**
  * Callback to start placing a bridge.
  * @param tile Start tile of the bridge.
+ * @param w The window to call back to when overbuilding a bridge.
  */
 static void PlaceRoad_Bridge(TileIndex tile, Window *w)
 {
@@ -878,6 +879,7 @@ struct BuildRoadToolbarWindow : Window {
 	 * Handler for global hotkeys of the BuildRoadToolbarWindow.
 	 * @param hotkey Hotkey
 	 * @param last_build Last build road type
+	 * @param rtt The road/tram type.
 	 * @return ES_HANDLED if hotkey was accepted.
 	 */
 	static EventState RoadTramToolbarGlobalHotkeys(int hotkey, RoadType last_build, RoadTramType rtt)

--- a/src/road_map.cpp
+++ b/src/road_map.cpp
@@ -47,7 +47,7 @@ bool MayHaveRoad(Tile t)
  * for bridge ramps and tunnel entrances is returned depending
  * on the orientation of the tunnel or bridge.
  * @param tile the tile to get the road bits for
- * @param rt   the road type to get the road bits form
+ * @param rtt the road type to get the road bits form
  * @param straight_tunnel_bridge_entrance whether to return straight road bits for tunnels/bridges.
  * @return the road bits of the given tile
  */

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -105,7 +105,7 @@ inline bool IsLevelCrossingTile(Tile t)
 /**
  * Get the present road bits for a specific road type.
  * @param t  The tile to query.
- * @param rt Road type.
+ * @param rtt Road type.
  * @pre IsNormalRoad(t)
  * @return The present road bits for the road type.
  */
@@ -131,7 +131,7 @@ inline RoadBits GetAllRoadBits(Tile tile)
  * Set the present road bits for a specific road type.
  * @param t  The tile to change.
  * @param r  The new road bits.
- * @param rt Road type.
+ * @param rtt Road type.
  * @pre IsNormalRoad(t)
  */
 inline void SetRoadBits(Tile t, RoadBits r, RoadTramType rtt)
@@ -189,7 +189,7 @@ inline bool HasRoadTypeTram(Tile t)
 /**
  * Check if a tile has a road or a tram road type.
  * @param t  The tile to check.
- * @param tram True to check tram, false to check road.
+ * @param rtt The road type.
  * @return True if the tile has the specified road type.
  */
 inline bool HasTileRoadType(Tile t, RoadTramType rtt)
@@ -244,7 +244,7 @@ inline void SetRoadOwner(Tile t, RoadTramType rtt, Owner o)
 /**
  * Check if a specific road type is owned by an owner.
  * @param t  The tile to query.
- * @param tram True to check tram, false to check road.
+ * @param rtt Road type to check.
  * @param o  Owner to compare with.
  * @pre HasTileRoadType(t, rt)
  * @return True if the road type is owned by the given owner.
@@ -269,7 +269,7 @@ inline bool HasTownOwnedRoad(Tile t)
 /**
  * Checks if a DisallowedRoadDirections is valid.
  *
- * @param wc The value to check
+ * @param drt The value to check
  * @return true if the given value is a valid DisallowedRoadDirections.
  */
 inline bool IsValidDisallowedRoadDirections(DisallowedRoadDirections drt)

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -929,6 +929,7 @@ static inline size_t SlCalcStdStringLen(const void *ptr)
  * because the validation looks for SCC_ENCODED. If there is something invalid,
  * just bail out and do not continue trying to replace the tokens.
  * @param str the string to fix.
+ * @param fix_code Whether to interpret/replace codes 0xE028 and 0xE02A as/with SCC_ENCODED.
  */
 void FixSCCEncoded(std::string &str, bool fix_code)
 {
@@ -1812,7 +1813,7 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 
 /**
  * Set the length of this list.
- * @param The length of the list.
+ * @param length The length of the list.
  */
 void SlSetStructListLength(size_t length)
 {
@@ -3251,6 +3252,7 @@ SaveOrLoadResult LoadWithFilter(std::shared_ptr<LoadFilter> reader)
  * handled. It opens the savegame, selects format and checks versions
  * @param filename The name of the savegame being created/loaded
  * @param fop Save or load mode. Load can also be a TTD(Patch) game.
+ * @param dft The type of file to save or load.
  * @param sb The sub directory to save the savegame in
  * @param threaded True when threaded saving is allowed
  * @return Return the result of the action. #SL_OK, #SL_ERROR, or #SL_REINIT ("unload" the game)
@@ -3431,8 +3433,8 @@ void FileToSaveLoad::SetMode(const FiosType &ft, SaveLoadOperation fop)
 }
 
 /**
- * Set the title of the file.
- * @param title Title of the file.
+ * Set the mode, title and name of the file.
+ * @param item Container with mode, title and name.
  */
 void FileToSaveLoad::Set(const FiosItem &item)
 {

--- a/src/saveload/saveload_error.hpp
+++ b/src/saveload/saveload_error.hpp
@@ -18,7 +18,7 @@
 
 /**
  * Issue an SlErrorCorrupt with a format string.
- * @param format_string The formatting string to tell what to do with the remaining arguments.
+ * @param format The formatting string to tell what to do with the remaining arguments.
  * @param fmt_args The arguments to be passed to fmt.
  * @tparam Args The types of the fmt arguments.
  * @note This function does never return as it throws an exception to

--- a/src/saveload/settings_sl.cpp
+++ b/src/saveload/settings_sl.cpp
@@ -101,6 +101,7 @@ static std::vector<SaveLoad> GetSettingsDesc(const SettingTable &settings, bool 
  * @param settings SettingDesc struct containing all information
  * @param object can be either nullptr in which case we load global variables or
  * a pointer to a struct which is getting saved
+ * @param slct Savegame compatibility mapping table.
  */
 static void LoadSettings(const SettingTable &settings, void *object, const SaveLoadCompatTable &slct)
 {

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -625,6 +625,7 @@ struct ScriptTextfileWindow : public TextfileWindow {
 
 /**
  * Open the Script version of the textfile window.
+ * @param parent The window we become a child of, and for which other textfile windows are closed.
  * @param file_type The type of textfile to display.
  * @param slot The slot the Script is using.
  */
@@ -745,6 +746,7 @@ struct ScriptDebugWindow : public Window {
 	 * Constructor for the window.
 	 * @param desc The description of the window.
 	 * @param number The window number (actually unused).
+	 * @param show_company The initial company to focus on.
 	 */
 	ScriptDebugWindow(WindowDesc &desc, WindowNumber number, Owner show_company) : Window(desc), break_editbox(MAX_BREAK_STR_STRING_LENGTH)
 	{
@@ -970,7 +972,7 @@ struct ScriptDebugWindow : public Window {
 
 	/**
 	 * Change all settings to select another Script.
-	 * @param show_ai The new AI to show.
+	 * @param show_script The new script to show.
 	 * @param new_window Open the script in a new window.
 	 */
 	void ChangeToScript(CompanyID show_script, bool new_window = false)

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -183,6 +183,7 @@ struct ScriptFileChecksumCreator : FileScanner {
  * @param ci The information to compare to.
  * @param md5sum Whether to check the MD5 checksum.
  * @param info The script to get the shortname and md5 sum from.
+ * @param dir The directory to look in for scripts.
  * @return True iff they're the same.
  */
 static bool IsSameScript(const ContentInfo &ci, bool md5sum, const ScriptInfo &info, Subdirectory dir)

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -257,14 +257,6 @@ const void *ResolveObject(const GameSettings *settings_ptr, const IntSettingDesc
 	return settings_ptr;
 }
 
-/**
- * Function to draw setting value (button + text + current value)
- * @param settings_ptr Pointer to current values of all settings
- * @param left         Left-most position in window/panel to start drawing
- * @param right        Right-most position in window/panel to draw
- * @param y            Upper-most position in window/panel to start drawing
- * @param highlight    Highlight entry.
- */
 void SettingEntry::DrawSetting(GameSettings *settings_ptr, int left, int right, int y, bool highlight) const
 {
 	const IntSettingDesc *sd = this->setting;
@@ -602,12 +594,6 @@ uint SettingsPage::Draw(GameSettings *settings_ptr, int left, int right, int y, 
 	return cur_row;
 }
 
-/**
- * Function to draw setting value (button + text + current value)
- * @param left         Left-most position in window/panel to start drawing
- * @param right        Right-most position in window/panel to draw
- * @param y            Upper-most position in window/panel to start drawing
- */
 void SettingsPage::DrawSetting(GameSettings *, int left, int right, int y, bool) const
 {
 	bool rtl = _current_text_dir == TD_RTL;

--- a/src/settingentry_gui.h
+++ b/src/settingentry_gui.h
@@ -87,6 +87,14 @@ struct BaseSettingEntry {
 	static inline int line_height; ///< Height of a single setting.
 
 protected:
+	/**
+	 * Function to draw setting value (button + text + current value)
+	 * @param settings_ptr Pointer to current values of all settings.
+	 * @param left Left-most position in window/panel to start drawing.
+	 * @param right Right-most position in window/panel to draw.
+	 * @param y Upper-most position in window/panel to start drawing.
+	 * @param highlight Whether to highlight the entry.
+	 */
 	virtual void DrawSetting(GameSettings *settings_ptr, int left, int right, int y, bool highlight) const = 0;
 };
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -299,13 +299,10 @@ static bool LoadIntList(std::optional<std::string_view> str, void *array, int ne
 }
 
 /**
- * Convert an integer-array (intlist) to a string representation. Each value
+ * Convert a list to a string representation. Each value
  * is separated by a comma or a space character
- * @param buf output buffer where the string-representation will be stored
- * @param last last item to write to in the output buffer
- * @param array pointer to the integer-arrays that is read from
- * @param nelems the number of elements the array holds.
- * @param type the type of elements the array holds (eg INT8, UINT16, etc.)
+ * @param object The object to read the list from.
+ * @return The string representation of the list.
  */
 std::string ListSettingDesc::FormatValue(const void *object) const
 {
@@ -693,7 +690,7 @@ void ListSettingDesc::ParseValue(const IniItem *item, void *object) const
 /**
  * Save the values of settings to the inifile.
  * @param ini pointer to IniFile structure
- * @param sd read-only SettingDesc structure which contains the unmodified,
+ * @param settings_table read-only structure which contains the unmodified,
  *        loaded values of the configuration file and various information about it
  * @param grpname holds the name of the group (eg. [network]) where these will be saved
  * @param object pointer to the object been saved
@@ -1810,8 +1807,7 @@ CommandCost CmdChangeCompanySetting(DoCommandFlags flags, const std::string &nam
 
 /**
  * Top function to save the new value of an element of the Settings struct
- * @param index offset in the SettingDesc array of the Settings struct which
- * identifies the setting member we want to change
+ * @param sd The SettingDesc we want to change.
  * @param value new value of the setting
  * @param force_newgame force the newgame settings
  */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -119,6 +119,7 @@ struct BaseSetTextfileWindow : public TextfileWindow {
 
 /**
  * Open the BaseSet version of the textfile window.
+ * @param parent The parent of this window,
  * @param file_type The type of textfile to display.
  * @param baseset The BaseSet to use.
  * @param content_type STR_CONTENT_TYPE_xxx for title.

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -322,8 +322,8 @@ static void AppendFile(std::optional<std::string_view> fname, FILE *out_fp)
 
 /**
  * Compare two files for identity.
- * @param n1 First file.
- * @param n2 Second file.
+ * @param path1 First file.
+ * @param path2 Second file.
  * @return True if both files are identical.
  */
 static bool CompareFiles(std::filesystem::path path1, std::filesystem::path path2)

--- a/src/signs_cmd.h
+++ b/src/signs_cmd.h
@@ -22,6 +22,6 @@ DEF_CMD_TRAIT(Commands::PlaceSign, CmdPlaceSign, CommandFlag::Deity, CommandType
 DEF_CMD_TRAIT(Commands::RenameSign, CmdRenameSign, CommandFlag::Deity, CommandType::OtherManagement)
 DEF_CMD_TRAIT(Commands::MoveSign, CmdMoveSign, CommandFlag::Deity, CommandType::OtherManagement)
 
-void CcPlaceSign(Commands cmd, const CommandCost &result, SignID new_sign);
+void CcPlaceSign(Commands, const CommandCost &result, SignID new_sign);
 
 #endif /* SIGNS_CMD_H */

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -986,6 +986,7 @@ protected:
 	/**
 	 * Adds town names to the smallmap.
 	 * @param dpi the part of the smallmap to be drawn into
+	 * @param vertical_padding The amount to show the industry name above the industry tile.
 	 */
 	void DrawTowns(const DrawPixelInfo *dpi, const int vertical_padding) const
 	{
@@ -1009,6 +1010,7 @@ protected:
 	/**
 	 * Adds industry names to the smallmap.
 	 * @param dpi the part of the smallmap to be drawn into
+	 * @param vertical_padding The amount to show the industry name above the industry tile.
 	 */
 	void DrawIndustryNames(const DrawPixelInfo *dpi, const int vertical_padding) const
 	{
@@ -2096,6 +2098,7 @@ bool ScrollMainWindowTo(int x, int y, int z, bool instant)
 
 /**
  * Determine the middle of a station in the smallmap window.
+ * @param w The smallmap window to get the station middle for.
  * @param st The station we're looking for.
  * @return Middle point of the station in the smallmap window.
  */

--- a/src/social_integration.cpp
+++ b/src/social_integration.cpp
@@ -168,6 +168,7 @@ void SocialIntegration::Initialize()
  *
  * @param plugin Plugin to call the function pointer on.
  * @param func   Function pointer to call.
+ * @param args The arguments to pass to the given function pointer.
  */
 template <typename T, typename... Ts>
 static void PluginCall(std::unique_ptr<InternalSocialIntegrationPlugin> &plugin, T func, Ts... args)

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -89,8 +89,12 @@ void DrawCommonTileSeqInGUI(int x, int y, const DrawTileSprites *dts, int32_t or
 
 /**
  * Draw tile sprite sequence on tile with railroad specifics.
+ * @param ti Tile to draw to.
+ * @param dts Sprite and subsprites to draw.
+ * @param to Transparency settings for the sprite.
  * @param total_offset Spriteoffset from normal rail to current railtype.
  * @param newgrf_offset Startsprite of the Action1 to use.
+ * @param default_palette The default recolour sprite to use (typically company colour).
  */
 inline void DrawRailTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, int32_t total_offset, uint32_t newgrf_offset, PaletteID default_palette)
 {
@@ -99,8 +103,12 @@ inline void DrawRailTileSeq(const struct TileInfo *ti, const DrawTileSprites *dt
 
 /**
  * Draw tile sprite sequence in GUI with railroad specifics.
+ * @param x X position to draw to.
+ * @param y Y position to draw to.
+ * @param dts Sprite and subsprites to draw.
  * @param total_offset Spriteoffset from normal rail to current railtype.
  * @param newgrf_offset Startsprite of the Action1 to use.
+ * @param default_palette The default recolour sprite to use (typically company colour).
  */
 inline void DrawRailTileSeqInGUI(int x, int y, const DrawTileSprites *dts, int32_t total_offset, uint32_t newgrf_offset, PaletteID default_palette)
 {
@@ -109,6 +117,10 @@ inline void DrawRailTileSeqInGUI(int x, int y, const DrawTileSprites *dts, int32
 
 /**
  * Draw TTD sprite sequence on tile.
+ * @param ti Tile to draw to.
+ * @param dts Sprite and subsprites to draw.
+ * @param to Transparency settings for the sprite.
+ * @param default_palette The default recolour sprite to use (typically company colour).
  */
 inline void DrawOrigTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, PaletteID default_palette)
 {
@@ -117,6 +129,10 @@ inline void DrawOrigTileSeq(const struct TileInfo *ti, const DrawTileSprites *dt
 
 /**
  * Draw TTD sprite sequence in GUI.
+ * @param x X position to draw to.
+ * @param y Y position to draw to.
+ * @param dts Sprite and subsprites to draw.
+ * @param default_palette The default recolour sprite to use (typically company colour).
  */
 inline void DrawOrigTileSeqInGUI(int x, int y, const DrawTileSprites *dts, PaletteID default_palette)
 {
@@ -125,7 +141,11 @@ inline void DrawOrigTileSeqInGUI(int x, int y, const DrawTileSprites *dts, Palet
 
 /**
  * Draw NewGRF industrytile or house sprite layout
+ * @param ti Tile to draw to.
+ * @param dts Sprite and subsprites to draw.
+ * @param to Transparency settings for the sprite.
  * @param stage Sprite inside the Action1 spritesets to use, i.e. construction stage.
+ * @param default_palette The default recolour sprite to use (typically company colour).
  */
 inline void DrawNewGRFTileSeq(const struct TileInfo *ti, const DrawTileSprites *dts, TransparencyOption to, uint32_t stage, PaletteID default_palette)
 {
@@ -134,7 +154,11 @@ inline void DrawNewGRFTileSeq(const struct TileInfo *ti, const DrawTileSprites *
 
 /**
  * Draw NewGRF object in GUI
+ * @param x X position to draw to.
+ * @param y Y position to draw to.
+ * @param dts Sprite and subsprites to draw.
  * @param stage Sprite inside the Action1 spritesets to use, i.e. construction stage.
+ * @param default_palette The default recolour sprite to use (typically company colour)
  */
 inline void DrawNewGRFTileSeqInGUI(int x, int y, const DrawTileSprites *dts, uint32_t stage, PaletteID default_palette)
 {

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -97,6 +97,7 @@ SpriteFile &OpenCachedSpriteFile(const std::string &filename, Subdirectory subdi
 
 /**
  * Skip the given amount of sprite graphics data.
+ * @param file The file to read from.
  * @param type the type of sprite (compressed etc)
  * @param num the amount of sprites to skip
  * @return true if the data could be correctly skipped.
@@ -168,7 +169,7 @@ uint32_t GetSpriteLocalID(SpriteID sprite)
 
 /**
  * Count the sprites which originate from a specific file in a range of SpriteIDs.
- * @param file The loaded SpriteFile.
+ * @param filename The loaded SpriteFile.
  * @param begin First sprite in range.
  * @param end First sprite not in range.
  * @return Number of sprites.
@@ -553,7 +554,7 @@ size_t GetGRFSpriteOffset(uint32_t id)
 
 /**
  * Parse the sprite section of GRFs.
- * @param container_version Container version of the GRF we're currently processing.
+ * @param file The file to read the sprite offsets for.
  */
 void ReadGRFSpriteOffsets(SpriteFile &file)
 {
@@ -802,6 +803,7 @@ void *UniquePtrSpriteAllocator::AllocatePtr(size_t size)
  * @param sprite ID of loaded sprite
  * @param requested requested sprite type
  * @param sc the currently known sprite cache for the requested sprite
+ * @param allocator Callback that provides the memory when loading sprites.
  * @return fallback sprite
  * @note this function will do UserError() in the case the fallback sprite isn't available
  */

--- a/src/spriteloader/grf.cpp
+++ b/src/spriteloader/grf.cpp
@@ -25,7 +25,7 @@ extern const uint8_t _palmap_w2d[];
 /**
  * We found a corrupted sprite. This means that the sprite itself
  * contains invalid data or is too small for the given dimensions.
- * @param file_slot the file the errored sprite is in
+ * @param file The file the errored sprite is in.
  * @param file_pos the location in the file of the errored sprite
  * @param line the line where the error occurs.
  * @return always false (to tell loading the sprite failed)

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -637,7 +637,7 @@ void RebuildStationKdtree();
 /**
  * Call a function on all stations that have any part of the requested area within their catchment.
  * @tparam Func The type of function to call
- * @param area The TileArea to check
+ * @param ta The TileArea to check.
  * @param func The function to call, must take two parameters: Station* and TileIndex and return true
  *             if coverage of that tile is acceptable for a given station or false if search should continue
  */

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -877,7 +877,7 @@ static StringID GetBridgeTooLowMessageForStationType(StationType type)
 /**
  * Test if a bridge can be built above a station.
  * @param tile Tile to test.
- * @param spec Custom station spec to test.
+ * @param bridgeable_info Minimum height before bridge is okay for each of the layouts.
  * @param type Type of station.
  * @param layout Layout piece of road station to test.
  * @param bridge_height Height of bridge to test.
@@ -1251,6 +1251,7 @@ StationGfx RailStationTileLayout::Iterator::operator*() const
  * @param adjacent whether adjacent stations are allowed
  * @param ta the area of the newly build station
  * @param st 'return' pointer for the found station
+ * @param filter The filter to remove unwanted stations.
  * @return command cost with the error or 'okay'
  */
 template <class T, StringID error_message, class F>
@@ -2023,7 +2024,7 @@ static CommandCost FindJoiningRoadStop(StationID existing_stop, StationID statio
  * @param unit_cost The cost to build one road stop of the current type.
  * @return The cost in case of success, or an error code if it failed.
  */
-CommandCost CalculateRoadStopCost(TileArea tile_area, DoCommandFlags flags, bool is_drive_through, StationType station_type, const RoadStopSpec *roadstopspec, Axis axis, DiagDirection ddir, StationID *est, RoadType rt, Money unit_cost)
+CommandCost CalculateRoadStopCost(TileArea tile_area, DoCommandFlags flags, bool is_drive_through, StationType station_type, const RoadStopSpec *roadstopspec, Axis axis, DiagDirection ddir, StationID *station, RoadType rt, Money unit_cost)
 {
 	DiagDirections invalid_dirs{};
 	if (is_drive_through) {
@@ -2037,7 +2038,7 @@ CommandCost CalculateRoadStopCost(TileArea tile_area, DoCommandFlags flags, bool
 	int allowed_z = -1;
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 	for (TileIndex cur_tile : tile_area) {
-		CommandCost ret = CheckFlatLandRoadStop(cur_tile, allowed_z, roadstopspec, flags, invalid_dirs, is_drive_through, station_type, axis, est, rt);
+		CommandCost ret = CheckFlatLandRoadStop(cur_tile, allowed_z, roadstopspec, flags, invalid_dirs, is_drive_through, station_type, axis, station, rt);
 		if (ret.Failed()) return ret;
 
 		bool is_preexisting_roadstop = IsTileType(cur_tile, TileType::Station) && IsAnyRoadStop(cur_tile);
@@ -2590,7 +2591,7 @@ Town *AirportGetNearestTown(const AirportSpec *as, Direction rotation, TileIndex
 /**
  * Finds the town nearest to given existing airport. Based on minimal manhattan distance to any airport's tile.
  * If two towns have the same distance, town with lower index is returned.
- * @param station existing station with airport
+ * @param st Existing station with airport.
  * @param[out] mindist Minimum distance to town
  * @return nearest town to airport
  */
@@ -4257,7 +4258,8 @@ void DeleteStaleLinks(Station *from)
  * @param next_station_id Station the consist will be travelling to next.
  * @param capacity Capacity to add to link stat.
  * @param usage Usage to add to link stat.
- * @param mode Update mode to be applied.
+ * @param time The travel time for the link.
+ * @param modes Update modes to be applied.
  */
 void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint capacity, uint usage, uint32_t time, EdgeUpdateModes modes)
 {
@@ -4310,6 +4312,7 @@ void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint
  * @param st Station to get the link stats from.
  * @param front First vehicle in the consist.
  * @param next_station_id Station the consist will be travelling to next.
+ * @param time The travel time for the links.
  */
 void IncreaseStats(Station *st, const Vehicle *front, StationID next_station_id, uint32_t time)
 {

--- a/src/station_cmd.h
+++ b/src/station_cmd.h
@@ -43,6 +43,6 @@ DEF_CMD_TRAIT(Commands::RenameStation, CmdRenameStation, {}, CommandType::OtherM
 DEF_CMD_TRAIT(Commands::MoveStationName, CmdMoveStationName, {}, CommandType::OtherManagement)
 DEF_CMD_TRAIT(Commands::OpenCloseAirport, CmdOpenCloseAirport, {}, CommandType::RouteManagement)
 
-void CcMoveStationName(Commands cmd, const CommandCost &result, StationID station_id);
+void CcMoveStationName(Commands, const CommandCost &result, StationID station_id);
 
 #endif /* STATION_CMD_H */

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -1097,7 +1097,7 @@ void CargoDataEntry::Clear()
 
 /**
  * Remove a subentry from this one and delete it.
- * @param child the entry to be removed. This may also be a synthetic entry
+ * @param entry The entry to be removed. This may also be a synthetic entry
  * which only contains the ID of the entry to be removed. In this case child is
  * not deleted.
  */
@@ -1489,7 +1489,7 @@ struct StationViewWindow : public Window {
 	/**
 	 * Rebuild the cache for estimated destinations which is used to quickly show the "destination" entries
 	 * even if we actually don't know the destination of a certain packet from just looking at it.
-	 * @param i Cargo to recalculate the cache for.
+	 * @param cargo Cargo to recalculate the cache for.
 	 */
 	void RecalcDestinations(CargoType cargo)
 	{
@@ -2453,9 +2453,9 @@ static bool StationJoinerNeeded(const StationPickerCmdProc &proc)
 
 /**
  * Show the station selection window when needed. If not, build the station.
- * @param cmd Command to build the station.
  * @param ta Area to build the station in
- * @tparam the class to find stations for
+ * @param proc Callback to check whether we can build.
+ * @tparam T the class to find stations for
  */
 template <class T>
 void ShowSelectBaseStationIfNeeded(TileArea ta, StationPickerCmdProc&& proc)

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -111,7 +111,7 @@ enum StoryPageButtonCursor : uint8_t {
 /**
  * Checks if a StoryPageButtonCursor value is valid.
  *
- * @param wc The value to check
+ * @param cursor The value to check.
  * @return true if the given value is a valid StoryPageButtonCursor.
  */
 inline bool IsValidStoryPageButtonCursor(StoryPageButtonCursor cursor)

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -507,7 +507,7 @@ protected:
 	 * @param width Width of the region available for drawing.
 	 * @param line_height Height of one line of text.
 	 * @param action_sprite The sprite to draw.
-	 * @param string_id The string id to draw.
+	 * @param text The text to draw.
 	 * @return the number of lines.
 	 */
 	void DrawActionElement(int &y_offset, int width, int line_height, SpriteID action_sprite, const std::string &text) const

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -74,7 +74,8 @@ struct StringReader {
 
 	/**
 	 * Handle the pragma of the file.
-	 * @param str    The pragma string to parse.
+	 * @param str The pragma string to parse.
+	 * @param lang The header metadata to write the parsed pragma data to.
 	 */
 	virtual void HandlePragma(std::string_view str, LanguagePackHeader &lang);
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -343,7 +343,7 @@ bool StrContainsIgnoreCase(std::string_view str, std::string_view value)
 /**
  * Get the length of an UTF-8 encoded string in number of characters
  * and thus not the number of bytes that the encoded string contains.
- * @param s The string to get the length for.
+ * @param str The string to get the length for.
  * @return The length of the string in characters.
  */
 size_t Utf8StringLength(std::string_view str)

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -45,6 +45,7 @@ public:
 	/**
 	 * Constructor for filter.
 	 * @param case_sensitive Pointer to a (usually static) variable controlling the case-sensitivity. nullptr means always case-insensitive.
+	 * @param locale_aware Whether to match using the locale.
 	 */
 	StringFilter(const bool *case_sensitive = nullptr, bool locale_aware = true) : case_sensitive(case_sensitive), locale_aware(locale_aware) {}
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -406,7 +406,7 @@ void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters
  * Get a parsed string with most special stringcodes replaced by the string parameters.
  * @param builder The builder of the string.
  * @param string The ID of the string to parse.
- * @param args Span of arguments for the string.
+ * @param params Span of arguments for the string.
  * @param case_index The "case index". This will only be set when FormatString wants to print the string in a different case.
  * @param game_script The string is coming directly from a game script.
  */
@@ -962,7 +962,8 @@ static const Units GetVelocityUnits(VehicleType type)
 
 /**
  * Convert the given (internal) speed to the display speed.
- * @param speed the speed to convert
+ * @param speed The speed to convert.
+ * @param type The associated vehicle type.
  * @return the converted speed.
  */
 uint ConvertSpeedToDisplaySpeed(uint speed, VehicleType type)
@@ -975,7 +976,8 @@ uint ConvertSpeedToDisplaySpeed(uint speed, VehicleType type)
 
 /**
  * Convert the given display speed to the (internal) speed.
- * @param speed the speed to convert
+ * @param speed The speed to convert.
+ * @param type The associated vehicle type.
  * @return the converted speed.
  */
 uint ConvertDisplaySpeedToSpeed(uint speed, VehicleType type)
@@ -985,7 +987,8 @@ uint ConvertDisplaySpeedToSpeed(uint speed, VehicleType type)
 
 /**
  * Convert the given km/h-ish speed to the display speed.
- * @param speed the speed to convert
+ * @param speed The speed to convert.
+ * @param type The associated vehicle type.
  * @return the converted speed.
  */
 uint ConvertKmhishSpeedToDisplaySpeed(uint speed, VehicleType type)
@@ -995,7 +998,8 @@ uint ConvertKmhishSpeedToDisplaySpeed(uint speed, VehicleType type)
 
 /**
  * Convert the given display speed to the km/h-ish speed.
- * @param speed the speed to convert
+ * @param speed The speed to convert.
+ * @param type The associated vehicle type.
  * @return the converted speed.
  */
 uint ConvertDisplaySpeedToKmhishSpeed(uint speed, VehicleType type)
@@ -1099,6 +1103,8 @@ static bool IsColourSafe(std::string_view buffer)
  * @param builder The string builder to write the final string to.
  * @param str_arg The original string with format codes.
  * @param args    Pointer to extra arguments used by various string codes.
+ * @param orig_case_index The selected case when entering the function.
+ * @param game_script Whether this string originates from a game-script.
  * @param dry_run True when the args' type data is not yet initialized.
  */
 static void FormatString(StringBuilder &builder, std::string_view str_arg, StringParameters &args, uint orig_case_index, bool game_script, bool dry_run)

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -160,6 +160,7 @@ static void SurveySettingsTable(nlohmann::json &survey, const SettingTable &tabl
  * Convert settings to JSON.
  *
  * @param survey The JSON object.
+ * @param skip_if_default If true, skip any settings that are on their default value.
  */
 void SurveySettings(nlohmann::json &survey, bool skip_if_default)
 {

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -309,7 +309,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlags flags,
  * @param tile end tile of area-drag
  * @param start_tile start tile of area drag
  * @param diagonal Whether to use the Diagonal or Orthogonal tile iterator.
- * @param LevelMode Mode of leveling \c LevelMode.
+ * @param lm Mode of leveling \c LevelMode.
  * @return the cost of this operation or an error
  */
 std::tuple<CommandCost, Money, TileIndex> CmdLevelLand(DoCommandFlags flags, TileIndex tile, TileIndex start_tile, bool diagonal, LevelMode lm)

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -151,7 +151,7 @@ bool Textbuf::InsertChar(char32_t key)
  * @param marked Replace the currently marked text with the new text.
  * @param caret Move the caret to this point in the insertion string.
  * @param insert_location Position at which to insert the string.
- * @param replacement_end Replace all characters from #insert_location up to this location with the new string.
+ * @param replacement_end Replace all characters from insert_location up to this location with the new string.
  * @return True on successful change of Textbuf, or false otherwise.
  */
 bool Textbuf::InsertString(std::string_view str, bool marked, std::optional<size_t> caret, std::optional<size_t> insert_location, std::optional<size_t> replacement_end)

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -525,7 +525,7 @@ static void AdvanceHouseConstruction(TileIndex tile)
 /**
  * Generate cargo for a house, scaled by the current economy scale.
  * @param t The current town.
- * @param ct Type of cargo to generate, usually CT_PASSENGERS or CT_MAIL.
+ * @param cargo Type of cargo to generate, usually CT_PASSENGERS or CT_MAIL.
  * @param amount The number of cargo units.
  * @param stations Available stations for this house.
  * @param affected_by_recession Is this cargo halved during recessions?
@@ -1208,6 +1208,7 @@ static RoadBits GetTownRoadGridElement(Town *t, TileIndex tile, DiagDirection di
  *
  * @param t The current town.
  * @param tile The target tile for the extra house.
+ * @param modes The parts of the town that are being grown.
  * @return true if an extra house has been added.
  */
 static bool GrowTownWithExtraHouse(Town *t, TileIndex tile, TownExpandModes modes)
@@ -1530,6 +1531,7 @@ enum class TownGrowthResult {
  * @param cur_rb The current tiles RoadBits
  * @param target_dir The target road dir
  * @param t1 The current town
+ * @param modes The parts of the town that are being grown.
  * @return Result so far.
  */
 static TownGrowthResult GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection target_dir, Town *t1, TownExpandModes modes)
@@ -1746,6 +1748,7 @@ static TownGrowthResult GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, Dia
  * This only checks trivial but often cases.
  * @param tile Start tile for road.
  * @param dir Direction for road to follow or build.
+ * @param modes The parts of the town that are being grown.
  * @return true If road is or can be connected in the specified direction.
  */
 static bool CanFollowRoad(TileIndex tile, DiagDirection dir, TownExpandModes modes)
@@ -1788,6 +1791,7 @@ static bool CanFollowRoad(TileIndex tile, DiagDirection dir, TownExpandModes mod
  * Try to grow a town at a given road tile.
  * @param t The town to grow.
  * @param tile The road tile to try growing from.
+ * @param modes The parts of the town that are being grown.
  * @return true if we successfully expanded the town.
  */
 static bool GrowTownAtRoad(Town *t, TileIndex tile, TownExpandModes modes)
@@ -1892,6 +1896,7 @@ static RoadBits GenRandomRoadBits()
 /**
  * Grow the town.
  * @param t The town to grow
+ * @param modes The parts of the town that are being grown.
  * @return true if we successfully grew the town with a road or house.
  */
 static bool GrowTown(Town *t, TownExpandModes modes)
@@ -2553,11 +2558,11 @@ static inline void ClearMakeHouseTile(TileIndex tile, Town *t, uint8_t counter, 
 
 /**
  * Write house information into the map. For multi-tile houses, all tiles are marked.
- * @param town The town related to this house
- * @param t The tile to build on. If a multi-tile house, this is the northern-most tile.
+ * @param tile The tile to build on. If a multi-tile house, this is the northern-most tile.
+ * @param t The town related to this house
  * @param counter The counter of the construction stage.
+ * @param type The type of house.
  * @param stage The current construction stage.
- * @param The type of house.
  * @param random_bits Random bits for newgrf houses to use.
  * @param is_protected Whether the house is protected from the town upgrading it.
  * @pre The house can be built here.
@@ -2646,6 +2651,7 @@ static bool CheckFree2x2Area(TileIndex tile, int z, bool noslope)
  * Checks if the current town layout allows building here.
  * @param t The town.
  * @param tile The tile to check.
+ * @param modes The parts of the town that are being grown.
  * @return true iff town layout allows building here.
  * @note see layouts
  */
@@ -2679,6 +2685,7 @@ static inline bool TownLayoutAllowsHouseHere(Town *t, TileIndex tile, TownExpand
  * Checks if the current town layout allows a 2x2 building here.
  * @param t The town.
  * @param tile The tile to check.
+ * @param modes The parts of the town that are being grown.
  * @return true iff town layout allows a 2x2 building here.
  * @note see layouts
  */
@@ -2720,6 +2727,7 @@ static inline bool TownLayoutAllows2x2HouseHere(Town *t, TileIndex tile, TownExp
  * @param maxz The maximum Z level, since all tiles must have the same height.
  * @param noslope Are foundations disallowed for this house?
  * @param second The diagdir from the first tile to the second tile.
+ * @param modes The parts of the town that are being grown.
  */
 static bool CheckTownBuild2House(TileIndex *tile, Town *t, int maxz, bool noslope, DiagDirection second, TownExpandModes modes)
 {
@@ -2745,6 +2753,7 @@ static bool CheckTownBuild2House(TileIndex *tile, Town *t, int maxz, bool noslop
  * @param t The town.
  * @param maxz The maximum Z level, since all tiles must have the same height.
  * @param noslope Are foundations disallowed for this house?
+ * @param modes The parts of the town that are being grown.
  */
 static bool CheckTownBuild2x2House(TileIndex *tile, Town *t, int maxz, bool noslope, TownExpandModes modes)
 {
@@ -2809,6 +2818,7 @@ static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID
  * Tries to build a house at this tile.
  * @param t The town the house will belong to.
  * @param tile The tile to try building on.
+ * @param modes The parts of the town that are being grown.
  * @return false iff no house can be built on this tile.
  */
 static bool TryBuildTownHouse(Town *t, TileIndex tile, TownExpandModes modes)
@@ -2939,7 +2949,7 @@ static bool TryBuildTownHouse(Town *t, TileIndex tile, TownExpandModes modes)
  * Place an individual house.
  * @param flags Type of operation.
  * @param tile Tile on which to place the house.
- * @param HouseID The HouseID of the house spec.
+ * @param house The HouseID of the house spec.
  * @param is_protected Whether the house is protected from the town upgrading it.
  * @param replace Whether to automatically demolish an existing house on this tile, if present.
  * @return Empty cost or an error.
@@ -3005,7 +3015,7 @@ CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, b
  * @param flags Type of operation.
  * @param tile End tile of area dragging.
  * @param start_tile Start tile of area dragging.
- * @param HouseID The HouseID of the house spec.
+ * @param house The HouseID of the house spec.
  * @param is_protected Whether the house is protected from the town upgrading it.
  * @param replace Whether we can replace existing houses.
  * @param diagonal Whether to use the Diagonal or Orthogonal tile iterator.
@@ -3303,7 +3313,8 @@ CommandCost CmdTownRating(DoCommandFlags flags, TownID town_id, CompanyID compan
 /**
  * Expand a town (scenario editor only).
  * @param flags Type of operation.
- * @param TownID Town ID to expand.
+ * @param town_id Town ID to expand.
+ * @param modes The parts of the town that are being grown.
  * @param grow_amount Amount to grow, or 0 to grow a random size up to the current amount of houses.
  * @return Empty cost or an error.
  */

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -834,6 +834,7 @@ public:
 	/**
 	 * Get the string to draw the town name.
 	 * @param t Town to draw.
+	 * @param population The population of the town.
 	 * @return The string to use.
 	 */
 	static std::string GetTownString(const Town *t, uint64_t population)

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -489,6 +489,7 @@ static SpriteID GetDefaultTrainSprite(uint8_t spritenum, Direction direction)
  * Get the sprite to display the train.
  * @param direction Direction of view/travel.
  * @param image_type Visualisation context.
+ * @param result Sprite sequence to add the to be drawn sprites to.
  * @return Sprite to display.
  */
 void Train::GetImage(Direction direction, EngineImageType image_type, VehicleSpriteSeq *result) const

--- a/src/train_cmd.h
+++ b/src/train_cmd.h
@@ -26,6 +26,6 @@ DEF_CMD_TRAIT(Commands::MoveRailVehicle, CmdMoveRailVehicle, CommandFlag::Locati
 DEF_CMD_TRAIT(Commands::ForceTrainProceed, CmdForceTrainProceed, CommandFlag::Location, CommandType::VehicleManagement)
 DEF_CMD_TRAIT(Commands::ReverseTrainDirection, CmdReverseTrainDirection, CommandFlag::Location, CommandType::VehicleManagement)
 
-void CcBuildWagon(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16_t, CargoArray, TileIndex tile, EngineID, bool, CargoType, ClientID);
+void CcBuildWagon(Commands, const CommandCost &result, VehicleID new_veh_id, uint, uint16_t, CargoArray, TileIndex tile, EngineID, bool, CargoType, ClientID);
 
 #endif /* TRAIN_CMD_H */

--- a/src/tunnel_map.h
+++ b/src/tunnel_map.h
@@ -45,7 +45,8 @@ bool IsTunnelInWayDir(TileIndex tile, int z, DiagDirection dir);
  * @param t the entrance of the tunnel
  * @param o the owner of the entrance
  * @param d the direction facing out of the tunnel
- * @param r the road type used in the tunnel
+ * @param road_rt The road type used in the tunnel.
+ * @param tram_rt The tram type used in the tunnel.
  */
 inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType road_rt, RoadType tram_rt)
 {

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -258,6 +258,7 @@ CommandCost CheckBridgeAvailability(BridgeType bridge_type, uint bridge_len, DoC
 /**
  * Calculate the base cost of clearing a tunnel/bridge per tile.
  * @param tile Start tile of the tunnel/bridge.
+ * @param base_price The base cost for clearing the tile.
  * @return How much clearing this tunnel/bridge costs per tile.
  */
 static Money TunnelBridgeClearCost(TileIndex tile, Price base_price)

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1909,6 +1909,7 @@ UnitID GetFreeUnitNumber(VehicleType type)
  * vehicle type. This to disable building stations etc. when
  * you are not allowed/able to have the vehicle type yet.
  * @param type the vehicle type to check this for
+ * @param subtype The vehicle's sub to to check this for.
  * @return true if there is any reason why you may build
  *         the infrastructure for the given vehicle type
  */
@@ -2318,6 +2319,7 @@ void Vehicle::BeginLoading()
 /**
  * Return all reserved cargo packets to the station and reset all packets
  * staged for transfer.
+ * @param next ID of the next station the cargo wants to go to.
  * @param st the station where the reserved packets should go.
  */
 void Vehicle::CancelReservation(StationID next, Station *st)
@@ -3266,7 +3268,7 @@ uint32_t Vehicle::GetDisplayMinPowerToWeight() const
 /**
  * Checks if two vehicle chains have the same list of engines.
  * @param v1 First vehicle chain.
- * @param v1 Second vehicle chain.
+ * @param v2 Second vehicle chain.
  * @return True if same, false if different.
  */
 bool VehiclesHaveSameEngineList(const Vehicle *v1, const Vehicle *v2)
@@ -3283,7 +3285,7 @@ bool VehiclesHaveSameEngineList(const Vehicle *v1, const Vehicle *v2)
 /**
  * Checks if two vehicles have the same list of orders.
  * @param v1 First vehicles.
- * @param v1 Second vehicles.
+ * @param v2 Second vehicles.
  * @return True if same, false if different.
  */
 bool VehiclesHaveSameOrderList(const Vehicle *v1, const Vehicle *v2)

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -1129,7 +1129,7 @@ struct SpecializedVehicle : public Vehicle {
 
 	/**
 	 * Creates a new T-object in the vehicle pool.
-	 * @param args... The arguments to the constructor.
+	 * @param args The arguments to the constructor.
 	 * @return The created object.
 	 */
 	template <typename... Targs>
@@ -1141,7 +1141,7 @@ struct SpecializedVehicle : public Vehicle {
 	/**
 	 * Creates a new T-object in the vehicle pool.
 	 * @param index The index allocate the object at.
-	 * @param args... The arguments to the constructor.
+	 * @param args The arguments to the constructor.
 	 * @return The created object.
 	 */
 	template <typename... Targs>

--- a/src/vehicle_cmd.h
+++ b/src/vehicle_cmd.h
@@ -41,8 +41,8 @@ DEF_CMD_TRAIT(Commands::MassStartStop, CmdMassStartStopVehicle, {}, CommandType:
 DEF_CMD_TRAIT(Commands::DepotMassSell, CmdDepotSellAllVehicles, {}, CommandType::VehicleConstruction)
 DEF_CMD_TRAIT(Commands::DepotMassAutoreplace, CmdDepotMassAutoReplace, {}, CommandType::VehicleConstruction)
 
-void CcBuildPrimaryVehicle(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16_t, CargoArray);
-void CcStartStopVehicle(Commands cmd, const CommandCost &result, VehicleID veh_id, bool);
+void CcBuildPrimaryVehicle(Commands, const CommandCost &result, VehicleID new_veh_id, uint, uint16_t, CargoArray);
+void CcStartStopVehicle(Commands, const CommandCost &result, VehicleID veh_id, bool);
 
 template <typename Tcont, typename Titer>
 inline EndianBufferWriter<Tcont, Titer> &operator <<(EndianBufferWriter<Tcont, Titer> &buffer, const CargoArray &cargo_array)

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -823,7 +823,10 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 
 /**
  * Internal handler of keyboard keys.
- * @param event Information about occurred event.
+ * @param keycode The raw keycode of the key press.
+ * @param unicode The unicode character of the key press.
+ * @param down Whether pressing or releasing the key.
+ * @param modifiers Flags to denote other (special) keys that might have been pressed.
  * @return Whether event should be interpreted.
  */
 - (BOOL)internalHandleKeycode:(unsigned short)keycode unicode:(char32_t)unicode pressed:(BOOL)down modifiers:(NSUInteger)modifiers

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1270,6 +1270,7 @@ void OpenGLBackend::ReleaseAnimBuffer(const Rect &update_rect)
 /**
  * Render a sprite to the back buffer.
  * @param gl_sprite Sprite to render.
+ * @param pal The palette to draw the sprite with.
  * @param x X position of the sprite.
  * @param y Y position of the sprite.
  * @param zoom Zoom level to use.
@@ -1395,6 +1396,7 @@ void OpenGLBackend::RenderOglSprite(const OpenGLSprite *gl_sprite, PaletteID pal
 
 /**
  * Create an OpenGL sprite with a palette remap part.
+ * @param sprite_type The type of sprite to load.
  * @param sprite The sprite to create the OpenGL sprite for
  */
 OpenGLSprite::OpenGLSprite(SpriteType sprite_type, const SpriteLoader::SpriteCollection &sprite)

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -650,14 +650,9 @@ static void AddCombinedSprite(SpriteID image, PaletteID pal, int x, int y, int z
  * @param pal the provided palette,
  * @param x position X (world) of the sprite,
  * @param y position Y (world) of the sprite,
- * @param w bounding box extent towards positive X (world),
- * @param h bounding box extent towards positive Y (world),
- * @param dz bounding box extent towards positive Z (world),
  * @param z position Z (world) of the sprite,
+ * @param bounds Bounding box extent towards positive X/Y/Z (world).
  * @param transparent if true, switch the palette between the provided palette and the transparent palette,
- * @param bb_offset_x bounding box extent towards negative X (world),
- * @param bb_offset_y bounding box extent towards negative Y (world),
- * @param bb_offset_z bounding box extent towards negative Z (world)
  * @param sub Only draw a part of the sprite.
  */
 void AddSortableSpriteToDraw(SpriteID image, PaletteID pal, int x, int y, int z, const SpriteBounds &bounds, bool transparent, const SubSprite *sub)

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -833,6 +833,7 @@ static void DrawCanalWater(TileIndex tile)
  * @param base    Base sprite.
  * @param offset  Additional sprite offset.
  * @param palette Palette to use.
+ * @param feature The canal feature to get the sprite offset to apply from.
  */
 static void DrawWaterTileStruct(const TileInfo *ti, std::span<const DrawTileSeqStruct> seq, SpriteID base, uint offset, PaletteID palette, CanalFeature feature)
 {

--- a/src/waypoint_cmd.h
+++ b/src/waypoint_cmd.h
@@ -32,6 +32,6 @@ DEF_CMD_TRAIT(Commands::BuildBuoy, CmdBuildBuoy, CommandFlag::Auto, CommandType:
 DEF_CMD_TRAIT(Commands::RenameWaypoint, CmdRenameWaypoint, {}, CommandType::OtherManagement)
 DEF_CMD_TRAIT(Commands::MoveWaypointNAme, CmdMoveWaypointName, {}, CommandType::OtherManagement)
 
-void CcMoveWaypointName(Commands cmd, const CommandCost &result, StationID waypoint_id);
+void CcMoveWaypointName(Commands, const CommandCost &result, StationID waypoint_id);
 
 #endif /* WAYPOINT_CMD_H */

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -53,7 +53,7 @@ static inline RectPadding ScaleGUITrad(const RectPadding &r)
 
 /**
  * Scale a Dimension to GUI zoom level.
- * @param d Dimension at ZOOM_BASE (traditional "normal" interface size).
+ * @param dim Dimension at ZOOM_BASE (traditional "normal" interface size).
  * @return Dimension at current interface size.
  */
 static inline Dimension ScaleGUITrad(const Dimension &dim)
@@ -975,6 +975,7 @@ void NWidgetBase::AdjustPaddingForZoom()
 /**
  * Constructor for resizable nested widgets.
  * @param tp     Nested widget type.
+ * @param index Index of the widget within the window.
  * @param fill_x Horizontal fill step size, \c 0 means no filling is allowed.
  * @param fill_y Vertical fill step size, \c 0 means no filling is allowed.
  */
@@ -1080,7 +1081,7 @@ void NWidgetResizeBase::SetResize(uint resize_x, uint resize_y)
  * Try to set optimum widget size for a multiline text widget.
  * The window will need to be reinited if the size is changed.
  * @param str Multiline string contents that will fill the widget.
- * @param max_line Maximum number of lines.
+ * @param max_lines Maximum number of lines.
  * @return true iff the widget minimum size has changed.
  */
 bool NWidgetResizeBase::UpdateMultilineWidgetSize(const std::string &str, int max_lines)
@@ -2440,7 +2441,7 @@ Scrollbar::size_type Scrollbar::GetScrolledRowFromWidget(int clickpos, const Win
  * With WKC_HOME the first position is selected and with WKC_END the last position is selected.
  * This function ensures that pos is in the range [0..count).
  * @param list_position The current position in the list.
- * @param key_code      The pressed key code.
+ * @param keycode The pressed key code.
  * @return ES_NOT_HANDLED when another key than the 6 specific keys was pressed, otherwise ES_HANDLED.
  */
 EventState Scrollbar::UpdateListPositionOnKeyPress(int &list_position, uint16_t keycode) const
@@ -3426,7 +3427,7 @@ std::unique_ptr<NWidgetBase> MakeWindowNWidgetTree(std::span<const NWidgetPart> 
  * Make a number of rows with button-like graphics, for enabling/disabling each company.
  * @param widget_first The first widget index to use.
  * @param widget_last The last widget index to use.
- * @param colour The colour in which to draw the button.
+ * @param button_colour The colour in which to draw the button.
  * @param max_length Maximal number of company buttons in one row.
  * @param button_tooltip The tooltip-string of every button.
  * @param resizable Whether the rows are resizable.

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -1347,7 +1347,7 @@ constexpr NWidgetPart SetPadding(uint8_t horizontal, uint8_t vertical)
 
 /**
  * Widget part function for setting additional space around a widget.
- * @param r The padding around the widget.
+ * @param padding The padding around the widget.
  * @ingroup NestedWidgetParts
  */
 constexpr NWidgetPart SetPadding(const RectPadding &padding)
@@ -1379,9 +1379,9 @@ constexpr NWidgetPart SetPIP(uint8_t pre, uint8_t inter, uint8_t post)
 
 /**
  * Widget part function for setting a pre/inter/post ratio.
- * @param pre The ratio of space before the first widget.
- * @param inter The ratio of space between widgets.
- * @param post The ratio of space after the last widget.
+ * @param ratio_pre The ratio of space before the first widget.
+ * @param ratio_inter The ratio of space between widgets.
+ * @param ratio_post The ratio of space after the last widget.
  * @ingroup NestedWidgetParts
  */
 constexpr NWidgetPart SetPIPRatio(uint8_t ratio_pre, uint8_t ratio_inter, uint8_t ratio_post)
@@ -1430,6 +1430,7 @@ constexpr NWidgetPart NWidget(WidgetType tp, Colours col, WidgetID idx = INVALID
  * Widget part function for starting a new horizontal container, vertical container, or spacer widget.
  * @param tp         Type of the new nested widget, #NWID_HORIZONTAL, #NWID_VERTICAL, #NWID_SPACER, #NWID_SELECTION, and #NWID_MATRIX.
  * @param cont_flags Flags for the containers (#NWID_HORIZONTAL and #NWID_VERTICAL).
+ * @param idx Optional identifier of the widget.
  * @ingroup NestedWidgetParts
  */
 constexpr NWidgetPart NWidget(WidgetType tp, NWidContainerFlags cont_flags = {}, WidgetID idx = INVALID_WIDGET)

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1191,6 +1191,7 @@ Window *GetMainWindow()
  * @param cls Window class
  * @param number Number of the window within the window class
  * @param force force closing; if false don't close when stickied
+ * @param data Arbitrary data to pass to the Close function.
  */
 void CloseWindowById(WindowClass cls, WindowNumber number, bool force, int data)
 {
@@ -1203,6 +1204,7 @@ void CloseWindowById(WindowClass cls, WindowNumber number, bool force, int data)
 /**
  * Close all windows of a given class
  * @param cls Window class of windows to delete
+ * @param data Arbitrary data to pass to the Close function.
  */
 void CloseWindowByClass(WindowClass cls, int data)
 {
@@ -2094,6 +2096,7 @@ static void EnsureVisibleCaption(Window *w, int nx, int ny)
  * @param delta_x Delta x-size of changed window (positive if larger, etc.)
  * @param delta_y Delta y-size of changed window
  * @param clamp_to_screen Whether to make sure the whole window stays visible
+ * @param schedule_resize Whether to schedule for resizing (when a Window isn't fully initialised yet), or resize immediately.
  */
 void ResizeWindow(Window *w, int delta_x, int delta_y, bool clamp_to_screen, bool schedule_resize)
 {
@@ -2717,6 +2720,10 @@ void HandleCtrlChanged()
  * Insert a text string at the cursor position into the edit box widget.
  * @param wid Edit box widget.
  * @param str Text string to insert.
+ * @param marked Replace the currently marked text with the new text.
+ * @param caret Move the caret to this point in the insertion string.
+ * @param insert_location Position at which to insert the string.
+ * @param replacement_end Replace all characters from insert_location up to this location with the new string.
  */
 /* virtual */ void Window::InsertTextString(WidgetID wid, std::string_view str, bool marked, std::optional<size_t> caret, std::optional<size_t> insert_location, std::optional<size_t> replacement_end)
 {
@@ -2732,8 +2739,10 @@ void HandleCtrlChanged()
 /**
  * Handle text input.
  * @param str Text string to input.
- * @param marked Is the input a marked composition string from an IME?
+ * @param marked Replace the currently marked text with the new text.
  * @param caret Move the caret to this point in the insertion string.
+ * @param insert_location Position at which to insert the string.
+ * @param replacement_end Replace all characters from insert_location up to this location with the new string.
  */
 void HandleTextInput(std::string_view str, bool marked, std::optional<size_t> caret, std::optional<size_t> insert_location, std::optional<size_t> replacement_end)
 {

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -811,7 +811,8 @@ public:
 
 	/**
 	 * The user clicked on a vehicle while HT_VEHICLE has been set.
-	 * @param v clicked vehicle
+	 * @param begin Begin iterator of the vehicle list.
+	 * @param end End iterator of the vehicle list.
 	 * @return True if the click is handled, false if it is ignored
 	 * @pre v->IsPrimaryVehicle() == true
 	 */


### PR DESCRIPTION
## Motivation / Problem

Lots of doxygen warnings about partially missing parameters. Either because there is a name mismatch, or some but not all of the parameters are documented.


## Description

Fix some documentation.

I mostly went through the ones where parameters were documented, but not all. This incidentally also triggers when doxygen parameter and function parameter names mismatch.

In the case of command callbacks, the parameter name was removed in some cases of the declaration to denote that they are not used. This also silences the doxygen warning about the parameter.


## Limitations

Similar to #15205 as this is basically a second tranche of similar changes split into multiple PRs to not have too much to review at a time.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
