### PR TITLE
Codechange: use scope enum and rename DestType to NetworkChatDestinationType

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -126,7 +126,7 @@ void SetLocalCompany(CompanyID new_company)
 	bool switching_company = _local_company != new_company;
 
 	/* Delete the chat window, if you were team chatting. */
-	if (switching_company) InvalidateWindowData(WC_SEND_NETWORK_MSG, DESTTYPE_TEAM, _local_company);
+	if (switching_company) InvalidateWindowData(WC_SEND_NETWORK_MSG, NetworkChatDestinationType::Team, _local_company);
 
 	assert(IsLocalCompany());
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2047,10 +2047,10 @@ static bool ConSay(std::span<std::string_view> argv)
 	if (argv.size() != 2) return false;
 
 	if (!_network_server) {
-		NetworkClientSendChat(NETWORK_ACTION_CHAT, DESTTYPE_BROADCAST, 0 /* param does not matter */, argv[1]);
+		NetworkClientSendChat(NETWORK_ACTION_CHAT, NetworkChatDestinationType::Broadcast, 0 /* param does not matter */, argv[1]);
 	} else {
 		bool from_admin = (_redirect_console_to_admin < AdminID::Invalid());
-		NetworkServerSendChat(NETWORK_ACTION_CHAT, DESTTYPE_BROADCAST, 0, argv[1], CLIENT_ID_SERVER, from_admin);
+		NetworkServerSendChat(NETWORK_ACTION_CHAT, NetworkChatDestinationType::Broadcast, 0, argv[1], CLIENT_ID_SERVER, from_admin);
 	}
 
 	return true;
@@ -2079,10 +2079,10 @@ static bool ConSayCompany(std::span<std::string_view> argv)
 	}
 
 	if (!_network_server) {
-		NetworkClientSendChat(NETWORK_ACTION_CHAT_COMPANY, DESTTYPE_TEAM, company_id->base(), argv[2]);
+		NetworkClientSendChat(NETWORK_ACTION_CHAT_COMPANY, NetworkChatDestinationType::Team, company_id->base(), argv[2]);
 	} else {
 		bool from_admin = (_redirect_console_to_admin < AdminID::Invalid());
-		NetworkServerSendChat(NETWORK_ACTION_CHAT_COMPANY, DESTTYPE_TEAM, company_id->base(), argv[2], CLIENT_ID_SERVER, from_admin);
+		NetworkServerSendChat(NETWORK_ACTION_CHAT_COMPANY, NetworkChatDestinationType::Team, company_id->base(), argv[2], CLIENT_ID_SERVER, from_admin);
 	}
 
 	return true;
@@ -2106,10 +2106,10 @@ static bool ConSayClient(std::span<std::string_view> argv)
 	}
 
 	if (!_network_server) {
-		NetworkClientSendChat(NETWORK_ACTION_CHAT_CLIENT, DESTTYPE_CLIENT, *client_id, argv[2]);
+		NetworkClientSendChat(NETWORK_ACTION_CHAT_CLIENT, NetworkChatDestinationType::Client, *client_id, argv[2]);
 	} else {
 		bool from_admin = (_redirect_console_to_admin < AdminID::Invalid());
-		NetworkServerSendChat(NETWORK_ACTION_CHAT_CLIENT, DESTTYPE_CLIENT, *client_id, argv[2], CLIENT_ID_SERVER, from_admin);
+		NetworkServerSendChat(NETWORK_ACTION_CHAT_CLIENT, NetworkChatDestinationType::Client, *client_id, argv[2], CLIENT_ID_SERVER, from_admin);
 	}
 
 	return true;

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -391,12 +391,12 @@ struct MainWindow : Window
 					const NetworkClientInfo *cio = NetworkClientInfo::GetByClientID(_network_own_client_id);
 					if (cio == nullptr) break;
 
-					ShowNetworkChatQueryWindow(NetworkClientPreferTeamChat(cio) ? DESTTYPE_TEAM : DESTTYPE_BROADCAST, cio->client_playas.base());
+					ShowNetworkChatQueryWindow(NetworkClientPreferTeamChat(cio) ? NetworkChatDestinationType::Team : NetworkChatDestinationType::Broadcast, cio->client_playas.base());
 				}
 				break;
 
 			case GHK_CHAT_ALL: // send text message to all clients
