### PR TITLE
Fix #15105: Czech townname generation causing crashes.

### DIFF
--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -701,25 +701,9 @@ static void MakeCzechTownName(StringBuilder &builder, uint32_t seed)
 			std::string_view poststr = _name_czech_subst_postfix[postfix];
 			std::string_view endstr = _name_czech_subst_ending[ending].name;
 
-			size_t postlen = poststr.size();
-			size_t endlen = endstr.size();
-			assert(postlen > 0 && endlen > 0);
-
 			/* Kill the "avava" and "Jananna"-like cases */
-			if (postlen < 2 || postlen > endlen ||
-					((poststr[1] != 'v' || poststr[1] != endstr[1]) &&
-					poststr[2] != endstr[1])) {
+			if (poststr[1] != 'v' || poststr[1] != endstr[1]) {
 				builder += poststr;
-
-				/* k-i -> c-i, h-i -> z-i */
-				if (endstr[0] == 'i') {
-					std::string &str = builder.GetString();
-					switch (str.back()) {
-						case 'k': str.back() = 'c'; break;
-						case 'h': str.back() = 'z'; break;
-						default: break;
-					}
-				}
 			}
 		}
 		builder += _name_czech_subst_ending[ending].name;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
#15105 

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Generating towns with Czech names causes crashes. This was due to an access on the prefixes with `poststr[2]`, despite all possible prefixes are only of length 2. Changing it to `poststr[1]` should produce the intended behavior according to the comment in code.
There was also redundant code, that is never executed using the values from `_name_czech_subst_postfix`. This was also removed. Those were:
`postlen < 2` all possible values are of length 2.
`postlen > endlen` there are no possible values for `endlen` (from `_name_czech_subst_ending[]`) that are shorter than postlen.
And the following switch case, because while there are possible values that match `endstr[0] == 'i'`, there are no possible values for the `poststr` that end with `k` or `h`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
The code removals do not change functionality for the given values of the Czech townname generation. It could only create unintended names, if someone were to add new (and longer) values for `_name_czech_subst_postfix`, which seems unlikely.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
