### PR TITLE
Codechange: make enums in toolbar_gui.cpp file scoped

### DIFF
--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -27,31 +27,68 @@
 
 #include "safeguards.h"
 
+/**
+ * Creates new #DropDownListDividerItem.
+ * @return Unique pointer to newly created drop down item.
+ */
 std::unique_ptr<DropDownListItem> MakeDropDownListDividerItem()
 {
 	return std::make_unique<DropDownListDividerItem>(-1);
 }
 
+/**
+ * Creates new #DropDownListStringItem.
+ * @param str The string to show on this item in the drop down menu.
+ * @param value The value to use when the item becomes selected.
+ * @param masked Whether the item should be masked out.
+ * @param shaded Whether the item should be shaded.
+ * @return Unique pointer to newly created drop down item.
+ */
 std::unique_ptr<DropDownListItem> MakeDropDownListStringItem(StringID str, int value, bool masked, bool shaded)
 {
 	return MakeDropDownListStringItem(GetString(str), value, masked, shaded);
 }
 
+/** @copydoc MakeDropDownListStringItem */
 std::unique_ptr<DropDownListItem> MakeDropDownListStringItem(std::string &&str, int value, bool masked, bool shaded)
 {
 	return std::make_unique<DropDownListStringItem>(std::move(str), value, masked, shaded);
 }
 
+/**
+ * Creates new #DropDownListIconItem.
+ * @param sprite The sprite id to use as an icon on the side of the string.
+ * @param palette The palette to use when drawing icon.
+ * @param str The string to show on this item in the drop down menu.
+ * @param value The value to use when the item becomes selected.
+ * @param masked Whether the item should be masked out.
+ * @param shaded Whether the item should be shaded.
+ * @return Unique pointer to newly created drop down item.
+ */
 std::unique_ptr<DropDownListItem> MakeDropDownListIconItem(SpriteID sprite, PaletteID palette, StringID str, int value, bool masked, bool shaded)
 {
 	return std::make_unique<DropDownListIconItem>(sprite, palette, GetString(str), value, masked, shaded);
 }
 
+/**
+ * @copydoc MakeDropDownListIconItem
+ * @param dim The rect specifying what part from the sprite should be used as an icon.
+ */
 std::unique_ptr<DropDownListItem> MakeDropDownListIconItem(const Dimension &dim, SpriteID sprite, PaletteID palette, StringID str, int value, bool masked, bool shaded)
 {
 	return std::make_unique<DropDownListIconItem>(dim, sprite, palette, GetString(str), value, masked, shaded);
 }
 
+/**
+ * Creates new #DropDownListCheckedItem.
+ * @param checked Whether the tick before the string should be visible or not.
+ * @param str The string to show on this item in the drop down menu.
+ * @param value The value to use when the item becomes selected.
+ * @param masked Whether the item should be masked out.
+ * @param shaded Whether the item should be shaded.
+ * @param indent By what factor the tick and string should be indent.
+ * @return Unique pointer to newly created drop down item.
+ */
 std::unique_ptr<DropDownListItem> MakeDropDownListCheckedItem(bool checked, StringID str, int value, bool masked, bool shaded, uint indent)
 {
 	return std::make_unique<DropDownListCheckedItem>(indent, checked, GetString(str), value, masked, shaded);

--- a/src/dropdown_common_type.h
+++ b/src/dropdown_common_type.h
@@ -299,9 +299,9 @@ public:
 	bool Selectable() const override { return false; }
 };
 
-using DropDownListDividerItem = DropDownDivider<DropDownListItem>;
-using DropDownListStringItem = DropDownString<DropDownListItem>;
-using DropDownListIconItem = DropDownIcon<DropDownString<DropDownListItem>>;
-using DropDownListCheckedItem = DropDownIndent<DropDownCheck<DropDownString<DropDownListItem>>>;
+using DropDownListDividerItem = DropDownDivider<DropDownListItem>; ///< Drop down list item that divides list horizontally into two parts.
+using DropDownListStringItem = DropDownString<DropDownListItem>; ///< Drop down list item that contains a single string.
+using DropDownListIconItem = DropDownIcon<DropDownString<DropDownListItem>>; ///< Drop down list item that contains a single string and an icon.
+using DropDownListCheckedItem = DropDownIndent<DropDownCheck<DropDownString<DropDownListItem>>>; ///< Drop down list item with a single string and a space for tick.
 
 #endif /* DROPDOWN_COMMON_TYPE_H */

--- a/src/dropdown_func.h
+++ b/src/dropdown_func.h
@@ -10,6 +10,7 @@
 #ifndef DROPDOWN_FUNC_H
 #define DROPDOWN_FUNC_H
 
+#include "core/enum_type.hpp"
 #include "dropdown_type.h"
 #include "window_gui.h"
 
