### PR TITLE
Codefix: Double-counting of object types when loading pre-147 savegames

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2164,7 +2164,6 @@ bool AfterLoadGame()
 					o->build_date    = TimerGameCalendar::date;
 					o->town          = type == OBJECT_STATUE ? Town::Get(t.m2()) : CalcClosestTownFromTile(t, UINT_MAX);
 					t.m2() = o->index.base();
-					Object::IncTypeCount(type);
 				} else {
 					/* We're at an offset, so get the ID from our "root". */
 					Tile northern_tile = t - TileXY(GB(offset, 0, 4), GB(offset, 4, 4));


### PR DESCRIPTION
## Motivation / Problem

Loading savegames from before version 147 resulted in objects being counted twice in the per type list, so Object::GetTypeCount gave incorrect results. (Later counted in InitializeWindowsAndCaches).
This could in theory create desync problems if someone loaded a multiplayer server from a pre-147 save, but this seems a rather tenuous use-case.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
