### PR TITLE
Codechange: document a few other parameters and return types

### DIFF
--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -52,9 +52,9 @@ static inline uint8_t CalcOldVarLen(OldChunkType type)
 }
 
 /**
- *
- * Reads a byte from a file (do not call yourself, use ReadByte())
- *
+ * Reads a byte from a file (do not call yourself, use ReadByte()).
+ * @param ls The state for loading the save game.
+ * @return A single byte.
  */
 static uint8_t ReadByteFromFile(LoadgameState &ls)
 {
@@ -79,9 +79,9 @@ static uint8_t ReadByteFromFile(LoadgameState &ls)
 }
 
 /**
- *
- * Reads a byte from the buffer and decompress if needed
- *
+ * Reads a byte from the buffer and decompress if needed.
+ * @param ls The state for loading the save game.
+ * @return A single byte.
  */
 uint8_t ReadByte(LoadgameState &ls)
 {
@@ -113,9 +113,11 @@ uint8_t ReadByte(LoadgameState &ls)
 }
 
 /**
- *
- * Loads a chunk from the old savegame
- *
+ * Loads a chunk from the old savegame.
+ * @param ls The state for loading the save game.
+ * @param base The pointer to the object to load the data into, or \c nullptr for global objects.
+ * @param chunks The definition of the elements to load for this object.
+ * @return \c true if the chunk was loaded without problems.
  */
 bool LoadChunk(LoadgameState &ls, void *base, const OldChunks *chunks)
 {

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -156,6 +156,7 @@ static void FixOldTowns()
  * Convert the old style vehicles into something that resembles
  * the old new style savegames. Then #AfterLoadGame can handle
  * the rest of the conversion.
+ * @param ls The state for loading the save game.
  */
 void FixOldVehicles(LoadgameState &ls)
 {

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -533,7 +533,11 @@ static void SlWriteSimpleGamma(size_t i)
 	SlWriteByte((uint8_t)i);
 }
 
-/** Return how many bytes used to encode a gamma value */
+/**
+ * Return how many bytes used to encode a gamma value.
+ * @param i The value to encode with gamma encoding.
+ * @return The length in bytes.
+ */
 static inline uint SlGetGammaLength(size_t i)
 {
 	return 1 + (i >= (1 << 7)) + (i >= (1 << 14)) + (i >= (1 << 21)) + (i >= (1 << 28));
@@ -566,6 +570,8 @@ static inline uint SlGetArrayLength(size_t length)
 
 /**
  * Return the type as saved/loaded inside the savegame.
+ * @param sld The save-load configuration for a single variable.
+ * @return The type description part for the way the data is stored in the file.
  */
 static uint8_t GetSavegameFileType(const SaveLoad &sld)
 {
@@ -656,7 +662,10 @@ static inline uint8_t SlCalcConvFileLen(VarType conv)
 	}
 }
 
-/** Return the size in bytes of a reference (pointer) */
+/**
+ * Return the size in bytes of a reference (pointer).
+ * @return Return the size of this type in bytes.
+ */
 static inline size_t SlCalcRefLen()
 {
 	return IsSavegameVersionBefore(SLV_69) ? 2 : 4;
@@ -796,7 +805,10 @@ static void SlCopyBytes(void *ptr, size_t length)
 	}
 }
 
