### PR TITLE
Codechange: document a number of parameters and return types

### DIFF
--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -187,7 +187,15 @@ void UnreserveRailTrack(TileIndex tile, Track t)
 }
 
 
-/** Follow a reservation starting from a specific tile to the end. */
+/**
+ * Follow a reservation starting from a specific tile to the end.
+ * @param o The owner of the track to follow; tracks of other owners are excluded.
+ * @param rts The rail types to follow the reservation for; rail types not in the mask are excluded.
+ * @param tile The start tile.
+ * @param trackdir The start trackdir on the tile.
+ * @param ignore_oneway Whether one way signals are to be ignored.
+ * @return The end of the path.
+ */
 static PBSTileInfo FollowReservation(Owner o, RailTypes rts, TileIndex tile, Trackdir trackdir, bool ignore_oneway = false)
 {
 	TileIndex start_tile = tile;
@@ -263,7 +271,11 @@ struct FindTrainOnTrackInfo {
 	FindTrainOnTrackInfo() : best(nullptr) {}
 };
 
-/** Find the best matching vehicle on a tile. */
+/**
+ * Find the best matching vehicle on a tile.
+ * @param[in,out] info State of the finding a vehicle on a reservation.
+ * @param tile The tile to search for.
+ */
 static void CheckTrainsOnTrack(FindTrainOnTrackInfo &info, TileIndex tile)
 {
 	for (Vehicle *v : VehiclesOnTile(tile)) {

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -928,7 +928,7 @@ void PickerWindow::BuildPickerCollectionList()
 	if (!this->has_class_picker) return;
 }
 
-/** Create nested widgets for the class picker widgets. */
+/** Create nested widgets for the class picker widgets. @copydoc NWidgetFunctionType */
 std::unique_ptr<NWidgetBase> MakePickerClassWidgets()
 {
 	static constexpr std::initializer_list<NWidgetPart> picker_class_widgets = {
@@ -963,7 +963,7 @@ std::unique_ptr<NWidgetBase> MakePickerClassWidgets()
 	return MakeNWidgets(picker_class_widgets, nullptr);
 }
 
-/** Create nested widgets for the type picker widgets. */
+/** Create nested widgets for the type picker widgets. @copydoc NWidgetFunctionType */
 std::unique_ptr<NWidgetBase> MakePickerTypeWidgets()
 {
 	static constexpr std::initializer_list<NWidgetPart> picker_type_widgets = {

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -33,6 +33,8 @@ RailType RailTypeInfo::Index() const
 
 /**
  * Return the rail type of tile, or INVALID_RAILTYPE if this is no rail tile.
+ * @param tile An arbitrary tile.
+ * @return The rail type, or \c INVALID_RAILTYPE.
  */
 RailType GetTileRailType(Tile tile)
 {

--- a/src/rail.h
+++ b/src/rail.h
@@ -282,6 +282,7 @@ public:
 	 *    is determined by normal rail. Check sprites 1005 and following for this order<p>
 	 * 2) The position where the railtype is loaded must always be the same, otherwise
 	 *    the offset will fail.
+	 * @return The offset.
 	 */
 	inline uint GetRailtypeSpriteOffset() const
 	{

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -144,6 +144,8 @@ void InitRailTypes()
 
 /**
  * Allocate a new rail type label
+ * @param label The label of the rail type.
+ * @return The allocated type, or \c INVALID_RAILTYPE upon failures.
  */
 RailType AllocateRailType(RailTypeLabel label)
 {
@@ -924,7 +926,7 @@ static CommandCost CmdRailTrackHelper(DoCommandFlags flags, TileIndex tile, Tile
  * @param track track-orientation
  * @param auto_remove_signals false = build up to an obstacle, true = fail if an obstacle is found (used for AIs).
  * @param fail_on_obstacle false = error on signal in the way, true = auto remove signals when in the way
-
+ * @return The cost of this operation or an error.
  * @see CmdRailTrackHelper
  */
 CommandCost CmdBuildRailroadTrack(DoCommandFlags flags, TileIndex end_tile, TileIndex start_tile, RailType railtype, Track track, bool auto_remove_signals, bool fail_on_obstacle)
@@ -1850,8 +1852,12 @@ static CommandCost ClearTile_Rail(TileIndex tile, DoCommandFlags flags)
 /**
  * Get surface height in point (x,y)
  * On tiles with halftile foundations move (x,y) to a safe point wrt. track
+ * @param x The world X-coordinate.
+ * @param y The world Y-coordinate.
+ * @param track The track to get the height for.
+ * @return The world Z-coordinate.
  */
-static uint GetSaveSlopeZ(uint x, uint y, Track track)
+static uint GetSafeSlopeZ(uint x, uint y, Track track)
 {
 	switch (track) {
 		case TRACK_UPPER: x &= ~0xF; y &= ~0xF; break;
@@ -1900,7 +1906,7 @@ static void DrawSingleSignal(TileIndex tile, const RailTypeInfo *rti, Track trac
 		sprite += type * 16 + variant * 64 + image * 2 + condition + (type > SIGTYPE_LAST_NOPBS ? 64 : 0);
 	}
 
-	AddSortableSpriteToDraw(sprite, PAL_NONE, x, y, GetSaveSlopeZ(x, y, track), {{}, {1, 1, BB_HEIGHT_UNDER_BRIDGE}, {}});
+	AddSortableSpriteToDraw(sprite, PAL_NONE, x, y, GetSafeSlopeZ(x, y, track), {{}, {1, 1, BB_HEIGHT_UNDER_BRIDGE}, {}});
 }
 
 /** Offsets for drawing fences */
@@ -1949,6 +1955,9 @@ static void DrawTrackFence(const TileInfo *ti, const PalSpriteID &psid, uint num
 
 /**
  * Draw fence at NW border matching the tile slope.
+ * @param ti Tile drawing information.
+ * @param psid First fence sprite and palette.
+ * @param num_sprites Number of fence sprites.
  */
 static void DrawTrackFence_NW(const TileInfo *ti, const PalSpriteID &psid, uint num_sprites)
 {
@@ -1959,6 +1968,9 @@ static void DrawTrackFence_NW(const TileInfo *ti, const PalSpriteID &psid, uint 
 
 /**
  * Draw fence at SE border matching the tile slope.
+ * @param ti Tile drawing information.
+ * @param psid First fence sprite and palette.
+ * @param num_sprites Number of fence sprites.
  */
 static void DrawTrackFence_SE(const TileInfo *ti, const PalSpriteID &psid, uint num_sprites)
 {
@@ -1969,6 +1981,9 @@ static void DrawTrackFence_SE(const TileInfo *ti, const PalSpriteID &psid, uint 
 
 /**
  * Draw fence at NE border matching the tile slope.
+ * @param ti Tile drawing information.
+ * @param psid First fence sprite and palette.
+ * @param num_sprites Number of fence sprites.
  */
 static void DrawTrackFence_NE(const TileInfo *ti, const PalSpriteID &psid, uint num_sprites)
 {
@@ -1979,6 +1994,9 @@ static void DrawTrackFence_NE(const TileInfo *ti, const PalSpriteID &psid, uint 
 
 /**
  * Draw fence at SW border matching the tile slope.
+ * @param ti Tile drawing information.
+ * @param psid First fence sprite and palette.
+ * @param num_sprites Number of fence sprites.
  */
 static void DrawTrackFence_SW(const TileInfo *ti, const PalSpriteID &psid, uint num_sprites)
 {
@@ -3007,6 +3025,7 @@ static VehicleEnterTileStates VehicleEnterTile_Rail(Vehicle *v, TileIndex tile, 
  * @param z_new New TileZ.
  * @param tileh_new New TileSlope.
  * @param rail_bits Trackbits.
+ * @return The cost of this operation or an error.
  */
 static CommandCost TestAutoslopeOnRailTile(TileIndex tile, DoCommandFlags flags, int z_old, Slope tileh_old, int z_new, Slope tileh_new, TrackBits rail_bits)
 {

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -83,6 +83,7 @@ static void ShowSignalBuilder(Window *parent);
 
 /**
  * Check whether a station type can be build.
+ * @param statspec The specification of the station, or \c nullptr.
  * @return true if building is allowed.
  */
 static bool IsStationAvailable(const StationSpec *statspec)
@@ -303,7 +304,11 @@ static void PlaceRail_Bridge(TileIndex tile, Window *w)
 	}
 }
 
-/** Command callback for building a tunnel */
+/**
+ * Command callback for building a tunnel.
+ * @param result The result of the command.
+ * @param tile The tile where the command was executed on.
+ */
 void CcBuildRailTunnel(Commands, const CommandCost &result, TileIndex tile)
 {
 	if (result.Succeeded()) {
@@ -1485,7 +1490,11 @@ static WindowDesc _station_builder_desc(
 	&BuildRailStationWindow::hotkeys
 );
 
-/** Open station build window */
+/**
+ * Open station build window.
+ * @param parent The parent window.
+ * @return The created window.
+ */
 static Window *ShowStationBuilder(Window *parent)
 {
 	return new BuildRailStationWindow(_station_builder_desc, parent);
@@ -1740,6 +1749,7 @@ static WindowDesc _signal_builder_desc(
 
 /**
  * Open the signal selection window
+ * @param parent The parent window.
  */
 static void ShowSignalBuilder(Window *parent)
 {
@@ -2036,12 +2046,13 @@ void ResetSignalVariant(int32_t)
 	}
 }
 
-static const IntervalTimer<TimerGameCalendar> _check_reset_signal({TimerGameCalendar::Trigger::Year, TimerGameCalendar::Priority::None}, [](auto)
+/** Yearly time to check whether to set the signal variant to electric signals. */
+static const IntervalTimer<TimerGameCalendar> _check_reset_signal{{TimerGameCalendar::Trigger::Year, TimerGameCalendar::Priority::None}, [](auto)
 {
 	if (TimerGameCalendar::year != _settings_client.gui.semaphore_build_before) return;
 
 	ResetSignalVariant();
-});
+}};
 
 /**
  * Resets the rail GUI - sets default railtype to build

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -124,7 +124,10 @@ void InitRoadTypes()
 }
 
 /**
- * Allocate a new road type label
+ * Allocate a new road type label.
+ * @param label The label of the road type.
+ * @param rtt Whether it's a road or tram type.
+ * @return The allocated road type, or \c INVALID_ROADTYPE upon failures.
  */
 RoadType AllocateRoadType(RoadTypeLabel label, RoadTramType rtt)
 {
@@ -310,6 +313,7 @@ CommandCost CheckAllowRemoveRoad(TileIndex tile, RoadBits remove, Owner owner, R
  * @param pieces roadbits to remove
  * @param rtt Road type to remove.
  * @param town_check should we check if the town allows removal?
+ * @return The cost or an error message.
  */
 static CommandCost RemoveRoad(TileIndex tile, DoCommandFlags flags, RoadBits pieces, RoadTramType rtt, bool town_check)
 {
@@ -1550,6 +1554,7 @@ void DrawRoadOverlays(const TileInfo *ti, PaletteID pal, const RoadTypeInfo *roa
  * @param offset Road sprite offset
  * @param snow_or_desert Whether to get snow/desert ground sprite
  * @param[out] pal Palette to draw.
+ * @return The sprite.
  */
 static SpriteID GetRoadGroundSprite(const TileInfo *ti, Roadside roadside, const RoadTypeInfo *rti, uint offset, bool snow_or_desert, PaletteID *pal)
 {

--- a/src/road_func.h
+++ b/src/road_func.h
@@ -131,6 +131,7 @@ inline Money RoadMaintenanceCost(RoadType roadtype, uint32_t num, uint32_t total
 /**
  * Test if a road type has catenary
  * @param roadtype Road type to test
+ * @return \c true iff the road should have catenary.
  */
 inline bool HasRoadCatenary(RoadType roadtype)
 {
@@ -141,6 +142,7 @@ inline bool HasRoadCatenary(RoadType roadtype)
 /**
  * Test if we should draw road catenary
  * @param roadtype Road type to test
+ * @return \c true iff the road should have catenary and catenary is visible.
  */
 inline bool HasRoadCatenaryDrawn(RoadType roadtype)
 {

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -98,6 +98,8 @@ static bool IsRoadStopEverAvailable(const RoadStopSpec *spec, StationType type)
 
 /**
  * Check whether a road stop type can be built.
+ * @param spec The specification, or \c nullptr.
+ * @param type The type of road stop that is being considered.
  * @return true if building is allowed.
  */
 static bool IsRoadStopAvailable(const RoadStopSpec *spec, StationType type)
@@ -1050,6 +1052,7 @@ static WindowDesc _build_tramway_desc(
  *
  * If the terraform toolbar is linked to the toolbar, that window is also opened.
  *
+ * @param roadtype The road type for the toolbar.
  * @return newly opened road toolbar, or nullptr if the toolbar could not be opened.
  */
 Window *ShowBuildRoadToolbar(RoadType roadtype)
@@ -1141,6 +1144,7 @@ static WindowDesc _build_tramway_scen_desc(
 
 /**
  * Show the road building toolbar in the scenario editor.
+ * @param roadtype The road type for the toolbar.
  * @return The just opened toolbar, or \c nullptr if the toolbar was already open.
  */
 Window *ShowBuildRoadScenToolbar(RoadType roadtype)
@@ -1476,6 +1480,8 @@ public:
 
 	/**
 	 * Simply to have a easier way to get the StationType for bus, truck and trams from the WindowClass.
+	 * @param window_class The window class to get the type for.
+	 * @return The associated station type.
 	 */
 	StationType GetRoadStationTypeByWindowClass(WindowClass window_class) const
 	{

--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -71,7 +71,11 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 	TileIndex xy = INVALID_TILE; ///< Position on the map
 	RoadStop *next = nullptr; ///< Next stop of the given type at this station
 
-	/** Initializes a RoadStop */
+	/**
+	 * Initializes a RoadStop.
+	 * @param index The pool identifier of the road stop.
+	 * @param tile The tile the road stop is at.
+	 */
 	inline RoadStop(RoadStopID index, TileIndex tile = INVALID_TILE) : RoadStopPool::PoolItem<&_roadstop_pool>(index), xy(tile) { }
 
 	~RoadStop();

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -135,6 +135,7 @@ void ShowBaseSetTextfileWindow(Window *parent, TextfileType file_type, const TBa
  * Get string to use when listing this set in the settings window.
  * If there are no invalid files, then this is just the set name,
  * otherwise a string is formatted including the number of invalid files.
+ * @param baseset The selected baseset.
  * @return the string to display.
  */
 template <typename TBaseSet>
@@ -356,7 +357,7 @@ private:
 	std::vector<SocialIntegrationPlugin *> plugins{};
 };
 
-/** Construct nested container widget for managing the list of social plugins. */
+/** Construct nested container widget for managing the list of social plugins. @copydoc NWidgetFunctionType */
 std::unique_ptr<NWidgetBase> MakeNWidgetSocialPlugins()
 {
 	return std::make_unique<NWidgetSocialPlugins>();

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -149,6 +149,7 @@ struct SettingDesc {
 
 	/**
 	 * Reset the setting to its default value.
+	 * @param object The object to set the value of.
 	 */
 	virtual void ResetToDefault(void *object) const = 0;
 };

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -697,6 +697,7 @@ extern VehicleDefaultSettings _old_vds;
 /**
  * Get the settings-object applicable for the current situation: the newgame settings
  * when we're in the main menu and otherwise the settings of the current game.
+ * @return A reference to the new game (in the menu) or current game settings.
  */
 inline GameSettings &GetGameSettings()
 {

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -380,6 +380,7 @@ static void ProcessIniFile(std::string_view fname)
  * And the main program (what else?)
  * @param argc Number of command-line arguments including the program name itself.
  * @param argv Vector of the command-line arguments.
+ * @return The exit code of the application.
  */
 int CDECL main(int argc, char *argv[])
 {

--- a/src/string_base.h
+++ b/src/string_base.h
@@ -49,12 +49,14 @@ public:
 
 	/**
 	 * Advance the cursor by one iteration unit.
+	 * @param what The iteration unit to advance by.
 	 * @return New cursor position (in bytes) or #END if the cursor is already at the end of the string.
 	 */
 	virtual size_t Next(IterType what = ITER_CHARACTER) = 0;
 
 	/**
 	 * Move the cursor back by one iteration unit.
+	 * @param what The iteration unit to move by.
 	 * @return New cursor position (in bytes) or #END if the cursor is already at the start of the string.
 	 */
 	virtual size_t Prev(IterType what = ITER_CHARACTER) = 0;


### PR DESCRIPTION
## Motivation / Problem

Doxygen is quite vocal about our code.


## Description

Document a number of parameter and return types.

One function `GetSaveSlopeZ` is renamed to `GetSafeSlopeZ`; it's documentation was already talking about something that is safe.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
