### PR TITLE
Codechange: add missing parameter/return documentation to NewGRF code

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -121,7 +121,10 @@ static GRFFile *GetFileByFilename(const std::string &filename)
 	return nullptr;
 }
 
-/** Reset all NewGRFData that was used only while processing data */
+/**
+ * Reset all NewGRFData that was used only while processing data.
+ * @param gf The file to reset the data for.
+ */
 static void ClearTemporaryNewGRFData(GRFFile *gf)
 {
 	gf->labels.clear();
@@ -312,6 +315,8 @@ EngineID GetNewEngineID(const GRFFile *file, VehicleType type, uint16_t internal
 
 /**
  * Translate the refit mask. refit_mask is uint32_t as it has not been mapped to CargoTypes.
+ * @param refit_mask The bitmask to convert.
+ * @return The converted CargoTypes.
  */
 CargoTypes TranslateRefitMask(uint32_t refit_mask)
 {

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -166,7 +166,11 @@ struct GRFFile {
 	GRFFile(GRFFile &&other);
 	~GRFFile();
 
-	/** Get GRF Parameter with range checking */
+	/**
+	 * Get GRF Parameter with range checking.
+	 * @param number The parameter number/index.
+	 * @return The parameter, or \c 0 when the number is out of bounds.
+	 */
 	uint32_t GetParam(uint number) const
 	{
 		/* Note: We implicitly test for number < this->param.size() and return 0 for invalid parameters.

--- a/src/newgrf/newgrf_act10.cpp
+++ b/src/newgrf/newgrf_act10.cpp
@@ -14,7 +14,10 @@
 
 #include "../safeguards.h"
 
-/** Action 0x10 - Define goto label */
+/**
+ * Action 0x10 - Define goto label.
+ * @param buf Reader of the NewGRF.
+ */
 static void DefineGotoLabel(ByteReader &buf)
 {
 	/* <10> <label> [<comment>]

--- a/src/newgrf/newgrf_act12.cpp
+++ b/src/newgrf/newgrf_act12.cpp
@@ -16,7 +16,10 @@
 
 #include "../safeguards.h"
 
-/** Action 0x12 */
+/**
+ * Action 0x12 - Define fonts.
+ * @param buf Reader of the NewGRF.
+ */
 static void LoadFontGlyph(ByteReader &buf)
 {
 	/* <12> <num_def> <font_size> <num_char> <base_char>
@@ -47,7 +50,10 @@ static void LoadFontGlyph(ByteReader &buf)
 	}
 }
 
-/** Action 0x12 (SKIP) */
+/**
+ * Action 0x12 (SKIP).
+ * @param buf Reader of the NewGRF.
+ */
 static void SkipAct12(ByteReader &buf)
 {
 	/* <12> <num_def> <font_size> <num_char> <base_char>

--- a/src/newgrf/newgrf_act13.cpp
+++ b/src/newgrf/newgrf_act13.cpp
@@ -18,7 +18,10 @@
 
 #include "../safeguards.h"
 
-/** Action 0x13 */
+/**
+ * Action 0x13 - Load translation.
+ * @param buf Reader of the NewGRF.
+ */
 static void TranslateGRFStrings(ByteReader &buf)
 {
 	/* <13> <grfid> <num-ent> <offset> <text...>

--- a/src/newgrf/newgrf_act3.cpp
+++ b/src/newgrf/newgrf_act3.cpp
@@ -173,8 +173,13 @@ struct MapSpriteGroupHandler {
 	virtual void MapDefault(uint16_t local_id, const SpriteGroup *group) = 0;
 };
 
-/** Specializable function to retrieve a NewGRF spec of a particular type. */
-template <typename T> static auto *GetSpec(GRFFile *, uint16_t);
+/**
+ * Specializable function to retrieve a NewGRF spec of a particular type.
+ * @param grffile The NewGRF the spec belongs to.
+ * @param local_id The local id of the spec to retrieve.
+ * @return The retrieved spec.
+ */
+template <typename T> static auto *GetSpec(GRFFile *grffile, uint16_t local_id);
 
 /** Common handler for mapping sprite groups for features which only support "Purchase" and "Default" sprites. */
 template <typename T>

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -178,7 +178,10 @@ static uint32_t PerformGRM(std::span<uint32_t> grm, uint16_t count, uint8_t op, 
 	return UINT_MAX;
 }
 
-/** Action 0x0D: Set parameter */
+/**
+ * Action 0x0D - Set parameter.
+ * @param buf Reader of the NewGRF.
+ */
 static void ParamSet(ByteReader &buf)
 {
 	/* <0D> <target> <operation> <source1> <source2> [<data>]

--- a/src/newgrf/newgrf_actf.cpp
+++ b/src/newgrf/newgrf_actf.cpp
@@ -17,7 +17,10 @@
 
 #include "../safeguards.h"
 
-/** Action 0x0F - Define Town names */
+/**
+ * Action 0x0F - Define Town names.
+ * @param buf Reader of the NewGRF.
+ */
 static void FeatureTownName(ByteReader &buf)
 {
 	/* <0F> <id> <style-name> <num-parts> <parts>

--- a/src/newgrf/newgrf_bytereader.cpp
+++ b/src/newgrf/newgrf_bytereader.cpp
@@ -15,6 +15,7 @@
 
 /**
  * Read a value of the given number of bytes.
+ * @param size Number of bytes to read; must be 1, 2 or 4.
  * @returns Value read from buffer.
  */
 uint32_t ByteReader::ReadVarSize(uint8_t size)

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -82,7 +82,10 @@ AirportSpec AirportSpec::specs[NUM_AIRPORTS]; ///< Airport specifications.
 	return &AirportSpec::specs[type];
 }
 
-/** Check whether this airport is available to build. */
+/**
+ * Check whether this airport is available to build.
+ * @return \c true iff the airport is available.
+ */
 bool AirportSpec::IsAvailable() const
 {
 	if (!this->enabled) return false;

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -58,7 +58,10 @@ public:
 		return *this;
 	}
 
-	/** Get the StationGfx for the current tile. */
+	/**
+	 * Get the StationGfx for the current tile.
+	 * @return The identifier of the graphics for this tile.
+	 */
 	StationGfx GetStationGfx() const
 	{
 		return this->iter->gfx;
@@ -133,7 +136,10 @@ struct AirportSpec : NewGRFSpecBase<AirportClassID> {
 
 	static void ResetAirports();
 
-	/** Get the index of this spec. */
+	/**
+	 * Get the index of this spec.
+	 * @return The offset in the specs table.
+	 */
 	uint8_t GetIndex() const
 	{
 		assert(this >= std::begin(specs) && this < std::end(specs));

--- a/src/newgrf_badge.cpp
+++ b/src/newgrf_badge.cpp
@@ -232,6 +232,8 @@ uint32_t GetBadgeVariableResult(const GRFFile &grffile, std::span<const BadgeID>
 
 /**
  * Mark a badge a seen (used) by a feature.
+ * @param index The badge's identifier.
+ * @param feature The feature the badge is used for.
  */
 void MarkBadgeSeen(BadgeID index, GrfSpecFeature feature)
 {

--- a/src/newgrf_badge.h
+++ b/src/newgrf_badge.h
@@ -64,7 +64,7 @@ Badge *GetBadgeByLabel(std::string_view label);
 Badge *GetClassBadge(BadgeClassID class_index);
 std::span<const BadgeID> GetClassBadges();
 
-uint32_t GetBadgeVariableResult(const struct GRFFile &grffile, std::span<const BadgeID> badges, uint32_t parameter);
+uint32_t GetBadgeVariableResult(const GRFFile &grffile, std::span<const BadgeID> badges, uint32_t parameter);
 
 PalSpriteID GetBadgeSprite(const Badge &badge, GrfSpecFeature feature, std::optional<TimerGameCalendar::Date> introduction_date, PaletteID remap);
 

--- a/src/newgrf_badge_config.cpp
+++ b/src/newgrf_badge_config.cpp
@@ -61,6 +61,7 @@ static BadgeClassConfig _badge_config;
 
 /**
  * Get the badge user configuration for a feature.
+ * @param feature The feature to load the configuration for.
  * @returns badge configuration for the given feature.
  */
 std::span<BadgeClassConfigItem> GetBadgeClassConfiguration(GrfSpecFeature feature)

--- a/src/newgrf_class.h
+++ b/src/newgrf_class.h
@@ -66,14 +66,26 @@ public:
 	void Insert(Tspec *spec);
 
 	Tindex Index() const { return this->index; }
-	/** Get the number of allocated specs within the class. */
+
+	/**
+	 * Get the number of allocated specs within the class.
+	 * @return Number of specs.
+	 */
 	uint GetSpecCount() const { return static_cast<uint>(this->spec.size()); }
-	/** Get the number of potentially user-available specs within the class. */
+
+	/**
+	 * Get the number of potentially user-available specs within the class.
+	 * @return Number of specs for which can be available for the end user.
+	 */
 	uint GetUISpecCount() const { return this->ui_count; }
 
 	const Tspec *GetSpec(uint index) const;
 
-	/** Check whether the spec will be available to the user at some point in time. */
+	/**
+	 * Check whether the spec will be available to the user at some point in time.
+	 * @param index The index into the spec table.
+	 * @return \c true iff it can be available for the end user.
+	 */
 	bool IsUIAvailable(uint index) const;
 
 	static void Reset();

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -77,6 +77,7 @@ void NewGRFClass<Tspec, Tindex, Tmax>::Assign(Tspec *spec)
  * Get a particular class.
  * @param class_index The index of the class.
  * @pre class_index < Tmax
+ * @return Pointer to the class.
  */
 template <typename Tspec, typename Tindex, Tindex Tmax>
 NewGRFClass<Tspec, Tindex, Tmax> *NewGRFClass<Tspec, Tindex, Tmax>::Get(Tindex class_index)

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -144,7 +144,10 @@ class SpriteLayoutProcessor {
 public:
 	SpriteLayoutProcessor() = default;
 
-	/** Constructor for spritelayout, which do not need preprocessing. */
+	/**
+	 * Constructor for spritelayout, which do not need preprocessing.
+	 * @param raw_layout The raw sprite layout.
+	 */
 	SpriteLayoutProcessor(const NewGRFSpriteLayout &raw_layout) : raw_layout(&raw_layout) {}
 
 	SpriteLayoutProcessor(const NewGRFSpriteLayout &raw_layout, uint32_t orig_offset, uint32_t newgrf_ground_offset, uint32_t newgrf_offset, uint constr_stage, bool separate_ground);
@@ -152,6 +155,7 @@ public:
 	/**
 	 * Get values for variable 10 to resolve sprites for.
 	 * NewStations only.
+	 * @return Iterator over the bits of Var10.
 	 */
 	SetBitIterator<uint8_t, uint32_t> Var10Values() const { return this->var10_values; }
 
@@ -383,6 +387,7 @@ struct StandardGRFFileProps : FixedGRFFileProps<StandardSpriteGroup, static_cast
 
 	/**
 	 * Check whether the entity has sprite groups.
+	 * @return \c true iff this has a default sprite group.
 	 */
 	bool HasSpriteGroups() const
 	{
@@ -392,6 +397,7 @@ struct StandardGRFFileProps : FixedGRFFileProps<StandardSpriteGroup, static_cast
 	/**
 	 * Get the standard sprite group.
 	 * @param entity_exists Whether the entity exists (true), or is being constructed or shown in the GUI (false).
+	 * @return The purchase sprite group if \c entity_exists is \c true and it exists, otherwise the default sprite group or \c nullptr.
 	 */
 	const struct SpriteGroup *GetSpriteGroup(bool entity_exists) const
 	{
@@ -464,11 +470,14 @@ struct CargoGRFFileProps : VariableGRFFileProps<CargoType> {
  * NewGRF entities which can replace default entities.
  */
 struct SubstituteGRFFileProps : StandardGRFFileProps {
-	/** Set all default data constructor for the props. */
+	/**
+	 * Set all default data constructor for the props.
+	 * @param subst_id The id of the entity to replace.
+	 */
 	constexpr SubstituteGRFFileProps(uint16_t subst_id = 0) : subst_id(subst_id), override_id(subst_id) {}
 
-	uint16_t subst_id;
-	uint16_t override_id; ///< id of the entity been replaced by
+	uint16_t subst_id; ///< The id of the entity to replace.
+	uint16_t override_id; ///< The id of the entity been replaced by.
 };
 
 /** Container for a label for rail or road type conversion. */

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -62,6 +62,8 @@ void GRFConfig::SetParams(std::span<const uint32_t> pars)
 
 /**
  * Return whether this NewGRF can replace an older version of the same NewGRF.
+ * @param old_version The older version of the NewGRF (savegame loading).
+ * @return Whether the NewGRF says that this version can be loaded for games with the old version.
  */
 bool GRFConfig::IsCompatible(uint32_t old_version) const
 {
@@ -212,7 +214,7 @@ void GRFParameterInfo::Finalize()
  * Update the palettes of the graphics from the config file.
  * Called when changing the default palette in advanced settings.
  */
-void UpdateNewGRFConfigPalette(int32_t)
+void UpdateNewGRFConfigPalette()
 {
 	for (const auto &c : _grfconfig_newgame) c->SetSuitablePalette();
 	for (const auto &c : _grfconfig_static ) c->SetSuitablePalette();
@@ -403,7 +405,10 @@ void AppendToGRFConfigList(GRFConfigList &dst, std::unique_ptr<GRFConfig> &&el)
 }
 
 
-/** Reset the current GRF Config to either blank or newgame settings. */
+/**
+ * Reset the current GRF Config to either blank or newgame settings.
+ * @param defaults Whether configure to fully load the copied NewGRFs.
+ */
 void ResetGRFConfig(bool defaults)
 {
 	CopyGRFConfigList(_grfconfig, _grfconfig_newgame, !defaults);
@@ -493,7 +498,10 @@ public:
 
 	bool AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename) override;
 
-	/** Do the scan for GRFs. */
+	/**
+	 * Do the scan for GRFs.
+	 * @return The number of GRFs that have been found.
+	 */
 	static uint DoScan()
 	{
 		if (_skip_all_newgrf_scanning > 0) {
@@ -624,7 +632,11 @@ GRFConfig *GetGRFConfig(uint32_t grfid, uint32_t mask)
 }
 
 
-/** Build a string containing space separated parameter values, and terminate */
+/**
+ * Build a string containing space separated parameter values.
+ * @param c The GRFConfig to create the parameter list for.
+ * @return The parameter list.
+ */
 std::string GRFBuildParamList(const GRFConfig &c)
 {
 	std::string result;

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -245,6 +245,6 @@ void ShowNewGRFSettings(bool editable, bool show_params, bool exec_changes, GRFC
 void OpenGRFParameterWindow(bool is_baseset, GRFConfig &c, bool editable);
 
 void UpdateNewGRFScanStatus(uint num, std::string &&name);
-void UpdateNewGRFConfigPalette(int32_t new_value = 0);
+void UpdateNewGRFConfigPalette();
 
 #endif /* NEWGRF_CONFIG_H */

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -293,6 +293,7 @@ struct NewGRFInspectWindow : Window {
 
 	/**
 	 * Check whether this feature has chain index, i.e. refers to ground vehicles.
+	 * @return \c true iff the feature can have a chain of elements.
 	 */
 	bool HasChainIndex() const
 	{

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -129,6 +129,8 @@ enum TTDPAircraftMovementStates : uint8_t {
 /**
  * Map OTTD aircraft movement states to TTDPatch style movement states
  * (VarAction 2 Variable 0xE2)
+ * @param v The aircraft to consider.
+ * @return The TTDP movement state.
  */
 static uint8_t MapAircraftMovementState(const Aircraft *v)
 {
@@ -256,6 +258,8 @@ enum TTDPAircraftMovementActions : uint8_t {
  * Map OTTD aircraft movement states to TTDPatch style movement actions
  * (VarAction 2 Variable 0xE6)
  * This is not fully supported yet but it's enough for Planeset.
+ * @param v The aircraft to consider.
+ * @return The TTDP movement action.
  */
 static uint8_t MapAircraftMovementAction(const Aircraft *v)
 {

--- a/src/newgrf_generic.h
+++ b/src/newgrf_generic.h
@@ -50,7 +50,10 @@ void AddGenericCallback(GrfSpecFeature feature, const GRFFile *file, const Sprit
 std::pair<const GRFFile *, uint16_t> GetAiPurchaseCallbackResult(GrfSpecFeature feature, CargoType cargo_type, uint8_t default_selection, IndustryType src_industry, IndustryType dst_industry, uint8_t distance, AIConstructionEvent event, uint8_t count, uint8_t station_size);
 void AmbientSoundEffectCallback(TileIndex tile);
 
-/** Play an ambient sound effect for an empty tile. */
+/**
+ * Play an ambient sound effect for an empty tile.
+ * @param tile The tile to play the sound at.
+ */
 inline void AmbientSoundEffect(TileIndex tile)
 {
 	/* Only run callback if enabled. */

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1401,7 +1401,7 @@ private:
 		return a->ident.md5sum < b->ident.md5sum;
 	}
 
-	/** Filter grfs by tags/name */
+	/** Filter grfs by tags/name. @copydoc GUIList::FilterFunction */
 	static bool TagNameFilter(const GRFConfig * const *a, StringFilter &filter)
 	{
 		filter.ResetState();
@@ -1877,7 +1877,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_newgrf_infopanel_wid
 	EndContainer(),
 };
 
-/** Construct nested container widget for managing the lists and the info panel of the NewGRF GUI. */
+/** Construct nested container widget for managing the lists and the info panel of the NewGRF GUI. @copydoc NWidgetFunctionType */
 std::unique_ptr<NWidgetBase> NewGRFDisplay()
 {
 	std::unique_ptr<NWidgetBase> avs = MakeNWidgets(_nested_newgrf_availables_widgets, nullptr);

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -305,9 +305,6 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 	return 0;
 }
 
-/**
- * @note Used by the resolver to get values for feature 07 deterministic spritegroups.
- */
 /* virtual */ uint32_t HouseScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const
 {
 	if (this->tile == INVALID_TILE) {

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -50,6 +50,7 @@ uint32_t GetNearbyIndustryTileInformation(uint8_t parameter, TileIndex tile, Ind
  * YY        same, but stored in a byte instead of a nibble
  * @param tile TileIndex of the tile to evaluate
  * @param ind_tile northernmost tile of the industry
+ * @return The relative position.
  */
 uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 {

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -258,7 +258,6 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 	return Object::GetTypeCount(idx) << 16 | ClampTo<uint16_t>(GetClosestObject(tile, idx, current));
 }
 
-/** Used by the resolver to get values for feature 0F deterministic spritegroups. */
 /* virtual */ uint32_t ObjectScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const
 {
 	/* We get the town from the object, or we calculate the closest
@@ -573,6 +572,7 @@ static bool DoTriggerObjectTileAnimation(Object *o, TileIndex tile, ObjectAnimat
  * @param tile    The location of the triggered tile.
  * @param trigger The trigger that is triggered.
  * @param spec    The spec associated with the object.
+ * @return \c true iff the object has an animation trigger set.
  */
 bool TriggerObjectTileAnimation(Object *o, TileIndex tile, ObjectAnimationTrigger trigger, const ObjectSpec *spec)
 {
@@ -584,6 +584,7 @@ bool TriggerObjectTileAnimation(Object *o, TileIndex tile, ObjectAnimationTrigge
  * @param o       The object that got triggered.
  * @param trigger The trigger that is triggered.
  * @param spec    The spec associated with the object.
+ * @return \c true iff all tiles of the object had an animation trigger set.
  */
 bool TriggerObjectAnimation(Object *o, ObjectAnimationTrigger trigger, const ObjectSpec *spec)
 {

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -58,6 +58,7 @@ void NewGRFProfiler::BeginResolve(const ResolverObject &resolver)
 
 /**
  * Capture the completion of a sprite group resolution.
+ * @param result The result to process.
  */
 void NewGRFProfiler::EndResolve(const ResolverResult &result)
 {
@@ -183,6 +184,7 @@ static TimeoutTimer<TimerGameTick> _profiling_finish_timeout({ TimerGameTick::Pr
 
 /**
  * Start the timeout timer that will finish all profiling sessions.
+ * @param ticks The timemout in game ticks.
  */
 /* static */ void NewGRFProfiler::StartTimer(uint64_t ticks)
 {

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -357,7 +357,16 @@ std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadS
 	return group->ProcessRegisters(object, nullptr);
 }
 
-/** Wrapper for animation control, see GetRoadStopCallback. */
+/**
+ * Perform the road stop callback in the context of the AnimationBase callback.
+ * @param callback The identifier of the callback.
+ * @param param1 The first parameter of the NewGRF callback.
+ * @param param2 The second parameter of the NewGRF callback.
+ * @param roadstopspec The specification to run the callback on.
+ * @param st The station the road stop is part of.
+ * @param tile The tile the road stop is at.
+ * @return The NewGRF result of the callback.
+ */
 uint16_t GetAnimRoadStopCallback(CallbackID callback, uint32_t param1, uint32_t param2, const RoadStopSpec *roadstopspec, BaseStation *st, TileIndex tile, int)
 {
 	return GetRoadStopCallback(callback, param1, param2, roadstopspec, st, tile, INVALID_ROADTYPE, GetStationType(tile), GetStationGfx(tile));

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -145,12 +145,14 @@ struct RoadStopSpec : NewGRFSpecBase<RoadStopClassID> {
 
 	/**
 	 * Get the cost for building a road stop of this type.
+	 * @param category The specific category to get the cost for.
 	 * @return The cost for building.
 	 */
 	Money GetBuildCost(Price category) const { return GetPrice(category, this->build_cost_multiplier, this->grf_prop.grffile, -4); }
 
 	/**
 	 * Get the cost for clearing a road stop of this type.
+	 * @param category The specific category to get the cost for.
 	 * @return The cost for clearing.
 	 */
 	Money GetClearCost(Price category) const { return GetPrice(category, this->clear_cost_multiplier, this->grf_prop.grffile, -4); }

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -30,6 +30,9 @@
  * Special values for rr, tt, RR:
  * - 0xFF: Track not present on tile.
  * - 0xFE: Track present, but no matching entry in translation table.
+ * @param tile The tile to consider.
+ * @param grffile The NewGRF the types are for.
+ * @return The track types.
  */
 uint32_t GetTrackTypes(TileIndex tile, const GRFFile *grffile)
 {

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -427,6 +427,7 @@ public:
 
 	/**
 	 * Used by RandomizedSpriteGroup: Triggers for rerandomisation
+	 * @return The triggers waiting for randomisation.
 	 */
 	uint32_t GetWaitingRandomTriggers() const
 	{
@@ -435,6 +436,7 @@ public:
 
 	/**
 	 * Used by RandomizedSpriteGroup: Consume triggers.
+	 * @param triggers The triggers t0 set as having used random triggers.
 	 */
 	void AddUsedRandomTriggers(uint32_t triggers)
 	{
@@ -480,6 +482,7 @@ struct SpecializedResolverObject : public ResolverObject {
 	/**
 	 * Set waiting triggers for rerandomisation.
 	 * This is scope independent, even though this is broken-by-design in most cases.
+	 * @param triggers The triggers to set wating.
 	 */
 	void SetWaitingRandomTriggers(RandomTriggers triggers)
 	{
@@ -489,6 +492,7 @@ struct SpecializedResolverObject : public ResolverObject {
 	/**
 	 * Get the triggers, which were "consumed" by some rerandomisation.
 	 * This is scope independent, even though this is broken-by-design in most cases.
+	 * @return The triggers that have used random triggers.
 	 */
 	RandomTriggers GetUsedRandomTriggers() const
 	{

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -115,6 +115,13 @@ TileArea GetRailTileArea(const BaseStation *st, TileIndex tile, TriggerArea ta)
  * - P = Position along platform from start, p = from end
  * .
  * if centered, C/P start from the centre and c/p are not available.
+ * @param axis The axis of the platform.
+ * @param tile The tile layout number.
+ * @param platforms Number of platforms.
+ * @param length Length of platforms.
+ * @param x The platform number.
+ * @param y Position along the platform.
+ * @param centred Whether to 'center' the platform location, or use the absolute location.
  * @return Platform information in bit-stuffed format.
  */
 uint32_t GetPlatformInfo(Axis axis, uint8_t tile, int platforms, int length, int x, int y, bool centred)
@@ -884,7 +891,16 @@ const StationSpec *GetStationSpec(TileIndex t)
 	return specindex < st->speclist.size() ? st->speclist[specindex].spec : nullptr;
 }
 
-/** Wrapper for animation control, see GetStationCallback. */
+/**
+ * Perform the station callback in the context of the AnimationBase callback.
+ * @param callback The identifier of the callback.
+ * @param param1 The first parameter of the NewGRF callback.
+ * @param param2 The second parameter of the NewGRF callback.
+ * @param statspec The specification to run the callback on.
+ * @param st The station for the calback.
+ * @param tile The tile the station is at.
+ * @return The NewGRF result of the callback.
+ */
 uint16_t GetAnimStationCallback(CallbackID callback, uint32_t param1, uint32_t param2, const StationSpec *statspec, BaseStation *st, TileIndex tile, int)
 {
 	return GetStationCallback(callback, param1, param2, statspec, st, tile);

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -48,6 +48,7 @@ protected:
 	/**
 	 * Check whether currently changes to the storage shall be persistent or
 	 * temporary till the next call to ClearChanges().
+	 * @return \c true iff the changes should be persisted or not. For example, when testing commands we do not persist the changes.
 	 */
 	static bool AreChangesPersistent() { return (gameloop || command) && !testmode; }
 

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -532,6 +532,14 @@ void AddGRFTextToList(GRFTextWrapper &list, std::string_view text_to_add)
 
 /**
  * Add the new read string into our structure.
+ * @param grfid The GRF to load the string for.
+ * @param stringid The GRF-local identifier of the string.
+ * @param langid_to_add The language to add them to.
+ * @param new_scheme Is the NewGRF version 7 or higher?
+ * @param allow_newlines Whether newlines are allowed in the string.
+ * @param text_to_add The actual text of the string.
+ * @param def_string The fallback string if a translation for this string isn't available.
+ * @return The OpenTTD internal string identifer.
  */
 StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid_to_add, bool new_scheme, bool allow_newlines, std::string_view text_to_add, StringID def_string)
 {
@@ -575,7 +583,10 @@ StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid_to_ad
 }
 
 /**
- * Returns the index for this stringid associated with its grfID
+ * Returns the index for this stringid associated with its grfID.
+ * @param grfid The GRF to find the string for.
+ * @param stringid The GRF-local identifier of the string.
+ * @return The string identifier, or STR_UNDEFINED when it can't be found.
  */
 StringID GetGRFStringID(uint32_t grfid, GRFStringID stringid)
 {
@@ -595,6 +606,7 @@ StringID GetGRFStringID(uint32_t grfid, GRFStringID stringid)
  * is returned. If there is neither a default nor a translation for the
  * current language nullptr is returned.
  * @param text_list The GRFTextList to get the string from.
+ * @return The content of the requested string, or \c std::nullopt.
  */
 std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextList &text_list)
 {
@@ -619,7 +631,8 @@ std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextList &text_
  * current language it is returned, otherwise the default translation
  * is returned. If there is neither a default nor a translation for the
  * current language nullptr is returned.
- * @param text The GRFTextList to get the string from.
+ * @param text The GRFTextWrapper to get the string from.
+ * @return The content of the requested string, or \c std::nullopt.
  */
 std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextWrapper &text)
 {
@@ -628,6 +641,8 @@ std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextWrapper &te
 
 /**
  * Get a C-string from a stringid set by a newgrf.
+ * @param stringid The index of the string in the NewGRF string-tab.
+ * @return The raw string.
  */
 std::string_view GetGRFStringPtr(StringIndexInTab stringid)
 {

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -843,7 +843,7 @@ flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiD
 def      = 1
 min      = 0
 max      = 1
-post_cb  = UpdateNewGRFConfigPalette
+post_cb  = [](auto) { UpdateNewGRFConfigPalette(); }
 cat      = SC_EXPERT
 
 [SDTC_VAR]


### PR DESCRIPTION
## Motivation / Problem

Lots of doxygen warnings.


## Description

Fix 76 doxygen warnings by adding parameter/return documentation.

In the case of `GetVariable` it made more sense to remove the documentation, so the documentation of the superclass is picked up.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