-/** Get the length of the current object */
+/**
+ * Get the length of the current object.
+ * @return The length of the object in bytes.
+ */
 size_t SlGetFieldLength()
 {
 	return _sl.obj_len;
@@ -1166,6 +1178,7 @@ void SlCopy(void *object, size_t length, VarType conv)
  * Return the size in bytes of a certain type of atomic array
  * @param length The length of the array counted in elements
  * @param conv VarType type of the variable that is used in calculating the size
+ * @return The size of this type in bytes.
  */
 static inline size_t SlCalcArrayLen(size_t length, VarType conv)
 {
@@ -1358,6 +1371,7 @@ public:
 	 * @param storage The storage to find the size of
 	 * @param conv VarType type of variable that is used for calculating the size
 	 * @param cmd The SaveLoadType ware are saving/loading.
+	 * @return The size of this type in bytes.
 	 */
 	static size_t SlCalcLen(const void *storage, VarType conv, SaveLoadType cmd = SL_VAR)
 	{
@@ -1444,6 +1458,7 @@ public:
  * Return the size in bytes of a list.
  * @param list The std::list to find the size of.
  * @param conv VarType type of variable that is used for calculating the size.
+ * @return The size of this type in bytes.
  */
 static inline size_t SlCalcRefListLen(const void *list, VarType conv)
 {
@@ -1471,6 +1486,7 @@ static void SlRefList(void *list, VarType conv)
  * Return the size in bytes of a vector.
  * @param vector The std::vector to find the size of.
  * @param conv VarType type of variable that is used for calculating the size.
+ * @return The size of this type in bytes.
  */
 static size_t SlCalcRefVectorLen(const void *vector, VarType conv)
 {
@@ -1498,6 +1514,7 @@ static void SlRefVector(void *vector, VarType conv)
  * Return the size in bytes of a std::deque.
  * @param deque The std::deque to find the size of
  * @param conv VarType type of variable that is used for calculating the size
+ * @return The size of this type in bytes.
  */
 static inline size_t SlCalcDequeLen(const void *deque, VarType conv)
 {
@@ -1556,6 +1573,7 @@ static void SlDeque(void *deque, VarType conv)
  * Return the size in bytes of a std::vector.
  * @param vector The std::vector to find the size of
  * @param conv VarType type of variable that is used for calculating the size
+ * @return The size of this type in bytes.
  */
 static inline size_t SlCalcVectorLen(const void *vector, VarType conv)
 {
@@ -1610,7 +1628,11 @@ static void SlVector(void *vector, VarType conv)
 	}
 }
 
-/** Are we going to save this object or not? */
+/**
+ * Are we going to save this object or not?
+ * @param sld The save-load configuration for a single variable.
+ * @return \c true iff the version of the current save game is within the range of the configuration.
+ */
 static inline bool SlIsObjectValidInSavegame(const SaveLoad &sld)
 {
 	return (_sl_version >= sld.version_from && _sl_version < sld.version_to);
@@ -2958,19 +2980,28 @@ static void SaveFileDone()
 #endif
 }
 
-/** Set the error message from outside of the actual loading/saving of the game (AfterLoadGame and friends) */
+/**
+ * Set the error message from outside of the actual loading/saving of the game (AfterLoadGame and friends).
+ * @param str The string describing the error.
+ */
 void SetSaveLoadError(StringID str)
 {
 	_sl.error_str = str;
 }
 
-/** Return the appropriate initial string for an error depending on whether we are saving or loading. */
+/**
+ * Return the appropriate initial string for an error depending on whether we are saving or loading.
+ * @return The encoded string with the error type.
+ */
 EncodedString GetSaveLoadErrorType()
 {
 	return GetEncodedString(_sl.action == SLA_SAVE ? STR_ERROR_GAME_SAVE_FAILED : STR_ERROR_GAME_LOAD_FAILED);
 }
 
-/** Return the description of the error. **/
+/**
+ * Return the description of the error.
+ * @return The encoded string with the error message.
+ */
 EncodedString GetSaveLoadErrorMessage()
 {
 	return GetEncodedString(_sl.error_str, _sl.extra_msg);
@@ -2986,6 +3017,8 @@ static void SaveFileError()
 /**
  * We have written the whole game into memory, _memory_savegame, now find
  * and appropriate compressor and start writing to file.
+ * @param threaded Whether to run the compression in the background or not.
+ * @return SL_OK when everything went okay, otherwise an error.
  */
 static SaveOrLoadResult SaveFileToDisk(bool threaded)
 {
@@ -3372,6 +3405,7 @@ void DoExitSave()
 
 /**
  * Get the default name for a savegame *or* screenshot.
+ * @return The default name, i.e. company name and (play) time.
  */
 std::string GenerateDefaultSaveName()
 {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -581,6 +581,7 @@ public:
 	 * Get the description for how to load the chunk. Depending on the
 	 * savegame version this can either use the headers in the savegame or
 	 * fall back to backwards compatibility and uses hard-coded headers.
+	 * @return The description to load the complete chunk.
 	 */
 	SaveLoadTable GetLoadDescription() const;
 };
@@ -1333,6 +1334,9 @@ inline bool SlIsObjectCurrentlyValid(SaveLoadVersion version_from, SaveLoadVersi
  * Get the address of the variable. Null-variables don't have an address,
  * everything else has a callback function that returns the address based
  * on the saveload data and the current object for non-globals.
+ * @param object The object to get a relative address from, or \c nullptr for global objects.
+ * @param sld The save-load configuration for a single variable.
+ * @return The address where to store the given variable into.
  */
 inline void *GetVariableAddress(const void *object, const SaveLoad &sld)
 {

--- a/src/saveload/saveload_filter.h
+++ b/src/saveload/saveload_filter.h
@@ -47,6 +47,7 @@ struct LoadFilter {
  * Instantiator for a load filter.
  * @param chain The next filter in this chain.
  * @tparam T    The type of load filter to create.
+ * @return The created load filter.
  */
 template <typename T> std::shared_ptr<LoadFilter> CreateLoadFilter(std::shared_ptr<LoadFilter> chain)
 {
@@ -90,6 +91,7 @@ struct SaveFilter {
  * @param chain             The next filter in this chain.
  * @param compression_level The requested level of compression.
  * @tparam T                The type of save filter to create.
+ * @return The created save filter.
  */
 template <typename T> std::shared_ptr<SaveFilter> CreateSaveFilter(std::shared_ptr<SaveFilter> chain, uint8_t compression_level)
 {

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -419,7 +419,10 @@ void AfterLoadVehiclesPhase1(bool part_of_load)
 	CheckValidVehicles();
 }
 
-/** Called after load for phase 2 of vehicle initialisation */
+/**
+ * Called after load for phase 2 of vehicle initialisation.
+ * @param part_of_load Whether we are being called during loading a savegame, or due to NewGRFs being changed.
+ */
 void AfterLoadVehiclesPhase2(bool part_of_load)
 {
 	for (Vehicle *v : Vehicle::Iterate()) {

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -57,7 +57,10 @@ static const ScreenshotProvider *GetScreenshotProvider()
 	return providers.front();
 }
 
-/** Get filename extension of current screenshot file format. */
+/**
+ * Get filename extension of current screenshot file format.
+ * @return The screenshot extension.
+ */
 std::string_view GetCurrentScreenshotExtension()
 {
 	auto provider = GetScreenshotProvider();
@@ -68,6 +71,10 @@ std::string_view GetCurrentScreenshotExtension()
 
 /**
  * Callback of the screenshot generator that dumps the current video buffer.
+ * @param buf Videobuffer with same bitdepth as current blitter
+ * @param y First line to render
+ * @param pitch Pitch of the videobuffer
+ * @param n Number of lines to render
  * @see ScreenshotCallback
  */
 static void CurrentScreenCallback(void *buf, uint y, uint pitch, uint n)
@@ -169,7 +176,11 @@ static std::string_view MakeScreenshotName(std::string_view default_fn, std::str
 	return _full_screenshot_path;
 }
 
-/** Make a screenshot of the current screen. */
+/**
+ * Make a screenshot of the current screen.
+ * @param crashlog Whether this is called in the context of a crashlog, for the file name.
+ * @return \c true iff the screenshot was made successfully.
+ */
 static bool MakeSmallScreenshot(bool crashlog)
 {
 	auto provider = GetScreenshotProvider();
@@ -310,6 +321,7 @@ static void HeightmapCallback(void *buffer, uint y, uint, uint n)
 /**
  * Make a heightmap of the current map.
  * @param filename Filename to use for saving.
+ * @return \c true iff the screenshot was made successfully.
  */
 bool MakeHeightmapScreenshot(std::string_view filename)
 {
@@ -493,6 +505,7 @@ static void MinimapScreenCallback(void *buf, uint y, uint pitch, uint n)
 
 /**
  * Make a minimap screenshot.
+ * @return \c true iff the screenshot was made successfully.
  */
 bool MakeMinimapWorldScreenshot()
 {


### PR DESCRIPTION
## Motivation / Problem

Loads of doxygen warnings.


## Description

Add parameter and return type documentation.


## Limitations

Besides there being a few hundred more of these doxygen warnings, I can't think of any.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
