### PR TITLE
Codechange: remove unneeded/unused return type

### DIFF
--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -226,12 +226,11 @@ static bool CreateMainSurface(uint w, uint h)
 	return true;
 }
 
-bool VideoDriver_Allegro::ClaimMousePointer()
+void VideoDriver_Allegro::ClaimMousePointer()
 {
 	select_mouse_cursor(MOUSE_CURSOR_NONE);
 	show_mouse(nullptr);
 	disable_hardware_cursor();
-	return true;
 }
 
 std::vector<int> VideoDriver_Allegro::GetListOfMonitorRefreshRates()

--- a/src/video/allegro_v.h
+++ b/src/video/allegro_v.h
@@ -29,7 +29,7 @@ public:
 
 	bool AfterBlitterChange() override;
 
-	bool ClaimMousePointer() override;
+	void ClaimMousePointer() override;
 
 	std::vector<int> GetListOfMonitorRefreshRates() override;
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -195,13 +195,12 @@ bool VideoDriver_SDL_Base::CreateMainSurface(uint w, uint h, bool resize)
 	return true;
 }
 
-bool VideoDriver_SDL_Base::ClaimMousePointer()
+void VideoDriver_SDL_Base::ClaimMousePointer()
 {
 	/* Emscripten never claims the pointer, so we do not need to change the cursor visibility. */
 #ifndef __EMSCRIPTEN__
 	SDL_ShowCursor(0);
 #endif
-	return true;
 }
 
 /**

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -33,7 +33,7 @@ public:
 
 	bool AfterBlitterChange() override;
 
-	bool ClaimMousePointer() override;
+	void ClaimMousePointer() override;
 
 	void EditBoxGainedFocus() override;
 

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -83,10 +83,10 @@ public:
 		return true;
 	}
 
-	virtual bool ClaimMousePointer()
-	{
-		return true;
-	}
+	/**
+	 * Claim the exclusive rights for the mouse pointer.
+	 */
+	virtual void ClaimMousePointer() {}
 
 	/**
 	 * Get whether the mouse cursor is drawn by the video driver.

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -60,10 +60,9 @@ DWORD _imm_props;
 
 static Palette _local_palette; ///< Current palette to use for drawing.
 
-bool VideoDriver_Win32Base::ClaimMousePointer()
+void VideoDriver_Win32Base::ClaimMousePointer()
 {
 	MyShowCursor(false, true);
-	return true;
 }
 
 struct Win32VkMapping {

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -30,7 +30,7 @@ public:
 
 	bool ToggleFullscreen(bool fullscreen) override;
 
-	bool ClaimMousePointer() override;
+	void ClaimMousePointer() override;
 
 	void EditBoxLostFocus() override;
 


### PR DESCRIPTION
## Motivation / Problem

`VideoDriver::ClaimMousePointer` return a `bool` which is always `true` and never read.


## Description

Remove the return type and `return true` statements.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
