### PR TITLE
Fix: [Script] Narrow cast, over and underflow in ScriptCargo::GetCargoIncome

### DIFF
--- a/src/script/api/script_cargo.cpp
+++ b/src/script/api/script_cargo.cpp
@@ -75,7 +75,10 @@
 
 	distance = Clamp<SQInteger>(distance, 0, UINT32_MAX);
 
-	return ::GetTransportedGoodsIncome(1, distance, Clamp(days_in_transit * 2 / 5, 0, UINT16_MAX), cargo_type);
+	static const SQInteger max_days_in_transit = ::CeilDiv(UINT16_MAX * 5, 2);
+	days_in_transit = Clamp<SQInteger>(days_in_transit, 0, max_days_in_transit);
+
+	return ::GetTransportedGoodsIncome(1, distance, days_in_transit, cargo_type);
 }
 
 /* static */ ScriptCargo::DistributionType ScriptCargo::GetDistributionType(CargoType cargo_type)


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Arithmetic overflow and underflow, with a narrowing cast in `ScriptCargo::GetCargoIncome`:
https://github.com/OpenTTD/OpenTTD/blob/396aa75a8432f605aee15d846bbc6af8f225abaa/src/script/api/script_cargo.cpp#L78

Example with `days_in_transit = 4611686018427387904`
4611686018427387904 * 2 / 5 = -1844674407370955161 -> overflow

Clamp first parameter is `int`, as defined in:
https://github.com/OpenTTD/OpenTTD/blob/396aa75a8432f605aee15d846bbc6af8f225abaa/src/core/math_func.hpp#L129

-1844674407370955161 = 1717986919 as int which is incorrect.

`Clamps` returns 65535 which is correct by chance. But there's situations it's not always correct.
Example with `days_in_transit = 9223372031486066690`
9223372031486066690 * 2 / 5 = -2147483647 -> overflow
-2147483647 = -2147483647 as int which is correct.
`Clamps` returns 0 which is incorrect.

Underflow case, `days_in_transit = -9223372036854775253`:
-9223372036854775253 * 2 / 5 = 222 -> underflow
222 = 222 as int which is correct.
Clamps returns 222 which is incorrect.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Fix them by precomputing the `max_days_in_transit` value, and use it to clamp `days_in_transit` without any arithmetic operation in `Clamp`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Codewise, I think none, but the value for `max_days_in_transit` is 163838. Documentation mentions it should be 637. I believe the documentation is outdated.
https://github.com/OpenTTD/OpenTTD/blob/396aa75a8432f605aee15d846bbc6af8f225abaa/src/script/api/script_cargo.hpp#L152

Values higher than 637 are definitely possible and can return results different than 637 would.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
