### PR TITLE
Fix: [Script] Always return a string when it's expected

### DIFF
--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1369,7 +1369,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   SetPresidentName():                true
   GetPresidentName():                Regression AI
   GetBankBalance():                  100000
-  GetName():                         (null : 0x00000000)
+  GetName():                         
   GetLoanAmount():                   100000
   GetMaxLoanAmount():                2000000000
   GetLoanInterval():                 10000
@@ -1664,10 +1664,10 @@ ERROR: IsEnd() is invalid as Begin() is never called
   Bridge -1
     IsValidBridge():    false
     GetName():
-     VT_RAIL:           (null : 0x00000000)
-     VT_ROAD:           (null : 0x00000000)
-     VT_WATER:          (null : 0x00000000)
-     VT_AIR:            (null : 0x00000000)
+     VT_RAIL:           
+     VT_ROAD:           
+     VT_WATER:          
+     VT_AIR:            
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1
@@ -1678,7 +1678,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Wooden rail bridge
      VT_ROAD:           Wooden road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      32
     GetPrice():         450
     GetMaxLength():     66
@@ -1689,7 +1689,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Concrete rail bridge
      VT_ROAD:           Concrete road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      48
     GetPrice():         630
     GetMaxLength():     4
@@ -1700,7 +1700,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Steel girder rail bridge
      VT_ROAD:           Steel girder road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      64
     GetPrice():         811
     GetMaxLength():     7
@@ -1711,7 +1711,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Reinforced concrete suspension rail bridge
      VT_ROAD:           Reinforced concrete suspension road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      80
     GetPrice():         946
     GetMaxLength():     12
@@ -1722,7 +1722,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Steel suspension rail bridge
      VT_ROAD:           Steel suspension road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      96
     GetPrice():         1042
     GetMaxLength():     66
@@ -1733,7 +1733,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Steel suspension rail bridge
      VT_ROAD:           Steel suspension road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      112
     GetPrice():         1081
     GetMaxLength():     66
@@ -1744,7 +1744,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Steel cantilever rail bridge
      VT_ROAD:           Steel cantilever road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      160
     GetPrice():         1261
     GetMaxLength():     9
@@ -1755,7 +1755,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Steel cantilever rail bridge
      VT_ROAD:           Steel cantilever road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      208
     GetPrice():         1306
     GetMaxLength():     10
@@ -1766,7 +1766,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Steel cantilever rail bridge
      VT_ROAD:           Steel cantilever road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      240
     GetPrice():         1396
     GetMaxLength():     11
@@ -1777,7 +1777,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
      VT_RAIL:           Steel girder rail bridge
      VT_ROAD:           Steel girder road bridge
      VT_WATER:          Aqueduct
-     VT_AIR:            (null : 0x00000000)
+     VT_AIR:            
     GetMaxSpeed():      256
     GetPrice():         1351
     GetMaxLength():     4
@@ -1785,10 +1785,10 @@ ERROR: IsEnd() is invalid as Begin() is never called
   Bridge 10
     IsValidBridge():    false
     GetName():
-     VT_RAIL:           (null : 0x00000000)
-     VT_ROAD:           (null : 0x00000000)
-     VT_WATER:          (null : 0x00000000)
-     VT_AIR:            (null : 0x00000000)
+     VT_RAIL:           
+     VT_ROAD:           
+     VT_WATER:          
+     VT_AIR:            
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1
@@ -1796,10 +1796,10 @@ ERROR: IsEnd() is invalid as Begin() is never called
   Bridge 11
     IsValidBridge():    false
     GetName():
-     VT_RAIL:           (null : 0x00000000)
-     VT_ROAD:           (null : 0x00000000)
-     VT_WATER:          (null : 0x00000000)
-     VT_AIR:            (null : 0x00000000)
+     VT_RAIL:           
+     VT_ROAD:           
+     VT_WATER:          
+     VT_AIR:            
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1
@@ -1807,10 +1807,10 @@ ERROR: IsEnd() is invalid as Begin() is never called
   Bridge 12
     IsValidBridge():    false
     GetName():
