### PR TITLE
Codechange: make GrfLoadingStage a scoped enum and remove unused GLS_END

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1220,12 +1220,12 @@ struct InvokeGrfActionHandler {
 	static void Invoke(ByteReader &buf, GrfLoadingStage stage)
 	{
 		switch (stage) {
-			case GLS_FILESCAN: GrfActionHandler<TAction>::FileScan(buf); break;
-			case GLS_SAFETYSCAN: GrfActionHandler<TAction>::SafetyScan(buf); break;
-			case GLS_LABELSCAN: GrfActionHandler<TAction>::LabelScan(buf); break;
-			case GLS_INIT: GrfActionHandler<TAction>::Init(buf); break;
-			case GLS_RESERVE: GrfActionHandler<TAction>::Reserve(buf); break;
-			case GLS_ACTIVATION: GrfActionHandler<TAction>::Activation(buf); break;
+			case GrfLoadingStage::FileScan: GrfActionHandler<TAction>::FileScan(buf); break;
+			case GrfLoadingStage::SafetyScan: GrfActionHandler<TAction>::SafetyScan(buf); break;
+			case GrfLoadingStage::LabelScan: GrfActionHandler<TAction>::LabelScan(buf); break;
+			case GrfLoadingStage::Init: GrfActionHandler<TAction>::Init(buf); break;
+			case GrfLoadingStage::Reserve: GrfActionHandler<TAction>::Reserve(buf); break;
+			case GrfLoadingStage::Activation: GrfActionHandler<TAction>::Activation(buf); break;
 			default: NOT_REACHED();
 		}
 	}
@@ -1311,7 +1311,7 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 		return;
 	}
 
