### PR TITLE
Codechange: document some script related functions

### DIFF
--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -37,6 +37,7 @@ public:
 
 	/**
 	 * Get the current AI tick.
+	 * @return The tick number.
 	 */
 	static uint GetTick();
 
@@ -97,30 +98,35 @@ public:
 
 	/**
 	 * Queue a new event for an AI.
+	 * @param company The company to receive the event.
+	 * @param event The event.
 	 */
 	static void NewEvent(CompanyID company, ScriptEvent *event);
 
 	/**
 	 * Broadcast a new event to all active AIs.
+	 * @param event The event to broadcast.
+	 * @param skip_company The optional company not to send the event to.
 	 */
 	static void BroadcastNewEvent(ScriptEvent *event, CompanyID skip_company = CompanyID::Invalid());
 
 	/**
 	 * Save data from an AI to a savegame.
+	 * @param company To company to save.
 	 */
 	static void Save(CompanyID company);
 
-	/** Wrapper function for AIScanner::GetAIConsoleList */
+	/** @copydoc ScriptScanner::GetConsoleList */
 	static void GetConsoleList(std::back_insert_iterator<std::string> &output_iterator, bool newest_only);
-	/** Wrapper function for AIScanner::GetAIConsoleLibraryList */
-	static void GetConsoleLibraryList(std::back_insert_iterator<std::string> &output_iterator);
-	/** Wrapper function for AIScanner::GetAIInfoList */
+	/** @copydoc ScriptScanner::GetConsoleList */
+	static void GetConsoleLibraryList(std::back_insert_iterator<std::string> &output_iterator, bool newest_only);
+	/** @copydoc ScriptScanner::GetInfoList */
 	static const ScriptInfoList *GetInfoList();
-	/** Wrapper function for AIScanner::GetUniqueAIInfoList */
+	/** @copydoc ScriptScanner::GetUniqueInfoList */
 	static const ScriptInfoList *GetUniqueInfoList();
-	/** Wrapper function for AIScanner::FindInfo */
+	/** @copydoc ScriptConfig::FindInfo */
 	static class AIInfo *FindInfo(const std::string &name, int version, bool force_exact_match);
-	/** Wrapper function for AIScanner::FindLibrary */
+	/** @copydoc ScriptInstance::FindLibrary */
 	static class AILibrary *FindLibrary(const std::string &library, int version);
 
 	/**

--- a/src/ai/ai_config.hpp
+++ b/src/ai/ai_config.hpp
@@ -13,10 +13,14 @@
 #include "../script/script_config.hpp"
 #include "../company_type.h"
 
+/** AI instantion of script configuration. */
 class AIConfig : public ScriptConfig {
 public:
 	/**
-	 * Get the config of a company.
+	 * Get the AI configuration of specific company.
+	 * @param company The company to get the configuration for.
+	 * @param source The context, i.e. current / new game mode.
+	 * @return The configuration.
 	 */
 	static AIConfig *GetConfig(CompanyID company, ScriptSettingSource source = SSS_DEFAULT);
 
@@ -24,10 +28,15 @@ public:
 		ScriptConfig()
 	{}
 
+	/**
+	 * Copy constructor.
+	 * @param config The configuration to copy.
+	 */
 	AIConfig(const AIConfig &config) :
 		ScriptConfig(config)
 	{}
 
+	/** @copydoc ScriptConfig::GetInfo. */
 	class AIInfo *GetInfo() const;
 
 	/**

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -290,9 +290,9 @@
 	AI::scanner_info->GetConsoleList(output_iterator, newest_only);
 }
 
-/* static */ void AI::GetConsoleLibraryList(std::back_insert_iterator<std::string> &output_iterator)
+/* static */ void AI::GetConsoleLibraryList(std::back_insert_iterator<std::string> &output_iterator, bool newest_only)
 {
-	 AI::scanner_library->GetConsoleList(output_iterator, true);
+	 AI::scanner_library->GetConsoleList(output_iterator, newest_only);
 }
 
 /* static */ const ScriptInfoList *AI::GetInfoList()
@@ -329,26 +329,40 @@
 }
 
 /**
- * Check whether we have an AI (library) with the exact characteristics as ci.
+ * Check whether we have an AI with the exact characteristics as ci.
  * @param ci the characteristics to search on (shortname and md5sum)
  * @param md5sum whether to check the MD5 checksum
- * @return true iff we have an AI (library) matching.
+ * @return true iff we have an AI matching.
  */
 /* static */ bool AI::HasAI(const ContentInfo &ci, bool md5sum)
 {
 	return AI::scanner_info->HasScript(ci, md5sum);
 }
 
