### PR TITLE
Codefix: override already implies virtual, so don't add virtual

### DIFF
--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -661,8 +661,8 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CHECK_NEWGRFS(P
 }
 
 class ClientGamePasswordRequestHandler : public NetworkAuthenticationPasswordRequestHandler {
-	virtual void SendResponse() override { MyClient::SendAuthResponse(); }
-	virtual void AskUserForPassword(std::shared_ptr<NetworkAuthenticationPasswordRequest> request) override
+	void SendResponse() override { MyClient::SendAuthResponse(); }
+	void AskUserForPassword(std::shared_ptr<NetworkAuthenticationPasswordRequest> request) override
 	{
 		if (!_network_join.server_password.empty()) {
 			request->Reply(_network_join.server_password);

--- a/src/network/network_crypto.h
+++ b/src/network/network_crypto.h
@@ -88,7 +88,7 @@ protected:
 	std::string password; ///< The entered password.
 public:
 
-	virtual void Reply(const std::string &password) override;
+	void Reply(const std::string &password) override;
 
 	/**
 	 * Callback to trigger sending the response for the password request.

--- a/src/network/network_crypto_internal.h
+++ b/src/network/network_crypto_internal.h
@@ -140,15 +140,15 @@ public:
 	 */
 	X25519KeyExchangeOnlyClientHandler(const X25519SecretKey &secret_key) : X25519AuthenticationHandler(secret_key) {}
 
-	virtual RequestResult ReceiveRequest(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveRequest(p) ? RequestResult::ReadyForResponse : RequestResult::Invalid; }
-	virtual bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, {}); }
+	RequestResult ReceiveRequest(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveRequest(p) ? RequestResult::ReadyForResponse : RequestResult::Invalid; }
+	bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, {}); }
 
-	virtual std::string_view GetName() const override { return "X25519-KeyExchangeOnly-client"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_KeyExchangeOnly; }
+	std::string_view GetName() const override { return "X25519-KeyExchangeOnly-client"; }
+	NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_KeyExchangeOnly; }
 
-	virtual bool ReceiveEnableEncryption(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveEnableEncryption(p); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
+	bool ReceiveEnableEncryption(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveEnableEncryption(p); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
 };
 
 /**
@@ -164,17 +164,17 @@ public:
 	 */
 	X25519KeyExchangeOnlyServerHandler(const X25519SecretKey &secret_key) : X25519AuthenticationHandler(secret_key) {}
 
-	virtual void SendRequest(struct Packet &p) override { this->X25519AuthenticationHandler::SendRequest(p); }
-	virtual ResponseResult ReceiveResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveResponse(p, {}); }
+	void SendRequest(struct Packet &p) override { this->X25519AuthenticationHandler::SendRequest(p); }
+	ResponseResult ReceiveResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveResponse(p, {}); }
 
-	virtual std::string_view GetName() const override { return "X25519-KeyExchangeOnly-server"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_KeyExchangeOnly; }
-	virtual bool CanBeUsed() const override { return true; }
+	std::string_view GetName() const override { return "X25519-KeyExchangeOnly-server"; }
+	NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_KeyExchangeOnly; }
+	bool CanBeUsed() const override { return true; }
 
-	virtual std::string GetPeerPublicKey() const override { return this->X25519AuthenticationHandler::GetPeerPublicKey(); }
-	virtual void SendEnableEncryption(struct Packet &p) override { this->X25519AuthenticationHandler::SendEnableEncryption(p); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
+	std::string GetPeerPublicKey() const override { return this->X25519AuthenticationHandler::GetPeerPublicKey(); }
+	void SendEnableEncryption(struct Packet &p) override { this->X25519AuthenticationHandler::SendEnableEncryption(p); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
 };
 
 /**
@@ -194,15 +194,15 @@ public:
 	 */
 	X25519PAKEClientHandler(const X25519SecretKey &secret_key, std::shared_ptr<NetworkAuthenticationPasswordRequestHandler> handler) : X25519AuthenticationHandler(secret_key), handler(std::move(handler)) {}
 
-	virtual RequestResult ReceiveRequest(struct Packet &p) override;
-	virtual bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, this->handler->password); }
+	RequestResult ReceiveRequest(struct Packet &p) override;
+	bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, this->handler->password); }
 
