### PR TITLE
Codechange: use designated initialisers for TileTypeProcs instances

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -23,6 +23,7 @@
 
 #include "safeguards.h"
 
+/** @copydoc ClearTileProc */
 static CommandCost ClearTile_Clear(TileIndex tile, DoCommandFlags flags)
 {
 	static constexpr Price clear_price_table[to_underlying(ClearGround::MaxSize)] = {
@@ -115,6 +116,7 @@ static void DrawClearLandFence(const TileInfo *ti)
 	EndSpriteCombine();
 }
 
+/** @copydoc DrawTileProc */
 static void DrawTile_Clear(TileInfo *ti)
 {
 	if (IsSnowTile(ti->tile)) {
@@ -164,16 +166,12 @@ static void DrawTile_Clear(TileInfo *ti)
 	DrawBridgeMiddle(ti, {});
 }
 
-static int GetSlopePixelZ_Clear(TileIndex tile, uint x, uint y, bool)
+/** @copydoc GetSlopePixelZProc */
+static int GetSlopePixelZ_Clear(TileIndex tile, uint x, uint y, [[maybe_unused]] bool ground_vehicle)
 {
 	auto [tileh, z] = GetTilePixelSlope(tile);
 
 	return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
-}
-
-static Foundation GetFoundation_Clear(TileIndex, Slope)
-{
-	return FOUNDATION_NONE;
 }
 
 static void UpdateFences(TileIndex tile)
@@ -268,6 +266,7 @@ static void TileLoopClearDesert(TileIndex tile)
 	MarkTileDirtyByTile(tile);
 }
 
+/** @copydoc TileLoopProc */
 static void TileLoop_Clear(TileIndex tile)
 {
 	AmbientSoundEffect(tile);
@@ -367,11 +366,7 @@ get_out:;
 	} while (--i);
 }
 
-static TrackStatus GetTileTrackStatus_Clear(TileIndex, TransportType, uint, DiagDirection)
-{
-	return 0;
-}
-
+/** @copydoc GetTileDescProc */
 static void GetTileDesc_Clear(TileIndex tile, TileDesc &td)
 {
 	/* Each pair holds a normal and a snowy ClearGround description. */
@@ -395,36 +390,13 @@ static void GetTileDesc_Clear(TileIndex tile, TileDesc &td)
 	td.owner[0] = GetTileOwner(tile);
 }
 
-static void ChangeTileOwner_Clear(TileIndex, Owner, Owner)
-{
-	return;
-}
-
-static CommandCost TerraformTile_Clear(TileIndex tile, DoCommandFlags flags, int, Slope)
-{
-	return Command<Commands::LandscapeClear>::Do(flags, tile);
-}
-
-static CommandCost CheckBuildAbove_Clear(TileIndex, DoCommandFlags, Axis, int)
-{
-	/* Can always build above clear tiles. */
-	return CommandCost();
-}
-
+/** TileTypeProcs definitions for TileType::Clear tiles. */
 extern const TileTypeProcs _tile_type_clear_procs = {
-	DrawTile_Clear,           ///< draw_tile_proc
-	GetSlopePixelZ_Clear,     ///< get_slope_z_proc
-	ClearTile_Clear,          ///< clear_tile_proc
-	nullptr,                     ///< add_accepted_cargo_proc
-	GetTileDesc_Clear,        ///< get_tile_desc_proc
-	GetTileTrackStatus_Clear, ///< get_tile_track_status_proc
-	nullptr,                     ///< click_tile_proc
-	nullptr,                     ///< animate_tile_proc
-	TileLoop_Clear,           ///< tile_loop_proc
-	ChangeTileOwner_Clear,    ///< change_tile_owner_proc
-	nullptr,                     ///< add_produced_cargo_proc
-	nullptr,                     ///< vehicle_enter_tile_proc
-	GetFoundation_Clear,      ///< get_foundation_proc
-	TerraformTile_Clear,      ///< terraform_tile_proc
-	CheckBuildAbove_Clear, // check_build_above_proc
+	.draw_tile_proc = DrawTile_Clear,
+	.get_slope_pixel_z_proc = GetSlopePixelZ_Clear,
+	.clear_tile_proc = ClearTile_Clear,
+	.get_tile_desc_proc = GetTileDesc_Clear,
+	.tile_loop_proc = TileLoop_Clear,
+	.terraform_tile_proc = [](TileIndex tile, DoCommandFlags flags, int, Slope) { return Command<Commands::LandscapeClear>::Do(flags, tile); },
+	.check_build_above_proc = [](TileIndex, DoCommandFlags, Axis, int) { return CommandCost(); }, // Can always build above clear tiles
 };

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -326,6 +326,7 @@ static IndustryDrawTileProc * const _industry_draw_tile_procs[5] = {
 	IndustryDrawCoalPlantSparks,
 };
 
+/** @copydoc DrawTileProc */
 static void DrawTile_Industry(TileInfo *ti)
 {
 	IndustryGfx gfx = GetIndustryGfx(ti->tile);
@@ -386,11 +387,7 @@ static void DrawTile_Industry(TileInfo *ti)
 	}
 }
 
-static int GetSlopePixelZ_Industry(TileIndex tile, uint, uint, bool)
-{
-	return GetTileMaxPixelZ(tile);
-}
-
+/** @copydoc GetFoundationProc */
 static Foundation GetFoundation_Industry(TileIndex tile, Slope tileh)
 {
 	IndustryGfx gfx = GetIndustryGfx(tile);
@@ -409,6 +406,7 @@ static Foundation GetFoundation_Industry(TileIndex tile, Slope tileh)
 	return FlatteningFoundation(tileh);
 }
 
+/** @copydoc AddAcceptedCargoProc */
 static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, CargoTypes &always_accepted)
 {
 	IndustryGfx gfx = GetIndustryGfx(tile);
@@ -469,6 +467,7 @@ static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, Ca
 	}
 }
 
+/** @copydoc GetTileDescProc */
 static void GetTileDesc_Industry(TileIndex tile, TileDesc &td)
 {
 	const Industry *i = Industry::GetByTile(tile);
@@ -486,6 +485,7 @@ static void GetTileDesc_Industry(TileIndex tile, TileDesc &td)
 	}
 }
 
+/** @copydoc ClearTileProc */
 static CommandCost ClearTile_Industry(TileIndex tile, DoCommandFlags flags)
 {
 	Industry *i = Industry::GetByTile(tile);
@@ -688,6 +688,7 @@ static void AnimateMineTower(TileIndex tile)
 	}
 }
 
+/** @copydoc AnimateTileProc */
 static void AnimateTile_Industry(TileIndex tile)
 {
 	IndustryGfx gfx = GetIndustryGfx(tile);
@@ -830,6 +831,7 @@ static void TileLoopIndustry_BubbleGenerator(TileIndex tile)
 	if (v != nullptr) v->animation_substate = dir;
 }
 
+/** @copydoc TileLoopProc */
 static void TileLoop_Industry(TileIndex tile)
 {
 	if (IsTileOnWater(tile)) TileLoop_Water(tile);
@@ -949,17 +951,14 @@ static void TileLoop_Industry(TileIndex tile)
 	}
 }
 
+/** @copydoc ClickTileProc */
 static bool ClickTile_Industry(TileIndex tile)
 {
 	ShowIndustryViewWindow(GetIndustryIndex(tile));
 	return true;
 }
 
-static TrackStatus GetTileTrackStatus_Industry(TileIndex, TransportType, uint, DiagDirection)
-{
-	return 0;
-}
-
+/** @copydoc ChangeTileOwnerProc */
 static void ChangeTileOwner_Industry(TileIndex tile, Owner old_owner, Owner new_owner)
 {
 	/* If the founder merges, the industry was created by the merged company */
@@ -3235,6 +3234,7 @@ bool IndustrySpec::UsesOriginalEconomy() const
 			IndustryCallbackMask::ProdChangeBuild}); // production change callbacks
 }
 
