### PR TITLE
Codechange: reduce ottd_cpuid boilerplate, make static and rename

### DIFF
--- a/src/cpu.h
+++ b/src/cpu.h
@@ -11,13 +11,6 @@
 #define CPU_H
 
 /**
- * Get the CPUID information from the CPU.
- * @param info The retrieved info. All zeros on architectures without CPUID.
- * @param type The information this instruction should retrieve.
- */
-void ottd_cpuid(int info[4], int type);
-
-/**
  * Check whether the current CPU has the given flag.
  * @param type  The type to be passing to cpuid (usually 1).
  * @param index The index in the returned info array.


### PR DESCRIPTION
## Motivation / Problem

There are quite a few things wrong with `ottd_cpuid`.

- its name does not following the coding style.
- its publicly declared, but only used locally. Why not `static`?
- the declaration is copied multiple times in all kinds of `#ifdef`s. Why  aren't the `#ifdef`s inside?
- passing C-style arrays to functions is considered dangerous.


## Description

- Rename to `CPUID`.
- Remove declaration from header and make `static`.
- Move `#ifdef`s inside the function, and flatten the structure.
- Pass a reference to `std::array`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
