### PR TITLE
Codechange: fix some more doxygen comments, mostly network

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -321,6 +321,7 @@ PREDEFINED             = WITH_ZLIB \
                          DOXYGEN_API \
                          _UNICODE \
                          _GNU_SOURCE \
+                         CDECL= \
                          FINAL=
 EXPAND_AS_DEFINED      = DEFINE_POOL_METHOD
 SKIP_FUNCTION_MACROS   = YES

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -244,7 +244,10 @@ public:
 	}
 
 protected:
-	/** Helper to process a single ClientID argument. */
+	/**
+	 * Helper to process a single ClientID argument.
+	 * @param data The data to process.
+	 */
 	template <class T>
 	static inline void SetClientIdHelper([[maybe_unused]] T &data)
 	{
@@ -253,14 +256,21 @@ protected:
 		}
 	}
 
-	/** Set all invalid ClientID's to the proper value. */
+	/**
+	 * Set all invalid ClientIDs to the proper value.
+	 * @param values The values to go through.
+	 */
 	template <class Ttuple, size_t... Tindices>
 	static inline void SetClientIds(Ttuple &values, std::index_sequence<Tindices...>)
 	{
 		((SetClientIdHelper(std::get<Tindices>(values))), ...);
 	}
 
-	/** Remove the first element of a tuple. */
+	/**
+	 * Remove the first element of a tuple.
+	 * @param tuple The tuple to go through.
+	 * @return The tuple without the first element.
+	 */
 	template <template <typename...> typename Tt, typename T1, typename... Ts>
 	static inline Tt<Ts...> RemoveFirstTupleElement(const Tt<T1, Ts...> &tuple)
 	{

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -151,6 +151,7 @@ public:
 	/**
 	 * Compare the address of this class with the address of another.
 	 * @param address the other address.
+	 * @return The std::strong_ordering of the comparison.
 	 */
 	auto operator <=>(NetworkAddress &address)
 	{

--- a/src/network/core/http_shared.h
+++ b/src/network/core/http_shared.h
@@ -42,6 +42,7 @@ public:
 
 	/**
 	 * Similar to HTTPCallback::OnReceiveData, but thread-safe.
+	 * @copydoc HTTPCallback::OnReceiveData
 	 */
 	void OnReceiveData(std::unique_ptr<char[]> data, size_t length)
 	{
@@ -88,6 +89,7 @@ public:
 
 	/**
 	 * Check if the queue is empty.
+	 * @return \c true iff the queue is empty.
 	 */
 	bool IsQueueEmpty()
 	{

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -40,6 +40,7 @@ NetworkServerGameInfo _network_game_info; ///< Information about our game.
 /**
  * Get the network version string used by this build.
  * The returned string is guaranteed to be at most NETWORK_REVISION_LENGTH bytes including '\0' terminator.
+ * @return The revision string.
  */
 std::string_view GetNetworkRevisionString()
 {
@@ -98,6 +99,7 @@ static std::string_view ExtractNetworkRevisionHash(std::string_view revision_str
  * Checks whether the given version string is compatible with our version.
  * First tries to match the full string, if that fails, attempts to compare just git hashes.
  * @param other the version string to compare to
+ * @return \c true if the other version is deemed compatible.
  */
 bool IsNetworkCompatibleVersion(std::string_view other)
 {
@@ -120,6 +122,7 @@ bool IsNetworkCompatibleVersion(std::string_view other)
 
 /**
  * Check if an game entry is compatible with our client.
+ * @param ngi The game information to process and update the compatible field of.
  */
 void CheckGameCompatibility(NetworkGameInfo &ngi)
 {

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -256,6 +256,7 @@ void TCPConnecter::Resolve()
 
 /**
  * Thunk to start Resolve() on the right instance.
+ * @param connecter The connector to resolve on.
  */
 /* static */ void TCPConnecter::ResolveThunk(TCPConnecter *connecter)
 {

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -33,9 +33,9 @@ NetworkGameSocketHandler::NetworkGameSocketHandler(SOCKET s) : NetworkTCPSocketH
  *  A socket can make errors. When that happens this handles what to do.
  * For clients: close connection and drop back to main-menu
  * For servers: close connection and that is it
- * @return the new status
+ * @copydoc NetworkTCPSocketHandler::CloseConnection
  */
-NetworkRecvStatus NetworkGameSocketHandler::CloseConnection(bool)
+NetworkRecvStatus NetworkGameSocketHandler::CloseConnection([[maybe_unused]] bool error)
 {
 	/* Clients drop back to the main menu */
 	if (!_network_server && _networking) {

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -37,11 +37,11 @@ AdminID _redirect_console_to_admin = AdminID::Invalid();
 NetworkAdminSocketPool _networkadminsocket_pool("NetworkAdminSocket");
 INSTANTIATE_POOL_METHODS(NetworkAdminSocket)
 
-static NetworkAuthenticationDefaultPasswordProvider _admin_password_provider(_settings_client.network.admin_password); ///< Provides the password validation for the game's password.
-static NetworkAuthenticationDefaultAuthorizedKeyHandler _admin_authorized_key_handler(_settings_client.network.admin_authorized_keys); ///< Provides the authorized key handling for the game authentication.
+static NetworkAuthenticationDefaultPasswordProvider _admin_password_provider{_settings_client.network.admin_password}; ///< Provides the password validation for the game's password.
+static NetworkAuthenticationDefaultAuthorizedKeyHandler _admin_authorized_key_handler{_settings_client.network.admin_authorized_keys}; ///< Provides the authorized key handling for the game authentication.
 
 /** The timeout for authorisation of the client. */
-static const std::chrono::seconds ADMIN_AUTHORISATION_TIMEOUT(10);
+static const std::chrono::seconds ADMIN_AUTHORISATION_TIMEOUT{10};
 
 
 /** Frequencies, which may be registered for a certain update type. */
@@ -597,6 +597,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendGameScript(std::string_vi
 
 /**
  * Send ping-reply (pong) to admin.
+ * @param d1 Request ID from the admin, to return back to them.
  * @return The new state the network.
  */
 NetworkRecvStatus ServerNetworkAdminSocketHandler::SendPong(uint32_t d1)
@@ -1023,6 +1024,12 @@ void NetworkAdminCompanyRemove(CompanyID company_id, AdminCompanyRemoveReason bc
 
 /**
  * Send chat to the admin network (if they did opt in for the respective update).
+ * @param action The action that's performed.
+ * @param desttype The type of destination.
+ * @param client_id The destination client.
+ * @param msg The actual message.
+ * @param data Arbitrary data.
+ * @param from_admin Whether the message is coming from the admin.
  */
 void NetworkAdminChat(NetworkAction action, DestType desttype, ClientID client_id, std::string_view msg, int64_t data, bool from_admin)
 {

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -407,7 +407,11 @@ void NetworkGameSocketHandler::SendCommand(Packet &p, const CommandPacket &cp)
 	p.Send_uint8 ((uint8_t)callback);
 }
 
-/** Helper to process a single ClientID argument. */
+/**
+ * Helper to process a single ClientID argument.
+ * @param data The data to process.
+ * @param client_id The client ID to set.
+ */
 template <class T>
 static inline void SetClientIdHelper(T &data, [[maybe_unused]] ClientID client_id)
 {
@@ -416,7 +420,11 @@ static inline void SetClientIdHelper(T &data, [[maybe_unused]] ClientID client_i
 	}
 }
 
-/** Set all invalid ClientID's to the proper value. */
+/**
+ * Set all invalid ClientIDs to the proper value.
+ * @param values The values to process.
+ * @param client_id The client ID to set.
+ */
 template <class Ttuple, size_t... Tindices>
 static inline void SetClientIds(Ttuple &values, ClientID client_id, std::index_sequence<Tindices...>)
 {
@@ -447,7 +455,11 @@ void NetworkReplaceCommandClientId(CommandPacket &cp, ClientID client_id)
 }
 
 
-/** Validate a single string argument coming from network. */
+/**
+ * Validate a single string argument coming from network.
+ * @param cmd_flags The flags for validation.
+ * @param data The data to validate.
+ */
 template <class T>
 static inline void SanitizeSingleStringHelper([[maybe_unused]] CommandFlags cmd_flags, T &data)
 {
@@ -460,7 +472,11 @@ static inline void SanitizeSingleStringHelper([[maybe_unused]] CommandFlags cmd_
 	}
 }
 
-/** Helper function to perform validation on command data strings. */
+/**
+ * Helper function to perform validation on command data strings.
+ * @param cmd_flags The flags for validation.
+ * @param values The data to validate.
+ */
 template <class Ttuple, size_t... Tindices>
 static inline void SanitizeStringsHelper(CommandFlags cmd_flags, Ttuple &values, std::index_sequence<Tindices...>)
 {

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -46,7 +46,7 @@ extern bool HasScenario(const ContentInfo &ci, bool md5sum);
 /** The client we use to connect to the server. */
 ClientNetworkContentSocketHandler _network_content_client;
 
-/** Wrapper function for the HasProc */
+/** Check whether NewGRF content exists. @copydoc HasContentProc */
 static bool HasGRFConfig(const ContentInfo &ci, bool md5sum)
 {
 	return FindGRFConfig(std::byteswap(ci.unique_id), md5sum ? FGCM_EXACT : FGCM_ANY, md5sum ? &ci.md5sum : nullptr) != nullptr;
@@ -729,10 +729,8 @@ void ClientNetworkContentSocketHandler::Connect()
 	TCPConnecter::Create<NetworkContentConnecter>(NetworkContentServerConnectionString());
 }
 
-/**
- * Disconnect from the content server.
- */
-NetworkRecvStatus ClientNetworkContentSocketHandler::CloseConnection(bool)
+/** Disconnect from the content server. @copydoc NetworkTCPSocketHandler::CloseConnection */
+NetworkRecvStatus ClientNetworkContentSocketHandler::CloseConnection([[maybe_unused]] bool error)
 {
 	NetworkContentSocketHandler::CloseConnection();
 
@@ -893,7 +891,10 @@ void ClientNetworkContentSocketHandler::UnselectAll()
 	}
 }
 
-/** Toggle the state of a content info and check its dependencies */
+/**
+ * Toggle the state of a content info and check its dependencies.
+ * @param ci The content info to change.
+ */
 void ClientNetworkContentSocketHandler::ToggleSelectedState(const ContentInfo &ci)
 {
 	switch (ci.state) {

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -135,9 +135,16 @@ public:
 
 	void Clear();
 
-	/** Add a callback to this class */
+	/**
+	 * Add a callback to this class, if it doesn't already exist.
+	 * @param cb The callback to add.
+	 */
 	void AddCallback(ContentCallback *cb) { include(this->callbacks, cb); }
-	/** Remove a callback */
+
+	/**
+	 * Remove a callback.
+	 * @param cb The callback to remove.
+	 */
 	void RemoveCallback(ContentCallback *cb) { this->callbacks.erase(std::ranges::find(this->callbacks, cb)); }
 };
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -386,6 +386,8 @@ class NetworkContentListWindow : public Window, ContentCallback {
 
 	/**
 	 * Callback function for disclaimer about entering external websites.
+	 * @param w The window to open the external search on.
+	 * @param accepted Whether the disclaimer was accepted.
 	 */
 	static void ExternalSearchDisclaimerCallback(Window *w, bool accepted)
 	{
@@ -459,7 +461,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		if (idx >= 0) this->list_pos = idx;
 	}
 
-	/** Filter content by tags/name */
+	/** Filter content by tags/name. @copydoc GUIList::FilterFunction */
 	static bool TagNameFilter(const ContentInfo * const *a, ContentListFilterData &filter)
 	{
 		if ((*a)->state == ContentInfo::State::Selected || (*a)->state == ContentInfo::State::Autoselected) return true;
@@ -471,7 +473,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		return filter.string_filter.GetState();
 	}
 
-	/** Filter content by type, but still show content selected for download. */
+	/** Filter content by type, but still show content selected for download. @copydoc GUIList::FilterFunction */
 	static bool TypeOrSelectedFilter(const ContentInfo * const *a, ContentListFilterData &filter)
 	{
 		if (filter.types.None()) return true;

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -618,6 +618,9 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(std::string_view toke
  *
  * This helps the Game Coordinator not to wait for a timeout on its end, but
  * rather react as soon as the client/server knows the result.
+ * @param token The token of the STUN connection attempt.
+ * @param family The used network family.
+ * @param result Whether the STUN was successful.
  */
 void ClientNetworkCoordinatorSocketHandler::StunResult(std::string_view token, uint8_t family, bool result)
 {

--- a/src/network/network_crypto.cpp
+++ b/src/network/network_crypto.cpp
@@ -458,6 +458,7 @@ void CombinedAuthenticationServerHandler::Add(CombinedAuthenticationServerHandle
  * @param password_handler The handler for when a request for password needs to be passed on to the user.
  * @param secret_key The location where the secret key is stored; can be overwritten when invalid.
  * @param public_key The location where the public key is stored; can be overwritten when invalid.
+ * @return A new client handler.
  */
 /* static */ std::unique_ptr<NetworkAuthenticationClientHandler> NetworkAuthenticationClientHandler::Create(std::shared_ptr<NetworkAuthenticationPasswordRequestHandler> password_handler, std::string &secret_key, std::string &public_key)
 {
@@ -474,6 +475,7 @@ void CombinedAuthenticationServerHandler::Add(CombinedAuthenticationServerHandle
  * @param password_provider Callback to provide the password handling. Must remain valid until the authentication has succeeded or failed. Can be \c nullptr to skip password checks.
  * @param authorized_key_handler Callback to provide the authorized key handling. Must remain valid until the authentication has succeeded or failed. Can be \c nullptr to skip authorized key checks.
  * @param client_supported_method_mask Bitmask of the methods that are supported by the client. Defaults to support of all methods.
+ * @return A new server handler.
  */
 std::unique_ptr<NetworkAuthenticationServerHandler> NetworkAuthenticationServerHandler::Create(const NetworkAuthenticationPasswordProvider *password_provider, const NetworkAuthenticationAuthorizedKeyHandler *authorized_key_handler, NetworkAuthenticationMethodMask client_supported_method_mask)
 {

--- a/src/network/network_crypto.h
+++ b/src/network/network_crypto.h
@@ -74,6 +74,7 @@ public:
 
 	/**
 	 * Reply to the request with the given password.
+	 * @param password The requested password from the user.
 	 */
 	virtual void Reply(const std::string &password) = 0;
 };
@@ -245,6 +246,7 @@ public:
 	/**
 	 * Read the request to enable encryption from the server.
 	 * @param p The request from the server.
+	 * @return \c true when enough bytes could be read for the nonce, otherwise \c false.
 	 */
 	virtual bool ReceiveEnableEncryption(struct Packet &p) = 0;
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1349,6 +1349,8 @@ public:
 
 	/**
 	 * OnClick handler for when the button is pressed.
+	 * @param w The window the click was in.
+	 * @param pt The location the click was at.
 	 */
 	virtual void OnClick(struct NetworkClientListWindow *w, Point pt) = 0;
 };

--- a/src/network/network_query.cpp
+++ b/src/network/network_query.cpp
@@ -36,6 +36,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::CloseConnection(NetworkRecvStat
 
 /**
  * Check the connection's state, i.e. is the connection still up?
+ * @return \c true if the connection remains valid, otherwise it will be closed.
  */
 bool QueryNetworkGameSocketHandler::CheckConnection()
 {
@@ -76,6 +77,7 @@ void QueryNetworkGameSocketHandler::Send()
 
 /**
  * Query the server for server information.
+ * @return The status the network should have.
  */
 NetworkRecvStatus QueryNetworkGameSocketHandler::SendGameInfo()
 {

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -58,9 +58,9 @@ INSTANTIATE_POOL_METHODS(NetworkClientSocket)
 /** Instantiate the listen sockets. */
 template SocketList TCPListenHandler<ServerNetworkGameSocketHandler, PACKET_SERVER_FULL, PACKET_SERVER_BANNED>::sockets;
 
-static NetworkAuthenticationDefaultPasswordProvider _password_provider(_settings_client.network.server_password); ///< Provides the password validation for the game's password.
-static NetworkAuthenticationDefaultAuthorizedKeyHandler _authorized_key_handler(_settings_client.network.server_authorized_keys); ///< Provides the authorized key handling for the game authentication.
-static NetworkAuthenticationDefaultAuthorizedKeyHandler _rcon_authorized_key_handler(_settings_client.network.rcon_authorized_keys); ///< Provides the authorized key validation for rcon.
+static NetworkAuthenticationDefaultPasswordProvider _password_provider{_settings_client.network.server_password}; ///< Provides the password validation for the game's password.
+static NetworkAuthenticationDefaultAuthorizedKeyHandler _authorized_key_handler{_settings_client.network.server_authorized_keys}; ///< Provides the authorized key handling for the game authentication.
+static NetworkAuthenticationDefaultAuthorizedKeyHandler _rcon_authorized_key_handler{_settings_client.network.rcon_authorized_keys}; ///< Provides the authorized key validation for rcon.
 
 
 /** Writing a savegame directly to a number of packets. */
@@ -1531,6 +1531,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_MOVE(Packet &p)
 
 /**
  * Get the company stats.
+ * @return Array with the statistics.
  */
 NetworkCompanyStatsArray NetworkGetCompanyStats()
 {
@@ -2015,7 +2016,6 @@ void NetworkServerUpdateGameInfo()
  * Handle the tid-bits of moving a client from one company to another.
  * @param client_id id of the client we want to move.
  * @param company_id id of the company we want to move the client to.
- * @return void
  */
 void NetworkServerDoMove(ClientID client_id, CompanyID company_id)
 {
@@ -2081,6 +2081,7 @@ void NetworkServerKickClient(ClientID client_id, std::string_view reason)
  * @param client_id The client to check for.
  * @param ban Whether to ban or kick.
  * @param reason In case of kicking a client, specifies the reason for kicking the client.
+ * @return The number of clients that were kicked.
  */
 uint NetworkServerKickOrBanIP(ClientID client_id, bool ban, std::string_view reason)
 {
@@ -2092,6 +2093,7 @@ uint NetworkServerKickOrBanIP(ClientID client_id, bool ban, std::string_view rea
  * @param ip The IP address/range to ban/kick.
  * @param ban Whether to ban or just kick.
  * @param reason In case of kicking a client, specifies the reason for kicking the client.
+ * @return The number of clients that were kicked.
  */
 uint NetworkServerKickOrBanIP(std::string_view ip, bool ban, std::string_view reason)
 {
@@ -2142,6 +2144,7 @@ bool NetworkCompanyHasClients(CompanyID company)
 
 /**
  * Get the name of the client, if the user did not send it yet, Client ID is used.
+ * @return The name of a the client.
  */
 std::string ServerNetworkGameSocketHandler::GetClientName() const
 {

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -87,7 +87,10 @@ void ClientNetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet &, NetworkAdd
 	NetworkAddServer(client_addr.GetAddressAsString(false), false, true);
 }
 
-/** Broadcast to all ips */
+/**
+ * Broadcast to all IPs.
+ * @param socket The socket to broadcast on.
+ */
 static void NetworkUDPBroadCast(NetworkUDPSocketHandler &socket)
 {
 	for (NetworkAddress &addr : _broadcast_list) {

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -355,7 +355,10 @@ private:
 };
 
 namespace ScriptObjectInternal {
-	/** Validate a single string argument coming from network. */
+	/**
+	 * Validate a single string argument coming from a script.
+	 * @param data The data to validate.
+	 */
 	template <class T>
 	static inline void SanitizeSingleStringHelper(T &data)
 	{
@@ -366,14 +369,20 @@ namespace ScriptObjectInternal {
 		}
 	}
 
-	/** Helper function to perform validation on command data strings. */
+	/**
+	 * Helper function to perform validation on command data strings.
+	 * @param values The data to validate.
+	 */
 	template <class Ttuple, size_t... Tindices>
 	static inline void SanitizeStringsHelper(Ttuple &values, std::index_sequence<Tindices...>)
 	{
 		((SanitizeSingleStringHelper(std::get<Tindices>(values))), ...);
 	}
 
-	/** Helper to process a single ClientID argument. */
+	/**
+	 * Helper to process a single ClientID argument.
+	 * @param data The data to process.
+	 */
 	template <class T>
 	static inline void SetClientIdHelper(T &data)
 	{
@@ -382,7 +391,10 @@ namespace ScriptObjectInternal {
 		}
 	}
 
-	/** Set all invalid ClientID's to the proper value. */
+	/**
+	 * Set all invalid ClientIDs to the proper value.
+	 * @param values The values to go through.
+	 */
 	template <class Ttuple, size_t... Tindices>
 	static inline void SetClientIds(Ttuple &values, std::index_sequence<Tindices...>)
 	{

--- a/src/sortlist_type.h
+++ b/src/sortlist_type.h
@@ -60,7 +60,14 @@ public:
 	using SorterWithFilter = bool(const T &a, const T &b, const P filter);
 
 	using SortFunction = std::conditional_t<std::is_same_v<P, std::nullptr_t>, bool (const T&, const T&), bool (const T&, const T&, const P)>; ///< Signature of sort function.
-	using FilterFunction = bool(const T*, F); ///< Signature of filter function.
+
+	/**
+	 * Check whether an element should be kept in the list.
+	 * @param a The element to check.
+	 * @param filter The filter parameter.
+	 * @return \c true iff the element should be in the list.
+	 */
+	using FilterFunction = bool(const T *a, F filter); ///< Signature of filter function.
 
 protected:
 	std::span<SortFunction * const> sort_func_list;     ///< the sort criteria functions


### PR DESCRIPTION
## Motivation / Problem

Lots of doxygen warnings.


## Description

There are a few functions with the `CDECL` macro and Doxygen interprets that as a (return) type. Let Doxygen process that as an empty macro, so it doesn't consider the `CDECL` to be there at all.

Add parameter/return type documentation, mostly related to networking code. `sortlist_type.h` so a `@copydoc` could be done to the filter function prototype.

Also a few initialisations with parentheses converted to curly brackets; with parentheses Doxygen considers them functions, so the params/return are considered not documented.

Fixes 67 doxygen warnings.


## Limitations

Did focus on documented functions with missing parameters/returns, and mostly network related. So there are many more missing bits of documentation.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
