### PR TITLE
Codechange: use PoolID for newgrf class ids

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -249,7 +249,7 @@ class BuildAirportWindow : public PickerWindowBase {
 		DropDownList list;
 
 		for (const auto &cls : AirportClass::Classes()) {
-			list.push_back(MakeDropDownListStringItem(cls.name, cls.Index()));
+			list.push_back(MakeDropDownListStringItem(cls.name, cls.Index().base()));
 		}
 
 		return list;
@@ -271,7 +271,7 @@ public:
 		this->OnInvalidateData();
 
 		/* Ensure airport class is valid (changing NewGRFs). */
-		_selected_airport_class = Clamp(_selected_airport_class, APC_BEGIN, (AirportClassID)(AirportClass::GetClassCount() - 1));
+		_selected_airport_class = Clamp(_selected_airport_class, AirportClassID::Begin(), static_cast<AirportClassID>(AirportClass::GetClassCount() - 1));
 		const AirportClass *ac = AirportClass::Get(_selected_airport_class);
 		this->vscroll->SetCount(ac->GetSpecCount());
 
@@ -498,7 +498,7 @@ public:
 	{
 		switch (widget) {
 			case WID_AP_CLASS_DROPDOWN:
-				ShowDropDownList(this, BuildAirportClassDropDown(), _selected_airport_class, WID_AP_CLASS_DROPDOWN);
+				ShowDropDownList(this, BuildAirportClassDropDown(), _selected_airport_class.base(), WID_AP_CLASS_DROPDOWN);
 				break;
 
 			case WID_AP_AIRPORT_LIST: {
@@ -636,6 +636,6 @@ static void ShowBuildAirportPicker(Window *parent)
 
 void InitializeAirportGui()
 {
-	_selected_airport_class = APC_BEGIN;
+	_selected_airport_class = AirportClassID::Begin();
 	_selected_airport_index = -1;
 }

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -43,7 +43,7 @@ bool AirportClass::IsUIAvailable(uint) const
 }
 
 /* Instantiate AirportClass. */
-template class NewGRFClass<AirportSpec, AirportClassID, APC_MAX>;
+template class NewGRFClass<AirportSpec, AirportClassID>;
 
 
 AirportOverrideManager _airport_mngr(NEW_AIRPORT_OFFSET, NUM_AIRPORTS, AT_INVALID);

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -70,18 +70,13 @@ public:
 	}
 };
 
-/** List of default airport classes. */
-enum AirportClassID : uint8_t {
-	APC_BEGIN     = 0,  ///< Lowest valid airport class id
-	APC_SMALL     = 0,  ///< id for small airports class
-	APC_LARGE,          ///< id for large airports class
-	APC_HUB,            ///< id for hub airports class
-	APC_HELIPORT,       ///< id for heliports
-	APC_MAX       = 16, ///< maximum number of airport classes
-};
+/** Class IDs for airports. */
+using AirportClassID = PoolID<uint8_t, struct AirportClassIDTag, 16, UINT8_MAX>;
 
-/** Allow incrementing of AirportClassID variables */
-DECLARE_INCREMENT_DECREMENT_OPERATORS(AirportClassID)
+static constexpr AirportClassID APC_SMALL{0}; ///< id for small airports class.
+static constexpr AirportClassID APC_LARGE{1}; ///< id for large airports class.
+static constexpr AirportClassID APC_HUB{2}; ///< id for hub airports class.
+static constexpr AirportClassID APC_HELIPORT{3}; ///< id for heliports.
 
 /** TTDP airport types. Used to map our types to TTDPatch's */
 enum TTDPAirportType : uint8_t {
@@ -149,7 +144,7 @@ private:
 };
 
 /** Information related to airport classes. */
-using AirportClass = NewGRFClass<AirportSpec, AirportClassID, APC_MAX>;
+using AirportClass = NewGRFClass<AirportSpec, AirportClassID>;
 
 void BindAirportSpecs();
 

--- a/src/newgrf_class.h
+++ b/src/newgrf_class.h
@@ -12,7 +12,7 @@
 
 #include "strings_type.h"
 
-/* Base for each type of NewGRF spec to be used with NewGRFClass. */
+/** Base for each type of NewGRF spec to be used with NewGRFClass. */
 template <typename Tindex>
 struct NewGRFSpecBase {
 	Tindex class_index; ///< Class index of this spec, invalid until class is allocated.
@@ -22,21 +22,21 @@ struct NewGRFSpecBase {
 /**
  * Struct containing information relating to NewGRF classes for stations and airports.
  */
-template <typename Tspec, typename Tindex, Tindex Tmax>
+template <typename Tspec, typename Tindex>
 class NewGRFClass {
 private:
 	/* Tspec must be of NewGRFSpecBase<Tindex>. */
 	static_assert(std::is_base_of_v<NewGRFSpecBase<Tindex>, Tspec>);
 
 	uint ui_count = 0; ///< Number of specs in this class potentially available to the user.
-	Tindex index = static_cast<Tindex>(0); ///< Index of class within the list of classes.
+	Tindex index{}; ///< Index of class within the list of classes.
 	std::vector<Tspec *> spec; ///< List of specifications.
 
 	/**
 	 * The actual classes.
 	 * @note This may be reallocated during initialization so pointers may be invalidated.
 	 */
-	static inline std::vector<NewGRFClass<Tspec, Tindex, Tmax>> classes;
+	static inline std::vector<NewGRFClass<Tspec, Tindex>> classes;
 
 	/** Initialise the defaults. */
 	static void InsertDefaults();
@@ -61,7 +61,7 @@ public:
 	 * Get read-only span of all classes of this type.
 	 * @return Read-only span of classes.
 	 */
-	static std::span<NewGRFClass<Tspec, Tindex, Tmax> const> Classes() { return NewGRFClass::classes; }
+	static std::span<NewGRFClass<Tspec, Tindex> const> Classes() { return NewGRFClass::classes; }
 
 	void Insert(Tspec *spec);
 

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -12,8 +12,8 @@
 #include "table/strings.h"
 
 /** Reset the classes, i.e. clear everything. */
-template <typename Tspec, typename Tindex, Tindex Tmax>
-void NewGRFClass<Tspec, Tindex, Tmax>::Reset()
+template <typename Tspec, typename Tindex>
+void NewGRFClass<Tspec, Tindex>::Reset()
 {
 	NewGRFClass::classes.clear();
 	NewGRFClass::classes.shrink_to_fit();
@@ -28,8 +28,8 @@ void NewGRFClass<Tspec, Tindex, Tmax>::Reset()
  * @note Upon allocating the same global class ID for a
  *       second time, this first allocation will be given.
  */
-template <typename Tspec, typename Tindex, Tindex Tmax>
-Tindex NewGRFClass<Tspec, Tindex, Tmax>::Allocate(uint32_t global_id)
+template <typename Tspec, typename Tindex>
+Tindex NewGRFClass<Tspec, Tindex>::Allocate(uint32_t global_id)
 {
 	auto found = std::ranges::find(NewGRFClass::classes, global_id, &NewGRFClass::global_id);
 
@@ -37,13 +37,13 @@ Tindex NewGRFClass<Tspec, Tindex, Tmax>::Allocate(uint32_t global_id)
 	if (found != std::end(NewGRFClass::classes)) return found->Index();
 
 	/* More slots available, allocate a slot to the global id. */
-	if (NewGRFClass::classes.size() < Tmax) {
+	if (NewGRFClass::classes.size() < Tindex::End().base()) {
 		auto it = NewGRFClass::classes.emplace(std::end(NewGRFClass::classes), global_id, STR_EMPTY);
 		it->index = static_cast<Tindex>(std::distance(std::begin(NewGRFClass::classes), it));
 		return it->Index();
 	}
 
-	GrfMsg(2, "ClassAllocate: already allocated {} classes, using default", Tmax);
+	GrfMsg(2, "ClassAllocate: already allocated {} classes, using default", Tindex::End().base());
 	return static_cast<Tindex>(0);
 }
 
@@ -51,8 +51,8 @@ Tindex NewGRFClass<Tspec, Tindex, Tmax>::Allocate(uint32_t global_id)
  * Insert a spec into the class, and update its index.
  * @param spec The spec to insert.
  */
-template <typename Tspec, typename Tindex, Tindex Tmax>
-void NewGRFClass<Tspec, Tindex, Tmax>::Insert(Tspec *spec)
+template <typename Tspec, typename Tindex>
+void NewGRFClass<Tspec, Tindex>::Insert(Tspec *spec)
 {
 	auto it = this->spec.insert(std::end(this->spec), spec);
 	uint16_t index = static_cast<uint16_t>(std::distance(std::begin(this->spec), it));
@@ -66,10 +66,10 @@ void NewGRFClass<Tspec, Tindex, Tmax>::Insert(Tspec *spec)
  * @param spec The spec to assign.
  * @note The spec must have a valid class index set.
  */
-template <typename Tspec, typename Tindex, Tindex Tmax>
-void NewGRFClass<Tspec, Tindex, Tmax>::Assign(Tspec *spec)
+template <typename Tspec, typename Tindex>
+void NewGRFClass<Tspec, Tindex>::Assign(Tspec *spec)
 {
-	assert(static_cast<size_t>(spec->class_index) < NewGRFClass::classes.size());
+	assert(spec->class_index.base() < NewGRFClass::classes.size());
 	Get(spec->class_index)->Insert(spec);
 }
 
@@ -78,19 +78,19 @@ void NewGRFClass<Tspec, Tindex, Tmax>::Assign(Tspec *spec)
  * @param class_index The index of the class.
  * @pre class_index < Tmax
  */
-template <typename Tspec, typename Tindex, Tindex Tmax>
-NewGRFClass<Tspec, Tindex, Tmax> *NewGRFClass<Tspec, Tindex, Tmax>::Get(Tindex class_index)
+template <typename Tspec, typename Tindex>
+NewGRFClass<Tspec, Tindex> *NewGRFClass<Tspec, Tindex>::Get(Tindex class_index)
 {
-	assert(static_cast<size_t>(class_index) < NewGRFClass::classes.size());
-	return &NewGRFClass::classes[class_index];
+	assert(class_index.base() < NewGRFClass::classes.size());
+	return &NewGRFClass::classes[class_index.base()];
 }
 
 /**
  * Get the number of allocated classes.
  * @return The number of classes.
  */
-template <typename Tspec, typename Tindex, Tindex Tmax>
-uint NewGRFClass<Tspec, Tindex, Tmax>::GetClassCount()
+template <typename Tspec, typename Tindex>
+uint NewGRFClass<Tspec, Tindex>::GetClassCount()
 {
 	return static_cast<uint>(NewGRFClass::classes.size());
 }
@@ -99,8 +99,8 @@ uint NewGRFClass<Tspec, Tindex, Tmax>::GetClassCount()
  * Get the number of classes available to the user.
  * @return The number of classes.
  */
-template <typename Tspec, typename Tindex, Tindex Tmax>
-uint NewGRFClass<Tspec, Tindex, Tmax>::GetUIClassCount()
+template <typename Tspec, typename Tindex>
+uint NewGRFClass<Tspec, Tindex>::GetUIClassCount()
 {
 	return std::ranges::count_if(NewGRFClass::classes, [](const auto &cls) { return cls.GetUISpecCount() > 0; });
 }
@@ -110,8 +110,8 @@ uint NewGRFClass<Tspec, Tindex, Tmax>::GetUIClassCount()
  * @param index  The index where to find the spec.
  * @return The spec at given location.
  */
-template <typename Tspec, typename Tindex, Tindex Tmax>
-const Tspec *NewGRFClass<Tspec, Tindex, Tmax>::GetSpec(uint index) const
+template <typename Tspec, typename Tindex>
+const Tspec *NewGRFClass<Tspec, Tindex>::GetSpec(uint index) const
 {
 	/* If the custom spec isn't defined any more, then the GRF file probably was not loaded. */
 	return index < this->GetSpecCount() ? this->spec[index] : nullptr;
@@ -123,8 +123,8 @@ const Tspec *NewGRFClass<Tspec, Tindex, Tmax>::GetSpec(uint index) const
  * @param local_id Index within GRF file of spec.
  * @return The spec.
  */
-template <typename Tspec, typename Tindex, Tindex Tmax>
-const Tspec *NewGRFClass<Tspec, Tindex, Tmax>::GetByGrf(uint32_t grfid, uint16_t local_id)
+template <typename Tspec, typename Tindex>
+const Tspec *NewGRFClass<Tspec, Tindex>::GetByGrf(uint32_t grfid, uint16_t local_id)
 {
 	for (const auto &cls : NewGRFClass::classes) {
 		for (const auto &spec : cls.spec) {

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -115,7 +115,7 @@ uint ObjectSpec::Index() const
 /* static */ void ObjectSpec::BindToClasses()
 {
 	for (auto &spec : _object_specs) {
-		if (spec.IsEnabled() && spec.class_index != INVALID_OBJECT_CLASS) {
+		if (spec.IsEnabled() && spec.class_index != ObjectClassID::Invalid()) {
 			ObjectClass::Assign(&spec);
 		}
 	}
@@ -154,7 +154,7 @@ bool ObjectClass::IsUIAvailable(uint index) const
 }
 
 /* Instantiate ObjectClass. */
-template class NewGRFClass<ObjectSpec, ObjectClassID, OBJECT_CLASS_MAX>;
+template class NewGRFClass<ObjectSpec, ObjectClassID>;
 
 /* virtual */ uint32_t ObjectScopeResolver::GetRandomBits() const
 {

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -10,6 +10,7 @@
 #ifndef NEWGRF_OBJECT_H
 #define NEWGRF_OBJECT_H
 
+#include "core/pool_type.hpp"
 #include "newgrf_callbacks.h"
 #include "newgrf_spritegroup.h"
 #include "newgrf_town.h"
@@ -45,13 +46,7 @@ static const uint8_t OBJECT_SIZE_1X1 = 0x11; ///< The value of a NewGRF's size p
 void ResetObjects();
 
 /** Class IDs for objects. */
-enum ObjectClassID : uint16_t {
-	OBJECT_CLASS_BEGIN = 0, ///< The lowest valid value
-	OBJECT_CLASS_MAX = UINT16_MAX, ///< Maximum number of classes.
-	INVALID_OBJECT_CLASS = UINT16_MAX, ///< Class for the less fortunate.
-};
-/** Allow incrementing of ObjectClassID variables */
-DECLARE_INCREMENT_DECREMENT_OPERATORS(ObjectClassID)
+using ObjectClassID = PoolID<uint16_t, struct ObjectClassIDTag, UINT16_MAX, UINT16_MAX>;
 
 /** An object that isn't use for transport, industries or houses.
  * @note If you change this struct, adopt the initialization of
@@ -164,7 +159,7 @@ private:
 };
 
 /** Class containing information relating to object classes. */
-using ObjectClass = NewGRFClass<ObjectSpec, ObjectClassID, OBJECT_CLASS_MAX>;
+using ObjectClass = NewGRFClass<ObjectSpec, ObjectClassID>;
 
 uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2, const ObjectSpec *spec, Object *o, TileIndex tile, std::span<int32_t> regs100 = {}, uint8_t view = 0);
 

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -49,7 +49,7 @@ bool RoadStopClass::IsUIAvailable(uint) const
 }
 
 /* Instantiate RoadStopClass. */
-template class NewGRFClass<RoadStopSpec, RoadStopClassID, ROADSTOP_CLASS_MAX>;
+template class NewGRFClass<RoadStopSpec, RoadStopClassID>;
 
 static const uint NUM_ROADSTOPSPECS_PER_STATION = 63; ///< Maximum number of parts per station.
 

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -28,13 +28,11 @@ static const int NUM_ROADSTOPS_PER_GRF = UINT16_MAX - 1;
 static const uint32_t ROADSTOP_CLASS_LABEL_DEFAULT = 'DFLT';
 static const uint32_t ROADSTOP_CLASS_LABEL_WAYPOINT = 'WAYP';
 
-enum RoadStopClassID : uint16_t {
-	ROADSTOP_CLASS_BEGIN = 0, ///< The lowest valid value
-	ROADSTOP_CLASS_DFLT = 0, ///< Default road stop class.
-	ROADSTOP_CLASS_WAYP, ///< Waypoint class.
-	ROADSTOP_CLASS_MAX = UINT16_MAX, ///< Maximum number of classes.
-};
-DECLARE_INCREMENT_DECREMENT_OPERATORS(RoadStopClassID)
+/** Class IDs for stations. */
+using RoadStopClassID = PoolID<uint16_t, struct RoadStopClassIDTag, UINT16_MAX, UINT16_MAX>;
+
+static constexpr RoadStopClassID ROADSTOP_CLASS_DFLT{0}; ///< Default road stop class.
+static constexpr RoadStopClassID ROADSTOP_CLASS_WAYP{1}; ///< Waypoint class.
 
 /**
  * Various different options for availability, restricting
@@ -158,7 +156,7 @@ struct RoadStopSpec : NewGRFSpecBase<RoadStopClassID> {
 	static const RoadStopSpec *Get(uint16_t index);
 };
 
-using RoadStopClass = NewGRFClass<RoadStopSpec, RoadStopClassID, ROADSTOP_CLASS_MAX>;
+using RoadStopClass = NewGRFClass<RoadStopSpec, RoadStopClassID>;
 
 std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view, std::span<int32_t> regs100 = {});
 void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec, StationType type, int view);

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -49,7 +49,7 @@ bool StationClass::IsUIAvailable(uint) const
 }
 
 /* Instantiate StationClass. */
-template class NewGRFClass<StationSpec, StationClassID, STAT_CLASS_MAX>;
+template class NewGRFClass<StationSpec, StationClassID>;
 
 static const uint NUM_STATIONSSPECS_PER_STATION = 255; ///< Maximum number of parts per station.
 

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -100,15 +100,11 @@ struct StationResolverObject : public SpecializedResolverObject<StationRandomTri
 static const uint32_t STATION_CLASS_LABEL_DEFAULT = 'DFLT';
 static const uint32_t STATION_CLASS_LABEL_WAYPOINT = 'WAYP';
 
-enum StationClassID : uint16_t {
-	STAT_CLASS_BEGIN = 0, ///< the lowest valid value
-	STAT_CLASS_DFLT = 0, ///< Default station class.
-	STAT_CLASS_WAYP, ///< Waypoint class.
-	STAT_CLASS_MAX = UINT16_MAX, ///< Maximum number of classes.
-};
+/** Class IDs for stations. */
+using StationClassID = PoolID<uint16_t, struct StationClassIDTag, UINT16_MAX, UINT16_MAX>;
 
-/** Allow incrementing of StationClassID variables */
-DECLARE_INCREMENT_DECREMENT_OPERATORS(StationClassID)
+static constexpr StationClassID STAT_CLASS_DFLT{0}; ///< Default station class.
+static constexpr StationClassID STAT_CLASS_WAYP{1}; ///< Waypoint class.
 
 /** Flags describing behaviour of NewGRF stations. */
 enum class StationSpecFlag : uint8_t {
@@ -183,7 +179,7 @@ struct StationSpec : NewGRFSpecBase<StationClassID> {
 };
 
 /** Class containing information relating to station classes. */
-using StationClass = NewGRFClass<StationSpec, StationClassID, STAT_CLASS_MAX>;
+using StationClass = NewGRFClass<StationSpec, StationClassID>;
 
 const StationSpec *GetStationSpec(TileIndex t);
 

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -62,7 +62,7 @@ public:
 		return false;
 	}
 
-	int GetSelectedClass() const override { return _object_gui.sel_class; }
+	int GetSelectedClass() const override { return _object_gui.sel_class.base(); }
 	void SetSelectedClass(int id) const override { _object_gui.sel_class = this->GetClassIndex(id); }
 
 	StringID GetClassName(int id) const override
@@ -111,7 +111,7 @@ public:
 		for (const Object *o : Object::Iterate()) {
 			if (GetTileOwner(o->location.tile) != _current_company) continue;
 			const ObjectSpec *spec = ObjectSpec::Get(o->type);
-			if (spec == nullptr || spec->class_index == INVALID_OBJECT_CLASS || !spec->IsEverAvailable()) continue;
+			if (spec == nullptr || spec->class_index == ObjectClassID::Invalid() || !spec->IsEverAvailable()) continue;
 			items.insert(GetPickerItem(spec));
 		}
 	}
@@ -429,5 +429,5 @@ Window *ShowBuildObjectPicker()
 /** Reset all data of the object GUI. */
 void InitializeObjectGui()
 {
-	_object_gui.sel_class = ObjectClassID::OBJECT_CLASS_BEGIN;
+	_object_gui.sel_class = ObjectClassID::Begin();
 }

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -153,7 +153,7 @@ public:
 	PickerItem GetPickerItem(const typename T::spec_type *spec, int cls_id = -1, int id = -1) const
 	{
 		if (spec == nullptr) return {0, 0, cls_id, id};
-		return {spec->grf_prop.grfid, spec->grf_prop.local_id, spec->class_index, spec->index};
+		return {spec->grf_prop.grfid, spec->grf_prop.local_id, spec->class_index.base(), spec->index};
 	}
 
 	PickerItem GetPickerItem(int cls_id, int id) const override

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1027,10 +1027,10 @@ public:
 
 	bool HasClassChoice() const override
 	{
-		return std::ranges::count_if(StationClass::Classes(), std::not_fn(IsWaypointClass)) > 1;
+		return std::ranges::count_if(StationClass::Classes(), [](const auto &cls) { return !IsWaypointClass(cls); }) > 1;
 	}
 
-	int GetSelectedClass() const override { return _station_gui.sel_class; }
+	int GetSelectedClass() const override { return _station_gui.sel_class.base(); }
 	void SetSelectedClass(int id) const override { _station_gui.sel_class = this->GetClassIndex(id); }
 
 	StringID GetClassName(int id) const override
@@ -1074,12 +1074,12 @@ public:
 		for (const Station *st : Station::Iterate()) {
 			if (st->owner != _local_company) continue;
 			if (!default_added && StationUsesDefaultType(st)) {
-				items.insert({0, 0, STAT_CLASS_DFLT, 0});
+				items.insert({0, 0, STAT_CLASS_DFLT.base(), 0});
 				default_added = true;
 			}
 			for (const auto &sm : st->speclist) {
 				if (sm.spec == nullptr) continue;
-				items.insert({sm.grfid, sm.localidx, sm.spec->class_index, sm.spec->index});
+				items.insert({sm.grfid, sm.localidx, sm.spec->class_index.base(), sm.spec->index});
 			}
 		}
 	}
@@ -1847,11 +1847,11 @@ public:
 
 	bool HasClassChoice() const override
 	{
-		return std::ranges::count_if(StationClass::Classes(), IsWaypointClass) > 1;
+		return std::ranges::count_if(StationClass::Classes(), [](const auto &cls) { return IsWaypointClass(cls); }) > 1;
 	}
 
 	void Close(int) override { ResetObjectToPlace(); }
-	int GetSelectedClass() const override { return _waypoint_gui.sel_class; }
+	int GetSelectedClass() const override { return _waypoint_gui.sel_class.base(); }
 	void SetSelectedClass(int id) const override { _waypoint_gui.sel_class = this->GetClassIndex(id); }
 
 	StringID GetClassName(int id) const override
@@ -1893,12 +1893,12 @@ public:
 		for (const Waypoint *wp : Waypoint::Iterate()) {
 			if (wp->owner != _local_company || HasBit(wp->waypoint_flags, WPF_ROAD)) continue;
 			if (!default_added && StationUsesDefaultType(wp)) {
-				items.insert({0, 0, STAT_CLASS_WAYP, 0});
+				items.insert({0, 0, STAT_CLASS_WAYP.base(), 0});
 				default_added = true;
 			}
 			for (const auto &sm : wp->speclist) {
 				if (sm.spec == nullptr) continue;
-				items.insert({sm.grfid, sm.localidx, sm.spec->class_index, sm.spec->index});
+				items.insert({sm.grfid, sm.localidx, sm.spec->class_index.base(), sm.spec->index});
 			}
 		}
 	}
@@ -1952,9 +1952,9 @@ static void ShowBuildWaypointPicker(Window *parent)
 void InitializeRailGui()
 {
 	_build_depot_direction = DIAGDIR_NW;
-	_station_gui.sel_class = StationClassID::STAT_CLASS_DFLT;
+	_station_gui.sel_class = STAT_CLASS_DFLT;
 	_station_gui.sel_type = 0;
-	_waypoint_gui.sel_class = StationClassID::STAT_CLASS_WAYP;
+	_waypoint_gui.sel_class = STAT_CLASS_WAYP;
 	_waypoint_gui.sel_type = 0;
 }
 

--- a/src/road_cmd.h
+++ b/src/road_cmd.h
@@ -15,8 +15,7 @@
 #include "command_type.h"
 #include "station_type.h"
 #include "town_type.h"
-
-enum RoadStopClassID : uint16_t;
+#include "newgrf_roadstop.h"
 
 void DrawRoadDepotSprite(int x, int y, DiagDirection dir, RoadType rt);
 void UpdateNearestTownForRoadTiles(bool invalidate);

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -203,7 +203,7 @@ void CcRoadStop(Commands, const CommandCost &result, TileIndex tile, uint8_t wid
 	if (!_settings_client.gui.persistent_buildingtools) ResetObjectToPlace();
 
 	bool connect_to_road = true;
-	if ((uint)spec_class < RoadStopClass::GetClassCount() && spec_index < RoadStopClass::Get(spec_class)->GetSpecCount()) {
+	if (spec_class.base() < RoadStopClass::GetClassCount() && spec_index < RoadStopClass::Get(spec_class)->GetSpecCount()) {
 		const RoadStopSpec *roadstopspec = RoadStopClass::Get(spec_class)->GetSpec(spec_index);
 		if (roadstopspec != nullptr && roadstopspec->flags.Test(RoadStopSpecFlag::NoAutoRoadConnection)) connect_to_road = false;
 	}
@@ -1275,7 +1275,7 @@ public:
 		return std::ranges::count_if(RoadStopClass::Classes(), IsClassChoice);
 	}
 
-	int GetSelectedClass() const override { return _roadstop_gui.sel_class; }
+	int GetSelectedClass() const override { return _roadstop_gui.sel_class.base(); }
 	void SetSelectedClass(int id) const override { _roadstop_gui.sel_class = this->GetClassIndex(id); }
 
 	StringID GetClassName(int id) const override
@@ -1327,12 +1327,12 @@ public:
 			if (st->owner != _local_company) continue;
 			if (roadstoptype == RoadStopType::Truck && !st->facilities.Test(StationFacility::TruckStop)) continue;
 			if (roadstoptype == RoadStopType::Bus && !st->facilities.Test(StationFacility::BusStop)) continue;
-			items.insert({0, 0, ROADSTOP_CLASS_DFLT, 0}); // We would need to scan the map to find out if default is used.
+			items.insert({0, 0, ROADSTOP_CLASS_DFLT.base(), 0}); // We would need to scan the map to find out if default is used.
 			for (const auto &sm : st->roadstop_speclist) {
 				if (sm.spec == nullptr) continue;
 				if (roadstoptype == RoadStopType::Truck && sm.spec->stop_type != ROADSTOPTYPE_FREIGHT && sm.spec->stop_type != ROADSTOPTYPE_ALL) continue;
 				if (roadstoptype == RoadStopType::Bus && sm.spec->stop_type != ROADSTOPTYPE_PASSENGER && sm.spec->stop_type != ROADSTOPTYPE_ALL) continue;
-				items.insert({sm.grfid, sm.localidx, sm.spec->class_index, sm.spec->index});
+				items.insert({sm.grfid, sm.localidx, sm.spec->class_index.base(), sm.spec->index});
 			}
 		}
 	}
@@ -1699,11 +1699,11 @@ public:
 
 	bool HasClassChoice() const override
 	{
-		return std::ranges::count_if(RoadStopClass::Classes(), IsWaypointClass) > 1;
+		return std::ranges::count_if(RoadStopClass::Classes(), [](const auto &cls) { return IsWaypointClass(cls); }) > 1;
 	}
 
 	void Close(int) override { ResetObjectToPlace(); }
-	int GetSelectedClass() const override { return _waypoint_gui.sel_class; }
+	int GetSelectedClass() const override { return _waypoint_gui.sel_class.base(); }
 	void SetSelectedClass(int id) const override { _waypoint_gui.sel_class = this->GetClassIndex(id); }
 
 	StringID GetClassName(int id) const override
@@ -1748,10 +1748,10 @@ public:
 	{
 		for (const Waypoint *wp : Waypoint::Iterate()) {
 			if (wp->owner != _local_company || !HasBit(wp->waypoint_flags, WPF_ROAD)) continue;
-			items.insert({0, 0, ROADSTOP_CLASS_WAYP, 0}); // We would need to scan the map to find out if default is used.
+			items.insert({0, 0, ROADSTOP_CLASS_WAYP.base(), 0}); // We would need to scan the map to find out if default is used.
 			for (const auto &sm : wp->roadstop_speclist) {
 				if (sm.spec == nullptr) continue;
-				items.insert({sm.grfid, sm.localidx, sm.spec->class_index, sm.spec->index});
+				items.insert({sm.grfid, sm.localidx, sm.spec->class_index.base(), sm.spec->index});
 			}
 		}
 	}
@@ -1803,7 +1803,7 @@ void InitializeRoadGui()
 {
 	_road_depot_orientation = DIAGDIR_NW;
 	_roadstop_gui.orientation = DIAGDIR_NW;
-	_waypoint_gui.sel_class = RoadStopClassID::ROADSTOP_CLASS_WAYP;
+	_waypoint_gui.sel_class = ROADSTOP_CLASS_WAYP;
 	_waypoint_gui.sel_type = 0;
 }
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1444,7 +1444,7 @@ CommandCost CmdBuildRailStation(DoCommandFlags flags, TileIndex tile_org, RailTy
 	if (!ValParamRailType(rt) || !IsValidAxis(axis)) return CMD_ERROR;
 
 	/* Check if the given station class is valid */
-	if (static_cast<uint>(spec_class) >= StationClass::GetClassCount()) return CMD_ERROR;
+	if (spec_class.base() >= StationClass::GetClassCount()) return CMD_ERROR;
 	const StationClass *cls = StationClass::Get(spec_class);
 	if (IsWaypointClass(*cls)) return CMD_ERROR;
 	if (spec_index >= cls->GetSpecCount()) return CMD_ERROR;
@@ -2077,7 +2077,7 @@ CommandCost CmdBuildRoadStop(DoCommandFlags flags, TileIndex tile, uint8_t width
 	bool distant_join = (station_to_join != StationID::Invalid());
 
 	/* Check if the given station class is valid */
-	if (static_cast<uint>(spec_class) >= RoadStopClass::GetClassCount()) return CMD_ERROR;
+	if (spec_class.base() >= RoadStopClass::GetClassCount()) return CMD_ERROR;
 	const RoadStopClass *cls = RoadStopClass::Get(spec_class);
 	if (IsWaypointClass(*cls)) return CMD_ERROR;
 	if (spec_index >= cls->GetSpecCount()) return CMD_ERROR;

--- a/src/station_cmd.h
+++ b/src/station_cmd.h
@@ -14,11 +14,10 @@
 #include "rail_type.h"
 #include "road_type.h"
 #include "station_type.h"
+#include "newgrf_roadstop.h"
+#include "newgrf_station.h"
 
 struct Town;
-
-enum StationClassID : uint16_t;
-enum RoadStopClassID : uint16_t;
 
 extern Town *AirportGetNearestTown(const struct AirportSpec *as, Direction rotation, TileIndex tile, TileIterator &&it, uint &mindist);
 extern uint8_t GetAirportNoiseLevelForDistance(const struct AirportSpec *as, uint distance);

--- a/src/table/airport_defaults.h
+++ b/src/table/airport_defaults.h
@@ -391,7 +391,7 @@ extern const AirportSpec _origin_airport_specs[] = {
 
 static_assert(NEW_AIRPORT_OFFSET == lengthof(_origin_airport_specs));
 
-const AirportSpec AirportSpec::dummy = AS_GENERIC(&_airportfta_dummy, {}, {}, 0, 0, 0, 0, CalendarTime::MIN_YEAR, CalendarTime::MIN_YEAR, 0, ATP_TTDP_LARGE, APC_BEGIN, STR_NULL, 0, false);
+const AirportSpec AirportSpec::dummy = AS_GENERIC(&_airportfta_dummy, {}, {}, 0, 0, 0, 0, CalendarTime::MIN_YEAR, CalendarTime::MIN_YEAR, 0, ATP_TTDP_LARGE, {}, STR_NULL, 0, false);
 
 #undef AS
 #undef AS_ND

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -106,7 +106,7 @@ static const DrawTileSpriteSpan _object_hq[] = {
 #undef TILE_SPRITE_LINE
 #undef TILE_SPRITE_LINE_NOTHING
 
-#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, introduction_date, climate, gen_amount, flags) {{INVALID_OBJECT_CLASS, 0}, StandardGRFFileProps{}, AnimationInfo<ObjectAnimationTriggers>{}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, introduction_date, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount, {}}
+#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, introduction_date, climate, gen_amount, flags) {{ObjectClassID::Invalid(), 0}, StandardGRFFileProps{}, AnimationInfo<ObjectAnimationTriggers>{}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, introduction_date, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount, {}}
 
 /* Climates
  * T = Temperate

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -209,7 +209,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 {
 	if (!IsValidAxis(axis)) return CMD_ERROR;
 	/* Check if the given station class is valid */
-	if (static_cast<uint>(spec_class) >= StationClass::GetClassCount()) return CMD_ERROR;
+	if (spec_class.base() >= StationClass::GetClassCount()) return CMD_ERROR;
 	const StationClass *cls = StationClass::Get(spec_class);
 	if (!IsWaypointClass(*cls)) return CMD_ERROR;
 	if (spec_index >= cls->GetSpecCount()) return CMD_ERROR;
@@ -343,7 +343,7 @@ CommandCost CmdBuildRoadWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 {
 	if (!IsValidAxis(axis)) return CMD_ERROR;
 	/* Check if the given station class is valid */
-	if (static_cast<uint>(spec_class) >= RoadStopClass::GetClassCount()) return CMD_ERROR;
+	if (spec_class.base() >= RoadStopClass::GetClassCount()) return CMD_ERROR;
 	const RoadStopClass *cls = RoadStopClass::Get(spec_class);
 	if (!IsWaypointClass(*cls)) return CMD_ERROR;
 	if (spec_index >= cls->GetSpecCount()) return CMD_ERROR;

--- a/src/waypoint_cmd.h
+++ b/src/waypoint_cmd.h
@@ -12,9 +12,8 @@
 
 #include "command_type.h"
 #include "station_type.h"
-
-enum StationClassID : uint16_t;
-enum RoadStopClassID : uint16_t;
+#include "newgrf_roadstop.h"
+#include "newgrf_station.h"
 
 CommandCost CmdBuildRailWaypoint(DoCommandFlags flags, TileIndex start_tile, Axis axis, uint8_t width, uint8_t height, StationClassID spec_class, uint16_t spec_index, StationID station_to_join, bool adjacent);
 CommandCost CmdRemoveFromRailWaypoint(DoCommandFlags flags, TileIndex start, TileIndex end, bool keep_rail);

--- a/src/waypoint_func.h
+++ b/src/waypoint_func.h
@@ -13,8 +13,7 @@
 #include "rail_type.h"
 #include "command_type.h"
 #include "station_type.h"
-
-enum StationClassID : uint16_t;
+#include "newgrf_station.h"
 
 CommandCost RemoveBuoy(TileIndex tile, DoCommandFlags flags);
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

NewGRF class IDs use `enum` as storage type. However the values are actually allocated on-demand from NewGRF data, which means they are not really enumerable anyway.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `PoolID` for these instead of `enum` (or `enum class`), modifying the NewGRFClass system to handle these instead.

This is probably misusing the `PoolID` type as it is intended for Pool indices, but DRY.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Header dependency creep

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
