### PR TITLE
Fix: Make building area of objects behave more like other tools

### DIFF
--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -404,7 +404,6 @@ CommandCost CmdBuildObjectArea(DoCommandFlags flags, TileIndex tile, TileIndex s
 
 	if (spec->size != OBJECT_SIZE_1X1) return CMD_ERROR;
 
-	Money money = GetAvailableMoneyForCommand();
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 	CommandCost last_error = CMD_ERROR;
 	bool had_success = false;
@@ -417,23 +416,29 @@ CommandCost CmdBuildObjectArea(DoCommandFlags flags, TileIndex tile, TileIndex s
 		TileIndex t = *iter;
 		CommandCost ret = Command<Commands::BuildObject>::Do(DoCommandFlags{flags}.Reset(DoCommandFlag::Execute), t, type, view);
 
-		/* If we've reached the limit, stop building (or testing). */
-		if (c != nullptr && limit-- <= 0) break;
+		/* Test object limit. */
+		if (c != nullptr && limit-- <= 0) {
+			last_error = CommandCost(STR_ERROR_BUILD_OBJECT_LIMIT_REACHED);
+			break;
+		}
 
+		/* Ignore individual tile failures. */
 		if (ret.Failed()) {
 			last_error = std::move(ret);
 			continue;
 		}
 
+		/* Build the object */
 		had_success = true;
 		if (flags.Test(DoCommandFlag::Execute)) {
-			money -= ret.GetCost();
-
-			/* If we run out of money, stop building. */
-			if (ret.GetCost() > 0 && money < 0) break;
 			Command<Commands::BuildObject>::Do(flags, t, type, view);
 		}
+
 		cost.AddCost(ret.GetCost());
+	}
+
+	if (!flags.Test(DoCommandFlag::Execute)) {
+		CheckCompanyHasMoney(cost);
 	}
 
 	return had_success ? cost : last_error;

--- a/src/object_cmd.h
+++ b/src/object_cmd.h
@@ -17,6 +17,6 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 CommandCost CmdBuildObjectArea(DoCommandFlags flags, TileIndex tile, TileIndex start_tile, ObjectType type, uint8_t view, bool diagonal);
 
 DEF_CMD_TRAIT(Commands::BuildObject, CmdBuildObject, CommandFlags({CommandFlag::Deity, CommandFlag::NoWater, CommandFlag::Auto}), CommandType::LandscapeConstruction)
-DEF_CMD_TRAIT(Commands::BuildObjectArea, CmdBuildObjectArea, CommandFlags({CommandFlag::Deity, CommandFlag::NoWater, CommandFlag::NoTest, CommandFlag::Auto}), CommandType::LandscapeConstruction)
+DEF_CMD_TRAIT(Commands::BuildObjectArea, CmdBuildObjectArea, CommandFlags({CommandFlag::Deity, CommandFlag::NoWater, CommandFlag::Auto}), CommandType::LandscapeConstruction)
 
 #endif /* OBJECT_CMD_H */


### PR DESCRIPTION
## Motivation / Problem

Buying land tiles and building objects (the two things handled by OpenTTD as objects and buildable using an area selection in-game) didn't give an error when there were insufficient funds to buy/build either a single tile or an area (#15178).

Linked with this, their build tools also had inconsistent behaviour with other build tools (#15216). All other area build tools (planting trees, building canals, building rail stations, upgrading rail) fail if the player doesn't have enough cash for the complete construction, while buy land/build object would do as much as possible until the player is out of cash.

## Description

Change the logic for the command for building an area of an object (which is also used for buying land) to, where appropriate, match planting an area of trees.

Now, buying land/building objects will give the "Not enough cash..." error, and behave in an 'all or nothing' if there is not enough money for the complete build command.

<img width="915" height="574" alt="image" src="https://github.com/user-attachments/assets/590f116c-51a6-49d9-89cb-01144e71c43c" />

## Limitations

Changes the user-facing behaviour of buy land, so pitchforks?

Makes buying land/building objects match area build tools, but not all tools behave this way (see #15216): terraforming or clearing an area of tile keeps going until the player runs out of cash. Changes the original behaviour implemented by @2TallTyler, which might be intentional and important.

Doesn't fix #15223 for buying land/building objects. Testing against the object limit was changed to match the logic for planting trees, but doesn't give the expected error message.

Doesn't touch building areas of town buildings, which will have the same issues if a cost for town buildings is added in the future.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
