### PR TITLE
Fix: [Script] IsBuildableRectangle for a 0x0 tile should return false

### DIFF
--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -48,7 +48,7 @@
 /* static */ bool ScriptTile::IsBuildableRectangle(TileIndex tile, SQInteger width, SQInteger height)
 {
 	/* Check whether we can extract valid X and Y */
-	if (!::IsValidTile(tile) || width < 0 || height < 0) return false;
+	if (!::IsValidTile(tile) || width < 1 || height < 1) return false;
 
 	uint tx = ScriptMap::GetTileX(tile);
 	uint ty = ScriptMap::GetTileY(tile);

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -157,8 +157,8 @@ public:
 	 * @param width The width of the rectangle.
 	 * @param height The height of the rectangle.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @pre width >= 0.
-	 * @pre height >= 0.
+	 * @pre width > 0.
+	 * @pre height > 0.
 	 * @return True if it is buildable, false if not.
 	 */
 	static bool IsBuildableRectangle(TileIndex tile, SQInteger width, SQInteger height);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
The script API `AITile::IsBuildableRectangle` is short for width of 1 and height of 1, checking a rectangle that is less than what it should be.

For instance when checking a rectangle with origin tile coordinates of 60 x 100, with width of 1 and heigh of 1 this makes the other end tile of the rectangle having coordinates 61 x 101, making a rectangle consisting of 4 tiles.

However in this case IsBuildableRectangle would check only the origin tile itself and fail to check the other 3 tiles.

I discovered this bug while using the API for AI I'm writing, feeding the width and height to 1 more into the API solved the problem.


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

The for loop that is checking tiles must include tiles for the whole width and height with:
- `x <= width + tx` and `y <= height + ty`,
instead of using less than operator:
- `x < width + tx` and `y < height + ty` which would make the rectangle too short.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

There are no limitations I'm aware of.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
