### PR TITLE
Codechange: remove @return documentation for void methods

### DIFF
--- a/src/autoreplace.cpp
+++ b/src/autoreplace.cpp
@@ -36,8 +36,7 @@ static EngineRenew *GetEngineReplacement(EngineRenewList erl, EngineID engine, G
 
 /**
  * Remove all engine replacement settings for the company.
- * @param  erl The renewlist for a given company.
- * @return The new renewlist for the company.
+ * @param erl The renewlist for a given company.
  */
 void RemoveAllEngineReplacement(EngineRenewList *erl)
 {

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -344,8 +344,7 @@ bool FioRemove(const std::string &filename)
 /**
  * Appends, if necessary, the path separator character to the end of the string.
  * It does not add the path separator to zero-sized strings.
- * @param buf  string to append the separator to
- * @return true iff the operation succeeded
+ * @param buf String to append the separator to.
  */
 void AppendPathSeparator(std::string &buf)
 {

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -77,7 +77,6 @@ static uint LoadGrfFile(const std::string &filename, SpriteID load_index, bool n
  * @param filename   The name of the file to open.
  * @param index_tbl  The offsets of each of the sprites.
  * @param needs_palette_remap Whether the colours in the GRF file need a palette remap.
- * @return The number of loaded sprites.
  */
 static void LoadGrfFileIndexed(const std::string &filename, std::span<const std::pair<SpriteID, SpriteID>> index_tbl, bool needs_palette_remap)
 {

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -185,7 +185,6 @@ struct GoalListWindow : public Window {
 	 * @param column Which column to draw.
 	 * @param wid Pointer to the goal list widget.
 	 * @param progress_col_width Width of the progress column.
-	 * @return max width of drawn text
 	 */
 	void DrawListColumn(GoalColumn column, NWidgetBase *wid, uint progress_col_width) const
 	{

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2760,12 +2760,12 @@ static bool CheckIndustryCloseDownProtection(IndustryType type)
 
 /**
  * Can given cargo type be accepted or produced by the industry?
- * @param cargo: Cargo type
- * @param ind: Industry
- * @param *c_accepts: Pointer to boolean for acceptance of cargo
- * @param *c_produces: Pointer to boolean for production of cargo
- * @return: \c *c_accepts is set when industry accepts the cargo type,
- *          \c *c_produces is set when the industry produces the cargo type
+ * @param cargo Cargo type to consider.
+ * @param ind The industry to consider.
+ * @param *c_accepts Pointer to boolean for acceptance of cargo
+ * @param *c_produces Pointer to boolean for production of cargo
+ * @post \c *c_accepts is set when industry accepts the cargo type,
+ *       \c *c_produces is set when the industry produces the cargo type
  */
 static void CanCargoServiceIndustry(CargoType cargo, Industry *ind, bool *c_accepts, bool *c_produces)
 {

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -285,7 +285,6 @@ uint16_t GetRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t para
  * @param spec the RoadStop's spec.
  * @param type The type of station.
  * @param view The road stop's view.
- * @return true of the tile was drawn (allows for fallback to default graphics)
  */
 void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec, StationType type, int view)
 {

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -245,7 +245,6 @@ struct ResultSpriteGroup : SpecializedSpriteGroup<ResultSpriteGroup> {
 	 * @param index Unique (pool) identifier of the SpriteGroup.
 	 * @param sprite The sprite number.
 	 * @param num_sprites The number of sprites per set.
-	 * @return A spritegroup representing the sprite number result.
 	 */
 	ResultSpriteGroup(SpriteGroupID index, SpriteID sprite, uint8_t num_sprites) : SpecializedSpriteGroup<ResultSpriteGroup>(index), num_sprites(num_sprites), sprite(sprite) {}
 

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -356,7 +356,6 @@ VehicleOrderID OrderList::GetNextDecisionNode(VehicleOrderID next, uint hops) co
  * @param v The vehicle we're looking at.
  * @param first Order to start searching at or INVALID_VEH_ORDER_ID to start at cur_implicit_order_index + 1.
  * @param hops Number of orders we have already looked at.
- * @return Next stopping station or StationID::Invalid().
  * @pre The vehicle is currently loading and v->last_station_visited is meaningful.
  * @note This function may draw a random number. Don't use it from the GUI.
  */

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -366,7 +366,7 @@ static const OptionData _opts[] = {
  *
  * Last but not least, the [post-amble] group is copied verbatim.
  *
- * @param fname  Ini file to process. @return Exit status of the processing.
+ * @param fname Ini file to process.
  */
 static void ProcessIniFile(std::string_view fname)
 {

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -508,7 +508,6 @@ protected:
 	 * @param line_height Height of one line of text.
 	 * @param action_sprite The sprite to draw.
 	 * @param text The text to draw.
-	 * @return the number of lines.
 	 */
 	void DrawActionElement(int &y_offset, int width, int line_height, SpriteID action_sprite, const std::string &text) const
 	{

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -490,7 +490,6 @@ static SpriteID GetDefaultTrainSprite(uint8_t spritenum, Direction direction)
  * @param direction Direction of view/travel.
  * @param image_type Visualisation context.
  * @param result Sprite sequence to add the to be drawn sprites to.
- * @return Sprite to display.
  */
 void Train::GetImage(Direction direction, EngineImageType image_type, VehicleSpriteSeq *result) const
 {
@@ -4138,7 +4137,7 @@ bool Train::Tick()
 
 /**
  * Check whether a train needs service, and if so, find a depot or service it.
- * @return v %Train to check.
+ * @param v %Train to check.
  */
 static void CheckIfTrainNeedsService(Train *v)
 {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1414,7 +1414,6 @@ static void BringWindowToFront(Window *w, bool dirty)
 /**
  * Initializes the data (except the position and initial size) of a new Window.
  * @param window_number Number being assigned to the new window
- * @return Window pointer of the newly created window
  * @pre If nested widgets are used (\a widget is \c nullptr), #nested_root and #nested_array_size must be initialized.
  *      In addition, #widget_lookup is either \c nullptr, or already initialized.
  */


### PR DESCRIPTION
## Motivation / Problem

Doxygen complains about `void` methods having documentation for what the function returns. That ain't right.


## Description

Remove the documentation, and some minor documentation coding style updates in the amended function documentation..


## Limitations

There is also `NetworkServerDoMove` that is `void` and has `@return`, but that's already part of #15283.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
