### PR TITLE
Codechange: [CMake] Remove -flifetime-dse=1 as this is no longer required

### DIFF
--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -100,19 +100,12 @@ macro(compile_flags)
         endif()
 
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-            include(CheckCXXCompilerFlag)
-            check_cxx_compiler_flag("-flifetime-dse=1" LIFETIME_DSE_FOUND)
-
             add_compile_options(
                 # GCC 4.2+ automatically assumes that signed overflows do
                 # not occur in signed arithmetics, whereas we are not
                 # sure that they will not happen. It furthermore complains
                 # about its own optimized code in some places.
                 "-fno-strict-overflow"
-
-                # -flifetime-dse=2 (default since GCC 6) doesn't play
-                # well with our custom pool item allocator
-                "$<$<BOOL:${LIFETIME_DSE_FOUND}>:-flifetime-dse=1>"
 
                 # We have a fight between clang wanting std::move() and gcc not wanting it
                 # and of course they both warn when the other compiler is happy


### PR DESCRIPTION
## Motivation / Problem

With recent changes in #14568 and #15027, passing -flifetime-dse=1 is no longer necessary as there aren't any operator new implementations or other pre-constructors which set fields inside the struct being constructed.

## Description

Remove -flifetime-dse=1 from CMake.

## Limitations

Not possible to test every combination of compilers/options/hardware/etc.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
