### PR TITLE
Codechange: add parameter and return documentation the Squirrel wrappers

### DIFF
--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -38,11 +38,14 @@ private:
 
 	/**
 	 * The internal RunError handler. It looks up the real error and calls RunError with it.
+	 * @param vm The virtual machine.
+	 * @return Always \c 0. Required return type due to this being passed to another function.
 	 */
 	static SQInteger _RunError(HSQUIRRELVM vm);
 
 	/**
 	 * Get the API name.
+	 * @return The name of the API (AI/GS).
 	 */
 	std::string_view GetAPIName() { return this->api_name; }
 
@@ -54,21 +57,32 @@ private:
 protected:
 	/**
 	 * The CompileError handler.
+	 * @param vm The virtual machine the error occurred for.
+	 * @param desc A description of the error.
+	 * @param source The file the error occurred in.
+	 * @param line The line the error was in.
+	 * @param column The column the error was in.
 	 */
 	static void CompileError(HSQUIRRELVM vm, std::string_view desc, std::string_view source, SQInteger line, SQInteger column);
 
 	/**
 	 * The RunError handler.
+	 * @param vm The virtual machine the error occurred for.
+	 * @param error A description of the error.
 	 */
 	static void RunError(HSQUIRRELVM vm, std::string_view error);
 
 	/**
 	 * If a user runs 'print' inside a script, this function gets the params.
+	 * @param vm The virtual machine to print for.
+	 * @param s The text to print.
 	 */
 	static void PrintFunc(HSQUIRRELVM vm, std::string_view s);
 
 	/**
 	 * If an error has to be print, this function is called.
+	 * @param vm The virtual machine to print for.
+	 * @param s The eroror text to print.
 	 */
 	static void ErrorPrintFunc(HSQUIRRELVM vm, std::string_view s);
 
@@ -78,6 +92,7 @@ public:
 
 	/**
 	 * Get the squirrel VM. Try to avoid using this.
+	 * @return Our virtual machine.
 	 */
 	HSQUIRRELVM GetVM() { return this->vm; }
 
@@ -91,50 +106,77 @@ public:
 
 	/**
 	 * Load a file to a given VM.
+	 * @param vm The virtual machine to load in.
+	 * @param filename The file to open.
+	 * @param printerror Whether to print errors, or completely ignore them.
+	 * @return \c 0 when the file could be loaded, otherwise another number denoting an error.
 	 */
 	SQRESULT LoadFile(HSQUIRRELVM vm, const std::string &filename, SQBool printerror);
 
 	/**
 	 * Adds a function to the stack. Depending on the current state this means
 	 *  either a method or a global function.
+	 * @param method_name The name of the method.
+	 * @param proc The actual method implementation to add.
+	 * @param params Description of all the parameters.
+	 * @param userdata Optional userdata to pass onto the created closure.
+	 * @param size Number of bytes in the user data.
+	 * @param suspendable Whether the method is suspendable.
 	 */
 	void AddMethod(std::string_view method_name, SQFUNCTION proc, std::string_view params = {}, void *userdata = nullptr, int size = 0, bool suspendable = false);
 
 	/**
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
+	 * @param var_name The name of the constant.
+	 * @param value The value to set the constant to.
 	 */
 	void AddConst(std::string_view var_name, SQInteger value);
 
 	/**
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
+	 * @param var_name The name of the constant.
+	 * @param value The value to set the constant to.
 	 */
 	void AddConst(std::string_view var_name, uint value) { this->AddConst(var_name, (SQInteger)value); }
 
 	/**
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
+	 * @param var_name The name of the constant.
+	 * @param value The value to set the constant to.
 	 */
 	void AddConst(std::string_view var_name, int value) { this->AddConst(var_name, (SQInteger)value); }
 
