### PR TITLE
Feature: Breakdown train on collision with road vehicle

### DIFF
--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -581,7 +581,13 @@ static bool RoadVehCheckTrainCrash(RoadVehicle *v)
 		if (!IsLevelCrossingTile(tile)) continue;
 
 		if (HasVehicleNearTileXY(v->x_pos, v->y_pos, 4, [&u](const Vehicle *t) {
-				return t->type == VEH_TRAIN && abs(t->z_pos - u->z_pos) <= 6;
+				if (t->type == VEH_TRAIN && abs(t->z_pos - u->z_pos) <= 6) {
+					/* Cause an immediate breakdown on the train upon colliding with a road vehicle. */
+					Vehicle *w = t->First();
+					if (CanVehicleBreakdown(w)) VehicleBreakdown(w, 0xFF);
+					return true;
+				}
+				return false;
 			})) {
 			RoadVehCrash(v);
 			return true;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1314,14 +1314,33 @@ static const uint8_t _breakdown_chance[64] = {
 };
 
 /**
+ * Basic set of conditions for a vehicle to break down.
+ * @param v The vehicle to check for breaking down.
+ * @return true iff the vehicle can break down.
+ */
+bool CanVehicleBreakdown(const Vehicle *v)
+{
+	assert(v == v->First());
+
+	/* Vehicles in the menu don't break down. */
+	if (_game_mode == GM_MENU) return false;
+
+	/* Breakdowns are disabled. */
+	if (_settings_game.difficulty.vehicle_breakdowns == VehicleBreakdowns::None) return false;
+	/* The vehicle is already broken down. */
+	if (v->breakdown_ctr != 0) return false;
+	/* The vehicle is stopped or going very slow. */
+	if (v->cur_speed < 5) return false;
+	/* The vehicle has been manually stopped. */
+	return !v->vehstatus.Test(VehState::Stopped);
+}
+
+/**
  * Periodic check for a vehicle to maybe break down.
  * @param v The vehicle to consider breaking.
  */
 void CheckVehicleBreakdown(Vehicle *v)
 {
-	/* Vehicles in the menu don't break down. */
-	if (_game_mode == GM_MENU) return;
-
 	/* If both breakdowns and automatic servicing are disabled, we don't decrease reliability or break down. */
 	if (_settings_game.difficulty.vehicle_breakdowns == VehicleBreakdowns::None && _settings_game.order.no_servicing_if_no_breakdowns) return;
 
@@ -1334,26 +1353,31 @@ void CheckVehicleBreakdown(Vehicle *v)
 	if ((rel_old >> 8) != (rel >> 8)) SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 
 	/* Some vehicles lose reliability but won't break down. */
-	/* Breakdowns are disabled. */
-	if (_settings_game.difficulty.vehicle_breakdowns == VehicleBreakdowns::None) return;
-	/* The vehicle is already broken down. */
-	if (v->breakdown_ctr != 0) return;
-	/* The vehicle is stopped or going very slow. */
-	if (v->cur_speed < 5) return;
-	/* The vehicle has been manually stopped. */
-	if (v->vehstatus.Test(VehState::Stopped)) return;
+	if (!CanVehicleBreakdown(v)) return;
 
 	/* Time to consider breaking down. */
+	VehicleBreakdown(v);
+}
+
+/**
+ * Consider breaking down a vehicle given the chance.
+ * @param v The vehicle to consider breaking down.
+ * @param chance The minimum added chance of failure.
+ */
+void VehicleBreakdown(Vehicle *v, int chance)
+{
+	assert(v == v->First());
+	assert(CanVehicleBreakdown(v));
 
 	uint32_t r = Random();
 
 	/* Increase chance of failure. */
-	int chance = v->breakdown_chance + 1;
+	chance = v->breakdown_chance + std::max(1, chance);
 	if (Chance16I(1, 25, r)) chance += 25;
 	v->breakdown_chance = ClampTo<uint8_t>(chance);
 
 	/* Calculate reliability value to use in comparison. */
-	rel = v->reliability;
+	int rel = v->reliability;
 	if (v->type == VEH_SHIP) rel += 0x6666;
 
 	/* Reduce the chance if the player has chosen the Reduced setting. */

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -207,6 +207,8 @@ void ShowNewGrfVehicleError(EngineID engine, StringID part1, StringID part2, GRF
 CommandCost TunnelBridgeIsFree(TileIndex tile, TileIndex endtile, const Vehicle *ignore = nullptr);
 
 void DecreaseVehicleValue(Vehicle *v);
+bool CanVehicleBreakdown(const Vehicle *v);
+void VehicleBreakdown(Vehicle *v, int chance = 1);
 void CheckVehicleBreakdown(Vehicle *v);
 void EconomyAgeVehicle(Vehicle *v);
 void AgeVehicle(Vehicle *v);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
I always thought about trains not being penalized at all when they crash on road vehicles.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
When a train and a road vehicle collide, the road vehicle crashes as it uses to, but now the train breakdowns, unless vehicle breakdowns are set to None.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
I am uncertain about the way the breakdown impact is supposed to look like, if it should be just a brick wall kind of impact, or a train slowing down into breakdown. I went with the later.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