-	virtual std::string_view GetName() const override { return "X25519-PAKE-client"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_PAKE; }
+	std::string_view GetName() const override { return "X25519-PAKE-client"; }
+	NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_PAKE; }
 
-	virtual bool ReceiveEnableEncryption(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveEnableEncryption(p); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
+	bool ReceiveEnableEncryption(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveEnableEncryption(p); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
 };
 
 /**
@@ -221,17 +221,17 @@ public:
 	 */
 	X25519PAKEServerHandler(const X25519SecretKey &secret_key, const NetworkAuthenticationPasswordProvider *password_provider) : X25519AuthenticationHandler(secret_key), password_provider(password_provider) {}
 
-	virtual void SendRequest(struct Packet &p) override { this->X25519AuthenticationHandler::SendRequest(p); }
-	virtual ResponseResult ReceiveResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveResponse(p, this->password_provider->GetPassword()); }
+	void SendRequest(struct Packet &p) override { this->X25519AuthenticationHandler::SendRequest(p); }
+	ResponseResult ReceiveResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveResponse(p, this->password_provider->GetPassword()); }
 
-	virtual std::string_view GetName() const override { return "X25519-PAKE-server"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_PAKE; }
-	virtual bool CanBeUsed() const override { return !this->password_provider->GetPassword().empty(); }
+	std::string_view GetName() const override { return "X25519-PAKE-server"; }
+	NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_PAKE; }
+	bool CanBeUsed() const override { return !this->password_provider->GetPassword().empty(); }
 
-	virtual std::string GetPeerPublicKey() const override { return this->X25519AuthenticationHandler::GetPeerPublicKey(); }
-	virtual void SendEnableEncryption(struct Packet &p) override { this->X25519AuthenticationHandler::SendEnableEncryption(p); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
+	std::string GetPeerPublicKey() const override { return this->X25519AuthenticationHandler::GetPeerPublicKey(); }
+	void SendEnableEncryption(struct Packet &p) override { this->X25519AuthenticationHandler::SendEnableEncryption(p); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
 };
 
 
@@ -249,15 +249,15 @@ public:
 	 */
 	X25519AuthorizedKeyClientHandler(const X25519SecretKey &secret_key) : X25519AuthenticationHandler(secret_key) {}
 
-	virtual RequestResult ReceiveRequest(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveRequest(p) ? RequestResult::ReadyForResponse : RequestResult::Invalid; }
-	virtual bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, {}); }
+	RequestResult ReceiveRequest(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveRequest(p) ? RequestResult::ReadyForResponse : RequestResult::Invalid; }
+	bool SendResponse(struct Packet &p) override { return this->X25519AuthenticationHandler::SendResponse(p, {}); }
 
-	virtual std::string_view GetName() const override { return "X25519-AuthorizedKey-client"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_AuthorizedKey; }
+	std::string_view GetName() const override { return "X25519-AuthorizedKey-client"; }
+	NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_AuthorizedKey; }
 
-	virtual bool ReceiveEnableEncryption(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveEnableEncryption(p); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
+	bool ReceiveEnableEncryption(struct Packet &p) override { return this->X25519AuthenticationHandler::ReceiveEnableEncryption(p); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
 
 	static X25519SecretKey GetValidSecretKeyAndUpdatePublicKey(std::string &secret_key, std::string &public_key);
 };
@@ -279,17 +279,17 @@ public:
 	 */
 	X25519AuthorizedKeyServerHandler(const X25519SecretKey &secret_key, const NetworkAuthenticationAuthorizedKeyHandler *authorized_key_handler) : X25519AuthenticationHandler(secret_key), authorized_key_handler(authorized_key_handler) {}
 
-	virtual void SendRequest(struct Packet &p) override { this->X25519AuthenticationHandler::SendRequest(p); }
-	virtual ResponseResult ReceiveResponse(struct Packet &p) override;
+	void SendRequest(struct Packet &p) override { this->X25519AuthenticationHandler::SendRequest(p); }
+	ResponseResult ReceiveResponse(struct Packet &p) override;
 
-	virtual std::string_view GetName() const override { return "X25519-AuthorizedKey-server"; }
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_AuthorizedKey; }
-	virtual bool CanBeUsed() const override { return this->authorized_key_handler->CanBeUsed(); }
+	std::string_view GetName() const override { return "X25519-AuthorizedKey-server"; }
+	NetworkAuthenticationMethod GetAuthenticationMethod() const override { return NetworkAuthenticationMethod::X25519_AuthorizedKey; }
+	bool CanBeUsed() const override { return this->authorized_key_handler->CanBeUsed(); }
 
