### PR TITLE
Codechange: [CI] Give examples in errors in file description checker.

### DIFF
--- a/.github/file-descriptions.py
+++ b/.github/file-descriptions.py
@@ -44,19 +44,21 @@ def check_descriptions(files):
         with open(path, "r") as f:
             content = f.read()
             ann = content.find(f"@file {name} ")
+            reason = f'Should be of the form "/** @file {name} Brief description of the file here. */"'
             if ann == -1:
                 if content.find("@file") == -1:
-                    errors.append(f'File "{path}" does not provide description.')
-                else:
-                    errors.append(f'Description of file "{path}" does not match coding style.')
-                continue
-            end = content.find("\n", ann)
-            start = content.rfind("\n", 0, ann) + 1
-            if content[start : ann] == "/** " and content[end - 3 : end] == " */" and content[end - 4] in END_OF_SENTENCE:
-                continue
-            elif content[start : ann] == " * " and content[start - 4 : start - 1] == "/**" and content[end - 1] in END_OF_SENTENCE and content[end + 1 : end + 4] != " */":
-                continue
-            errors.append(f'Description of file "{path}" does not match coding style.')
+                    errors.append(f'File "{path}" does not provide description. {reason}')
+                    continue
+            else:
+                end = content.find("\n", ann)
+                start = content.rfind("\n", 0, ann) + 1
+                if content[start : ann] == "/** " and content[end - 3 : end] == " */" and content[end - 4] in END_OF_SENTENCE:
+                        continue
+                elif content[start : ann] == " * ":
+                    if content[start - 4 : start - 1] == "/**" and content[end - 1] in END_OF_SENTENCE and content[end + 1 : end + 4] != " */":
+                        continue
+                    reason = f"Should be of the form:\n/**\n * @file {name} Brief description of the file here.\n * Detailed description of the file here.\n */"
+            errors.append(f'Description of file "{path}" does not match coding style. {reason}')
     return errors
 
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
`Description of file "{path}" does not match coding style.` is not very descriptive and can confuse new contributors.
> Does feel like an awful lot of code for what could be something along the lines of
> Could not find file description header, should be of the form '/** @file foo.h my description here */'

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
When no `@file` found in the file, print:
```
File "./test.cpp" does not provide description. Should be of the form "/** @file test.cpp Brief description of the file here. */"
```
When `@file` found in a single line comment but not everything is correct, print:
```
Description of file "./test.cpp" does not match coding style. Should be of the form "/** @file test.cpp Brief description of the file here. */"
```
When `@file` found in a multi-line comment but not everything is correct, print:
```
Description of file "./test.cpp" does not match coding style. Should be of the form:
/**
 * @file test.cpp Brief description of the file here.
 * Detailed description of the file here.
 */
```

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Solves the same problem as [#15361](https://github.com/OpenTTD/OpenTTD/pull/15361).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
