### PR TITLE
Codechange: add missing @param and @return

### DIFF
--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -121,6 +121,9 @@ static TrackBits GetRailTrackBitsUniversal(TileIndex t, DiagDirections *override
 
 /**
  * Masks out track bits when neighbouring tiles are unelectrified.
+ * @param t The tile to consider.
+ * @param tracks The track bits to consider.
+ * @return The track bits that should have catenary.
  */
 static TrackBits MaskWireBits(TileIndex t, TrackBits tracks)
 {
@@ -173,6 +176,9 @@ static TrackBits MaskWireBits(TileIndex t, TrackBits tracks)
 
 /**
  * Get the base wire sprite to use.
+ * @param tile The tile to get the wire sprite for.
+ * @param context The context to get the sprite for.
+ * @return The wire sprite.
  */
 static inline SpriteID GetWireBase(TileIndex tile, TileContext context = TCX_NORMAL)
 {
@@ -183,6 +189,9 @@ static inline SpriteID GetWireBase(TileIndex tile, TileContext context = TCX_NOR
 
 /**
  * Get the base pylon sprite to use.
+ * @param tile The tile to get the pylon sprite for.
+ * @param context The context to get the sprite for.
+ * @return The pylon sprite.
  */
 static inline SpriteID GetPylonBase(TileIndex tile, TileContext context = TCX_NORMAL)
 {
@@ -572,6 +581,7 @@ void DrawRailCatenary(const TileInfo *ti)
 	DrawRailCatenaryRailway(ti);
 }
 
+/** Callback for changes to the electrified rails setting. @copydoc IntSettingDesc::PostChangeCallback */
 void SettingsDisableElrail(int32_t new_value)
 {
 	bool disable = (new_value != 0);

--- a/src/elrail_func.h
+++ b/src/elrail_func.h
@@ -15,8 +15,9 @@
 #include "transparency.h"
 
 /**
- * Test if a rail type has catenary
- * @param rt Rail type to test
+ * Test if a rail type has catenary.
+ * @param rt Rail type to test.
+ * @return \c true iff the rail type has catenary.
  */
 inline bool HasRailCatenary(RailType rt)
 {
@@ -24,8 +25,9 @@ inline bool HasRailCatenary(RailType rt)
 }
 
 /**
- * Test if we should draw rail catenary
- * @param rt Rail type to test
+ * Test if we should draw rail catenary.
+ * @param rt Rail type to test.
+ * @return \c true iff catenary should be drawn for this rail type.
  */
 inline bool HasRailCatenaryDrawn(RailType rt)
 {
@@ -36,7 +38,7 @@ void DrawRailCatenary(const TileInfo *ti);
 void DrawRailCatenaryOnTunnel(const TileInfo *ti);
 void DrawRailCatenaryOnBridge(const TileInfo *ti);
 
-void SettingsDisableElrail(int32_t new_value); ///< _settings_game.disable_elrail callback
+void SettingsDisableElrail(int32_t new_value);
 void UpdateDisableElrailSettingState(bool disable, bool update_vehicles);
 
 #endif /* ELRAIL_FUNC_H */

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -109,7 +109,12 @@ struct ShipVehicleInfo {
 	uint8_t ocean_speed_frac = 0; ///< Fraction of maximum speed for ocean tiles.
 	uint8_t canal_speed_frac = 0; ///< Fraction of maximum speed for canal/river tiles.
 
-	/** Apply ocean/canal speed fraction to a velocity */
+	/**
+	 * Apply ocean/canal speed fraction to a velocity.
+	 * @param raw_speed The original speed.
+	 * @param is_ocean Whether to apply the ocean or canal/river speed fraction.
+	 * @return The actual maximum speed of the ship.
+	 */
 	uint ApplyWaterClassSpeedFrac(uint raw_speed, bool is_ocean) const
 	{
 		/* speed_frac == 0 means no reduction while 0xFF means reduction to 1/256. */
@@ -235,7 +240,13 @@ enum class EngineNameContext : uint8_t {
 	AutoreplaceVehicleInUse = 0x22, ///< Name is show in the autoreplace window 'Vehicles in use' panel.
 };
 
-/** Combine an engine ID and a name context to an engine name dparam. */
+/**
+ * Combine an engine ID and a name context to an engine name StringParameter.
+ * @param engine_id The engine's ID.
+ * @param context The context for the name.
+ * @param extra_data Arbitrary extra data.
+ * @return The packed StringParameter.
+ */
 inline uint64_t PackEngineNameDParam(EngineID engine_id, EngineNameContext context, uint32_t extra_data = 0)
 {
 	return engine_id.base() | (static_cast<uint64_t>(context) << 32) | (static_cast<uint64_t>(extra_data) << 40);

--- a/src/error.h
+++ b/src/error.h
@@ -40,7 +40,10 @@ protected:
 public:
 	ErrorMessageData(EncodedString &&summary_msg, EncodedString &&detailed_msg, bool is_critical = false, int x = 0, int y = 0, EncodedString &&extra_msg = {}, CompanyID company = CompanyID::Invalid());
 
-	/** Check whether error window shall display a company manager face */
+	/**
+	 * Check whether error window shall display a company manager face.
+	 * @return \c true if the company of this error message is valid.
+	 */
 	bool HasFace() const { return company != CompanyID::Invalid(); }
 };
 

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -384,6 +384,11 @@ uint TarScanner::DoScan(Subdirectory sd)
 	return num;
 }
 
+/**
+ * Perform the scanning of content in the given modes.
+ * @param modes The modes to scan for.
+ * @return The number of found tar files.
+ */
 /* static */ uint TarScanner::DoScan(TarScanner::Modes modes)
 {
 	Debug(misc, 2, "Scanning for tars");
@@ -672,6 +677,7 @@ char *getcwd(char *buf, size_t size);
  * so when we crop the path to there, when can remove the name of the bundle
  * in the same way we remove the name from the executable name.
  * @param exe the path to the executable
+ * @return \c true iff the path to the executable was found.
  */
 static bool ChangeWorkingDirectoryToExecutable(std::string_view exe)
 {
@@ -1066,6 +1072,7 @@ static bool MatchesExtension(std::string_view extension, const std::string &file
  * @param path            full path we're currently at
  * @param basepath_length from where in the path are we 'based' on the search path
  * @param recursive       whether to recursively search the sub directories
+ * @return The number of files that have been found.
  */
 static uint ScanPath(FileScanner *fs, std::string_view extension, const std::filesystem::path &path, size_t basepath_length, bool recursive)
 {
@@ -1094,6 +1101,7 @@ static uint ScanPath(FileScanner *fs, std::string_view extension, const std::fil
  * @param fs        the file scanner to scan for
  * @param extension the extension of files to search for.
  * @param tar       the tar to search in.
+ * @return The number of files that have been found.
  */
 static uint ScanTar(FileScanner *fs, std::string_view extension, const TarFileList::value_type &tar)
 {

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -125,6 +125,7 @@ const FiosItem *FileList::FindItem(std::string_view file)
 
 /**
  * Get the current path/working directory.
+ * @return The current path.
  */
 std::string FiosGetCurrentPath()
 {

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -152,6 +152,7 @@ void SetFont(FontSize fontsize, const std::string &font, uint size)
 
 /**
  * Test if a font setting uses the default font.
+ * @param setting The setting to consider.
  * @return true iff the font is not configured and no fallback font data is present.
  */
 static bool IsDefaultFont(const FontCacheSubSetting &setting)

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -137,6 +137,7 @@ public:
 
 	/**
 	 * Check whether the font cache has a parent.
+	 * @return \c true iff this font has a parent, i.e. is not the root.
 	 */
 	inline bool HasParent()
 	{
@@ -145,18 +146,29 @@ public:
 
 	/**
 	 * Is this a built-in sprite font?
+	 * @return \c true iff the font is the sprite font.
 	 */
 	virtual bool IsBuiltInFont() = 0;
 };
 
-/** Get the Sprite for a glyph */
+/**
+ * Get the Sprite for a glyph
+ * @param size The font size to look in.
+ * @param key The key to look up.
+ * @return The sprite.
+ */
 inline const Sprite *GetGlyph(FontSize size, char32_t key)
 {
 	FontCache *fc = FontCache::Get(size);
 	return fc->GetGlyph(fc->MapCharToGlyph(key));
 }
 
-/** Get the width of a glyph */
+/**
+ * Get the width of a glyph.
+ * @param size The font size to look in.
+ * @param key The key to look up.
+ * @return The sprite's width.
+ */
 inline uint GetGlyphWidth(FontSize size, char32_t key)
 {
 	FontCache *fc = FontCache::Get(size);

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -81,7 +81,11 @@ namespace {
 		 */
 		explicit PerformanceData(double expected_rate) : expected_rate(expected_rate) { }
 
-		/** Collect a complete measurement, given start and ending times for a processing block */
+		/**
+		 * Collect a complete measurement, given start and ending times for a processing block.
+		 * @param start_time The start of the measurement.
+		 * @param end_time The end of the measurement.
+		 */
 		void Add(TimingMeasurement start_time, TimingMeasurement end_time)
 		{
 			this->durations[this->next_index] = end_time - start_time;
@@ -92,7 +96,10 @@ namespace {
 			this->num_valid = std::min(NUM_FRAMERATE_POINTS, this->num_valid + 1);
 		}
 
-		/** Begin an accumulation of multiple measurements into a single value, from a given start time */
+		/**
+		 * Begin an accumulation of multiple measurements into a single value, from a given start time.
+		 * @param start_time The start of the measurement.
+		 */
 		void BeginAccumulate(TimingMeasurement start_time)
 		{
 			this->timestamps[this->next_index] = this->acc_timestamp;
@@ -106,13 +113,19 @@ namespace {
 			this->acc_timestamp = start_time;
 		}
 
-		/** Accumulate a period onto the current measurement */
+		/**
+		 * Accumulate a period onto the current measurement.
+		 * @param duration The duration to add.
+		 */
 		void AddAccumulate(TimingMeasurement duration)
 		{
 			this->acc_duration += duration;
 		}
 
-		/** Indicate a pause/expected discontinuity in processing the element */
+		/**
+		 * Indicate a pause/expected discontinuity in processing the element.
+		 * @param start_time The start of the pause..
+		 */
 		void AddPause(TimingMeasurement start_time)
 		{
 			if (this->durations[this->prev_index] != INVALID_DURATION) {
@@ -125,7 +138,11 @@ namespace {
 			}
 		}
 
-		/** Get average cycle processing time over a number of data points */
+		/**
+		 * Get average cycle processing time over a number of data points.
+		 * @param count The number of cycles to process.
+		 * @return The average in milliseconds.
+		 */
 		double GetAverageDurationMilliseconds(int count)
 		{
 			count = std::min(count, this->num_valid);
@@ -149,7 +166,10 @@ namespace {
 			return sumtime * 1000 / count / TIMESTAMP_PRECISION;
 		}
 
-		/** Get current rate of a performance element, based on approximately the past one second of data */
+		/**
+		 * Get current rate of a performance element, based on approximately the past one second of data.
+		 * @return The recent rate of the performance element.
+		 */
 		double GetRate()
 		{
 			/* Start at last recorded point, end at latest when reaching the earliest recorded point */
@@ -232,6 +252,7 @@ namespace {
  * Return a timestamp with \c TIMESTAMP_PRECISION ticks per second precision.
  * The basis of the timestamp is implementation defined, but the value should be steady,
  * so differences can be taken to reliably measure intervals.
+ * @return The current 'time' for performance measurements.
  */
 static TimingMeasurement GetPerformanceTimer()
 {
@@ -281,13 +302,19 @@ PerformanceMeasurer::~PerformanceMeasurer()
 	_pf_data[this->elem].Add(this->start_time, GetPerformanceTimer());
 }
 
-/** Set the rate of expected cycles per second of a performance element. */
+/**
+ * Set the rate of expected cycles per second of a performance element.
+ * @param rate The new rate.
+ */
 void PerformanceMeasurer::SetExpectedRate(double rate)
 {
 	_pf_data[this->elem].expected_rate = rate;
 }
 
-/** Mark a performance element as not currently in use. */
+/**
+ * Mark a performance element as not currently in use.
+ * @param elem The element to set as unused.
+ */
 /* static */ void PerformanceMeasurer::SetInactive(PerformanceElement elem)
 {
 	_pf_data[elem].num_valid = 0;
@@ -559,7 +586,12 @@ struct FramerateWindow : Window {
 		}
 	}
 
-	/** Render a column of formatted average durations */
+	/**
+	 * Render a column of formatted average durations.
+	 * @param r The bounding box to draw in.
+	 * @param heading_str The header of the column.
+	 * @param values The values to draw.
+	 */
 	void DrawElementTimesColumn(const Rect &r, StringID heading_str, std::span<const CachedDecimal> values) const
 	{
 		const Scrollbar *sb = this->GetScrollbar(WID_FRW_SCROLLBAR);
@@ -847,7 +879,15 @@ struct FrametimeGraphWindow : Window {
 		this->SetDirty();
 	}
 
-	/** Scale and interpolate a value from a source range into a destination range */
+	/**
+	 * Scale and interpolate a value from a source range into a destination range.
+	 * @param dst_min The minimum value in the destination range.
+	 * @param dst_max The maximum value in the destination range.
+	 * @param src_min The minimum value in the source range.
+	 * @param src_max The maximum value in the source range.
+	 * @param value The value to process.
+	 * @return The rescaled value.
+	 */
 	template <typename T>
 	static inline T Scinterlate(T dst_min, T dst_max, T src_min, T src_max, T value)
 	{
@@ -988,7 +1028,10 @@ void ShowFramerateWindow()
 	AllocateWindowDescFront<FramerateWindow>(_framerate_display_desc, 0);
 }
 
-/** Open a graph window for a performance element */
+/**
+ * Open a graph window for a performance element.
+ * @param elem The element to show the graph for.
+ */
 void ShowFrametimeGraphWindow(PerformanceElement elem)
 {
 	if (elem < PFE_FIRST || elem >= PFE_MAX) return; // maybe warn?

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -172,9 +172,9 @@ struct IntSettingDesc : SettingDesc {
 	using PreChangeCheck = bool(int32_t &value);
 	/**
 	 * A callback to denote that a setting has been changed.
-	 * @param The new value for the setting.
+	 * @param new_value The new value for the setting.
 	 */
-	using PostChangeCallback = void(int32_t value);
+	using PostChangeCallback = void(int32_t new_value);
 
 	template <ConvertibleThroughBaseOrUnderlyingOrTo<int32_t> Tdef, ConvertibleThroughBaseOrUnderlyingOrTo<int32_t> Tmin, ConvertibleThroughBaseOrUnderlyingOrTo<uint32_t> Tmax, ConvertibleThroughBaseOrUnderlyingOrTo<int32_t> Tinterval>
 	IntSettingDesc(const SaveLoad &save, SettingFlags flags, bool startup, Tdef def,


### PR DESCRIPTION
## Motivation / Problem

Lots of doxygen warnings.


## Description

Add some missing `@param` and `@return` lines to functions that already have documentation, but are missing bits.

Renamed `value` to `new_value` for the `PostChangeCallback` as that's more in line with the implementation of that callback and the documentation of the callback.


## Limitations

Plenty more warnings to tackle.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
