### PR TITLE
Feature: Fix #15152, Fix #7965: Expert game option to enable transfer profits as immediate payments to company

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1180,9 +1180,17 @@ CargoPayment::~CargoPayment()
 
 	if (this->visual_profit == 0 && this->visual_transfer == 0) return;
 
+	Money income_payment = 0;
+
+	if (_settings_game.economy.feeder_payment_immediate) {
+		income_payment = this->visual_profit + this->visual_transfer;
+	} else {
+		income_payment = this->route_profit;
+	}
+
 	Backup<CompanyID> cur_company(_current_company, this->front->owner);
 
-	SubtractMoneyFromCompany(_current_company, CommandCost(this->front->GetExpenseType(true), -this->route_profit));
+	SubtractMoneyFromCompany(_current_company, CommandCost(this->front->GetExpenseType(true), -income_payment));
 	this->front->profit_this_year += (this->visual_profit + this->visual_transfer) << 8;
 
 	if (this->route_profit != 0 && IsLocalCompany() && !PlayVehicleSound(this->front, VSE_LOAD_UNLOAD)) {

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1981,6 +1981,8 @@ STR_CONFIG_SETTING_ECONOMY_TYPE_FROZEN                          :Frozen
 
 STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE                         :Percentage of leg profit to pay in feeder systems: {STRING2}
 STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE_HELPTEXT                :Percentage of income given to the intermediate legs in feeder systems, giving more control over the income
+STR_CONFIG_SETTING_FEEDER_PAYMENT_UPDATES_MONEY                 :Enable feeder leg transfer profit to increase company money immediately: {STRING2}
+STR_CONFIG_SETTING_FEEDER_PAYMENT_UPDATES_MONEY_HELPTEXT        :Paying leg profit immediately allows you to spend that money straight away and not wait until final delivery has been made. Profit from transfers (manual transfer orders, unload not at dest, or cargodist transfers) will update your company's money at each transfer station, a poor final delivery could result in negative payment i.e. you will owe money and it will be taken from your company. Reducing the percentage of leg profit will reduce the risk of a final negative payment. Default (and original) behavior is to disable this option and only pay profit to your company once final delivery has been made
 
 STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY                         :When dragging, place signals every: {STRING2}
 STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY_HELPTEXT                :Set the distance at which signals will be built on a track up to the next obstacle (signal, junction), if signals are dragged

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -769,6 +769,7 @@ bool AfterLoadGame()
 		_settings_game.vehicle.train_slope_steepness = 3;
 	}
 	if (IsSavegameVersionBefore(SLV_134))  _settings_game.economy.feeder_payment_share = 75;
+	if (IsSavegameVersionBefore(SLV_REAL_FEEDER_PAYMENTS_AVAILABLE))  _settings_game.economy.feeder_payment_immediate = false;
 	if (IsSavegameVersionBefore(SLV_138))  _settings_game.vehicle.plane_crashes = 2;
 	if (IsSavegameVersionBefore(SLV_139)) {
 		_settings_game.vehicle.roadveh_acceleration_model = 0;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -414,6 +414,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_ENGINE_MULTI_RAILTYPE,              ///< 362  PR#14357 v15.0 Train engines can have multiple railtypes.
 	SLV_SIGN_TEXT_COLOURS,                  ///< 363  PR#14743 Configurable sign text colors in scenario editor.
 	SLV_BUOYS_AT_0_0,                       ///< 364  PR#14983 Allow to build buoys at (0x0).
+	SLV_REAL_FEEDER_PAYMENTS_AVAILABLE,     ///< 365  PR#15337 Expert game option to enable transfer profits as immediate payments to company.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -714,6 +714,7 @@ SettingsContainer &GetSettingsTree()
 			accounting->Add(new SettingEntry("difficulty.subsidy_multiplier"));
 			accounting->Add(new SettingEntry("difficulty.subsidy_duration"));
 			accounting->Add(new SettingEntry("economy.feeder_payment_share"));
+			accounting->Add(new SettingEntry("economy.feeder_payment_immediate"));
 			accounting->Add(new SettingEntry("economy.infrastructure_maintenance"));
 			accounting->Add(new SettingEntry("difficulty.vehicle_costs"));
 			accounting->Add(new SettingEntry("difficulty.construction_cost"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -569,7 +569,8 @@ struct EconomySettings {
 	bool   inflation;                        ///< disable inflation
 	bool   bribe;                            ///< enable bribing the local authority
 	EconomyType type;                        ///< economy type (original/smooth/frozen)
-	uint8_t  feeder_payment_share;             ///< percentage of leg payment to virtually pay in feeder systems
+	uint8_t  feeder_payment_share;           ///< percentage of leg payment to pay in feeder systems
+	bool     feeder_payment_immediate;       ///< enable immediate leg payment, not virtual payment
 	uint8_t dist_local_authority;             ///< distance for town local authority, default 20
 	bool   exclusive_rights;                 ///< allow buying exclusive rights
 	bool   fund_buildings;                   ///< allow funding new buildings

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -212,6 +212,15 @@ strhelp  = STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE_HELPTEXT
 strval   = STR_CONFIG_SETTING_PERCENTAGE
 cat      = SC_EXPERT
 
+[SDT_BOOL]
+var      = economy.feeder_payment_immediate
+flags    = SettingFlag::NewgameOnly
+from     = SLV_REAL_FEEDER_PAYMENTS_AVAILABLE
+def      = false
+str      = STR_CONFIG_SETTING_FEEDER_PAYMENT_UPDATES_MONEY
+strhelp  = STR_CONFIG_SETTING_FEEDER_PAYMENT_UPDATES_MONEY_HELPTEXT
+cat      = SC_EXPERT
+
 [SDT_VAR]
 var      = economy.town_growth_rate
 type     = SLE_UINT8


### PR DESCRIPTION
Feature: Fix #15152, Fix #7965: Expert game option to enable transfer profits as immediate payments to company


## Motivation / Problem

Finance reports had confusing information about which transport was profitable with a difference between annual company reports and individual vehicle or vehicle group reports.

This change allows the player to set a payment mode which makes these reports consistent. The profit reported for a vehicle is what is actually paid to the company, and the annual reports match each vehicle mode.

This also addresses an aspect of gameplay which can easily be misunderstood by players, especially those new to OpenTTD; When vehicles deliver cargo and a transfer value is shown to the player it is understandable they would assume that value was added to their money. Effectively this change adds a more intuitive and slightly easier level of play to the game.


## Description

A new expert game option is added _Enable feeder leg transfer profit to increase company money immediately_ which can be changed before creating a new game. Setting the value to true will affect the cargo package destructor where payment values are applied - any amount credited to a transfer will be paid immediately to the company. At final delivery any balance positive or negative will be applied to the company.

Players can have increased money flow at earlier stages of the game through each transfer making the game play easier and more intuitive.


## Limitations

The payment mode can't be changed in the middle of a game or for previously saved games as money would be under or over paid for journeys already in progress.

It introduces a game play where final delivery to a valid destination is not required for payment. Individual players can choose their level of difficulty or "honesty" in playing the game, multiplayer game designers can choose to adjust feeder share to a lower amount which would favour final delivery, or simply not to enable this option.

Further development along this train of thought could include penalties against transfer profit already paid when cargo decays in stations or is lost in crashes - adding an element of accountability for your cargo in transit and extra difficulty to the game.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