+/** @copydoc TerraformTileProc */
 static CommandCost TerraformTile_Industry(TileIndex tile, DoCommandFlags flags, int z_new, Slope tileh_new)
 {
 	if (AutoslopeEnabled()) {
@@ -3264,22 +3264,19 @@ static CommandCost TerraformTile_Industry(TileIndex tile, DoCommandFlags flags, 
 	return Command<Commands::LandscapeClear>::Do(flags, tile);
 }
 
+/** TileTypeProcs definitions for TileType::Industry tiles. */
 extern const TileTypeProcs _tile_type_industry_procs = {
-	DrawTile_Industry,           // draw_tile_proc
-	GetSlopePixelZ_Industry,     // get_slope_z_proc
-	ClearTile_Industry,          // clear_tile_proc
-	AddAcceptedCargo_Industry,   // add_accepted_cargo_proc
-	GetTileDesc_Industry,        // get_tile_desc_proc
-	GetTileTrackStatus_Industry, // get_tile_track_status_proc
-	ClickTile_Industry,          // click_tile_proc
-	AnimateTile_Industry,        // animate_tile_proc
-	TileLoop_Industry,           // tile_loop_proc
-	ChangeTileOwner_Industry,    // change_tile_owner_proc
-	nullptr,                        // add_produced_cargo_proc
-	nullptr,                        // vehicle_enter_tile_proc
-	GetFoundation_Industry,      // get_foundation_proc
-	TerraformTile_Industry,      // terraform_tile_proc
-	nullptr, // check_build_above_proc
+	.draw_tile_proc = DrawTile_Industry,
+	.get_slope_pixel_z_proc = [](TileIndex tile, uint, uint, bool) { return GetTileMaxPixelZ(tile); },
+	.clear_tile_proc = ClearTile_Industry,
+	.add_accepted_cargo_proc = AddAcceptedCargo_Industry,
+	.get_tile_desc_proc = GetTileDesc_Industry,
+	.click_tile_proc = ClickTile_Industry,
+	.animate_tile_proc = AnimateTile_Industry,
+	.tile_loop_proc = TileLoop_Industry,
+	.change_tile_owner_proc = ChangeTileOwner_Industry,
+	.get_foundation_proc = GetFoundation_Industry,
+	.terraform_tile_proc = TerraformTile_Industry,
 };
 
 bool IndustryCompare::operator() (const IndustryListEntry &lhs, const IndustryListEntry &rhs) const

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -314,7 +314,7 @@ int GetSlopePixelZ(int x, int y, bool ground_vehicle)
 {
 	TileIndex tile = TileVirtXY(x, y);
 
-	return _tile_type_procs[GetTileType(tile)]->get_slope_z_proc(tile, x, y, ground_vehicle);
+	return _tile_type_procs[GetTileType(tile)]->get_slope_pixel_z_proc(tile, x, y, ground_vehicle);
 }
 
 /**
@@ -330,7 +330,7 @@ int GetSlopePixelZOutsideMap(int x, int y)
 	if (IsInsideBS(x, 0, Map::SizeX() * TILE_SIZE) && IsInsideBS(y, 0, Map::SizeY() * TILE_SIZE)) {
 		return GetSlopePixelZ(x, y, false);
 	} else {
-		return _tile_type_procs[TileType::Void]->get_slope_z_proc(INVALID_TILE, x, y, false);
+		return _tile_type_procs[TileType::Void]->get_slope_pixel_z_proc(INVALID_TILE, x, y, false);
 	}
 }
 

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1218,6 +1218,7 @@ static CommandCost RemoveRoadDepot(TileIndex tile, DoCommandFlags flags)
 	return CommandCost(EXPENSES_CONSTRUCTION, _price[Price::ClearDepotRoad]);
 }
 
+/** @copydoc ClearTileProc */
 static CommandCost ClearTile_Road(TileIndex tile, DoCommandFlags flags)
 {
 	switch (GetRoadTileType(tile)) {
@@ -1703,7 +1704,7 @@ static void DrawRoadBits(TileInfo *ti)
 	}
 }
 
-/** Tile callback function for rendering a road tile to the screen */
+/** @copydoc DrawTileProc */
 static void DrawTile_Road(TileInfo *ti)
 {
 	BridgePillarFlags blocked_pillars{};
@@ -1958,7 +1959,8 @@ void UpdateNearestTownForRoadTiles(bool invalidate)
 	}
 }
 
-static int GetSlopePixelZ_Road(TileIndex tile, uint x, uint y, bool)
+/** @copydoc GetSlopePixelZProc */
+static int GetSlopePixelZ_Road(TileIndex tile, uint x, uint y, [[maybe_unused]] bool ground_vehicle)
 {
 
 	if (IsNormalRoad(tile)) {
@@ -1973,6 +1975,7 @@ static int GetSlopePixelZ_Road(TileIndex tile, uint x, uint y, bool)
 	}
 }
 
+/** @copydoc GetFoundationProc */
 static Foundation GetFoundation_Road(TileIndex tile, Slope tileh)
 {
 	if (IsNormalRoad(tile)) {
@@ -2003,6 +2006,7 @@ static const Roadside _town_road_types_2[][2] = {
 static_assert(lengthof(_town_road_types_2) == NUM_HOUSE_ZONES);
 
 
+/** @copydoc TileLoopProc */
 static void TileLoop_Road(TileIndex tile)
 {
 	switch (_settings_game.game_creation.landscape) {
@@ -2107,6 +2111,7 @@ static void TileLoop_Road(TileIndex tile)
 	}
 }
 
+/** @copydoc ClickTileProc */
 static bool ClickTile_Road(TileIndex tile)
 {
 	if (!IsRoadDepot(tile)) return false;
@@ -2135,6 +2140,7 @@ static const TrackBits _road_trackbits[16] = {
 	TRACK_BIT_ALL,                                   // ROAD_ALL
 };
 
+/** @copydoc GetTileTrackStatusProc */
 static TrackStatus GetTileTrackStatus_Road(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side)
 {
 	TrackdirBits trackdirbits = TRACKDIR_BIT_NONE;
@@ -2210,6 +2216,7 @@ static const StringID _road_tile_strings[] = {
 	STR_LAI_ROAD_DESCRIPTION_ROAD,
 };
 
+/** @copydoc GetTileDescProc */
 static void GetTileDesc_Road(TileIndex tile, TileDesc &td)
 {
 	Owner rail_owner = INVALID_OWNER;
@@ -2284,7 +2291,8 @@ static const uint8_t _roadveh_enter_depot_dir[4] = {
 	TRACKDIR_X_SW, TRACKDIR_Y_NW, TRACKDIR_X_NE, TRACKDIR_Y_SE
 };
 
-static VehicleEnterTileStates VehicleEnter_Road(Vehicle *v, TileIndex tile, int, int)
+/** @copydoc VehicleEnterTileProc */
+static VehicleEnterTileStates VehicleEnterTile_Road(Vehicle *v, TileIndex tile, [[maybe_unused]] int x, [[maybe_unused]] int y)
 {
 	switch (GetRoadTileType(tile)) {
 		case RoadTileType::Depot: {
@@ -2311,6 +2319,7 @@ static VehicleEnterTileStates VehicleEnter_Road(Vehicle *v, TileIndex tile, int,
 }
 
 
+/** @copydoc ChangeTileOwnerProc */
 static void ChangeTileOwner_Road(TileIndex tile, Owner old_owner, Owner new_owner)
 {
 	if (IsRoadDepot(tile)) {
@@ -2365,6 +2374,7 @@ static void ChangeTileOwner_Road(TileIndex tile, Owner old_owner, Owner new_owne
 	}
 }
 
+/** @copydoc TerraformTileProc */
 static CommandCost TerraformTile_Road(TileIndex tile, DoCommandFlags flags, int z_new, Slope tileh_new)
 {
 	if (_settings_game.construction.build_on_slopes && AutoslopeEnabled()) {
@@ -2648,27 +2658,25 @@ CommandCost CmdConvertRoad(DoCommandFlags flags, TileIndex tile, TileIndex area_
 	return found_convertible_road ? cost : error;
 }
 
-static CommandCost CheckBuildAbove_Road(TileIndex tile, DoCommandFlags flags, Axis, int)
+/** @copydoc CheckBuildAboveProc */
+static CommandCost CheckBuildAbove_Road(TileIndex tile, DoCommandFlags flags, [[maybe_unused]] Axis axis, [[maybe_unused]] int height)
 {
 	if (!IsRoadDepot(tile)) return CommandCost();
 	return Command<Commands::LandscapeClear>::Do(flags, tile);
 }
 
-/** Tile callback functions for road tiles */
+/** TileTypeProcs definitions for TileType::Road tiles. */
 extern const TileTypeProcs _tile_type_road_procs = {
-	DrawTile_Road,           // draw_tile_proc
-	GetSlopePixelZ_Road,     // get_slope_z_proc
-	ClearTile_Road,          // clear_tile_proc
-	nullptr,                    // add_accepted_cargo_proc
-	GetTileDesc_Road,        // get_tile_desc_proc
-	GetTileTrackStatus_Road, // get_tile_track_status_proc
-	ClickTile_Road,          // click_tile_proc
-	nullptr,                    // animate_tile_proc
-	TileLoop_Road,           // tile_loop_proc
-	ChangeTileOwner_Road,    // change_tile_owner_proc
-	nullptr,                    // add_produced_cargo_proc
-	VehicleEnter_Road,       // vehicle_enter_tile_proc
-	GetFoundation_Road,      // get_foundation_proc
-	TerraformTile_Road,      // terraform_tile_proc
-	CheckBuildAbove_Road, // check_build_above_proc
+	.draw_tile_proc = DrawTile_Road,
+	.get_slope_pixel_z_proc = GetSlopePixelZ_Road,
+	.clear_tile_proc = ClearTile_Road,
+	.get_tile_desc_proc = GetTileDesc_Road,
+	.get_tile_track_status_proc = GetTileTrackStatus_Road,
+	.click_tile_proc = ClickTile_Road,
+	.tile_loop_proc = TileLoop_Road,
+	.change_tile_owner_proc = ChangeTileOwner_Road,
+	.vehicle_enter_tile_proc = VehicleEnterTile_Road,
+	.get_foundation_proc = GetFoundation_Road,
+	.terraform_tile_proc = TerraformTile_Road,
+	.check_build_above_proc = CheckBuildAbove_Road,
 };

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3267,6 +3267,7 @@ static bool DrawCustomStationFoundations(const StationSpec *statspec, BaseStatio
 	return true;
 }
 
+/** @copydoc DrawTileProc */
 static void DrawTile_Station(TileInfo *ti)
 {
 	const NewGRFSpriteLayout *layout = nullptr;
@@ -3568,15 +3569,6 @@ void StationPickerDrawSprite(int x, int y, StationType st, RailType railtype, Ro
 	DrawRailTileSeqInGUI(x, y, t, (st == StationType::RailWaypoint || st == StationType::RoadWaypoint) ? 0 : total_offset, 0, pal);
 }
 
-static int GetSlopePixelZ_Station(TileIndex tile, uint, uint, bool)
-{
-	return GetTileMaxPixelZ(tile);
-}
-
-static Foundation GetFoundation_Station(TileIndex, Slope tileh)
-{
-	return FlatteningFoundation(tileh);
-}
 
 static void FillTileDescRoadStop(TileIndex tile, TileDesc &td)
 {
@@ -3653,6 +3645,7 @@ void FillTileDescAirport(TileIndex tile, TileDesc &td)
 	}
 }
 
+/** @copydoc GetTileDescProc */
 static void GetTileDesc_Station(TileIndex tile, TileDesc &td)
 {
 	td.owner[0] = GetTileOwner(tile);
@@ -3688,6 +3681,7 @@ static void GetTileDesc_Station(TileIndex tile, TileDesc &td)
 }
 
 
+/** @copydoc GetTileTrackStatusProc */
 static TrackStatus GetTileTrackStatus_Station(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side)
 {
 	TrackBits trackbits = TRACK_BIT_NONE;
@@ -3735,6 +3729,7 @@ static TrackStatus GetTileTrackStatus_Station(TileIndex tile, TransportType mode
 }
 
 
+/** @copydoc TileLoopProc */
 static void TileLoop_Station(TileIndex tile)
 {
 	auto *st = BaseStation::GetByTile(tile);
@@ -3805,6 +3800,7 @@ static void TileLoop_Station(TileIndex tile)
 }
 
 
+/** @copydoc AnimateTileProc */
 static void AnimateTile_Station(TileIndex tile)
 {
 	if (HasStationRail(tile)) {
@@ -3824,6 +3820,7 @@ static void AnimateTile_Station(TileIndex tile)
 }
 
 
+/** @copydoc ClickTileProc */
 static bool ClickTile_Station(TileIndex tile)
 {
 	const BaseStation *bst = BaseStation::GetByTile(tile);
@@ -3839,7 +3836,8 @@ static bool ClickTile_Station(TileIndex tile)
 	return true;
 }
 
-static VehicleEnterTileStates VehicleEnter_Station(Vehicle *v, TileIndex tile, int x, int y)
+/** @copydoc VehicleEnterTileProc */
+static VehicleEnterTileStates VehicleEnterTile_Station(Vehicle *v, TileIndex tile, int x, int y)
 {
 	if (v->type == VEH_TRAIN) {
 		StationID station_id = GetStationIndex(tile);
@@ -4777,9 +4775,9 @@ void DeleteOilRig(TileIndex tile)
 	delete st;
 }
 
+/** @copydoc ChangeTileOwnerProc */
 static void ChangeTileOwner_Station(TileIndex tile, Owner old_owner, Owner new_owner)
 {
-
 	if (IsAnyRoadStopTile(tile)) {
 		for (RoadTramType rtt : _roadtramtypes) {
 			/* Update all roadtypes, no matter if they are present */
@@ -4900,12 +4898,7 @@ static CommandCost CanRemoveRoadWithStop(TileIndex tile, DoCommandFlags flags)
 	return CommandCost();
 }
 
-/**
- * Clear a single tile of a station.
- * @param tile The tile to clear.
- * @param flags The DoCommand flags related to the "command".
- * @return The cost, or error of clearing.
- */
+/** @copydoc ClearTileProc */
 CommandCost ClearTile_Station(TileIndex tile, DoCommandFlags flags)
 {
 	if (flags.Test(DoCommandFlag::Auto)) {
@@ -4948,6 +4941,7 @@ CommandCost ClearTile_Station(TileIndex tile, DoCommandFlags flags)
 	return CMD_ERROR;
 }
 
+/** @copydoc TerraformTileProc */
 static CommandCost TerraformTile_Station(TileIndex tile, DoCommandFlags flags, int z_new, Slope tileh_new)
 {
 	if (_settings_game.construction.build_on_slopes && AutoslopeEnabled()) {
@@ -5368,7 +5362,8 @@ uint FlowStatMap::GetFlowFromVia(StationID from, StationID via) const
 	return i->second.GetShare(via);
 }
 
-static CommandCost CheckBuildAbove_Station(TileIndex tile, DoCommandFlags, Axis, int height)
+/** @copydoc CheckBuildAboveProc */
+static CommandCost CheckBuildAbove_Station(TileIndex tile, [[maybe_unused]] DoCommandFlags flags, [[maybe_unused]] Axis axis, int height)
 {
 	StationType type = GetStationType(tile);
 	auto bridgeable_info = GetStationBridgeableTileInfo(type);
@@ -5391,20 +5386,19 @@ static CommandCost CheckBuildAbove_Station(TileIndex tile, DoCommandFlags, Axis,
 	return IsStationBridgeAboveOk(tile, bridgeable_info, type, GetStationGfx(tile), height);
 }
 
+/** TileTypeProcs definitions for TileType::Station tiles. */
 extern const TileTypeProcs _tile_type_station_procs = {
-	DrawTile_Station,           // draw_tile_proc
-	GetSlopePixelZ_Station,     // get_slope_z_proc
-	ClearTile_Station,          // clear_tile_proc
-	nullptr,                       // add_accepted_cargo_proc
-	GetTileDesc_Station,        // get_tile_desc_proc
-	GetTileTrackStatus_Station, // get_tile_track_status_proc
-	ClickTile_Station,          // click_tile_proc
-	AnimateTile_Station,        // animate_tile_proc
-	TileLoop_Station,           // tile_loop_proc
-	ChangeTileOwner_Station,    // change_tile_owner_proc
-	nullptr,                       // add_produced_cargo_proc
-	VehicleEnter_Station,       // vehicle_enter_tile_proc
-	GetFoundation_Station,      // get_foundation_proc
-	TerraformTile_Station,      // terraform_tile_proc
-	CheckBuildAbove_Station, // check_build_above_proc
+	.draw_tile_proc = DrawTile_Station,
+	.get_slope_pixel_z_proc = [](TileIndex tile, uint, uint, bool) { return GetTileMaxPixelZ(tile); },
+	.clear_tile_proc = ClearTile_Station,
+	.get_tile_desc_proc = GetTileDesc_Station,
+	.get_tile_track_status_proc = GetTileTrackStatus_Station,
+	.click_tile_proc = ClickTile_Station,
+	.animate_tile_proc = AnimateTile_Station,
+	.tile_loop_proc = TileLoop_Station,
+	.change_tile_owner_proc = ChangeTileOwner_Station,
+	.vehicle_enter_tile_proc = VehicleEnterTile_Station,
+	.get_foundation_proc = [](TileIndex, Slope tileh) { return FlatteningFoundation(tileh); },
+	.terraform_tile_proc = TerraformTile_Station,
+	.check_build_above_proc = CheckBuildAbove_Station,
 };

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -211,7 +211,7 @@ using CheckBuildAboveProc = CommandCost(TileIndex tile, DoCommandFlags flags, Ax
  */
 struct TileTypeProcs {
 	DrawTileProc *draw_tile_proc; ///< Called to render the tile and its contents to the screen.
-	GetSlopePixelZProc *get_slope_z_proc; ///< Called to get the world Z coordinate for a given location within the tile.
+	GetSlopePixelZProc *get_slope_pixel_z_proc; ///< Called to get the world Z coordinate for a given location within the tile.
 	ClearTileProc *clear_tile_proc; ////< Called to clear a tile.
 	AddAcceptedCargoProc *add_accepted_cargo_proc = nullptr; ///< Adds accepted cargo of the tile to cargo array supplied as parameter.
 	GetTileDescProc *get_tile_desc_proc; ///< Get a description of a tile (for the 'land area information' tool).

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -213,18 +213,18 @@ struct TileTypeProcs {
 	DrawTileProc *draw_tile_proc; ///< Called to render the tile and its contents to the screen.
 	GetSlopePixelZProc *get_slope_z_proc; ///< Called to get the world Z coordinate for a given location within the tile.
 	ClearTileProc *clear_tile_proc; ////< Called to clear a tile.
-	AddAcceptedCargoProc *add_accepted_cargo_proc; ///< Adds accepted cargo of the tile to cargo array supplied as parameter.
+	AddAcceptedCargoProc *add_accepted_cargo_proc = nullptr; ///< Adds accepted cargo of the tile to cargo array supplied as parameter.
 	GetTileDescProc *get_tile_desc_proc; ///< Get a description of a tile (for the 'land area information' tool).
-	GetTileTrackStatusProc *get_tile_track_status_proc; ///< Get available tracks and status of a tile.
-	ClickTileProc *click_tile_proc; ///< Called when tile is clicked
-	AnimateTileProc *animate_tile_proc; ///< Called to animate a tile.
+	GetTileTrackStatusProc *get_tile_track_status_proc = [](TileIndex, TransportType, uint, DiagDirection) -> TrackStatus { return {}; }; ///< Get available tracks and status of a tile.
+	ClickTileProc *click_tile_proc = nullptr; ///< Called when tile is clicked
+	AnimateTileProc *animate_tile_proc = nullptr; ///< Called to animate a tile.
 	TileLoopProc *tile_loop_proc; ///< Called to periodically update the tile.
-	ChangeTileOwnerProc *change_tile_owner_proc; ///< Called to change the ownership of elements on a tile.
-	AddProducedCargoProc *add_produced_cargo_proc; ///< Adds produced cargo of the tile to cargo array supplied as parameter.
-	VehicleEnterTileProc *vehicle_enter_tile_proc; ///< Called when a vehicle enters a tile.
-	GetFoundationProc *get_foundation_proc; ///< Called to get the foundation.
+	ChangeTileOwnerProc *change_tile_owner_proc = [](TileIndex, CompanyID, CompanyID) {}; ///< Called to change the ownership of elements on a tile.
+	AddProducedCargoProc *add_produced_cargo_proc = nullptr; ///< Adds produced cargo of the tile to cargo array supplied as parameter.
+	VehicleEnterTileProc *vehicle_enter_tile_proc = nullptr; ///< Called when a vehicle enters a tile.
+	GetFoundationProc *get_foundation_proc = [](TileIndex, Slope) { return FOUNDATION_NONE; }; ///< Called to get the foundation.
 	TerraformTileProc *terraform_tile_proc; ///< Called when a terraforming operation is about to take place.
-	CheckBuildAboveProc *check_build_above_proc; ///< Called to check whether a bridge can be build above.
+	CheckBuildAboveProc *check_build_above_proc = nullptr; ///< Called to check whether a bridge can be build above.
 };
 
 extern const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::MaxSize)>, TileType> _tile_type_procs;

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -60,7 +60,7 @@ struct TileDesc {
  * Tile callback function signature for drawing a tile and its contents to the screen
  * @param ti Information about the tile to draw
  */
-typedef void DrawTileProc(TileInfo *ti);
+using DrawTileProc = void(TileInfo *ti);
 
 /**
  * Tile callback function signature for obtaining the world \c Z coordinate of a given
@@ -73,23 +73,33 @@ typedef void DrawTileProc(TileInfo *ti);
  * @return World Z coordinate at tile ground (vehicle) level, including slopes and foundations.
  * @see GetSlopePixelZ
  */
-typedef int GetSlopeZProc(TileIndex tile, uint x, uint y, bool ground_vehicle);
-typedef CommandCost ClearTileProc(TileIndex tile, DoCommandFlags flags);
+using GetSlopePixelZProc = int(TileIndex tile, uint x, uint y, bool ground_vehicle);
+
+/**
+ * Tile callback function signature for clearing a tile.
+ * @param tile The tile to clear.
+ * @param flags The command flags.
+ * @return The cost or error.
+ * @see ClearTile
+ */
+using ClearTileProc = CommandCost(TileIndex tile, DoCommandFlags flags);
 
 /**
  * Tile callback function signature for obtaining cargo acceptance of a tile
  * @param tile            Tile queried for its accepted cargo
  * @param acceptance      Storage destination of the cargo acceptance in 1/8
  * @param always_accepted Bitmask of always accepted cargo types
+ * @see AddAcceptedCargo
  */
-typedef void AddAcceptedCargoProc(TileIndex tile, CargoArray &acceptance, CargoTypes &always_accepted);
+using AddAcceptedCargoProc = void(TileIndex tile, CargoArray &acceptance, CargoTypes &always_accepted);
 
 /**
  * Tile callback function signature for obtaining a tile description
  * @param tile Tile being queried
  * @param td   Storage pointer for returned tile description
+ * @see GetTileDesc
  */
-typedef void GetTileDescProc(TileIndex tile, TileDesc &td);
+using GetTileDescProc = void(TileIndex tile, TileDesc &td);
 
 /**
  * Tile callback function signature for getting the possible tracks
@@ -102,23 +112,69 @@ typedef void GetTileDescProc(TileIndex tile, TileDesc &td);
  * @param tile     the tile to get the track status from
  * @param mode     the mode of transportation
  * @param sub_mode used to differentiate between different kinds within the mode
+ * @param side The side where the tile is entered.
  * @return the track status information
+ * @see GetTileTrackStatus
  */
-typedef TrackStatus GetTileTrackStatusProc(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side);
+using GetTileTrackStatusProc = TrackStatus(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side);
 
 /**
  * Tile callback function signature for obtaining the produced cargo of a tile.
  * @param tile      Tile being queried
  * @param produced  Destination array for produced cargo
+ * @see AddProducedCargo
  */
-typedef void AddProducedCargoProc(TileIndex tile, CargoArray &produced);
-typedef bool ClickTileProc(TileIndex tile);
-typedef void AnimateTileProc(TileIndex tile);
-typedef void TileLoopProc(TileIndex tile);
-typedef void ChangeTileOwnerProc(TileIndex tile, Owner old_owner, Owner new_owner);
+using AddProducedCargoProc = void(TileIndex tile, CargoArray &produced);
 
-typedef VehicleEnterTileStates VehicleEnterTileProc(Vehicle *v, TileIndex tile, int x, int y);
-typedef Foundation GetFoundationProc(TileIndex tile, Slope tileh);
+/**
+ * Tile callback function signature for clicking a tile.
+ * @param tile The tile that was clicked.
+ * @return Whether any action was taken.
+ * @see ClickTile
+ */
+using ClickTileProc = bool(TileIndex tile);
+
+/**
+ * Tile callback function signature for animating a tile.
+ * @param tile The tile to animate.
+ * @see AnimateTile
+ */
+using AnimateTileProc = void(TileIndex tile);
+
+/**
+ * Tile callback function signature for running periodic tile updates.
+ * @param tile The tile to update.
+ * @see RunTileLoop
+ */
+using TileLoopProc = void(TileIndex tile);
+
+/**
+ * Tile callback function signature for changing the owner of a tile.
+ * @param tile The tile to process.
+ * @param old_owner The owner to replace.
+ * @param new_owner The owner to replace with.
+ * @see ChangeTileOwner
+ */
+using ChangeTileOwnerProc = void(TileIndex tile, Owner old_owner, Owner new_owner);
+
+/**
+ * Tile callback function for a vehicle entering a tile.
+ * @param v Vehicle entering the tile.
+ * @param tile Tile entered.
+ * @param x X position in world coordinates.
+ * @param y Y position in world coordinates.
+ * @return Some meta-data over the to be entered tile.
+ * @see VehicleEnterTile
+ */
+using VehicleEnterTileProc = VehicleEnterTileStates(Vehicle *v, TileIndex tile, int x, int y);
+
+/**
+ * Tile callback function signature for getting the foundation of a tile.
+ * @param tile The tile to check.
+ * @param tileh The current slope.
+ * @return The foundation that will be used.
+ */
+using GetFoundationProc = Foundation(TileIndex tile, Slope tileh);
 
 /**
  * Tile callback function signature of the terraforming callback.
@@ -134,8 +190,9 @@ typedef Foundation GetFoundationProc(TileIndex tile, Slope tileh);
  * @param z_new     TileZ after terraforming.
  * @param tileh_new Slope after terraforming.
  * @return Error code or extra cost for terraforming (like clearing land, building foundations, etc., but not the terraforming itself.)
+ * @see TerraformTile
  */
-typedef CommandCost TerraformTileProc(TileIndex tile, DoCommandFlags flags, int z_new, Slope tileh_new);
+using TerraformTileProc = CommandCost(TileIndex tile, DoCommandFlags flags, int z_new, Slope tileh_new);
 
 /**
  * Tile callback function signature to test if a bridge can be built above a tile.
@@ -144,6 +201,7 @@ typedef CommandCost TerraformTileProc(TileIndex tile, DoCommandFlags flags, int 
  * @param axis Axis of bridge being built.
  * @param height Absolute height of bridge platform.
  * @return Error code or extra cost for building bridge above the tile.
+ * @see CheckBuildAbove
  */
 using CheckBuildAboveProc = CommandCost(TileIndex tile, DoCommandFlags flags, Axis axis, int height);
 
@@ -152,21 +210,21 @@ using CheckBuildAboveProc = CommandCost(TileIndex tile, DoCommandFlags flags, Ax
  * @see TileType
  */
 struct TileTypeProcs {
-	DrawTileProc *draw_tile_proc;                  ///< Called to render the tile and its contents to the screen
-	GetSlopeZProc *get_slope_z_proc;
-	ClearTileProc *clear_tile_proc;
-	AddAcceptedCargoProc *add_accepted_cargo_proc; ///< Adds accepted cargo of the tile to cargo array supplied as parameter
-	GetTileDescProc *get_tile_desc_proc;           ///< Get a description of a tile (for the 'land area information' tool)
-	GetTileTrackStatusProc *get_tile_track_status_proc; ///< Get available tracks and status of a tile
-	ClickTileProc *click_tile_proc;                ///< Called when tile is clicked
-	AnimateTileProc *animate_tile_proc;
-	TileLoopProc *tile_loop_proc;
-	ChangeTileOwnerProc *change_tile_owner_proc;
-	AddProducedCargoProc *add_produced_cargo_proc; ///< Adds produced cargo of the tile to cargo array supplied as parameter
-	VehicleEnterTileProc *vehicle_enter_tile_proc; ///< Called when a vehicle enters a tile
-	GetFoundationProc *get_foundation_proc;
-	TerraformTileProc *terraform_tile_proc;        ///< Called when a terraforming operation is about to take place
-	CheckBuildAboveProc *check_build_above_proc;
+	DrawTileProc *draw_tile_proc; ///< Called to render the tile and its contents to the screen.
+	GetSlopePixelZProc *get_slope_z_proc; ///< Called to get the world Z coordinate for a given location within the tile.
+	ClearTileProc *clear_tile_proc; ////< Called to clear a tile.
+	AddAcceptedCargoProc *add_accepted_cargo_proc; ///< Adds accepted cargo of the tile to cargo array supplied as parameter.
+	GetTileDescProc *get_tile_desc_proc; ///< Get a description of a tile (for the 'land area information' tool).
+	GetTileTrackStatusProc *get_tile_track_status_proc; ///< Get available tracks and status of a tile.
+	ClickTileProc *click_tile_proc; ///< Called when tile is clicked
+	AnimateTileProc *animate_tile_proc; ///< Called to animate a tile.
+	TileLoopProc *tile_loop_proc; ///< Called to periodically update the tile.
+	ChangeTileOwnerProc *change_tile_owner_proc; ///< Called to change the ownership of elements on a tile.
+	AddProducedCargoProc *add_produced_cargo_proc; ///< Adds produced cargo of the tile to cargo array supplied as parameter.
+	VehicleEnterTileProc *vehicle_enter_tile_proc; ///< Called when a vehicle enters a tile.
+	GetFoundationProc *get_foundation_proc; ///< Called to get the foundation.
+	TerraformTileProc *terraform_tile_proc; ///< Called when a terraforming operation is about to take place.
+	CheckBuildAboveProc *check_build_above_proc; ///< Called to check whether a bridge can be build above.
 };
 
 extern const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::MaxSize)>, TileType> _tile_type_procs;

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -257,10 +257,7 @@ static inline DiagDirection RandomDiagDir()
 	return (DiagDirection)(RandomRange(DIAGDIR_END));
 }
 
-/**
- * Draw a house and its tile. This is a tile callback routine.
- * @param ti TileInfo of the tile to draw
- */
+/** @copydoc DrawTileProc */
 static void DrawTile_Town(TileInfo *ti)
 {
 	HouseID house_id = GetHouseType(ti->tile);
@@ -302,16 +299,7 @@ static void DrawTile_Town(TileInfo *ti)
 	}
 }
 
-static int GetSlopePixelZ_Town(TileIndex tile, uint, uint, bool)
-{
-	return GetTileMaxPixelZ(tile);
-}
-
-/**
- * Get the foundation for a house. This is a tile callback routine.
- * @param tile The tile to find a foundation for.
- * @param tileh The slope of the tile.
- */
+/** @copydoc GetFoundationProc */
 static Foundation GetFoundation_Town(TileIndex tile, Slope tileh)
 {
 	HouseID hid = GetHouseType(tile);
@@ -331,10 +319,10 @@ static Foundation GetFoundation_Town(TileIndex tile, Slope tileh)
 }
 
 /**
- * Animate a tile for a town.
+ * @copydoc AnimateTileProc
+ *
  * Only certain houses can be animated.
  * The newhouses animation supersedes regular ones.
- * @param tile TileIndex of the house to animate.
  */
 static void AnimateTile_Town(TileIndex tile)
 {
@@ -593,12 +581,7 @@ static void TownGenerateCargoBinomial(Town *t, TownProductionEffect tpe, uint8_t
 	}
 }
 
-/**
- * Tile callback function.
- *
- * Tile callback function. Periodic tick handler for the tiles of a town.
- * @param tile been asked to do its stuff
- */
+/** @copydoc TileLoopProc */
 static void TileLoop_Town(TileIndex tile)
 {
 	HouseID house_id = GetHouseType(tile);
@@ -708,12 +691,7 @@ static void TileLoop_Town(TileIndex tile)
 	cur_company.Restore();
 }
 
-/**
- * Callback function to clear a house tile.
- * @param tile The tile to clear.
- * @param flags Type of operation.
- * @return The cost of this operation or an error.
- */
+/** @copydoc ClearTileProc */
 static CommandCost ClearTile_Town(TileIndex tile, DoCommandFlags flags)
 {
 	if (flags.Test(DoCommandFlag::Auto)) return CommandCost(STR_ERROR_BUILDING_MUST_BE_DEMOLISHED);
@@ -748,6 +726,7 @@ static CommandCost ClearTile_Town(TileIndex tile, DoCommandFlags flags)
 	return cost;
 }
 
+/** @copydoc AddProducedCargoProc */
 static void AddProducedCargo_Town(TileIndex tile, CargoArray &produced)
 {
 	HouseID house_id = GetHouseType(tile);
@@ -844,6 +823,7 @@ void AddAcceptedCargoOfHouse(TileIndex tile, HouseID house, const HouseSpec *hs,
 	}
 }
 
+/** @copydoc AddAcceptedCargoProc */
 static void AddAcceptedCargo_Town(TileIndex tile, CargoArray &acceptance, CargoTypes &always_accepted)
 {
 	HouseID house = GetHouseType(tile);
@@ -863,6 +843,7 @@ CargoArray GetAcceptedCargoOfHouse(const HouseSpec *hs)
 	return acceptance;
 }
 
+/** @copydoc GetTileDescProc */
 static void GetTileDesc_Town(TileIndex tile, TileDesc &td)
 {
 	const HouseID house = GetHouseType(tile);
@@ -899,17 +880,6 @@ static void GetTileDesc_Town(TileIndex tile, TileDesc &td)
 	}
 
 	td.owner[0] = OWNER_TOWN;
-}
-
-static TrackStatus GetTileTrackStatus_Town(TileIndex, TransportType, uint, DiagDirection)
-{
-	/* not used */
-	return 0;
-}
-
-static void ChangeTileOwner_Town(TileIndex, Owner, Owner)
-{
-	/* not used */
 }
 
 static bool GrowTown(Town *t, TownExpandModes modes);
@@ -4215,6 +4185,7 @@ static const IntervalTimer<TimerGameEconomy> _economy_towns_yearly({TimerGameEco
 	}
 });
 
+/** @copydoc TerraformTileProc */
 static CommandCost TerraformTile_Town(TileIndex tile, DoCommandFlags flags, int z_new, Slope tileh_new)
 {
 	if (AutoslopeEnabled()) {
@@ -4243,23 +4214,18 @@ static CommandCost TerraformTile_Town(TileIndex tile, DoCommandFlags flags, int 
 	return Command<Commands::LandscapeClear>::Do(flags, tile);
 }
 
-/** Tile callback functions for a town */
+/** TileTypeProcs definitions for TileType::Town tiles. */
 extern const TileTypeProcs _tile_type_town_procs = {
-	DrawTile_Town,           // draw_tile_proc
-	GetSlopePixelZ_Town,     // get_slope_z_proc
-	ClearTile_Town,          // clear_tile_proc
-	AddAcceptedCargo_Town,   // add_accepted_cargo_proc
-	GetTileDesc_Town,        // get_tile_desc_proc
-	GetTileTrackStatus_Town, // get_tile_track_status_proc
-	nullptr,                    // click_tile_proc
-	AnimateTile_Town,        // animate_tile_proc
-	TileLoop_Town,           // tile_loop_proc
-	ChangeTileOwner_Town,    // change_tile_owner_proc
-	AddProducedCargo_Town,   // add_produced_cargo_proc
-	nullptr,                    // vehicle_enter_tile_proc
-	GetFoundation_Town,      // get_foundation_proc
-	TerraformTile_Town,      // terraform_tile_proc
-	nullptr, // check_build_above_proc
+	.draw_tile_proc = DrawTile_Town,
+	.get_slope_pixel_z_proc = [](TileIndex tile, uint, uint, bool) { return GetTileMaxPixelZ(tile); },
+	.clear_tile_proc = ClearTile_Town,
+	.add_accepted_cargo_proc = AddAcceptedCargo_Town,
+	.get_tile_desc_proc = GetTileDesc_Town,
+	.animate_tile_proc = AnimateTile_Town,
+	.tile_loop_proc = TileLoop_Town,
+	.add_produced_cargo_proc = AddProducedCargo_Town,
+	.get_foundation_proc = GetFoundation_Town,
+	.terraform_tile_proc = TerraformTile_Town,
 };
 
 std::span<const DrawBuildingsTileStruct> GetTownDrawTileData()

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1619,7 +1619,7 @@ static void UpdateStatusAfterSwap(Train *v)
 	if (v->track != TRACK_BIT_WORMHOLE) {
 		VehicleEnterTile(v, v->tile, v->x_pos, v->y_pos);
 	} else {
-		/* VehicleEnter_TunnelBridge() sets TRACK_BIT_WORMHOLE when the vehicle
+		/* VehicleEnterTile_TunnelBridge() sets TRACK_BIT_WORMHOLE when the vehicle
 		 * is on the last bit of the bridge head (frame == TILE_SIZE - 1).
 		 * If we were swapped with such a vehicle, we have set TRACK_BIT_WORMHOLE,
 		 * when we shouldn't have. Check if this is the case. */

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1031,12 +1031,7 @@ static CommandCost DoClearBridge(TileIndex tile, DoCommandFlags flags)
 	return CommandCost(EXPENSES_CONSTRUCTION, len * base_cost);
 }
 
-/**
- * Remove a tunnel or a bridge from the game.
- * @param tile Tile containing one of the endpoints.
- * @param flags Command flags.
- * @return Succeeded or failed command.
- */
+/** @copydoc ClearTileProc */
 static CommandCost ClearTile_TunnelBridge(TileIndex tile, DoCommandFlags flags)
 {
 	if (IsTunnel(tile)) {
@@ -1277,11 +1272,12 @@ static void DrawBridgeRoadBits(TileIndex head_tile, int x, int y, int z, int off
 }
 
 /**
+ * @copydoc DrawTileProc
+ *
  * Draws a tunnel of bridge tile.
  * For tunnels, this is rather simple, as you only need to draw the entrance.
  * Bridges are a bit more complex. base_offset is where the sprite selection comes into play
  * and it works a bit like a bitmask.<p> For bridge heads:
- * @param ti TileInfo of the structure to draw
  * <ul><li>Bit 0: direction</li>
  * <li>Bit 1: northern or southern heads</li>
  * <li>Bit 2: Set if the bridge head is sloped</li>
@@ -1726,6 +1722,7 @@ void DrawBridgeMiddle(const TileInfo *ti, BridgePillarFlags blocked_pillars)
 }
 
 
+/** @copydoc GetSlopePixelZProc */
 static int GetSlopePixelZ_TunnelBridge(TileIndex tile, uint x, uint y, bool ground_vehicle)
 {
 	auto [tileh, z] = GetTilePixelSlope(tile);
@@ -1757,11 +1754,13 @@ static int GetSlopePixelZ_TunnelBridge(TileIndex tile, uint x, uint y, bool grou
 	return z + GetPartialPixelZ(x, y, tileh);
 }
 
+/** @copydoc GetFoundationProc */
 static Foundation GetFoundation_TunnelBridge(TileIndex tile, Slope tileh)
 {
 	return IsTunnel(tile) ? FOUNDATION_NONE : GetBridgeFoundation(tileh, DiagDirToAxis(GetTunnelBridgeDirection(tile)));
 }
 
+/** @copydoc GetTileDescProc */
 static void GetTileDesc_TunnelBridge(TileIndex tile, TileDesc &td)
 {
 	TransportType tt = GetTunnelBridgeTransportType(tile);
@@ -1828,6 +1827,7 @@ static void GetTileDesc_TunnelBridge(TileIndex tile, TileDesc &td)
 }
 
 
+/** @copydoc TileLoopProc */
 static void TileLoop_TunnelBridge(TileIndex tile)
 {
 	bool snow_or_desert = HasTunnelBridgeSnowOrDesert(tile);
@@ -1856,6 +1856,7 @@ static void TileLoop_TunnelBridge(TileIndex tile)
 	}
 }
 
+/** @copydoc GetTileTrackStatusProc */
 static TrackStatus GetTileTrackStatus_TunnelBridge(TileIndex tile, TransportType mode, uint sub_mode, DiagDirection side)
 {
 	TransportType transport_type = GetTunnelBridgeTransportType(tile);
@@ -1866,6 +1867,7 @@ static TrackStatus GetTileTrackStatus_TunnelBridge(TileIndex tile, TransportType
 	return CombineTrackStatus(TrackBitsToTrackdirBits(DiagDirToDiagTrackBits(dir)), TRACKDIR_BIT_NONE);
 }
 
+/** @copydoc ChangeTileOwnerProc */
 static void ChangeTileOwner_TunnelBridge(TileIndex tile, Owner old_owner, Owner new_owner)
 {
 	TileIndex other_end = GetOtherTunnelBridgeEnd(tile);
@@ -1960,7 +1962,8 @@ static const uint8_t TUNNEL_SOUND_FRAME = 1;
  */
 extern const uint8_t _tunnel_visibility_frame[DIAGDIR_END] = {12, 8, 8, 12};
 
-static VehicleEnterTileStates VehicleEnter_TunnelBridge(Vehicle *v, TileIndex tile, int x, int y)
+/** @copydoc VehicleEnterTileProc */
+static VehicleEnterTileStates VehicleEnterTile_TunnelBridge(Vehicle *v, TileIndex tile, int x, int y)
 {
 	int z = GetSlopePixelZ(x, y, true) - v->z_pos;
 
@@ -2100,6 +2103,7 @@ static VehicleEnterTileStates VehicleEnter_TunnelBridge(Vehicle *v, TileIndex ti
 	return {};
 }
 
+/** @copydoc TerraformTileProc */
 static CommandCost TerraformTile_TunnelBridge(TileIndex tile, DoCommandFlags flags, int z_new, Slope tileh_new)
 {
 	if (_settings_game.construction.build_on_slopes && AutoslopeEnabled() && IsBridge(tile) && GetTunnelBridgeTransportType(tile) != TRANSPORT_WATER) {
@@ -2124,6 +2128,7 @@ static CommandCost TerraformTile_TunnelBridge(TileIndex tile, DoCommandFlags fla
 	return Command<Commands::LandscapeClear>::Do(flags, tile);
 }
 
+/** @copydoc CheckBuildAboveProc */
 static CommandCost CheckBuildAbove_TunnelBridge(TileIndex tile, DoCommandFlags flags, Axis axis, int height)
 {
 	if (IsTunnel(tile)) return CommandCost();
@@ -2135,20 +2140,17 @@ static CommandCost CheckBuildAbove_TunnelBridge(TileIndex tile, DoCommandFlags f
 	return Command<Commands::LandscapeClear>::Do(flags, tile);
 }
 
+/** TileTypeProcs definitions for TileType::TunnelBridge tiles. */
 extern const TileTypeProcs _tile_type_tunnelbridge_procs = {
-	DrawTile_TunnelBridge,           // draw_tile_proc
-	GetSlopePixelZ_TunnelBridge,     // get_slope_z_proc
-	ClearTile_TunnelBridge,          // clear_tile_proc
-	nullptr,                            // add_accepted_cargo_proc
-	GetTileDesc_TunnelBridge,        // get_tile_desc_proc
-	GetTileTrackStatus_TunnelBridge, // get_tile_track_status_proc
-	nullptr,                            // click_tile_proc
-	nullptr,                            // animate_tile_proc
-	TileLoop_TunnelBridge,           // tile_loop_proc
-	ChangeTileOwner_TunnelBridge,    // change_tile_owner_proc
-	nullptr,                            // add_produced_cargo_proc
-	VehicleEnter_TunnelBridge,       // vehicle_enter_tile_proc
-	GetFoundation_TunnelBridge,      // get_foundation_proc
-	TerraformTile_TunnelBridge,      // terraform_tile_proc
-	CheckBuildAbove_TunnelBridge, // check_build_above_proc
+	.draw_tile_proc = DrawTile_TunnelBridge,
+	.get_slope_pixel_z_proc = GetSlopePixelZ_TunnelBridge,
+	.clear_tile_proc = ClearTile_TunnelBridge,
+	.get_tile_desc_proc = GetTileDesc_TunnelBridge,
+	.get_tile_track_status_proc = GetTileTrackStatus_TunnelBridge,
+	.tile_loop_proc = TileLoop_TunnelBridge,
+	.change_tile_owner_proc = ChangeTileOwner_TunnelBridge,
+	.vehicle_enter_tile_proc = VehicleEnterTile_TunnelBridge,
+	.get_foundation_proc = GetFoundation_TunnelBridge,
+	.terraform_tile_proc = TerraformTile_TunnelBridge,
+	.check_build_above_proc = CheckBuildAbove_TunnelBridge,
 };

--- a/src/void_cmd.cpp
+++ b/src/void_cmd.cpp
@@ -19,6 +19,7 @@
 
 #include "safeguards.h"
 
+/** @copydoc DrawTileProc */
 static void DrawTile_Void(TileInfo *ti)
 {
 	/* If freeform edges are off, draw infinite water off the edges of the map. */
@@ -29,8 +30,8 @@ static void DrawTile_Void(TileInfo *ti)
 	}
 }
 
-
-static int GetSlopePixelZ_Void(TileIndex, uint x, uint y, bool)
+/** @copydoc GetSlopePixelZProc */
+static int GetSlopePixelZ_Void([[maybe_unused]] TileIndex tile, uint x, uint y, [[maybe_unused]] bool ground_vehicle)
 {
 	/* This function may be called on tiles outside the map, don't assume
 	 * that 'tile' is a valid tile index. See GetSlopePixelZOutsideMap. */
@@ -39,58 +40,26 @@ static int GetSlopePixelZ_Void(TileIndex, uint x, uint y, bool)
 	return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
 }
 
-static Foundation GetFoundation_Void(TileIndex, Slope)
-{
-	return FOUNDATION_NONE;
-}
-
-static CommandCost ClearTile_Void(TileIndex, DoCommandFlags)
-{
-	return CommandCost(STR_ERROR_OFF_EDGE_OF_MAP);
-}
-
-
-static void GetTileDesc_Void(TileIndex, TileDesc &td)
+/** @copydoc GetTileDescProc */
+static void GetTileDesc_Void([[maybe_unused]] TileIndex tile, TileDesc &td)
 {
 	td.str = STR_EMPTY;
 	td.owner[0] = OWNER_NONE;
 }
 
+/** @copydoc TileLoopProc */
 static void TileLoop_Void(TileIndex tile)
 {
 	/* Floods adjacent edge tile to prevent maps without water. */
 	TileLoop_Water(tile);
 }
 
-static void ChangeTileOwner_Void(TileIndex, Owner, Owner)
-{
-	/* not used */
-}
-
-static TrackStatus GetTileTrackStatus_Void(TileIndex, TransportType, uint, DiagDirection)
-{
-	return 0;
-}
-
-static CommandCost TerraformTile_Void(TileIndex, DoCommandFlags, int, Slope)
-{
-	return CommandCost(STR_ERROR_OFF_EDGE_OF_MAP);
-}
-
+/** TileTypeProcs definitions for TileType::Void tiles. */
 extern const TileTypeProcs _tile_type_void_procs = {
-	DrawTile_Void,            // draw_tile_proc
-	GetSlopePixelZ_Void,      // get_slope_z_proc
-	ClearTile_Void,           // clear_tile_proc
-	nullptr,                     // add_accepted_cargo_proc
-	GetTileDesc_Void,         // get_tile_desc_proc
-	GetTileTrackStatus_Void,  // get_tile_track_status_proc
-	nullptr,                     // click_tile_proc
-	nullptr,                     // animate_tile_proc
-	TileLoop_Void,            // tile_loop_proc
-	ChangeTileOwner_Void,     // change_tile_owner_proc
-	nullptr,                     // add_produced_cargo_proc
-	nullptr,                     // vehicle_enter_tile_proc
-	GetFoundation_Void,       // get_foundation_proc
-	TerraformTile_Void,       // terraform_tile_proc
-	nullptr, // check_build_above_proc
+	.draw_tile_proc = DrawTile_Void,
+	.get_slope_pixel_z_proc = GetSlopePixelZ_Void,
+	.clear_tile_proc = [](TileIndex, DoCommandFlags) { return CommandCost(STR_ERROR_OFF_EDGE_OF_MAP); },
+	.get_tile_desc_proc = GetTileDesc_Void,
+	.tile_loop_proc = TileLoop_Void,
+	.terraform_tile_proc = [](TileIndex, DoCommandFlags, int, Slope) { return CommandCost(STR_ERROR_OFF_EDGE_OF_MAP); },
 };

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -570,6 +570,7 @@ CommandCost CmdBuildCanal(DoCommandFlags flags, TileIndex tile, TileIndex start_
 }
 
 
+/** @copydoc ClearTileProc */
 static CommandCost ClearTile_Water(TileIndex tile, DoCommandFlags flags)
 {
 	switch (GetWaterTileType(tile)) {
@@ -958,6 +959,7 @@ void DrawWaterClassGround(const TileInfo *ti)
 	}
 }
 
+/** @copydoc DrawTileProc */
 static void DrawTile_Water(TileInfo *ti)
 {
 	switch (GetWaterTileType(ti->tile)) {
@@ -996,18 +998,15 @@ void DrawShipDepotSprite(int x, int y, Axis axis, DepotPart part)
 }
 
 
-static int GetSlopePixelZ_Water(TileIndex tile, uint x, uint y, bool)
+/** @copydoc GetSlopePixelZProc */
+static int GetSlopePixelZ_Water(TileIndex tile, uint x, uint y, [[maybe_unused]] bool ground_vehicle)
 {
 	auto [tileh, z] = GetTilePixelSlope(tile);
 
 	return z + GetPartialPixelZ(x & 0xF, y & 0xF, tileh);
 }
 
-static Foundation GetFoundation_Water(TileIndex, Slope)
-{
-	return FOUNDATION_NONE;
-}
-
+/** @copydoc GetTileDescProc */
 static void GetTileDesc_Water(TileIndex tile, TileDesc &td)
 {
 	switch (GetWaterTileType(tile)) {
@@ -1272,10 +1271,10 @@ static void DoDryUp(TileIndex tile)
 }
 
 /**
+ * @copydoc TileLoopProc
+ *
  * Let a water tile floods its diagonal adjoining tiles
  * called from tunnelbridge_cmd, and by TileLoop_Industry() and TileLoop_Track()
- *
- * @param tile the water/shore tile that floods
  */
 void TileLoop_Water(TileIndex tile)
 {
@@ -1367,7 +1366,8 @@ void ConvertGroundTilesIntoWaterTiles()
 	}
 }
 
-static TrackStatus GetTileTrackStatus_Water(TileIndex tile, TransportType mode, uint, DiagDirection)
+/** @copydoc GetTileTrackStatusProc */
+static TrackStatus GetTileTrackStatus_Water(TileIndex tile, TransportType mode, [[maybe_unused]] uint sub_mode, [[maybe_unused]] DiagDirection side)
 {
 	static const TrackBits coast_tracks[] = {TRACK_BIT_NONE, TRACK_BIT_RIGHT, TRACK_BIT_UPPER, TRACK_BIT_NONE, TRACK_BIT_LEFT, TRACK_BIT_NONE, TRACK_BIT_NONE,
 		TRACK_BIT_NONE, TRACK_BIT_LOWER, TRACK_BIT_NONE, TRACK_BIT_NONE, TRACK_BIT_NONE, TRACK_BIT_NONE, TRACK_BIT_NONE, TRACK_BIT_NONE, TRACK_BIT_NONE};
@@ -1394,6 +1394,7 @@ static TrackStatus GetTileTrackStatus_Water(TileIndex tile, TransportType mode, 
 	return CombineTrackStatus(TrackBitsToTrackdirBits(ts), TRACKDIR_BIT_NONE);
 }
 
+/** @copydoc ClickTileProc */
 static bool ClickTile_Water(TileIndex tile)
 {
 	if (GetWaterTileType(tile) == WaterTileType::Depot) {
@@ -1403,6 +1404,7 @@ static bool ClickTile_Water(TileIndex tile)
 	return false;
 }
 
+/** @copydoc ChangeTileOwnerProc */
 static void ChangeTileOwner_Water(TileIndex tile, Owner old_owner, Owner new_owner)
 {
 	if (!IsTileOwner(tile, old_owner)) return;
@@ -1439,12 +1441,8 @@ static void ChangeTileOwner_Water(TileIndex tile, Owner old_owner, Owner new_own
 	}
 }
 
-static VehicleEnterTileStates VehicleEnter_Water(Vehicle *, TileIndex, int, int)
-{
-	return {};
-}
-
-static CommandCost TerraformTile_Water(TileIndex tile, DoCommandFlags flags, int, Slope)
+/** @copydoc TerraformTileProc */
+static CommandCost TerraformTile_Water(TileIndex tile, DoCommandFlags flags, [[maybe_unused]] int z_new, [[maybe_unused]] Slope tileh_new)
 {
 	/* Canals can't be terraformed */
 	if (IsWaterTile(tile) && IsCanal(tile)) return CommandCost(STR_ERROR_MUST_DEMOLISH_CANAL_FIRST);
@@ -1455,7 +1453,8 @@ static CommandCost TerraformTile_Water(TileIndex tile, DoCommandFlags flags, int
 	return Command<Commands::LandscapeClear>::Do(flags, tile);
 }
 
-static CommandCost CheckBuildAbove_Water(TileIndex tile, DoCommandFlags flags, Axis, int height)
+/** @copydoc CheckBuildAboveProc */
+static CommandCost CheckBuildAbove_Water(TileIndex tile, DoCommandFlags flags, [[maybe_unused]] Axis axis, int height)
 {
 	if (IsWater(tile) || IsCoast(tile)) return CommandCost();
 	if (IsLock(tile)) {
@@ -1466,20 +1465,17 @@ static CommandCost CheckBuildAbove_Water(TileIndex tile, DoCommandFlags flags, A
 	return Command<Commands::LandscapeClear>::Do(flags, tile);
 }
 
+/** TileTypeProcs definitions for TileType::Water tiles. */
 extern const TileTypeProcs _tile_type_water_procs = {
-	DrawTile_Water,           // draw_tile_proc
-	GetSlopePixelZ_Water,     // get_slope_z_proc
-	ClearTile_Water,          // clear_tile_proc
-	nullptr,                     // add_accepted_cargo_proc
-	GetTileDesc_Water,        // get_tile_desc_proc
-	GetTileTrackStatus_Water, // get_tile_track_status_proc
-	ClickTile_Water,          // click_tile_proc
-	nullptr,                     // animate_tile_proc
-	TileLoop_Water,           // tile_loop_proc
-	ChangeTileOwner_Water,    // change_tile_owner_proc
-	nullptr,                     // add_produced_cargo_proc
-	VehicleEnter_Water,       // vehicle_enter_tile_proc
-	GetFoundation_Water,      // get_foundation_proc
-	TerraformTile_Water,      // terraform_tile_proc
-	CheckBuildAbove_Water, // check_build_above_proc
+	.draw_tile_proc = DrawTile_Water,
+	.get_slope_pixel_z_proc = GetSlopePixelZ_Water,
+	.clear_tile_proc = ClearTile_Water,
+	.get_tile_desc_proc = GetTileDesc_Water,
+	.get_tile_track_status_proc = GetTileTrackStatus_Water,
+	.click_tile_proc = ClickTile_Water,
+	.tile_loop_proc = TileLoop_Water,
+	.change_tile_owner_proc = ChangeTileOwner_Water,
+	.vehicle_enter_tile_proc = [](Vehicle *, TileIndex, int, int) -> VehicleEnterTileStates { return {}; },
+	.terraform_tile_proc = TerraformTile_Water,
+	.check_build_above_proc = CheckBuildAbove_Water,
 };


### PR DESCRIPTION
## Motivation / Problem

Lots of missing documentation.

Then struggling how to get things documented and seeing lots of duplicated code, or trivial functions that could be handled by a simple lambda.


## Description

Complete documentation of the `TileTypeProc`s and its function prototypes, as well as using `using` over `typedef`.

Adding some decent defaults for a number of functions. Note, if you remove the default (at least some) compilers start complaining that the variable isn't instantiated, so missing one should end up with a build failure. You can also use that trick to check whether you considered each case before setting the default.

Renaming `get_slope_z_proc` to `get_slope_pixel_z_proc` to mirror the `GetSlopePixelZ` function it is called from.

Going through all the TileTypeProc instances, i.e. one for each tile type.

Fixes 264 doxygen warnings.


## Limitations

Documenting the implementations is kinda messy. With `@copydoc` the documentation of the function prototype can be copied, but doxygen will start warning about all the parameters for which you removed the name.
There are two 'practical' ways:
* Actually defining `TileTypeProc` as a class with all the function prototypes as (pure) virtual functions. Then doxygen will generally do the right thing, and links will be clear. It does introduce an indirection.
* Using loads of `[[maybe_unused]]`s.

The class inheritance is the more elegant thing, as that's what we basically implemented back in the C-era. The problem is the extra indirection which ought to be unneeded. With `final` and a tangle of crap you might be able to remove the indirection (with LTO helping), but that feels very unappealing.

On the other hand sprinkling `[[maybe_unused]]` isn't the nicest either. Though probably less of a maintenance hassle. With trivial things handled by defaults and lambdas, it's not as bad as I feared.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
