### PR TITLE
Codechange: Cache last vehicle of chains

### DIFF
--- a/src/cachecheck.cpp
+++ b/src/cachecheck.cpp
@@ -223,4 +223,21 @@ void CheckCaches()
 		}
 		i++;
 	}
+
+	/* Check the last vehicle cache. */
+	for (Vehicle *v : Vehicle::Iterate()) {
+		if (v != v->First() || v->vehstatus.Test(VehState::Crashed) || !v->IsPrimaryVehicle()) continue;
+
+		/* Check that the last vehicle is actually last. */
+		if (v->Last()->Next() != nullptr) {
+			Debug(desync, 2, "warning: vehicle cache mismatch, last vehicle must not have a next vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
+		}
+
+		/* Ensure that all vehicles in the chain have the same last vehicle. */
+		for (Vehicle *u = v; u != nullptr; u = u->Next()) {
+			if (u->Last() != v->Last()) {
+				Debug(desync, 2, "warning: vehicle cache mismatch, all vehicles in chain must have same last vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
+			}
+		}
+	}
 }

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -265,6 +265,7 @@ void AfterLoadVehiclesPhase1(bool part_of_load)
 
 		if (part_of_load) v->fill_percent_te_id = INVALID_TE_ID;
 		v->first = nullptr;
+		v->last = nullptr;
 		if (v->IsGroundVehicle()) v->GetGroundVehicleCache()->first_engine = EngineID::Invalid();
 	}
 
@@ -311,10 +312,17 @@ void AfterLoadVehiclesPhase1(bool part_of_load)
 	}
 
 	for (Vehicle *v : Vehicle::Iterate()) {
-		/* Fill the first pointers */
+		/* Fill the first pointers. */
 		if (v->Previous() == nullptr) {
 			for (Vehicle *u = v; u != nullptr; u = u->Next()) {
 				u->first = v;
+			}
+		}
+
+		/* Fill the last pointers. */
+		if (v->Next() == nullptr) {
+			for (Vehicle *u = v; u != nullptr; u = u->Previous()) {
+				u->last = v;
 			}
 		}
 	}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -913,7 +913,16 @@ static void RestoreTrainBackup(TrainList &list)
  */
 static void RemoveFromConsist(Train *part, bool chain = false)
 {
-	Train *tail = chain ? part->Last() : part->GetLastEnginePart();
+	Train *tail;
+
+	if (chain) {
+		/* We're moving several vehicles, find the last one in the chain. */
+		tail = part;
+		while (tail->Next() != nullptr) tail = tail->Next();
+	} else {
+		/* We're just moving one vehicle, but make sure we get all the articulated parts. */
+		tail = part->GetLastEnginePart();
+	}
 
 	/* Unlink at the front, but make it point to the next
 	 * vehicle after the to be remove part. */

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -384,6 +384,7 @@ Vehicle::Vehicle(VehicleID index, VehicleType type) : VehiclePool::PoolItem<&_ve
 	this->group_id           = DEFAULT_GROUP;
 	this->fill_percent_te_id = INVALID_TE_ID;
 	this->first              = this;
+	this->last               = this;
 	this->colourmap          = PAL_NONE;
 	this->cargo_age_counter  = 1;
 	this->last_station_visited = StationID::Invalid();
@@ -2988,6 +2989,13 @@ void Vehicle::SetNext(Vehicle *next)
 		for (Vehicle *v = this->next; v != nullptr; v = v->Next()) {
 			v->first = this->first;
 		}
+	}
+
+	/* Update last vehicle of the entire chain. */
+	Vehicle *new_last = this;
+	while (new_last->Next() != nullptr) new_last = new_last->Next();
+	for (Vehicle *v = this->first; v!= nullptr; v = v->Next()) {
+		v->last = new_last;
 	}
 }
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -209,6 +209,7 @@ private:
 	Vehicle *next = nullptr; ///< pointer to the next vehicle in the chain
 	Vehicle *previous = nullptr; ///< NOSAVE: pointer to the previous vehicle in the chain
 	Vehicle *first = nullptr; ///< NOSAVE: pointer to the first vehicle in the chain
+	Vehicle *last = nullptr; ///< NOSAVE: pointer for the last vehicle in the chain
 
 	Vehicle *next_shared = nullptr; ///< pointer to the next vehicle that shares the order
 	Vehicle *previous_shared = nullptr; ///< NOSAVE: pointer to the previous vehicle in the shared order chain
@@ -606,23 +607,13 @@ public:
 	 * Get the last vehicle of this vehicle chain.
 	 * @return the last vehicle of the chain.
 	 */
-	inline Vehicle *Last()
-	{
-		Vehicle *v = this;
-		while (v->Next() != nullptr) v = v->Next();
-		return v;
-	}
+	inline Vehicle *Last() { return this->last; }
 
 	/**
 	 * Get the last vehicle of this vehicle chain.
 	 * @return the last vehicle of the chain.
 	 */
-	inline const Vehicle *Last() const
-	{
-		const Vehicle *v = this;
-		while (v->Next() != nullptr) v = v->Next();
-		return v;
-	}
+	inline const Vehicle *Last() const { return this->last; }
 
 	/**
 	 * Get the vehicle at offset \a n of this vehicle chain.


### PR DESCRIPTION
## Motivation / Problem

We currently do not cache the last vehicle of chains, instead iterating through the chain each time it's needed.

This is fine currently, but in #15379 we will frequently need to know the last vehicle.

For ease of review and testing, I'm opening this as a separate PR.

## Description

Add a new member variable `last` for vehicles, copying the implementation of `first`.

## Limitations

I've tested with vanilla, NewGRF, and dual-headed vehicles, but I don't know what a failure state would look like so I'm not confident that I haven't missed anything.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
