### PR TITLE
Codechange: add missing @param and @return for kdtree

### DIFF
--- a/src/core/kdtree.hpp
+++ b/src/core/kdtree.hpp
@@ -48,7 +48,11 @@ class Kdtree {
 	size_t root;                   ///< Index of root node
 	size_t unbalanced;             ///< Number approximating how unbalanced the tree might be
 
-	/** Create one new node in the tree, return its index in the pool */
+	/**
+	 * Create one new node in the tree
+	 * @param element The element to add.
+	 * @return The element's index in the pool.
+	 */
 	size_t AddNode(const T &element)
 	{
 		if (this->free_list.empty()) {
@@ -62,7 +66,13 @@ class Kdtree {
 		}
 	}
 
-	/** Find a coordinate value to split a range of elements at */
+	/**
+	 * Find a coordinate value to split a range of elements at.
+	 * @param begin The begin of the range to consider.
+	 * @param end The end of the range to consider.
+	 * @param level The depth into the tree.
+	 * @return The coordinate to split at.
+	 */
 	template <typename It>
 	CoordT SelectSplitCoord(It begin, It end, int level)
 	{
@@ -71,7 +81,13 @@ class Kdtree {
 		return TxyFunc()(*mid, level % 2);
 	}
 
-	/** Construct a subtree from elements between begin and end iterators, return index of root */
+	/**
+	 * Construct a subtree from elements between begin and end iterators.
+	 * @param begin The begin of the range to consider.
+	 * @param end The end of the range to consider.
+	 * @param level The depth into the tree.
+	 * @return The index of root.
+	 */
 	template <typename It>
 	size_t BuildSubtree(It begin, It end, int level)
 	{
@@ -93,7 +109,12 @@ class Kdtree {
 		}
 	}
 
-	/** Rebuild the tree with all existing elements, optionally adding or removing one more */
+	/**
+	 * Rebuild the tree with all existing elements, optionally adding or removing one more.
+	 * @param include_element Element to add to the tree, if not \c nullptr.
+	 * @param exclude_element Element to remove from the tree, if not \c nullptr.
+	 * @return \c true iff the tree is still considered balanced.
+	 */
 	bool Rebuild(const T *include_element, const T *exclude_element)
 	{
 		size_t initial_count = this->Count();
@@ -118,7 +139,12 @@ class Kdtree {
 		return true;
 	}
 
-	/** Insert one element in the tree somewhere below node_idx */
+	/**
+	 * Insert one element in the tree somewhere below node_idx.
+	 * @param element The element to insert.
+	 * @param node_idx The root of the sub-tree to try to insert to.
+	 * @param level The current depth in the tree.
+	 */
 	void InsertRecursive(const T &element, size_t node_idx, int level)
 	{
 		/* Dimension index of current level */
@@ -145,7 +171,8 @@ class Kdtree {
 	}
 
 	/**
-	 * Free all children of the given node
+	 * Free all children of the given node.
+	 * @param node_idx The root node.
 	 * @return Collection of elements that were removed from tree.
 	 */
 	std::vector<T> FreeSubtree(size_t node_idx)
@@ -225,7 +252,12 @@ class Kdtree {
 
 	/** A data element and its distance to a searched-for point */
 	using node_distance = std::pair<T, DistT>;
-	/** Ordering function for node_distance objects, elements with equal distance are ordered by less-than comparison */
+	/**
+	 * Ordering function for node_distance objects, elements with equal distance are ordered by less-than comparison.
+	 * @param a The first distance to compare.
+	 * @param b The second distance to compare.
+	 * @return The nearest distance.
+	 */
 	static node_distance SelectNearestNodeDistance(const node_distance &a, const node_distance &b)
 	{
 		if (a.second < b.second) return a;
@@ -234,7 +266,14 @@ class Kdtree {
 		if (b.first < a.first) return b;
 		NOT_REACHED(); // a.first == b.first: same element must not be inserted twice
 	}
-	/** Search a sub-tree for the element nearest to a given point */
+	/**
+	 * Search a sub-tree for the element nearest to a given point.
+	 * @param xy The coordinate to start from.
+	 * @param node_idx The root node to start from.
+	 * @param level The current search level.
+	 * @param limit Distance to limit searching at.
+	 * @return The distance to the nearest element.
+	 */
 	node_distance FindNearestRecursive(CoordT xy[2], size_t node_idx, int level, DistT limit = std::numeric_limits<DistT>::max()) const
 	{
 		/* Dimension index of current level */
@@ -292,7 +331,12 @@ class Kdtree {
 		if (p2[dim] > ec && n.right != INVALID_NODE) this->FindContainedRecursive(p1, p2, n.right, level + 1, outputter);
 	}
 
-	/** Debugging function, counts number of occurrences of an element regardless of its correct position in the tree */
+	/**
+	 * Debugging function, counts number of occurrences of an element regardless of its correct position in the tree.
+	 * @param element The element to look for.
+	 * @param node_idx The root to start searching from.
+	 * @return The number of occurences.
+	 */
 	size_t CountValue(const T &element, size_t node_idx) const
 	{
 		if (node_idx == INVALID_NODE) return 0;
@@ -305,7 +349,10 @@ class Kdtree {
 		this->unbalanced += amount;
 	}
 
-	/** Check if the entire tree is in need of rebuilding */
+	/**
+	 * Check if the entire tree is in need of rebuilding.
+	 * @return \c true iff the tree should be rebalanced.
+	 */
 	bool IsUnbalanced() const
 	{
 		size_t count = this->Count();
@@ -313,7 +360,15 @@ class Kdtree {
 		return this->unbalanced > count / 4;
 	}
 
-	/** Verify that the invariant is true for a sub-tree, assert if not */
+	/**
+	 * Verify that the invariant is true for a sub-tree, assert if not.
+	 * @param node_idx The root of the sub-tree.
+	 * @param level The current level in the tree.
+	 * @param min_x The expected minimum X-coordinate.
+	 * @param max_x The expected maximum X-coordinate.
+	 * @param min_y The expected minimum Y-coordinate.
+	 * @param max_y The expected maximum Y-coordinate.
+	 */
 	void CheckInvariant(size_t node_idx, int level, CoordT min_x, CoordT max_x, CoordT min_y, CoordT max_y) const
 	{
 		if (node_idx == INVALID_NODE) return;
@@ -392,6 +447,7 @@ public:
 	 * Insert a single element in the tree.
 	 * Repeatedly inserting single elements may cause the tree to become unbalanced.
 	 * Undefined behaviour if the element already exists in the tree.
+	 * @param element The elemnt to add.
 	 */
 	void Insert(const T &element)
 	{
@@ -411,6 +467,7 @@ public:
 	 * Since elements are stored in interior nodes as well as leaf nodes, removing one may
 	 * require a larger sub-tree to be re-built. Because of this, worst case run time is
 	 * as bad as a full tree rebuild.
+	 * @param element The element to remove.
 	 */
 	void Remove(const T &element)
 	{
@@ -424,7 +481,10 @@ public:
 		this->CheckInvariant();
 	}
 
-	/** Get number of elements stored in tree */
+	/**
+	 * Get number of elements stored in tree.
+	 * @return The element count.
+	 */
 	size_t Count() const
 	{
 		assert(this->free_list.size() <= this->nodes.size());
@@ -435,6 +495,9 @@ public:
 	 * Find the element closest to given coordinate, in Manhattan distance.
 	 * For multiple elements with the same distance, the one comparing smaller with
 	 * a less-than comparison is chosen.
+	 * @param x The X-coordinate.
+	 * @param y The Y-coordinate.
+	 * @return The nearest element.
 	 */
 	T FindNearest(CoordT x, CoordT y) const
 	{
@@ -446,7 +509,7 @@ public:
 
 	/**
 	 * Find all items contained within the given rectangle.
-	 * @note Start coordinates are inclusive, end coordinates are exclusive. x1<x2 && y1<y2 is a precondition.
+	 * @note Start coordinates are inclusive, end coordinates are exclusive. x1 < x2 && y1 < y2 is a precondition.
 	 * @param x1 Start first coordinate, points found are greater or equals to this.
 	 * @param y1 Start second coordinate, points found are greater or equals to this.
 	 * @param x2 End first coordinate, points found are less than this.
@@ -468,7 +531,12 @@ public:
 
 	/**
 	 * Find all items contained within the given rectangle.
-	 * @note End coordinates are exclusive, x1<x2 && y1<y2 is a precondition.
+	 * @note End coordinates are exclusive, x1 < x2 && y1 < y2 is a precondition.
+	 * @param x1 Start first coordinate, points found are greater or equals to this.
+	 * @param y1 Start second coordinate, points found are greater or equals to this.
+	 * @param x2 End first coordinate, points found are less than this.
+	 * @param y2 End second coordinate, points found are less than this.
+	 * @return The result of the search.
 	 */
 	std::vector<T> FindContained(CoordT x1, CoordT y1, CoordT x2, CoordT y2) const
 	{


### PR DESCRIPTION
## Motivation / Problem

Lots of missing doxygen.


## Description

Add missing `@param`s and `@return`s for the kdtree code.


## Limitations

There are still a few thousand more warnings.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