+/**
+ * Check whether we have an AI library with the exact characteristics as ci.
+ * @param ci the characteristics to search on (shortname and md5sum)
+ * @param md5sum whether to check the MD5 checksum
+ * @return true iff we have an AI library matching.
+ */
 /* static */ bool AI::HasAILibrary(const ContentInfo &ci, bool md5sum)
 {
 	return AI::scanner_library->HasScript(ci, md5sum);
 }
 
+/**
+ * Get the scanner info for AIs.
+ * @return The AI scanner info.
+ */
 /* static */ AIScannerInfo *AI::GetScannerInfo()
 {
 	return AI::scanner_info.get();
 }
 
+/**
+ * Get the scanner info for AI libraries.
+ * @return The AI library scanner info.
+ */
 /* static */ AIScannerLibrary *AI::GetScannerLibrary()
 {
 	return AI::scanner_library.get();

--- a/src/ai/ai_info.cpp
+++ b/src/ai/ai_info.cpp
@@ -21,6 +21,7 @@
 /**
  * Check if the API version provided by the AI is supported.
  * @param api_version The API version as provided by the AI.
+ * @return \c true if the given version is supported by this version of OpenTTD.
  */
 static bool CheckAPIVersion(const std::string &api_version)
 {

--- a/src/ai/ai_info.hpp
+++ b/src/ai/ai_info.hpp
@@ -15,38 +15,47 @@
 /** All static information from an AI like name, version, etc. */
 class AIInfo : public ScriptInfo {
 public:
-	/* All valid AI API versions, in order. */
+	/** All valid AI API versions, in order. */
 	static constexpr std::string_view ApiVersions[]{ "0.7", "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "12", "13", "14", "15", "16" };
 
 	AIInfo();
 
 	/**
 	 * Register the functions of this class.
+	 * @param engine The engine to register to.
 	 */
 	static void RegisterAPI(Squirrel &engine);
 
 	/**
 	 * Create an AI, using this AIInfo as start-template.
+	 * @param vm The virtual machine to push the instance to.
+	 * @return The number of stack places occupied.
 	 */
 	static SQInteger Constructor(HSQUIRRELVM vm);
 
 	/**
 	 * Create a dummy-AI.
+	 * @param vm The virtual machine to push the instance to.
+	 * @return The number of stack places occupied.
 	 */
 	static SQInteger DummyConstructor(HSQUIRRELVM vm);
 
 	/**
 	 * Check if we can start this AI.
+	 * @param version The version to check.
+	 * @return \c true if this script can load the data from that version.
 	 */
 	bool CanLoadFromVersion(int version) const;
 
 	/**
 	 * Use this AI as a random AI.
+	 * @return \c true when it can be used as random AI, \c false when the user must specifically request it.
 	 */
 	bool UseAsRandomAI() const { return this->use_as_random; }
 
 	/**
 	 * Get the API version this AI is written for.
+	 * @return The API version.
 	 */
 	const std::string &GetAPIVersion() const { return this->api_version; }
 
@@ -63,16 +72,20 @@ public:
 
 	/**
 	 * Register the functions of this class.
+	 * @param engine The engine to register to.
 	 */
 	static void RegisterAPI(Squirrel &engine);
 
 	/**
 	 * Create an AI, using this AIInfo as start-template.
+	 * @param vm The virtual machine to push the instance to.
+	 * @return The number of stack places occupied.
 	 */
 	static SQInteger Constructor(HSQUIRRELVM vm);
 
 	/**
 	 * Get the category this library is in.
+	 * @return The category.
 	 */
 	const std::string &GetCategory() const { return this->category; }
 

--- a/src/ai/ai_scanner.hpp
+++ b/src/ai/ai_scanner.hpp
@@ -12,6 +12,7 @@
 
 #include "../script/script_scanner.hpp"
 
+/** AI instantiation of a ScriptScanner. */
 class AIScannerInfo : public ScriptScanner {
 public:
 	AIScannerInfo();
@@ -36,6 +37,7 @@ public:
 
 	/**
 	 * Set the Dummy AI.
+	 * @param info The new dummy AI.
 	 */
 	void SetDummyAI(std::unique_ptr<class AIInfo> &&info);
 
@@ -50,6 +52,7 @@ private:
 	std::unique_ptr<AIInfo> info_dummy; ///< The dummy AI.
 };
 
+/** AI instantiation of a ScriptScanner for libraries. */
 class AIScannerLibrary : public ScriptScanner {
 public:
 	void Initialize() override;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1410,7 +1410,7 @@ static bool ConListAILibs(std::span<std::string_view> argv)
 		return true;
 	}
 
-	return PrintList(AI::GetConsoleLibraryList);
+	return PrintList(AI::GetConsoleLibraryList, true);
 }
 
 static bool ConListAI(std::span<std::string_view> argv)
@@ -1430,7 +1430,7 @@ static bool ConListGameLibs(std::span<std::string_view> argv)
 		return true;
 	}
 
-	return PrintList(Game::GetConsoleLibraryList);
+	return PrintList(Game::GetConsoleLibraryList, true);
 }
 
 static bool ConListGame(std::span<std::string_view> argv)

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -36,6 +36,7 @@ public:
 
 	/**
 	 * Uninitialize the Game system.
+	 * @param keepConfig Should we keep GameConfigs, or can we free that memory?
 	 */
 	static void Uninitialize(bool keepConfig);
 
@@ -60,16 +61,27 @@ public:
 	static bool IsPaused();
 
 	/**
-	 * Queue a new event for a Game Script.
+	 * Queue a new event for the game script.
+	 * @param event The event.
 	 */
 	static void NewEvent(class ScriptEvent *event);
 
 	/**
 	 * Get the current GameInfo.
+	 * @return The info, or nullptr when there is no Game script.
 	 */
 	static class GameInfo *GetInfo() { return Game::info; }
 
+	/**
+	 * Rescans all searchpaths for available Game scripts. If a used Game script is no longer
+	 * found it is removed from the config.
+	 */
 	static void Rescan();
+
+	/**
+	 * Reset all GameConfigs, and make them reload their GameInfo.
+	 * If the GameInfo could no longer be found, an error is reported to the user.
+	 */
 	static void ResetConfig();
 
 	/**
@@ -77,21 +89,22 @@ public:
 	 */
 	static void Save();
 
-	/** Wrapper function for GameScanner::GetConsoleList */
+	/** @copydoc ScriptScanner::GetConsoleList */
 	static void GetConsoleList(std::back_insert_iterator<std::string> &output_iterator, bool newest_only);
-	/** Wrapper function for GameScanner::GetConsoleLibraryList */
-	static void GetConsoleLibraryList(std::back_insert_iterator<std::string> &output_iterator);
-	/** Wrapper function for GameScanner::GetInfoList */
+	/** @copydoc ScriptScanner::GetConsoleList */
+	static void GetConsoleLibraryList(std::back_insert_iterator<std::string> &output_iterator, bool newest_only);
+	/** @copydoc ScriptScanner::GetInfoList */
 	static const ScriptInfoList *GetInfoList();
-	/** Wrapper function for GameScanner::GetUniqueInfoList */
+	/** @copydoc ScriptScanner::GetUniqueInfoList */
 	static const ScriptInfoList *GetUniqueInfoList();
-	/** Wrapper function for GameScannerInfo::FindInfo */
+	/** @copydoc ScriptConfig::FindInfo */
 	static class GameInfo *FindInfo(const std::string &name, int version, bool force_exact_match);
-	/** Wrapper function for GameScanner::FindLibrary */
+	/** @copydoc ScriptInstance::FindLibrary */
 	static class GameLibrary *FindLibrary(const std::string &library, int version);
 
 	/**
 	 * Get the current active instance.
+	 * @return The current Game script instance.
 	 */
 	static class GameInstance *GetInstance() { return Game::instance.get(); }
 

--- a/src/game/game_config.hpp
+++ b/src/game/game_config.hpp
@@ -12,10 +12,13 @@
 
 #include "../script/script_config.hpp"
 
+/** Game script instantion of script configuration. */
 class GameConfig : public ScriptConfig {
 public:
 	/**
-	 * Get the config of a company.
+	 * Get the script configuration.
+	 * @param source The context, i.e. current / new game mode.
+	 * @return The configuration.
 	 */
 	static GameConfig *GetConfig(ScriptSettingSource source = SSS_DEFAULT);
 
@@ -23,10 +26,15 @@ public:
 		ScriptConfig()
 	{}
 
+	/**
+	 * Copy constructor.
+	 * @param config The configuration to copy.
+	 */
 	GameConfig(const GameConfig &config) :
 		ScriptConfig(config)
 	{}
 
+	/** @copydoc ScriptConfig::GetInfo. */
 	class GameInfo *GetInfo() const;
 
 	/**

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -205,9 +205,9 @@
 	Game::scanner_info->GetConsoleList(output_iterator, newest_only);
 }
 
-/* static */ void Game::GetConsoleLibraryList(std::back_insert_iterator<std::string> &output_iterator)
+/* static */ void Game::GetConsoleLibraryList(std::back_insert_iterator<std::string> &output_iterator, bool newest_only)
 {
-	Game::scanner_library->GetConsoleList(output_iterator, true);
+	Game::scanner_library->GetConsoleList(output_iterator, newest_only);
 }
 
 /* static */ const ScriptInfoList *Game::GetInfoList()
@@ -237,25 +237,40 @@
 }
 
 /**
- * Check whether we have an Game (library) with the exact characteristics as ci.
+ * Check whether we have an Game with the exact characteristics as ci.
  * @param ci the characteristics to search on (shortname and md5sum)
  * @param md5sum whether to check the MD5 checksum
- * @return true iff we have an Game (library) matching.
+ * @return true iff we have an Game matching.
  */
 /* static */ bool Game::HasGame(const ContentInfo &ci, bool md5sum)
 {
 	return Game::scanner_info->HasScript(ci, md5sum);
 }
 
+/**
+ * Check whether we have an Game library with the exact characteristics as ci.
+ * @param ci the characteristics to search on (shortname and md5sum)
+ * @param md5sum whether to check the MD5 checksum
+ * @return true iff we have an Game library matching.
+ */
 /* static */ bool Game::HasGameLibrary(const ContentInfo &ci, bool md5sum)
 {
 	return Game::scanner_library->HasScript(ci, md5sum);
 }
 
+/**
+ * Get the scanner info for Game scripts.
+ * @return The Game Script scanner info.
+ */
 /* static */ GameScannerInfo *Game::GetScannerInfo()
 {
 	return Game::scanner_info.get();
 }
+
+/**
+ * Get the scanner info for Game script libraries.
+ * @return The Game script library scanner info.
+ */
 /* static */ GameScannerLibrary *Game::GetScannerLibrary()
 {
 	return Game::scanner_library.get();

--- a/src/game/game_info.cpp
+++ b/src/game/game_info.cpp
@@ -19,6 +19,7 @@
 /**
  * Check if the API version provided by the Game is supported.
  * @param api_version The API version as provided by the Game.
+ * @return \c true if the given version is supported by this version of OpenTTD.
  */
 static bool CheckAPIVersion(const std::string &api_version)
 {

--- a/src/game/game_info.hpp
+++ b/src/game/game_info.hpp
@@ -15,28 +15,34 @@
 /** All static information from an Game like name, version, etc. */
 class GameInfo : public ScriptInfo {
 public:
-	/* All valid GameScript API versions, in order. */
+	/** All valid GameScript API versions, in order. */
 	static constexpr std::string_view ApiVersions[]{ "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "12", "13", "14", "15", "16" };
 
 	GameInfo();
 
 	/**
 	 * Register the functions of this class.
+	 * @param engine The engine to register to.
 	 */
 	static void RegisterAPI(Squirrel &engine);
 
 	/**
 	 * Create an Game, using this GameInfo as start-template.
+	 * @param vm The virtual machine to push the instance to.
+	 * @return The number of stack places occupied.
 	 */
 	static SQInteger Constructor(HSQUIRRELVM vm);
 
 	/**
 	 * Check if we can start this Game.
+	 * @param version The version to check.
+	 * @return \c true if this script can load the data from that version.
 	 */
 	bool CanLoadFromVersion(int version) const;
 
 	/**
 	 * Get the API version this Game is written for.
+	 * @return The API version.
 	 */
 	const std::string &GetAPIVersion() const { return this->api_version; }
 
@@ -55,16 +61,20 @@ public:
 
 	/**
 	 * Register the functions of this class.
+	 * @param engine The engine to register to.
 	 */
 	static void RegisterAPI(Squirrel &engine);
 
 	/**
 	 * Create an GSLibrary, using this GSInfo as start-template.
+	 * @param vm The virtual machine to push the instance to.
+	 * @return The number of stack places occupied.
 	 */
 	static SQInteger Constructor(HSQUIRRELVM vm);
 
 	/**
 	 * Get the category this library is in.
+	 * @return The category.
 	 */
 	const std::string &GetCategory() const { return this->category; }
 

--- a/src/game/game_scanner.hpp
+++ b/src/game/game_scanner.hpp
@@ -12,6 +12,7 @@
 
 #include "../script/script_scanner.hpp"
 
+/** Game instantiation of a ScriptScanner. */
 class GameScannerInfo : public ScriptScanner {
 public:
 	void Initialize() override;
@@ -34,6 +35,7 @@ protected:
 };
 
 
+/** Game instantiation of a ScriptScanner for libraries. */
 class GameScannerLibrary : public ScriptScanner {
 public:
 	void Initialize() override;

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -82,6 +82,7 @@ public:
 
 	/**
 	 * Get the ScriptInfo linked to this ScriptConfig.
+	 * @return The info.
 	 */
 	class ScriptInfo *GetInfo() const;
 
@@ -187,8 +188,11 @@ protected:
 	void ClearConfigList();
 
 	/**
-	 * This function should call back to the Scanner in charge of this Config,
-	 *  to find the ScriptInfo belonging to a name+version.
+	 * Finds the appropriate ScriptInfo for a given script name and version.
+	 * @param name The script name to find.
+	 * @param version The version the script should have.
+	 * @param force_exact_match Whether an exact match is required.
+	 * @return The script if found, nullptr otherwise.
 	 */
 	virtual ScriptInfo *FindInfo(const std::string &name, int version, bool force_exact_match) = 0;
 };

--- a/src/script/script_info.hpp
+++ b/src/script/script_info.hpp
@@ -31,51 +31,61 @@ class ScriptInfo : public SimpleCountedObject {
 public:
 	/**
 	 * Get the Author of the script.
+	 * @return The author's name.
 	 */
 	const std::string &GetAuthor() const { return this->author; }
 
 	/**
 	 * Get the Name of the script.
+	 * @return The script's name.
 	 */
 	const std::string &GetName() const { return this->name; }
 
 	/**
 	 * Get the 4 character long short name of the script.
+	 * @return The short name.
 	 */
 	const std::string &GetShortName() const { return this->short_name; }
 
 	/**
 	 * Get the description of the script.
+	 * @return The description.
 	 */
 	const std::string &GetDescription() const { return this->description; }
 
 	/**
 	 * Get the version of the script.
+	 * @return The numeric versionof the script.
 	 */
 	int GetVersion() const { return this->version; }
 
 	/**
 	 * Get the last-modified date of the script.
+	 * @return The date.
 	 */
 	const std::string &GetDate() const { return this->date; }
 
 	/**
 	 * Get the name of the instance of the script to create.
+	 * @return Name of the instance.
 	 */
 	const std::string &GetInstanceName() const { return this->instance_name; }
 
 	/**
 	 * Get the website for this script.
+	 * @return Optional URL.
 	 */
 	const std::string &GetURL() const { return this->url; }
 
 	/**
 	 * Get the filename of the main.nut script.
+	 * @return The path to the main script.
 	 */
 	const std::string &GetMainScript() const { return this->main_script; }
 
 	/**
 	 * Get the filename of the tar the script is in.
+	 * @return The tar file the script is in, or an empty string.
 	 */
 	const std::string &GetTarFile() const { return this->tar_file; }
 

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -100,46 +100,55 @@ public:
 
 	/**
 	 * Return a true/false reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
 	 */
 	static void DoCommandReturn(ScriptInstance &instance);
 
 	/**
 	 * Return a VehicleID reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
 	 */
 	static void DoCommandReturnVehicleID(ScriptInstance &instance);
 
 	/**
 	 * Return a SignID reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
 	 */
 	static void DoCommandReturnSignID(ScriptInstance &instance);
 
 	/**
 	 * Return a GroupID reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
 	 */
 	static void DoCommandReturnGroupID(ScriptInstance &instance);
 
 	/**
 	 * Return a GoalID reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
 	 */
 	static void DoCommandReturnGoalID(ScriptInstance &instance);
 
 	/**
 	 * Return a StoryPageID reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
 	 */
 	static void DoCommandReturnStoryPageID(ScriptInstance &instance);
 
 	/**
 	 * Return a StoryPageElementID reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
 	 */
 	static void DoCommandReturnStoryPageElementID(ScriptInstance &instance);
 
 	/**
 	 * Return a LeagueTableID reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
 	 */
 	static void DoCommandReturnLeagueTableID(ScriptInstance &instance);
 
 	/**
 	 * Return a LeagueTableElementID reply for a DoCommand.
+	 * @param instance The instance to return the reply to.
 	 */
 	static void DoCommandReturnLeagueTableElementID(ScriptInstance &instance);
 

--- a/src/script/script_scanner.hpp
+++ b/src/script/script_scanner.hpp
@@ -28,31 +28,37 @@ public:
 
 	/**
 	 * Get the engine of the main squirrel handler (it indexes all available scripts).
+	 * @return The engine.
 	 */
 	class Squirrel *GetEngine() { return this->engine.get(); }
 
 	/**
 	 * Get the current main script the ScanDir is currently tracking.
+	 * @return The path to the main script.
 	 */
 	std::string GetMainScript() { return this->main_script; }
 
 	/**
 	 * Get the current tar file the ScanDir is currently tracking.
+	 * @return The tar file the script is in, or an empty string.
 	 */
 	std::string GetTarFile() { return this->tar_file; }
 
 	/**
 	 * Get the list of all registered scripts.
+	 * @return The list of ScriptInfo elements.
 	 */
 	const ScriptInfoList *GetInfoList() { return &this->info_list; }
 
 	/**
 	 * Get the list of the latest version of all registered scripts.
+	 * @return The list of ScriptInfo elements.
 	 */
 	const ScriptInfoList *GetUniqueInfoList() { return &this->info_single_list; }
 
 	/**
 	 * Register a ScriptInfo to the scanner.
+	 * @param info The script to register.
 	 */
 	void RegisterScript(std::unique_ptr<class ScriptInfo> &&info);
 
@@ -91,7 +97,7 @@ protected:
 	std::string main_script; ///< The full path of the script.
 	std::string tar_file;    ///< If, which tar file the script was in.
 
-	std::vector<std::unique_ptr<ScriptInfo>> info_vector;
+	std::vector<std::unique_ptr<ScriptInfo>> info_vector; ///< The known ScriptInfo objects.
 
 	ScriptInfoList info_list; ///< The list of all script.
 	ScriptInfoList info_single_list; ///< The list of all unique script. The best script (highest version) is shown.
@@ -104,26 +110,32 @@ protected:
 
 	/**
 	 * Get the script name how to store the script in memory.
+	 * @param info The information to get name for.
+	 * @return The script's name.
 	 */
 	virtual std::string GetScriptName(ScriptInfo &info) = 0;
 
 	/**
 	 * Get the filename to scan for this type of script.
+	 * @return The file name of the main file of the script/library.
 	 */
 	virtual std::string_view GetFileName() const = 0;
 
 	/**
 	 * Get the directory to scan in.
+	 * @return The sub directory to search in.
 	 */
 	virtual Subdirectory GetDirectory() const = 0;
 
 	/**
 	 * Register the API for this ScriptInfo.
+	 * @param engine The engine to register to.
 	 */
 	virtual void RegisterAPI(class Squirrel &engine) = 0;
 
 	/**
 	 * Get the type of the script, in plural.
+	 * @return Type of script to show on the console.
 	 */
 	virtual std::string_view GetScannerName() const = 0;
 

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -16,7 +16,12 @@
 #include "../core/convertible_through_base.hpp"
 #include "squirrel_helper_type.hpp"
 
-template <class CL, ScriptType ST> SQInteger PushClassName(HSQUIRRELVM);
+/**
+ * Helper to push the class name of a script type onto the Squirrel stack
+ * @param vm The virtual machine to push to.
+ * @return The number of stack places used.
+ */
+template <class CL, ScriptType ST> SQInteger PushClassName(HSQUIRRELVM vm);
 
 /**
  * The Squirrel convert routines


### PR DESCRIPTION
## Motivation / Problem

Lots of doxygen warnings.


## Description

Solve 153 warnings.

Mostly missing parameters or return types.

In some cases `static` variants of `AI`/`Game` call a `Script` variant, so just `@copydoc` them. For consistency I've added a `newest_only` parameter to `GetConsoleLibraryList` like `GetConsoleList` has, since both just call the same Script function. This also makes the `PrintList` calls in 'console_cmds.cpp' more consistent and clearer that for libraries something else is happening.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