+	/**
+	 * Adds a const to the stack. Depending on the current state this means
+	 *  either a const to a class or to the global space.
+	 * @param var_name The name of the constant.
+	 * @param value The value to set the constant to.
+	 */
 	void AddConst(std::string_view var_name, const ConvertibleThroughBase auto &value) { this->AddConst(var_name, static_cast<SQInteger>(value.base())); }
 
 	/**
 	 * Adds a const to the stack. Depending on the current state this means
 	 *  either a const to a class or to the global space.
+	 * @param var_name The name of the constant.
+	 * @param value The value to set the constant to.
 	 */
 	void AddConst(std::string_view var_name, bool value);
 
 	/**
 	 * Adds a class to the global scope. Make sure to call AddClassEnd when you
 	 *  are done adding methods.
+	 * @param class_name The name of the class.
 	 */
 	void AddClassBegin(std::string_view class_name);
 
 	/**
 	 * Adds a class to the global scope, extending 'parent_class'.
 	 * Make sure to call AddClassEnd when you are done adding methods.
+	 * @param class_name The name of the class.
+	 * @param parent_class The name of the class that is being extended.
 	 */
 	void AddClassBegin(std::string_view class_name, std::string_view parent_class);
 
@@ -146,6 +188,8 @@ public:
 
 	/**
 	 * Resume a VM when it was suspended via a throw.
+	 * @param suspend The number of opcodes that are allowed before suspending.
+	 * @return \c true iff the VM is still alive.
 	 */
 	bool Resume(int suspend = -1);
 
@@ -165,17 +209,59 @@ public:
 	void InsertResult(ConvertibleThroughBase auto result) { this->InsertResult(static_cast<int>(result.base())); }
 
 	/**
-	 * Call a method of an instance, in various flavors.
-	 * @return False if the script crashed or returned a wrong type.
+	 * Call a method of an instance returning a Squirrel object.
+	 * @param instance The object to call the method on.
+	 * @param method_name The name of the method to call.
+	 * @param[out] ret The object to write the method result to.
+	 * @param suspend Maximum number of operations until the method gets suspended.
+	 * @return \c false iff the script crashed or returned a wrong type.
 	 */
 	bool CallMethod(HSQOBJECT instance, std::string_view method_name, HSQOBJECT *ret, int suspend);
+
+	/**
+	 * Call a method of an instance returning nothing.
+	 * @param instance The object to call the method on.
+	 * @param method_name The name of the method to call.
+	 * @param suspend Maximum number of operations until the method gets suspended.
+	 * @return \c false iff the script crashed or returned a wrong type.
+	 */
 	bool CallMethod(HSQOBJECT instance, std::string_view method_name, int suspend) { return this->CallMethod(instance, method_name, nullptr, suspend); }
+
+	/**
+	 * Call a method of an instance returning a string.
+	 * @param instance The object to call the method on.
+	 * @param method_name The name of the method to call.
+	 * @param[out] res The result of calling the method.
+	 * @param suspend Maximum number of operations until the method gets suspended.
+	 * @return \c false iff the script crashed or returned a wrong type.
+	 */
 	bool CallStringMethod(HSQOBJECT instance, std::string_view method_name, std::string *res, int suspend);
+
+	/**
+	 * Call a method of an instance returning a integer.
+	 * @param instance The object to call the method on.
+	 * @param method_name The name of the method to call.
+	 * @param[out] res The result of calling the method.
+	 * @param suspend Maximum number of operations until the method gets suspended.
+	 * @return \c false iff the script crashed or returned a wrong type.
+	 */
 	bool CallIntegerMethod(HSQOBJECT instance, std::string_view method_name, int *res, int suspend);
+
+	/**
+	 * Call a method of an instance returning a boolean.
+	 * @param instance The object to call the method on.
+	 * @param method_name The name of the method to call.
+	 * @param[out] res The result of calling the method.
+	 * @param suspend Maximum number of operations until the method gets suspended.
+	 * @return \c false iff the script crashed or returned a wrong type.
+	 */
 	bool CallBoolMethod(HSQOBJECT instance, std::string_view method_name, bool *res, int suspend);
 
 	/**
 	 * Check if a method exists in an instance.
+	 * @param instance The object to check.
+	 * @param method_name The method to look for.
+	 * @return \c true iff the object has the method.
 	 */
 	bool MethodExists(HSQOBJECT instance, std::string_view method_name);
 
@@ -192,7 +278,11 @@ public:
 	static bool CreateClassInstanceVM(HSQUIRRELVM vm, const std::string &class_name, void *real_instance, HSQOBJECT *instance, SQRELEASEHOOK release_hook, bool prepend_API_name = false);
 
 	/**
-	 * Exactly the same as CreateClassInstanceVM, only callable without instance of Squirrel.
+	 * Create a class instance. Exactly the same as CreateClassInstanceVM, only callable without instance of Squirrel.
+	 * @param class_name The name of the class of which we create an instance.
+	 * @param real_instance The instance to the real class, if it represents a real class.
+	 * @param instance Returning value with the pointer to the instance.
+	 * @return \c true iff the class could be created.
 	 */
 	bool CreateClassInstance(const std::string &class_name, void *real_instance, HSQOBJECT *instance);
 