-	virtual std::string GetPeerPublicKey() const override { return this->X25519AuthenticationHandler::GetPeerPublicKey(); }
-	virtual void SendEnableEncryption(struct Packet &p) override { this->X25519AuthenticationHandler::SendEnableEncryption(p); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
+	std::string GetPeerPublicKey() const override { return this->X25519AuthenticationHandler::GetPeerPublicKey(); }
+	void SendEnableEncryption(struct Packet &p) override { this->X25519AuthenticationHandler::SendEnableEncryption(p); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateClientToServerEncryptionHandler(); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->X25519AuthenticationHandler::CreateServerToClientEncryptionHandler(); }
 };
 
 
@@ -312,15 +312,15 @@ public:
 	 */
 	void Add(Handler &&handler) { this->handlers.push_back(std::move(handler)); }
 
-	virtual RequestResult ReceiveRequest(struct Packet &p) override;
-	virtual bool SendResponse(struct Packet &p) override;
+	RequestResult ReceiveRequest(struct Packet &p) override;
+	bool SendResponse(struct Packet &p) override;
 
-	virtual std::string_view GetName() const override;
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override;
+	std::string_view GetName() const override;
+	NetworkAuthenticationMethod GetAuthenticationMethod() const override;
 
-	virtual bool ReceiveEnableEncryption(struct Packet &p) override { return this->current_handler->ReceiveEnableEncryption(p); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->current_handler->CreateClientToServerEncryptionHandler(); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->current_handler->CreateServerToClientEncryptionHandler(); }
+	bool ReceiveEnableEncryption(struct Packet &p) override { return this->current_handler->ReceiveEnableEncryption(p); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->current_handler->CreateClientToServerEncryptionHandler(); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->current_handler->CreateServerToClientEncryptionHandler(); }
 };
 
 /**
@@ -337,17 +337,17 @@ private:
 public:
 	void Add(Handler &&handler);
 
-	virtual void SendRequest(struct Packet &p) override;
-	virtual ResponseResult ReceiveResponse(struct Packet &p) override;
+	void SendRequest(struct Packet &p) override;
+	ResponseResult ReceiveResponse(struct Packet &p) override;
 
-	virtual std::string_view GetName() const override;
-	virtual NetworkAuthenticationMethod GetAuthenticationMethod() const override;
-	virtual bool CanBeUsed() const override;
+	std::string_view GetName() const override;
+	NetworkAuthenticationMethod GetAuthenticationMethod() const override;
+	bool CanBeUsed() const override;
 
-	virtual std::string GetPeerPublicKey() const override { return this->handlers.back()->GetPeerPublicKey(); }
-	virtual void SendEnableEncryption(struct Packet &p) override { this->handlers.back()->SendEnableEncryption(p); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->handlers.back()->CreateClientToServerEncryptionHandler(); }
-	virtual std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->handlers.back()->CreateServerToClientEncryptionHandler(); }
+	std::string GetPeerPublicKey() const override { return this->handlers.back()->GetPeerPublicKey(); }
+	void SendEnableEncryption(struct Packet &p) override { this->handlers.back()->SendEnableEncryption(p); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateClientToServerEncryptionHandler() const override { return this->handlers.back()->CreateClientToServerEncryptionHandler(); }
+	std::unique_ptr<NetworkEncryptionHandler> CreateServerToClientEncryptionHandler() const override { return this->handlers.back()->CreateServerToClientEncryptionHandler(); }
 };
 
 #endif /* NETWORK_CRYPTO_INTERNAL_H */

--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -85,7 +85,7 @@ class CrashLogOSX : public CrashLog {
 	}
 #endif
 
