### PR TITLE
Codechange: make ConNetworkAuthorizedKeyAction a scoped enum

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2122,21 +2122,22 @@ static const std::initializer_list<std::pair<std::string_view, NetworkAuthorized
 	{ "server", &_settings_client.network.server_authorized_keys },
 };
 
-enum ConNetworkAuthorizedKeyAction : uint8_t {
-	CNAKA_LIST,
-	CNAKA_ADD,
-	CNAKA_REMOVE,
+/** Actions that can be performed on authorized keys from the console. */
+enum class ConNetworkAuthorizedKeyAction : uint8_t {
+	List, ///< List all authorized keys.
+	Add, ///< Add an authorized key.
+	Remove, ///< Remove an authorized key.
 };
 
 static void PerformNetworkAuthorizedKeyAction(std::string_view name, NetworkAuthorizedKeys *authorized_keys, ConNetworkAuthorizedKeyAction action, const std::string &authorized_key, CompanyID company = CompanyID::Invalid())
 {
 	switch (action) {
-		case CNAKA_LIST:
+		case ConNetworkAuthorizedKeyAction::List:
 			IConsolePrint(CC_WHITE, "The authorized keys for {} are:", name);
 			for (auto &ak : *authorized_keys) IConsolePrint(CC_INFO, "  {}", ak);
 			return;
 
-		case CNAKA_ADD:
+		case ConNetworkAuthorizedKeyAction::Add:
 			if (authorized_keys->Contains(authorized_key)) {
 				IConsolePrint(CC_WARNING, "Not added {} to {} as it already exists.", authorized_key, name);
 				return;
@@ -2151,7 +2152,7 @@ static void PerformNetworkAuthorizedKeyAction(std::string_view name, NetworkAuth
 			IConsolePrint(CC_INFO, "Added {} to {}.", authorized_key, name);
 			return;
 
-		case CNAKA_REMOVE:
+		case ConNetworkAuthorizedKeyAction::Remove:
 			if (!authorized_keys->Contains(authorized_key)) {
 				IConsolePrint(CC_WARNING, "Not removed {} from {} as it does not exist.", authorized_key, name);
 				return;
@@ -2187,18 +2188,18 @@ static bool ConNetworkAuthorizedKey(std::span<std::string_view> argv)
 	ConNetworkAuthorizedKeyAction action;
 	std::string_view action_string = argv[1];
 	if (StrEqualsIgnoreCase(action_string, "list")) {
-		action = CNAKA_LIST;
+		action = ConNetworkAuthorizedKeyAction::List;
 	} else if (StrEqualsIgnoreCase(action_string, "add")) {
-		action = CNAKA_ADD;
+		action = ConNetworkAuthorizedKeyAction::Add;
 	} else if (StrEqualsIgnoreCase(action_string, "remove") || StrEqualsIgnoreCase(action_string, "delete")) {
-		action = CNAKA_REMOVE;
+		action = ConNetworkAuthorizedKeyAction::Remove;
 	} else {
 		IConsolePrint(CC_WARNING, "No valid action was given.");
 		return false;
 	}
 
 	std::string authorized_key;
-	if (action != CNAKA_LIST) {
+	if (action != ConNetworkAuthorizedKeyAction::List) {
 		if (argv.size() <= 3) {
 			IConsolePrint(CC_ERROR, "You must enter the key.");
 			return false;


### PR DESCRIPTION
## Motivation / Problem

Doxygen warnings and the migration to scoped enums.


## Description

Just convert `ConNetworkAuthorizedKeyAction` to a scoped enum.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