@@ -200,6 +290,10 @@ public:
 	 * Get the real-instance pointer.
 	 * @note This will only work just after a function-call from within Squirrel
 	 *  to your C++ function.
+	 * @param vm The virtual machine to work in.
+	 * @param index The location on the stack. A negative value is the location from the top.
+	 * @param tag Name of the class without the Script/AI/GS moniker.
+	 * @return The pointer.
 	 */
 	static SQUserPointer GetRealInstance(HSQUIRRELVM vm, int index, std::string_view tag);
 
@@ -207,52 +301,69 @@ public:
 	 * Get the Squirrel-instance pointer.
 	 * @note This will only work just after a function-call from within Squirrel
 	 *  to your C++ function.
+	 * @param vm The virtual machine to work in.
+	 * @param[out] ptr The pointer to write the object to.
+	 * @param pos The position of the stack.
 	 */
-	static bool GetInstance(HSQUIRRELVM vm, HSQOBJECT *ptr, int pos = 1) { sq_getclass(vm, pos); sq_getstackobj(vm, pos, ptr); sq_pop(vm, 1); return true; }
+	static void GetInstance(HSQUIRRELVM vm, HSQOBJECT *ptr, int pos = 1) { sq_getclass(vm, pos); sq_getstackobj(vm, pos, ptr); sq_pop(vm, 1); }
 
 	/**
 	 * Convert a Squirrel-object to a string.
+	 * @param ptr The object to convert.
+	 * @return The \c std::string_view or \c std::nullopt.
 	 */
 	static std::optional<std::string_view> ObjectToString(HSQOBJECT *ptr) { return sq_objtostring(ptr); }
 
 	/**
 	 * Convert a Squirrel-object to an integer.
+	 * @param ptr The object to convert.
+	 * @return An integer.
 	 */
 	static int ObjectToInteger(HSQOBJECT *ptr) { return sq_objtointeger(ptr); }
 
 	/**
 	 * Convert a Squirrel-object to a bool.
+	 * @param ptr The object to convert.
+	 * @return A boolean.
 	 */
 	static bool ObjectToBool(HSQOBJECT *ptr) { return sq_objtobool(ptr) == 1; }
 
 	/**
 	 * Sets a pointer in the VM that is reachable from where ever you are in SQ.
 	 *  Useful to keep track of the main instance.
+	 * @param ptr Arbitrary pointer.
 	 */
 	void SetGlobalPointer(void *ptr) { this->global_pointer = ptr; }
 
 	/**
 	 * Get the pointer as set by SetGlobalPointer.
+	 * @param vm The virtual machine to get the pointer for.
+	 * @return The pointer previously set.
 	 */
 	static void *GetGlobalPointer(HSQUIRRELVM vm) { return ((Squirrel *)sq_getforeignptr(vm))->global_pointer; }
 
 	/**
 	 * Set a custom print function, so you can handle outputs from SQ yourself.
+	 * @param func The print function.
 	 */
 	void SetPrintFunction(SQPrintFunc *func) { this->print_func = func; }
 
 	/**
 	 * Throw a Squirrel error that will be nicely displayed to the user.
+	 * @param error The error to show to the user.
 	 */
 	void ThrowError(std::string_view error) { sq_throwerror(this->vm, error); }
 
 	/**
 	 * Release a SQ object.
+	 * @param ptr The object to release.
 	 */
 	void ReleaseObject(HSQOBJECT *ptr) { sq_release(this->vm, ptr); }
 
 	/**
 	 * Tell the VM to remove \c amount ops from the number of ops till suspend.
+	 * @param vm The virtual machine to change.
+	 * @param amount The amount of operations to change by.
 	 */
 	static void DecreaseOps(HSQUIRRELVM vm, int amount);
 
@@ -264,6 +375,7 @@ public:
 
 	/**
 	 * Find out if the squirrel script made an error before.
+	 * @return \c true iff \c CrashOccurred has been called.
 	 */
 	bool HasScriptCrashed();
 
