### PR TITLE
Add: Screensaver Mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -397,6 +397,8 @@ add_files(
     roadveh_cmd.h
     roadveh_gui.cpp
     safeguards.h
+	screensaver.cpp
+	screensaver.h
     screenshot_bmp.cpp
     screenshot_gui.cpp
     screenshot_gui.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -400,6 +400,8 @@ add_files(
     roadveh_cmd.h
     roadveh_gui.cpp
     safeguards.h
+    screensaver.cpp
+    screensaver.h
     screenshot_bmp.cpp
     screenshot_gui.cpp
     screenshot_gui.h

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -538,6 +538,7 @@ STR_NEWS_MENU_DELETE_ALL_MESSAGES                               :Delete all mess
 # About menu
 STR_ABOUT_MENU_LAND_BLOCK_INFO                                  :Land area information
 STR_ABOUT_MENU_HELP                                             :Help & manuals
+STR_ABOUT_MENU_ENTER_SCREENSAVER_MODE                           :Toggle screensaver mode
 STR_ABOUT_MENU_TOGGLE_CONSOLE                                   :Toggle console
 STR_ABOUT_MENU_AI_DEBUG                                         :AI/Game script debug
 STR_ABOUT_MENU_SCREENSHOT                                       :Screenshot

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -538,6 +538,7 @@ STR_NEWS_MENU_DELETE_ALL_MESSAGES                               :Delete all mess
 # About menu
 STR_ABOUT_MENU_LAND_BLOCK_INFO                                  :Land area information
 STR_ABOUT_MENU_HELP                                             :Help & manuals
+STR_ABOUT_MENU_ENTER_SCREENSAVER_MODE                           :Toggle Screensaver Mode
 STR_ABOUT_MENU_TOGGLE_CONSOLE                                   :Toggle console
 STR_ABOUT_MENU_AI_DEBUG                                         :AI/Game script debug
 STR_ABOUT_MENU_SCREENSHOT                                       :Screenshot

--- a/src/screensaver.cpp
+++ b/src/screensaver.cpp
@@ -1,0 +1,187 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file screensaver.cpp Code for automatically following vehicles for a screensaver effect. */
+
+#include "screensaver.h"
+
+#include "stdafx.h"
+
+#include "core/random_func.hpp"
+#include "timer/timer.h"
+#include "timer/timer_game_tick.h"
+#include "vehicle_base.h"
+#include "vehicle_func.h"
+#include "vehicle_type.h"
+#include "window_func.h"
+
+#include "safeguards.h"
+
+/**
+ * Selects a random vehicle of any type.
+ *
+ * This function can return \c nullptr if it cannot find any valid vehicles to pick from.
+ *
+ * @return A pointer to the selected vehicle or \c nullptr if there are no vehicles.
+ */
+static const Vehicle *PickRandomVehicle()
+{
+	/* First pass, add up vehicles of all buildable types for all companies. */
+	uint n = 0;
+	for (const Company *c : Company::Iterate()) {
+		for (VehicleType v = VehicleType::Begin; v < VehicleType::CompanyEnd; ++v) {
+			n += c->group_all[v].num_vehicle;
+		}
+	}
+
+	/* If we have no vehicles, we can't pick a vehicle so exit. */
+	if (n == 0) return nullptr;
+
+	/* Otherwise, pick a random vehicle index between 0 and n. */
+	n = InteractiveRandomRange(n);
+
+	/* Loop over all the vehicles until we get to that vehicle. */
+	for (const Vehicle *v : Vehicle::Iterate()) {
+		/* Skip count anything companies can't build. */
+		if (!IsCompanyBuildableVehicleType(v)) continue;
+
+		/* Skip vehicles if they're not "front vehicles" so we don't count train cars (or similar) as targets to follow. */
+		if (!v->IsPrimaryVehicle()) continue;
+
+		/* Otherwise, it is a vehicle we should count, so count down until zero. */
+		if (n-- == 0) return v;
+	}
+
+	/* In case we go over all the vehicles, return \c nullptr in that case. */
+	return nullptr;
+}
+
+/**
+ * Switches the current followed vehicle to a new random one.
+ *
+ * This is intended to be used as the callback of an IntervalTimer object to periodically
+ * update the main window's followed vehicle so that it rotates between randomly selected
+ * vehicles in a "screensaver" effect.
+ *
+ * @param exit_on_invalid if true (the default) this function exits screensaver mode if following was cancelled
+ *
+ * @see PickRandomVehicle
+ */
+static void SwitchVehicle(bool exit_on_invalid = true)
+{
+	/* Do not do anything in the main menu. */
+	if (_game_mode == GameMode::Menu) return;
+
+	const Window *main_win = GetMainWindow();
+
+	/* We start with a high chance of keeping with a moving vehicle. */
+	static int movement_bias = 48;
+
+	/* If we are targeting an invalid vehicle, stop running */
+	if (exit_on_invalid && main_win->viewport->follow_vehicle == VehicleID::Invalid()) {
+		ExitScreensaverMode();
+		return;
+	}
+
+	/* If we're targeting a vehicle, we have a chance to return early and not pick a new one. */
+	auto v = Vehicle::GetIfValid(main_win->viewport->follow_vehicle);
+	if (v != nullptr) {
+
+		/* Every time we stick on a moving vehicle, we make it less likely that
+		 * we stick around next cycle to prevent staying on one vehicle for forever. */
+		if (v->cur_speed > 0 && !Chance16I(1, movement_bias, InteractiveRandom())) {
+			movement_bias -= 1;
+			return;
+		}
+
+		/* If we're not moving, we have a flat 25% chance to stay until the call
+		 * to encourage switching to a moving vehicle. */
+		if (v->cur_speed == 0 && Chance16I(3, 4, InteractiveRandom())) {
+			return;
+		}
+	}
+
+	/* Reset our bias so that the next vehicle gets its full time. */
+	movement_bias = 48;
+
+	/* Try to get a vehicle (this fails if the vehicle picked isn't valid to follow). */
+	const Vehicle *new_vehicle = PickRandomVehicle();
+	/* If we didn't find vehicle to follow, try again next cycle. */
+	if (new_vehicle == nullptr) return;
+
+	/* Swap the main window over to following the new vehicle. */
+	main_win->viewport->CancelFollow(*main_win);
+	main_win->viewport->follow_vehicle = new_vehicle->index;
+}
+
+
+/* The screensaver is based off a timer on a fixed interval which rotates between vehicles. */
+
+/**
+ * We use a fixed period for updating the screensaver's followed vehicle, stored in this variable.
+ *
+ * @see ToggleScreensaverMode
+ */
+const static auto _screensaver_check_interval = TimerGameTick::TPeriod(TimerGameTick::Priority::None, 128);
+
+/**
+ * The screensaver runs on an interval timer, stored in this pointer when it is running and freed when
+ * it is no longer in use.
+ *
+ * @see ToggleScreensaverMode
+ */
+static std::unique_ptr<IntervalTimer<TimerGameTick>> _switch_timer;
+
+/**
+ * Exits "Screensaver Mode"
+ *
+ * This function always disables screensaver mode, which is useful for any automated actions that should exit the screensaver.
+ *
+ * If the screensaver is not enabled, this function is a no-op.
+ *
+ * @see ToggleScreensaverMode
+ */
+void ExitScreensaverMode()
+{
+	const Window *main_win = GetMainWindow();
+
+	_switch_timer.reset();
+	main_win->viewport->CancelFollow(*main_win);
+}
+
+/**
+ * Enters or exits "Screensaver Mode".
+ *
+ * Screensaver mode is simply rotating the main window's followed vehicle every so often to show off
+ * a world full of moving trains, planes, boats, and automobiles.
+ *
+ * If not activated, the function allocates a new IntervalTimer which fires every so often to pick new vehicles to follow.
+ * There is some randomness in this to keep things interesting.
+ *
+ * If "Screensaver Mode" was previously activated, this instead deletes the aforementioned timer and
+ * stops following vehicles, returning the camera to the original position.
+ *
+ * @see SwitchVehicle
+ */
+void ToggleScreensaverMode()
+{
+	/* If we are in screensaver mode, exit it. */
+	if (_switch_timer != nullptr) {
+		ExitScreensaverMode();
+		return;
+	}
+
+	/* If we aren't, start it with a new timer. */
+	_switch_timer = std::make_unique<IntervalTimer<TimerGameTick>>(
+		_screensaver_check_interval,
+		[](uint) { SwitchVehicle(); }
+	);
+
+	/* Fire our callback once to start us following a first vehicle; otherwise we'd have to wait for the first time the timer fired.
+	 * We pass false here to ignore if there is no followed vehicle */
+	SwitchVehicle(false);
+}

--- a/src/screensaver.cpp
+++ b/src/screensaver.cpp
@@ -1,0 +1,161 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file screensaver.cpp Code for automatically following vehicles for a screensaver effect. */
+#include <memory>
+
+#include "core/random_func.hpp"
+#include "timer/timer.h"
+#include "timer/timer_game_tick.h"
+#include "vehicle_base.h"
+#include "vehicle_func.h"
+#include "vehicle_type.h"
+#include "window_func.h"
+
+
+/**
+ * Selects a random vehicle of any type.
+ *
+ * This function can return \c nullptr if it cannot find any valid vehicles to pick from.
+ *
+ * @return A pointer to the selected vehicle or \c nullptr if there are no vehicles.
+ */
+static Vehicle *PickRandomVehicle()
+{
+	/* first pass, add up vehicles of all buildable types for all companies */
+	uint n = 0;
+	for (const Company *c : Company::Iterate()) {
+		for (VehicleType v = VehicleType::Begin; v < VehicleType::CompanyEnd; ++v) {
+			n += c->group_all[v].num_vehicle;
+		}
+	}
+
+	/* If we have no vehicles, we can't pick a vehicle so exit */
+	if (n == 0) return nullptr;
+
+	/* otherwise, pick a random vehicle index between 0 and n */
+	n = InteractiveRandomRange(n);
+
+	/* loop over all the vehicles until we get to that vehicle */
+	for (Vehicle *v : Vehicle::Iterate()) {
+		/* skip count anything companies can't build */
+		if (!IsCompanyBuildableVehicleType(v)) continue;
+
+		/* skip vehicles if they're not "front vehicles" so we don't count train cars (or similar) as targets to follow */
+		if (!v->IsPrimaryVehicle()) continue;
+
+		/* otherwise, it is a vehicle we should count, so count down until zero */
+		if (n-- == 0) return v;
+	}
+
+	/* In case we go over all the vehicles, return \c nullptr in that case */
+	return nullptr;
+}
+
+/**
+ * Switches the current followed vehicle to a new random one.
+ *
+ * This is intended to be used as the callback of an IntervalTimer object to periodically
+ * update the main window's followed vehicle so that it rotates between randomly selected
+ * vehicles in a "screensaver" effect.
+ *
+ * @see PickRandomVehicle
+ *
+ * @todo Improve the screensaver effect or make it customizable?
+ */
+static void SwitchVehicle()
+{
+	const Window *main_win = GetMainWindow();
+
+	/* We start with a high chance of keeping with a moving vehicle */
+	static int movement_bias = 48;
+
+	/* if we're targeting a vehicle, we have a chance to return early and not pick a new one */
+	auto cur_v = main_win->viewport->follow_vehicle;
+	auto v = Vehicle::GetIfValid(cur_v);
+
+	if (v != nullptr) {
+		/* Every time we stick on a moving vehicle, we make it less likely that
+		 * we stick around next cycle to prevent staying on one vehicle for forever. */
+		if (v->cur_speed > 0 && !Chance16I(1, movement_bias, InteractiveRandom())) {
+			movement_bias -= 1;
+			return;
+		}
+
+		/* If we're not moving, we have a flat 25% chance to stay until the call
+		 * to encourage switching to a moving vehicle. */
+		if (v->cur_speed == 0 && Chance16I(3, 4, InteractiveRandom())) {
+			return;
+		}
+	}
+
+	/* reset our bias so that the next vehicle gets its full time */
+	movement_bias = 48;
+
+	/* try to get a vehicle (this fails if the vehicle picked isn't valid to follow) */
+	Vehicle *new_vehicle = PickRandomVehicle();
+	/* if we didn't find vehicle to follow, try again next cycle */
+	if (new_vehicle == nullptr) return;
+
+	/* swap the main window over to following the new vehicle */
+	main_win->viewport->CancelFollow(*main_win);
+	main_win->viewport->follow_vehicle = new_vehicle->index;
+}
+
+
+/* The screensaver is based off a timer on a fixed interval which rotates between vehicles */
+
+/**
+ * We use a fixed period for updating the screensaver's followed vehicle, stored in this variable.
+ *
+ * @see ToggleScreensaverMode
+ */
+const static auto _screensaver_check_interval = TimerGameTick::TPeriod(TimerGameTick::Priority::None, 128);
+
+/**
+ * The screensaver runs on an interval timer, stored in this pointer when it is running and freed when
+ * it is no longer in use.
+ *
+ * @see ToggleScreensaverMode
+ */
+static std::unique_ptr<IntervalTimer<TimerGameTick>> _switch_timer;
+
+/**
+ * Enters or exits "Screensaver Mode".
+ *
+ * Screensaver mode is simply rotating the main window's followed vehicle every so often to show off
+ * a world full of moving trains, planes, boats, and automobiles.
+ *
+ * If not activated, the function allocates a new IntervalTimer which fires every so often to pick new vehicles to follow.
+ * There is some randomness in this to keep things interesting.
+ *
+ * If "Screensaver Mode" was previously activated, this instead deletes the aforementioned timer and
+ * stops following vehicles, returning the camera to the original position.
+ *
+ * @see switchVehicle
+ */
+void ToggleScreensaverMode()
+{
+	const Window *main_win = GetMainWindow();
+
+	/* If we are in screensaver mode, exit it */
+	if (_switch_timer != nullptr) {
+		_switch_timer.reset();
+		main_win->viewport->CancelFollow(*main_win);
+		return;
+	}
+
+	/* If we aren't, start it with a new timer */
+	_switch_timer = std::make_unique<IntervalTimer<TimerGameTick>>(
+		_screensaver_check_interval,
+		[]([[maybe_unused]] uint _unused) { SwitchVehicle(); }
+	);
+
+	// fire our callback once to start us following a first vehicle;
+	// otherwise we'd have to wait for the first time the timer fired
+	SwitchVehicle();
+}

--- a/src/screensaver.h
+++ b/src/screensaver.h
@@ -1,0 +1,15 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file screensaver.h Exports a function to turn on and off a screensaver mode. */
+
+#ifndef SCREENSAVER_H
+#define SCREENSAVER_H
+
+void ToggleScreensaverMode();
+
+#endif

--- a/src/screensaver.h
+++ b/src/screensaver.h
@@ -1,0 +1,16 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file screensaver.h Exports a function to turn on and off a screensaver mode. */
+
+#ifndef SCREENSAVER_H
+#define SCREENSAVER_H
+
+void ExitScreensaverMode();
+void ToggleScreensaverMode();
+
+#endif /* SCREENSAVER_H */

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -65,6 +65,7 @@
 #include "timer/timer_game_calendar.h"
 #include "help_gui.h"
 #include "core/string_consumer.hpp"
+#include "screensaver.h"
 
 #include "widgets/toolbar_widget.h"
 
@@ -1085,13 +1086,14 @@ static CallBackFunction ToolbarHelpClick(Window *w)
 {
 	if (_settings_client.gui.newgrf_developer_tools) {
 		PopupMainToolbarMenu(w, _game_mode == GameMode::Editor ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
-				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
+				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_ENTER_SCREENSAVER_MODE,
+				STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
 				STR_ABOUT_MENU_SCREENSHOT, STR_ABOUT_MENU_SHOW_FRAMERATE, STR_ABOUT_MENU_ABOUT_OPENTTD,
 				STR_ABOUT_MENU_SPRITE_ALIGNER, STR_ABOUT_MENU_TOGGLE_BOUNDING_BOXES, STR_ABOUT_MENU_TOGGLE_DIRTY_BLOCKS,
 				STR_ABOUT_MENU_TOGGLE_WIDGET_OUTLINES});
 	} else {
 		PopupMainToolbarMenu(w, _game_mode == GameMode::Editor ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
-				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
+				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_ENTER_SCREENSAVER_MODE, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
 				STR_ABOUT_MENU_SCREENSHOT, STR_ABOUT_MENU_SHOW_FRAMERATE, STR_ABOUT_MENU_ABOUT_OPENTTD});
 	}
 	return CallBackFunction::None;
@@ -1174,17 +1176,18 @@ void SetStartingYear(TimerGameCalendar::Year year)
 static CallBackFunction MenuClickHelp(int index)
 {
 	switch (index) {
-		case  0: return PlaceLandBlockInfo();
-		case  1: ShowHelpWindow();                 break;
-		case  2: IConsoleSwitch();                 break;
-		case  3: ShowScriptDebugWindow(CompanyID::Invalid(), _ctrl_pressed); break;
-		case  4: ShowScreenshotWindow();           break;
-		case  5: ShowFramerateWindow();            break;
-		case  6: ShowAboutWindow();                break;
-		case  7: ShowSpriteAlignerWindow();        break;
-		case  8: ToggleBoundingBoxes();            break;
-		case  9: ToggleDirtyBlocks();              break;
-		case 10: ToggleWidgetOutlines();           break;
+		case 0: return PlaceLandBlockInfo();
+		case 1: ShowHelpWindow(); break;
+		case 2: ToggleScreensaverMode(); break;
+		case 3: IConsoleSwitch(); break;
+		case 4: ShowScriptDebugWindow(CompanyID::Invalid(), _ctrl_pressed); break;
+		case 5: ShowScreenshotWindow(); break;
+		case 6: ShowFramerateWindow(); break;
+		case 7: ShowAboutWindow(); break;
+		case 8: ShowSpriteAlignerWindow(); break;
+		case 9: ToggleBoundingBoxes(); break;
+		case 10: ToggleDirtyBlocks(); break;
+		case 11: ToggleWidgetOutlines(); break;
 	}
 	return CallBackFunction::None;
 }

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -64,6 +64,7 @@
 #include "timer/timer_game_calendar.h"
 #include "help_gui.h"
 #include "core/string_consumer.hpp"
+#include "screensaver.h"
 
 #include "widgets/toolbar_widget.h"
 
@@ -1084,13 +1085,14 @@ static CallBackFunction ToolbarHelpClick(Window *w)
 {
 	if (_settings_client.gui.newgrf_developer_tools) {
 		PopupMainToolbarMenu(w, _game_mode == GameMode::Editor ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
-				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
+				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_ENTER_SCREENSAVER_MODE,
+				STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
 				STR_ABOUT_MENU_SCREENSHOT, STR_ABOUT_MENU_SHOW_FRAMERATE, STR_ABOUT_MENU_ABOUT_OPENTTD,
 				STR_ABOUT_MENU_SPRITE_ALIGNER, STR_ABOUT_MENU_TOGGLE_BOUNDING_BOXES, STR_ABOUT_MENU_TOGGLE_DIRTY_BLOCKS,
 				STR_ABOUT_MENU_TOGGLE_WIDGET_OUTLINES});
 	} else {
 		PopupMainToolbarMenu(w, _game_mode == GameMode::Editor ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
-				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
+				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_ENTER_SCREENSAVER_MODE, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
 				STR_ABOUT_MENU_SCREENSHOT, STR_ABOUT_MENU_SHOW_FRAMERATE, STR_ABOUT_MENU_ABOUT_OPENTTD});
 	}
 	return CallBackFunction::None;
