### PR TITLE
Codechange: exclude tests/safeguards from main documentation

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -142,7 +142,8 @@ RECURSIVE              = YES
 EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = */3rdparty \
-                         */script/api
+                         */script/api \
+                         */tests
 EXCLUDE_SYMBOLS        =
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -16,6 +16,9 @@
 #ifndef SAFEGUARDS_H
 #define SAFEGUARDS_H
 
+/* Ignore everything in here for doxygen. These should not be used, so also not show up in the documentation. */
+#ifndef DOXYGEN_API
+
 /* Use std::vector/std::unique_ptr/new instead. */
 #define malloc    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define calloc    SAFEGUARD_DO_NOT_USE_THIS_METHOD
@@ -114,4 +117,5 @@
 #define strerror SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #endif /* defined(NETWORK_CORE_OS_ABSTRACTION_H) && defined(_WIN32) */
 
+#endif /* DOXYGEN_API */
 #endif /* SAFEGUARDS_H */


### PR DESCRIPTION
## Motivation / Problem

The goal of safeguards is to prevent people from using these macros, having (doxygen) documentation of these macros defeats that purpose.

Next to this, each of the tests would require doxygen documentation now. I'd say that's a bit too much at the moment. I rather have unit tests than people not making them due to the documentation constraint. This can always be reconsidered.


## Description

Exclude safeguards.h by means of a `#ifdef` so we document what the file does, but not the actual macros. Removes 45 doxygen warnings.

Exclude tests just the way 3rdparty and script APIs are excluded. Removes 162 doxygen warnings.


## Limitations

The tests exclusion might be considered controversial.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