-	/* virtual */ bool TryExecute(std::string_view section_name, std::function<bool()> &&func) override
+	bool TryExecute(std::string_view section_name, std::function<bool()> &&func) override
 	{
 		this->try_execute_active = true;
 

--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -85,7 +85,7 @@ class CrashLogUnix : public CrashLog {
 	}
 #endif
 
-	/* virtual */ bool TryExecute(std::string_view section_name, std::function<bool()> &&func) override
+	bool TryExecute(std::string_view section_name, std::function<bool()> &&func) override
 	{
 		this->try_execute_active = true;
 

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -115,7 +115,7 @@ public:
 #endif
 
 #if defined(_MSC_VER)
-	/* virtual */ bool TryExecute(std::string_view section_name, std::function<bool()> &&func) override
+	bool TryExecute(std::string_view section_name, std::function<bool()> &&func) override
 	{
 		this->try_execute_active = true;
 		bool res;
@@ -131,7 +131,7 @@ public:
 		return res;
 	}
 #else
-	/* virtual */ bool TryExecute(std::string_view section_name, std::function<bool()> &&func) override
+	bool TryExecute(std::string_view section_name, std::function<bool()> &&func) override
 	{
 		this->try_execute_active = true;
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1880,12 +1880,12 @@ class SlSkipHandler : public SaveLoadHandler {
 		this->Load(object);
 	}
 
-	virtual SaveLoadTable GetDescription() const override
+	SaveLoadTable GetDescription() const override
 	{
 		return {};
 	}
 
-	virtual SaveLoadCompatTable GetCompatDescription() const override
+	SaveLoadCompatTable GetCompatDescription() const override
 	{
 		NOT_REACHED();
 	}

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -145,9 +145,9 @@ protected:
 		ScriptList::FillList<T>(vm, list, [](const T *) { return true; });
 	}
 
-	virtual bool SaveObject(HSQUIRRELVM vm) const override;
-	virtual bool LoadObject(HSQUIRRELVM vm) override;
-	virtual ScriptObject *CloneObject() const override;
+	bool SaveObject(HSQUIRRELVM vm) const override;
+	bool LoadObject(HSQUIRRELVM vm) override;
+	ScriptObject *CloneObject() const override;
 
 	/**
 	 * Copy the content of a list.

--- a/src/script/api/script_tilelist.hpp
+++ b/src/script/api/script_tilelist.hpp
@@ -23,8 +23,8 @@ class ScriptTileList : public ScriptList {
 private:
 	std::optional<OrthogonalTileIterator> resume_iter;
 protected:
-	virtual bool SaveObject(HSQUIRRELVM) const override;
-	virtual ScriptObject *CloneObject() const override;
+	bool SaveObject(HSQUIRRELVM) const override;
+	ScriptObject *CloneObject() const override;
 public:
 	/**
 	 * Adds the rectangle between tile_from and tile_to to the to-be-evaluated tiles.

--- a/src/video/sdl2_opengl_v.h
+++ b/src/video/sdl2_opengl_v.h
@@ -52,7 +52,7 @@ private:
 class FVideoDriver_SDL_OpenGL : public DriverFactoryBase {
 public:
 	FVideoDriver_SDL_OpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 8, "sdl-opengl", "SDL OpenGL Video Driver") {}
-	/* virtual */ std::unique_ptr<Driver> CreateInstance() const override { return std::make_unique<VideoDriver_SDL_OpenGL>(); }
+	std::unique_ptr<Driver> CreateInstance() const override { return std::make_unique<VideoDriver_SDL_OpenGL>(); }
 
 protected:
 	bool UsesHardwareAcceleration() const override { return true; }

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -167,7 +167,7 @@ protected:
 class FVideoDriver_Win32OpenGL : public DriverFactoryBase {
 public:
 	FVideoDriver_Win32OpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 10, "win32-opengl", "Win32 OpenGL Video Driver") {}
-	/* virtual */ std::unique_ptr<Driver> CreateInstance() const override { return std::make_unique<VideoDriver_Win32OpenGL>(); }
+	std::unique_ptr<Driver> CreateInstance() const override { return std::make_unique<VideoDriver_Win32OpenGL>(); }
 
 protected:
 	bool UsesHardwareAcceleration() const override { return true; }


### PR DESCRIPTION
## Motivation / Problem

`virtual void Function() override;`. Generally we don't use `virtual` when using `override`, because `override` implies `virtual`. But it's done inconsistently.


## Description

Remove the unneeded `virtual`s.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