@@ -1173,17 +1175,18 @@ void SetStartingYear(TimerGameCalendar::Year year)
 static CallBackFunction MenuClickHelp(int index)
 {
 	switch (index) {
-		case  0: return PlaceLandBlockInfo();
-		case  1: ShowHelpWindow();                 break;
-		case  2: IConsoleSwitch();                 break;
-		case  3: ShowScriptDebugWindow(CompanyID::Invalid(), _ctrl_pressed); break;
-		case  4: ShowScreenshotWindow();           break;
-		case  5: ShowFramerateWindow();            break;
-		case  6: ShowAboutWindow();                break;
-		case  7: ShowSpriteAlignerWindow();        break;
-		case  8: ToggleBoundingBoxes();            break;
-		case  9: ToggleDirtyBlocks();              break;
-		case 10: ToggleWidgetOutlines();           break;
+		case 0: return PlaceLandBlockInfo();
+		case 1: ShowHelpWindow(); break;
+		case 2: ToggleScreensaverMode(); break;
+		case 3: IConsoleSwitch(); break;
+		case 4: ShowScriptDebugWindow(CompanyID::Invalid(), _ctrl_pressed); break;
+		case 5: ShowScreenshotWindow(); break;
+		case 6: ShowFramerateWindow(); break;
+		case 7: ShowAboutWindow(); break;
+		case 8: ShowSpriteAlignerWindow(); break;
+		case 9: ToggleBoundingBoxes(); break;
+		case 10: ToggleDirtyBlocks(); break;
+		case 11: ToggleWidgetOutlines(); break;
 	}
 	return CallBackFunction::None;
 }


