### PR TITLE
Codefix: do not remove (last) newline when sorting doxygen warnings

### DIFF
--- a/.github/sort_doxygen_warnings.py
+++ b/.github/sort_doxygen_warnings.py
@@ -21,6 +21,7 @@ def main():
     warnings = sorted(set(warnings))
     with open(sys.argv[2], "w") as out:
         out.write("\n".join(warnings))
+        out.write("\n")
     print("Doxygen warnings sorted successfully.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation / Problem

The sorting/grouping of warnings for the doxygen check remove the last newline. This causes the `diff` to check for additions to 'fail' when the last warning is solved, because the new last warning would not have a newline and is therefore different according to `diff`.


## Description

Add a newline at the end of the sorted file.


## Limitations

Obviously the doxygen checker is going to complain about there being more doxygen warnings.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
