### PR TITLE
Codefix: Fix duplicate copies of industry tables

### DIFF
--- a/src/newgrf/newgrf_act0_industries.cpp
+++ b/src/newgrf/newgrf_act0_industries.cpp
@@ -19,9 +19,11 @@
 #include "newgrf_stringmapping.h"
 
 #include "table/strings.h"
-#include "../table/build_industry.h"
 
 #include "../safeguards.h"
+
+/** Extern declaration for _origin_industry_specs in table/build_industry.h */
+extern const IndustrySpec _origin_industry_specs[NEW_INDUSTRYOFFSET];
 
 /**
  * Ignore an industry tile property

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -1146,7 +1146,7 @@ enum IndustryTypes : uint8_t {
 	   industry behaviours
 	   industry name                           building text
 	   messages : Closure                      production up                      production down   */
-static const IndustrySpec _origin_industry_specs[NEW_INDUSTRYOFFSET] = {
+extern const IndustrySpec _origin_industry_specs[NEW_INDUSTRYOFFSET] = {
 	MI(_tile_table_coal_mine,                  {},
 	   210,  0xB3333333,                       2, 3, 0, 0,    8, 8, 0, 0,          1,
 	   IT_POWER_STATION,  IT_INVALID,          IT_INVALID,       CHECK_NOTHING,


### PR DESCRIPTION
## Motivation / Problem

table/build_industry.h is included in two places, so there are two copies of all the industry tables in the binary.

## Description

Remove one of them.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