### PR DESCRIPTION
This PR adds a "Screensaver Mode" to OpenTTD.  

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

I like just watching OpenTTD saves once they're "finished" and I thought it would be fun to use as OpenTTD in that fashion as a backdrop in my twitch streams, so I wrote an (initially very hacky) screensaver rotated between vehicles to make that a reality.  

I asked if there would be any interest in up-streaming the ability in the discord and got positive feedback, so this is the significantly more polished version of the same functionality.  I intentionally kept this simplistic to avoid creating a very complex system out of the gate, since I don't know what the ideal "OpenTTD Screensaver" mode would actually be, only what I think it might look like.  I'm open to changing behavior of this either before merging or in future PRs.  

Also, I'd like to note that this is my first time submitting a PR to OpenTTD and I'm not super familiar with the codebase; it is possible I missed an easier way to do things.  I've tried my best to go through and find the "correct" ways to do things, but please let me know if there are things I should change.


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

The "Screensaver Mode" is essentially just a wrapper around the existing "Follow Vehicle" functionality.  When toggled in the about menu, it picks a random vehicle to follow and then updates that vehicle on an interval.  There's a bias to avoid stopped vehicles and another to encourage switching to new vehicles if we've been stuck on any one vehicle too long.  I think it is a fairly pleasing, if simple, "screensaver" to watch and I've enjoyed just using it as a way to view OpenTTD saves.  


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

This affect is very simple for the time being.  Things that I considered/prototyped include:
- Smooth scrolling between vehicles rather than hard-cutting
- Selecting vehicles nearby to the current vehicle rather than any vehicle on the map each time
- Hiding the menus during the "screensaver"

I don't know of any current bugs in the implementation.  


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