@@ -23,5 +24,40 @@ std::unique_ptr<DropDownListItem> MakeDropDownListStringItem(std::string &&str, 
 std::unique_ptr<DropDownListItem> MakeDropDownListIconItem(SpriteID sprite, PaletteID palette, StringID str, int value, bool masked = false, bool shaded = false);
 std::unique_ptr<DropDownListItem> MakeDropDownListIconItem(const Dimension &dim, SpriteID sprite, PaletteID palette, StringID str, int value, bool masked = false, bool shaded = false);
 std::unique_ptr<DropDownListItem> MakeDropDownListCheckedItem(bool checked, StringID str, int value, bool masked = false, bool shaded = false, uint indent = 0);
+
+/** @copydoc MakeDropDownListStringItem */
+template <typename EnumType> requires is_scoped_enum_v<EnumType>
+inline std::unique_ptr<DropDownListItem> MakeDropDownListStringItem(StringID str, EnumType value, bool masked = false, bool shaded = false)
+{
+	return MakeDropDownListStringItem(str, to_underlying(value), masked, shaded);
+}
+
+/** @copydoc MakeDropDownListStringItem */
+template <typename EnumType> requires is_scoped_enum_v<EnumType>
+inline std::unique_ptr<DropDownListItem> MakeDropDownListStringItem(std::string &&str, EnumType value, bool masked = false, bool shaded = false)
+{
+	return MakeDropDownListStringItem(std::move(str), to_underlying(value), masked, shaded);
+}
+
+/** @copydoc MakeDropDownListIconItem */
+template <typename EnumType> requires is_scoped_enum_v<EnumType>
+inline std::unique_ptr<DropDownListItem> MakeDropDownListIconItem(SpriteID sprite, PaletteID palette, StringID str, EnumType value, bool masked = false, bool shaded = false)
+{
+	return MakeDropDownListIconItem(sprite, palette, str, to_underlying(value), masked, shaded);
+}
+
+/** @copydoc MakeDropDownListIconItem(const Dimension &, SpriteID, PaletteID, StringID, int, bool, bool) */
+template <typename EnumType> requires is_scoped_enum_v<EnumType>
+inline std::unique_ptr<DropDownListItem> MakeDropDownListIconItem(const Dimension &dim, SpriteID sprite, PaletteID palette, StringID str, EnumType value, bool masked = false, bool shaded = false)
+{
+	return MakeDropDownListIconItem(dim, sprite, palette, str, to_underlying(value), masked, shaded);
+}
+
+/** @copydoc MakeDropDownListCheckedItem */
+template <typename EnumType> requires is_scoped_enum_v<EnumType>
+inline std::unique_ptr<DropDownListItem> MakeDropDownListCheckedItem(bool checked, StringID str, EnumType value, bool masked = false, bool shaded = false, uint indent = 0)
+{
+	return MakeDropDownListCheckedItem(checked, str, to_underlying(value), masked, shaded, indent);
+}
 
 #endif /* DROPDOWN_FUNC_H */

--- a/src/hotkeys.h
+++ b/src/hotkeys.h
@@ -10,6 +10,7 @@
 #ifndef HOTKEYS_H
 #define HOTKEYS_H
 
+#include "core/enum_type.hpp"
 #include "gfx_type.h"
 #include "window_type.h"
 #include "string_type.h"
@@ -21,6 +22,14 @@
 struct Hotkey {
 	Hotkey(uint16_t default_keycode, const std::string &name, int num);
 	Hotkey(const std::vector<uint16_t> &default_keycodes, const std::string &name, int num);
+
+	/** @copydoc Hotkey(uint16_t, const std::string &, int) */
+	template <typename EnumType> requires is_scoped_enum_v<EnumType>
+	Hotkey(uint16_t default_keycode, const std::string &name, EnumType num) : Hotkey(default_keycode, name, to_underlying(num)) {}
+
+	/** @copydoc Hotkey(const std::vector<uint16_t> &, const std::string &, int) */
+	template <typename EnumType> requires is_scoped_enum_v<EnumType>
+	Hotkey(const std::vector<uint16_t> &default_keycodes, const std::string &name, EnumType num) : Hotkey(default_keycodes, name, to_underlying(num)) {}
 
 	void AddKeycode(uint16_t keycode);
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -342,23 +342,23 @@ static CallBackFunction MenuClickSettings(int index)
 /**
  * SaveLoad entries in scenario editor mode.
  */
-enum SaveLoadEditorMenuEntries : uint8_t {
-	SLEME_SAVE_SCENARIO = 0,
-	SLEME_LOAD_SCENARIO,
-	SLEME_SAVE_HEIGHTMAP,
-	SLEME_LOAD_HEIGHTMAP,
-	SLEME_EXIT_TOINTRO,
-	SLEME_EXIT_GAME,
+enum class SaveLoadEditorMenuEntries : uint8_t {
+	SaveScenario = 0, ///< Save the scenario.
+	LoadScenario, ///< Load a scenario.
+	SaveHeightmap, ///< Save the heightmap.
+	LoadHeightmap, ///< Load a heightmap.
+	ExitToMainMenu, ///< Exit to main menu.
+	ExitGame, ///< Exit to desktop.
 };
 
 /**
  * SaveLoad entries in normal game mode.
  */
-enum SaveLoadNormalMenuEntries : uint8_t {
-	SLNME_SAVE_GAME = 0,
-	SLNME_LOAD_GAME,
-	SLNME_EXIT_TOINTRO,
-	SLNME_EXIT_GAME,
+enum class SaveLoadNormalMenuEntries : uint8_t {
+	SaveGame = 0, ///< Save the game.
+	LoadGame, ///< Load a save.
+	ExitToMainMenu, ///< Exit to main menu.
+	ExitGame, ///< Exit to desktop.
 };
 
 /**
@@ -397,20 +397,20 @@ static CallBackFunction ToolbarScenSaveOrLoad(Window *w)
 static CallBackFunction MenuClickSaveLoad(int index = 0)
 {
 	if (_game_mode == GM_EDITOR) {
-		switch (index) {
-			case SLEME_SAVE_SCENARIO:  ShowSaveLoadDialog(FT_SCENARIO, SLO_SAVE);  break;
-			case SLEME_LOAD_SCENARIO:  ShowSaveLoadDialog(FT_SCENARIO, SLO_LOAD);  break;
-			case SLEME_SAVE_HEIGHTMAP: ShowSaveLoadDialog(FT_HEIGHTMAP, SLO_SAVE); break;
-			case SLEME_LOAD_HEIGHTMAP: ShowSaveLoadDialog(FT_HEIGHTMAP, SLO_LOAD); break;
-			case SLEME_EXIT_TOINTRO:   AskExitToGameMenu();                    break;
-			case SLEME_EXIT_GAME:      HandleExitGameRequest();                break;
+		switch (SaveLoadEditorMenuEntries(index)) {
+			case SaveLoadEditorMenuEntries::SaveScenario: ShowSaveLoadDialog(FT_SCENARIO, SLO_SAVE); break;
+			case SaveLoadEditorMenuEntries::LoadScenario: ShowSaveLoadDialog(FT_SCENARIO, SLO_LOAD); break;
+			case SaveLoadEditorMenuEntries::SaveHeightmap: ShowSaveLoadDialog(FT_HEIGHTMAP, SLO_SAVE); break;
+			case SaveLoadEditorMenuEntries::LoadHeightmap: ShowSaveLoadDialog(FT_HEIGHTMAP, SLO_LOAD); break;
+			case SaveLoadEditorMenuEntries::ExitToMainMenu: AskExitToGameMenu(); break;
+			case SaveLoadEditorMenuEntries::ExitGame: HandleExitGameRequest(); break;
 		}
 	} else {
-		switch (index) {
-			case SLNME_SAVE_GAME:      ShowSaveLoadDialog(FT_SAVEGAME, SLO_SAVE); break;
-			case SLNME_LOAD_GAME:      ShowSaveLoadDialog(FT_SAVEGAME, SLO_LOAD); break;
-			case SLNME_EXIT_TOINTRO:   AskExitToGameMenu();               break;
-			case SLNME_EXIT_GAME:      HandleExitGameRequest();           break;
+		switch (SaveLoadNormalMenuEntries(index)) {
+			case SaveLoadNormalMenuEntries::SaveGame: ShowSaveLoadDialog(FT_SAVEGAME, SLO_SAVE); break;
+			case SaveLoadNormalMenuEntries::LoadGame: ShowSaveLoadDialog(FT_SAVEGAME, SLO_LOAD); break;
+			case SaveLoadNormalMenuEntries::ExitToMainMenu: AskExitToGameMenu(); break;
+			case SaveLoadNormalMenuEntries::ExitGame: HandleExitGameRequest(); break;
 		}
 	}
 	return CallBackFunction::None;

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2290,30 +2290,35 @@ static ToolbarButtonProc * const _scen_toolbar_button_procs[] = {
 	ToolbarSwitchClick,
 };
 
-enum MainToolbarEditorHotkeys : int32_t {
-	MTEHK_PAUSE,
-	MTEHK_FASTFORWARD,
-	MTEHK_SETTINGS,
-	MTEHK_SAVEGAME,
-	MTEHK_GENLAND,
-	MTEHK_GENTOWN,
-	MTEHK_GENINDUSTRY,
-	MTEHK_BUILD_ROAD,
-	MTEHK_BUILD_TRAM,
-	MTEHK_BUILD_DOCKS,
-	MTEHK_BUILD_TREES,
-	MTEHK_SIGN,
-	MTEHK_MUSIC,
-	MTEHK_LANDINFO,
-	MTEHK_SMALL_SCREENSHOT,
-	MTEHK_ZOOMEDIN_SCREENSHOT,
-	MTEHK_DEFAULTZOOM_SCREENSHOT,
-	MTEHK_GIANT_SCREENSHOT,
-	MTEHK_ZOOM_IN,
-	MTEHK_ZOOM_OUT,
-	MTEHK_TERRAFORM,
-	MTEHK_SMALLMAP,
-	MTEHK_EXTRA_VIEWPORT,
+/**
+ * List of hotkeys available in scenario editor.
+ * @note Hotkeys that behave like toolbar buttons must have the same value as corresponding widget.
+ *       Other hotkeys have to have SPECIAL_HOTKEY_BIT set.
+ */
+enum class MainToolbarEditorHotkeys : int32_t {
+	Pause = WID_TE_PAUSE, ///< (Un)pause the game.
+	FastForward = WID_TE_FAST_FORWARD, ///< Toggle the fast-forward mode.
+	ZoomIn = WID_TE_ZOOM_IN, ///< Zoom in.
+	ZoomOut = WID_TE_ZOOM_OUT, ///< Zoom out.
+	GenerateLand = WID_TE_LAND_GENERATE, ///< Open land generation window.
+	GenerateIndustry = WID_TE_INDUSTRY, ///< Open industry funding window.
+	BuildWater = WID_TE_WATER, ///< Open window for building locks, canals, rivers and aqueducts.
+	BuildTrees = WID_TE_TREES, ///< Open tree selection window.
+	Sign = WID_TE_SIGNS, ///< Toggle sign creation tool.
+	Settings = 1 << SPECIAL_HOTKEY_BIT, ///< Open game options window.
+	SaveGame, ///< Open save scenario window.
+	Music, ///< Open sound end music window.
+	LandInfo, ///< Toggle land info tool.
+	SmallScreenshot, ///< Take small screenshot.
+	ZoomedInScreenshot, ///< Take zoomed in screenshot.
+	DefaultZoomScreenshot, ///< Take screenshot with default zoom.
+	GiantScreenshot, ///< Take detailed screenshot of whole map.
+	Terraform, ///< Open land generation window.
+	SmallMap, ///< Open small map window.
+	ExtraViewport, ///< Open new extra viewport window.
+	GenerateTown, ///< Open town generation window.
+	BuildRoad, ///< Open toolbar window with tools for building roads.
+	BuildTram, ///< Open toolbar window with tools for building tramways.
 };
 
 struct ScenarioEditorToolbarWindow : Window {
@@ -2398,34 +2403,29 @@ struct ScenarioEditorToolbarWindow : Window {
 
 	EventState OnHotkey(int hotkey) override
 	{
-		CallBackFunction cbf = CallBackFunction::None;
-		switch (hotkey) {
-			case MTEHK_PAUSE:                  ToolbarPauseClick(this); break;
-			case MTEHK_FASTFORWARD:            ToolbarFastForwardClick(this); break;
-			case MTEHK_SETTINGS:               ShowGameOptions(); break;
-			case MTEHK_SAVEGAME:               MenuClickSaveLoad(); break;
-			case MTEHK_GENLAND:                ToolbarScenGenLand(this); break;
-			case MTEHK_GENTOWN:                ToolbarScenGenTownClick(this); break;
-			case MTEHK_GENINDUSTRY:            ToolbarScenGenIndustry(this); break;
-			case MTEHK_BUILD_ROAD:             ToolbarScenBuildRoadClick(this); break;
-			case MTEHK_BUILD_TRAM:             ToolbarScenBuildTramClick(this); break;
-			case MTEHK_BUILD_DOCKS:            ToolbarScenBuildDocks(this); break;
-			case MTEHK_BUILD_TREES:            ToolbarScenPlantTrees(this); break;
-			case MTEHK_SIGN:                   cbf = ToolbarScenPlaceSign(this); break;
-			case MTEHK_MUSIC:                  ShowMusicWindow(); break;
-			case MTEHK_LANDINFO:               cbf = PlaceLandBlockInfo(); break;
-			case MTEHK_SMALL_SCREENSHOT:       MakeScreenshotWithConfirm(SC_VIEWPORT); break;
-			case MTEHK_ZOOMEDIN_SCREENSHOT:    MakeScreenshotWithConfirm(SC_ZOOMEDIN); break;
-			case MTEHK_DEFAULTZOOM_SCREENSHOT: MakeScreenshotWithConfirm(SC_DEFAULTZOOM); break;
-			case MTEHK_GIANT_SCREENSHOT:       MakeScreenshotWithConfirm(SC_WORLD); break;
-			case MTEHK_ZOOM_IN:                ToolbarZoomInClick(this); break;
-			case MTEHK_ZOOM_OUT:               ToolbarZoomOutClick(this); break;
-			case MTEHK_TERRAFORM:              ShowEditorTerraformToolbar(); break;
-			case MTEHK_SMALLMAP:               ShowSmallMap(); break;
-			case MTEHK_EXTRA_VIEWPORT:         ShowExtraViewportWindowForTileUnderCursor(); break;
-			default: return ES_NOT_HANDLED;
+		if (IsSpecialHotkey(hotkey)) {
+			CallBackFunction cbf = CallBackFunction::None;
+			switch (MainToolbarEditorHotkeys(hotkey)) {
+				case MainToolbarEditorHotkeys::Settings: ShowGameOptions(); break;
+				case MainToolbarEditorHotkeys::SaveGame: MenuClickSaveLoad(); break;
+				case MainToolbarEditorHotkeys::Music: ShowMusicWindow(); break;
+				case MainToolbarEditorHotkeys::LandInfo: cbf = PlaceLandBlockInfo(); break;
+				case MainToolbarEditorHotkeys::SmallScreenshot: MakeScreenshotWithConfirm(SC_VIEWPORT); break;
+				case MainToolbarEditorHotkeys::ZoomedInScreenshot: MakeScreenshotWithConfirm(SC_ZOOMEDIN); break;
+				case MainToolbarEditorHotkeys::DefaultZoomScreenshot: MakeScreenshotWithConfirm(SC_DEFAULTZOOM); break;
+				case MainToolbarEditorHotkeys::GiantScreenshot: MakeScreenshotWithConfirm(SC_WORLD); break;
+				case MainToolbarEditorHotkeys::Terraform: ShowEditorTerraformToolbar(); break;
+				case MainToolbarEditorHotkeys::SmallMap: ShowSmallMap(); break;
+				case MainToolbarEditorHotkeys::ExtraViewport: ShowExtraViewportWindowForTileUnderCursor(); break;
+				case MainToolbarEditorHotkeys::GenerateTown: ShowFoundTownWindow(); break;
+				case MainToolbarEditorHotkeys::BuildRoad: ShowBuildRoadScenToolbar(_last_built_roadtype); break;
+				case MainToolbarEditorHotkeys::BuildTram: ShowBuildRoadScenToolbar(_last_built_tramtype); break;
+				default: return ES_NOT_HANDLED;
+			}
+			if (cbf != CallBackFunction::None) _last_started_action = cbf;
+		} else {
+			this->OnClick({}, hotkey, 0);
 		}
-		if (cbf != CallBackFunction::None) _last_started_action = cbf;
 		return ES_HANDLED;
 	}
 
@@ -2500,29 +2500,29 @@ struct ScenarioEditorToolbarWindow : Window {
 	}
 
 	static inline HotkeyList hotkeys{"scenedit_maintoolbar", {
-		Hotkey({WKC_F1, WKC_PAUSE}, "pause", MTEHK_PAUSE),
-		Hotkey(0, "fastforward", MTEHK_FASTFORWARD),
-		Hotkey(WKC_F2, "settings", MTEHK_SETTINGS),
-		Hotkey(WKC_F3, "saveload", MTEHK_SAVEGAME),
-		Hotkey(WKC_F4, "gen_land", MTEHK_GENLAND),
-		Hotkey(WKC_F5, "gen_town", MTEHK_GENTOWN),
-		Hotkey(WKC_F6, "gen_industry", MTEHK_GENINDUSTRY),
-		Hotkey(WKC_F7, "build_road", MTEHK_BUILD_ROAD),
-		Hotkey(0, "build_tram", MTEHK_BUILD_TRAM),
-		Hotkey(WKC_F8, "build_docks", MTEHK_BUILD_DOCKS),
-		Hotkey(WKC_F9, "build_trees", MTEHK_BUILD_TREES),
-		Hotkey(WKC_F10, "build_sign", MTEHK_SIGN),
-		Hotkey(WKC_F11, "music", MTEHK_MUSIC),
-		Hotkey(WKC_F12, "land_info", MTEHK_LANDINFO),
-		Hotkey(WKC_CTRL  | 'S', "small_screenshot", MTEHK_SMALL_SCREENSHOT),
-		Hotkey(WKC_CTRL  | 'P', "zoomedin_screenshot", MTEHK_ZOOMEDIN_SCREENSHOT),
-		Hotkey(WKC_CTRL  | 'D', "defaultzoom_screenshot", MTEHK_DEFAULTZOOM_SCREENSHOT),
-		Hotkey(0, "giant_screenshot", MTEHK_GIANT_SCREENSHOT),
-		Hotkey({WKC_NUM_PLUS, WKC_EQUALS, WKC_SHIFT | WKC_EQUALS, WKC_SHIFT | WKC_F5}, "zoomin", MTEHK_ZOOM_IN),
-		Hotkey({WKC_NUM_MINUS, WKC_MINUS, WKC_SHIFT | WKC_MINUS, WKC_SHIFT | WKC_F6}, "zoomout", MTEHK_ZOOM_OUT),
-		Hotkey('L', "terraform", MTEHK_TERRAFORM),
-		Hotkey('M', "smallmap", MTEHK_SMALLMAP),
-		Hotkey('V', "extra_viewport", MTEHK_EXTRA_VIEWPORT),
+		Hotkey({WKC_F1, WKC_PAUSE}, "pause", MainToolbarEditorHotkeys::Pause),
+		Hotkey(0, "fastforward", MainToolbarEditorHotkeys::FastForward),
+		Hotkey(WKC_F2, "settings", MainToolbarEditorHotkeys::Settings),
+		Hotkey(WKC_F3, "saveload", MainToolbarEditorHotkeys::SaveGame),
+		Hotkey(WKC_F4, "gen_land", MainToolbarEditorHotkeys::GenerateLand),
+		Hotkey(WKC_F5, "gen_town", MainToolbarEditorHotkeys::GenerateTown),
+		Hotkey(WKC_F6, "gen_industry", MainToolbarEditorHotkeys::GenerateIndustry),
+		Hotkey(WKC_F7, "build_road", MainToolbarEditorHotkeys::BuildRoad),
+		Hotkey(0, "build_tram", MainToolbarEditorHotkeys::BuildTram),
+		Hotkey(WKC_F8, "build_docks", MainToolbarEditorHotkeys::BuildWater),
+		Hotkey(WKC_F9, "build_trees", MainToolbarEditorHotkeys::BuildTrees),
+		Hotkey(WKC_F10, "build_sign", MainToolbarEditorHotkeys::Sign),
+		Hotkey(WKC_F11, "music", MainToolbarEditorHotkeys::Music),
+		Hotkey(WKC_F12, "land_info", MainToolbarEditorHotkeys::LandInfo),
+		Hotkey(WKC_CTRL | 'S', "small_screenshot", MainToolbarEditorHotkeys::SmallScreenshot),
+		Hotkey(WKC_CTRL | 'P', "zoomedin_screenshot", MainToolbarEditorHotkeys::ZoomedInScreenshot),
+		Hotkey(WKC_CTRL | 'D', "defaultzoom_screenshot", MainToolbarEditorHotkeys::DefaultZoomScreenshot),
+		Hotkey(0, "giant_screenshot", MainToolbarEditorHotkeys::GiantScreenshot),
+		Hotkey({WKC_NUM_PLUS, WKC_EQUALS, WKC_SHIFT | WKC_EQUALS, WKC_SHIFT | WKC_F5}, "zoomin", MainToolbarEditorHotkeys::ZoomIn),
+		Hotkey({WKC_NUM_MINUS, WKC_MINUS, WKC_SHIFT | WKC_MINUS, WKC_SHIFT | WKC_F6}, "zoomout", MainToolbarEditorHotkeys::ZoomOut),
+		Hotkey('L', "terraform", MainToolbarEditorHotkeys::Terraform),
+		Hotkey('M', "smallmap", MainToolbarEditorHotkeys::SmallMap),
+		Hotkey('V', "extra_viewport", MainToolbarEditorHotkeys::ExtraViewport),
 	}};
 };
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -89,13 +89,13 @@ enum class ToolbarMode : uint8_t {
 };
 
 /** Callback functions. */
-enum CallBackFunction : uint8_t {
-	CBF_NONE,
-	CBF_PLACE_SIGN,
-	CBF_PLACE_LANDINFO,
+enum class CallBackFunction : uint8_t {
+	None, ///< No action will happen when tile is selected afterwards.
+	PlaceSign, ///< A new sign will be placed when tile is selected afterwards.
+	PlaceLandInfo, ///< Land info window will appear when tile is selected afterwards.
 };
 
-static CallBackFunction _last_started_action = CBF_NONE; ///< Last started user action.
+static CallBackFunction _last_started_action = CallBackFunction::None; ///< Last started user action.
 
 /**
  * Company name list item, with company-colour icon, name, and lock components.
@@ -194,12 +194,12 @@ static ToolbarMode _toolbar_mode;
 
 static CallBackFunction SelectSignTool()
 {
-	if (_last_started_action == CBF_PLACE_SIGN) {
+	if (_last_started_action == CallBackFunction::PlaceSign) {
 		ResetObjectToPlace();
-		return CBF_NONE;
+		return CallBackFunction::None;
 	} else {
 		SetObjectToPlace(SPR_CURSOR_SIGN, PAL_NONE, HT_RECT, WC_MAIN_TOOLBAR, 0);
-		return CBF_PLACE_SIGN;
+		return CallBackFunction::PlaceSign;
 	}
 }
 
@@ -207,27 +207,27 @@ static CallBackFunction SelectSignTool()
 
 static CallBackFunction ToolbarPauseClick(Window *)
 {
-	if (_networking && !_network_server) return CBF_NONE; // only server can pause the game
+	if (_networking && !_network_server) return CallBackFunction::None; // only server can pause the game
 
 	if (Command<Commands::Pause>::Post(PauseMode::Normal, _pause_mode.None())) {
 		SndConfirmBeep();
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Toggle fast forward mode.
  *
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction ToolbarFastForwardClick(Window *)
 {
-	if (_networking) return CBF_NONE; // no fast forward in network game
+	if (_networking) return CallBackFunction::None; // no fast forward in network game
 
 	ChangeGameSpeed(_game_speed == 100);
 
 	SndClickBeep();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
@@ -261,7 +261,7 @@ enum OptionMenuEntries : uint8_t {
  * Handle click on Options button in toolbar.
  *
  * @param w parent window the shown Drop down list is attached to.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction ToolbarOptionsClick(Window *w)
 {
@@ -297,22 +297,22 @@ static CallBackFunction ToolbarOptionsClick(Window *w)
 	list.push_back(MakeDropDownListCheckedItem(IsTransparencySet(TO_SIGNS), STR_SETTINGS_MENU_TRANSPARENT_SIGNS, OME_SHOW_STATIONSIGNS));
 
 	ShowDropDownList(w, std::move(list), 0, WID_TN_SETTINGS, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on one of the entries in the Options button menu.
  *
  * @param index Index being clicked.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickSettings(int index)
 {
 	switch (index) {
-		case OME_GAMEOPTIONS:          ShowGameOptions();                               return CBF_NONE;
-		case OME_AI_SETTINGS:          ShowAIConfigWindow();                            return CBF_NONE;
-		case OME_GAMESCRIPT_SETTINGS:  ShowGSConfigWindow();                            return CBF_NONE;
-		case OME_NEWGRFSETTINGS:       ShowNewGRFSettings(!_networking && _settings_client.gui.UserIsAllowedToChangeNewGRFs(), true, true, _grfconfig); return CBF_NONE;
+		case OME_GAMEOPTIONS: ShowGameOptions(); return CallBackFunction::None;
+		case OME_AI_SETTINGS: ShowAIConfigWindow(); return CallBackFunction::None;
+		case OME_GAMESCRIPT_SETTINGS: ShowGSConfigWindow(); return CallBackFunction::None;
+		case OME_NEWGRFSETTINGS: ShowNewGRFSettings(!_networking && _settings_client.gui.UserIsAllowedToChangeNewGRFs(), true, true, _grfconfig); return CallBackFunction::None;
 		case OME_SANDBOX:              ShowCheatWindow();                               break;
 		case OME_TRANSPARENCIES:       ShowTransparencyToolbar();                       break;
 
@@ -336,7 +336,7 @@ static CallBackFunction MenuClickSettings(int index)
 		case OME_SHOW_STATIONSIGNS:    ToggleTransparency(TO_SIGNS);                    break;
 	}
 	MarkWholeScreenDirty();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
@@ -365,34 +365,34 @@ enum SaveLoadNormalMenuEntries : uint8_t {
  * Handle click on Save button in toolbar in normal game mode.
  *
  * @param w parent window the shown save dialogue is attached to.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction ToolbarSaveClick(Window *w)
 {
 	PopupMainToolbarMenu(w, WID_TN_SAVE, {STR_FILE_MENU_SAVE_GAME, STR_FILE_MENU_LOAD_GAME, STR_FILE_MENU_QUIT_GAME,
 			STR_NULL, STR_FILE_MENU_EXIT});
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on SaveLoad button in toolbar in the scenario editor.
  *
  * @param w parent window the shown save dialogue is attached to.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction ToolbarScenSaveOrLoad(Window *w)
 {
 	PopupMainToolbarMenu(w, WID_TE_SAVE, {STR_SCENEDIT_FILE_MENU_SAVE_SCENARIO, STR_SCENEDIT_FILE_MENU_LOAD_SCENARIO,
 			STR_SCENEDIT_FILE_MENU_SAVE_HEIGHTMAP, STR_SCENEDIT_FILE_MENU_LOAD_HEIGHTMAP,
 			STR_SCENEDIT_FILE_MENU_QUIT_EDITOR, STR_NULL, STR_SCENEDIT_FILE_MENU_QUIT});
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on one of the entries in the SaveLoad menu.
  *
  * @param index Index being clicked.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickSaveLoad(int index = 0)
 {
@@ -413,7 +413,7 @@ static CallBackFunction MenuClickSaveLoad(int index = 0)
 			case SLNME_EXIT_GAME:      HandleExitGameRequest();           break;
 		}
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Map button menu --- */
@@ -435,7 +435,7 @@ static CallBackFunction ToolbarMapClick(Window *w)
 	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_LINGRAPH_LEGEND,         MME_SHOW_LINKGRAPH));
 	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_SIGN_LIST,               MME_SHOW_SIGNLISTS));
 	PopupMainToolbarMenu(w, WID_TN_SMALL_MAP, std::move(list), 0);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenMapTownDir(Window *w)
@@ -447,14 +447,14 @@ static CallBackFunction ToolbarScenMapTownDir(Window *w)
 	list.push_back(MakeDropDownListStringItem(STR_TOWN_MENU_TOWN_DIRECTORY,         MME_SHOW_TOWNDIRECTORY));
 	list.push_back(MakeDropDownListStringItem(STR_INDUSTRY_MENU_INDUSTRY_DIRECTORY, MME_SHOW_INDUSTRYDIRECTORY));
 	PopupMainToolbarMenu(w, WID_TE_SMALL_MAP, std::move(list), 0);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on one of the entries in the Map menu.
  *
  * @param index Index being clicked.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickMap(int index)
 {
@@ -466,7 +466,7 @@ static CallBackFunction MenuClickMap(int index)
 		case MME_SHOW_TOWNDIRECTORY:     ShowTownDirectory();       break;
 		case MME_SHOW_INDUSTRYDIRECTORY: ShowIndustryDirectory();   break;
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Town button menu --- */
@@ -486,14 +486,14 @@ static CallBackFunction ToolbarTownClick(Window *w)
 
 	PopupMainToolbarMenu(w, WID_TN_TOWNS, std::move(list), 0);
 
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on one of the entries in the Town menu.
  *
  * @param index Index being clicked.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickTown(int index)
 {
@@ -506,7 +506,7 @@ static CallBackFunction MenuClickTown(int index)
 			if (_settings_game.economy.place_houses != PlaceHouses::Forbidden) ShowBuildHousePicker(nullptr);
 			break;
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Subidies button menu --- */
@@ -514,18 +514,18 @@ static CallBackFunction MenuClickTown(int index)
 static CallBackFunction ToolbarSubsidiesClick(Window *w)
 {
 	PopupMainToolbarMenu(w, WID_TN_SUBSIDIES, {STR_SUBSIDIES_MENU_SUBSIDIES});
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Subsidies menu.
  *
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickSubsidies(int)
 {
 	ShowSubsidiesList();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Stations button menu --- */
@@ -533,19 +533,19 @@ static CallBackFunction MenuClickSubsidies(int)
 static CallBackFunction ToolbarStationsClick(Window *w)
 {
 	PopupMainCompanyToolbMenu(w, WID_TN_STATIONS);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Stations menu
  *
  * @param index CompanyID to show station list for
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickStations(int index)
 {
 	ShowCompanyStations((CompanyID)index);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Finances button menu --- */
@@ -553,19 +553,19 @@ static CallBackFunction MenuClickStations(int index)
 static CallBackFunction ToolbarFinancesClick(Window *w)
 {
 	PopupMainCompanyToolbMenu(w, WID_TN_FINANCES);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the finances overview menu.
  *
  * @param index CompanyID to show finances for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickFinances(int index)
 {
 	ShowCompanyFinances((CompanyID)index);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Company's button menu --- */
@@ -573,14 +573,14 @@ static CallBackFunction MenuClickFinances(int index)
 static CallBackFunction ToolbarCompaniesClick(Window *w)
 {
 	PopupMainCompanyToolbMenu(w, WID_TN_COMPANIES);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Company menu.
  *
  * @param index Menu entry to handle.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickCompany(int index)
 {
@@ -588,7 +588,7 @@ static CallBackFunction MenuClickCompany(int index)
 		switch (index) {
 			case CTMN_CLIENT_LIST:
 				ShowClientList();
-				return CBF_NONE;
+				return CallBackFunction::None;
 
 			case CTMN_SPECTATE:
 				if (_network_server) {
@@ -597,11 +597,11 @@ static CallBackFunction MenuClickCompany(int index)
 				} else {
 					NetworkClientRequestMove(COMPANY_SPECTATOR);
 				}
-				return CBF_NONE;
+				return CallBackFunction::None;
 		}
 	}
 	ShowCompany((CompanyID)index);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Story button menu --- */
@@ -609,19 +609,19 @@ static CallBackFunction MenuClickCompany(int index)
 static CallBackFunction ToolbarStoryClick(Window *w)
 {
 	PopupMainCompanyToolbMenu(w, WID_TN_STORY);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Story menu
  *
  * @param index CompanyID to show story book for
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickStory(int index)
 {
 	ShowStoryBook(CompanyID(index));
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Goal button menu --- */
@@ -629,19 +629,19 @@ static CallBackFunction MenuClickStory(int index)
 static CallBackFunction ToolbarGoalClick(Window *w)
 {
 	PopupMainCompanyToolbMenu(w, WID_TN_GOAL);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Goal menu
  *
  * @param index CompanyID to show story book for
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickGoal(int index)
 {
 	ShowGoalsList(CompanyID(index));
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Graphs and League Table button menu --- */
@@ -689,7 +689,7 @@ static CallBackFunction ToolbarGraphsClick(Window *w)
 	if (_toolbar_mode != ToolbarMode::Normal) AddDropDownLeagueTableOptions(list);
 
 	ShowDropDownList(w, std::move(list), GRMN_OPERATING_PROFIT_GRAPH, WID_TN_GRAPHS, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarLeagueClick(Window *w)
@@ -700,14 +700,14 @@ static CallBackFunction ToolbarLeagueClick(Window *w)
 
 	int selected = list[0]->result;
 	ShowDropDownList(w, std::move(list), selected, WID_TN_LEAGUE, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Graphs or CompanyLeague.
  *
  * @param index Graph to show.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickGraphsOrLeague(int index)
 {
@@ -727,7 +727,7 @@ static CallBackFunction MenuClickGraphsOrLeague(int index)
 			}
 		}
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 
@@ -742,14 +742,14 @@ static CallBackFunction ToolbarIndustryClick(Window *w)
 	} else {
 		PopupMainToolbarMenu(w, WID_TN_INDUSTRIES, {STR_INDUSTRY_MENU_INDUSTRY_DIRECTORY, STR_INDUSTRY_MENU_INDUSTRY_CHAIN, STR_INDUSTRY_MENU_FUND_NEW_INDUSTRY});
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Industry menu.
  *
  * @param index Menu entry number.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickIndustry(int index)
 {
@@ -758,7 +758,7 @@ static CallBackFunction MenuClickIndustry(int index)
 		case 1: ShowIndustryCargoesWindow(); break;
 		case 2: ShowBuildIndustryWindow();   break;
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Trains button menu + 1 helper function for all vehicles. --- */
@@ -777,19 +777,19 @@ static void ToolbarVehicleClick(Window *w, VehicleType veh)
 static CallBackFunction ToolbarTrainClick(Window *w)
 {
 	ToolbarVehicleClick(w, VEH_TRAIN);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Train menu.
  *
  * @param index CompanyID to show train list for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickShowTrains(int index)
 {
 	ShowVehicleListWindow((CompanyID)index, VEH_TRAIN);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Road vehicle button menu --- */
@@ -797,19 +797,19 @@ static CallBackFunction MenuClickShowTrains(int index)
 static CallBackFunction ToolbarRoadClick(Window *w)
 {
 	ToolbarVehicleClick(w, VEH_ROAD);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Road Vehicles menu.
  *
  * @param index CompanyID to show road vehicles list for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickShowRoad(int index)
 {
 	ShowVehicleListWindow((CompanyID)index, VEH_ROAD);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Ship button menu --- */
@@ -817,19 +817,19 @@ static CallBackFunction MenuClickShowRoad(int index)
 static CallBackFunction ToolbarShipClick(Window *w)
 {
 	ToolbarVehicleClick(w, VEH_SHIP);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Ships menu.
  *
  * @param index CompanyID to show ship list for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickShowShips(int index)
 {
 	ShowVehicleListWindow((CompanyID)index, VEH_SHIP);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Aircraft button menu --- */
@@ -837,19 +837,19 @@ static CallBackFunction MenuClickShowShips(int index)
 static CallBackFunction ToolbarAirClick(Window *w)
 {
 	ToolbarVehicleClick(w, VEH_AIRCRAFT);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Aircraft menu.
  *
  * @param index CompanyID to show aircraft list for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickShowAir(int index)
 {
 	ShowVehicleListWindow((CompanyID)index, VEH_AIRCRAFT);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Zoom in button --- */
@@ -859,7 +859,7 @@ static CallBackFunction ToolbarZoomInClick(Window *w)
 	if (DoZoomInOutWindow(ZOOM_IN, GetMainWindow())) {
 		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (WidgetID)WID_TE_ZOOM_IN : (WidgetID)WID_TN_ZOOM_IN);
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Zoom out button --- */
@@ -869,7 +869,7 @@ static CallBackFunction ToolbarZoomOutClick(Window *w)
 	if (DoZoomInOutWindow(ZOOM_OUT, GetMainWindow())) {
 		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (WidgetID)WID_TE_ZOOM_OUT : (WidgetID)WID_TN_ZOOM_OUT);
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Rail button menu --- */
@@ -877,20 +877,20 @@ static CallBackFunction ToolbarZoomOutClick(Window *w)
 static CallBackFunction ToolbarBuildRailClick(Window *w)
 {
 	ShowDropDownList(w, GetRailTypeDropDownList(), _last_built_railtype, WID_TN_RAILS, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Build Rail menu.
  *
  * @param index RailType to show the build toolbar for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickBuildRail(int index)
 {
 	_last_built_railtype = (RailType)index;
 	ShowBuildRailToolbar(_last_built_railtype);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Road button menu --- */
@@ -898,20 +898,20 @@ static CallBackFunction MenuClickBuildRail(int index)
 static CallBackFunction ToolbarBuildRoadClick(Window *w)
 {
 	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TN_ROADS, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Build Road menu.
  *
  * @param index RoadType to show the build toolbar for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickBuildRoad(int index)
 {
 	_last_built_roadtype = (RoadType)index;
 	ShowBuildRoadToolbar(_last_built_roadtype);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Tram button menu --- */
@@ -919,20 +919,20 @@ static CallBackFunction MenuClickBuildRoad(int index)
 static CallBackFunction ToolbarBuildTramClick(Window *w)
 {
 	ShowDropDownList(w, GetRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TN_TRAMS, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Build Tram menu.
  *
  * @param index RoadType to show the build toolbar for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickBuildTram(int index)
 {
 	_last_built_tramtype = (RoadType)index;
 	ShowBuildRoadToolbar(_last_built_tramtype);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Water button menu --- */
@@ -942,18 +942,18 @@ static CallBackFunction ToolbarBuildWaterClick(Window *w)
 	DropDownList list;
 	list.push_back(MakeDropDownListIconItem(SPR_IMG_BUILD_CANAL, PAL_NONE, STR_WATERWAYS_MENU_WATERWAYS_CONSTRUCTION, 0));
 	ShowDropDownList(w, std::move(list), 0, WID_TN_WATER, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Build Waterways menu.
  *
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickBuildWater(int)
 {
 	ShowBuildDocksToolbar();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Airport button menu --- */
@@ -963,18 +963,18 @@ static CallBackFunction ToolbarBuildAirClick(Window *w)
 	DropDownList list;
 	list.push_back(MakeDropDownListIconItem(SPR_IMG_AIRPORT, PAL_NONE, STR_AIRCRAFT_MENU_AIRPORT_CONSTRUCTION, 0));
 	ShowDropDownList(w, std::move(list), 0, WID_TN_AIR, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Build Air menu.
  *
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickBuildAir(int)
 {
 	ShowBuildAirToolbar();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Forest button menu --- */
@@ -986,14 +986,14 @@ static CallBackFunction ToolbarForestClick(Window *w)
 	list.push_back(MakeDropDownListIconItem(SPR_IMG_PLANTTREES, PAL_NONE, STR_LANDSCAPING_MENU_PLANT_TREES, 1));
 	list.push_back(MakeDropDownListIconItem(SPR_IMG_SIGN, PAL_NONE, STR_LANDSCAPING_MENU_PLACE_SIGN, 2));
 	ShowDropDownList(w, std::move(list), 0, WID_TN_LANDSCAPE, 100, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the landscaping menu.
  *
  * @param index Menu entry clicked.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickForest(int index)
 {
@@ -1002,7 +1002,7 @@ static CallBackFunction MenuClickForest(int index)
 		case 1: ShowBuildTreesToolbar(); break;
 		case 2: return SelectSignTool();
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Music button menu --- */
@@ -1010,18 +1010,18 @@ static CallBackFunction MenuClickForest(int index)
 static CallBackFunction ToolbarMusicClick(Window *w)
 {
 	PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (WidgetID)WID_TE_MUSIC_SOUND : (WidgetID)WID_TN_MUSIC_SOUND, {STR_TOOLBAR_SOUND_MUSIC});
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Music menu.
  *
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickMusicWindow(int)
 {
 	ShowMusicWindow();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Newspaper button menu --- */
@@ -1029,14 +1029,14 @@ static CallBackFunction MenuClickMusicWindow(int)
 static CallBackFunction ToolbarNewspaperClick(Window *w)
 {
 	PopupMainToolbarMenu(w, WID_TN_MESSAGES, {STR_NEWS_MENU_LAST_MESSAGE_NEWS_REPORT, STR_NEWS_MENU_MESSAGE_HISTORY_MENU, STR_NEWS_MENU_DELETE_ALL_MESSAGES});
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Newspaper menu.
  *
  * @param index Menu entry clicked.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction MenuClickNewspaper(int index)
 {
@@ -1045,19 +1045,19 @@ static CallBackFunction MenuClickNewspaper(int index)
 		case 1: ShowMessageHistory();  break;
 		case 2: DeleteAllMessages();   break;
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Help button menu --- */
 
 static CallBackFunction PlaceLandBlockInfo()
 {
-	if (_last_started_action == CBF_PLACE_LANDINFO) {
+	if (_last_started_action == CallBackFunction::PlaceLandInfo) {
 		ResetObjectToPlace();
-		return CBF_NONE;
+		return CallBackFunction::None;
 	} else {
 		SetObjectToPlace(SPR_CURSOR_QUERY, PAL_NONE, HT_RECT, WC_MAIN_TOOLBAR, 0);
-		return CBF_PLACE_LANDINFO;
+		return CallBackFunction::PlaceLandInfo;
 	}
 }
 
@@ -1074,7 +1074,7 @@ static CallBackFunction ToolbarHelpClick(Window *w)
 				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
 				STR_ABOUT_MENU_SCREENSHOT, STR_ABOUT_MENU_SHOW_FRAMERATE, STR_ABOUT_MENU_ABOUT_OPENTTD});
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
@@ -1149,7 +1149,7 @@ void SetStartingYear(TimerGameCalendar::Year year)
 /**
  * Choose the proper callback function for the main toolbar's help menu.
  * @param index The menu index which was selected.
- * @return CBF_NONE
+ * @return CallBackFunction::None
  */
 static CallBackFunction MenuClickHelp(int index)
 {
@@ -1166,7 +1166,7 @@ static CallBackFunction MenuClickHelp(int index)
 		case  9: ToggleDirtyBlocks();              break;
 		case 10: ToggleWidgetOutlines();           break;
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Switch toolbar button --- */
@@ -1182,7 +1182,7 @@ static CallBackFunction ToolbarSwitchClick(Window *w)
 	w->ReInit();
 	w->SetWidgetLoweredState(_game_mode == GM_EDITOR ? (WidgetID)WID_TE_SWITCH_BAR : (WidgetID)WID_TN_SWITCH_BAR, _toolbar_mode == ToolbarMode::Lower);
 	SndClickBeep();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /* --- Scenario editor specific handlers. */
@@ -1194,7 +1194,7 @@ static CallBackFunction ToolbarSwitchClick(Window *w)
 static CallBackFunction ToolbarScenDatePanel(Window *w)
 {
 	ShowQueryString(GetString(STR_JUST_INT, _settings_game.game_creation.starting_year), STR_MAPGEN_START_DATE_QUERY_CAPT, 8, w, CS_NUMERAL, QueryStringFlag::EnableDefault);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenDateBackward(Window *w)
@@ -1207,7 +1207,7 @@ static CallBackFunction ToolbarScenDateBackward(Window *w)
 		SetStartingYear(_settings_game.game_creation.starting_year - 1);
 	}
 	_left_button_clicked = false;
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenDateForward(Window *w)
@@ -1220,7 +1220,7 @@ static CallBackFunction ToolbarScenDateForward(Window *w)
 		SetStartingYear(_settings_game.game_creation.starting_year + 1);
 	}
 	_left_button_clicked = false;
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenGenLand(Window *w)
@@ -1228,13 +1228,13 @@ static CallBackFunction ToolbarScenGenLand(Window *w)
 	w->HandleButtonClick(WID_TE_LAND_GENERATE);
 
 	ShowEditorTerraformToolbar();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenGenTownClick(Window *w)
 {
 	PopupMainToolbarMenu(w, WID_TE_TOWN_GENERATE, {STR_SCENEDIT_TOWN_MENU_BUILD_TOWN, STR_SCENEDIT_TOWN_MENU_PACE_HOUSE});
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenGenTown(int index)
@@ -1243,66 +1243,66 @@ static CallBackFunction ToolbarScenGenTown(int index)
 		case 0: ShowFoundTownWindow(); break;
 		case 1: ShowBuildHousePicker(nullptr); break;
 	}
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenGenIndustry(Window *w)
 {
 	w->HandleButtonClick(WID_TE_INDUSTRY);
 	ShowBuildIndustryWindow();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenBuildRoadClick(Window *w)
 {
 	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_ROAD), _last_built_roadtype, WID_TE_ROADS, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Build Road menu.
  *
  * @param index RoadType to show the build toolbar for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction ToolbarScenBuildRoad(int index)
 {
 	_last_built_roadtype = (RoadType)index;
 	ShowBuildRoadScenToolbar(_last_built_roadtype);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenBuildTramClick(Window *w)
 {
 	ShowDropDownList(w, GetScenRoadTypeDropDownList(RTTB_TRAM), _last_built_tramtype, WID_TE_TRAMS, 140, GetToolbarDropDownOptions());
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 /**
  * Handle click on the entry in the Build Tram menu.
  *
  * @param index RoadType to show the build toolbar for.
- * @return #CBF_NONE
+ * @return #CallBackFunction::None
  */
 static CallBackFunction ToolbarScenBuildTram(int index)
 {
 	_last_built_tramtype = (RoadType)index;
 	ShowBuildRoadScenToolbar(_last_built_tramtype);
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenBuildDocks(Window *w)
 {
 	w->HandleButtonClick(WID_TE_WATER);
 	ShowBuildDocksScenToolbar();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenPlantTrees(Window *w)
 {
 	w->HandleButtonClick(WID_TE_TREES);
 	ShowBuildTreesToolbar();
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 static CallBackFunction ToolbarScenPlaceSign(Window *w)
@@ -1313,7 +1313,7 @@ static CallBackFunction ToolbarScenPlaceSign(Window *w)
 
 static CallBackFunction ToolbarBtn_NULL(Window *)
 {
-	return CBF_NONE;
+	return CallBackFunction::None;
 }
 
 typedef CallBackFunction MenuClickedProc(int index);
@@ -1987,7 +1987,7 @@ struct MainToolbarWindow : Window {
 	{
 		this->InitNested(0);
 
-		_last_started_action = CBF_NONE;
+		_last_started_action = CallBackFunction::None;
 		this->flags.Reset(WindowFlag::WhiteBorder);
 		this->SetWidgetDisabledState(WID_TN_PAUSE, _networking && !_network_server); // if not server, disable pause button
 		this->SetWidgetDisabledState(WID_TN_FAST_FORWARD, _networking); // if networking, disable fast-forward button
@@ -2023,12 +2023,12 @@ struct MainToolbarWindow : Window {
 	void OnDropdownSelect(WidgetID widget, int index, int) override
 	{
 		CallBackFunction cbf = _menu_clicked_procs[widget](index);
-		if (cbf != CBF_NONE) _last_started_action = cbf;
+		if (cbf != CallBackFunction::None) _last_started_action = cbf;
 	}
 
 	EventState OnHotkey(int hotkey) override
 	{
-		CallBackFunction cbf = CBF_NONE;
+		CallBackFunction cbf = CallBackFunction::None;
 		switch (hotkey) {
 			case MTHK_PAUSE: ToolbarPauseClick(this); break;
 			case MTHK_FASTFORWARD: ToolbarFastForwardClick(this); break;
@@ -2072,18 +2072,18 @@ struct MainToolbarWindow : Window {
 			case MTHK_LANDINFO: cbf = PlaceLandBlockInfo(); break;
 			default: return ES_NOT_HANDLED;
 		}
-		if (cbf != CBF_NONE) _last_started_action = cbf;
+		if (cbf != CallBackFunction::None) _last_started_action = cbf;
 		return ES_HANDLED;
 	}
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
 	{
 		switch (_last_started_action) {
-			case CBF_PLACE_SIGN:
+			case CallBackFunction::PlaceSign:
 				PlaceProc_Sign(tile);
 				break;
 
-			case CBF_PLACE_LANDINFO:
+			case CallBackFunction::PlaceLandInfo:
 				ShowLandInfo(tile);
 				break;
 
@@ -2093,7 +2093,7 @@ struct MainToolbarWindow : Window {
 
 	void OnPlaceObjectAbort() override
 	{
-		_last_started_action = CBF_NONE;
+		_last_started_action = CallBackFunction::None;
 	}
 
 	/** Refresh the state of pause / game-speed on a regular interval.*/
@@ -2319,7 +2319,7 @@ struct ScenarioEditorToolbarWindow : Window {
 	{
 		this->InitNested(0);
 
-		_last_started_action = CBF_NONE;
+		_last_started_action = CallBackFunction::None;
 		this->flags.Reset(WindowFlag::WhiteBorder);
 		PositionMainToolbar(this);
 		DoZoomInOutWindow(ZOOM_NONE, this);
@@ -2384,19 +2384,19 @@ struct ScenarioEditorToolbarWindow : Window {
 	{
 		if (_game_mode == GM_MENU) return;
 		CallBackFunction cbf = _scen_toolbar_button_procs[widget](this);
-		if (cbf != CBF_NONE) _last_started_action = cbf;
+		if (cbf != CallBackFunction::None) _last_started_action = cbf;
 	}
 
 	void OnDropdownSelect(WidgetID widget, int index, int) override
 	{
 		CallBackFunction cbf = _scen_toolbar_dropdown_procs[widget](index);
-		if (cbf != CBF_NONE) _last_started_action = cbf;
+		if (cbf != CallBackFunction::None) _last_started_action = cbf;
 		SndClickBeep();
 	}
 
 	EventState OnHotkey(int hotkey) override
 	{
-		CallBackFunction cbf = CBF_NONE;
+		CallBackFunction cbf = CallBackFunction::None;
 		switch (hotkey) {
 			case MTEHK_PAUSE:                  ToolbarPauseClick(this); break;
 			case MTEHK_FASTFORWARD:            ToolbarFastForwardClick(this); break;
@@ -2423,18 +2423,18 @@ struct ScenarioEditorToolbarWindow : Window {
 			case MTEHK_EXTRA_VIEWPORT:         ShowExtraViewportWindowForTileUnderCursor(); break;
 			default: return ES_NOT_HANDLED;
 		}
-		if (cbf != CBF_NONE) _last_started_action = cbf;
+		if (cbf != CallBackFunction::None) _last_started_action = cbf;
 		return ES_HANDLED;
 	}
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
 	{
 		switch (_last_started_action) {
-			case CBF_PLACE_SIGN:
+			case CallBackFunction::PlaceSign:
 				PlaceProc_Sign(tile);
 				break;
 
-			case CBF_PLACE_LANDINFO:
+			case CallBackFunction::PlaceLandInfo:
 				ShowLandInfo(tile);
 				break;
 
@@ -2444,7 +2444,7 @@ struct ScenarioEditorToolbarWindow : Window {
 
 	void OnPlaceObjectAbort() override
 	{
-		_last_started_action = CBF_NONE;
+		_last_started_action = CallBackFunction::None;
 	}
 
 	void OnTimeout() override

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -82,10 +82,10 @@ RoadType _last_built_roadtype;
 RoadType _last_built_tramtype;
 
 /** Toolbar modes */
-enum ToolbarMode : uint8_t {
-	TB_NORMAL,
-	TB_UPPER,
-	TB_LOWER
+enum class ToolbarMode : uint8_t {
+	Normal, ///< Toolbar is in normal mode, in wich all 30 buttons are accessible.
+	Upper, ///< Toolbar is in split mode and the first part is selected.
+	Lower, ///< Toolbar is in split mode and the second part is selected.
 };
 
 /** Callback functions. */
@@ -686,7 +686,7 @@ static CallBackFunction ToolbarGraphsClick(Window *w)
 	list.push_back(MakeDropDownListStringItem(STR_GRAPH_MENU_COMPANY_VALUE_GRAPH, GRMN_COMPANY_VALUE_GRAPH));
 	list.push_back(MakeDropDownListStringItem(STR_GRAPH_MENU_CARGO_PAYMENT_RATES, GRMN_CARGO_PAYMENT_RATES));
 
-	if (_toolbar_mode != TB_NORMAL) AddDropDownLeagueTableOptions(list);
+	if (_toolbar_mode != ToolbarMode::Normal) AddDropDownLeagueTableOptions(list);
 
 	ShowDropDownList(w, std::move(list), GRMN_OPERATING_PROFIT_GRAPH, WID_TN_GRAPHS, 140, GetToolbarDropDownOptions());
 	return CBF_NONE;
@@ -1173,14 +1173,14 @@ static CallBackFunction MenuClickHelp(int index)
 
 static CallBackFunction ToolbarSwitchClick(Window *w)
 {
-	if (_toolbar_mode != TB_LOWER) {
-		_toolbar_mode = TB_LOWER;
+	if (_toolbar_mode != ToolbarMode::Lower) {
+		_toolbar_mode = ToolbarMode::Lower;
 	} else {
-		_toolbar_mode = TB_UPPER;
+		_toolbar_mode = ToolbarMode::Upper;
 	}
 
 	w->ReInit();
-	w->SetWidgetLoweredState(_game_mode == GM_EDITOR ? (WidgetID)WID_TE_SWITCH_BAR : (WidgetID)WID_TN_SWITCH_BAR, _toolbar_mode == TB_LOWER);
+	w->SetWidgetLoweredState(_game_mode == GM_EDITOR ? (WidgetID)WID_TE_SWITCH_BAR : (WidgetID)WID_TN_SWITCH_BAR, _toolbar_mode == ToolbarMode::Lower);
 	SndClickBeep();
 	return CBF_NONE;
 }
@@ -1805,6 +1805,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 		/* If at least BIGGEST_ARRANGEMENT fit, just spread all the buttons nicely */
 		uint full_buttons = std::max(CeilDiv(width, this->smallest_x), SMALLEST_ARRANGEMENT);
 		if (full_buttons > BIGGEST_ARRANGEMENT) {
+			_toolbar_mode = ToolbarMode::Normal;
 			button_count = arrangeable_count = lengthof(arrange_all);
 			spacer_count = this->spacers;
 			return arrange_all;
@@ -1815,7 +1816,7 @@ class NWidgetMainToolbarContainer : public NWidgetToolbarContainer {
 
 		button_count = arrangeable_count = full_buttons;
 		spacer_count = this->spacers;
-		return arrangements[full_buttons - SMALLEST_ARRANGEMENT] + ((_toolbar_mode == TB_LOWER) ? full_buttons : 0);
+		return arrangements[full_buttons - SMALLEST_ARRANGEMENT] + ((_toolbar_mode == ToolbarMode::Lower) ? full_buttons : 0);
 	}
 };
 
@@ -1933,7 +1934,7 @@ class NWidgetScenarioToolbarContainer : public NWidgetToolbarContainer {
 		arrangeable_count = lengthof(arrange_switch) / 2;
 		button_count = arrangeable_count - 1;
 		spacer_count = 0;
-		return arrange_switch + ((_toolbar_mode == TB_LOWER) ? arrangeable_count : 0);
+		return arrange_switch + ((_toolbar_mode == ToolbarMode::Lower) ? arrangeable_count : 0);
 	}
 };
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -472,18 +472,19 @@ static CallBackFunction MenuClickMap(int index)
 
 /* --- Town button menu --- */
 
-enum TownMenuEntries {
-	TME_SHOW_DIRECTORY = 0,
-	TME_SHOW_FOUND_TOWN,
-	TME_SHOW_PLACE_HOUSES,
+/** Town button menu entries. */
+enum class TownMenuEntries {
+	ShowDirectory = 0, ///< Open window with list of towns.
+	ShowFoundTown, ///< Open town generation window.
+	ShowPlaceHouses, ///< Open house selection window.
 };
 
 static CallBackFunction ToolbarTownClick(Window *w)
 {
 	DropDownList list;
-	list.push_back(MakeDropDownListStringItem(STR_TOWN_MENU_TOWN_DIRECTORY, TME_SHOW_DIRECTORY));
-	if (_settings_game.economy.found_town != TF_FORBIDDEN) list.push_back(MakeDropDownListStringItem(STR_TOWN_MENU_FOUND_TOWN, TME_SHOW_FOUND_TOWN));
-	if (_settings_game.economy.place_houses != PlaceHouses::Forbidden) list.push_back(MakeDropDownListStringItem(STR_SCENEDIT_TOWN_MENU_PACE_HOUSE, TME_SHOW_PLACE_HOUSES));
+	list.push_back(MakeDropDownListStringItem(STR_TOWN_MENU_TOWN_DIRECTORY, TownMenuEntries::ShowDirectory));
+	if (_settings_game.economy.found_town != TF_FORBIDDEN) list.push_back(MakeDropDownListStringItem(STR_TOWN_MENU_FOUND_TOWN, TownMenuEntries::ShowFoundTown));
+	if (_settings_game.economy.place_houses != PlaceHouses::Forbidden) list.push_back(MakeDropDownListStringItem(STR_SCENEDIT_TOWN_MENU_PACE_HOUSE, TownMenuEntries::ShowPlaceHouses));
 
 	PopupMainToolbarMenu(w, WID_TN_TOWNS, std::move(list), 0);
 
@@ -498,12 +499,12 @@ static CallBackFunction ToolbarTownClick(Window *w)
  */
 static CallBackFunction MenuClickTown(int index)
 {
-	switch (index) {
-		case TME_SHOW_DIRECTORY: ShowTownDirectory(); break;
-		case TME_SHOW_FOUND_TOWN: // Setting could be changed when the dropdown was open
+	switch (TownMenuEntries(index)) {
+		case TownMenuEntries::ShowDirectory: ShowTownDirectory(); break;
+		case TownMenuEntries::ShowFoundTown: // Setting could be changed when the dropdown was open
 			if (_settings_game.economy.found_town != TF_FORBIDDEN) ShowFoundTownWindow();
 			break;
-		case TME_SHOW_PLACE_HOUSES: // Setting could be changed when the dropdown was open
+		case TownMenuEntries::ShowPlaceHouses: // Setting could be changed when the dropdown was open
 			if (_settings_game.economy.place_houses != PlaceHouses::Forbidden) ShowBuildHousePicker(nullptr);
 			break;
 	}

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -233,28 +233,28 @@ static CallBackFunction ToolbarFastForwardClick(Window *)
 /**
  * Game Option button menu entries.
  */
-enum OptionMenuEntries : uint8_t {
-	OME_GAMEOPTIONS,
-	OME_AI_SETTINGS,
-	OME_GAMESCRIPT_SETTINGS,
-	OME_NEWGRFSETTINGS,
-	OME_SANDBOX,
-	OME_TRANSPARENCIES,
-	OME_SHOW_TOWNNAMES,
-	OME_SHOW_STATIONNAMES,
-	OME_SHOW_STATIONNAMES_TRAIN,
-	OME_SHOW_STATIONNAMES_LORRY,
-	OME_SHOW_STATIONNAMES_BUS,
-	OME_SHOW_STATIONNAMES_SHIP,
-	OME_SHOW_STATIONNAMES_PLANE,
-	OME_SHOW_STATIONNAMES_GHOST,
-	OME_SHOW_WAYPOINTNAMES,
-	OME_SHOW_SIGNS,
-	OME_SHOW_COMPETITOR_SIGNS,
-	OME_FULL_ANIMATION,
-	OME_FULL_DETAILS,
-	OME_TRANSPARENTBUILDINGS,
-	OME_SHOW_STATIONSIGNS,
+enum class OptionMenuEntries : uint8_t {
+	GameOptions, ///< Open game options window.
+	AISettings, ///< Open AI settings window.
+	GameScriptSettings, ///< Open GS settings window.
+	NewGRFSettings, ///< Open NewGRF settings window.
+	SandboxOptions, ///< Open sandbox options window.
+	Transparencies, ///< Open transparency options window.
+	ShowTownNames, ///< Toggle visibility of town names.
+	ShowStationNames, ///< Toggle visibility of station names.
+	ShowTrainStationNames, ///< Toggle visibility of train station names.
+	ShowLorryStationNames, ///< Toggle visibility of lorry station names.
+	ShowBusStationNames, ///< Toggle visibility of bus station names.
+	ShowDockNames, ///< Toggle visibility of dock names.
+	ShowAirportNames, ///< Toggle visibility of airport names.
+	ShowGhostStationNames, ///< Toggle visibility of ghost station names.
+	ShowWaypointNames, ///< Toggle visibility of waypoint names.
+	ShowSigns, ///< Toggle visibility of signs.
+	ShowCompetitorSigns, ///< Toggle visibility of competitor signs and names.
+	FullAnimation, ///< Toggle full animations.
+	FullDetails, ///< Toggle full details.
+	TransparentBuildings, ///< Toggle buildings transparency.
+	TransparentStationSigns, ///< Toggle transparency of signs and names.
 };
 
 /**
@@ -266,35 +266,35 @@ enum OptionMenuEntries : uint8_t {
 static CallBackFunction ToolbarOptionsClick(Window *w)
 {
 	DropDownList list;
-	list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_GAME_OPTIONS,             OME_GAMEOPTIONS));
+	list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_GAME_OPTIONS, OptionMenuEntries::GameOptions));
 	/* Changes to the per-AI settings don't get send from the server to the clients. Clients get
 	 * the settings once they join but never update it. As such don't show the window at all
 	 * to network clients. */
 	if (!_networking || _network_server) {
-		list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_AI_SETTINGS,          OME_AI_SETTINGS));
-		list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_GAMESCRIPT_SETTINGS,  OME_GAMESCRIPT_SETTINGS));
+		list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_AI_SETTINGS, OptionMenuEntries::AISettings));
+		list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_GAMESCRIPT_SETTINGS, OptionMenuEntries::GameScriptSettings));
 	}
-	list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_NEWGRF_SETTINGS,          OME_NEWGRFSETTINGS));
+	list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_NEWGRF_SETTINGS, OptionMenuEntries::NewGRFSettings));
 	if (_game_mode != GM_EDITOR && !_networking) {
-		list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_SANDBOX_OPTIONS,      OME_SANDBOX));
+		list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_SANDBOX_OPTIONS, OptionMenuEntries::SandboxOptions));
 	}
-	list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_TRANSPARENCY_OPTIONS,     OME_TRANSPARENCIES));
+	list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_TRANSPARENCY_OPTIONS, OptionMenuEntries::Transparencies));
 	list.push_back(MakeDropDownListDividerItem());
-	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_TOWN_NAMES), STR_SETTINGS_MENU_TOWN_NAMES_DISPLAYED, OME_SHOW_TOWNNAMES));
-	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_STATION_NAMES), STR_SETTINGS_MENU_STATION_NAMES_DISPLAYED, OME_SHOW_STATIONNAMES));
-	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::Train), STR_SETTINGS_MENU_STATION_NAMES_TRAIN, OME_SHOW_STATIONNAMES_TRAIN, false, false, 1));
-	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::TruckStop), STR_SETTINGS_MENU_STATION_NAMES_LORRY, OME_SHOW_STATIONNAMES_LORRY, false, false, 1));
-	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::BusStop), STR_SETTINGS_MENU_STATION_NAMES_BUS, OME_SHOW_STATIONNAMES_BUS, false, false, 1));
-	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::Dock), STR_SETTINGS_MENU_STATION_NAMES_SHIP, OME_SHOW_STATIONNAMES_SHIP, false, false, 1));
-	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::Airport), STR_SETTINGS_MENU_STATION_NAMES_PLANE, OME_SHOW_STATIONNAMES_PLANE, false, false, 1));
-	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(STATION_FACILITY_GHOST), STR_SETTINGS_MENU_STATION_NAMES_GHOST, OME_SHOW_STATIONNAMES_GHOST, false, false, 1));
-	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_WAYPOINT_NAMES), STR_SETTINGS_MENU_WAYPOINTS_DISPLAYED, OME_SHOW_WAYPOINTNAMES));
-	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_SIGNS), STR_SETTINGS_MENU_SIGNS_DISPLAYED, OME_SHOW_SIGNS));
-	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_COMPETITOR_SIGNS), STR_SETTINGS_MENU_SHOW_COMPETITOR_SIGNS, OME_SHOW_COMPETITOR_SIGNS));
-	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_FULL_ANIMATION), STR_SETTINGS_MENU_FULL_ANIMATION, OME_FULL_ANIMATION));
-	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_FULL_DETAIL), STR_SETTINGS_MENU_FULL_DETAIL, OME_FULL_DETAILS));
-	list.push_back(MakeDropDownListCheckedItem(IsTransparencySet(TO_HOUSES), STR_SETTINGS_MENU_TRANSPARENT_BUILDINGS, OME_TRANSPARENTBUILDINGS));
-	list.push_back(MakeDropDownListCheckedItem(IsTransparencySet(TO_SIGNS), STR_SETTINGS_MENU_TRANSPARENT_SIGNS, OME_SHOW_STATIONSIGNS));
+	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_TOWN_NAMES), STR_SETTINGS_MENU_TOWN_NAMES_DISPLAYED, OptionMenuEntries::ShowTownNames));
+	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_STATION_NAMES), STR_SETTINGS_MENU_STATION_NAMES_DISPLAYED, OptionMenuEntries::ShowStationNames));
+	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::Train), STR_SETTINGS_MENU_STATION_NAMES_TRAIN, OptionMenuEntries::ShowTrainStationNames, false, false, 1));
+	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::TruckStop), STR_SETTINGS_MENU_STATION_NAMES_LORRY, OptionMenuEntries::ShowLorryStationNames, false, false, 1));
+	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::BusStop), STR_SETTINGS_MENU_STATION_NAMES_BUS, OptionMenuEntries::ShowBusStationNames, false, false, 1));
+	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::Dock), STR_SETTINGS_MENU_STATION_NAMES_SHIP, OptionMenuEntries::ShowDockNames, false, false, 1));
+	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(StationFacility::Airport), STR_SETTINGS_MENU_STATION_NAMES_PLANE, OptionMenuEntries::ShowAirportNames, false, false, 1));
+	list.push_back(MakeDropDownListCheckedItem(_facility_display_opt.Test(STATION_FACILITY_GHOST), STR_SETTINGS_MENU_STATION_NAMES_GHOST, OptionMenuEntries::ShowGhostStationNames, false, false, 1));
+	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_WAYPOINT_NAMES), STR_SETTINGS_MENU_WAYPOINTS_DISPLAYED, OptionMenuEntries::ShowWaypointNames));
+	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_SIGNS), STR_SETTINGS_MENU_SIGNS_DISPLAYED, OptionMenuEntries::ShowSigns));
+	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_SHOW_COMPETITOR_SIGNS), STR_SETTINGS_MENU_SHOW_COMPETITOR_SIGNS, OptionMenuEntries::ShowCompetitorSigns));
+	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_FULL_ANIMATION), STR_SETTINGS_MENU_FULL_ANIMATION, OptionMenuEntries::FullAnimation));
+	list.push_back(MakeDropDownListCheckedItem(HasBit(_display_opt, DO_FULL_DETAIL), STR_SETTINGS_MENU_FULL_DETAIL, OptionMenuEntries::FullDetails));
+	list.push_back(MakeDropDownListCheckedItem(IsTransparencySet(TO_HOUSES), STR_SETTINGS_MENU_TRANSPARENT_BUILDINGS, OptionMenuEntries::TransparentBuildings));
+	list.push_back(MakeDropDownListCheckedItem(IsTransparencySet(TO_SIGNS), STR_SETTINGS_MENU_TRANSPARENT_SIGNS, OptionMenuEntries::TransparentStationSigns));
 
 	ShowDropDownList(w, std::move(list), 0, WID_TN_SETTINGS, 140, GetToolbarDropDownOptions());
 	return CallBackFunction::None;
