### PR TITLE
Codechange: [CI] Upload to the Windows Store automatically.

### DIFF
--- a/.github/workflows/release-windows-store.yml
+++ b/.github/workflows/release-windows-store.yml
@@ -124,7 +124,7 @@ jobs:
       run: |
         cd builds
 
-        REM We need to provide a signed .appx to the Windows Store, so generate a certificate with password 'password'
+        REM We need to provide a signed .msix to the Windows Store, so generate a certificate with password 'password'
         call ..\os\windows\winstore\generate-key.bat "CN=78024DA8-4BE4-4C77-B12E-547BBF7359D2" password cert.pfx
 
     - name: Generate assets
@@ -176,13 +176,13 @@ jobs:
 
         REM Build and sign the package
         makeappx build /v /f PackagingLayout.xml /op output\ /bv %OTTD_VERSION% /pv %OTTD_VERSION% /ca
-        SignTool sign /fd sha256 /a /f cert.pfx /p password "output\OpenTTD.appxbundle"
+        SignTool sign /fd sha256 /a /f cert.pfx /p password "output\OpenTTD.msixbundle"
 
         REM Move resulting files to bundles folder
         mkdir bundles
         mkdir bundles\internal
         move cert.pfx bundles\internal\openttd-${{ inputs.version }}-windows-store.pfx
-        move output\OpenTTD.appxbundle bundles\internal\openttd-${{ inputs.version }}-windows-store.appxbundle
+        move output\OpenTTD.msixbundle bundles\internal\openttd-${{ inputs.version }}-windows-store.msixbundle
 
     - name: Store bundles
       uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,3 +153,18 @@ jobs:
 
     with:
       version: ${{ needs.source.outputs.version }}
+
+  upload-windows-store:
+    name: Upload (Windows Store)
+    needs:
+    - upload
+
+    # Only upload final release builds to Windows Store; "-beta" or "-RC" tags should be ignored
+    if: needs.source.outputs.is_tag == 'true' && !contains(needs.source.outputs.version, '-')
+
+    uses: ./.github/workflows/upload-windows-store.yml
+    secrets: inherit
+
+    with:
+      version: ${{ needs.source.outputs.version }}
+      trigger_type: ${{ needs.source.outputs.trigger_type }}

--- a/.github/workflows/upload-windows-store.yml
+++ b/.github/workflows/upload-windows-store.yml
@@ -1,0 +1,44 @@
+name: Upload (Windows Store)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      trigger_type:
+        required: true
+        type: string
+
+jobs:
+  upload:
+    name: Upload (Windows Store)
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Download bundle (Windows Store)
+      uses: actions/download-artifact@v6
+      with:
+        name: openttd-windows-store
+        path: openttd-windows-store
+
+    - name: Configure Microsoft Store CLI
+      uses: microsoft/microsoft-store-apppublisher@v1.1
+
+    - name: Reconfigure store credentials
+      run: msstore reconfigure `
+            --tenantId ${{ secrets.AZURE_TENANT_ID }} `
+            --sellerId ${{ secrets.WINSTORE_SELLER_ID }} `
+            --clientId ${{ secrets.AZURE_WINSTORE_APPLICATION_CLIENT_ID }} `
+            --clientSecret ${{ secrets.AZURE_WINSTORE_APPLICATION_SECRET }}
+
+    - name: Publish msix package
+      shell: pwsh
+      run: |
+        $bundle = Get-ChildItem openttd-windows-store/internal/openttd-*.msixbundle | Select-Object -First 1
+        if (-not $bundle) {
+          throw "No msixbundle found"
+        }
+
+        msstore publish $bundle.FullName -id 9NCJG5RVRR1C -v

--- a/os/windows/winstore/manifests/AssetsPackage.appxmanifest
+++ b/os/windows/winstore/manifests/AssetsPackage.appxmanifest
@@ -63,6 +63,6 @@
       <Resource Language="cy-gb" />
    </Resources>
    <Dependencies>
-      <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17134.0" MaxVersionTested="10.0.18363.0" />
+      <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17701.0" MaxVersionTested="10.0.18363.0" />
    </Dependencies>
 </Package>

--- a/os/windows/winstore/manifests/Package.appxmanifest
+++ b/os/windows/winstore/manifests/Package.appxmanifest
@@ -7,7 +7,7 @@
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17134.0" MaxVersionTested="10.0.18363.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17701.0" MaxVersionTested="10.0.18363.0" />
   </Dependencies>
   <Resources>
     <Resource Language="en-gb" />


### PR DESCRIPTION
## Motivation / Problem

I currently have to manually upload packages to the Windows Store. It would be nice for this to happen automatically.

## Description

These changes enable Windows Store packages to be uploaded automatically. I have set up the necessary Azure Active Directory infrastructure (which was partially set up for Azure code signing anyway) and linked it to our Store listing, so this can now be automated via the `msstore` CLI tool.

The `msstore` utility doesn't recognise `.appxbundle` files, instead it expects an `.msixbundle`. The two formats are - in practice - identical (for our purposes at least). Setting the minimum Windows version to 10.0.17701.0 (which was necessary, the msstore util rejected it otherwise) seems to cause an `.msixbundle` to be generated automatically.

## Limitations

We don't have an easy way of handling RC/beta versions on the MS Store (it might well be possible, but I haven't investigated it), so we only upload a final build.

If a build has an identical version number (e.g. due to an instance of bug #15225) then the upload will fail. As such we must ensure the major/minor version number is bumped when doing a new release, 

I uploaded 15.1 today via a test version of this workflow, and have tested (without actually performing the upload) the behaviour of the rest of the changes. Without running this against a production tag I can't 100% guarantee it will work, but I'm confident it should be fine.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
