### PR TITLE
Codefix: various tweaks to improve doxygen parsing

### DIFF
--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -19,14 +19,15 @@
 
 #include "../safeguards.h"
 
-NetworkSurveyHandler _survey = {};
-
+/** Mapping to a string representation of the Reason enumeration. */
 NLOHMANN_JSON_SERIALIZE_ENUM(NetworkSurveyHandler::Reason, {
 	{NetworkSurveyHandler::Reason::Preview, "preview"},
 	{NetworkSurveyHandler::Reason::Leave, "leave"},
 	{NetworkSurveyHandler::Reason::Exit, "exit"},
 	{NetworkSurveyHandler::Reason::Crash, "crash"},
 })
+
+NetworkSurveyHandler _survey = {};
 
 /**
  * Create the payload for the survey.

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -18,6 +18,8 @@
 #include "newgrf_callbacks.h"
 #include "newgrf_text_type.h"
 
+struct GRFConfig;
+
 /**
  * List of different canal 'features'.
  * Each feature gets an entry in the canal spritegroup table
@@ -159,7 +161,7 @@ struct GRFFile {
 	GrfSpecFeatures grf_features{}; ///< Bitset of GrfSpecFeature the grf uses
 	PriceMultipliers price_base_multipliers{}; ///< Price base multipliers as set by the grf.
 
-	GRFFile(const struct GRFConfig &config);
+	GRFFile(const GRFConfig &config);
 	GRFFile();
 	GRFFile(GRFFile &&other);
 	~GRFFile();

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -25,12 +25,14 @@ struct OrderBackup;
 using OrderBackupPool = Pool<OrderBackup, OrderBackupID, 1>;
 /** The pool with order backups. */
 extern OrderBackupPool _order_backup_pool;
+/** An item in the OrderBackupPool. */
+using OrderBackupPoolItem = OrderBackupPool::PoolItem<&_order_backup_pool>;
 
 /**
  * Data for backing up an order of a vehicle so it can be
  * restored after a vehicle is rebuilt in the same depot.
  */
-struct OrderBackup : OrderBackupPool::PoolItem<&_order_backup_pool>, BaseConsist {
+struct OrderBackup : OrderBackupPoolItem, BaseConsist {
 private:
 	friend SaveLoadTable GetOrderBackupDescription(); ///< Saving and loading of order backups.
 	friend struct BKORChunkHandler; ///< Creating empty orders upon savegame loading.
@@ -47,7 +49,7 @@ private:
 
 	void DoRestore(Vehicle *v);
 
-	friend OrderBackupPool::PoolItem<&_order_backup_pool>;
+	friend OrderBackupPoolItem; ///< Loading of order backups.
 	OrderBackup(OrderBackupID index);
 	OrderBackup(OrderBackupID index, const Vehicle *v, uint32_t user);
 

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -515,6 +515,7 @@ struct IndustryCompare {
 };
 
 typedef std::set<IndustryListEntry, IndustryCompare> IndustryList;
+struct RoadVehicle;
 
 /** Station data structure */
 struct Station final : SpecializedStation<Station, false> {
@@ -524,7 +525,7 @@ public:
 		return type == RoadStopType::Bus ? bus_stops : truck_stops;
 	}
 
-	RoadStop *GetPrimaryRoadStop(const struct RoadVehicle *v) const;
+	RoadStop *GetPrimaryRoadStop(const RoadVehicle *v) const;
 
 	RoadStop *bus_stops = nullptr; ///< All the road stops
 	TileArea bus_station{}; ///< Tile area the bus 'station' part covers

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -169,9 +169,6 @@ extern VehiclePool _vehicle_pool;
 /* Some declarations of functions, so we can make them friendly */
 struct GroundVehicleCache;
 struct LoadgameState;
-extern bool LoadOldVehicle(LoadgameState &ls, int num);
-extern void FixOldVehicles(LoadgameState &ls);
-
 struct GRFFile;
 
 /**

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -691,7 +691,7 @@ static inline void DrawResizeBox(const Rect &r, Colours colour, bool at_left, bo
 
 /**
  * Draw a close box.
- * @param r      Rectangle of the box.`
+ * @param r      Rectangle of the box.
  * @param colour Colour of the close box.
  */
 static inline void DrawCloseBox(const Rect &r, Colours colour)
@@ -701,7 +701,7 @@ static inline void DrawCloseBox(const Rect &r, Colours colour)
 	Dimension d = GetSpriteSize(SPR_CLOSEBOX, &offset);
 	d.width  -= offset.x;
 	d.height -= offset.y;
-	int s = ScaleSpriteTrad(1); /* Offset to account for shadow of SPR_CLOSEBOX */
+	int s = ScaleSpriteTrad(1); // Offset to account for shadow of SPR_CLOSEBOX.
 	DrawSprite(SPR_CLOSEBOX, (colour != COLOUR_WHITE ? TC_BLACK : TC_SILVER) | (1U << PALETTE_TEXT_RECOLOUR), CentreBounds(r.left, r.right, d.width - s) - offset.x, CentreBounds(r.top, r.bottom, d.height - s) - offset.y);
 }
 


### PR DESCRIPTION
## Motivation / Problem

Rooting out the last few warnings about `@param` in doxygen.


## Description

* For some reason doxygen doesn't understand forward declaration of types in functions, so move them out.
* `extern` forward declaring for `friend` triggers warnings about the parameters not being documented, even though they are.
* `NLOHMANN_JSON_SERIALIZE_ENUM` before a function behaves weirdly, but with a variable after it there's no problem.
* `friend` with template instantiation is troublesome, so move that to `using` and it's fine.
* A stray '`' makes it complain about no closing comment.
* `/* .. */` on the previous line (coupled with the above) made it think weird stuff.


## Limitations

I can't quite explain why these locations are problematic. Though the changes are relatively nonintrusive to the quality of the code base, so lets change it before someone stumbles into them while changing something unrelated.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