-				if (_networking) ShowNetworkChatQueryWindow(DESTTYPE_BROADCAST, 0);
+				if (_networking) ShowNetworkChatQueryWindow(NetworkChatDestinationType::Broadcast, 0);
 				break;
 
 			case GHK_CHAT_COMPANY: // send text to all team mates
@@ -404,13 +404,13 @@ struct MainWindow : Window
 					const NetworkClientInfo *cio = NetworkClientInfo::GetByClientID(_network_own_client_id);
 					if (cio == nullptr) break;
 
-					ShowNetworkChatQueryWindow(DESTTYPE_TEAM, cio->client_playas.base());
+					ShowNetworkChatQueryWindow(NetworkChatDestinationType::Team, cio->client_playas.base());
 				}
 				break;
 
 			case GHK_CHAT_SERVER: // send text to the server
 				if (_networking && !_network_server) {
-					ShowNetworkChatQueryWindow(DESTTYPE_CLIENT, CLIENT_ID_SERVER);
+					ShowNetworkChatQueryWindow(NetworkChatDestinationType::Client, CLIENT_ID_SERVER);
 				}
 				break;
 

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -159,7 +159,7 @@ protected:
 	/**
 	 * Send chat as the server:
 	 * uint8_t   Action such as NETWORK_ACTION_CHAT_CLIENT (see #NetworkAction).
-	 * uint8_t   Destination type such as DESTTYPE_BROADCAST (see #DestType).
+	 * uint8_t   Destination type such as NetworkChatDestinationType::Broadcast (see #NetworkChatDestinationType).
 	 * uint32_t  ID of the destination such as company or client id.
 	 * string  Message.
 	 * @param p The packet that was just received.
@@ -434,7 +434,7 @@ protected:
 	/**
 	 * Send chat from the game into the admin network:
 	 * uint8_t   Action such as NETWORK_ACTION_CHAT_CLIENT (see #NetworkAction).
-	 * uint8_t   Destination type such as DESTTYPE_BROADCAST (see #DestType).
+	 * uint8_t   Destination type such as NetworkChatDestinationType::Broadcast (see #NetworkChatDestinationType).
 	 * uint32_t  ID of the client who sent this message.
 	 * string  Message.
 	 * uint64_t  Money (only when it is a 'give money' action).

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -372,7 +372,7 @@ protected:
 	/**
 	 * Sends a chat-packet to the server:
 	 * uint8_t   ID of the action (see NetworkAction).
-	 * uint8_t   ID of the destination type (see DestType).
+	 * uint8_t   ID of the destination type (see #NetworkChatDestinationType).
 	 * uint32_t  ID of the client or company (destination of the chat).
 	 * string  Message (max NETWORK_CHAT_LENGTH).
 	 * uint64_t  data (used e.g. for 'give money' actions).

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -107,7 +107,7 @@ bool HasClients()
 NetworkClientInfo::~NetworkClientInfo()
 {
 	/* Delete the chat window, if you were chatting with this client. */
-	InvalidateWindowData(WC_SEND_NETWORK_MSG, DESTTYPE_CLIENT, this->client_id);
+	InvalidateWindowData(WC_SEND_NETWORK_MSG, NetworkChatDestinationType::Client, this->client_id);
 }
 
 /**

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -468,12 +468,12 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyStats()
  * @param data Arbitrary extra data.
  * @return The new state the network.
  */
