### PR TITLE
Codechange: use scoped enum for NetworkVehicleType

### DIFF
--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -450,14 +450,8 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyStats()
 
 		/* Send the information. */
 		p->Send_uint8(company->index);
-
-		for (uint i = 0; i < NETWORK_VEH_END; i++) {
-			p->Send_uint16(company_stats[company->index].num_vehicle[i]);
-		}
-
-		for (uint i = 0; i < NETWORK_VEH_END; i++) {
-			p->Send_uint16(company_stats[company->index].num_station[i]);
-		}
+		for (uint16_t value : company_stats[company->index].num_vehicle) p->Send_uint16(value);
+		for (uint16_t value : company_stats[company->index].num_station) p->Send_uint16(value);
 
 		this->SendPacket(std::move(p));
 	}

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1546,12 +1546,12 @@ NetworkCompanyStatsArray NetworkGetCompanyStats()
 	/* Go through all vehicles and count the type of vehicles */
 	for (const Vehicle *v : Vehicle::Iterate()) {
 		if (!Company::IsValidID(v->owner) || !v->IsPrimaryVehicle()) continue;
-		uint8_t type = 0;
+		NetworkVehicleType type;
 		switch (v->type) {
-			case VEH_TRAIN: type = NETWORK_VEH_TRAIN; break;
-			case VEH_ROAD: type = RoadVehicle::From(v)->IsBus() ? NETWORK_VEH_BUS : NETWORK_VEH_LORRY; break;
-			case VEH_AIRCRAFT: type = NETWORK_VEH_PLANE; break;
-			case VEH_SHIP: type = NETWORK_VEH_SHIP; break;
+			case VEH_TRAIN: type = NetworkVehicleType::Train; break;
+			case VEH_ROAD: type = RoadVehicle::From(v)->IsBus() ? NetworkVehicleType::Bus : NetworkVehicleType::Truck; break;
+			case VEH_AIRCRAFT: type = NetworkVehicleType::Aircraft; break;
+			case VEH_SHIP: type = NetworkVehicleType::Ship; break;
 			default: continue;
 		}
 		stats[v->owner].num_vehicle[type]++;
@@ -1562,11 +1562,11 @@ NetworkCompanyStatsArray NetworkGetCompanyStats()
 		if (Company::IsValidID(s->owner)) {
 			NetworkCompanyStats *npi = &stats[s->owner];
 
-			if (s->facilities.Test(StationFacility::Train))     npi->num_station[NETWORK_VEH_TRAIN]++;
-			if (s->facilities.Test(StationFacility::TruckStop)) npi->num_station[NETWORK_VEH_LORRY]++;
-			if (s->facilities.Test(StationFacility::BusStop))   npi->num_station[NETWORK_VEH_BUS]++;
-			if (s->facilities.Test(StationFacility::Airport))   npi->num_station[NETWORK_VEH_PLANE]++;
-			if (s->facilities.Test(StationFacility::Dock))      npi->num_station[NETWORK_VEH_SHIP]++;
+			if (s->facilities.Test(StationFacility::Train)) npi->num_station[NetworkVehicleType::Train]++;
+			if (s->facilities.Test(StationFacility::TruckStop)) npi->num_station[NetworkVehicleType::Truck]++;
+			if (s->facilities.Test(StationFacility::BusStop)) npi->num_station[NetworkVehicleType::Bus]++;
+			if (s->facilities.Test(StationFacility::Airport)) npi->num_station[NetworkVehicleType::Aircraft]++;
+			if (s->facilities.Test(StationFacility::Dock)) npi->num_station[NetworkVehicleType::Ship]++;
 		}
 	}
 

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -19,14 +19,14 @@ static const uint MAX_CLIENTS = 255;
 /**
  * Vehicletypes in the order they are send in info packets.
  */
-enum NetworkVehicleType : uint8_t {
-	NETWORK_VEH_TRAIN = 0,
-	NETWORK_VEH_LORRY,
-	NETWORK_VEH_BUS,
-	NETWORK_VEH_PLANE,
-	NETWORK_VEH_SHIP,
+enum class NetworkVehicleType : uint8_t {
+	Train = 0, ///< A train.
+	Truck, ///< A road vehicle that stops at truck stops
+	Bus, ///< A road vehicle that stops at bus stops.
+	Aircraft, ///< An airplane or helicopter.
+	Ship, ///< A ship.
 
-	NETWORK_VEH_END
+	End ///< End marker for array sizes.
 };
 
 /**
@@ -54,9 +54,10 @@ using AdminID = PoolID<uint8_t, struct AdminIDTag, 16, 0xFF>;
 
 /** Simple calculated statistics of a company */
 struct NetworkCompanyStats {
-	uint16_t num_vehicle[NETWORK_VEH_END];            ///< How many vehicles are there of this type?
-	uint16_t num_station[NETWORK_VEH_END];            ///< How many stations are there of this type?
-	bool ai;                                        ///< Is this company an AI
+	/** Array indexed by NetworkVehicleType. */
+	using NetworkVehicleTypeArray = EnumClassIndexContainer<std::array<uint16_t, to_underlying(NetworkVehicleType::End)>, NetworkVehicleType>;
+	NetworkVehicleTypeArray num_vehicle; ///< How many vehicles are there of this type?
+	NetworkVehicleTypeArray num_station; ///< How many stations are there of this type?
 };
 
 struct NetworkClientInfo;


### PR DESCRIPTION
## Motivation / Problem

Our 'goal' to use more strict types, e.g. scoped enums.


## Description

* Convert `NetworkVehicleType` to a scoped enum.
* Use `std::array` instead of a C-style array, and simplify passing the data into a packet.
* Remove unused `ai` field in `NetworkCompanyStats`.
* Rename `LORRY` to `Truck`, to match `StationFacility::TruckStop`.
* Rename `PLANE` to `Aircraft`, to match `VEH_AIRCRAFT`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