-	if (stage == GLS_INIT || stage == GLS_ACTIVATION) {
+	if (stage == GrfLoadingStage::Init || stage == GrfLoadingStage::Activation) {
 		/* We need the sprite offsets in the init stage for NewGRF sounds
 		 * and in the activation stage for real sprites. */
 		ReadGRFSpriteOffsets(file);
@@ -1407,11 +1407,11 @@ void LoadNewGRFFile(GRFConfig &config, GrfLoadingStage stage, Subdirectory subdi
 	 * During activation, only actions 0, 1, 2, 3, 4, 5, 7, 8, 9, 0A and 0B are
 	 * carried out.  All others are ignored, because they only need to be
 	 * processed once at initialization.  */
-	if (stage != GLS_FILESCAN && stage != GLS_SAFETYSCAN && stage != GLS_LABELSCAN) {
+	if (stage != GrfLoadingStage::FileScan && stage != GrfLoadingStage::SafetyScan && stage != GrfLoadingStage::LabelScan) {
 		_cur_gps.grffile = GetFileByFilename(filename);
 		if (_cur_gps.grffile == nullptr) UserError("File '{}' lost in cache.\n", filename);
-		if (stage == GLS_RESERVE && config.status != GCS_INITIALISED) return;
-		if (stage == GLS_ACTIVATION && !config.flags.Test(GRFConfigFlag::Reserved)) return;
+		if (stage == GrfLoadingStage::Reserve && config.status != GCS_INITIALISED) return;
+		if (stage == GrfLoadingStage::Activation && !config.flags.Test(GRFConfigFlag::Reserved)) return;
 	}
 
 	bool needs_palette_remap = config.palette & GRFP_USE_MASK;
@@ -1810,14 +1810,14 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 	/* Load newgrf sprites
 	 * in each loading stage, (try to) open each file specified in the config
 	 * and load information from it. */
-	for (GrfLoadingStage stage = GLS_LABELSCAN; stage <= GLS_ACTIVATION; stage++) {
+	for (GrfLoadingStage stage = GrfLoadingStage::LabelScan; stage <= GrfLoadingStage::Activation; stage++) {
 		/* Set activated grfs back to will-be-activated between reservation- and activation-stage.
 		 * This ensures that action7/9 conditions 0x06 - 0x0A work correctly. */
 		for (const auto &c : _grfconfig) {
 			if (c->status == GCS_ACTIVATED) c->status = GCS_INITIALISED;
 		}
 
-		if (stage == GLS_RESERVE) {
+		if (stage == GrfLoadingStage::Reserve) {
 			static const std::pair<uint32_t, uint32_t> default_grf_overrides[] = {
 				{ std::byteswap(0x44442202), std::byteswap(0x44440111) }, // UKRS addons modifies UKRS
 				{ std::byteswap(0x6D620402), std::byteswap(0x6D620401) }, // DBSetXL ECS extension modifies DBSetXL
@@ -1834,7 +1834,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 		_cur_gps.stage = stage;
 		for (const auto &c : _grfconfig) {
 			if (c->status == GCS_DISABLED || c->status == GCS_NOT_FOUND) continue;
-			if (stage > GLS_INIT && c->flags.Test(GRFConfigFlag::InitOnly)) continue;
+			if (stage > GrfLoadingStage::Init && c->flags.Test(GRFConfigFlag::InitOnly)) continue;
 
 			Subdirectory subdir = num_grfs < num_baseset ? BASESET_DIR : NEWGRF_DIR;
 			if (!FioCheckFileExists(c->filename, subdir)) {
@@ -1843,7 +1843,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 				continue;
 			}
 
-			if (stage == GLS_LABELSCAN) InitNewGRFFile(*c);
+			if (stage == GrfLoadingStage::LabelScan) InitNewGRFFile(*c);
 
 			if (!c->flags.Test(GRFConfigFlag::Static) && !c->flags.Test(GRFConfigFlag::System)) {
 				if (num_non_static == NETWORK_MAX_GRF_COUNT) {
@@ -1858,15 +1858,15 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 			num_grfs++;
 
 			LoadNewGRFFile(*c, stage, subdir, false);
-			if (stage == GLS_RESERVE) {
+			if (stage == GrfLoadingStage::Reserve) {
 				c->flags.Set(GRFConfigFlag::Reserved);
-			} else if (stage == GLS_ACTIVATION) {
+			} else if (stage == GrfLoadingStage::Activation) {
 				c->flags.Reset(GRFConfigFlag::Reserved);
 				assert(GetFileByGRFID(c->ident.grfid) == _cur_gps.grffile);
 				ClearTemporaryNewGRFData(_cur_gps.grffile);
 				BuildCargoTranslationMap();
 				Debug(sprite, 2, "LoadNewGRF: Currently {} sprites are loaded", _cur_gps.spriteid);
-			} else if (stage == GLS_INIT && c->flags.Test(GRFConfigFlag::InitOnly)) {
+			} else if (stage == GrfLoadingStage::Init && c->flags.Test(GRFConfigFlag::InitOnly)) {
 				/* We're not going to activate this, so free whatever data we allocated */
 				ClearTemporaryNewGRFData(_cur_gps.grffile);
 			}

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -43,14 +43,14 @@ struct CanalProperties {
 	uint8_t flags;          ///< Flags controlling display.
 };
 
+/** Stages of loading all NewGRFs. */
 enum GrfLoadingStage : uint8_t {
-	GLS_FILESCAN,
-	GLS_SAFETYSCAN,
-	GLS_LABELSCAN,
-	GLS_INIT,
-	GLS_RESERVE,
-	GLS_ACTIVATION,
-	GLS_END,
+	FileScan, ///< Load the Action 8 metadata (GRF ID, name).
+	SafetyScan, ///< Checks whether the NewGRF can be used in a static context.
+	LabelScan, ///< First step of NewGRF loading; find the 'goto' labels in the NewGRF.
+	Init, ///< Second step of NewGRF loading; load all actions into memory.
+	Reserve, ///< Third step of NewGRF loading; reserve features and GRMs.
+	Activation, ///< Forth step of NewGRF loading; activate the features.
 };
 
 DECLARE_INCREMENT_DECREMENT_OPERATORS(GrfLoadingStage)

--- a/src/newgrf/newgrf_act0.cpp
+++ b/src/newgrf/newgrf_act0.cpp
@@ -144,8 +144,8 @@ struct InvokeGrfChangeInfoHandler {
 	static ChangeInfoResult Invoke(uint first, uint last, int prop, ByteReader &buf, GrfLoadingStage stage)
 	{
 		switch (stage) {
-			case GLS_RESERVE: return GrfChangeInfoHandler<TFeature>::Reserve(first, last, prop, buf);
-			case GLS_ACTIVATION: return GrfChangeInfoHandler<TFeature>::Activation(first, last, prop, buf);
+			case GrfLoadingStage::Reserve: return GrfChangeInfoHandler<TFeature>::Reserve(first, last, prop, buf);
+			case GrfLoadingStage::Activation: return GrfChangeInfoHandler<TFeature>::Activation(first, last, prop, buf);
 			default: NOT_REACHED();
 		}
 	}
@@ -196,7 +196,7 @@ static void FeatureChangeInfo(ByteReader &buf)
 	               feature, numprops, engine, numinfo);
 
 	/* Test if feature handles change. */
-	ChangeInfoResult cir_test = InvokeGrfChangeInfoHandler::Invoke(feature, 0, 0, 0, buf, GLS_ACTIVATION);
+	ChangeInfoResult cir_test = InvokeGrfChangeInfoHandler::Invoke(feature, 0, 0, 0, buf, GrfLoadingStage::Activation);
 	if (cir_test == CIR_UNHANDLED) return;
 	if (cir_test == CIR_UNKNOWN) {
 		GrfMsg(1, "FeatureChangeInfo: Unsupported feature 0x{:02X}, skipping", feature);
@@ -209,12 +209,12 @@ static void FeatureChangeInfo(ByteReader &buf)
 	while (numprops-- && buf.HasData()) {
 		uint8_t prop = buf.ReadByte();
 
-		ChangeInfoResult cir = InvokeGrfChangeInfoHandler::Invoke(feature, engine, engine + numinfo, prop, buf, GLS_ACTIVATION);
+		ChangeInfoResult cir = InvokeGrfChangeInfoHandler::Invoke(feature, engine, engine + numinfo, prop, buf, GrfLoadingStage::Activation);
 		if (HandleChangeInfoResult("FeatureChangeInfo", cir, feature, prop)) return;
 	}
 }
 
-/* Action 0x00 (GLS_SAFETYSCAN) */
+/* Action 0x00 (GrfLoadingStage::SafetyScan) */
 static void SafeChangeInfo(ByteReader &buf)
 {
 	GrfSpecFeature feature{buf.ReadByte()};
@@ -248,13 +248,13 @@ static void SafeChangeInfo(ByteReader &buf)
 	GRFUnsafe(buf);
 }
 
-/* Action 0x00 (GLS_RESERVE) */
+/* Action 0x00 (GrfLoadingStage::Reserve) */
 static void ReserveChangeInfo(ByteReader &buf)
 {
 	GrfSpecFeature feature{buf.ReadByte()};
 
 	/* Test if feature handles reservation. */
-	ChangeInfoResult cir_test = InvokeGrfChangeInfoHandler::Invoke(feature, 0, 0, 0, buf, GLS_RESERVE);
+	ChangeInfoResult cir_test = InvokeGrfChangeInfoHandler::Invoke(feature, 0, 0, 0, buf, GrfLoadingStage::Reserve);
 	if (cir_test == CIR_UNHANDLED) return;
 	if (cir_test == CIR_UNKNOWN) {
 		GrfMsg(1, "ReserveChangeInfo: Unsupported feature 0x{:02X}, skipping", feature);
@@ -268,7 +268,7 @@ static void ReserveChangeInfo(ByteReader &buf)
 	while (numprops-- && buf.HasData()) {
 		uint8_t prop = buf.ReadByte();
 
-		ChangeInfoResult cir = InvokeGrfChangeInfoHandler::Invoke(feature, index, index + numinfo, prop, buf, GLS_RESERVE);
+		ChangeInfoResult cir = InvokeGrfChangeInfoHandler::Invoke(feature, index, index + numinfo, prop, buf, GrfLoadingStage::Reserve);
 		if (HandleChangeInfoResult("ReserveChangeInfo", cir, feature, prop)) return;
 	}
 }

--- a/src/newgrf/newgrf_act11.cpp
+++ b/src/newgrf/newgrf_act11.cpp
@@ -110,7 +110,7 @@ static void GRFSound(ByteReader &buf)
 				file.SkipBytes(len);
 			} else {
 				uint32_t id = file.ReadDword();
-				if (_cur_gps.stage == GLS_INIT) LoadGRFSound(GetGRFSpriteOffset(id), sound + i);
+				if (_cur_gps.stage == GrfLoadingStage::Init) LoadGRFSound(GetGRFSpriteOffset(id), sound + i);
 			}
 			continue;
 		}
@@ -131,7 +131,7 @@ static void GRFSound(ByteReader &buf)
 		switch (action) {
 			case 0xFF:
 				/* Allocate sound only in init stage. */
-				if (_cur_gps.stage == GLS_INIT) {
+				if (_cur_gps.stage == GrfLoadingStage::Init) {
 					if (grf_container_version >= 2) {
 						GrfMsg(1, "GRFSound: Inline sounds are not supported for container version >= 2");
 					} else {
@@ -142,7 +142,7 @@ static void GRFSound(ByteReader &buf)
 				break;
 
 			case 0xFE:
-				if (_cur_gps.stage == GLS_ACTIVATION) {
+				if (_cur_gps.stage == GrfLoadingStage::Activation) {
 					/* XXX 'Action 0xFE' isn't really specified. It is only mentioned for
 					 * importing sounds, so this is probably all wrong... */
 					if (file.ReadByte() != 0) GrfMsg(1, "GRFSound: Import type mismatch");

--- a/src/newgrf/newgrf_act7_9.cpp
+++ b/src/newgrf/newgrf_act7_9.cpp
@@ -125,9 +125,9 @@ uint32_t GetParamVal(uint8_t param, uint32_t *cond_val)
 		case 0x84: { // GRF loading stage
 			uint32_t res = 0;
 
-			if (_cur_gps.stage > GLS_INIT) SetBit(res, 0);
-			if (_cur_gps.stage == GLS_RESERVE) SetBit(res, 8);
-			if (_cur_gps.stage == GLS_ACTIVATION) SetBit(res, 9);
+			if (_cur_gps.stage > GrfLoadingStage::Init) SetBit(res, 0);
+			if (_cur_gps.stage == GrfLoadingStage::Reserve) SetBit(res, 8);
+			if (_cur_gps.stage == GrfLoadingStage::Activation) SetBit(res, 9);
 			return res;
 		}
 
@@ -332,7 +332,7 @@ static void SkipIf(ByteReader &buf)
 		_cur_gps.skip_sprites = -1;
 
 		/* If an action 8 hasn't been encountered yet, disable the grf. */
-		if (_cur_gps.grfconfig->status != (_cur_gps.stage < GLS_RESERVE ? GCS_INITIALISED : GCS_ACTIVATED)) {
+		if (_cur_gps.grfconfig->status != (_cur_gps.stage < GrfLoadingStage::Reserve ? GCS_INITIALISED : GCS_ACTIVATED)) {
 			DisableGrf();
 		}
 	}

--- a/src/newgrf/newgrf_act8.cpp
+++ b/src/newgrf/newgrf_act8.cpp
@@ -17,7 +17,7 @@
 
 #include "../safeguards.h"
 
-/* Action 0x08 (GLS_FILESCAN) */
+/* Action 0x08 (GrfLoadingStage::FileScan) */
 static void ScanInfo(ByteReader &buf)
 {
 	uint8_t grf_version = buf.ReadByte();
@@ -41,7 +41,7 @@ static void ScanInfo(ByteReader &buf)
 		AddGRFTextToList(_cur_gps.grfconfig->info, 0x7F, grfid, true, info);
 	}
 
-	/* GLS_INFOSCAN only looks for the action 8, so we can skip the rest of the file */
+	/* GrfLoadingStage::FileScan only looks for the action 8, so we can skip the rest of the file */
 	_cur_gps.skip_sprites = -1;
 }
 
@@ -59,7 +59,7 @@ static void GRFInfo(ByteReader &buf)
 	uint32_t grfid     = buf.ReadDWord();
 	std::string_view name = buf.ReadString();
 
-	if (_cur_gps.stage < GLS_RESERVE && _cur_gps.grfconfig->status != GCS_UNKNOWN) {
+	if (_cur_gps.stage < GrfLoadingStage::Reserve && _cur_gps.grfconfig->status != GCS_UNKNOWN) {
 		DisableGrf(STR_NEWGRF_ERROR_MULTIPLE_ACTION_8);
 		return;
 	}
@@ -70,7 +70,7 @@ static void GRFInfo(ByteReader &buf)
 	}
 
 	_cur_gps.grffile->grf_version = version;
-	_cur_gps.grfconfig->status = _cur_gps.stage < GLS_RESERVE ? GCS_INITIALISED : GCS_ACTIVATED;
+	_cur_gps.grfconfig->status = _cur_gps.stage < GrfLoadingStage::Reserve ? GCS_INITIALISED : GCS_ACTIVATED;
 
 	/* Do swap the GRFID for displaying purposes since people expect that */
 	Debug(grf, 1, "GRFInfo: Loaded GRFv{} set {:08X} - {} (palette: {}, version: {})", version, std::byteswap(grfid), StrMakeValid(name), (_cur_gps.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur_gps.grfconfig->version);

--- a/src/newgrf/newgrf_actb.cpp
+++ b/src/newgrf/newgrf_actb.cpp
@@ -60,7 +60,7 @@ static void GRFLoadError(ByteReader &buf)
 
 	/* Skip the error until the activation stage unless bit 7 of the severity
 	 * is set. */
-	if (!HasBit(severity, 7) && _cur_gps.stage == GLS_INIT) {
+	if (!HasBit(severity, 7) && _cur_gps.stage == GrfLoadingStage::Init) {
 		GrfMsg(7, "GRFLoadError: Skipping non-fatal GRFLoadError in stage {}", _cur_gps.stage);
 		return;
 	}

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -40,7 +40,7 @@ void ResetGRM()
 	_grm_cargoes.fill(0);
 }
 
-/* Action 0x0D (GLS_SAFETYSCAN) */
+/* Action 0x0D (GrfLoadingStage::SafetyScan) */
 static void SafeParamSet(ByteReader &buf)
 {
 	uint8_t target = buf.ReadByte();
@@ -240,7 +240,7 @@ static void ParamSet(ByteReader &buf)
 				GrfSpecFeature feature{static_cast<uint8_t>(GB(data, 8, 8))};
 				uint16_t count   = GB(data, 16, 16);
 
-				if (_cur_gps.stage == GLS_RESERVE) {
+				if (_cur_gps.stage == GrfLoadingStage::Reserve) {
 					if (feature == GSF_GLOBALVAR) {
 						/* General sprites */
 						if (op == 0) {
@@ -259,7 +259,7 @@ static void ParamSet(ByteReader &buf)
 					}
 					/* Ignore GRM result during reservation */
 					src1 = 0;
-				} else if (_cur_gps.stage == GLS_ACTIVATION) {
+				} else if (_cur_gps.stage == GrfLoadingStage::Activation) {
 					switch (feature) {
 						case GSF_TRAINS:
 						case GSF_ROADVEHICLES:

--- a/src/newgrf/newgrf_acte.cpp
+++ b/src/newgrf/newgrf_acte.cpp
@@ -16,7 +16,7 @@
 
 #include "../safeguards.h"
 
-/* Action 0x0E (GLS_SAFETYSCAN) */
+/* Action 0x0E (GrfLoadingStage::SafetyScan) */
 static void SafeGRFInhibit(ByteReader &buf)
 {
 	/* <0E> <num> <grfids...>

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -299,7 +299,7 @@ bool FillGRFDetails(GRFConfig &config, bool is_static, Subdirectory subdir)
 	}
 
 	/* Find and load the Action 8 information */
-	LoadNewGRFFile(config, GLS_FILESCAN, subdir, true);
+	LoadNewGRFFile(config, GrfLoadingStage::FileScan, subdir, true);
 	config.SetSuitablePalette();
 	config.FinalizeParameterInfo();
 
@@ -308,9 +308,9 @@ bool FillGRFDetails(GRFConfig &config, bool is_static, Subdirectory subdir)
 
 	if (is_static) {
 		/* Perform a 'safety scan' for static GRFs */
-		LoadNewGRFFile(config, GLS_SAFETYSCAN, subdir, true);
+		LoadNewGRFFile(config, GrfLoadingStage::SafetyScan, subdir, true);
 
-		/* GRFConfigFlag::Unsafe is set if GLS_SAFETYSCAN finds unsafe actions */
+		/* GRFConfigFlag::Unsafe is set if GrfLoadingStage::SafetyScan finds unsafe actions */
 		if (config.flags.Test(GRFConfigFlag::Unsafe)) return false;
 	}
 
@@ -332,7 +332,7 @@ void ClearGRFConfigList(GRFConfigList &config)
  * Append a GRF Config list onto another list.
  * @param dst The destination list
  * @param src The source list
- * @param init_only the copied GRF will be processed up to GLS_INIT
+ * @param init_only the copied GRF will be processed up to GrfLoadingStage::Init
  */
 static void AppendGRFConfigList(GRFConfigList &dst, const GRFConfigList &src, bool init_only)
 {
@@ -350,7 +350,7 @@ static void AppendGRFConfigList(GRFConfigList &dst, const GRFConfigList &src, bo
  * Copy a GRF Config list.
  * @param dst The destination list
  * @param src The source list
- * @param init_only the copied GRF will be processed up to GLS_INIT
+ * @param init_only the copied GRF will be processed up to GrfLoadingStage::Init
  */
 void CopyGRFConfigList(GRFConfigList &dst, const GRFConfigList &src, bool init_only)
 {

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -23,8 +23,8 @@ enum class GRFConfigFlag : uint8_t {
 	Static, ///< GRF file is used statically (can be used in any MP game)
 	Compatible, ///< GRF file does not exactly match the requested GRF (different MD5SUM), but grfid matches)
 	Copy, ///< The data is copied from a grf in _all_grfs
-	InitOnly, ///< GRF file is processed up to GLS_INIT
-	Reserved, ///< GRF file passed GLS_RESERVE stage
+	InitOnly, ///< GRF file is processed up to GrfLoadingStage::Init
+	Reserved, ///< GRF file passed GrfLoadingStage::Reserve stage
 	Invalid, ///< GRF is unusable with this version of OpenTTD
 };
 using GRFConfigFlags = EnumBitSet<GRFConfigFlag, uint8_t>;


### PR DESCRIPTION
## Motivation / Problem

Non-scoped enums and non-documented enums.


## Description

* Make `GrfLoadingStage` a scoped enum and document its stages.
* Remove `GLS_END` as it's not used.
* Fix a comment referencing an old `GLS_...` name.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
