### PR TITLE
Codechange: document missing parameters and return types

### DIFF
--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -191,6 +191,7 @@ static NSImage *NSImageFromSprite(SpriteID sprite_id, ZoomLevel zoom)
 
 /**
  * Start the game loop.
+ * @param note Notification containing the application object. Exists because the API requires it.
  */
 - (void)launchGameEngine: (NSNotification*) note
 {
@@ -210,6 +211,7 @@ static NSImage *NSImageFromSprite(SpriteID sprite_id, ZoomLevel zoom)
 
 /**
  * Called when the internal event loop has just started running.
+ * @param note Notification containing the application object. Exists because the API requires it.
  */
 - (void) applicationDidFinishLaunching: (NSNotification*) note
 {
@@ -222,6 +224,8 @@ static NSImage *NSImageFromSprite(SpriteID sprite_id, ZoomLevel zoom)
 
 /**
  * Display the in game quit confirmation dialog.
+ * @param sender The application object. Exists because the API requires it.
+ * @return Whether the application should be terminating right now.
  */
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication*) sender
 {
@@ -244,6 +248,8 @@ static NSImage *NSImageFromSprite(SpriteID sprite_id, ZoomLevel zoom)
  * Starting with 14, macOS logs a warning if we don't implement this ourselves. Since OpenTTD does not (yet) make use of restorable state, we simply don't care what happens with it.
  *
  * Explained here: https://developer.apple.com/documentation/foundation/nssecurecoding
+ * @param sender The application object. Exists because the API requires it.
+ * @return Always \c YES.
  */
 - (BOOL)applicationSupportsSecureRestorableState:(NSApplication*) sender
 {
@@ -434,6 +440,12 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 
 /**
  * Initialize event system for the application rectangle
+ * @param contentRect The boundaries of the window.
+ * @param styleMask The window style to apply.
+ * @param backingType How the drawing is buffered.
+ * @param flag Whether to create the window immediately, or once it's moved on screen.
+ * @param drv The underlying video driver.
+ * @return The initialized window.
  */
 - (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag driver:(VideoDriver_Cocoa *)drv
 {
@@ -454,7 +466,9 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 }
 
 /**
- * Define the rectangle we draw our window in
+ * Define the rectangle we draw our window in.
+ * @param frameRect The new boundaries of the window.
+ * @param flag Whether the window redraws the views.
  */
 - (void)setFrame:(NSRect)frameRect display:(BOOL)flag
 {
@@ -567,7 +581,8 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 }
 
 /**
- * Allow to handle events
+ * Allow to handle events.
+ * @return Always \c YES.
  */
 - (BOOL)acceptsFirstResponder
 {
@@ -582,7 +597,10 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	}
 }
 
-/** Update mouse cursor to use for this view. */
+/**
+ * Update mouse cursor to use for this view.
+ * @param event Event from the operating system. Exists because the API requires it.
+ */
 - (void)cursorUpdate:(NSEvent *)event
 {
 	[ (_game_mode == GM_BOOTSTRAP ? [ NSCursor arrowCursor ] : [ NSCursor clearCocoaCursor ]) set ];
@@ -987,7 +1005,11 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 }
 
 
-/** Insert the given text at the given range. */
+/**
+ * Insert the given text at the given range.
+ * @param aString The string to insert.
+ * @param replacementRange The range of the original string to replace.
+ */
 - (void)insertText:(id)aString replacementRange:(NSRange)replacementRange
 {
 	if (!EditBoxInGlobalFocus()) return;
@@ -1007,13 +1029,21 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	HandleTextInput([ s UTF8String ], false, std::nullopt, insert_point, replace_range);
 }
 
-/** Insert the given text at the caret. */
+/**
+ * Insert the given text at the caret.
+ * @param aString The string to insert.
+ */
 - (void)insertText:(id)aString
 {
 	[ self insertText:aString replacementRange:NSMakeRange(NSNotFound, 0) ];
 }
 
-/** Set a new marked text and reposition the caret. */
+/**
+ * Set a new marked text and reposition the caret.
+ * @param aString The string to set the marked text for.
+ * @param selRange The new selection range.
+ * @param replacementRange The range to replace, counted from the marked range.
+ */
 - (void)setMarkedText:(id)aString selectedRange:(NSRange)selRange replacementRange:(NSRange)replacementRange
 {
 	if (!EditBoxInGlobalFocus()) return;
@@ -1039,7 +1069,11 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	}
 }
 
-/** Set a new marked text and reposition the caret. */
+/**
+ * Set a new marked text and reposition the caret.
+ * @param aString The string to set the marked text for.
+ * @param selRange The new selection range.
+ */
 - (void)setMarkedText:(id)aString selectedRange:(NSRange)selRange
 {
 	[ self setMarkedText:aString selectedRange:selRange replacementRange:NSMakeRange(NSNotFound, 0) ];
@@ -1051,7 +1085,10 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	HandleTextInput({}, true);
 }
 
-/** Get the caret position. */
+/**
+ * Get the caret position.
+ * @return The range with caret position.
+ */
 - (NSRange)selectedRange
 {
 	if (!EditBoxInGlobalFocus()) return NSMakeRange(NSNotFound, 0);
@@ -1062,7 +1099,10 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	return NSMakeRange(start, 0);
 }
 
-/** Get the currently marked range. */
+/**
+ * Get the currently marked range.
+ * @return The currently marked range.
+ */
 - (NSRange)markedRange
 {
 	if (!EditBoxInGlobalFocus()) return NSMakeRange(NSNotFound, 0);
@@ -1079,7 +1119,10 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	return NSMakeRange(NSNotFound, 0);
 }
 
-/** Is any text marked? */
+/**
+ * Is any text marked?
+ * @return \c YES iff text is marked.
+ */
 - (BOOL)hasMarkedText
 {
 	if (!EditBoxInGlobalFocus()) return NO;
@@ -1087,7 +1130,12 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	return _focused_window->GetFocusedTextbuf()->markend != 0;
 }
 
-/** Get a string corresponding to the given range. */
+/**
+ * Get a string corresponding to the given range.
+ * @param theRange The requested range of the string to return.
+ * @param[out] actualRange Optional output of range after validation.
+ * @return The requested substring.
+ */
 - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)theRange actualRange:(NSRangePointer)actualRange
 {
 	if (!EditBoxInGlobalFocus()) return nil;
@@ -1102,13 +1150,20 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	return [ [ [ NSAttributedString alloc ] initWithString:[ s substringWithRange:valid_range ] ] autorelease ];
 }
 
-/** Get a string corresponding to the given range. */
+/**
+ * Get a string corresponding to the given range.
+ * @param theRange The requested range of the string to return.
+ * @return The requested substring.
+ */
 - (NSAttributedString *)attributedSubstringFromRange:(NSRange)theRange
 {
 	return [ self attributedSubstringForProposedRange:theRange actualRange:nil ];
 }
 
-/** Get the current edit box string. */
+/**
+ * Get the current edit box string.
+ * @return The string from the edit box.
+ */
 - (NSAttributedString *)attributedString
 {
 	if (!EditBoxInGlobalFocus()) return [ [ [ NSAttributedString alloc ] initWithString:@"" ] autorelease ];
@@ -1117,7 +1172,11 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	return [ [ [ NSAttributedString alloc ] initWithString:[ [ NSString alloc ] initWithBytes:text.data() length:text.size() encoding:NSUTF8StringEncoding ] ] autorelease ];
 }
 
-/** Get the character that is rendered at the given point. */
+/**
+ * Get the character that is rendered at the given point.
+ * @param thePoint The point in screen coordinates to get the character index for.
+ * @return A negative number to denote an error, otherwise the number of UTF-16 characters up to \c thePoint.
+ */
 - (NSUInteger)characterIndexForPoint:(NSPoint)thePoint
 {
 	if (!EditBoxInGlobalFocus()) return NSNotFound;
@@ -1133,7 +1192,11 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	return CountUtf16Units(text.substr(0, index));
 }
 
-/** Get the bounding rect for the given range. */
+/**
+ * Get the bounding rect for the given range.
+ * @param aRange The start and end location of the string in UTF-16 characters.
+ * @return The rectangle in screen coordinates for the given range.
+ */
 - (NSRect)firstRectForCharacterRange:(NSRange)aRange
 {
 	if (!EditBoxInGlobalFocus()) return NSMakeRect(0, 0, 0, 0);
@@ -1150,13 +1213,21 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	return [ [ self window ] convertRectToScreen:[ self convertRect:view_rect toView:nil ] ];
 }
 
-/** Get the bounding rect for the given range. */
+/**
+ * Get the bounding rect for the given range.
+ * @param aRange The start and end location of the string in UTF-16 characters.
+ * @param[out] actualRange Optional output of range after validation. Exists because the API requires it.
+ * @return The rectangle in screen coordinates for the given range.
+ */
 - (NSRect)firstRectForCharacterRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
 {
 	return [ self firstRectForCharacterRange:aRange ];
 }
 
-/** Get all string attributes that we can process for marked text. */
+/**
+ * Get all string attributes that we can process for marked text.
+ * @return The valid attributes, in this case an empty array.
+ */
 - (NSArray*)validAttributesForMarkedText
 {
 	return [ NSArray array ];
@@ -1378,7 +1449,11 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	VideoDriver_Cocoa *driver;
 }
 
-/** Initialize the video driver */
+/**
+ * Initialize the video driver.
+ * @param drv Instance of the video driver.
+ * @return The new instance, or \c nullptr.
+ */
 - (instancetype)initWithDriver:(VideoDriver_Cocoa *)drv
 {
 	if (self = [ super init ]) {
@@ -1387,8 +1462,9 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	return self;
 }
 /**
- * Handle closure requests
+ * Handle closure requests.
  * @param sender Where the event comes from.
+ * @return \c NO as we want to ask the user whether to quit.
  */
 - (BOOL)windowShouldClose:(id)sender
 {
@@ -1396,7 +1472,10 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 
 	return NO;
 }
-/** Window entered fullscreen mode (10.7). */
+/**
+ * Window entered fullscreen mode (10.7).
+ * @param aNotification Notification containing the window object.
+ */
 - (void)windowDidEnterFullScreen:(NSNotification *)aNotification
 {
 	NSPoint loc = [ driver->cocoaview convertPoint:[ [ aNotification object ] mouseLocationOutsideOfEventStream ] fromView:nil ];
@@ -1409,7 +1488,10 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 		[ e release ];
 	}
 }
-/** Screen the window is on changed. */
+/**
+ * Screen the window is on changed.
+ * @param notification Notification containing the window object. Exists because the API requires it.
+ */
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification
 {
 	bool did_adjust = AdjustGUIZoom(true);
@@ -1420,7 +1502,12 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 	if (did_adjust) ReInitAllWindows(true);
 }
 
-/** Presentation options to use for full screen mode. */
+/**
+ * Presentation options to use for full screen mode.
+ * @param window The window to get the presentation options for.
+ * @param proposedOptions A proposed set of options.
+ * @return The actual options we want.
+ */
 - (NSApplicationPresentationOptions)window:(NSWindow *)window willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions
 {
 	return NSApplicationPresentationFullScreen | NSApplicationPresentationHideMenuBar | NSApplicationPresentationHideDock;

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2631,7 +2631,12 @@ void SetTileSelectBigSize(int ox, int oy, int sx, int sy)
 	_thd.new_outersize.y = sy * TILE_SIZE;
 }
 
-/** returns the best autorail highlight type from map coordinates */
+/**
+ * Determine the best autorail highlight type from map coordinates.
+ * @param x The map X-coordinate.
+ * @param y The map Y-coordinate.
+ * @return The best highlight style.
+ */
 static HighLightStyle GetAutorailHT(int x, int y)
 {
 	return HT_RAIL | _autorail_piece[x & TILE_UNIT_MASK][y & TILE_UNIT_MASK];
@@ -2793,7 +2798,12 @@ static void HideMeasurementTooltips()
 	CloseWindowById(WC_TOOLTIPS, 0);
 }
 
-/** highlighting tiles while only going over them with the mouse */
+/**
+ * Prepare state for highlighting tiles while dragging with the mouse.
+ * @param tile The start tile.
+ * @param method The method/limits for what area can be selected.
+ * @param process Unique identifier of the thing to do after the dragging is done.
+ */
 void VpStartPlaceSizing(TileIndex tile, ViewportPlaceMethod method, ViewportDragDropSelectionProcess process)
 {
 	_thd.select_method = method;
@@ -3068,7 +3078,12 @@ static void CheckOverflow(int &test, int &other, int max, int mult)
 	test = max;
 }
 
-/** while dragging */
+/**
+ * Determine and set the draw style, as well as the end point of the drag.
+ * @param x The current X-coordinate of the mouse in map coordinates.
+ * @param y The current Y-coordinate of the mouse in map coordinates.
+ * @param method The user chosen method for dragging rails (specific orientation, autorail).
+ */
 static void CalcRaildirsDrawstyle(int x, int y, int method)
 {
 	HighLightStyle b;


### PR DESCRIPTION
## Motivation / Problem

Doxygen warnings about missing parameters and return types of method that already have some documentation.


## Description

Add the missing parameter and return type documentation.

Fixes 41 warnings.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
