### PR TITLE
Codechange: Remove redundant snowy road logic

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2006,8 +2006,8 @@ static void TileLoop_Road(TileIndex tile)
 {
 	switch (_settings_game.game_creation.landscape) {
 		case LandscapeType::Arctic: {
-			/* Roads on flat or elevated foundations use the snow level of the height they are elevated to. All others use the snow level of their minimum height. */
-			int tile_z = (std::get<Slope>(GetFoundationSlope(tile)) == SLOPE_FLAT || std::get<Slope>(GetFoundationSlope(tile)) & SLOPE_ELEVATED) ? GetTileMaxZ(tile) : GetTileZ(tile);
+			/* Roads use the snow level of their maximum height minus one, unless flat. */
+			int tile_z = (std::get<Slope>(GetFoundationSlope(tile)) == SLOPE_FLAT) ? GetTileMaxZ(tile) : GetTileMaxZ(tile) - 1;
 			if (IsOnSnowOrDesert(tile) != (tile_z > GetSnowLine())) {
 				ToggleSnowOrDesert(tile);
 				MarkTileDirtyByTile(tile);


### PR DESCRIPTION
## Motivation / Problem

As per discussion on https://github.com/OpenTTD/OpenTTD/pull/15190, the fix for https://github.com/OpenTTD/OpenTTD/issues/15137 by @abi9ail gave the correct result but, as @JGRennison pointed, there was excess logic which had unreachable results.

"testing for the foundation slope being either `== SLOPE_FLAT` or & `SLOPE_ELEVATED` makes the `GetTileZ(tile)` path unreachable, because those conditions can never both be false at the same time for road tiles.
In effect this change is just `int tile_z = GetTileMaxZ(tile)`."

## Description

Change to determine tile snowyness with just `GetTileMaxZ(tile)`.

As expected, looks right for roads on the ground or on foundations (including steep foundations) at the snowline.

<img width="921" height="636" alt="image" src="https://github.com/user-attachments/assets/a7e6c138-c0f8-438f-95c5-97d1b076ddb1" />

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
