### PR TITLE
Codechange: add missing map-accessor documentation

### DIFF
--- a/src/bridge_map.cpp
+++ b/src/bridge_map.cpp
@@ -18,6 +18,7 @@
  * Finds the end of a bridge in the specified direction starting at a middle tile
  * @param tile the bridge tile to find the bridge ramp for
  * @param dir  the direction to search in
+ * @return The tile at the bridge end.
  */
 static TileIndex GetBridgeEnd(TileIndex tile, DiagDirection dir)
 {
@@ -35,6 +36,7 @@ static TileIndex GetBridgeEnd(TileIndex tile, DiagDirection dir)
 /**
  * Finds the northern end of a bridge starting at a middle tile
  * @param t the bridge tile to find the bridge ramp for
+ * @return The tile at the northern bridge end.
  */
 TileIndex GetNorthernBridgeEnd(TileIndex t)
 {
@@ -45,6 +47,7 @@ TileIndex GetNorthernBridgeEnd(TileIndex t)
 /**
  * Finds the southern end of a bridge starting at a middle tile
  * @param t the bridge tile to find the bridge ramp for
+ * @return The tile at the southern bridge end.
  */
 TileIndex GetSouthernBridgeEnd(TileIndex t)
 {
@@ -55,6 +58,7 @@ TileIndex GetSouthernBridgeEnd(TileIndex t)
 /**
  * Starting at one bridge end finds the other bridge end
  * @param tile the bridge ramp tile to find the other bridge ramp for
+ * @return The tile at the other bridge end.
  */
 TileIndex GetOtherBridgeEnd(TileIndex tile)
 {

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -60,6 +60,7 @@ inline ClearGround GetClearGround(Tile t)
  * @param t  the tile to set the clear ground type of
  * @param ct the ground type
  * @pre IsTileType(t, TileType::Clear)
+ * @return \c true when the ground is of the given ground type.
  */
 inline bool IsClearGround(Tile t, ClearGround ct)
 {

--- a/src/depot_map.h
+++ b/src/depot_map.h
@@ -15,6 +15,9 @@
 
 /**
  * Check if a tile is a depot and it is a depot of the given type.
+ * @param tile The tile to check.
+ * @param type The type of transport.
+ * @return \c true iff the given tile is a depot for the given transport type.
  */
 inline bool IsDepotTypeTile(Tile tile, TransportType type)
 {

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -195,6 +195,7 @@ inline void ResetIndustryConstructionStage(Tile tile)
  * Get the animation loop number
  * @param tile the tile to get the animation loop number of
  * @pre IsTileType(tile, TileType::Industry)
+ * @return The loop/frame number.
  */
 inline uint8_t GetIndustryAnimationLoop(Tile tile)
 {

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -2468,7 +2468,7 @@ static void DrawTile_Track(TileInfo *ti)
 		}
 
 		/* Adjust ground tile for desert and snow. */
-		if (IsSnowRailGround(ti->tile)) {
+		if (IsSnowOrDesertRailGround(ti->tile)) {
 			if (image != SPR_FLAT_GRASS_TILE) {
 				image += rti->snow_offset; // tile with tracks
 			} else {

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -284,11 +284,23 @@ inline TrackBits GetDepotReservationTrackBits(Tile t)
 }
 
 
+/**
+ * Checks whether the given signal is a path based signal.
+ * @param s The signal to check.
+ * @return \c true when it is a path based signal.
+ */
 inline bool IsPbsSignal(SignalType s)
 {
 	return s == SIGTYPE_PBS || s == SIGTYPE_PBS_ONEWAY;
 }
 
+/**
+ * Get the signal type for a track on a tile.
+ * In horizontal and vertical orientation there may be two tracks on a tile with a signal.
+ * @param t The tile to query.
+ * @param track The track to query for.
+ * @return The signal type.
+ */
 inline SignalType GetSignalType(Tile t, Track track)
 {
 	assert(GetRailTileType(t) == RailTileType::Signals);
@@ -296,6 +308,13 @@ inline SignalType GetSignalType(Tile t, Track track)
 	return (SignalType)GB(t.m2(), pos, 3);
 }
 
+/**
+ * Set the signal type for a track on a tile.
+ * In horizontal and vertical orientation there may be two tracks on a tile with a signal.
+ * @param t The tile to update.
+ * @param track The track to update for.
+ * @param s The new signal type.
+ */
 inline void SetSignalType(Tile t, Track track, SignalType s)
 {
 	assert(GetRailTileType(t) == RailTileType::Signals);
@@ -304,22 +323,49 @@ inline void SetSignalType(Tile t, Track track, SignalType s)
 	if (track == INVALID_TRACK) SB(t.m2(), 4, 3, s);
 }
 
+/**
+ * Is the signal at the given track on a tile a presignal entry signal?
+ * In horizontal and vertical orientation there may be two tracks on a tile with a signal.
+ * @param t The tile to query.
+ * @param track The track to query for.
+ * @return \c true iff it is a presignal entry signal.
+ */
 inline bool IsPresignalEntry(Tile t, Track track)
 {
 	return GetSignalType(t, track) == SIGTYPE_ENTRY || GetSignalType(t, track) == SIGTYPE_COMBO;
 }
 
+/**
+ * Is the signal at the given track on a tile a presignal exit signal?
+ * In horizontal and vertical orientation there may be two tracks on a tile with a signal.
+ * @param t The tile to query.
+ * @param track The track to query for.
+ * @return \c true iff it is a presignal exit signal.
+ */
 inline bool IsPresignalExit(Tile t, Track track)
 {
 	return GetSignalType(t, track) == SIGTYPE_EXIT || GetSignalType(t, track) == SIGTYPE_COMBO;
 }
 
-/** One-way signals can't be passed the 'wrong' way. */
+/**
+ * Is the signal at the given track on a tile a one way signal?
+ * One-way signals can't be passed the 'wrong' way.
+ * In horizontal and vertical orientation there may be two tracks on a tile with a signal.
+ * @param t The tile to query.
+ * @param track The track to query for.
+ * @return \c true iff it is an one way signal.
+ */
 inline bool IsOnewaySignal(Tile t, Track track)
 {
 	return GetSignalType(t, track) != SIGTYPE_PBS;
 }
 
+/**
+ * Cycle to the next signal side at the given track on a tile.
+ * For path based signals there are two options, for other signals there is a third option with both sides.
+ * @param t The tile to update.
+ * @param track The track to update for.
+ */
 inline void CycleSignalSide(Tile t, Track track)
 {
 	uint8_t sig;
@@ -330,12 +376,26 @@ inline void CycleSignalSide(Tile t, Track track)
 	SB(t.m3(), pos, 2, sig);
 }
 
+/**
+ * Get the signal variant for a track on a tile.
+ * In horizontal and vertical orientation there may be two tracks on a tile with a signal.
+ * @param t The tile to query.
+ * @param track The track to query for.
+ * @return The signal variant.
+ */
 inline SignalVariant GetSignalVariant(Tile t, Track track)
 {
 	uint8_t pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
 	return (SignalVariant)GB(t.m2(), pos, 1);
 }
 
+/**
+ * Set the signal variant for a track on a tile.
+ * In horizontal and vertical orientation there may be two tracks on a tile with a signal.
+ * @param t The tile to update.
+ * @param track The track to update for.
+ * @param v The new signal variant.
+ */
 inline void SetSignalVariant(Tile t, Track track, SignalVariant v)
 {
 	uint8_t pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
@@ -408,6 +468,9 @@ inline bool IsSignalPresent(Tile t, uint8_t signalbit)
 /**
  * Checks for the presence of signals (either way) on the given track on the
  * given rail tile.
+ * @param tile The tile to query.
+ * @param track The track to query for.
+ * @return \c true iff there is a signal in any direction.
  */
 inline bool HasSignalOnTrack(Tile tile, Track track)
 {
@@ -421,6 +484,9 @@ inline bool HasSignalOnTrack(Tile tile, Track track)
  *
  * Along meaning if you are currently driving on the given trackdir, this is
  * the signal that is facing us (for which we stop when it's red).
+ * @param tile The tile to query.
+ * @param trackdir The trackdir to query for.
+ * @return \c true iff there is a signal in the given direction.
  */
 inline bool HasSignalOnTrackdir(Tile tile, Trackdir trackdir)
 {
@@ -433,6 +499,9 @@ inline bool HasSignalOnTrackdir(Tile tile, Trackdir trackdir)
  *
  * Along meaning if you are currently driving on the given trackdir, this is
  * the signal that is facing us (for which we stop when it's red).
+ * @param tile The tile to query.
+ * @param trackdir The trackdir to query for.
+ * @return The signal state for the given trackdir.
  */
 inline SignalState GetSignalStateByTrackdir(Tile tile, Trackdir trackdir)
 {
@@ -444,6 +513,9 @@ inline SignalState GetSignalStateByTrackdir(Tile tile, Trackdir trackdir)
 
 /**
  * Sets the state of the signal along the given trackdir.
+ * @param tile The tile to update.
+ * @param trackdir The trackdir to update for.
+ * @param state The new signal state.
  */
 inline void SetSignalStateByTrackdir(Tile tile, Trackdir trackdir, SignalState state)
 {
@@ -458,6 +530,7 @@ inline void SetSignalStateByTrackdir(Tile tile, Trackdir trackdir, SignalState s
  * Is a pbs signal present along the trackdir?
  * @param tile the tile to check
  * @param td the trackdir to check
+ * @return \c true iff there is a path based signal on the trackdir.
  */
 inline bool HasPbsSignalOnTrackdir(Tile tile, Trackdir td)
 {
@@ -470,6 +543,7 @@ inline bool HasPbsSignalOnTrackdir(Tile tile, Trackdir td)
  * trackdir against will block, but signals on both trackdirs won't.
  * @param tile the tile to check
  * @param td the trackdir to check
+ * @return \c true iff a one way signals blocks the trackdir.
  */
 inline bool HasOnewaySignalBlockingTrackdir(Tile tile, Trackdir td)
 {
@@ -499,22 +573,44 @@ enum class RailGroundType : uint8_t {
 	HalfTileSnow = 14, ///< Snow only on higher part of slope (steep or one corner raised)
 };
 
+/**
+ * Set the ground type for rail tiles.
+ * @param t The tile to update.
+ * @param rgt The new ground type.
+ */
 inline void SetRailGroundType(Tile t, RailGroundType rgt)
 {
 	SB(t.m4(), 0, 4, to_underlying(rgt));
 }
 
+/**
+ * Get the ground type for rail tiles.
+ * @param t The tile to query.
+ * @return The ground type.
+ */
 inline RailGroundType GetRailGroundType(Tile t)
 {
 	return static_cast<RailGroundType>(GB(t.m4(), 0, 4));
 }
 
-inline bool IsSnowRailGround(Tile t)
+/**
+ * Is the given rail tile snowy or deserty.
+ * @param t The tile to query.
+ * @return \c true iff the tile is snowy or deserty.
+ */
+inline bool IsSnowOrDesertRailGround(Tile t)
 {
 	return GetRailGroundType(t) == RailGroundType::SnowOrDesert;
 }
 
 
+/**
+ * Make the given tile a normal rail.
+ * @param t The tile to convert.
+ * @param o The new owner.
+ * @param b The bits/tracks to set.
+ * @param r The new rail type.
+ */
 inline void MakeRailNormal(Tile t, Owner o, TrackBits b, RailType r)
 {
 	SetTileType(t, TileType::Railway);

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -144,18 +144,34 @@ inline void SetRoadBits(Tile t, RoadBits r, RoadTramType rtt)
 	}
 }
 
+/**
+ * Get the road type for RoadTramType being RTT_ROAD.
+ * @param t The tile to query.
+ * @return The road type.
+ */
 inline RoadType GetRoadTypeRoad(Tile t)
 {
 	assert(MayHaveRoad(t));
 	return (RoadType)GB(t.m4(), 0, 6);
 }
 
+/**
+ * Get the road type for RoadTramType being RTT_TRAM.
+ * @param t The tile to query.
+ * @return The road (tram) type.
+ */
 inline RoadType GetRoadTypeTram(Tile t)
 {
 	assert(MayHaveRoad(t));
 	return (RoadType)GB(t.m8(), 6, 6);
 }
 
+/**
+ * Get the road type for the given RoadTramType.
+ * @param t The tile to query.
+ * @param rtt The sub type to check for.
+ * @return The road type.
+ */
 inline RoadType GetRoadType(Tile t, RoadTramType rtt)
 {
 	return (rtt == RTT_TRAM) ? GetRoadTypeTram(t) : GetRoadTypeRoad(t);
@@ -176,11 +192,21 @@ inline RoadTypes GetPresentRoadTypes(Tile t)
 	return result;
 }
 
+/**
+ * Check if a tile has a road type when RoadTramType is RTT_ROAD.
+ * @param t  The tile to check.
+ * @return True if the tile has a road type.
+ */
 inline bool HasRoadTypeRoad(Tile t)
 {
 	return GetRoadTypeRoad(t) != INVALID_ROADTYPE;
 }
 
+/**
+ * Check if a tile has a road type when RoadTramType is RTT_TRAM.
+ * @param t  The tile to check.
+ * @return True if the tile has a (tram) road type.
+ */
 inline bool HasRoadTypeTram(Tile t)
 {
 	return GetRoadTypeTram(t) != INVALID_ROADTYPE;

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -601,6 +601,9 @@ inline DiagDirection GetDockDirection(Tile t)
 
 /**
  * Check whether a dock tile is the tile on water.
+ * @param t Tile to query.
+ * @pre IsDockTile(t)
+ * @return \c true iff the given tile is the water part.
  */
 inline bool IsDockWaterPart(Tile t)
 {

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -122,6 +122,7 @@ inline TreeGround GetTreeGround(Tile t)
  *
  * @param t The tile to get the 'density'
  * @pre Tile must be of type TileType::Trees
+ * @return The current density.
  * @see GetTreeCount
  */
 inline uint GetTreeDensity(Tile t)

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -170,6 +170,12 @@ CommandCost CmdBuildShipDepot(DoCommandFlags flags, TileIndex tile, Axis axis)
 	return cost;
 }
 
+/**
+ * Check whether it is feasible that the given tile could be a docking tile.
+ * @param t The tile to query.
+ * @return \c true iff there is a chance the tile could be a docking tile.
+ * @see CheckForDockingTile
+ */
 bool IsPossibleDockingTile(Tile t)
 {
 	assert(IsValidTile(t));

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -68,7 +68,7 @@ enum class LockPart : uint8_t {
 	Upper = 2, ///< Upper part of a lock.
 	End, ///< End marker.
 };
-DECLARE_INCREMENT_DECREMENT_OPERATORS(LockPart);
+DECLARE_INCREMENT_DECREMENT_OPERATORS(LockPart)
 
 bool IsPossibleDockingTile(Tile t);
 
@@ -346,6 +346,7 @@ inline uint8_t GetWaterTileRandomBits(Tile t)
 /**
  * Checks whether the tile has water at the ground.
  * That is, it is either some plain water tile, or a object/industry/station/... with water under it.
+ * @param t The tile to query.
  * @return true iff the tile has water at the ground.
  * @note Coast tiles are not considered waterish, even if there is water on a halftile.
  */
@@ -368,6 +369,7 @@ inline void SetDockingTile(Tile t, bool b)
 
 /**
  * Checks whether the tile is marked as a dockling tile.
+ * @param t The tile to query.
  * @return true iff the tile is marked as a docking tile.
  */
 inline bool IsDockingTile(Tile t)
@@ -534,6 +536,7 @@ inline void SetNonFloodingWaterTile(Tile t, bool b)
 }
 /**
  * Checks whether the tile is marked as a non-flooding water tile.
+ * @param t The tile to query.
  * @return true iff the tile is marked as a non-flooding water tile.
  */
 inline bool IsNonFloodingWaterTile(Tile t)


### PR DESCRIPTION
## Motivation / Problem

Doxygen warnings.


## Description

Add documentation.

Rename `IsSnowRailGround` to `IsSnowOrDesertRailGround` as both the caller and accessor already mentioned both.

Fixes 63 warnings.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
