### PR TITLE
Doc: Add ottd-claude as admin network client reference in Python

### DIFF
--- a/docs/admin_network.md
+++ b/docs/admin_network.md
@@ -43,6 +43,10 @@ Last updated:    2024-03-26
   A reference implementation in Java for a client connecting to the admin interface
   can be found at: [http://dev.openttdcoop.org/projects/joan](http://dev.openttdcoop.org/projects/joan)
 
+  A Python implementation that connects an AI advisor (Claude) to the admin
+  interface, with support for GameScript actions (signs, goals, story pages),
+  can be found at: [https://github.com/rachittshah/ottd-claude](https://github.com/rachittshah/ottd-claude)
+
 
 ## 2.0) Joining the network
 


### PR DESCRIPTION
## Summary

- Adds a reference to [ottd-claude](https://github.com/rachittshah/ottd-claude), a Python admin port client, in `docs/admin_network.md`
- Placed alongside the existing joan (Java) reference implementation in the Preface section

ottd-claude is a Python asyncio client that connects to OpenTTD via the admin network protocol. It demonstrates:
- Admin Port binary protocol (join, poll, update frequency)
- RCON command execution
- Chat integration
- GameScript communication (`ADMIN_PACKET_ADMIN_GAMESCRIPT`) for in-game actions (signs, goals, story pages)

## Motivation

The admin network docs currently reference one implementation (joan, Java). Adding a second reference in a different language (Python) gives developers another example to learn from when building admin port clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)