### PR TITLE
Fix: Crash when OpenGLSpriteAllocator::AllocatePtr is called

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1087,14 +1087,12 @@ void OpenGLBackend::DrawMouseCursor()
 	}
 }
 
-class OpenGLSpriteAllocator : public SpriteAllocator {
+class OpenGLSpriteAllocator : public UniquePtrSpriteAllocator {
 public:
 	OpenGLSpriteLRUCache &lru;
 	SpriteID sprite;
 
 	OpenGLSpriteAllocator(OpenGLSpriteLRUCache &lru, SpriteID sprite) : lru(lru), sprite(sprite) {}
-protected:
-	void *AllocatePtr(size_t) override { NOT_REACHED(); }
 };
 
 void OpenGLBackend::PopulateCursorCache()


### PR DESCRIPTION
## Motivation / Problem

Incorrectly coded GRFs and/or unfortunate combinations of GRFs can result in OpenGLSpriteAllocator::AllocatePtr being called when preparing cursor sprites.
OpenGLSpriteAllocator::AllocatePtr is not unreachable so should not contain a NOT_REACHED.

See attached for an example unfortunate combination of GRFs (drag the wagon in the depot).

[OpenGL Cursor Problems Ltd, 1750-01-28.sav.zip](https://github.com/user-attachments/files/25161323/OpenGL.Cursor.Problems.Ltd.1750-01-28.sav.zip)

## Description

Change OpenGLSpriteAllocator to inherit from UniquePtrSpriteAllocator such that it calls malloc as requested instead of calling NOT_REACHED.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
