### PR TITLE
Codechange: document parameters of destructors...

### DIFF
--- a/src/autocompletion.h
+++ b/src/autocompletion.h
@@ -30,6 +30,7 @@ public:
 	{
 		this->Reset();
 	}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~AutoCompletion() = default;
 
 	bool AutoComplete();

--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -49,6 +49,7 @@ struct BaseConsist {
 
 	VehicleFlags vehicle_flags{}; ///< Used for gradual loading and other miscellaneous things (@see VehicleFlags enum)
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~BaseConsist() = default;
 
 	void CopyConsistPropertiesFrom(const BaseConsist *src);

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -48,6 +48,7 @@ template <class T> struct BaseSetTraits;
  */
 template <class T>
 struct BaseSet {
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~BaseSet() = default;
 
 	typedef std::unordered_map<std::string, std::string, StringHash, std::equal_to<>> TranslatedStrings;

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -93,6 +93,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	 */
 	BaseStation(StationID index, TileIndex tile) : StationPool::PoolItem<&_station_pool>(index), xy(tile) {}
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~BaseStation();
 
 	/**

--- a/src/blitter/32bpp_sse2.hpp
+++ b/src/blitter/32bpp_sse2.hpp
@@ -29,6 +29,7 @@
 /** Base methods for 32bpp SSE blitters. */
 class Blitter_32bppSSE_Base {
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~Blitter_32bppSSE_Base() = default;
 
 	struct MapValue {

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -82,6 +82,7 @@ protected:
 	}
 
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~BlitterFactory()
 	{
 		GetBlitters().erase(this->name);

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -304,6 +304,7 @@ public:
 		_network_content_client.Connect();
 	}
 
+	/** Remove us from the content client's callbacks. */
 	~BootstrapEmscripten() override
 	{
 		_network_content_client.RemoveCallback(this);

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -175,6 +175,7 @@ public:
 		this->vscroll->SetCount(this->bridges.size());
 	}
 
+	/** Save the last sorting state. */
 	~BuildBridgeWindow() override
 	{
 		BuildBridgeWindow::last_sorting = this->bridges.GetListing();

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -57,7 +57,9 @@ static constexpr inline DoCommandFlags CommandFlagsToDCFlags(CommandFlags cmd_fl
 
 /** Helper class to keep track of command nesting level. */
 struct RecursiveCommandCounter {
+	/** Increment the recursion counter. */
 	RecursiveCommandCounter() noexcept { _counter++; }
+	/** Decrement the recursion counter. */
 	~RecursiveCommandCounter() noexcept { _counter--; }
 
 	/**

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -79,7 +79,7 @@ Company::Company(CompanyID index, StringID name_1, bool is_ai) : CompanyPool::Po
 	InvalidateWindowData(WC_PERFORMANCE_DETAIL, 0, CompanyID::Invalid());
 }
 
-/** Destructor. */
+/** Close the associated company windows. */
 Company::~Company()
 {
 	if (CleaningPool()) return;

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -108,6 +108,7 @@ struct PoolBase {
 		PoolBase::GetPools()->push_back(this);
 	}
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~PoolBase();
 
 	/**

--- a/src/core/string_builder.hpp
+++ b/src/core/string_builder.hpp
@@ -20,6 +20,7 @@ public:
 	/** The type of the size of our strings. */
 	using size_type = std::string_view::size_type;
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~BaseStringBuilder() = default;
 
 	/**

--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -49,7 +49,7 @@ protected:
 	std::string CreateFileName(std::string_view ext, bool with_dir = true) const;
 
 public:
-	/** Stub destructor to silence some compilers. */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~CrashLog() = default;
 
 	nlohmann::json survey;

--- a/src/debug.h
+++ b/src/debug.h
@@ -86,6 +86,7 @@ struct TicToc {
 			GetStates().push_back(this);
 		}
 
+		/** Remove ourselves from the thread local states. */
 		~State()
 		{
 			/* Container might be already destroyed. */
@@ -111,6 +112,7 @@ struct TicToc {
 
 	inline TicToc(State &state) : state(state), chrono_start(std::chrono::high_resolution_clock::now()) { }
 
+	/** Update the state with the time since the constructor call. */
 	inline ~TicToc()
 	{
 		this->state.chrono_sum += (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - this->chrono_start)).count();

--- a/src/depot.cpp
+++ b/src/depot.cpp
@@ -23,7 +23,7 @@ DepotPool _depot_pool("Depot");
 INSTANTIATE_POOL_METHODS(Depot)
 
 /**
- * Clean up a depot
+ * Remove any references to this depot.
  */
 Depot::~Depot()
 {

--- a/src/driver.h
+++ b/src/driver.h
@@ -32,6 +32,7 @@ public:
 	 */
 	virtual void Stop() = 0;
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~Driver() = default;
 
 	/** The type of driver */
@@ -106,6 +107,7 @@ private:
 protected:
 	DriverFactoryBase(Driver::Type type, int priority, std::string_view name, std::string_view description);
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~DriverFactoryBase();
 
 	/**

--- a/src/dropdown_type.h
+++ b/src/dropdown_type.h
@@ -27,6 +27,7 @@ public:
 	bool shaded; ///< Shaded item, affects text colour.
 
 	explicit DropDownListItem(int result, bool masked = false, bool shaded = false) : result(result), masked(masked), shaded(shaded) {}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~DropDownListItem() = default;
 
 	/**

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1172,6 +1172,7 @@ CargoPayment::CargoPayment(CargoPaymentID index, Vehicle *front) :
 {
 }
 
+/** Execute the actual payment to the coffers of the company. */
 CargoPayment::~CargoPayment()
 {
 	if (CleaningPool()) return;

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -38,7 +38,7 @@ class FileScanner {
 protected:
 	Subdirectory subdir{}; ///< The current sub directory we are searching through
 public:
-	/** Destruct the proper one... */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~FileScanner() = default;
 
 	uint Scan(std::string_view extension, Subdirectory sd, bool tars = true, bool recursive = true);

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -32,6 +32,7 @@ protected:
 	static void Register(std::unique_ptr<FontCache> &&fc);
 
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~FontCache() = default;
 
 	static void InitializeFontCaches();

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -237,6 +237,7 @@ public:
 		ProviderManager<FontCacheFactory>::Register(*this);
 	}
 
+	/** Unregister this factory. */
 	~FontCacheFactory() override
 	{
 		ProviderManager<FontCacheFactory>::Unregister(*this);

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -213,6 +213,7 @@ class FreeTypeFontCacheFactory : public FontCacheFactory {
 public:
 	FreeTypeFontCacheFactory() : FontCacheFactory("freetype", "FreeType font provider") {}
 
+	/** Close the freetype library. */
 	~FreeTypeFontCacheFactory() override
 	{
 		FT_Done_FreeType(_ft_library);

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -37,6 +37,7 @@ Gamelog::Gamelog()
 	this->current_action = nullptr;
 }
 
+/** Needs to be manually defined due to incomplete definition of GamelogInternalData in the header. */
 Gamelog::~Gamelog()
 {
 }

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -31,6 +31,7 @@ using GrfIDMapping = std::map<uint32_t, GRFPresence>;
 
 struct LoggedChange {
 	LoggedChange(GamelogChangeType type = GLCT_NONE) : ct(type) {}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~LoggedChange() = default;
 
 	/**

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -110,6 +110,7 @@ using FontMap = std::vector<std::pair<int, Font *>>;
  */
 class ParagraphLayouter {
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~ParagraphLayouter() = default;
 
 	/** Position of a glyph within a VisualRun. */
@@ -131,6 +132,7 @@ public:
 	/** Visual run contains data about the bit of text with the same font. */
 	class VisualRun {
 	public:
+		/** Ensure the destructor of the sub classes are called as well. */
 		virtual ~VisualRun() = default;
 
 		/**
@@ -173,6 +175,7 @@ public:
 	/** A single line worth of VisualRuns. */
 	class Line {
 	public:
+		/** Ensure the destructor of the sub classes are called as well. */
 		virtual ~Line() = default;
 
 		/**

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -449,6 +449,7 @@ public:
 		this->SortVehicleList();
 	}
 
+	/** Save the last sorting state. */
 	~VehicleGroupWindow()
 	{
 		*this->sorting = this->vehgroups.GetListing();

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -257,6 +257,7 @@ HotkeyList::HotkeyList(const std::string &ini_group, const std::vector<Hotkey> &
 	_hotkey_lists->push_back(this);
 }
 
+/** Remove outselves from the global hotkey list. */
 HotkeyList::~HotkeyList()
 {
 	_hotkey_lists->erase(std::ranges::find(*_hotkey_lists, this));

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -143,6 +143,7 @@ const IndustryTileSpec *GetIndustryTileSpec(IndustryGfx gfx)
 	return &_industry_tile_specs[gfx];
 }
 
+/** Remove any reference to this industry from the game. */
 Industry::~Industry()
 {
 	if (CleaningPool()) return;

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -821,6 +821,7 @@ public:
 		this->InvalidateData();
 	}
 
+	/** Close the industry production window. */
 	~IndustryViewWindow() override
 	{
 		CloseWindowById(WC_INDUSTRY_PRODUCTION, this->window_number, false);
@@ -1656,6 +1657,7 @@ public:
 		this->industry_editbox.cancel_button = QueryString::ACTION_CLEAR;
 	}
 
+	/** Save the last sorting state. */
 	~IndustryDirectoryWindow() override
 	{
 		this->last_sorting = this->industries.GetListing();

--- a/src/ini_type.h
+++ b/src/ini_type.h
@@ -56,6 +56,7 @@ struct IniLoadFile {
 	const IniGroupNameList seq_group_names;  ///< list of group names that are sequences.
 
 	IniLoadFile(const IniGroupNameList &list_group_names = {}, const IniGroupNameList &seq_group_names = {});
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~IniLoadFile() = default;
 
 	const IniGroup *GetGroup(std::string_view name) const;

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -279,6 +279,7 @@ public:
 	static Path *invalid_path;
 
 	Path(NodeID n, bool source = false);
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~Path() = default;
 
 	/**

--- a/src/linkgraph/linkgraphschedule.h
+++ b/src/linkgraph/linkgraphschedule.h
@@ -20,9 +20,7 @@ class LinkGraphJob;
  */
 class ComponentHandler {
 public:
-	/**
-	 * Destroy the handler. Must be given due to virtual Run.
-	 */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~ComponentHandler() = default;
 
 	/**

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -1189,7 +1189,7 @@ std::optional<std::string_view> MusicDriver_DMusic::Start(const StringList &parm
 	return std::nullopt;
 }
 
-
+/** Stop the playing of the music. */
 MusicDriver_DMusic::~MusicDriver_DMusic()
 {
 	this->Stop();

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -1130,6 +1130,7 @@ MidiFile::MidiFile()
 	RegisterConsoleMidiCommands();
 }
 
+/** Remove ourselves from the _midifile_instance if needed. */
 MidiFile::~MidiFile()
 {
 	if (_midifile_instance == this) {

--- a/src/network/core/core.h
+++ b/src/network/core/core.h
@@ -51,7 +51,7 @@ public:
 	/** Create a new unbound socket */
 	NetworkSocketHandler() = default;
 
-	/** Close the socket when destructing the socket handler */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NetworkSocketHandler() = default;
 
 	/**

--- a/src/network/core/http.h
+++ b/src/network/core/http.h
@@ -39,7 +39,7 @@ struct HTTPCallback {
 	 */
 	virtual bool IsCancelled() const = 0;
 
-	/** Silentium */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~HTTPCallback() = default;
 };
 

--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -67,6 +67,7 @@ public:
 		_new_http_callbacks.push_back(&this->callback);
 	}
 
+	/** Remove ourselves from the callback list. */
 	~NetworkHTTPRequest()
 	{
 		std::lock_guard<std::mutex> lock(_http_callback_mutex);

--- a/src/network/core/http_shared.h
+++ b/src/network/core/http_shared.h
@@ -99,6 +99,7 @@ public:
 
 	HTTPThreadSafeCallback(HTTPCallback *callback) : callback(callback) {}
 
+	/** Ensure our queues are emptied while holding a lock. */
 	~HTTPThreadSafeCallback()
 	{
 		std::lock_guard<std::mutex> lock(this->mutex);

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -14,6 +14,7 @@
 
 #include "../../safeguards.h"
 
+/** Close the socket. */
 NetworkTCPSocketHandler::~NetworkTCPSocketHandler()
 {
 	this->CloseSocket();

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -55,6 +55,7 @@ TCPServerConnecter::TCPServerConnecter(std::string_view connection_string, uint1
 	}
 }
 
+/** Wait until the resolving is done, then release the sockets. */
 TCPConnecter::~TCPConnecter()
 {
 	if (this->resolve_thread.joinable()) {

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -53,7 +53,7 @@ struct ContentCallback {
 	 */
 	virtual void OnDownloadComplete([[maybe_unused]] ContentID cid) {}
 
-	/** Silentium */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~ContentCallback() = default;
 };
 

--- a/src/network/network_crypto.h
+++ b/src/network/network_crypto.h
@@ -40,6 +40,7 @@
  */
 class NetworkEncryptionHandler {
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NetworkEncryptionHandler() = default;
 
 	/**
@@ -70,6 +71,7 @@ public:
  */
 class NetworkAuthenticationPasswordRequest {
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NetworkAuthenticationPasswordRequest() = default;
 
 	/**
@@ -109,6 +111,7 @@ public:
  */
 class NetworkAuthenticationPasswordProvider {
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NetworkAuthenticationPasswordProvider() = default;
 
 	/**
@@ -140,6 +143,7 @@ public:
  */
 class NetworkAuthenticationAuthorizedKeyHandler {
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NetworkAuthenticationAuthorizedKeyHandler() = default;
 
 	/**
@@ -190,6 +194,7 @@ using NetworkAuthenticationMethodMask = EnumBitSet<NetworkAuthenticationMethod, 
  */
 class NetworkAuthenticationHandler {
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NetworkAuthenticationHandler() = default;
 
 	/**

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -465,6 +465,7 @@ public:
 		this->servers.ForceRebuild();
 	}
 
+	/** Save the last sorting state. */
 	~NetworkGameWindow() override
 	{
 		this->last_sorting = this->servers.GetListing();

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1337,6 +1337,7 @@ public:
 		this->height = d.height + WidgetDimensions::scaled.framerect.Vertical();
 		this->width = d.width + WidgetDimensions::scaled.framerect.Horizontal();
 	}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~ButtonCommon() = default;
 
 	/**
@@ -1384,6 +1385,7 @@ class ButtonLine {
 public:
 	std::vector<std::unique_ptr<ButtonCommon>> buttons{}; ///< Buttons for this line.
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~ButtonLine() = default;
 
 	/**

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -80,7 +80,7 @@ struct PacketWriter : SaveFilter {
 	{
 	}
 
-	/** Make sure everything is cleaned up. */
+	/** Make sure everything is cleaned up under lock. */
 	~PacketWriter() override
 	{
 		std::unique_lock<std::mutex> lock(this->mutex);

--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -118,6 +118,7 @@ NetworkRecvStatus ClientNetworkStunSocketHandler::CloseConnection(bool error)
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
+/** Stop the attempt to connect. */
 ClientNetworkStunSocketHandler::~ClientNetworkStunSocketHandler()
 {
 	if (this->connecter != nullptr) {

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -125,6 +125,7 @@ NetworkRecvStatus ClientNetworkTurnSocketHandler::CloseConnection(bool error)
 	return NETWORK_RECV_STATUS_OKAY;
 }
 
+/** Stop the attempt to connect. */
 ClientNetworkTurnSocketHandler::~ClientNetworkTurnSocketHandler()
 {
 	if (this->connecter != nullptr) {

--- a/src/newgrf/newgrf_act3.cpp
+++ b/src/newgrf/newgrf_act3.cpp
@@ -155,6 +155,7 @@ static void VehicleMapSpriteGroup(ByteReader &buf, GrfSpecFeature feature, uint8
 
 /** Handler interface for mapping sprite groups to their respective feature specific specifications. */
 struct MapSpriteGroupHandler {
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~MapSpriteGroupHandler() = default;
 
 	/**

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -216,6 +216,7 @@ public:
 	std::vector<EntityIDMapping> mappings; ///< mapping of ids from grf files.  Public out of convenience
 
 	OverrideManagerBase(uint16_t offset, uint16_t maximum, uint16_t invalid);
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~OverrideManagerBase() = default;
 
 	void ResetOverride();

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -220,7 +220,7 @@ extern uint _missing_extra_graphics;  ///< Number of sprites provided by the fal
 
 /** Callback for NewGRF scanning. */
 struct NewGRFScanCallback {
-	/** Make sure the right destructor gets called. */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NewGRFScanCallback() = default;
 	/** Called whenever the NewGRF scan completed. */
 	virtual void OnNewGRFsScanned() = 0;

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -128,7 +128,7 @@ struct NIVariable {
 /** Helper class to wrap some functionality/queries in. */
 class NIHelper {
 public:
-	/** Silence a warning. */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NIHelper() = default;
 
 	/**

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -55,6 +55,7 @@ protected:
 	virtual ResolverResult Resolve(ResolverObject &object) const = 0;
 
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~SpriteGroup() = default;
 
 	uint32_t nfo_line = 0;
@@ -292,6 +293,7 @@ struct ScopeResolver {
 	ResolverObject &ro; ///< Surrounding resolver object.
 
 	ScopeResolver(ResolverObject &ro) : ro(ro) {}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~ScopeResolver() = default;
 
 	virtual uint32_t GetRandomBits() const;
@@ -324,6 +326,7 @@ public:
 	{
 	}
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~ResolverObject() = default;
 
 	ResolverResult DoResolve()

--- a/src/newgrf_storage.cpp
+++ b/src/newgrf_storage.cpp
@@ -24,9 +24,7 @@ bool BasePersistentStorageArray::gameloop;
 bool BasePersistentStorageArray::command;
 bool BasePersistentStorageArray::testmode;
 
-/**
- * Remove references to use.
- */
+/** Remove references to us. */
 BasePersistentStorageArray::~BasePersistentStorageArray()
 {
 	_changed_storage_arrays->erase(this);

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -129,6 +129,7 @@ struct NewsTypeData {
 
 /** Container for any custom data that must be deleted after the news item has reached end-of-life. */
 struct NewsAllocatedData {
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NewsAllocatedData() = default;
 };
 

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -95,6 +95,7 @@ Win32FontCache::Win32FontCache(FontSize fs, const LOGFONT &logfont, int pixels) 
 	this->SetFontSize(pixels);
 }
 
+/** Release all the operating system objects. */
 Win32FontCache::~Win32FontCache()
 {
 	this->ClearFontCache();

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -52,6 +52,7 @@ PickerCallbacks::PickerCallbacks(const std::string &ini_group) : ini_group(ini_g
 	GetPickerCallbacks().push_back(this);
 }
 
+/** Remove references to us. */
 PickerCallbacks::~PickerCallbacks()
 {
 	auto &callbacks = GetPickerCallbacks();

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -39,6 +39,7 @@ struct PickerItem {
 class PickerCallbacks {
 public:
 	explicit PickerCallbacks(const std::string &ini_group);
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~PickerCallbacks();
 
 	/** @copydoc Window::Close */

--- a/src/provider_manager.h
+++ b/src/provider_manager.h
@@ -54,6 +54,7 @@ template <typename T>
 class BaseProvider {
 public:
 	constexpr BaseProvider(std::string_view name, std::string_view description) : name(name), description(description) {}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~BaseProvider() = default;
 
 	inline std::string_view GetName() const { return this->name; }

--- a/src/random_access_file_type.h
+++ b/src/random_access_file_type.h
@@ -40,6 +40,7 @@ public:
 	RandomAccessFile(const RandomAccessFile&) = delete;
 	void operator=(const RandomAccessFile&) = delete;
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~RandomAccessFile() = default;
 
 	const std::string &GetFilename() const;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -483,6 +483,7 @@ struct ChunkHandler {
 
 	ChunkHandler(uint32_t id, ChunkType type) : id(id), type(type) {}
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~ChunkHandler() = default;
 
 	/**
@@ -539,6 +540,7 @@ class SaveLoadHandler {
 public:
 	std::optional<std::vector<SaveLoad>> load_description; ///< Description derived from savegame being loaded.
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~SaveLoadHandler() = default;
 
 	/**

--- a/src/saveload/saveload_filter.h
+++ b/src/saveload/saveload_filter.h
@@ -23,7 +23,7 @@ struct LoadFilter {
 	{
 	}
 
-	/** Make sure the writers are properly closed. */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~LoadFilter() = default;
 
 	/**
@@ -67,7 +67,7 @@ struct SaveFilter {
 	{
 	}
 
-	/** Make sure the writers are properly closed. */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~SaveFilter() = default;
 
 	/**

--- a/src/screenshot_type.h
+++ b/src/screenshot_type.h
@@ -31,6 +31,7 @@ public:
 		ProviderManager<ScreenshotProvider>::Register(*this);
 	}
 
+	/** Unregister ourselves from the screenshot providers. */
 	~ScreenshotProvider() override
 	{
 		ProviderManager<ScreenshotProvider>::Unregister(*this);

--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -40,9 +40,7 @@ protected:
 	virtual void RetargetIterator() = 0;
 
 public:
-	/**
-	 * Virtual dtor, needed to mute warnings.
-	 */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~ScriptListSorter() = default;
 
 	/**

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -44,6 +44,7 @@ typedef bool (ScriptAsyncModeProc)();
 class SimpleCountedObject {
 public:
 	SimpleCountedObject() : ref_count(0) {}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~SimpleCountedObject() = default;
 
 	/** Increase the reference count by one. */

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -783,6 +783,7 @@ struct ScriptDebugWindow : public Window {
 		this->InvalidateData(-1);
 	}
 
+	/** Save the last sorting state. */
 	~ScriptDebugWindow() override
 	{
 		ScriptDebugWindow::initial_state = this->filter;

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -152,6 +152,7 @@ bool ScriptInstance::LoadCompatibilityScripts(Subdirectory dir, std::span<const 
 	return true;
 }
 
+/** Release our hold on the engine and reset it in the right scope. */
 ScriptInstance::~ScriptInstance()
 {
 	ScriptObject::ActiveInstance active(*this);

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -160,6 +160,7 @@ public:
 		if (this->allocation_limit == 0) this->allocation_limit = SAFE_LIMIT; // in case the setting is somehow zero
 	}
 
+	/** Ensure the allocations have already been released. */
 	~ScriptAllocator()
 	{
 #ifdef SCRIPT_DEBUG_ALLOCATIONS
@@ -735,6 +736,7 @@ bool Squirrel::LoadScript(const std::string &script)
 	return LoadScript(this->vm, script);
 }
 
+/** Clean up the Squirrel virtual machine state. */
 Squirrel::~Squirrel()
 {
 	this->Uninitialize();

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -434,6 +434,7 @@ public:
 		_squirrel_allocator = engine != nullptr ? engine->allocator.get() : nullptr;
 	}
 
+	/** Restore the previous allocator. */
 	~ScriptAllocatorScope()
 	{
 		_squirrel_allocator = this->old_allocator;

--- a/src/settingentry_gui.h
+++ b/src/settingentry_gui.h
@@ -54,6 +54,7 @@ struct BaseSettingEntry {
 	uint8_t level; ///< Nesting level of this setting entry
 
 	BaseSettingEntry() : flags(), level(0) {}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~BaseSettingEntry() = default;
 
 	virtual void Init(uint8_t level = 0);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2034,6 +2034,7 @@ ScriptConfigSettings::ScriptConfigSettings()
 	/* Instantiate here, because unique_ptr needs a complete type. */
 }
 
+/** Needs to be manually defined due to incomplete definition of types in the header. */
 ScriptConfigSettings::~ScriptConfigSettings()
 {
 	/* Instantiate here, because unique_ptr needs a complete type. */

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -81,6 +81,7 @@ concept ConvertibleThroughBaseOrUnderlyingOrTo = ConvertibleThroughBaseOrTo<T, T
 struct SettingDesc {
 	SettingDesc(const SaveLoad &save, SettingFlags flags, bool startup) :
 		flags(flags), startup(startup), save(save) {}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~SettingDesc() = default;
 
 	SettingFlags flags;  ///< Handles how a setting would show up in the GUI (text/currency, etc.).

--- a/src/soundloader_type.h
+++ b/src/soundloader_type.h
@@ -21,6 +21,7 @@ public:
 		ProviderManager<SoundLoader>::Register(*this);
 	}
 
+	/** Unregister this sound loader. */
 	~SoundLoader() override
 	{
 		ProviderManager<SoundLoader>::Unregister(*this);

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -58,6 +58,7 @@ struct DrawTileSprites {
 	DrawTileSprites(PalSpriteID ground) : ground(ground) {}
 	DrawTileSprites() = default;
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~DrawTileSprites() = default;
 
 	/**

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -97,12 +97,14 @@ public:
 	 */
 	virtual ZoomLevels LoadSprite(SpriteLoader::SpriteCollection &sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, SpriteCacheCtrlFlags control_flags, ZoomLevels &avail_8bpp, ZoomLevels &avail_32bpp) = 0;
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~SpriteLoader() = default;
 };
 
 /** Interface for something that can allocate memory for a sprite. */
 class SpriteAllocator {
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~SpriteAllocator() = default;
 
 	/**
@@ -130,6 +132,7 @@ protected:
 class SpriteEncoder {
 public:
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~SpriteEncoder() = default;
 
 	/**

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -443,6 +443,7 @@ public:
 		this->GetWidget<NWidgetCore>(WID_STL_SORTDROPBTN)->SetString(CompanyStationsWindow::sorter_names[this->stations.SortType()]);
 	}
 
+	/** Save the last sorting state. */
 	~CompanyStationsWindow() override
 	{
 		/* Save filter state. */
@@ -1088,6 +1089,7 @@ CargoDataEntry::CargoDataEntry(CargoType cargo) :
 	children(nullptr)
 {}
 
+/** Remove ourselves from our parent. */
 CargoDataEntry::~CargoDataEntry()
 {
 	this->Clear();

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -37,6 +37,7 @@ StoryPagePool _story_page_pool("StoryPage");
 INSTANTIATE_POOL_METHODS(StoryPageElement)
 INSTANTIATE_POOL_METHODS(StoryPage)
 
+/** Delete all of our StoryPageElements. */
 StoryPage::~StoryPage()
 {
 	if (CleaningPool()) return;

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -63,6 +63,7 @@ struct StringReader {
 	bool translation; ///< Are we reading a translation, implies !master. However, the base translation will have this false.
 
 	StringReader(StringData &data, const std::string &file, bool master, bool translation);
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~StringReader() = default;
 	void HandleString(std::string_view str);
 
@@ -100,7 +101,7 @@ struct HeaderWriter {
 	 */
 	virtual void Finalise(const StringData &data) = 0;
 
-	/** Especially destroy the subclasses. */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~HeaderWriter() = default;
 
 	void WriteHeader(const StringData &data);
@@ -126,7 +127,7 @@ struct LanguageWriter {
 	 */
 	virtual void Finalise() = 0;
 
-	/** Especially destroy the subclasses. */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~LanguageWriter() = default;
 
 	virtual void WriteLength(size_t length);

--- a/src/string_base.h
+++ b/src/string_base.h
@@ -30,6 +30,7 @@ public:
 	 */
 	static std::unique_ptr<StringIterator> Create();
 
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~StringIterator() = default;
 
 	/**

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -156,7 +156,7 @@ EncodedString GetEncodedString(StringID string, const Args&... args)
  */
 class MissingGlyphSearcher {
 public:
-	/** Make sure everything gets destructed right. */
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~MissingGlyphSearcher() = default;
 
 	/**

--- a/src/tilearea_type.h
+++ b/src/tilearea_type.h
@@ -115,6 +115,7 @@ protected:
 	}
 
 public:
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~TileIterator() = default;
 
 	/**

--- a/src/timer/timer.h
+++ b/src/timer/timer.h
@@ -37,7 +37,7 @@ public:
 	}
 
 	/**
-	 * Delete the timer.
+	 * Unregister this timer.
 	 */
 	virtual ~BaseTimer()
 	{

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1965,6 +1965,7 @@ public:
 		this->SortVehicleList();
 	}
 
+	/** Save the last sorting state. */
 	~VehicleListWindow() override
 	{
 		*this->sorting = this->vehgroups.GetListing();

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1476,6 +1476,7 @@ OpenGLSprite::OpenGLSprite(SpriteType sprite_type, const SpriteLoader::SpriteCol
 	assert(_glGetError() == GL_NO_ERROR);
 }
 
+/** Delete the textures we allocated. */
 OpenGLSprite::~OpenGLSprite()
 {
 	_glDeleteTextures(NUM_TEX, this->tex.data());

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -213,11 +213,13 @@ public:
 	 * will make sure the buffer is unlocked no matter how the scope is exited.
 	 */
 	struct VideoBufferLocker {
+		/** Lock the video buffer. */
 		VideoBufferLocker()
 		{
 			this->unlock = VideoDriver::GetInstance()->LockVideoBuffer();
 		}
 
+		/** Release the video buffer. */
 		~VideoBufferLocker()
 		{
 			if (this->unlock) VideoDriver::GetInstance()->UnlockVideoBuffer();

--- a/src/waypoint.cpp
+++ b/src/waypoint.cpp
@@ -42,6 +42,7 @@ TileArea Waypoint::GetTileArea(StationType type) const
 	}
 }
 
+/** Remove all references to this waypoint. */
 Waypoint::~Waypoint()
 {
 	if (CleaningPool()) return;

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -136,6 +136,7 @@ using WidgetLookup = std::map<WidgetID, class NWidgetBase *>;
 class NWidgetBase {
 public:
 	NWidgetBase(WidgetType tp, WidgetID index = INVALID_WIDGET) : type(tp), index(index) {}
+	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~NWidgetBase() = default;
 
 	void ApplyAspectRatio();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -136,6 +136,7 @@ WindowDesc::WindowDesc(WindowPosition def_pos, std::string_view ini_key, int16_t
 	_window_descs->push_back(this);
 }
 
+/** Remove ourselves from the global list of window descs. */
 WindowDesc::~WindowDesc()
 {
 	_window_descs->erase(std::ranges::find(*_window_descs, this));


### PR DESCRIPTION
## Motivation / Problem

Doxygen errors like `<~IConsoleLine>:$: warning: parameters of member IConsoleLine::~IConsoleLine are not documented`.


## Description

Just document the destructors; there is no parameter, but by documenting the warning goes away.

Fixes 43 doxygen errors.


## Limitations

Not all destructors are documented, but those should likely just be removed. That is however, not in scope for this PR.

~~Likely the doxygen checker is going to fail on this PR because it doesn't add a newline to the warnings file, so if you remove the last warning, the new last warning will seem new to diff as its line doesn't have a newline.~~


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
