### PR TITLE
Fix: Incorrect scroll bar capacity for train details window total cargo tab

### DIFF
--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -333,7 +333,7 @@ int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab)
 		}
 
 		num = max_cargo.GetCount();
-		num++; // needs one more because first line is description string
+		num += 2; // needs two more because the first line is the description string and the last is the feeder share
 	} else {
 		for (const Train *v = Train::Get(veh_id); v != nullptr; v = v->GetNextVehicle()) {
 			GetCargoSummaryOfArticulatedVehicle(v, _cargo_summary);


### PR DESCRIPTION
## Motivation / Problem

The scrollbar capacity for the total cargo tab in the train details tab is too small by one due to not accounting for the feeder share/transfer credits line.
This is observable for trains with more than two cargoes.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
