### PR TITLE
Codechange: use scoped enum for ScriptSettingSource

### DIFF
--- a/src/ai/ai_config.cpp
+++ b/src/ai/ai_config.cpp
@@ -21,14 +21,14 @@
 {
 	assert(company < MAX_COMPANIES);
 
-	if (source == SSS_DEFAULT && _game_mode == GM_MENU) source = SSS_FORCE_NEWGAME;
+	if (source == ScriptSettingSource::Default && _game_mode == GM_MENU) source = ScriptSettingSource::ForceNewGame;
 
-	if (source == SSS_DEFAULT) {
+	if (source == ScriptSettingSource::Default) {
 		Company *c = Company::GetIfValid(company);
 		if (c != nullptr && c->ai_config != nullptr) return c->ai_config.get();
 	}
 
-	auto &config = (source == SSS_FORCE_NEWGAME) ? _settings_newgame.script_config.ai[company] : _settings_game.script_config.ai[company];
+	auto &config = (source == ScriptSettingSource::ForceNewGame) ? _settings_newgame.script_config.ai[company] : _settings_game.script_config.ai[company];
 	if (config == nullptr) config = std::make_unique<AIConfig>();
 
 	return config.get();

--- a/src/ai/ai_config.hpp
+++ b/src/ai/ai_config.hpp
@@ -22,7 +22,7 @@ public:
 	 * @param source The context, i.e. current / new game mode.
 	 * @return The configuration.
 	 */
-	static AIConfig *GetConfig(CompanyID company, ScriptSettingSource source = SSS_DEFAULT);
+	static AIConfig *GetConfig(CompanyID company, ScriptSettingSource source = ScriptSettingSource::Default);
 
 	AIConfig() :
 		ScriptConfig()

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -45,7 +45,7 @@
 
 	AIConfig *config = c->ai_config.get();
 	if (config == nullptr) {
-		c->ai_config = std::make_unique<AIConfig>(*AIConfig::GetConfig(company, AIConfig::SSS_FORCE_GAME));
+		c->ai_config = std::make_unique<AIConfig>(*AIConfig::GetConfig(company, AIConfig::ScriptSettingSource::ForceCurrentGame));
 		config = c->ai_config.get();
 	}
 

--- a/src/game/game_config.cpp
+++ b/src/game/game_config.cpp
@@ -17,9 +17,9 @@
 
 /* static */ GameConfig *GameConfig::GetConfig(ScriptSettingSource source)
 {
-	if (source == SSS_DEFAULT && _game_mode == GM_MENU) source = SSS_FORCE_NEWGAME;
+	if (source == ScriptSettingSource::Default && _game_mode == GM_MENU) source = ScriptSettingSource::ForceNewGame;
 
-	auto &config = (source == SSS_FORCE_NEWGAME) ? _settings_newgame.script_config.game : _settings_game.script_config.game;
+	auto &config = (source == ScriptSettingSource::ForceNewGame) ? _settings_newgame.script_config.game : _settings_game.script_config.game;
 	if (config == nullptr) config = std::make_unique<GameConfig>();
 
 	return config.get();

--- a/src/game/game_config.hpp
+++ b/src/game/game_config.hpp
@@ -20,7 +20,7 @@ public:
 	 * @param source The context, i.e. current / new game mode.
 	 * @return The configuration.
 	 */
-	static GameConfig *GetConfig(ScriptSettingSource source = SSS_DEFAULT);
+	static GameConfig *GetConfig(ScriptSettingSource source = ScriptSettingSource::Default);
 
 	GameConfig() :
 		ScriptConfig()

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -79,7 +79,7 @@
 	/* Clients shouldn't start GameScripts */
 	if (_networking && !_network_server) return;
 
-	GameConfig *config = GameConfig::GetConfig(GameConfig::SSS_FORCE_GAME);
+	GameConfig *config = GameConfig::GetConfig(GameConfig::ScriptSettingSource::ForceCurrentGame);
 	GameInfo *info = config->GetInfo();
 	if (info == nullptr) return;
 

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -44,7 +44,7 @@ static const SaveLoad _ai_running_desc[] = {
 static void SaveReal_AIPL(int arg)
 {
 	CompanyID index = static_cast<CompanyID>(arg);
-	AIConfig *config = AIConfig::GetConfig(index, AIConfig::SSS_FORCE_GAME);
+	AIConfig *config = AIConfig::GetConfig(index, AIConfig::ScriptSettingSource::ForceCurrentGame);
 
 	if (config->HasScript()) {
 		_ai_saveload_name = config->GetName();
@@ -81,7 +81,7 @@ struct AIPLChunkHandler : ChunkHandler {
 
 		/* Free all current data */
 		for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
-			AIConfig::GetConfig(c, AIConfig::SSS_FORCE_GAME)->Change(std::nullopt);
+			AIConfig::GetConfig(c, AIConfig::ScriptSettingSource::ForceCurrentGame)->Change(std::nullopt);
 		}
 
 		CompanyID index;
@@ -100,7 +100,7 @@ struct AIPLChunkHandler : ChunkHandler {
 				continue;
 			}
 
-			AIConfig *config = AIConfig::GetConfig(index, AIConfig::SSS_FORCE_GAME);
+			AIConfig *config = AIConfig::GetConfig(index, AIConfig::ScriptSettingSource::ForceCurrentGame);
 			if (_ai_saveload_name.empty() || _ai_saveload_is_random) {
 				/* A random AI. */
 				config->Change(std::nullopt, -1, false);

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -59,7 +59,7 @@ struct GSDTChunkHandler : ChunkHandler {
 		const std::vector<SaveLoad> slt = SlCompatTableHeader(_game_script_desc, _game_script_sl_compat);
 
 		/* Free all current data */
-		GameConfig::GetConfig(GameConfig::SSS_FORCE_GAME)->Change(std::nullopt);
+		GameConfig::GetConfig(GameConfig::ScriptSettingSource::ForceCurrentGame)->Change(std::nullopt);
 
 		if (SlIterateArray() == -1) return;
 
@@ -72,7 +72,7 @@ struct GSDTChunkHandler : ChunkHandler {
 			return;
 		}
 
-		GameConfig *config = GameConfig::GetConfig(GameConfig::SSS_FORCE_GAME);
+		GameConfig *config = GameConfig::GetConfig(GameConfig::ScriptSettingSource::ForceCurrentGame);
 		if (!_game_saveload_name.empty()) {
 			config->Change(_game_saveload_name, _game_saveload_version, false);
 			if (!config->HasScript()) {

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -96,10 +96,10 @@ public:
 	 * Where to get the config from, either default (depends on current game
 	 * mode) or force either newgame or normal
 	 */
-	enum ScriptSettingSource : uint8_t {
-		SSS_DEFAULT,       ///< Get the Script config from the current game mode
-		SSS_FORCE_NEWGAME, ///< Get the newgame Script config
-		SSS_FORCE_GAME,    ///< Get the Script config from the current game
+	enum class ScriptSettingSource : uint8_t {
+		Default, ///< Get the Script config from the current game mode
+		ForceNewGame, ///< Get the newgame Script config
+		ForceCurrentGame, ///< Get the Script config from the current game
 	};
 
 	/**

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -955,7 +955,7 @@ static void AILoadConfig(const IniFile &ini, std::string_view grpname)
 
 	/* Clean any configured AI */
 	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
-		AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME)->Change(std::nullopt);
+		AIConfig::GetConfig(c, AIConfig::ScriptSettingSource::ForceNewGame)->Change(std::nullopt);
 	}
 
 	/* If no group exists, return */
@@ -963,7 +963,7 @@ static void AILoadConfig(const IniFile &ini, std::string_view grpname)
 
 	CompanyID c = CompanyID::Begin();
 	for (const IniItem &item : group->items) {
-		AIConfig *config = AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME);
+		AIConfig *config = AIConfig::GetConfig(c, AIConfig::ScriptSettingSource::ForceNewGame);
 
 		config->Change(item.name);
 		if (!config->HasScript()) {
@@ -983,14 +983,14 @@ static void GameLoadConfig(const IniFile &ini, std::string_view grpname)
 	const IniGroup *group = ini.GetGroup(grpname);
 
 	/* Clean any configured GameScript */
-	GameConfig::GetConfig(GameConfig::SSS_FORCE_NEWGAME)->Change(std::nullopt);
+	GameConfig::GetConfig(GameConfig::ScriptSettingSource::ForceNewGame)->Change(std::nullopt);
 
 	/* If no group exists, return */
 	if (group == nullptr || group->items.empty()) return;
 
 	const IniItem &item = group->items.front();
 
-	GameConfig *config = GameConfig::GetConfig(AIConfig::SSS_FORCE_NEWGAME);
+	GameConfig *config = GameConfig::GetConfig(AIConfig::ScriptSettingSource::ForceNewGame);
 
 	config->Change(item.name);
 	if (!config->HasScript()) {
@@ -1186,7 +1186,7 @@ static void AISaveConfig(IniFile &ini, std::string_view grpname)
 	group.Clear();
 
 	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
-		AIConfig *config = AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME);
+		AIConfig *config = AIConfig::GetConfig(c, AIConfig::ScriptSettingSource::ForceNewGame);
 		std::string name;
 		std::string value = config->SettingsToString();
 
@@ -1205,7 +1205,7 @@ static void GameSaveConfig(IniFile &ini, std::string_view grpname)
 	IniGroup &group = ini.GetOrCreateGroup(grpname);
 	group.Clear();
 
-	GameConfig *config = GameConfig::GetConfig(AIConfig::SSS_FORCE_NEWGAME);
+	GameConfig *config = GameConfig::GetConfig(AIConfig::ScriptSettingSource::ForceNewGame);
 	std::string name;
 	std::string value = config->SettingsToString();
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Scoped enums...

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use scoped num for `ScriptSettingSource`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
