### PR TITLE
Fix #15234: Null pointer dereference opening sign edit window when sign 0 does not exist

### DIFF
--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -407,7 +407,7 @@ struct SignWindow : Window, SignList {
 	WidgetID last_user_action = INVALID_WIDGET; ///< Last started user action.
 	std::optional<Colours> new_colour; ///< New colour selected by the user. Will be assigned when the OK button is clicked.
 
-	SignWindow(WindowDesc &desc, const Sign *si) : Window(desc), name_editbox(MAX_LENGTH_SIGN_NAME_CHARS * MAX_CHAR_LENGTH, MAX_LENGTH_SIGN_NAME_CHARS)
+	SignWindow(WindowDesc &desc, const Sign *si) : Window(desc), name_editbox(MAX_LENGTH_SIGN_NAME_CHARS * MAX_CHAR_LENGTH, MAX_LENGTH_SIGN_NAME_CHARS), cur_sign(si->index)
 	{
 		this->querystrings[WID_QES_TEXT] = &this->name_editbox;
 		this->name_editbox.caption = STR_EDIT_SIGN_CAPTION;


### PR DESCRIPTION
## Motivation / Problem

#15234

## Description

`SignWindow::cur_sign` is now initialised (as in `UpdateSignEditWindow`) before `InitNested` is called.

## Limitations
N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
