### PR TITLE
Codechange: improve filter parameter name, add documentation

### DIFF
--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -462,23 +462,23 @@ class NetworkContentListWindow : public Window, ContentCallback {
 	}
 
 	/** Filter content by tags/name. @copydoc GUIList::FilterFunction */
-	static bool TagNameFilter(const ContentInfo * const *a, ContentListFilterData &filter)
+	static bool TagNameFilter(const ContentInfo * const *item, ContentListFilterData &filter)
 	{
-		if ((*a)->state == ContentInfo::State::Selected || (*a)->state == ContentInfo::State::Autoselected) return true;
+		if ((*item)->state == ContentInfo::State::Selected || (*item)->state == ContentInfo::State::Autoselected) return true;
 
 		filter.string_filter.ResetState();
-		for (auto &tag : (*a)->tags) filter.string_filter.AddLine(tag);
+		for (auto &tag : (*item)->tags) filter.string_filter.AddLine(tag);
 
-		filter.string_filter.AddLine((*a)->name);
+		filter.string_filter.AddLine((*item)->name);
 		return filter.string_filter.GetState();
 	}
 
 	/** Filter content by type, but still show content selected for download. @copydoc GUIList::FilterFunction */
-	static bool TypeOrSelectedFilter(const ContentInfo * const *a, ContentListFilterData &filter)
+	static bool TypeOrSelectedFilter(const ContentInfo * const *item, ContentListFilterData &filter)
 	{
 		if (filter.types.None()) return true;
-		if (filter.types.Test((*a)->type)) return true;
-		return ((*a)->state == ContentInfo::State::Selected || (*a)->state == ContentInfo::State::Autoselected);
+		if (filter.types.Test((*item)->type)) return true;
+		return ((*item)->state == ContentInfo::State::Selected || (*item)->state == ContentInfo::State::Autoselected);
 	}
 
 	/** Filter the content list */

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -335,14 +335,15 @@ protected:
 		}
 	}
 
-	static bool NGameSearchFilter(NetworkGame * const *item, StringFilter &sf)
+	/** Filter the servers by the server name. @copydoc GUIList::FilterFunction */
+	static bool NGameSearchFilter(NetworkGame * const *item, StringFilter &filter)
 	{
 		assert(item != nullptr);
 		assert((*item) != nullptr);
 
-		sf.ResetState();
-		sf.AddLine((*item)->info.server_name);
-		return sf.GetState();
+		filter.ResetState();
+		filter.AddLine((*item)->info.server_name);
+		return filter.GetState();
 	}
 
 	/**

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1402,12 +1402,12 @@ private:
 	}
 
 	/** Filter grfs by tags/name. @copydoc GUIList::FilterFunction */
-	static bool TagNameFilter(const GRFConfig * const *a, StringFilter &filter)
+	static bool TagNameFilter(const GRFConfig * const *item, StringFilter &filter)
 	{
 		filter.ResetState();
-		filter.AddLine((*a)->GetName());
-		filter.AddLine((*a)->filename);
-		if (auto desc = (*a)->GetDescription(); desc.has_value()) filter.AddLine(*desc);
+		filter.AddLine((*item)->GetName());
+		filter.AddLine((*item)->filename);
+		if (auto desc = (*item)->GetDescription(); desc.has_value()) filter.AddLine(*desc);
 		return filter.GetState();;
 	}
 

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -148,7 +148,7 @@ static bool ClassIDSorter(int const &a, int const &b)
 	return a < b;
 }
 
-/** Filter classes by class name. */
+/** Filter classes by class name. @copydoc GUIList::FilterFunction */
 static bool ClassTagNameFilter(int const *item, PickerFilterData &filter)
 {
 	filter.ResetState();
@@ -164,7 +164,7 @@ static bool TypeIDSorter(PickerItem const &a, PickerItem const &b)
 	return r < 0;
 }
 
-/** Filter types by class name. */
+/** Filter types by class name. @copydoc GUIList::FilterFunction */
 static bool TypeTagNameFilter(PickerItem const *item, PickerFilterData &filter)
 {
 	auto badges = filter.callbacks->GetTypeBadges(item->class_index, item->index);

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -95,30 +95,30 @@ struct SignList {
 		if (!this->signs.Sort(&SignNameSorter)) return;
 	}
 
-	/** Filter sign list by sign name */
-	static bool SignNameFilter(const Sign * const *a, StringFilter &filter)
+	/** Filter sign list by sign name. @copydoc GUIList::FilterFunction */
+	static bool SignNameFilter(const Sign * const *item, StringFilter &filter)
 	{
 		/* Same performance benefit as above for sorting. */
-		const std::string &a_name = (*a)->name.empty() ? SignList::default_name : (*a)->name;
+		const std::string_view name = (*item)->name.empty() ? SignList::default_name : (*item)->name;
 
 		filter.ResetState();
-		filter.AddLine(a_name);
+		filter.AddLine(name);
 		return filter.GetState();
 	}
 
-	/** Filter sign list excluding OWNER_DEITY */
-	static bool OwnerDeityFilter(const Sign * const *a, StringFilter &)
+	/** Filter sign list excluding OWNER_DEITY. @copydoc GUIList::FilterFunction */
+	static bool OwnerDeityFilter(const Sign * const *item, [[maybe_unused]] StringFilter &filter)
 	{
 		/* You should never be able to edit signs of owner DEITY */
-		return (*a)->owner != OWNER_DEITY;
+		return (*item)->owner != OWNER_DEITY;
 	}
 
-	/** Filter sign list by owner */
-	static bool OwnerVisibilityFilter(const Sign * const *a, StringFilter &)
+	/** Filter sign list by owner. @copydoc GUIList::FilterFunction */
+	static bool OwnerVisibilityFilter(const Sign * const *item, [[maybe_unused]] StringFilter &filter)
 	{
 		assert(!HasBit(_display_opt, DO_SHOW_COMPETITOR_SIGNS));
 		/* Hide sign if non-own signs are hidden in the viewport */
-		return (*a)->owner == _local_company || (*a)->owner == OWNER_DEITY;
+		return (*item)->owner == _local_company || (*item)->owner == OWNER_DEITY;
 	}
 
 	/** Filter out signs from the sign list that does not match the name filter */

--- a/src/sortlist_type.h
+++ b/src/sortlist_type.h
@@ -63,11 +63,11 @@ public:
 
 	/**
 	 * Check whether an element should be kept in the list.
-	 * @param a The element to check.
+	 * @param item The element to check.
 	 * @param filter The filter parameter.
 	 * @return \c true iff the element should be in the list.
 	 */
-	using FilterFunction = bool(const T *a, F filter); ///< Signature of filter function.
+	using FilterFunction = bool(const T *item, F filter); ///< Signature of filter function.
 
 protected:
 	std::span<SortFunction * const> sort_func_list;     ///< the sort criteria functions


### PR DESCRIPTION
## Motivation / Problem

Many implementations of filters used `a` as parameter name. Mostly because it seems to have been copied from the comparator for sorters. `item` would be a better parameter name.


## Description

Change the parameter name, and update/add some documentation.

Also replace `const std::string &` variable with `std::string_view`.

Fixes 10 doxygen warnings.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
