### PR TITLE
Codechange: use scoped enum for PacketCoordinatorType

### DIFF
--- a/src/network/core/tcp_coordinator.cpp
+++ b/src/network/core/tcp_coordinator.cpp
@@ -25,23 +25,23 @@ bool NetworkCoordinatorSocketHandler::HandlePacket(Packet &p)
 	PacketCoordinatorType type = static_cast<PacketCoordinatorType>(p.Recv_uint8());
 
 	switch (type) {
-		case PACKET_COORDINATOR_GC_ERROR:              return this->Receive_GC_ERROR(p);
-		case PACKET_COORDINATOR_SERVER_REGISTER:       return this->Receive_SERVER_REGISTER(p);
-		case PACKET_COORDINATOR_GC_REGISTER_ACK:       return this->Receive_GC_REGISTER_ACK(p);
-		case PACKET_COORDINATOR_SERVER_UPDATE:         return this->Receive_SERVER_UPDATE(p);
-		case PACKET_COORDINATOR_CLIENT_LISTING:        return this->Receive_CLIENT_LISTING(p);
-		case PACKET_COORDINATOR_GC_LISTING:            return this->Receive_GC_LISTING(p);
-		case PACKET_COORDINATOR_CLIENT_CONNECT:        return this->Receive_CLIENT_CONNECT(p);
-		case PACKET_COORDINATOR_GC_CONNECTING:         return this->Receive_GC_CONNECTING(p);
-		case PACKET_COORDINATOR_SERCLI_CONNECT_FAILED: return this->Receive_SERCLI_CONNECT_FAILED(p);
-		case PACKET_COORDINATOR_GC_CONNECT_FAILED:     return this->Receive_GC_CONNECT_FAILED(p);
-		case PACKET_COORDINATOR_CLIENT_CONNECTED:      return this->Receive_CLIENT_CONNECTED(p);
-		case PACKET_COORDINATOR_GC_DIRECT_CONNECT:     return this->Receive_GC_DIRECT_CONNECT(p);
-		case PACKET_COORDINATOR_GC_STUN_REQUEST:       return this->Receive_GC_STUN_REQUEST(p);
-		case PACKET_COORDINATOR_SERCLI_STUN_RESULT:    return this->Receive_SERCLI_STUN_RESULT(p);
-		case PACKET_COORDINATOR_GC_STUN_CONNECT:       return this->Receive_GC_STUN_CONNECT(p);
-		case PACKET_COORDINATOR_GC_NEWGRF_LOOKUP:      return this->Receive_GC_NEWGRF_LOOKUP(p);
-		case PACKET_COORDINATOR_GC_TURN_CONNECT:       return this->Receive_GC_TURN_CONNECT(p);
+		case PacketCoordinatorType::GameCoordinatorError: return this->ReceiveGameCoordinatorError(p);
+		case PacketCoordinatorType::ServerRegister: return this->ReceiveServerRegister(p);
+		case PacketCoordinatorType::GameCoordinatorRegisterAck: return this->ReceiveGameCoordinatorRegisterAck(p);
+		case PacketCoordinatorType::ServerUpdate: return this->ReceiveServerUpdate(p);
+		case PacketCoordinatorType::ClientListing: return this->ReceiveClientListing(p);
+		case PacketCoordinatorType::GameCoordinatorListing: return this->ReceiveGameCoordinatorListing(p);
+		case PacketCoordinatorType::ClientConnect: return this->ReceiveClientConnect(p);
+		case PacketCoordinatorType::GameCoordinatorConnecting: return this->ReceiveGameCoordinatorConnecting(p);
+		case PacketCoordinatorType::ServerOrClientConnectFailed: return this->ReceiveServerOrClientConnectFailed(p);
+		case PacketCoordinatorType::GameCoordinatorConnectFailed: return this->ReceiveGameCoordinatorConnectFailed(p);
+		case PacketCoordinatorType::ClientConnected: return this->ReceiveClientConnected(p);
+		case PacketCoordinatorType::GameCoordinatorDirectConnect: return this->ReceiveGameCoordinatorDirectConnect(p);
+		case PacketCoordinatorType::GameCoordinatorStunRequest: return this->ReceiveGameCoordinatorStunRequest(p);
+		case PacketCoordinatorType::ServerOrClientStunResult: return this->ReceiveServerOrClientStunResult(p);
+		case PacketCoordinatorType::GameCoordinatorStunConnect: return this->ReceiveGameCoordinatorStunConnect(p);
+		case PacketCoordinatorType::GameCoordinatorNewGRFLookup: return this->ReceiveGameCoordinatorNewGRFLookup(p);
+		case PacketCoordinatorType::GameCoordinatorTurnConnect: return this->ReceiveGameCoordinatorTurnConnect(p);
 
 		default:
 			Debug(net, 0, "[tcp/coordinator] Received invalid packet type {}", type);
@@ -84,20 +84,20 @@ bool NetworkCoordinatorSocketHandler::ReceiveInvalidPacket(PacketCoordinatorType
 	return false;
 }
 
-bool NetworkCoordinatorSocketHandler::Receive_GC_ERROR(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_ERROR); }
-bool NetworkCoordinatorSocketHandler::Receive_SERVER_REGISTER(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERVER_REGISTER); }
-bool NetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_REGISTER_ACK); }
-bool NetworkCoordinatorSocketHandler::Receive_SERVER_UPDATE(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERVER_UPDATE); }
-bool NetworkCoordinatorSocketHandler::Receive_CLIENT_LISTING(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_CLIENT_LISTING); }
-bool NetworkCoordinatorSocketHandler::Receive_GC_LISTING(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_LISTING); }
-bool NetworkCoordinatorSocketHandler::Receive_CLIENT_CONNECT(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_CLIENT_CONNECT); }
-bool NetworkCoordinatorSocketHandler::Receive_GC_CONNECTING(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_CONNECTING); }
-bool NetworkCoordinatorSocketHandler::Receive_SERCLI_CONNECT_FAILED(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERCLI_CONNECT_FAILED); }
-bool NetworkCoordinatorSocketHandler::Receive_GC_CONNECT_FAILED(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_CONNECT_FAILED); }
-bool NetworkCoordinatorSocketHandler::Receive_CLIENT_CONNECTED(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_CLIENT_CONNECTED); }
-bool NetworkCoordinatorSocketHandler::Receive_GC_DIRECT_CONNECT(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_DIRECT_CONNECT); }
-bool NetworkCoordinatorSocketHandler::Receive_GC_STUN_REQUEST(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_STUN_REQUEST); }
-bool NetworkCoordinatorSocketHandler::Receive_SERCLI_STUN_RESULT(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERCLI_STUN_RESULT); }
-bool NetworkCoordinatorSocketHandler::Receive_GC_STUN_CONNECT(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_STUN_CONNECT); }
-bool NetworkCoordinatorSocketHandler::Receive_GC_NEWGRF_LOOKUP(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_NEWGRF_LOOKUP); }
-bool NetworkCoordinatorSocketHandler::Receive_GC_TURN_CONNECT(Packet &) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_TURN_CONNECT); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorError(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorError); }
+bool NetworkCoordinatorSocketHandler::ReceiveServerRegister(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::ServerRegister); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorRegisterAck(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorRegisterAck); }
+bool NetworkCoordinatorSocketHandler::ReceiveServerUpdate(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::ServerUpdate); }
+bool NetworkCoordinatorSocketHandler::ReceiveClientListing(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::ClientListing); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorListing(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorListing); }
+bool NetworkCoordinatorSocketHandler::ReceiveClientConnect(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::ClientConnect); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnecting(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorConnecting); }
+bool NetworkCoordinatorSocketHandler::ReceiveServerOrClientConnectFailed(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::ServerOrClientConnectFailed); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnectFailed(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorConnectFailed); }
+bool NetworkCoordinatorSocketHandler::ReceiveClientConnected(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::ClientConnected); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorDirectConnect(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorDirectConnect); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorStunRequest(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorStunRequest); }
+bool NetworkCoordinatorSocketHandler::ReceiveServerOrClientStunResult(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::ServerOrClientStunResult); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorStunConnect(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorStunConnect); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorNewGRFLookup(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorNewGRFLookup); }
+bool NetworkCoordinatorSocketHandler::ReceiveGameCoordinatorTurnConnect(Packet &) { return this->ReceiveInvalidPacket(PacketCoordinatorType::GameCoordinatorTurnConnect); }

