### PR TITLE
Codechange: document some virtual functions

### DIFF
--- a/src/autocompletion.h
+++ b/src/autocompletion.h
@@ -38,7 +38,20 @@ public:
 private:
 	void InitSuggestions(std::string_view text);
 
+	/**
+	 * Get suggestions for auto completion with the given 'query' input text.
+	 * @param prefix The text before the token that is auto completed on.
+	 * @param query The token to perform the auto completion on.
+	 * @return All potential auto complete suggestions.
+	 */
 	virtual std::vector<std::string> GetSuggestions(std::string_view prefix, std::string_view query) = 0;
+
+	/**
+	 * Format the given suggestion after the given prefix, and write that to the buffer.
+	 * For example, in case of a name in chat format '{name}: ' when the prefix is empty, otherwise '{prefix}{name}'.
+	 * @param prefix The text before the token that was auto completed on.
+	 * @param suggestion The chosen suggestion.
+	 */
 	virtual void ApplySuggestion(std::string_view prefix, std::string_view suggestion) = 0;
 };
 

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -123,6 +123,10 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 		return this->cached_name;
 	}
 
+	/**
+	 * Move this station's main coordinate somewhere else.
+	 * @param new_xy New tile location of the sign.
+	 */
 	virtual void MoveSign(TileIndex new_xy)
 	{
 		this->xy = new_xy;

--- a/src/dropdown_type.h
+++ b/src/dropdown_type.h
@@ -29,20 +29,53 @@ public:
 	explicit DropDownListItem(int result, bool masked = false, bool shaded = false) : result(result), masked(masked), shaded(shaded) {}
 	virtual ~DropDownListItem() = default;
 
+	/**
+	 * Can this dropdown item be selected?
+	 * @return Whether this item can be selected.
+	 */
 	virtual bool Selectable() const { return true; }
+
+	/**
+	 * The height of this item.
+	 * @return The height.
+	 */
 	virtual uint Height() const { return 0; }
+
+	/**
+	 * The width of this item.
+	 * @return The width.
+	 */
 	virtual uint Width() const { return 0; }
 
-	virtual int OnClick(const Rect &, const Point &) const
+	/**
+	 * Callback when this item is clicked.
+	 * @param r The bounds of this item.
+	 * @param pt The location within the bounds where the item is clicked.
+	 * @return The 'click_result' for the OnDropdownClose callback on the dropdown's parent.
+	 */
+	virtual int OnClick([[maybe_unused]] const Rect &r, [[maybe_unused]] const Point &pt) const
 	{
 		return -1;
 	}
 
-	virtual void Draw(const Rect &full, const Rect &, bool, int, Colours bg_colour) const
+	/**
+	 * Callback for drawing this item.
+	 * @param full The full bounds of the item including padding.
+	 * @param r The bounds to draw the item in.
+	 * @param sel Whether the item is elected or not.
+	 * @param click_result When selected, the previously set 'click_result' otherwise -1.
+	 * @param bg_colour The background color for the item.
+	 */
+	virtual void Draw(const Rect &full, [[maybe_unused]] const Rect &r, [[maybe_unused]] bool sel, [[maybe_unused]] int click_result, Colours bg_colour) const
 	{
 		if (this->masked) GfxFillRect(full, GetColourGradient(bg_colour, SHADE_LIGHT), FILLRECT_CHECKER);
 	}
 
+	/**
+	 * Get the colour of the text.
+	 * @param sel Whether the item is selected or not.
+	 * @return The text colour.
+	 */
 	TextColour GetColour(bool sel) const
 	{
 		if (this->shaded) return (sel ? TC_SILVER : TC_GREY) | TC_NO_SHADE;

--- a/src/screenshot_type.h
+++ b/src/screenshot_type.h
@@ -36,6 +36,16 @@ public:
 		ProviderManager<ScreenshotProvider>::Unregister(*this);
 	}
 
+	/**
+	 * Create and write an image to a file.
+	 * @param name The file name to write to.
+	 * @param callb The callback that fills a buffer with pixel data.
+	 * @param w The width of the image.
+	 * @param h The height of the image.
+	 * @param pixelformat The number of bits per pixel for the image.
+	 * @param palette The palette that is currently being used.
+	 * @return Whether writing the image was successful of not.
+	 */
 	virtual bool MakeImage(std::string_view name, const ScreenshotCallback &callb, uint w, uint h, int pixelformat, const Colour *palette) const = 0;
 };
 

