### PR TITLE
Codechange: Make CMD_ERROR constexpr to avoid many copies in binary

### DIFF
--- a/src/command_func.h
+++ b/src/command_func.h
@@ -25,7 +25,7 @@
  * Other functions just need to return this error if there is an error,
  * which doesn't need to specific by a StringID.
  */
-static const CommandCost CMD_ERROR = CommandCost(INVALID_STRING_ID);
+static constexpr CommandCost CMD_ERROR = CommandCost(INVALID_STRING_ID);
 
 void NetworkSendCommand(Commands cmd, StringID err_message, CommandCallback *callback, CompanyID company, const CommandDataBuffer &cmd_data);
 bool IsNetworkRegisteredCallback(CommandCallback *callback);

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -34,27 +34,27 @@ public:
 	/**
 	 * Creates a command cost return with no cost and no error
 	 */
-	CommandCost() : cost(0), message(INVALID_STRING_ID), expense_type(INVALID_EXPENSES), success(true) {}
+	constexpr CommandCost() : cost(0), message(INVALID_STRING_ID), expense_type(INVALID_EXPENSES), success(true) {}
 
 	/**
 	 * Creates a command return value with one, or optionally two, error message strings.
 	 * @param msg The error message.
 	 * @param extra_msg Optional secondary error message.
 	 */
-	explicit CommandCost(StringID msg, StringID extra_msg = INVALID_STRING_ID) : cost(0), message(msg), expense_type(INVALID_EXPENSES), success(false), extra_message(extra_msg) {}
+	explicit constexpr CommandCost(StringID msg, StringID extra_msg = INVALID_STRING_ID) : cost(0), message(msg), expense_type(INVALID_EXPENSES), success(false), extra_message(extra_msg) {}
 
 	/**
 	 * Creates a command cost with given expense type and start cost of 0
 	 * @param ex_t the expense type
 	 */
-	explicit CommandCost(ExpensesType ex_t) : cost(0), message(INVALID_STRING_ID), expense_type(ex_t), success(true) {}
+	explicit constexpr CommandCost(ExpensesType ex_t) : cost(0), message(INVALID_STRING_ID), expense_type(ex_t), success(true) {}
 
 	/**
 	 * Creates a command return value with the given start cost and expense type
 	 * @param ex_t the expense type
 	 * @param cst the initial cost of this command
 	 */
-	CommandCost(ExpensesType ex_t, const Money &cst) : cost(cst), message(INVALID_STRING_ID), expense_type(ex_t), success(true) {}
+	constexpr CommandCost(ExpensesType ex_t, const Money &cst) : cost(cst), message(INVALID_STRING_ID), expense_type(ex_t), success(true) {}
 
 	/**
 	 * Set the 'owner' (the originator) of this error message. This is used to show a company owner's face if you


### PR DESCRIPTION
## Motivation / Problem

CMD_ERROR is defined as `static const CommandCost CMD_ERROR` in a header, so there are >200 copies of it in the output binary (for my local builds at least), which doesn't seem ideal.

## Description

Make it constexpr so that there are significantly fewer copies.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