--- a/src/network/core/tcp_coordinator.h
+++ b/src/network/core/tcp_coordinator.h
@@ -16,32 +16,37 @@
 #include "network_game_info.h"
 
 /**
- * Enum with all types of TCP Game Coordinator packets. The order MUST not be changed.
+ * Enum with all types of TCP Game Coordinator packets.
  *
- * GC     -> packets from Game Coordinator to either Client or Server.
- * SERVER -> packets from Server to Game Coordinator.
- * CLIENT -> packets from Client to Game Coordinator.
- * SERCLI -> packets from either the Server or Client to Game Coordinator.
- **/
-enum PacketCoordinatorType : uint8_t {
-	PACKET_COORDINATOR_GC_ERROR,              ///< Game Coordinator indicates there was an error.
-	PACKET_COORDINATOR_SERVER_REGISTER,       ///< Server registration.
-	PACKET_COORDINATOR_GC_REGISTER_ACK,       ///< Game Coordinator accepts the registration.
-	PACKET_COORDINATOR_SERVER_UPDATE,         ///< Server sends an set intervals an update of the server.
-	PACKET_COORDINATOR_CLIENT_LISTING,        ///< Client is requesting a listing of all public servers.
-	PACKET_COORDINATOR_GC_LISTING,            ///< Game Coordinator returns a listing of all public servers.
-	PACKET_COORDINATOR_CLIENT_CONNECT,        ///< Client wants to connect to a server based on an invite code.
-	PACKET_COORDINATOR_GC_CONNECTING,         ///< Game Coordinator informs the client of the token assigned to the connection attempt.
-	PACKET_COORDINATOR_SERCLI_CONNECT_FAILED, ///< Client/server tells the Game Coordinator the current connection attempt failed.
-	PACKET_COORDINATOR_GC_CONNECT_FAILED,     ///< Game Coordinator informs client/server it has given up on the connection attempt.
-	PACKET_COORDINATOR_CLIENT_CONNECTED,      ///< Client informs the Game Coordinator the connection with the server is established.
-	PACKET_COORDINATOR_GC_DIRECT_CONNECT,     ///< Game Coordinator tells client to directly connect to the hostname:port of the server.
-	PACKET_COORDINATOR_GC_STUN_REQUEST,       ///< Game Coordinator tells client/server to initiate a STUN request.
-	PACKET_COORDINATOR_SERCLI_STUN_RESULT,    ///< Client/server informs the Game Coordinator of the result of the STUN request.
-	PACKET_COORDINATOR_GC_STUN_CONNECT,       ///< Game Coordinator tells client/server to connect() reusing the STUN local address.
-	PACKET_COORDINATOR_GC_NEWGRF_LOOKUP,      ///< Game Coordinator informs client about NewGRF lookup table updates needed for GC_LISTING.
-	PACKET_COORDINATOR_GC_TURN_CONNECT,       ///< Game Coordinator tells client/server to connect to a specific TURN server.
-	PACKET_COORDINATOR_END,                   ///< Must ALWAYS be on the end of this list!! (period)
+ * GameCoordinator -> packets from Game Coordinator to either Client or Server.
+ * Server -> packets from Server to Game Coordinator.
+ * Client -> packets from Client to Game Coordinator.
+ * ServerOrClient -> packets from either the Server or Client to Game Coordinator.
+ *
+ * @important The order MUST not be changed.
+ */
+enum class PacketCoordinatorType : uint8_t {
+	GameCoordinatorError, ///< Game Coordinator indicates there was an error.
+	ServerRegister, ///< Server registration.
+	GameCoordinatorRegisterAck, ///< Game Coordinator accepts the registration.
+	ServerUpdate, ///< Server sends an set intervals an update of the server.
+	ClientListing, ///< Client is requesting a listing of all public servers.
+	GameCoordinatorListing, ///< Game Coordinator returns a listing of all public servers.
+	ClientConnect, ///< Client wants to connect to a server based on an invite code.
+	GameCoordinatorConnecting, ///< Game Coordinator informs the client of the token assigned to the connection attempt.
+	ServerOrClientConnectFailed, ///< Client/server tells the Game Coordinator the current connection attempt failed.
+	GameCoordinatorConnectFailed, ///< Game Coordinator informs client/server it has given up on the connection attempt.
+	ClientConnected, ///< Client informs the Game Coordinator the connection with the server is established.
+	GameCoordinatorDirectConnect, ///< Game Coordinator tells client to directly connect to the hostname:port of the server.
+	GameCoordinatorStunRequest, ///< Game Coordinator tells client/server to initiate a STUN request.
+	ServerOrClientStunResult, ///< Client/server informs the Game Coordinator of the result of the STUN request.
+	GameCoordinatorStunConnect, ///< Game Coordinator tells client/server to connect() reusing the STUN local address.
+	GameCoordinatorNewGRFLookup, ///< Game Coordinator informs client about NewGRF lookup table updates needed for GC_LISTING.
+	GameCoordinatorTurnConnect, ///< Game Coordinator tells client/server to connect to a specific TURN server.
+};
+/** Mark PacketCoordinatorType as PacketType. */
+template <> struct IsEnumPacketType<PacketCoordinatorType> {
+	static constexpr bool value = true; ///< This is an enumeration of a PacketType.
 };
 
 /**
@@ -81,7 +86,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_ERROR(Packet &p);
+	virtual bool ReceiveGameCoordinatorError(Packet &p);
 
 	/**
 	 * Server is starting a multiplayer game and wants to let the
@@ -96,7 +101,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_SERVER_REGISTER(Packet &p);
+	virtual bool ReceiveServerRegister(Packet &p);
 
 	/**
 	 * Game Coordinator acknowledges the registration.
@@ -108,7 +113,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_REGISTER_ACK(Packet &p);
+	virtual bool ReceiveGameCoordinatorRegisterAck(Packet &p);
 
 	/**
 	 * Send an update of the current state of the server to the Game Coordinator.
@@ -119,7 +124,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_SERVER_UPDATE(Packet &p);
+	virtual bool ReceiveServerUpdate(Packet &p);
 
 	/**
 	 * Client requests a list of all public servers.
@@ -132,7 +137,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_CLIENT_LISTING(Packet &p);
+	virtual bool ReceiveClientListing(Packet &p);
 
 	/**
 	 * Game Coordinator replies with a list of all public servers. Multiple
@@ -147,7 +152,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_LISTING(Packet &p);
+	virtual bool ReceiveGameCoordinatorListing(Packet &p);
 
 	/**
 	 * Client wants to connect to a Server.
@@ -158,7 +163,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_CLIENT_CONNECT(Packet &p);
+	virtual bool ReceiveClientConnect(Packet &p);
 
 	/**
 	 * Game Coordinator informs the Client under what token it will start the
@@ -170,7 +175,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_CONNECTING(Packet &p);
+	virtual bool ReceiveGameCoordinatorConnecting(Packet &p);
 
 	/**
 	 * Client or Server failed to connect to the remote side.
@@ -182,7 +187,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_SERCLI_CONNECT_FAILED(Packet &p);
+	virtual bool ReceiveServerOrClientConnectFailed(Packet &p);
 
 	/**
 	 * Game Coordinator informs the Client that it failed to find a way to
@@ -194,7 +199,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_CONNECT_FAILED(Packet &p);
+	virtual bool ReceiveGameCoordinatorConnectFailed(Packet &p);
 
 	/**
 	 * Client informs the Game Coordinator the connection with the Server is
@@ -206,7 +211,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_CLIENT_CONNECTED(Packet &p);
+	virtual bool ReceiveClientConnected(Packet &p);
 
 	/**
 	 * Game Coordinator requests that the Client makes a direct connection to
@@ -220,7 +225,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_DIRECT_CONNECT(Packet &p);
+	virtual bool ReceiveGameCoordinatorDirectConnect(Packet &p);
 
 	/**
 	 * Game Coordinator requests the client/server to do a STUN request to the
@@ -235,7 +240,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_STUN_REQUEST(Packet &p);
+	virtual bool ReceiveGameCoordinatorStunRequest(Packet &p);
 
 	/**
 	 * Client/server informs the Game Coordinator the result of a STUN request.
@@ -248,7 +253,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_SERCLI_STUN_RESULT(Packet &p);
+	virtual bool ReceiveServerOrClientStunResult(Packet &p);
 
 	/**
 	 * Game Coordinator informs the client/server of its STUN peer (the host:ip
@@ -264,7 +269,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_STUN_CONNECT(Packet &p);
+	virtual bool ReceiveGameCoordinatorStunConnect(Packet &p);
 
 	/**
 	 * Game Coordinator informs the client of updates for the NewGRFs lookup table
@@ -287,7 +292,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_NEWGRF_LOOKUP(Packet &p);
+	virtual bool ReceiveGameCoordinatorNewGRFLookup(Packet &p);
 
 	/**
 	 * Game Coordinator requests that we make a connection to the indicated
@@ -301,7 +306,7 @@ protected:
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */
-	virtual bool Receive_GC_TURN_CONNECT(Packet &p);
+	virtual bool ReceiveGameCoordinatorTurnConnect(Packet &p);
 
 	bool HandlePacket(Packet &p);
 public:

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -124,11 +124,11 @@ public:
 	}
 };
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_ERROR(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorError(Packet &p)
 {
 	NetworkCoordinatorErrorType error = (NetworkCoordinatorErrorType)p.Recv_uint8();
 	std::string detail = p.Recv_string(NETWORK_ERROR_DETAIL_LENGTH);
-	Debug(net, 9, "Coordinator::Receive_GC_ERROR({}, {})", error, detail);
+	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorError({}, {})", error, detail);
 
 	switch (error) {
 		case NETWORK_COORDINATOR_ERROR_UNKNOWN:
@@ -175,7 +175,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_ERROR(Packet &p)
 	}
 }
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorRegisterAck(Packet &p)
 {
 	/* Schedule sending an update. */
 	this->next_update = std::chrono::steady_clock::now();
@@ -183,7 +183,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet &p)
 	_settings_client.network.server_invite_code = p.Recv_string(NETWORK_INVITE_CODE_LENGTH);
 	_settings_client.network.server_invite_code_secret = p.Recv_string(NETWORK_INVITE_CODE_SECRET_LENGTH);
 	_network_server_connection_type = (ConnectionType)p.Recv_uint8();
-	Debug(net, 9, "Coordinator::Receive_GC_REGISTER_ACK({}, {})", _settings_client.network.server_invite_code, _network_server_connection_type);
+	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorRegisterAck({}, {})", _settings_client.network.server_invite_code, _network_server_connection_type);
 
 	if (_network_server_connection_type == CONNECTION_TYPE_ISOLATED) {
 		ShowErrorMessage(
@@ -235,10 +235,10 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet &p)
 	return true;
 }
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_LISTING(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorListing(Packet &p)
 {
 	uint8_t servers = p.Recv_uint16();
-	Debug(net, 9, "Coordinator::Receive_GC_LISTING({})", servers);
+	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorListing({})", servers);
 
 	/* End of list; we can now remove all expired items from the list. */
 	if (servers == 0) {
@@ -268,11 +268,11 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_LISTING(Packet &p)
 	return true;
 }
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_CONNECTING(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnecting(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
 	std::string invite_code = p.Recv_string(NETWORK_INVITE_CODE_LENGTH);
-	Debug(net, 9, "Coordinator::Receive_GC_CONNECTING({}, {})", token, invite_code);
+	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorConnecting({}, {})", token, invite_code);
 
 	/* Find the connecter based on the invite code. */
 	auto connecter_pre_it = this->connecter_pre.find(invite_code);
@@ -288,22 +288,22 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_CONNECTING(Packet &p)
 	return true;
 }
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_CONNECT_FAILED(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnectFailed(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
-	Debug(net, 9, "Coordinator::Receive_GC_CONNECT_FAILED({})", token);
+	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorConnectFailed({})", token);
 	this->CloseToken(token);
 
 	return true;
 }
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_DIRECT_CONNECT(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorDirectConnect(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
 	uint8_t tracking_number = p.Recv_uint8();
 	std::string hostname = p.Recv_string(NETWORK_HOSTNAME_LENGTH);
 	uint16_t port = p.Recv_uint16();
-	Debug(net, 9, "Coordinator::Receive_GC_DIRECT_CONNECT({}, {}, {}, {})", token, tracking_number, hostname, port);
+	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorDirectConnect({}, {}, {}, {})", token, tracking_number, hostname, port);
 
 	/* Ensure all other pending connection attempts are killed. */
 	if (this->game_connecter != nullptr) {
@@ -315,17 +315,17 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_DIRECT_CONNECT(Packet &p)
 	return true;
 }
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_STUN_REQUEST(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorStunRequest(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
-	Debug(net, 9, "Coordinator::Receive_GC_STUN_REQUEST({})", token);
+	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorStunRequest({})", token);
 
 	this->stun_handlers[token][AF_INET6] = ClientNetworkStunSocketHandler::Stun(token, AF_INET6);
 	this->stun_handlers[token][AF_INET] = ClientNetworkStunSocketHandler::Stun(token, AF_INET);
 	return true;
 }
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_STUN_CONNECT(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorStunConnect(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
 	uint8_t tracking_number = p.Recv_uint8();
@@ -359,12 +359,12 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_STUN_CONNECT(Packet &p)
 	return true;
 }
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_NEWGRF_LOOKUP(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorNewGRFLookup(Packet &p)
 {
 	this->newgrf_lookup_table_cursor = p.Recv_uint32();
 
 	uint16_t newgrfs = p.Recv_uint16();
-	Debug(net, 9, "Coordinator::Receive_GC_NEWGRF_LOOKUP({}, {})", this->newgrf_lookup_table_cursor, newgrfs);
+	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorNewGRFLookup({}, {})", this->newgrf_lookup_table_cursor, newgrfs);
 	for (; newgrfs> 0; newgrfs--) {
 		uint32_t index = p.Recv_uint32();
 		DeserializeGRFIdentifierWithName(p, this->newgrf_lookup_table[index]);
@@ -372,13 +372,13 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_NEWGRF_LOOKUP(Packet &p)
 	return true;
 }
 
-bool ClientNetworkCoordinatorSocketHandler::Receive_GC_TURN_CONNECT(Packet &p)
+bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorTurnConnect(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
 	uint8_t tracking_number = p.Recv_uint8();
 	std::string ticket = p.Recv_string(NETWORK_TOKEN_LENGTH);
 	std::string connection_string = p.Recv_string(NETWORK_HOSTNAME_PORT_LENGTH);
-	Debug(net, 9, "Coordinator::Receive_GC_TURN_CONNECT({}, {}, {}, {})", token, tracking_number, ticket, connection_string);
+	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorTurnConnect({}, {}, {}, {})", token, tracking_number, ticket, connection_string);
 
 	/* Ensure all other pending connection attempts are killed. */
 	if (this->game_connecter != nullptr) {
@@ -466,7 +466,7 @@ void ClientNetworkCoordinatorSocketHandler::Register()
 
 	this->Connect();
 
-	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_SERVER_REGISTER);
+	auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ServerRegister);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_uint8(_settings_client.network.server_game_type);
 	p->Send_uint16(_settings_client.network.server_port);
@@ -489,7 +489,7 @@ void ClientNetworkCoordinatorSocketHandler::SendServerUpdate()
 {
 	Debug(net, 6, "Sending server update to Game Coordinator");
 
-	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_SERVER_UPDATE, TCP_MTU);
+	auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ServerUpdate, TCP_MTU);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	SerializeNetworkGameInfo(*p, GetCurrentNetworkServerGameInfo(), this->next_update.time_since_epoch() != std::chrono::nanoseconds::zero());
 
@@ -508,7 +508,7 @@ void ClientNetworkCoordinatorSocketHandler::GetListing()
 
 	_network_game_list_version++;
 
-	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_CLIENT_LISTING);
+	auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ClientListing);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_uint8(NETWORK_GAME_INFO_VERSION);
 	p->Send_string(_openttd_revision);
@@ -541,7 +541,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectToServer(std::string_view inv
 
 	this->Connect();
 
-	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_CLIENT_CONNECT);
+	auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ClientConnect);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(invite_code);
 
@@ -559,7 +559,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectFailure(std::string_view toke
 	/* Connecter will destroy itself. */
 	this->game_connecter = nullptr;
 
-	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_SERCLI_CONNECT_FAILED);
+	auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ServerOrClientConnectFailed);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(token);
 	p->Send_uint8(tracking_number);
@@ -592,7 +592,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(std::string_view toke
 	} else {
 		/* The client informs the Game Coordinator about the success. The server
 		 * doesn't have to, as it is implied by the client telling. */
-		auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_CLIENT_CONNECTED);
+		auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ClientConnected);
 		p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 		p->Send_string(token);
 		Debug(net, 9, "Coordinator::SendConnectSuccess({})", token);
@@ -624,7 +624,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(std::string_view toke
  */
 void ClientNetworkCoordinatorSocketHandler::StunResult(std::string_view token, uint8_t family, bool result)
 {
-	auto p = std::make_unique<Packet>(this, PACKET_COORDINATOR_SERCLI_STUN_RESULT);
+	auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ServerOrClientStunResult);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(token);
 	p->Send_uint8(family);

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -63,16 +63,16 @@ private:
 	GameInfoNewGRFLookupTable newgrf_lookup_table; ///< Table to look up NewGRFs in the GC_LISTING packets.
 
 protected:
-	bool Receive_GC_ERROR(Packet &p) override;
-	bool Receive_GC_REGISTER_ACK(Packet &p) override;
-	bool Receive_GC_LISTING(Packet &p) override;
-	bool Receive_GC_CONNECTING(Packet &p) override;
-	bool Receive_GC_CONNECT_FAILED(Packet &p) override;
-	bool Receive_GC_DIRECT_CONNECT(Packet &p) override;
-	bool Receive_GC_STUN_REQUEST(Packet &p) override;
-	bool Receive_GC_STUN_CONNECT(Packet &p) override;
-	bool Receive_GC_NEWGRF_LOOKUP(Packet &p) override;
-	bool Receive_GC_TURN_CONNECT(Packet &p) override;
+	bool ReceiveGameCoordinatorError(Packet &p) override;
+	bool ReceiveGameCoordinatorRegisterAck(Packet &p) override;
+	bool ReceiveGameCoordinatorListing(Packet &p) override;
+	bool ReceiveGameCoordinatorConnecting(Packet &p) override;
+	bool ReceiveGameCoordinatorConnectFailed(Packet &p) override;
+	bool ReceiveGameCoordinatorDirectConnect(Packet &p) override;
+	bool ReceiveGameCoordinatorStunRequest(Packet &p) override;
+	bool ReceiveGameCoordinatorStunConnect(Packet &p) override;
+	bool ReceiveGameCoordinatorNewGRFLookup(Packet &p) override;
+	bool ReceiveGameCoordinatorTurnConnect(Packet &p) override;
 
 public:
 	/** The idle timeout; when to close the connection because it's idle. */


### PR DESCRIPTION
## Motivation / Problem

Using scoped enums to get rid of noise/conflicts in the global namespace.
In this particular case the `PacketCoordinatorType`.


## Description

Convert `PacketGameType` to a scope enumeration and rename the Receive_XXX functions appropriately.


## Limitations

External libraries might be using the old names in their code, but the mapping is fairly straight forward, so it's only a mild inconvenience at worst. There is no need to change the enumeration names in those external libraries.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
