### PR TITLE
Codefix 22f5b61: Paths with "/" in file-descriptions.py are invalid on Windows.

### DIFF
--- a/.github/file-descriptions.py
+++ b/.github/file-descriptions.py
@@ -9,7 +9,11 @@ import sys
 END_OF_SENTENCE = [".", "!", "?"]
 SOURCE_FILE_EXTENSION = ["cpp", "c", "hpp", "h", "mm", "m", "cc"]
 TEMPLATE_FILE_EXTENSION = ["preamble", "in"]
-EXCLUDED_FILES = ["./src/script/api/squirrel_export.sq.hpp.in", "./src/script/api/script_includes.hpp.in"]
+REPO_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+EXCLUDED_FILES = [
+    os.path.join(REPO_DIR, "src", "script", "api", "squirrel_export.sq.hpp.in"),
+    os.path.join(REPO_DIR, "src", "script", "api", "script_includes.hpp.in"),
+]
 
 
 def read_files_list_from_file(file_path):
@@ -27,7 +31,7 @@ def list_files_walk(start_path="."):
 def check_descriptions(files):
     errors = []
     for path in files:
-        if path in EXCLUDED_FILES:
+        if os.path.abspath(path) in EXCLUDED_FILES:
             continue
         if path.find("3rdparty") != -1 or path.find("lang") != -1:
             continue
@@ -62,7 +66,7 @@ def check_descriptions(files):
 
 def main():
     if len(sys.argv) == 1:
-        files = list_files_walk("./src")
+        files = list_files_walk(os.path.join(REPO_DIR, "src"))
     else:
         files = read_files_list_from_file(sys.argv[1])
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
On Windows paths `look\like\this` but file-descriptions.py uses UNIX system wich `looks/like/this`.
That's because it's primarily used by workflow which run on ubuntu. However sometimes some people might have problems with passing that check. Then it might be better if they run that script locally. And because not everyone use Linux it is good idea to suport Windows too.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Concentrate paths with `os.path.join`.
Make file-descriptions.py always check all source files in the repository when called without arguments regardless of current working directory.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
file-descriptions.py is located in hidden directory.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
