### PR TITLE
Codechange: use size_t for glyph/run counts, remove unneeded glyph count instance variable

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -592,7 +592,7 @@ static int DrawLayoutLine(const ParagraphLayouter::Line &line, int y, int left, 
 		int dpi_right = dpi->left + dpi->width - 1;
 		TextColour last_colour = initial_colour;
 
-		for (int run_index = 0; run_index < line.CountRuns(); run_index++) {
+		for (size_t run_index = 0; run_index < line.CountRuns(); run_index++) {
 			const ParagraphLayouter::VisualRun &run = line.GetVisualRun(run_index);
 			const auto &glyphs = run.GetGlyphs();
 			const auto &positions = run.GetPositions();
@@ -607,7 +607,7 @@ static int DrawLayoutLine(const ParagraphLayouter::Line &line, int y, int left, 
 			if (do_shadow && (!fc->GetDrawGlyphShadow() || !colour_has_shadow)) continue;
 			SetColourRemap(do_shadow ? TC_BLACK : colour);
 
-			for (int i = 0; i < run.GetGlyphCount(); i++) {
+			for (size_t i = 0; i < run.GetGlyphCount(); i++) {
 				GlyphID glyph = glyphs[i];
 
 				/* Not a valid glyph (empty) */

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -270,7 +270,7 @@ ParagraphLayouter::Position Layouter::GetCharPosition(std::string_view::const_it
 
 	/* Scan all runs until we've found our code point index. */
 	size_t best_index = SIZE_MAX;
-	for (int run_index = 0; run_index < line->CountRuns(); run_index++) {
+	for (size_t run_index = 0; run_index < line->CountRuns(); run_index++) {
 		const ParagraphLayouter::VisualRun &run = line->GetVisualRun(run_index);
 		const auto &positions = run.GetPositions();
 		const auto &charmap = run.GetGlyphToCharMap();
@@ -308,13 +308,13 @@ ptrdiff_t Layouter::GetCharAtPosition(int x, size_t line_index) const
 
 	const auto &line = this->at(line_index);
 
-	for (int run_index = 0; run_index < line->CountRuns(); run_index++) {
+	for (size_t run_index = 0; run_index < line->CountRuns(); run_index++) {
 		const ParagraphLayouter::VisualRun &run = line->GetVisualRun(run_index);
 		const auto &glyphs = run.GetGlyphs();
 		const auto &positions = run.GetPositions();
 		const auto &charmap = run.GetGlyphToCharMap();
 
-		for (int i = 0; i < run.GetGlyphCount(); i++) {
+		for (size_t i = 0; i < run.GetGlyphCount(); i++) {
 			/* Not a valid glyph (empty). */
 			if (glyphs[i] == 0xFFFF) continue;
 

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -143,7 +143,7 @@ public:
 		 * Get the number of glyphs.
 		 * @return The number of glyphs for this run.
 		 */
-		virtual int GetGlyphCount() const = 0;
+		virtual size_t GetGlyphCount() const = 0;
 
 		/**
 		 * Get the glyphs to draw.
@@ -191,14 +191,14 @@ public:
 		 * Get the number of runs in this line.
 		 * @return The number of runs.
 		 */
-		virtual int CountRuns() const = 0;
+		virtual size_t CountRuns() const = 0;
 
 		/**
 		 * Get a reference to the given run.
 		 * @param run The index into the runs.
 		 * @return The reference to the run.
 		 */
-		virtual const VisualRun &GetVisualRun(int run) const = 0;
+		virtual const VisualRun &GetVisualRun(size_t run) const = 0;
 
 		/**
 		 * Get the number of elements the given character occupies in the underlying text buffer of the Layouter.

--- a/src/gfx_layout_fallback.cpp
+++ b/src/gfx_layout_fallback.cpp
@@ -48,7 +48,7 @@ public:
 	public:
 		FallbackVisualRun(Font *font, const char32_t *chars, int glyph_count, int char_offset, int x);
 		const Font *GetFont() const override { return this->font; }
-		int GetGlyphCount() const override { return static_cast<int>(this->glyphs.size()); }
+		size_t GetGlyphCount() const override { return this->glyphs.size(); }
 		std::span<const GlyphID> GetGlyphs() const override { return this->glyphs; }
 		std::span<const Position> GetPositions() const override { return this->positions; }
 		int GetLeading() const override { return this->GetFont()->fc->GetHeight(); }
@@ -60,8 +60,8 @@ public:
 	public:
 		int GetLeading() const override;
 		int GetWidth() const override;
-		int CountRuns() const override;
-		const ParagraphLayouter::VisualRun &GetVisualRun(int run) const override;
+		size_t CountRuns() const override;
+		const ParagraphLayouter::VisualRun &GetVisualRun(size_t run) const override;
 
 		int GetInternalCharLength(char32_t) const override { return 1; }
 	};
@@ -159,12 +159,12 @@ int FallbackParagraphLayout::FallbackLine::GetWidth() const
 	return positions.back().right + 1;
 }
 
-int FallbackParagraphLayout::FallbackLine::CountRuns() const
+size_t FallbackParagraphLayout::FallbackLine::CountRuns() const
 {
-	return static_cast<int>(this->size());
+	return this->size();
 }
 
-const ParagraphLayouter::VisualRun &FallbackParagraphLayout::FallbackLine::GetVisualRun(int run) const
+const ParagraphLayouter::VisualRun &FallbackParagraphLayout::FallbackLine::GetVisualRun(size_t run) const
 {
 	return this->at(run);
 }

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -77,7 +77,7 @@ public:
 
 		const Font *GetFont() const override { return this->font; }
 		int GetLeading() const override { return this->font->fc->GetHeight(); }
-		int GetGlyphCount() const override { return this->glyphs.size(); }
+		size_t GetGlyphCount() const override { return this->glyphs.size(); }
 		int GetAdvance() const { return this->total_advance; }
 	};
 
@@ -86,8 +86,8 @@ public:
 	public:
 		int GetLeading() const override;
 		int GetWidth() const override;
-		int CountRuns() const override { return (uint)this->size();  }
-		const VisualRun &GetVisualRun(int run) const override { return this->at(run); }
+		size_t CountRuns() const override { return this->size();  }
+		const VisualRun &GetVisualRun(size_t run) const override { return this->at(run); }
 
 		int GetInternalCharLength(char32_t c) const override
 		{

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -61,7 +61,7 @@ public:
 
 		const Font *GetFont() const override { return this->font;  }
 		int GetLeading() const override { return this->font->fc->GetHeight(); }
-		int GetGlyphCount() const override { return (int)this->glyphs.size(); }
+		size_t GetGlyphCount() const override { return this->glyphs.size(); }
 		int GetAdvance() const { return this->total_advance; }
 	};
 
@@ -84,8 +84,8 @@ public:
 
 		int GetLeading() const override;
 		int GetWidth() const override;
-		int CountRuns() const override { return this->size(); }
-		const VisualRun &GetVisualRun(int run) const override { return this->at(run);  }
+		size_t CountRuns() const override { return this->size(); }
+		const VisualRun &GetVisualRun(size_t run) const override { return this->at(run);  }
 
 		int GetInternalCharLength(char32_t c) const override
 		{


### PR DESCRIPTION
## Motivation / Problem

Someone asking whether `CountRuns` should return `size_t`.


## Description

Let `CountRuns` and `GetGlyphCount` return `size_t`. This means that their users and `GetVisualRun`'s parameter should become `size_t` as well.

In Uniscribe there was a `num_glyphs` instance variable that was set to the size of the glyphs vector after that was populated. Just use that instead. As a nice bonus this 'solves' one doxygen warning ;)


## Limitations

Untested on OSX/Windows.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
