### PR TITLE
Fix 67ab3108: Gamescript custom names limited by random name generator

### DIFF
--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -304,12 +304,11 @@
 	}
 
 	std::string text;
+	uint32_t townnameparts = 0;
 	if (name != nullptr) {
 		text = name->GetDecodedText();
 		EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_TOWN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
-	}
-	uint32_t townnameparts;
-	if (!GenerateTownName(ScriptObject::GetRandomizer(), &townnameparts)) {
+	} else if (!GenerateTownName(ScriptObject::GetRandomizer(), &townnameparts)) {
 		ScriptObject::SetLastError(ScriptError::ERR_NAME_IS_NOT_UNIQUE);
 		return false;
 	}


### PR DESCRIPTION
Fix 67ab3108: Gamescript custom names limited by random name generator
Allow towns to be generated with custom names independently of the number of random names available.


## Motivation / Problem

If a game has used all available random names and a gamescript tries to create a new town with a custom name it will fail as the unique random name code is always executed. Seems to have been present since the function was first introduced, however can't find any issue reported relating to this.


## Description

Modify the gamescript town file and make the custom name and random name logic mutually exclusive. Default random name seed to 0, tested to ensure save and load game unaffected.

Tested with French name generation limited to 70 unique values and very basic gamescript

```
	GSLog.Info("Gamescript starting...");
	
	
	local tile = GSMap.GetTileIndex(GSMap.GetMapSizeX() / 2, GSMap.GetMapSizeY() / 2);
	GSLog.Info("Attempt to create town at tile: " + tile);
	
	local r = GSTown.FoundTown(tile,GSTown.TOWN_SIZE_LARGE,true,GSTown.ROAD_LAYOUT_RANDOM,"Utopia");
	
	GSLog.Info("Town generation result: " + r);
```

Here's before fix and after fix screenshots;

Before:
<img width="2460" height="831" alt="image" src="https://github.com/user-attachments/assets/86ecd06c-2623-48b7-a64e-033f8f9f0daf" />

After:
<img width="2329" height="592" alt="Screenshot 2026-02-16 163951" src="https://github.com/user-attachments/assets/081a811b-cd05-423b-b81c-5e9239490e70" />


## Limitations

Not aware of any.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