@@ -274,11 +386,13 @@ public:
 
 	/**
 	 * Are we allowed to suspend the squirrel script at this moment?
+	 * @return \c true iff it is safe to suspend the script.
 	 */
 	bool CanSuspend();
 
 	/**
 	 * How many operations can we execute till suspension?
+	 * @return The number of operations left.
 	 */
 	SQInteger GetOpsTillSuspend();
 
@@ -289,6 +403,7 @@ public:
 
 	/**
 	 * Get number of bytes allocated by this VM.
+	 * @return The size in bytes.
 	 */
 	size_t GetAllocatedMemory() const noexcept;
 

--- a/src/script/squirrel_class.hpp
+++ b/src/script/squirrel_class.hpp
@@ -31,6 +31,11 @@ public:
 	 * @note If you define params, make sure that the first param is always 'x',
 	 *  which is the 'this' inside the function. This is hidden from the rest
 	 *  of the code, but without it calling your function will fail!
+	 * @param engine The engine to add the function to.
+	 * @param function_proc The actual function to call.
+	 * @param function_name The name of the function.
+	 * @param params String describing the types of the parameters.
+	 * @param suspendable Whether this function can be suspended, or not.
 	 */
 	template <typename Func>
 	void DefSQMethod(Squirrel &engine, Func function_proc, std::string_view function_name, std::string_view params = {}, bool suspendable = false)
@@ -41,6 +46,10 @@ public:
 
 	/**
 	 * This defines a method inside a class for Squirrel, which has access to the 'engine' (experts only!).
+	 * @param engine The engine to add the function to.
+	 * @param function_proc The actual function to call.
+	 * @param function_name The name of the function.
+	 * @param suspendable Whether this function can be suspended, or not.
 	 */
 	template <typename Func>
 	void DefSQAdvancedMethod(Squirrel &engine, Func function_proc, std::string_view function_name, bool suspendable = false)
@@ -54,6 +63,11 @@ public:
 	 * @note If you define params, make sure that the first param is always 'x',
 	 *  which is the 'this' inside the function. This is hidden from the rest
 	 *  of the code, but without it calling your function will fail!
+	 * @param engine The engine to add the function to.
+	 * @param function_proc The actual function to call.
+	 * @param function_name The name of the function.
+	 * @param params String describing the types of the parameters.
+	 * @param suspendable Whether this function can be suspended, or not.
 	 */
 	template <typename Func>
 	void DefSQStaticMethod(Squirrel &engine, Func function_proc, std::string_view function_name, std::string_view params = {}, bool suspendable = false)