--- a/src/soundloader_type.h
+++ b/src/soundloader_type.h
@@ -26,6 +26,14 @@ public:
 		ProviderManager<SoundLoader>::Unregister(*this);
 	}
 
+	/**
+	 * Load a sound from the file and offset in the given sound entry.
+	 * It is up to the implementations to update the sound's channels, bits_per_sample and rate.
+	 * @param sound The entry to load.
+	 * @param new_format Whether this is an old format soundset (with some buggy data), or the new format.
+	 * @param[out] data The vector to write the decoded sound data into.
+	 * @return \c true iff the entry was loaded correctly.
+	 */
 	virtual bool Load(SoundEntry &sound, bool new_format, std::vector<std::byte> &data) const = 0;
 };
 

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -166,6 +166,10 @@ public:
 		return {};
 	}
 
+	/**
+	 * Get some information about the selected driver/backend to be shown to the user.
+	 * @return The information.
+	 */
 	virtual std::string_view GetInfoString() const
 	{
 		return this->GetName();

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -139,6 +139,10 @@ public:
 	virtual ~NWidgetBase() = default;
 
 	void ApplyAspectRatio();
+
+	/**
+	 * Adjust the padding based on the user interface zoom.
+	 */
 	virtual void AdjustPaddingForZoom();
 	virtual void SetupSmallestSize(Window *w) = 0;
 	virtual void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) = 0;
@@ -177,8 +181,23 @@ public:
 	}
 
 	inline WidgetID GetIndex() const { return this->index; }
+
+	/**
+	 * Whether the widget is currently highlighted or not.
+	 * @return \c true if it is, otherwise false.
+	 */
 	virtual bool IsHighlighted() const { return false; }
+
+	/**
+	 * Get the colour of the highlighted text.
+	 * @return The highlight colour.
+	 */
 	virtual TextColour GetHighlightColour() const { return TC_INVALID; }
+
+	/**
+	 * Highlight the widget or not.
+	 * @param highlight_colour Widget must be highlighted (blink).
+	 */
 	virtual void SetHighlighted([[maybe_unused]] TextColour highlight_colour) {}
 
 	/**
@@ -411,23 +430,17 @@ protected:
 	friend void ApplyNWidgetPartAttribute(const struct NWidgetPart &nwid, NWidgetBase *dest);
 };
 
-/**
- * Highlight the widget or not.
- * @param highlight_colour Widget must be highlighted (blink).
- */
 inline void NWidgetCore::SetHighlighted(TextColour highlight_colour)
 {
 	highlight_colour != TC_INVALID ? this->disp_flags.Set(NWidgetDisplayFlag::Highlight) : this->disp_flags.Reset(NWidgetDisplayFlag::Highlight);
 	this->highlight_colour = highlight_colour;
 }
 
-/** Return whether the widget is highlighted. */
 inline bool NWidgetCore::IsHighlighted() const
 {
 	return this->disp_flags.Test(NWidgetDisplayFlag::Highlight);
 }
 
-/** Return the colour of the highlight. */
 inline TextColour NWidgetCore::GetHighlightColour() const
 {
 	return this->highlight_colour;


### PR DESCRIPTION
## Motivation / Problem

Warnings in the documentation build.


## Description

Document a number of virtual functions, primarily because lots of gains can be made as many other functions will be documented by-proxy. Documenting these 16 functions solves 62 warnings.

For NWidget it meant moving some documentation to its superclass.


## Limitations

When virtual functions aren't pure virtual, there might be some parameters that aren't used. But not documenting them there is kinda silly, though it requires the use of more `[[maybe_unused]]`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