-     VT_RAIL:           (null : 0x00000000)
-     VT_ROAD:           (null : 0x00000000)
-     VT_WATER:          (null : 0x00000000)
-     VT_AIR:            (null : 0x00000000)
+     VT_RAIL:           
+     VT_ROAD:           
+     VT_WATER:          
+     VT_AIR:            
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1
@@ -1818,10 +1818,10 @@ ERROR: IsEnd() is invalid as Begin() is never called
   Bridge 13
     IsValidBridge():    false
     GetName():
-     VT_RAIL:           (null : 0x00000000)
-     VT_ROAD:           (null : 0x00000000)
-     VT_WATER:          (null : 0x00000000)
-     VT_AIR:            (null : 0x00000000)
+     VT_RAIL:           
+     VT_ROAD:           
+     VT_WATER:          
+     VT_AIR:            
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1
@@ -1904,8 +1904,8 @@ ERROR: IsEnd() is invalid as Begin() is never called
 --AICargo--
   Cargo -1
     IsValidCargo():          false
-    GetName():               '(null : 0x00000000)'
-    GetCargoLabel():         '(null : 0x00000000)'
+    GetName():               ''
+    GetCargoLabel():         ''
     IsFreight():             false
     HasCargoClass():         false
     GetTownEffect():         0
@@ -2060,8 +2060,8 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 11
     IsValidCargo():          false
-    GetName():               '(null : 0x00000000)'
-    GetCargoLabel():         '(null : 0x00000000)'
+    GetName():               ''
+    GetCargoLabel():         ''
     IsFreight():             false
     HasCargoClass():         false
     GetTownEffect():         0
@@ -2073,8 +2073,8 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 12
     IsValidCargo():          false
-    GetName():               '(null : 0x00000000)'
-    GetCargoLabel():         '(null : 0x00000000)'
+    GetName():               ''
+    GetCargoLabel():         ''
     IsFreight():             false
     HasCargoClass():         false
     GetTownEffect():         0
@@ -2086,8 +2086,8 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 13
     IsValidCargo():          false
-    GetName():               '(null : 0x00000000)'
-    GetCargoLabel():         '(null : 0x00000000)'
+    GetName():               ''
+    GetCargoLabel():         ''
     IsFreight():             false
     HasCargoClass():         false
     GetTownEffect():         0
@@ -2099,8 +2099,8 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 14
     IsValidCargo():          false
-    GetName():               '(null : 0x00000000)'
-    GetCargoLabel():         '(null : 0x00000000)'
+    GetName():               ''
+    GetCargoLabel():         ''
     IsFreight():             false
     HasCargoClass():         false
     GetTownEffect():         0