@@ -308,32 +308,32 @@ static CallBackFunction ToolbarOptionsClick(Window *w)
  */
 static CallBackFunction MenuClickSettings(int index)
 {
-	switch (index) {
-		case OME_GAMEOPTIONS: ShowGameOptions(); return CallBackFunction::None;
-		case OME_AI_SETTINGS: ShowAIConfigWindow(); return CallBackFunction::None;
-		case OME_GAMESCRIPT_SETTINGS: ShowGSConfigWindow(); return CallBackFunction::None;
-		case OME_NEWGRFSETTINGS: ShowNewGRFSettings(!_networking && _settings_client.gui.UserIsAllowedToChangeNewGRFs(), true, true, _grfconfig); return CallBackFunction::None;
-		case OME_SANDBOX:              ShowCheatWindow();                               break;
-		case OME_TRANSPARENCIES:       ShowTransparencyToolbar();                       break;
+	switch (OptionMenuEntries(index)) {
+		case OptionMenuEntries::GameOptions: ShowGameOptions(); return CallBackFunction::None;
+		case OptionMenuEntries::AISettings: ShowAIConfigWindow(); return CallBackFunction::None;
+		case OptionMenuEntries::GameScriptSettings: ShowGSConfigWindow(); return CallBackFunction::None;
+		case OptionMenuEntries::NewGRFSettings: ShowNewGRFSettings(!_networking && _settings_client.gui.UserIsAllowedToChangeNewGRFs(), true, true, _grfconfig); return CallBackFunction::None;
+		case OptionMenuEntries::SandboxOptions: ShowCheatWindow(); break;
+		case OptionMenuEntries::Transparencies: ShowTransparencyToolbar(); break;
 
-		case OME_SHOW_TOWNNAMES:       ToggleBit(_display_opt, DO_SHOW_TOWN_NAMES);     break;
-		case OME_SHOW_STATIONNAMES:    ToggleBit(_display_opt, DO_SHOW_STATION_NAMES);  break;
-		case OME_SHOW_STATIONNAMES_TRAIN: _facility_display_opt.Flip(StationFacility::Train); break;
-		case OME_SHOW_STATIONNAMES_LORRY: _facility_display_opt.Flip(StationFacility::TruckStop); break;
-		case OME_SHOW_STATIONNAMES_BUS: _facility_display_opt.Flip(StationFacility::BusStop); break;
-		case OME_SHOW_STATIONNAMES_SHIP: _facility_display_opt.Flip(StationFacility::Dock); break;
-		case OME_SHOW_STATIONNAMES_PLANE: _facility_display_opt.Flip(StationFacility::Airport); break;
-		case OME_SHOW_STATIONNAMES_GHOST: _facility_display_opt.Flip(STATION_FACILITY_GHOST); break;
-		case OME_SHOW_WAYPOINTNAMES:   ToggleBit(_display_opt, DO_SHOW_WAYPOINT_NAMES); break;
-		case OME_SHOW_SIGNS:           ToggleBit(_display_opt, DO_SHOW_SIGNS);          break;
-		case OME_SHOW_COMPETITOR_SIGNS:
+		case OptionMenuEntries::ShowTownNames: ToggleBit(_display_opt, DO_SHOW_TOWN_NAMES); break;
+		case OptionMenuEntries::ShowStationNames: ToggleBit(_display_opt, DO_SHOW_STATION_NAMES); break;
+		case OptionMenuEntries::ShowTrainStationNames: _facility_display_opt.Flip(StationFacility::Train); break;
+		case OptionMenuEntries::ShowLorryStationNames: _facility_display_opt.Flip(StationFacility::TruckStop); break;
+		case OptionMenuEntries::ShowBusStationNames: _facility_display_opt.Flip(StationFacility::BusStop); break;
+		case OptionMenuEntries::ShowDockNames: _facility_display_opt.Flip(StationFacility::Dock); break;
+		case OptionMenuEntries::ShowAirportNames: _facility_display_opt.Flip(StationFacility::Airport); break;
+		case OptionMenuEntries::ShowGhostStationNames: _facility_display_opt.Flip(STATION_FACILITY_GHOST); break;
+		case OptionMenuEntries::ShowWaypointNames: ToggleBit(_display_opt, DO_SHOW_WAYPOINT_NAMES); break;
+		case OptionMenuEntries::ShowSigns: ToggleBit(_display_opt, DO_SHOW_SIGNS); break;
+		case OptionMenuEntries::ShowCompetitorSigns:
 			ToggleBit(_display_opt, DO_SHOW_COMPETITOR_SIGNS);
 			InvalidateWindowClassesData(WC_SIGN_LIST, -1);
 			break;
-		case OME_FULL_ANIMATION:       ToggleBit(_display_opt, DO_FULL_ANIMATION); CheckBlitter(); break;
-		case OME_FULL_DETAILS:         ToggleBit(_display_opt, DO_FULL_DETAIL);         break;
-		case OME_TRANSPARENTBUILDINGS: ToggleTransparency(TO_HOUSES);                   break;
-		case OME_SHOW_STATIONSIGNS:    ToggleTransparency(TO_SIGNS);                    break;
+		case OptionMenuEntries::FullAnimation: ToggleBit(_display_opt, DO_FULL_ANIMATION); CheckBlitter(); break;
+		case OptionMenuEntries::FullDetails: ToggleBit(_display_opt, DO_FULL_DETAIL); break;
+		case OptionMenuEntries::TransparentBuildings: ToggleTransparency(TO_HOUSES); break;
+		case OptionMenuEntries::TransparentStationSigns: ToggleTransparency(TO_SIGNS); break;
 	}
 	MarkWholeScreenDirty();
 	return CallBackFunction::None;

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -418,22 +418,23 @@ static CallBackFunction MenuClickSaveLoad(int index = 0)
 
 /* --- Map button menu --- */
 
-enum MapMenuEntries : uint8_t {
-	MME_SHOW_SMALLMAP        = 0,
-	MME_SHOW_EXTRAVIEWPORTS,
-	MME_SHOW_LINKGRAPH,
-	MME_SHOW_SIGNLISTS,
-	MME_SHOW_TOWNDIRECTORY,
-	MME_SHOW_INDUSTRYDIRECTORY,
+/** Map button menu entries. */
+enum class MapMenuEntries : uint8_t {
+	ShowSmallMap = 0, ///< Open small map window.
+	ShowExtraViewport, ///< Open new extra viewport window.
+	ShowLinkGraph, ///< Open cargo flow legend window.
+	ShowSignList, ///< Open sign list window.
+	ShowTownDirectory, ///< Open window with list of towns.
+	ShowIndustryDirectory, ///< Open window with list of industries.
 };
 
 static CallBackFunction ToolbarMapClick(Window *w)
 {
 	DropDownList list;
-	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_MAP_OF_WORLD,            MME_SHOW_SMALLMAP));
-	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_EXTRA_VIEWPORT,          MME_SHOW_EXTRAVIEWPORTS));
-	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_LINGRAPH_LEGEND,         MME_SHOW_LINKGRAPH));
-	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_SIGN_LIST,               MME_SHOW_SIGNLISTS));
+	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_MAP_OF_WORLD, MapMenuEntries::ShowSmallMap));
+	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_EXTRA_VIEWPORT, MapMenuEntries::ShowExtraViewport));
+	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_LINGRAPH_LEGEND, MapMenuEntries::ShowLinkGraph));
+	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_SIGN_LIST, MapMenuEntries::ShowSignList));
 	PopupMainToolbarMenu(w, WID_TN_SMALL_MAP, std::move(list), 0);
 	return CallBackFunction::None;
 }
