### PR TITLE
Change: Decapitalise third line strings

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5488,19 +5488,19 @@ STR_ERROR_TOO_FAR_FROM_PREVIOUS_DESTINATION                     :too far from pr
 STR_ERROR_AIRCRAFT_NOT_ENOUGH_RANGE                             :aircraft has not enough range
 
 # Extra messages which go on the third line of errors, explaining why orders failed
-STR_ERROR_NO_RAIL_STATION                                       :There is no railway station
-STR_ERROR_NO_BUS_STATION                                        :There is no bus station
-STR_ERROR_NO_TRUCK_STATION                                      :There is no lorry station
-STR_ERROR_NO_DOCK                                               :There is no dock
-STR_ERROR_NO_AIRPORT                                            :There is no airport/heliport
-STR_ERROR_NO_STOP_COMPATIBLE_ROAD_TYPE                          :There are no stops with a compatible road type
-STR_ERROR_NO_STOP_COMPATIBLE_TRAM_TYPE                          :There are no stops with a compatible tram type
-STR_ERROR_NO_STOP_ARTICULATED_VEHICLE                           :There are no stops which are suitable for articulated road vehicles.{}Articulated road vehicles require a drive-through stop, not a bay stop
-STR_ERROR_AIRPORT_NO_PLANES                                     :This plane cannot land at this heliport
-STR_ERROR_AIRPORT_NO_HELICOPTERS                                :This helicopter cannot land at this airport
-STR_ERROR_NO_RAIL_WAYPOINT                                      :There is no rail waypoint
-STR_ERROR_NO_ROAD_WAYPOINT                                      :There is no road waypoint
-STR_ERROR_NO_BUOY                                               :There is no buoy
+STR_ERROR_NO_RAIL_STATION                                       :there is no railway station
+STR_ERROR_NO_BUS_STATION                                        :there is no bus station
+STR_ERROR_NO_TRUCK_STATION                                      :there is no lorry station
+STR_ERROR_NO_DOCK                                               :there is no dock
+STR_ERROR_NO_AIRPORT                                            :there is no airport/heliport
+STR_ERROR_NO_STOP_COMPATIBLE_ROAD_TYPE                          :there are no stops with a compatible road type
+STR_ERROR_NO_STOP_COMPATIBLE_TRAM_TYPE                          :there are no stops with a compatible tram type
+STR_ERROR_NO_STOP_ARTICULATED_VEHICLE                           :there are no stops which are suitable for articulated road vehicles.{}Articulated road vehicles require a drive-through stop, not a bay stop
+STR_ERROR_AIRPORT_NO_PLANES                                     :this plane cannot land at this heliport
+STR_ERROR_AIRPORT_NO_HELICOPTERS                                :this helicopter cannot land at this airport
+STR_ERROR_NO_RAIL_WAYPOINT                                      :there is no rail waypoint
+STR_ERROR_NO_ROAD_WAYPOINT                                      :there is no road waypoint
+STR_ERROR_NO_BUOY                                               :there is no buoy
 
 # Timetable related errors
 STR_ERROR_CAN_T_TIMETABLE_VEHICLE                               :Can't timetable vehicle...


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Addition to #15328. Resolves potential limitation of #15334.


## Description

The [updated strings](<https://github.com/OpenTTD/OpenTTD/blob/2cce03e2e12f8e1b3285cebbb03e4e298f4539b3/src/lang/english.txt#L5490-L5503>) can currently only appear on the third line of an error message when being returned from [`GetVehicleCannotUseStationReason`](<https://github.com/OpenTTD/OpenTTD/blob/2cce03e2e12f8e1b3285cebbb03e4e298f4539b3/src/vehicle.cpp#L3135>), and thus should not be capitalised.

In #15334, `STR_ERROR_NO_AIRPORT` can additionally be [returned](<https://github.com/OpenTTD/OpenTTD/pull/15334/changes/40fe04d5d0e6c67cdfde056e2d4dc635b1e19a3e#diff-25c559834fc05e15cc83980e2a74a183f49cfbe404945f8b0a9d29fb8f713039R2641>) from `Vehicle::SendToDepot`. This change would resolve the potential limitation identified with regard to the use of a capitalised string being displayed when not appropriate.


## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
