### PR TITLE
Change: Default townname generates new random name

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3118,10 +3118,10 @@ void ClearTownHouse(Town *t, TileIndex tile)
 
 /**
  * Rename a town (server-only).
- * @param flags type of operation
- * @param town_id town ID to rename
- * @param text the new name or an empty string when resetting to the default
- * @return the cost of this operation or an error
+ * @param flags Type of operation.
+ * @param town_id Town ID to rename.
+ * @param text The new name or an empty string when resetting to the default.
+ * @return The cost of this operation or an error.
  */
 CommandCost CmdRenameTown(DoCommandFlags flags, TownID town_id, const std::string &text)
 {
@@ -3129,15 +3129,22 @@ CommandCost CmdRenameTown(DoCommandFlags flags, TownID town_id, const std::strin
 	if (t == nullptr) return CMD_ERROR;
 
 	bool reset = text.empty();
+	uint32_t townnameparts;
+	bool is_name_unique;
 
-	if (!reset) {
+	if (reset) {
+		is_name_unique = GenerateTownName(_interactive_random, &townnameparts);
+	} else {
 		if (Utf8StringLength(text) >= MAX_LENGTH_TOWN_NAME_CHARS) return CMD_ERROR;
-		if (!IsUniqueTownName(text)) return CommandCost(STR_ERROR_NAME_MUST_BE_UNIQUE);
+		is_name_unique = IsUniqueTownName(text);
 	}
 
-	if (flags.Test(DoCommandFlag::Execute)) {
+	if (!is_name_unique) {
+		return CommandCost(STR_ERROR_NAME_MUST_BE_UNIQUE);
+	} else if (flags.Test(DoCommandFlag::Execute)) {
 		t->cached_name.clear();
 		if (reset) {
+			t->townnameparts = townnameparts;
 			t->name.clear();
 		} else {
 			t->name = text;


### PR DESCRIPTION
Change: Default townname generates new random name

## Motivation / Problem

To allow a player to remove a custom name or generate a new random name and to move reliance on a stored town name seed allowing other changes to progress.

## Description

A player can click default or set name to blank to generate a new random name.

## Limitations

If a player sets a custom name and changes their mind the old random name won't exist, they would have to set the old name as a custom name. This would be the same case if town name seeds are removed from save games etc.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