@@ -2151,7 +2151,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
 --Engine--
   Engine -1
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2190,7 +2190,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
       0
   Engine 1
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2209,7 +2209,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 2
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2228,7 +2228,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 3
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2247,7 +2247,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 4
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2266,7 +2266,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 5
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2285,7 +2285,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 6
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2304,7 +2304,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 7
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2363,7 +2363,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
       0
   Engine 10
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2382,7 +2382,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 11
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2401,7 +2401,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 12
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2420,7 +2420,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 13
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2439,7 +2439,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 14
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2458,7 +2458,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 15
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2477,7 +2477,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 16
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2496,7 +2496,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 17
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2515,7 +2515,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 18
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2534,7 +2534,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 19
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2553,7 +2553,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 20
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2572,7 +2572,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 21
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2591,7 +2591,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 22
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2610,7 +2610,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 23
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2629,7 +2629,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 24
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2648,7 +2648,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 25
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2667,7 +2667,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 26
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2906,7 +2906,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
       0
   Engine 38
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2925,7 +2925,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 39
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2944,7 +2944,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 40
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2963,7 +2963,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 41
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -2982,7 +2982,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 42
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3001,7 +3001,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 43
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3020,7 +3020,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 44
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3039,7 +3039,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 45
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3058,7 +3058,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 46
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3077,7 +3077,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 47
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3096,7 +3096,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 48
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3115,7 +3115,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 49
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3134,7 +3134,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 50
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3153,7 +3153,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 51
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3172,7 +3172,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 52
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3191,7 +3191,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 53
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3210,7 +3210,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 54
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3229,7 +3229,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 55
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3248,7 +3248,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 56
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3267,7 +3267,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 57
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3286,7 +3286,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 58
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3305,7 +3305,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 59
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3324,7 +3324,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 60
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3343,7 +3343,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 61
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3362,7 +3362,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 62
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3381,7 +3381,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 63
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3400,7 +3400,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 64
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3419,7 +3419,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 65
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3438,7 +3438,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 66
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3457,7 +3457,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 67
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3476,7 +3476,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 68
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3495,7 +3495,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 69
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3514,7 +3514,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 70
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3533,7 +3533,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 71
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3552,7 +3552,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 72
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3571,7 +3571,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 73
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3590,7 +3590,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 74
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3609,7 +3609,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 75
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3628,7 +3628,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 76
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3647,7 +3647,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 77
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3666,7 +3666,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 78
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3685,7 +3685,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 79
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3704,7 +3704,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 80
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3723,7 +3723,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 81
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3742,7 +3742,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 82
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3761,7 +3761,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 83
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3780,7 +3780,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 84
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3799,7 +3799,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 85
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3818,7 +3818,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 86
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3837,7 +3837,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 87
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3856,7 +3856,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 88
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3875,7 +3875,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 89
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3894,7 +3894,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 90
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3913,7 +3913,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 91
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3932,7 +3932,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 92
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3951,7 +3951,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 93
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3970,7 +3970,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 94
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -3989,7 +3989,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 95
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4008,7 +4008,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 96
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4027,7 +4027,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 97
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4046,7 +4046,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 98
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4065,7 +4065,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 99
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4084,7 +4084,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 100
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4103,7 +4103,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 101
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4122,7 +4122,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 102
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4141,7 +4141,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 103
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4160,7 +4160,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 104
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4179,7 +4179,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 105
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4198,7 +4198,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 106
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4217,7 +4217,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 107
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4236,7 +4236,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 108
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4255,7 +4255,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 109
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4274,7 +4274,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 110
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4293,7 +4293,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 111
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4312,7 +4312,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 112
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4331,7 +4331,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 113
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4350,7 +4350,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 114
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4369,7 +4369,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 115
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4407,7 +4407,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 117
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4426,7 +4426,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 118
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4445,7 +4445,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 119
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4464,7 +4464,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 120
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4483,7 +4483,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 121
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4502,7 +4502,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 122
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4540,7 +4540,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 124
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4559,7 +4559,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 125
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4597,7 +4597,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 127
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4616,7 +4616,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 128
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4635,7 +4635,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 129
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4654,7 +4654,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 130
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4673,7 +4673,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 131
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4711,7 +4711,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 133
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4730,7 +4730,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 134
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4768,7 +4768,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 136
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4787,7 +4787,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 137
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4825,7 +4825,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 139
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4844,7 +4844,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 140
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4882,7 +4882,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 142
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4901,7 +4901,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 143
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4939,7 +4939,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 145
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4958,7 +4958,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 146
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -4996,7 +4996,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 148
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5015,7 +5015,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 149
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5053,7 +5053,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 151
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5072,7 +5072,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 152
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5110,7 +5110,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 154
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5129,7 +5129,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 155
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5148,7 +5148,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 156
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5167,7 +5167,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 157
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5186,7 +5186,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 158
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5205,7 +5205,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 159
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5224,7 +5224,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 160
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5243,7 +5243,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 161
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5262,7 +5262,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 162
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5281,7 +5281,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 163
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5300,7 +5300,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 164
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5319,7 +5319,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 165
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5338,7 +5338,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 166
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5357,7 +5357,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 167
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5376,7 +5376,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 168
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5395,7 +5395,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 169
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5414,7 +5414,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 170
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5433,7 +5433,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 171
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5452,7 +5452,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 172
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5471,7 +5471,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 173
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5490,7 +5490,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 174
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5509,7 +5509,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 175
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5528,7 +5528,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 176
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5547,7 +5547,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 177
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5566,7 +5566,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 178
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5585,7 +5585,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 179
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5604,7 +5604,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 180
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5623,7 +5623,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 181
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5642,7 +5642,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 182
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5661,7 +5661,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 183
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5680,7 +5680,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 184
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5699,7 +5699,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 185
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5718,7 +5718,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 186
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5737,7 +5737,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 187
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5756,7 +5756,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 188
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5775,7 +5775,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 189
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5794,7 +5794,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 190
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5813,7 +5813,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 191
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5832,7 +5832,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 192
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5851,7 +5851,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 193
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5870,7 +5870,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 194
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5889,7 +5889,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 195
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5908,7 +5908,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 196
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5927,7 +5927,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 197
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5946,7 +5946,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 198
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5965,7 +5965,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 199
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -5984,7 +5984,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 200
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6003,7 +6003,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 201
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6022,7 +6022,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 202
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6041,7 +6041,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 203
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6079,7 +6079,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 205
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6117,7 +6117,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 207
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6136,7 +6136,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 208
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6155,7 +6155,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 209
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6174,7 +6174,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 210
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6212,7 +6212,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 212
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6231,7 +6231,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 213
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6250,7 +6250,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 214
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6307,7 +6307,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 217
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6326,7 +6326,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 218
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6364,7 +6364,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 220
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6383,7 +6383,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 221
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6402,7 +6402,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 222
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6421,7 +6421,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 223
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6440,7 +6440,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 224
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6459,7 +6459,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 225
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6478,7 +6478,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 226
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6497,7 +6497,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 227
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6516,7 +6516,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 228
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6535,7 +6535,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 229
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6554,7 +6554,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 230
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6573,7 +6573,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 231
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6592,7 +6592,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 232
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6611,7 +6611,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 233
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6630,7 +6630,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 234
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6649,7 +6649,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 235
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6668,7 +6668,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 236
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6687,7 +6687,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 237
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6706,7 +6706,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 238
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6725,7 +6725,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 239
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6744,7 +6744,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 240
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6763,7 +6763,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 241
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6782,7 +6782,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 242
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6801,7 +6801,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 243
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6820,7 +6820,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 244
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6839,7 +6839,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 245
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6858,7 +6858,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 246
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6877,7 +6877,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 247
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6896,7 +6896,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 248
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6915,7 +6915,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 249
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6934,7 +6934,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 250
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6953,7 +6953,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 251
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6972,7 +6972,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 252
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -6991,7 +6991,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 253
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -7010,7 +7010,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 254
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -7029,7 +7029,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 255
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -7048,7 +7048,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetAllRailTypes():  null
   Engine 256
     IsValidEngine():    false
-    GetName():          (null : 0x00000000)
+    GetName():          
     GetCargoType():     255
     CanRefitCargo():    false
     GetCapacity():      -1
@@ -7143,7 +7143,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   GetNumEngines():          1
   GetNumEngines():          0
   GetName():                Group 1
-  GetName():                (null : 0x00000000)
+  GetName():                
   AIVehicle.SellVehicle():  true
   AITile.DemolishTile():    true
   HasWagonRemoval():        false

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -63,7 +63,7 @@ namespace SQConvert {
 			if (res.has_value()) {
 				sq_pushstring(vm, res.value());
 			} else {
-				sq_pushnull(vm);
+				sq_pushstring(vm, "");
 			}
 			return 1;
 		}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Since the introduction of scripts we always returned `null` for failed precondition for function returning `string`.
But many scripts assume a `string` is returned and usually don't handle very well getting a `null` when the expect a `string`. 
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Return an empty `string` when we used to return `null`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Scripts properly handling the `null` we used to return may not detect precondition failures with the empty `string`.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