@@ -441,11 +442,11 @@ static CallBackFunction ToolbarMapClick(Window *w)
 static CallBackFunction ToolbarScenMapTownDir(Window *w)
 {
 	DropDownList list;
-	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_MAP_OF_WORLD,            MME_SHOW_SMALLMAP));
-	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_EXTRA_VIEWPORT,          MME_SHOW_EXTRAVIEWPORTS));
-	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_SIGN_LIST,               MME_SHOW_SIGNLISTS));
-	list.push_back(MakeDropDownListStringItem(STR_TOWN_MENU_TOWN_DIRECTORY,         MME_SHOW_TOWNDIRECTORY));
-	list.push_back(MakeDropDownListStringItem(STR_INDUSTRY_MENU_INDUSTRY_DIRECTORY, MME_SHOW_INDUSTRYDIRECTORY));
+	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_MAP_OF_WORLD, MapMenuEntries::ShowSmallMap));
+	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_EXTRA_VIEWPORT, MapMenuEntries::ShowExtraViewport));
+	list.push_back(MakeDropDownListStringItem(STR_MAP_MENU_SIGN_LIST, MapMenuEntries::ShowSignList));
+	list.push_back(MakeDropDownListStringItem(STR_TOWN_MENU_TOWN_DIRECTORY, MapMenuEntries::ShowTownDirectory));
+	list.push_back(MakeDropDownListStringItem(STR_INDUSTRY_MENU_INDUSTRY_DIRECTORY, MapMenuEntries::ShowIndustryDirectory));
 	PopupMainToolbarMenu(w, WID_TE_SMALL_MAP, std::move(list), 0);
 	return CallBackFunction::None;
 }