@@ -64,6 +78,10 @@ public:
 
 	/**
 	 * This defines a static method inside a class for Squirrel, which has access to the 'engine' (experts only!).
+	 * @param engine The engine to add the function to.
+	 * @param function_proc The actual function to call.
+	 * @param function_name The name of the function.
+	 * @param suspendable Whether this function can be suspended, or not.
 	 */
 	template <typename Func>
 	void DefSQAdvancedStaticMethod(Squirrel &engine, Func function_proc, std::string_view function_name, bool suspendable = false)

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -236,6 +236,8 @@ namespace SQConvert {
 	 * A general template for all non-static method callbacks from Squirrel.
 	 *  In here the function_proc is recovered, and the SQCall is called that
 	 *  can handle this exact amount of params.
+	 * @param vm The virtual machine to create the callback in.
+	 * @return \c 0 upon success, or any other number upon failure.
 	 */
 	template <typename Tcls, typename Tmethod, ScriptType Ttype>
 	inline SQInteger DefSQNonStaticCallback(HSQUIRRELVM vm)
@@ -279,6 +281,8 @@ namespace SQConvert {
 	 * A general template for all non-static advanced method callbacks from Squirrel.
 	 *  In here the function_proc is recovered, and the SQCall is called that
 	 *  can handle this exact amount of params.
+	 * @param vm The virtual machine to create the callback in.
+	 * @return \c 0 upon success, or any other number upon failure.
 	 */
 	template <typename Tcls, typename Tmethod, ScriptType Ttype>
 	inline SQInteger DefSQAdvancedNonStaticCallback(HSQUIRRELVM vm)
@@ -322,6 +326,8 @@ namespace SQConvert {
 	 * A general template for all function/static method callbacks from Squirrel.
 	 *  In here the function_proc is recovered, and the SQCall is called that
 	 *  can handle this exact amount of params.
+	 * @param vm The virtual machine to create the callback in.
+	 * @return \c 0 upon success, or any other number upon failure.
 	 */
 	template <typename Tcls, typename Tmethod>
 	inline SQInteger DefSQStaticCallback(HSQUIRRELVM vm)
@@ -348,6 +354,8 @@ namespace SQConvert {
 	 * A general template for all static advanced method callbacks from Squirrel.
 	 *  In here the function_proc is recovered, and the SQCall is called that
 	 *  can handle this exact amount of params.
+	 * @param vm The virtual machine to create the callback in.
+	 * @return \c 0 upon success, or any other number upon failure.
 	 */
 	template <typename Tcls, typename Tmethod>
 	inline SQInteger DefSQAdvancedStaticCallback(HSQUIRRELVM vm)
@@ -373,6 +381,8 @@ namespace SQConvert {
 	/**
 	 * A general template for the destructor of SQ instances. This is needed
 	 *  here as it has to be in the same scope as DefSQConstructorCallback.
+	 * @param p Pointer to the instance to release.
+	 * @return \c 0 upon success. Has a return type due to this being passed as a parameter to another function.
 	 */
 	template <typename Tcls>
 	static SQInteger DefSQDestructorCallback(SQUserPointer p, SQInteger)
@@ -386,6 +396,8 @@ namespace SQConvert {
 	 * A general template to handle creating of instance with any amount of
 	 *  params. It creates the instance in C++, and it sets all the needed
 	 *  settings in SQ to register the instance.
+	 * @param vm The virtual machine to create the callback in.
+	 * @return \c 0 upon success, or any other number upon failure.
 	 */
 	template <typename Tcls, typename Tmethod>
 	inline SQInteger DefSQConstructorCallback(HSQUIRRELVM vm)
@@ -408,6 +420,8 @@ namespace SQConvert {
 	/**
 	 * A general template to handle creating of an instance with a complex
 	 *  constructor.
+	 * @param vm The virtual machine to create the callback in.
+	 * @return \c 0 upon success, or any other number upon failure.
 	 */
 	template <typename Tcls>
 	inline SQInteger DefSQAdvancedConstructorCallback(HSQUIRRELVM vm)

--- a/src/script/squirrel_std.hpp
+++ b/src/script/squirrel_std.hpp
@@ -28,11 +28,15 @@ public:
 
 	/**
 	 * Get the lowest of two integers.
+	 * @param vm The virtual machine to get the integers from, and write the result to.
+	 * @return The number of stack spaces to pop.
 	 */
 	static SQInteger min(HSQUIRRELVM vm);
 
 	/**
 	 * Get the highest of two integers.
+	 * @param vm The virtual machine to get the integers from, and write the result to.
+	 * @return The number of stack spaces to pop.
 	 */
 	static SQInteger max(HSQUIRRELVM vm);
 
@@ -40,23 +44,29 @@ public:
 	 * Load another file on runtime.
 	 * @note This is always loaded on the root-level, no matter where you call this.
 	 * @note The filename is always relative from the script it is called from. Absolute calls are NOT allowed!
+	 * @param vm The virtual machine to load the file into.
+	 * @return \c 0 upon success, or any other integer upon failure.
 	 */
 	static SQInteger require(HSQUIRRELVM vm);
 
 	/**
 	 * Enable/disable stack trace showing for handled exceptions.
+	 * @param vm The virtual machine to change the notifications for.
+	 * @return \c 0 upon success, or any other integer upon failure.
 	 */
 	static SQInteger notifyallexceptions(HSQUIRRELVM vm);
 };
 
 /**
  * Register all standard functions we want to give to a script.
+ * @param engine The engine to register the standard function to.
  */
 void squirrel_register_std(Squirrel &engine);
 
 /**
  * Register all standard functions that are available on first startup.
  * @note this set is very limited, and is only meant to load other scripts and things like that.
+ * @param engine The engine to register the functions to.
  */
 void squirrel_register_global_std(Squirrel &engine);
 


### PR DESCRIPTION
## Motivation / Problem

Missing parameter and return documentation in the Squirrel wrappers.


## Description

Add the missing documentation.

In one case remove the unused return value of a function.

This fixes 79 warnings.


## Limitations

It could be said that some 'out' parameters should be converted into a `std::pair` return value. That's true, but out of scope for this PR. This and some other related PRs make it a lot easier to find them, as you can just search for `@param[out]`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