-NetworkRecvStatus ServerNetworkAdminSocketHandler::SendChat(NetworkAction action, DestType desttype, ClientID client_id, std::string_view msg, int64_t data)
+NetworkRecvStatus ServerNetworkAdminSocketHandler::SendChat(NetworkAction action, NetworkChatDestinationType desttype, ClientID client_id, std::string_view msg, int64_t data)
 {
 	auto p = std::make_unique<Packet>(this, ADMIN_PACKET_SERVER_CHAT);
 
-	p->Send_uint8 (action);
-	p->Send_uint8 (desttype);
+	p->Send_uint8(action);
+	p->Send_uint8(to_underlying(desttype));
 	p->Send_uint32(client_id);
 	p->Send_string(msg);
 	p->Send_uint64(data);
@@ -788,7 +788,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_CHAT(Packet &p)
 	if (this->status <= ADMIN_STATUS_AUTHENTICATE) return this->SendError(NETWORK_ERROR_NOT_EXPECTED);
 
 	NetworkAction action = (NetworkAction)p.Recv_uint8();
-	DestType desttype = (DestType)p.Recv_uint8();
+	NetworkChatDestinationType desttype = static_cast<NetworkChatDestinationType>(p.Recv_uint8());
 	int dest = p.Recv_uint32();
 
 	std::string msg = p.Recv_string(NETWORK_CHAT_LENGTH);
@@ -1025,7 +1025,7 @@ void NetworkAdminCompanyRemove(CompanyID company_id, AdminCompanyRemoveReason bc
  * @param data Arbitrary data.
  * @param from_admin Whether the message is coming from the admin.
  */
-void NetworkAdminChat(NetworkAction action, DestType desttype, ClientID client_id, std::string_view msg, int64_t data, bool from_admin)
+void NetworkAdminChat(NetworkAction action, NetworkChatDestinationType desttype, ClientID client_id, std::string_view msg, int64_t data, bool from_admin)
 {
 	if (from_admin) return;
 

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -68,7 +68,7 @@ public:
 	NetworkRecvStatus SendCompanyEconomy();
 	NetworkRecvStatus SendCompanyStats();
 
-	NetworkRecvStatus SendChat(NetworkAction action, DestType desttype, ClientID client_id, std::string_view msg, int64_t data);
+	NetworkRecvStatus SendChat(NetworkAction action, NetworkChatDestinationType desttype, ClientID client_id, std::string_view msg, int64_t data);
 	NetworkRecvStatus SendRcon(uint16_t colour, std::string_view command);
 	NetworkRecvStatus SendConsole(std::string_view origin, std::string_view command);
 	NetworkRecvStatus SendGameScript(std::string_view json);
@@ -113,7 +113,7 @@ void NetworkAdminCompanyNew(const Company *company);
 void NetworkAdminCompanyUpdate(const Company *company);
 void NetworkAdminCompanyRemove(CompanyID company_id, AdminCompanyRemoveReason bcrr);
 
-void NetworkAdminChat(NetworkAction action, DestType desttype, ClientID client_id, std::string_view msg, int64_t data = 0, bool from_admin = false);
+void NetworkAdminChat(NetworkAction action, NetworkChatDestinationType desttype, ClientID client_id, std::string_view msg, int64_t data = 0, bool from_admin = false);
 void NetworkAdminUpdate(AdminUpdateFrequency freq);
 void NetworkServerSendAdminRcon(AdminID admin_index, TextColour colour_code, std::string_view string);
 void NetworkAdminConsole(std::string_view origin, std::string_view string);

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -250,13 +250,22 @@ void NetworkDrawChatMessage()
  * @param type The type of destination.
  * @param dest The actual destination index.
  */
-static void SendChat(std::string_view buf, DestType type, int dest)
+static void SendChat(std::string_view buf, NetworkChatDestinationType type, int dest)
 {
 	if (buf.empty()) return;
+
+	NetworkAction action;
+	switch (type) {
+		case NetworkChatDestinationType::Broadcast: action = NETWORK_ACTION_CHAT; break;
+		case NetworkChatDestinationType::Team: action = NETWORK_ACTION_CHAT_COMPANY; break;
+		case NetworkChatDestinationType::Client: action = NETWORK_ACTION_CHAT_CLIENT; break;
+		default: NOT_REACHED();
+	}
+
 	if (!_network_server) {
-		MyClient::SendChat((NetworkAction)(NETWORK_ACTION_CHAT + type), type, dest, buf, 0);
+		MyClient::SendChat(action, type, dest, buf, 0);
 	} else {
-		NetworkServerSendChat((NetworkAction)(NETWORK_ACTION_CHAT + type), type, dest, buf, CLIENT_ID_SERVER);
+		NetworkServerSendChat(action, type, dest, buf, CLIENT_ID_SERVER);
 	}
 }
 
@@ -296,7 +305,7 @@ private:
 
 /** Window to enter the chat message in. */
 struct NetworkChatWindow : public Window {
-	DestType dtype{}; ///< The type of destination.
+	NetworkChatDestinationType dtype{}; ///< The type of destination.
 	int dest = 0; ///< The identifier of the destination.
 	QueryString message_editbox; ///< Message editbox.
 	NetworkChatAutoCompletion chat_tab_completion; ///< Holds the state and logic of auto-completion of player names and towns on Tab press.
@@ -307,7 +316,7 @@ struct NetworkChatWindow : public Window {
 	 * @param type The type of destination.
 	 * @param dest The actual destination index.
 	 */
-	NetworkChatWindow(WindowDesc &desc, DestType type, int dest)
+	NetworkChatWindow(WindowDesc &desc, NetworkChatDestinationType type, int dest)
 			: Window(desc), dtype(type), dest(dest), message_editbox(NETWORK_CHAT_LENGTH), chat_tab_completion(&message_editbox.text)
 	{
 		this->querystrings[WID_NC_TEXTBOX] = &this->message_editbox;
@@ -354,18 +363,11 @@ struct NetworkChatWindow : public Window {
 	{
 		if (widget != WID_NC_DESTINATION) return this->Window::GetWidgetString(widget, stringid);
 
-		static const StringID chat_captions[] = {
-			STR_NETWORK_CHAT_ALL_CAPTION,
-			STR_NETWORK_CHAT_COMPANY_CAPTION,
-			STR_NETWORK_CHAT_CLIENT_CAPTION
-		};
-		assert((uint)this->dtype < lengthof(chat_captions));
-
-		if (this->dtype == DESTTYPE_CLIENT) {
-			return GetString(STR_NETWORK_CHAT_CLIENT_CAPTION, NetworkClientInfo::GetByClientID((ClientID)this->dest)->client_name);
+		if (this->dtype == NetworkChatDestinationType::Client) {
+			return GetString(STR_NETWORK_CHAT_CLIENT_CAPTION, NetworkClientInfo::GetByClientID(static_cast<ClientID>(this->dest))->client_name);
 		}
 
-		return GetString(chat_captions[this->dtype]);
+		return GetString(this->dtype == NetworkChatDestinationType::Broadcast ? STR_NETWORK_CHAT_ALL_CAPTION : STR_NETWORK_CHAT_COMPANY_CAPTION);
 	}
 
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
@@ -438,7 +440,7 @@ static WindowDesc _chat_window_desc(
  * @param type The type of destination.
  * @param dest The actual destination index.
  */
-void ShowNetworkChatQueryWindow(DestType type, int dest)
+void ShowNetworkChatQueryWindow(NetworkChatDestinationType type, int dest)
 {
 	CloseWindowByClass(WC_SEND_NETWORK_MSG);
 	new NetworkChatWindow(_chat_window_desc, type, dest);

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -420,14 +420,14 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendCommand(const CommandPacke
  * @param data Optional arbitrary extra data.
  * @return The new state the network.
  */
-NetworkRecvStatus ClientNetworkGameSocketHandler::SendChat(NetworkAction action, DestType type, int dest, std::string_view msg, int64_t data)
+NetworkRecvStatus ClientNetworkGameSocketHandler::SendChat(NetworkAction action, NetworkChatDestinationType type, int dest, std::string_view msg, int64_t data)
 {
 	Debug(net, 9, "Client::SendChat(): action={}, type={}, dest={}", action, type, dest);
 
 	auto p = std::make_unique<Packet>(my_client, PACKET_CLIENT_CHAT);
 
-	p->Send_uint8 (action);
-	p->Send_uint8 (type);
+	p->Send_uint8(action);
+	p->Send_uint8(to_underlying(type));
 	p->Send_uint32(dest);
 	p->Send_string(msg);
 	p->Send_uint64(data);
@@ -1355,7 +1355,7 @@ void NetworkUpdateClientName(const std::string &client_name)
  * @param msg The actual message.
  * @param data Arbitrary extra data.
  */
-void NetworkClientSendChat(NetworkAction action, DestType type, int dest, std::string_view msg, int64_t data)
+void NetworkClientSendChat(NetworkAction action, NetworkChatDestinationType type, int dest, std::string_view msg, int64_t data)
 {
 	MyClient::SendChat(action, type, dest, msg, data);
 }

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -88,7 +88,7 @@ public:
 
 	static NetworkRecvStatus SendAuthResponse();
 
-	static NetworkRecvStatus SendChat(NetworkAction action, DestType type, int dest, std::string_view msg, int64_t data);
+	static NetworkRecvStatus SendChat(NetworkAction action, NetworkChatDestinationType type, int dest, std::string_view msg, int64_t data);
 	static NetworkRecvStatus SendSetName(const std::string &name);
 	static NetworkRecvStatus SendRCon(std::string_view password, std::string_view command);
 	static NetworkRecvStatus SendMove(CompanyID company);

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -54,7 +54,7 @@ bool NetworkClientConnectGame(std::string_view connection_string, CompanyID defa
 void NetworkClientJoinGame();
 void NetworkClientRequestMove(CompanyID company);
 void NetworkClientSendRcon(std::string_view password, std::string_view command);
-void NetworkClientSendChat(NetworkAction action, DestType type, int dest, std::string_view msg, int64_t data = 0);
+void NetworkClientSendChat(NetworkAction action, NetworkChatDestinationType type, int dest, std::string_view msg, int64_t data = 0);
 bool NetworkClientPreferTeamChat(const NetworkClientInfo *cio);
 uint NetworkMaxCompaniesAllowed();
 bool NetworkMaxCompaniesReached();
@@ -76,7 +76,7 @@ bool NetworkServerChangeClientName(ClientID client_id, const std::string &new_na
 bool NetworkCanJoinCompany(CompanyID company_id);
 void NetworkServerDoMove(ClientID client_id, CompanyID company_id);
 void NetworkServerSendRcon(ClientID client_id, TextColour colour_code, std::string_view string);
-void NetworkServerSendChat(NetworkAction action, DestType type, int dest, std::string_view msg, ClientID from_id, int64_t data = 0, bool from_admin = false);
+void NetworkServerSendChat(NetworkAction action, NetworkChatDestinationType type, int dest, std::string_view msg, ClientID from_id, int64_t data = 0, bool from_admin = false);
 void NetworkServerSendExternalChat(std::string_view source, TextColour colour, std::string_view user, std::string_view msg);
 
 void NetworkServerKickClient(ClientID client_id, std::string_view reason);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1569,7 +1569,7 @@ private:
 	 */
 	static void OnClickCompanyChat([[maybe_unused]] NetworkClientListWindow *w, [[maybe_unused]] Point pt, CompanyID company_id)
 	{
-		ShowNetworkChatQueryWindow(DESTTYPE_TEAM, company_id.base());
+		ShowNetworkChatQueryWindow(NetworkChatDestinationType::Team, company_id.base());
 	}
 
 	/**
@@ -1653,7 +1653,7 @@ private:
 	 */
 	static void OnClickClientChat([[maybe_unused]] NetworkClientListWindow *w, [[maybe_unused]] Point pt, ClientID client_id)
 	{
-		ShowNetworkChatQueryWindow(DESTTYPE_CLIENT, client_id);
+		ShowNetworkChatQueryWindow(NetworkChatDestinationType::Client, client_id);
 	}
 
 	static void OnClickClientAuthorize([[maybe_unused]] NetworkClientListWindow *w, [[maybe_unused]] Point pt, ClientID client_id)

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -18,7 +18,7 @@
 #include "network_gamelist.h"
 
 void ShowNetworkNeedPassword(std::shared_ptr<class NetworkAuthenticationPasswordRequest> request);
-void ShowNetworkChatQueryWindow(DestType type, int dest);
+void ShowNetworkChatQueryWindow(NetworkChatDestinationType type, int dest);
 void ShowJoinStatusWindow();
 void ShowNetworkGameWindow();
 void ShowClientList();

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1151,7 +1151,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_COMMAND(Packet 
 
 		/* Check if we are full - else it's possible for spectators to send a Commands::CompanyControl and the company is created regardless of max_companies! */
 		if (Company::GetNumItems() >= _settings_client.network.max_companies) {
-			NetworkServerSendChat(NETWORK_ACTION_SERVER_MESSAGE, DESTTYPE_CLIENT, ci->client_id, "cannot create new company, server full", CLIENT_ID_SERVER);
+			NetworkServerSendChat(NETWORK_ACTION_SERVER_MESSAGE, NetworkChatDestinationType::Client, ci->client_id, "cannot create new company, server full", CLIENT_ID_SERVER);
 			return NETWORK_RECV_STATUS_OKAY;
 		}
 	}
@@ -1296,12 +1296,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_ACK(Packet &p)
  * @param data Arbitrary data.
  * @param from_admin Whether the origin is an admin or not.
  */
-void NetworkServerSendChat(NetworkAction action, DestType desttype, int dest, std::string_view msg, ClientID from_id, int64_t data, bool from_admin)
+void NetworkServerSendChat(NetworkAction action, NetworkChatDestinationType desttype, int dest, std::string_view msg, ClientID from_id, int64_t data, bool from_admin)
 {
 	const NetworkClientInfo *ci, *ci_own, *ci_to;
 
 	switch (desttype) {
-		case DESTTYPE_CLIENT:
+		case NetworkChatDestinationType::Client:
 			/* Are we sending to the server? */
 			if ((ClientID)dest == CLIENT_ID_SERVER) {
 				ci = NetworkClientInfo::GetByClientID(from_id);
@@ -1341,7 +1341,7 @@ void NetworkServerSendChat(NetworkAction action, DestType desttype, int dest, st
 				}
 			}
 			break;
-		case DESTTYPE_TEAM: {
+		case NetworkChatDestinationType::Team: {
 			/* If this is false, the message is already displayed on the client who sent it. */
 			bool show_local = true;
 			/* Find all clients that belong to this company */
@@ -1391,7 +1391,7 @@ void NetworkServerSendChat(NetworkAction action, DestType desttype, int dest, st
 			Debug(net, 1, "Received unknown chat destination type {}; doing broadcast instead", desttype);
 			[[fallthrough]];
 
-		case DESTTYPE_BROADCAST:
+		case NetworkChatDestinationType::Broadcast:
 			for (NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {
 				if (cs->status >= ServerNetworkGameSocketHandler::STATUS_AUTHORIZED) cs->SendChat(action, from_id, false, msg, data);
 			}
@@ -1429,7 +1429,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_CHAT(Packet &p)
 	}
 
 	NetworkAction action = (NetworkAction)p.Recv_uint8();
-	DestType desttype = (DestType)p.Recv_uint8();
+	NetworkChatDestinationType desttype = static_cast<NetworkChatDestinationType>(p.Recv_uint8());
 	int dest = p.Recv_uint32();
 
 	Debug(net, 9, "client[{}] Receive_CLIENT_CHAT(): action={}, desttype={}, dest={}", this->client_id, action, desttype, dest);
@@ -2050,11 +2050,11 @@ void NetworkServerDoMove(ClientID client_id, CompanyID company_id)
 
 	if (company_id == COMPANY_SPECTATOR) {
 		/* The client has joined spectators. */
-		NetworkServerSendChat(NETWORK_ACTION_COMPANY_SPECTATOR, DESTTYPE_BROADCAST, 0, "", client_id);
+		NetworkServerSendChat(NETWORK_ACTION_COMPANY_SPECTATOR, NetworkChatDestinationType::Broadcast, 0, "", client_id);
 	} else {
 		/* The client has joined another company. */
 		std::string company_name = GetString(STR_COMPANY_NAME, company_id);
-		NetworkServerSendChat(NETWORK_ACTION_COMPANY_JOIN, DESTTYPE_BROADCAST, 0, company_name, client_id);
+		NetworkServerSendChat(NETWORK_ACTION_COMPANY_JOIN, NetworkChatDestinationType::Broadcast, 0, company_name, client_id);
 	}
 
 	InvalidateWindowData(WC_CLIENT_LIST, 0);
@@ -2218,6 +2218,6 @@ void NetworkServerNewCompany(const Company *c, NetworkClientInfo *ci)
 		Command<Commands::CompanyAllowListControl>::SendNet(STR_NULL, c->index, CompanyAllowListCtrlAction::AddKey, ci->public_key);
 		Command<Commands::RenamePresident>::SendNet(STR_NULL, c->index, ci->client_name);
 
-		NetworkServerSendChat(NETWORK_ACTION_COMPANY_NEW, DESTTYPE_BROADCAST, 0, "", ci->client_id, c->index + 1);
+		NetworkServerSendChat(NETWORK_ACTION_COMPANY_NEW, NetworkChatDestinationType::Broadcast, 0, "", ci->client_id, c->index + 1);
 	}
 }

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -66,12 +66,11 @@ struct NetworkClientInfo;
  * Destination of our chat messages.
  * @warning The values of the enum items are part of the admin network API. Only append at the end.
  */
-enum DestType : uint8_t {
-	DESTTYPE_BROADCAST, ///< Send message/notice to all clients (All)
-	DESTTYPE_TEAM,      ///< Send message/notice to everyone playing the same company (Team)
-	DESTTYPE_CLIENT,    ///< Send message/notice to only a certain client (Private)
+enum class NetworkChatDestinationType : uint8_t {
+	Broadcast, ///< Send message/notice to all clients (All)
+	Team, ///< Send message/notice to everyone playing the same company (Team)
+	Client, ///< Send message/notice to only a certain client (Private)
 };
-DECLARE_ENUM_AS_ADDABLE(DestType)
 
 /**
  * Actions that can be used for NetworkTextMessage.

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -510,7 +510,7 @@ enum WindowClass : uint16_t {
 
 	/**
 	 * Chatbox; %Window numbers:
-	 *   - #DestType = #NetWorkChatWidgets
+	 *   - #NetworkChatDestinationType = #NetWorkChatWidgets
 	 */
 	WC_SEND_NETWORK_MSG,
 

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -11,6 +11,7 @@
 #define WINDOW_TYPE_H
 
 #include "core/convertible_through_base.hpp"
+#include "core/enum_type.hpp"
 
 /**
  * Widget ID.
@@ -759,21 +760,46 @@ struct Window;
  */
 struct WindowNumber {
 private:
-	int32_t value = 0;
+	int32_t value = 0; ///< The identifier of the window.
 public:
+	/** Create a WindowNumber 0. */
 	WindowNumber() = default;
-	WindowNumber(int32_t value) : value(value) {}
-	WindowNumber(ConvertibleThroughBase auto value) : value(value.base()) {}
 
-	/* Automatically convert to int32_t. */
+	/**
+	 * Create a WindowNumber with the given value.
+	 * @param value The new window number.
+	 */
+	WindowNumber(int32_t value) : value(value) {}
+	/** @copydoc WindowNumber(int32_t) */
+	WindowNumber(ConvertibleThroughBase auto value) : value(value.base()) {}
+	/** @copydoc WindowNumber(int32_t) */
+	template <typename T> requires is_scoped_enum_v<T>
+	WindowNumber(T value) : value(to_underlying(value)) {}
+
+	/**
+	 * Automatically convert to int32_t.
+	 * @return The window number.
+	 */
 	operator int32_t() const { return value; }
 
-	/* Automatically convert to any other type that might be requested. */
+	/**
+	 * Automatically convert to any other type that might be requested.
+	 * @return The window number in the requested type.
+	 */
 	template <typename T> requires (std::is_enum_v<T> || std::is_class_v<T>)
 	operator T() const { return static_cast<T>(value); };
 
+	/**
+	 * Compare the right hand side against our window number.
+	 * @param rhs The other value to compare to.
+	 * @return \c true iff the underlying window number matches the underlying value.
+	 */
 	constexpr bool operator==(const std::integral auto &rhs) const { return this->value == static_cast<int32_t>(rhs); }
+	/** @copydoc operator== */
 	constexpr bool operator==(const ConvertibleThroughBase auto &rhs) const { return this->value == static_cast<int32_t>(rhs.base()); }
+	/** @copydoc operator== */
+	template <typename T> requires is_scoped_enum_v<T>
+	constexpr bool operator==(const T &rhs) const { return this->value == static_cast<int32_t>(to_underlying(rhs)); }
 };
 
 /** State of handling an event. */


### PR DESCRIPTION
## Motivation / Problem

The goal of using scoped enums and improving documentation.


## Description

* Introduce helper functions so scoped enums can be passed/become `WindowNumber`, and document that class' members.
* Rename `DestType` to `NetworkChatDestinationType` to improve clarity what it is about.
* Make `NetworkChatDestinationType` a scoped enum.
* Replace addition of `NetworkAction` and `DestType` with a simple switch.
* Replace lookup table that wasn't even completely used with a simple ternary.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