@@ -458,13 +459,13 @@ static CallBackFunction ToolbarScenMapTownDir(Window *w)
  */
 static CallBackFunction MenuClickMap(int index)
 {
-	switch (index) {
-		case MME_SHOW_SMALLMAP:          ShowSmallMap();            break;
-		case MME_SHOW_EXTRAVIEWPORTS:    ShowExtraViewportWindow(); break;
-		case MME_SHOW_LINKGRAPH:         ShowLinkGraphLegend();     break;
-		case MME_SHOW_SIGNLISTS:         ShowSignList();            break;
-		case MME_SHOW_TOWNDIRECTORY:     ShowTownDirectory();       break;
-		case MME_SHOW_INDUSTRYDIRECTORY: ShowIndustryDirectory();   break;
+	switch (MapMenuEntries(index)) {
+		case MapMenuEntries::ShowSmallMap: ShowSmallMap(); break;
+		case MapMenuEntries::ShowExtraViewport: ShowExtraViewportWindow(); break;
+		case MapMenuEntries::ShowLinkGraph: ShowLinkGraphLegend(); break;
+		case MapMenuEntries::ShowSignList: ShowSignList(); break;
+		case MapMenuEntries::ShowTownDirectory: ShowTownDirectory(); break;
+		case MapMenuEntries::ShowIndustryDirectory: ShowIndustryDirectory(); break;
 	}
 	return CallBackFunction::None;
 }


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Doxygen warnings and the migration to scoped enums.
The fact that I want to extend one of them in [#14798](https://github.com/OpenTTD/OpenTTD/pull/14798)

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Make all enums in toolbar_gui.cpp file enum classes.
Allow to use scoped enums when creating drop down lists and hotkeys lists without the `to_underlying` because those lines are already long and adding `to_underlying` in each of them does not help with readability.
Rework values in MainToolbarEditorHotkeys to use SPECIAL_HOTKEY_BIT making OnHotkey function shorter.
Also I have noticed that some MainToolbarEditorHotkeys called wrong function wich instead of oppening the window oppened the dropdown which with traditional toolbar behavior disappears right away and opens the appropriate window only when mouse hovers on top of the specific toolbar button.
Fixes 92 doxygen warnings.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Does not modify the lines that create drop down lists or hotkeys lists and have `to_underlying` calls already.
Does not modify MainToolbarHotkeys because it is defined in toolbar_gui.h.
Ideally ToolbarMode enum should be replaced with an bool and the switch behavior of toolbar reworked to integrate all buttons in contracted mode, but that would be much much out of scope here.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
