### PR TITLE
Codechange: improve some pathfinder documentation

### DIFF
--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -95,7 +95,11 @@ struct CFollowTrackT {
 	static inline bool Allow90degTurns() { return T90deg_turns_allowed_; }
 	static inline bool DoTrackMasking() { return Tmask_reserved_tracks; }
 
-	/** Tests if a tile is a road tile with a single tramtrack (tram can reverse) */
+	/**
+	 * Tests if a tile is a road tile with a single tramtrack (tram can reverse).
+	 * @param tile The tile to get this for.
+	 * @return The direction of the tram bit, or \c INVALID_DIAGDIR when there are no or multiple tram bits.
+	 */
 	inline DiagDirection GetSingleTramBit(TileIndex tile)
 	{
 		assert(this->IsTram()); // this function shouldn't be called in other cases
@@ -114,8 +118,11 @@ struct CFollowTrackT {
 	}
 
 	/**
-	 * main follower routine. Fills all members and return true on success.
-	 *  Otherwise returns false if track can't be followed.
+	 * Main follower routine. Tries to follow the given track direction
+	 * onto the next tile (\c new_tile), while updating the internal state.
+	 * @param old_tile The previous tile.
+	 * @param old_td The track direction on the previous tile.
+	 * @return \c true iff there are one or more tracks to follow on the next tile (\c new_tile).
 	 */
 	inline bool Follow(TileIndex old_tile, Trackdir old_td)
 	{
@@ -235,7 +242,10 @@ protected:
 		}
 	}
 
-	/** stores track status (available trackdirs) for the new tile into new_td_bits */
+	/**
+	 * Stores track status (available trackdirs) for the new tile into new_td_bits.
+	 * @return \c true when at least one trackdir bit exists on the new tile.
+	 */
 	inline bool QueryNewTileTrackStatus()
 	{
 		if (IsRailTT() && IsPlainRailTile(this->new_tile)) {
@@ -248,7 +258,10 @@ protected:
 		return (this->new_td_bits != TRACKDIR_BIT_NONE);
 	}
 
-	/** return true if we can leave old_tile in exitdir */
+	/**
+	 * Check whether we can leave the old tile.
+	 * @return \c true iff we can leave old_tile in exitdir.
+	 */
 	inline bool CanExitOldTile()
 	{
 		/* road stop can be left at one direction only unless it's a drive-through stop */
@@ -280,7 +293,10 @@ protected:
 		return true;
 	}
 
-	/** return true if we can enter new_tile from exitdir */
+	/**
+	 * Checks whether we can enter the next tile.
+	 * @return \c true iff we can enter new_tile from exitdir.
+	 */
 	inline bool CanEnterNewTile()
 	{
 		if (IsRoadTT() && IsBayRoadStopTile(this->new_tile)) {
@@ -388,7 +404,10 @@ protected:
 		return true;
 	}
 
-	/** return true if we must reverse (in depots and single tram bits) */
+	/**
+	 * Are we forced to reverse the vehicle?
+	 * @return \c true iff we must reverse (in depots and single tram bits).
+	 */
 	inline bool ForcedReverse()
 	{
 		/* rail and road depots cause reversing */
@@ -424,7 +443,10 @@ protected:
 		return false;
 	}
 
-	/** return true if we successfully reversed at end of road/track */
+	/**
+	 * Try whether we can reverse our road vehicle.
+	 * @return \c true iff we successfully reversed at end of road/track.
+	 */
 	inline bool TryReverse()
 	{
 		if (IsRoadTT() && !this->IsTram()) {
@@ -445,7 +467,11 @@ protected:
 	}
 
 public:
-	/** Helper for pathfinders - get min/max speed on the old_tile/old_td */
+	/**
+	 * Helper for pathfinders - get min/max speed on the old_tile/old_td.
+	 * @param[out] pmin_speed Optional pointer to location to store the minimum speed to.
+	 * @return The speed limit.
+	 */
 	int GetSpeedLimit(int *pmin_speed = nullptr) const
 	{
 		int min_speed = 0;

--- a/src/pathfinder/pathfinder_func.h
+++ b/src/pathfinder/pathfinder_func.h
@@ -55,6 +55,9 @@ inline TileIndex CalcClosestStationTile(StationID station, TileIndex tile, Stati
  * are in fact on a straight tram track tile. CFollowTrackT will make sure
  * the pathfinders cannot exit on the wrong side and allows reversing on such
  * tiles.
+ * @param tile The tile to check.
+ * @param rtt Whether to check the road or tram type.
+ * @return The trackdir bits on the tile.
  */
 inline TrackdirBits GetTrackdirBitsForRoad(TileIndex tile, RoadTramType rtt)
 {

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -262,6 +262,7 @@ static WaterRegion GetUpdatedWaterRegion(TileIndex tile)
 /**
  * Returns the index of the water region.
  * @param water_region The water region to return the index for.
+ * @return The index of the region.
  */
 static WaterRegionIndex GetWaterRegionIndex(const WaterRegionDesc &water_region)
 {
@@ -271,6 +272,7 @@ static WaterRegionIndex GetWaterRegionIndex(const WaterRegionDesc &water_region)
 /**
  * Calculates a number that uniquely identifies the provided water region patch.
  * @param water_region_patch The Water region to calculate the hash for.
+ * @return The calculated hash.
  */
 int CalculateWaterRegionPatchHash(const WaterRegionPatchDesc &water_region_patch)
 {
@@ -290,6 +292,7 @@ TileIndex GetWaterRegionCenterTile(const WaterRegionDesc &water_region)
 /**
  * Returns basic water region information for the provided tile.
  * @param tile The tile for which the information will be calculated.
+ * @return The region information.
  */
 WaterRegionDesc GetWaterRegionInfo(TileIndex tile)
 {
@@ -299,6 +302,7 @@ WaterRegionDesc GetWaterRegionInfo(TileIndex tile)
 /**
  * Returns basic water region patch information for the provided tile.
  * @param tile The tile for which the information will be calculated.
+ * @return Information about the patches of a region.
  */
 WaterRegionPatchDesc GetWaterRegionPatchInfo(TileIndex tile)
 {

--- a/src/pathfinder/yapf/nodelist.hpp
+++ b/src/pathfinder/yapf/nodelist.hpp
@@ -37,32 +37,47 @@ public:
 		this->new_node = nullptr;
 	}
 
-	/** return number of open nodes */
+	/**
+	 * Get open node count.
+	 * @return Number of open nodes.
+	 */
 	inline int OpenCount()
 	{
 		return this->open_nodes.Count();
 	}
 
-	/** return number of closed nodes */
+	/**
+	 * Get closed node count.
+	 * @return Number of closed nodes.
+	 */
 	inline int ClosedCount()
 	{
 		return this->closed_nodes.Count();
 	}
 
-	/** return the total number of nodes. */
+	/**
+	 * Get the total node count.
+	 * @return The total number of nodes.
+	 */
 	inline int TotalCount()
 	{
 		return this->items.Length();
 	}
 
-	/** allocate new data item from items */
+	/**
+	 * Allocate new data item from items.
+	 * @return The allocated node.
+	 */
 	inline Titem &CreateNewNode()
 	{
 		if (this->new_node == nullptr) this->new_node = &this->items.emplace_back();
 		return *this->new_node;
 	}
 
-	/** Notify the nodelist that we don't want to discard the given node. */
+	/**
+	 * Notify the nodelist that we don't want to discard the given node.
+	 * @param item The new best node.
+	 */
 	inline void FoundBestNode(Titem &item)
 	{
 		/* for now it is enough to invalidate new_node if it is our given node */
@@ -72,7 +87,10 @@ public:
 		/* TODO: do we need to store best nodes found in some extra list/array? Probably not now. */
 	}
 
-	/** insert given item as open node (into open_nodes and open_queue) */
+	/**
+	 * Insert given item as open node (into open_nodes and open_queue).
+	 * @param item The node to add.
+	 */
 	inline void InsertOpenNode(Titem &item)
 	{
 		assert(this->closed_nodes.Find(item.GetKey()) == nullptr);
@@ -83,7 +101,10 @@ public:
 		}
 	}
 
-	/** return the best open node */
+	/**
+	 * Get the open node at the begin of the open queue.
+	 * @return The best open node, or \c nullptr when there isn't any.
+	 */
 	inline Titem *GetBestOpenNode()
 	{
 		if (!this->open_queue.IsEmpty()) {
@@ -92,7 +113,10 @@ public:
 		return nullptr;
 	}
 
-	/** remove and return the best open node */
+	/**
+	 * Remove and return the best open node.
+	 * @return The best open node, or \c nullptr when there isn't any.
+	 */
 	inline Titem *PopBestOpenNode()
 	{
 		if (!this->open_queue.IsEmpty()) {
@@ -103,13 +127,21 @@ public:
 		return nullptr;
 	}
 
-	/** return the open node specified by a key or nullptr if not found */
+	/**
+	 * Find an open node by key.
+	 * @param key The key to look for.
+	 * @return The open node specified by a key or \c nullptr if not found.
+	 */
 	inline Titem *FindOpenNode(const Key &key)
 	{
 		return this->open_nodes.Find(key);
 	}
 
-	/** remove and return the open node specified by a key */
+	/**
+	 * Find and remove an open node by key.
+	 * @param key The key to look for.
+	 * @return The open node specified by a key.
+	 */
 	inline Titem &PopOpenNode(const Key &key)
 	{
 		Titem &item = this->open_nodes.Pop(key);
@@ -118,26 +150,40 @@ public:
 		return item;
 	}
 
-	/** close node */
+	/**
+	 * Insert the given item into the closed nodes set.
+	 * @param item The item to add.
+	 */
 	inline void InsertClosedNode(Titem &item)
 	{
 		assert(this->open_nodes.Find(item.GetKey()) == nullptr);
 		this->closed_nodes.Push(item);
 	}
 
-	/** return the closed node specified by a key or nullptr if not found */
+	/**
+	 * Find a closed node by its key.
+	 * @param key The key to look for.
+	 * @return The closed node specified by a key or \c nullptr if not found.
+	 */
 	inline Titem *FindClosedNode(const Key &key)
 	{
 		return this->closed_nodes.Find(key);
 	}
 
-	/** Get a particular item. */
+	/**
+	 * Get a particular item.
+	 * @param index The index of the item.
+	 * @return The item.
+	 */
 	inline Titem &ItemAt(int index)
 	{
 		return this->items[index];
 	}
 
-	/** Helper for creating output of this array. */
+	/**
+	 * Helper for creating output of this array.
+	 * @param dmp The data to dump.
+	 */
 	template <class D>
 	void Dump(D &dmp) const
 	{

--- a/src/pathfinder/yapf/yapf_base.hpp
+++ b/src/pathfinder/yapf/yapf_base.hpp
@@ -56,6 +56,53 @@ public:
 
 	NodeList nodes; ///< node list multi-container
 
+	/**
+	 * Called by YAPF to move from the given node to the next tile. For each
+	 * reachable trackdir on the new tile creates new node, initializes it
+	 * and adds it to the open list by calling Yapf().AddNewNode(n).
+	 * @param old_node The node to follow from.
+	 */
+	using PfFollowNodeFunc = void(Node &old_node);
+
+	/**
+	 * Called by YAPF to calculate the cost from the origin to the given node.
+	 * Calculates only the cost of given node, adds it to the parent node cost
+	 * and stores the result into Node::cost member.
+	 * @param n The node to consider.
+	 * @param follower The track follower to the next node.
+	 * @return \c true iff the costs could be calculated.
+	 */
+	using PfCalcCostFunc = bool(Node &n, const TrackFollower *follower);
+
+	/**
+	 * Called by YAPF to calculate cost estimate. Calculates distance to the destination
+	 * adds it to the actual cost from origin and stores the sum to the Node::estimate.
+	 * @param n The node to start from.
+	 * @return \c true iff the cost could be estimated.
+	 */
+	using PfCalcEstimateFunc = bool(Node &n);
+
+	/**
+	 * Called by YAPF to detect if node ends in the desired destination.
+	 * @param n The current node.
+	 * @return \c true iff the destination has been reached.
+	 */
+	using PfDetectDestinationFunc = bool(Node &n);
+
+	/**
+	 * Called by YAPF to detect if node ends in the desired destination.
+	 * @param tile The reached tile.
+	 * @param td The reached track direction.
+	 * @return \c true iff the destination has been reached.
+	 */
+	using PfDetectDestinationTileFunc = bool(TileIndex tile, Trackdir td);
+
+	/**
+	 * Return debug report character to identify the transportation type.
+	 * @return The debug representation
+	 */
+	using TransportTypeCharFunc = char();
+
 protected:
 	Node *best_dest_node = nullptr; ///< pointer to the destination node found at last round
 	Node *best_intermediate_node = nullptr; ///< here should be node closest to the destination if path not found
@@ -77,14 +124,20 @@ public:
 	~CYapfBaseT() {}
 
 protected:
-	/** to access inherited path finder */
+	/**
+	 * Access the inherited path finder.
+	 * @return The current path finder.
+	 */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
 public:
-	/** return current settings (can be custom - company based - but later) */
+	/**
+	 * Return current settings (can be custom - company based - but later).
+	 * @return The pathfinder settings.
+	 */
 	inline const YAPFSettings &PfGetSettings() const
 	{
 		return *this->settings;
@@ -97,6 +150,7 @@ public:
 	 *      - the destination was found
 	 *      - or the open list is empty (no route to destination).
 	 *      - or the maximum amount of loops reached - max_search_nodes (default = 10000)
+	 * @param v The vehicle to find the path for.
 	 * @return true if the path was found
 	 */
 	inline bool FindPath(const VehicleType *v)
@@ -140,6 +194,7 @@ public:
 	/**
 	 * If path was found return the best node that has reached the destination. Otherwise
 	 *  return the best visited node (which was nearest to the destination).
+	 * @return The best node, or best intermediate node.
 	 */
 	inline Node *GetBestNode()
 	{
@@ -149,6 +204,7 @@ public:
 	/**
 	 * Calls NodeList::CreateNewNode() - allocates new node that can be filled and used
 	 *  as argument for AddStartupNode() or AddNewNode()
+	 * @return The created node.
 	 */
 	inline Node &CreateNewNode()
 	{
@@ -156,7 +212,10 @@ public:
 		return node;
 	}
 
-	/** Add new node (created by CreateNewNode and filled with data) into open list */
+	/**
+	 * Add new node (created by CreateNewNode and filled with data) into open list.
+	 * @param n The node to add.
+	 */
 	inline void AddStartupNode(Node &n)
 	{
 		assert(n.parent == nullptr);
@@ -169,7 +228,11 @@ public:
 		}
 	}
 
-	/** add multiple nodes - direct children of the given node */
+	/**
+	 * Add multiple nodes - direct children of the given node.
+	 * @param parent The parent of the nodes.
+	 * @param tf The track follower to keep following.
+	 */
 	inline void AddMultipleNodes(Node *parent, const TrackFollower &tf)
 	{
 		bool is_choice = (KillFirstBit(tf.new_td_bits) != TRACKDIR_BIT_NONE);
@@ -184,6 +247,8 @@ public:
 	/**
 	 * AddNewNode() - called by Tderived::PfFollowNode() for each child node.
 	 *  Nodes are evaluated here and added into open list
+	 * @param n The node to add.
+	 * @param follower The track follower to keep calculate the cost with.
 	 */
 	void AddNewNode(Node &n, const TrackFollower &follower)
 	{

--- a/src/pathfinder/yapf/yapf_common.hpp
+++ b/src/pathfinder/yapf/yapf_common.hpp
@@ -23,14 +23,18 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables
 
 protected:
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
 public:
-	/** Set origin tile / trackdir mask */
+	/**
+	 * Set origin tile / trackdir mask.
+	 * @param tile The start tile.
+	 * @param trackdirs The start track directions.
+	 */
 	void SetOrigin(TileIndex tile, TrackdirBits trackdirs)
 	{
 		bool is_choice = (KillFirstBit(trackdirs) != TRACKDIR_BIT_NONE);
@@ -52,14 +56,21 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables
 
 protected:
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
 public:
-	/** set origin (tiles, trackdirs, etc.) */
+	/**
+	 * Set origin (tiles, trackdirs, etc.).
+	 * @param forward_tile The start tile when going forward.
+	 * @param forward_td The track direction when going forward.
+	 * @param reverse_tile The start tile when going backward.
+	 * @param reverse_td The track direction when going backward.
+	 * @param reverse_penalty The penalty for reversing.
+	 */
 	void SetOrigin(TileIndex forward_tile, Trackdir forward_td, TileIndex reverse_tile = INVALID_TILE,
 			Trackdir reverse_td = INVALID_TRACKDIR, int reverse_penalty = 0)
 	{

--- a/src/pathfinder/yapf/yapf_costcache.hpp
+++ b/src/pathfinder/yapf/yapf_costcache.hpp
@@ -27,7 +27,7 @@ public:
 
 	/**
 	 * Called by YAPF to attach cached or local segment cost data to the given node.
-	 *  @return true if globally cached data were used or false if local data was used
+	 * @return \c true if globally cached data were used or \c false if local data was used.
 	 */
 	inline bool PfNodeCacheFetch(Node &)
 	{
@@ -116,7 +116,7 @@ protected:
 
 	inline CYapfSegmentCostCacheGlobalT() : global_cache(stGetGlobalCache()) {};
 
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
@@ -138,7 +138,8 @@ protected:
 public:
 	/**
 	 * Called by YAPF to attach cached or local segment cost data to the given node.
-	 *  @return true if globally cached data were used or false if local data was used
+	 * @param n The node to get the cache for.
+	 * @return \c true if globally cached data were used or \c false if local data was used
 	 */
 	inline bool PfNodeCacheFetch(Node &n)
 	{

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -69,20 +69,26 @@ protected:
 		}
 	}
 
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
 public:
-	/** Sets whether the first two-way signal should be treated as a dead end */
+	/**
+	 * Sets whether the first two-way signal should be treated as a dead end.
+	 * @param enabled Whether to treat them as dead ends.
+	 */
 	void SetTreatFirstRedTwoWaySignalAsEOL(bool enabled)
 	{
 		this->treat_first_red_two_way_signal_as_eol = enabled;
 	}
 
-	/** Returns whether the first two-way signal should be treated as a dead end */
+	/**
+	 * Returns whether the first two-way signal should be treated as a dead end.
+	 * @return \c true iff the `rail_firstred_twoway_eol` setting is enabled, and it is enabled for this instance.
+	 */
 	inline bool TreatFirstRedTwoWaySignalAsEOL()
 	{
 		return Yapf().PfGetSettings().rail_firstred_twoway_eol && this->treat_first_red_two_way_signal_as_eol;
@@ -120,8 +126,13 @@ public:
 		return 0;
 	}
 
-	/** Return one tile cost (base cost + level crossing penalty). */
-	inline int OneTileCost(TileIndex &tile, Trackdir trackdir)
+	/**
+	 * Return one tile cost (base cost + level crossing penalty).
+	 * @param tile The tile to consider.
+	 * @param trackdir The direction of travel.
+	 * @return The cost.
+	 */
+	inline int OneTileCost(TileIndex tile, Trackdir trackdir)
 	{
 		int cost = 0;
 		/* set base cost */
@@ -145,17 +156,30 @@ public:
 		return cost;
 	}
 
-	/** Check for a reserved station platform. */
-	inline bool IsAnyStationTileReserved(TileIndex tile, Trackdir trackdir, int skipped)
+	/**
+	 * Check for a reserved station platform.
+	 * @param tile The tile to check.
+	 * @param trackdir The direction to check in.
+	 * @param distance The number of tiles to check.
+	 * @return \c true iff there is any reserved tile in the given direction for the given distance.
+	 */
+	inline bool IsAnyStationTileReserved(TileIndex tile, Trackdir trackdir, int distance)
 	{
 		TileIndexDiff diff = TileOffsByDiagDir(TrackdirToExitdir(ReverseTrackdir(trackdir)));
-		for (; skipped >= 0; skipped--, tile += diff) {
+		for (; distance >= 0; distance--, tile += diff) {
 			if (HasStationReservation(tile)) return true;
 		}
 		return false;
 	}
 
-	/** The cost for reserved tiles, including skipped ones. */
+	/**
+	 * Calculate the cost for reserved tiles, including skipped ones.
+	 * @param n The current node.
+	 * @param tile The start tile to look at.
+	 * @param trackdir The chosen track direction at the tile.
+	 * @param skipped The number of tiles the path follower skipped.
+	 * @return The total reservation cost.
+	 */
 	inline int ReservationCost(Node &n, TileIndex tile, Trackdir trackdir, int skipped)
 	{
 		if (n.num_signals_passed >= this->sig_look_ahead_costs.size() / 2) return 0;
@@ -266,11 +290,7 @@ public:
 		this->max_cost = max_cost;
 	}
 
-	/**
-	 * Called by YAPF to calculate the cost from the origin to the given node.
-	 *  Calculates only the cost of given node, adds it to the parent node cost
-	 *  and stores the result into Node::cost member
-	 */
+	/** @copydoc CYapfBaseT::PfCalcCostFunc */
 	inline bool PfCalcCost(Node &n, const TrackFollower *follower)
 	{
 		assert(!n.flags_u.flags_s.target_seen);

--- a/src/pathfinder/yapf/yapf_destrail.hpp
+++ b/src/pathfinder/yapf/yapf_destrail.hpp
@@ -43,28 +43,25 @@ public:
 	typedef typename Types::NodeList::Item Node; ///< this will be our node type
 	typedef typename Node::Key Key; ///< key to hash tables
 
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
-	/** Called by YAPF to detect if node ends in the desired destination */
+	/** @copydoc CYapfBaseT::PfDetectDestinationFunc */
 	inline bool PfDetectDestination(Node &n)
 	{
 		return this->PfDetectDestination(n.GetLastTile(), n.GetLastTrackdir());
 	}
 
-	/** Called by YAPF to detect if node ends in the desired destination */
-	inline bool PfDetectDestination(TileIndex tile, Trackdir)
+	/** @copydoc CYapfBaseT::PfDetectDestinationTileFunc */
+	inline bool PfDetectDestination(TileIndex tile, [[maybe_unused]] Trackdir td)
 	{
 		return IsRailDepotTile(tile);
 	}
 
-	/**
-	 * Called by YAPF to calculate cost estimate. Calculates distance to the destination
-	 *  adds it to the actual cost from origin and stores the sum to the Node::estimate
-	 */
+	/** @copydoc CYapfBaseT::PfCalcEstimateFunc */
 	inline bool PfCalcEstimate(Node &n)
 	{
 		n.estimate = n.cost;
@@ -80,29 +77,26 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables
 	typedef typename Types::TrackFollower TrackFollower; ///< TrackFollower. Need to typedef for gcc 2.95
 
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
-	/** Called by YAPF to detect if node ends in the desired destination */
+	/** @copydoc CYapfBaseT::PfDetectDestinationFunc */
 	inline bool PfDetectDestination(Node &n)
 	{
 		return this->PfDetectDestination(n.GetLastTile(), n.GetLastTrackdir());
 	}
 
-	/** Called by YAPF to detect if node ends in the desired destination */
+	/** @copydoc CYapfBaseT::PfDetectDestinationTileFunc */
 	inline bool PfDetectDestination(TileIndex tile, Trackdir td)
 	{
 		return IsSafeWaitingPosition(Yapf().GetVehicle(), tile, td, true, !TrackFollower::Allow90degTurns()) &&
 				IsWaitingPositionFree(Yapf().GetVehicle(), tile, td, !TrackFollower::Allow90degTurns());
 	}
 
-	/**
-	 * Called by YAPF to calculate cost estimate. Calculates distance to the destination
-	 *  adds it to the actual cost from origin and stores the sum to the Node::estimate.
-	 */
+	/** @copydoc CYapfBaseT::PfCalcEstimateFunc */
 	inline bool PfCalcEstimate(Node &n)
 	{
 		n.estimate = n.cost;
@@ -123,7 +117,7 @@ protected:
 	StationID dest_station_id;
 	bool any_depot;
 
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
@@ -166,13 +160,13 @@ public:
 		this->CYapfDestinationRailBase::SetDestination(v);
 	}
 
-	/** Called by YAPF to detect if node ends in the desired destination */
+	/** @copydoc CYapfBaseT::PfDetectDestinationFunc */
 	inline bool PfDetectDestination(Node &n)
 	{
 		return this->PfDetectDestination(n.GetLastTile(), n.GetLastTrackdir());
 	}
 
-	/** Called by YAPF to detect if node ends in the desired destination */
+	/** @copydoc CYapfBaseT::PfDetectDestinationTileFunc */
 	inline bool PfDetectDestination(TileIndex tile, Trackdir td)
 	{
 		if (this->dest_station_id != StationID::Invalid()) {
@@ -188,10 +182,7 @@ public:
 		return (tile == this->dest_tile) && HasTrackdir(this->dest_trackdirs, td);
 	}
 
-	/**
-	 * Called by YAPF to calculate cost estimate. Calculates distance to the destination
-	 *  adds it to the actual cost from origin and stores the sum to the Node::estimate
-	 */
+	/** @copydoc CYapfBaseT::PfCalcEstimateFunc */
 	inline bool PfCalcEstimate(Node &n)
 	{
 		if (this->PfDetectDestination(n)) {

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -40,7 +40,7 @@ public:
 	typedef typename Types::NodeList::Item Node; ///< this will be our node type
 
 protected:
-	/** to access inherited pathfinder */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
@@ -66,7 +66,12 @@ private:
 		return true;
 	}
 
-	/** Reserve a railway platform. Tile contains the failed tile on abort. */
+	/**
+	 * Reserve a railway platform. Tile contains the failed tile on abort.
+	 * @param tile The start tile.
+	 * @param dir The direction to reserve further tiles in.
+	 * @return \c true iff reservation succeeded.
+	 */
 	bool ReserveRailStationPlatform(TileIndex &tile, DiagDirection dir)
 	{
 		TileIndex     start = tile;
@@ -86,7 +91,12 @@ private:
 		return true;
 	}
 
-	/** Try to reserve a single track/platform. */
+	/**
+	 * Reserve a single track/platform.
+	 * @param tile The start tile.
+	 * @param td The track direction that is to be reserved.
+	 * @return \c true iff reservation succeeded.
+	 */
 	bool ReserveSingleTrack(TileIndex tile, Trackdir td)
 	{
 		Trackdir rev_td = ReverseTrackdir(td);
@@ -121,7 +131,12 @@ private:
 		return tile != this->res_dest_tile || td != this->res_dest_td;
 	}
 
-	/** Unreserve a single track/platform. Stops when the previous failure is reached. */
+	/**
+	 * Unreserve a single track/platform. Stops when the previous failure is reached.
+	 * @param tile The start tile.
+	 * @param td The track direction that is to be unreserved.
+	 * @return \c true iff the unreservation succeeded.
+	 */
 	bool UnreserveSingleTrack(TileIndex tile, Trackdir td)
 	{
 		if (IsRailStationTile(tile)) {
@@ -138,7 +153,12 @@ private:
 	}
 
 public:
-	/** Set the target to where the reservation should be extended. */
+	/**
+	 * Set the target to where the reservation should be extended.
+	 * @param node The destination node.
+	 * @param tile The destination tile.
+	 * @param td The destination track direction.
+	 */
 	inline void SetReservationTarget(Node *node, TileIndex tile, Trackdir td)
 	{
 		this->res_dest_node = node;
@@ -146,7 +166,10 @@ public:
 		this->res_dest_td = td;
 	}
 
-	/** Check the node for a possible reservation target. */
+	/**
+	 * Check the node for a possible reservation target.
+	 * @param node The node to check.
+	 */
 	inline void FindSafePositionOnNode(Node *node)
 	{
 		assert(node->parent != nullptr);
@@ -159,7 +182,12 @@ public:
 		}
 	}
 
-	/** Try to reserve the path till the reservation target. */
+	/**
+	 * Try to reserve the path till the reservation target.
+	 * @param target End location of the reservation.
+	 * @param origin Start location of the reservation.
+	 * @return \c true iff the path could be reserved.
+	 */
 	bool TryReservePath(PBSTileInfo *target, TileIndex origin)
 	{
 		this->res_fail_tile = INVALID_TILE;
@@ -215,18 +243,14 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables
 
 protected:
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
 public:
-	/**
-	 * Called by YAPF to move from the given node to the next tile. For each
-	 *  reachable trackdir on the new tile creates new node, initializes it
-	 *  and adds it to the open list by calling Yapf().AddNewNode(n)
-	 */
+	/** @copydoc CYapfBaseT::PfFollowNodeFunc */
 	inline void PfFollowNode(Node &old_node)
 	{
 		TrackFollower follower{Yapf().GetVehicle()};
@@ -235,7 +259,7 @@ public:
 		}
 	}
 
-	/** return debug report character to identify the transportation type */
+	/** @copydoc CYapfBaseT::TransportTypeCharFunc */
 	inline char TransportTypeChar() const
 	{
 		return 't';
@@ -306,18 +330,14 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables
 
 protected:
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
 public:
-	/**
-	 * Called by YAPF to move from the given node to the next tile. For each
-	 *  reachable trackdir on the new tile creates new node, initializes it
-	 *  and adds it to the open list by calling Yapf().AddNewNode(n)
-	 */
+	/** @copydoc CYapfBaseT::PfFollowNodeFunc */
 	inline void PfFollowNode(Node &old_node)
 	{
 		TrackFollower follower{Yapf().GetVehicle(), Yapf().GetCompatibleRailTypes()};
@@ -326,7 +346,7 @@ public:
 		}
 	}
 
-	/** Return debug report character to identify the transportation type */
+	/** @copydoc CYapfBaseT::TransportTypeCharFunc */
 	inline char TransportTypeChar() const
 	{
 		return 't';
@@ -388,18 +408,14 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables
 
 protected:
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
 public:
-	/**
-	 * Called by YAPF to move from the given node to the next tile. For each
-	 *  reachable trackdir on the new tile creates new node, initializes it
-	 *  and adds it to the open list by calling Yapf().AddNewNode(n)
-	 */
+	/** @copydoc CYapfBaseT::PfFollowNodeFunc */
 	inline void PfFollowNode(Node &old_node)
 	{
 		TrackFollower follower{Yapf().GetVehicle()};
@@ -408,7 +424,7 @@ public:
 		}
 	}
 
-	/** return debug report character to identify the transportation type */
+	/** @copydoc CYapfBaseT::TransportTypeCharFunc */
 	inline char TransportTypeChar() const
 	{
 		return 't';
@@ -555,6 +571,7 @@ struct CYapfRailBase : CYapfT<Types> {
 	 * the branch would not be pruned, the rail type change location would
 	 * remain the best intermediate node, and thus the vehicle would still
 	 * go towards the red EOL signal.
+	 * @param n The node to start pruning at.
 	 */
 	void PruneIntermediateNodeBranch(Node *n)
 	{

--- a/src/pathfinder/yapf/yapf_river_builder.cpp
+++ b/src/pathfinder/yapf/yapf_river_builder.cpp
@@ -64,17 +64,20 @@ public:
 		Yapf().AddStartupNode(node);
 	}
 
+	/** @copydoc CYapfBaseT::PfDetectDestinationFunc */
 	inline bool PfDetectDestination(Node &n) const
 	{
 		return n.GetTile() == this->end_tile;
 	}
 
-	inline bool PfCalcCost(Node &n, const RiverBuilderFollower *)
+	/** @copydoc CYapfBaseT::PfCalcCostFunc */
+	inline bool PfCalcCost(Node &n, [[maybe_unused]] const RiverBuilderFollower *follower)
 	{
 		n.cost = n.parent->cost + 1 + RandomRange(_settings_game.game_creation.river_route_random);
 		return true;
 	}
 
+	/** @copydoc CYapfBaseT::PfCalcEstimateFunc */
 	inline bool PfCalcEstimate(Node &n)
 	{
 		n.estimate = n.cost + DistanceManhattan(this->end_tile, n.GetTile());
@@ -82,6 +85,7 @@ public:
 		return true;
 	}
 
+	/** @copydoc CYapfBaseT::PfFollowNodeFunc */
 	inline void PfFollowNode(Node &old_node)
 	{
 		for (DiagDirection d = DIAGDIR_BEGIN; d < DIAGDIR_END; ++d) {
@@ -94,6 +98,7 @@ public:
 		}
 	}
 
+	/** @copydoc CYapfBaseT::TransportTypeCharFunc */
 	inline char TransportTypeChar() const
 	{
 		return '~';

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -28,7 +28,7 @@ protected:
 
 	CYapfCostRoadT() : max_cost(0) {};
 
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
@@ -53,7 +53,12 @@ protected:
 		return 0;
 	}
 
-	/** return one tile cost */
+	/**
+	 * Return one tile cost.
+	 * @param tile The tile to consider.
+	 * @param trackdir The direction of travel.
+	 * @return The cost.
+	 */
 	inline int OneTileCost(TileIndex tile, Trackdir trackdir)
 	{
 		int cost = 0;
@@ -105,12 +110,8 @@ public:
 		this->max_cost = max_cost;
 	}
 
-	/**
-	 * Called by YAPF to calculate the cost from the origin to the given node.
-	 *  Calculates only the cost of given node, adds it to the parent node cost
-	 *  and stores the result into Node::cost member
-	 */
-	inline bool PfCalcCost(Node &n, const TrackFollower *)
+	/** @copydoc CYapfBaseT::PfCalcCostFunc */
+	inline bool PfCalcCost(Node &n, [[maybe_unused]] const TrackFollower *follower)
 	{
 		int segment_cost = 0;
 		uint tiles = 0;
@@ -190,27 +191,25 @@ public:
 	typedef typename Types::NodeList::Item Node; ///< this will be our node type
 	typedef typename Node::Key Key; ///< key to hash tables
 
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
-	/** Called by YAPF to detect if node ends in the desired destination */
+	/** @copydoc CYapfBaseT::PfDetectDestinationFunc */
 	inline bool PfDetectDestination(Node &n)
 	{
 		return IsRoadDepotTile(n.segment_last_tile);
 	}
 
-	inline bool PfDetectDestinationTile(TileIndex tile, Trackdir)
+	/** @copydoc CYapfBaseT::PfDetectDestinationTileFunc */
+	inline bool PfDetectDestinationTile(TileIndex tile, [[maybe_unused]] Trackdir td)
 	{
 		return IsRoadDepotTile(tile);
 	}
 
-	/**
-	 * Called by YAPF to calculate cost estimate. Calculates distance to the destination
-	 *  adds it to the actual cost from origin and stores the sum to the Node::estimate
-	 */
+	/** @copydoc CYapfBaseT::PfCalcEstimateFunc */
 	inline bool PfCalcEstimate(Node &n)
 	{
 		n.estimate = n.cost;
@@ -262,20 +261,21 @@ public:
 	}
 
 protected:
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
 	}
 
 public:
-	/** Called by YAPF to detect if node ends in the desired destination */
+	/** @copydoc CYapfBaseT::PfDetectDestinationFunc */
 	inline bool PfDetectDestination(Node &n)
 	{
 		return this->PfDetectDestinationTile(n.segment_last_tile, n.segment_last_td);
 	}
 
-	inline bool PfDetectDestinationTile(TileIndex tile, Trackdir trackdir)
+	/** @copydoc CYapfBaseT::PfDetectDestinationTileFunc */
+	inline bool PfDetectDestinationTile(TileIndex tile, Trackdir td)
 	{
 		if (this->dest_station != StationID::Invalid()) {
 			return IsTileType(tile, TileType::Station) &&
@@ -284,13 +284,10 @@ public:
 				(this->non_artic || IsDriveThroughStopTile(tile));
 		}
 
-		return tile == this->dest_tile && HasTrackdir(this->dest_trackdirs, trackdir);
+		return tile == this->dest_tile && HasTrackdir(this->dest_trackdirs, td);
 	}
 
-	/**
-	 * Called by YAPF to calculate cost estimate. Calculates distance to the destination
-	 *  adds it to the actual cost from origin and stores the sum to the Node::estimate
-	 */
+	/** @copydoc CYapfBaseT::PfCalcEstimateFunc */
 	inline bool PfCalcEstimate(Node &n)
 	{
 		if (this->PfDetectDestination(n)) {
@@ -315,7 +312,7 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables
 
 protected:
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf *>(this);
@@ -323,11 +320,7 @@ protected:
 
 public:
 
-	/**
-	 * Called by YAPF to move from the given node to the next tile. For each
-	 *  reachable trackdir on the new tile creates new node, initializes it
-	 *  and adds it to the open list by calling Yapf().AddNewNode(n)
-	 */
+	/** @copydoc CYapfBaseT::PfFollowNodeFunc */
 	inline void PfFollowNode(Node &old_node)
 	{
 		TrackFollower F(Yapf().GetVehicle());
@@ -336,7 +329,7 @@ public:
 		}
 	}
 
-	/** return debug report character to identify the transportation type */
+	/** @copydoc CYapfBaseT::TransportTypeCharFunc */
 	inline char TransportTypeChar() const
 	{
 		return 'r';
@@ -442,7 +435,11 @@ public:
 		return dist;
 	}
 
-	/** Return true if the valid origin (tile/trackdir) was set from the current vehicle position. */
+	/**
+	 * Return true if the valid origin (tile/trackdir) was set from the current vehicle position.
+	 * @param v The vehicle to get the position from.
+	 * @return \c true iff the origin was set.
+	 */
 	inline bool SetOriginFromVehiclePos(const RoadVehicle *v)
 	{
 		/* set origin (tile, trackdir) */
@@ -469,6 +466,7 @@ public:
 	 * @param tile Tile of the vehicle.
 	 * @param td Trackdir of the vehicle.
 	 * @param max_distance max length (penalty) for paths.
+	 * @return Information about the result of the search.
 	 */
 	inline FindDepotData FindNearestDepot(const RoadVehicle *v, TileIndex tile, Trackdir td, int max_distance)
 	{

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -62,20 +62,21 @@ public:
 	}
 
 protected:
-	/** To access inherited path finder. */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf& Yapf()
 	{
 		return *static_cast<Tpf*>(this);
 	}
 
 public:
-	/** Called by YAPF to detect if node ends in the desired destination. */
+	/** @copydoc CYapfBaseT::PfDetectDestinationFunc */
 	inline bool PfDetectDestination(Node &n)
 	{
 		return this->PfDetectDestinationTile(n.GetTile(), n.GetTrackdir());
 	}
 
-	inline bool PfDetectDestinationTile(TileIndex tile, Trackdir trackdir)
+	/** @copydoc CYapfBaseT::PfDetectDestinationTileFunc */
+	inline bool PfDetectDestinationTile(TileIndex tile, Trackdir td)
 	{
 		if (this->has_intermediate_dest) {
 			/* GetWaterRegionInfo is much faster than GetWaterRegionPatchInfo so we try that first. */
@@ -85,13 +86,10 @@ public:
 
 		if (this->dest_station != StationID::Invalid()) return IsDockingTile(tile) && IsShipDestinationTile(tile, this->dest_station);
 
-		return tile == this->dest_tile && ((this->dest_trackdirs & TrackdirToTrackdirBits(trackdir)) != TRACKDIR_BIT_NONE);
+		return tile == this->dest_tile && ((this->dest_trackdirs & TrackdirToTrackdirBits(td)) != TRACKDIR_BIT_NONE);
 	}
 
-	/**
-	 * Called by YAPF to calculate cost estimate. Calculates distance to the destination
-	 * adds it to the actual cost from origin and stores the sum to the Node::estimate.
-	 */
+	/** @copydoc CYapfBaseT::PfCalcEstimateFunc */
 	inline bool PfCalcEstimate(Node &n)
 	{
 		const TileIndex destination_tile = this->has_intermediate_dest ? this->intermediate_dest_tile : this->dest_tile;
@@ -117,7 +115,7 @@ public:
 	typedef typename Node::Key Key; ///< key to hash tables.
 
 protected:
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	inline Tpf &Yapf()
 	{
 		return *static_cast<Tpf*>(this);
@@ -126,11 +124,7 @@ protected:
 	std::vector<WaterRegionDesc> water_region_corridor;
 
 public:
-	/**
-	 * Called by YAPF to move from the given node to the next tile. For each
-	 *  reachable trackdir on the new tile creates new node, initializes it
-	 *  and adds it to the open list by calling Yapf().AddNewNode(n)
-	 */
+	/** @copydoc CYapfBaseT::PfFollowNodeFunc */
 	inline void PfFollowNode(Node &old_node)
 	{
 		TrackFollower follower{Yapf().GetVehicle()};
@@ -142,20 +136,27 @@ public:
 		}
 	}
 
-	/** Restricts the search by creating corridor or water regions through which the ship is allowed to travel. */
+	/**
+	 * Restricts the search by creating corridor or water regions through which the ship is allowed to travel.
+	 * @param path The path to restrict the search by.
+	 */
 	inline void RestrictSearch(const std::vector<WaterRegionPatchDesc> &path)
 	{
 		this->water_region_corridor.clear();
 		for (const WaterRegionPatchDesc &path_entry : path) this->water_region_corridor.push_back(path_entry);
 	}
 
-	/** Return debug report character to identify the transportation type. */
+	/** @copydoc CYapfBaseT::TransportTypeCharFunc */
 	inline char TransportTypeChar() const
 	{
 		return 'w';
 	}
 
-	/** Returns a random trackdir out of a set of trackdirs. */
+	/**
+	 * Returns a random trackdir out of a set of trackdirs.
+	 * @param trackdirs The possible track dirs.
+	 * @return One of the possible track dirs.
+	 */
 	static Trackdir GetRandomTrackdir(TrackdirBits trackdirs)
 	{
 		const int strip_amount = RandomRange(CountBits(trackdirs));
@@ -163,7 +164,13 @@ public:
 		return FindFirstTrackdir(trackdirs);
 	}
 
-	/** Returns a random tile/trackdir that can be reached from the current tile/trackdir, or tile/INVALID_TRACK if none is available. */
+	/**
+	 * Returns a random tile/trackdir that can be reached from the current tile/trackdir, or tile/INVALID_TRACK if none is available.
+	 * @param v The ship to get the direction for.
+	 * @param tile The start tile.
+	 * @param dir the start direction.
+	 * @return The next tile and a direction.
+	 */
 	static std::pair<TileIndex, Trackdir> GetRandomFollowUpTileTrackdir(const Ship *v, TileIndex tile, Trackdir dir)
 	{
 		TrackFollower follower{v};
@@ -176,7 +183,13 @@ public:
 		return { follower.new_tile, INVALID_TRACKDIR };
 	}
 
-	/** Creates a random path, avoids 90 degree turns. */
+	/**
+	 * Creates a random path, avoids 90 degree turns.
+	 * @param v The ship to create the path for.
+	 * @param[in,out] path_cache Cache of the path for the ship.
+	 * @param path_length The length of the random path to create.
+	 * @return The next track direction to take, or \c INVALID_TRACKDIR when there is no option.
+	 */
 	static Trackdir CreateRandomPath(const Ship *v, ShipPathCache &path_cache, int path_length)
 	{
 		std::pair<TileIndex, Trackdir> tile_dir = { v->tile, v->GetVehicleTrackdir()};
@@ -317,7 +330,7 @@ public:
 	typedef typename Types::NodeList::Item Node; ///< this will be our node type.
 	typedef typename Node::Key Key; ///< key to hash tables.
 
-	/** to access inherited path finder */
+	/** @copydoc CYapfBaseT::Yapf */
 	Tpf &Yapf()
 	{
 		return *static_cast<Tpf*>(this);
@@ -356,11 +369,7 @@ public:
 		return (odd_x ^ odd_y) ^ HasBit(TRACKDIR_BIT_RIGHT_N | TRACKDIR_BIT_LEFT_S | TRACKDIR_BIT_UPPER_W | TRACKDIR_BIT_LOWER_E, td);
 	}
 
-	/**
-	 * Called by YAPF to calculate the cost from the origin to the given node.
-	 * Calculates only the cost of given node, adds it to the parent node cost
-	 * and stores the result into Node::cost member.
-	 */
+	/** @copydoc CYapfBaseT::PfCalcCostFunc */
 	inline bool PfCalcCost(Node &n, const TrackFollower *follower)
 	{
 		/* Base tile cost depending on distance. */
@@ -426,7 +435,6 @@ struct CYapfShip : CYapfT<CYapfShip_TypesT<CYapfShip>> {
 	explicit CYapfShip(int max_nodes) { this->max_search_nodes = max_nodes; }
 };
 
-/** Ship controller helper - path finder invoker. */
 Track YapfShipChooseTrack(const Ship *v, TileIndex tile, bool &path_found, ShipPathCache &path_cache)
 {
 	Trackdir best_origin_dir = INVALID_TRACKDIR;

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -131,6 +131,7 @@ public:
 		this->dest.Set(water_region_patch);
 	}
 
+	/** @copydoc CYapfBaseT::PfFollowNodeFunc */
 	inline void PfFollowNode(Node &old_node)
 	{
 		VisitWaterRegionPatchCallback visit_func = [&](const WaterRegionPatchDesc &water_region_patch) {
@@ -141,12 +142,14 @@ public:
 		VisitWaterRegionPatchNeighbours(old_node.key.water_region_patch, visit_func);
 	}
 
+	/** @copydoc CYapfBaseT::PfDetectDestinationFunc */
 	inline bool PfDetectDestination(Node &n) const
 	{
 		return n.key == this->dest;
 	}
 
-	inline bool PfCalcCost(Node &n, const TrackFollower *)
+	/** @copydoc CYapfBaseT::PfCalcCostFunc */
+	inline bool PfCalcCost(Node &n, [[maybe_unused]] const TrackFollower *follower)
 	{
 		n.cost = n.parent->cost + ManhattanDistance(n.key, n.parent->key);
 
@@ -160,6 +163,7 @@ public:
 		return true;
 	}
 
+	/** @copydoc CYapfBaseT::PfCalcEstimateFunc */
 	inline bool PfCalcEstimate(Node &n)
 	{
 		if (this->PfDetectDestination(n)) {
@@ -172,8 +176,10 @@ public:
 		return true;
 	}
 
+	/** @copydoc CYapfBaseT::TransportTypeCharFunc */
 	inline char TransportTypeChar() const { return '^'; }
 
+	/** @copydoc YapfShipFindWaterRegionPath */
 	static std::vector<WaterRegionPatchDesc> FindWaterRegionPath(const Ship *v, TileIndex start_tile, int max_returned_path_length)
 	{
 		const WaterRegionPatchDesc start_water_region_patch = GetWaterRegionPatchInfo(start_tile);


### PR DESCRIPTION
## Motivation / Problem

Lots of doxygen warnings about missing parameter and return type documentation.


## Description

Adds a number of unused `using`/typedefs to `CYapfBaseT` for functions that are required to be implemented in every subclass. However, due to the templating of Yapf this is not a simple virtual function, so each implementation needs its own documentation, and then it's better to be able to just `@copydoc` them.
Due to this a few parameter names have been changed in some instances. Also a few of these without any documentation have gotten the `@copydoc` treatment.

The rest is mostly adding parameter or return type documentation.

This fixes 165 doxygen warnings.


## Limitations

It has grown quite big.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
