### PR TITLE
Add: Setting to disallow train magic flip, and reverse at reduced speed

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1352,8 +1352,13 @@ STR_CONFIG_SETTING_CONSTRUCTION_COSTS_HIGH                      :High
 STR_CONFIG_SETTING_RECESSIONS                                   :Recessions: {STRING2}
 STR_CONFIG_SETTING_RECESSIONS_HELPTEXT                          :If enabled, recessions may occur periodically. During a recession all production is significantly lower (it returns to previous level when the recession is over)
 
-STR_CONFIG_SETTING_TRAIN_REVERSING                              :Disallow train reversing in stations: {STRING2}
-STR_CONFIG_SETTING_TRAIN_REVERSING_HELPTEXT                     :If enabled, trains will not reverse in non-terminus stations, even if there is a shorter path to their next destination when reversing
+STR_CONFIG_SETTING_TRAIN_FLIP_REVERSE                           :Allow trains to flip when reversing: {STRING2}
+STR_CONFIG_SETTING_TRAIN_FLIP_REVERSE_HELPTEXT                  :Choose where trains may flip to reverse direction. With "All" trains may flip anywhere. With "End of line only" trains will not flip in stations if a route forwards is possible. With "None" trains cannot flip and will drive backwards if needed, but at reduced speed if the rear vehicle lacks a driving cab
+
+###length 3
+STR_CONFIG_SETTING_TRAIN_FLIP_REVERSE_ALL                       :All
+STR_CONFIG_SETTING_TRAIN_FLIP_REVERSE_END_OF_LINE_ONLY          :End of line only
+STR_CONFIG_SETTING_TRAIN_FLIP_REVERSE_NONE                      :None
 
 STR_CONFIG_SETTING_DISASTERS                                    :Disasters: {STRING2}
 STR_CONFIG_SETTING_DISASTERS_HELPTEXT                           :Toggle disasters which may occasionally block or destroy vehicles or infrastructure

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -618,6 +618,16 @@ bool YapfTrainCheckReverse(const Train *v)
 
 	int reverse_penalty = 0;
 
+	/* Consider whether the train might back up at reduced speed. */
+	if (_settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::None && !v->Last()->CanLeadTrain()) {
+		constexpr int DRIVING_BACKWARDS_PENALTY = 100 * YAPF_TILE_LENGTH;
+
+		if (!v->vehicle_flags.Test(VehicleFlag::DrivingBackwards)) {
+			/* We're currently driving forwards at full speed, and would rather not reverse if possible. */
+			reverse_penalty += DRIVING_BACKWARDS_PENALTY;
+		}
+	}
+
 	if (moving_front->track == TRACK_BIT_WORMHOLE) {
 		/* front in tunnel / on bridge */
 		DiagDirection dir_into_wormhole = GetTunnelBridgeDirection(tile);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2943,6 +2943,9 @@ bool AfterLoadGame()
 				u->direction = ReverseDir(u->direction);
 			}
 		}
+
+		/* Update the setting for train flipping. */
+		_settings_game.difficulty.train_flip_reverse_allowed = _settings_game.difficulty.line_reverse_mode ? TrainFlipReversingAllowed::EndOfLineOnly : TrainFlipReversingAllowed::All;
 	}
 
 	if (IsSavegameVersionBefore(SLV_165)) {

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -737,7 +737,7 @@ SettingsContainer &GetSettingsTree()
 			SettingsPage *routing = vehicles->Add(new SettingsPage(STR_CONFIG_SETTING_VEHICLES_ROUTING));
 			{
 				routing->Add(new SettingEntry("vehicle.road_side"));
-				routing->Add(new SettingEntry("difficulty.line_reverse_mode"));
+				routing->Add(new SettingEntry("difficulty.train_flip_reverse_allowed"));
 				routing->Add(new SettingEntry("pf.reverse_at_signals"));
 				routing->Add(new SettingEntry("pf.forbid_90_deg"));
 			}

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -144,10 +144,18 @@ enum class VehicleBreakdowns : uint8_t {
 	Normal,
 };
 
+/** Possible values for "train_flip_reverse_allowed" setting. */
+enum class TrainFlipReversingAllowed : uint8_t {
+	All = 0, ///< Trains can flip anywhere.
+	EndOfLineOnly, ///< Trains can only flip when the track ends.
+	None, ///< Trains cannot flip anywhere and must back up if the track ends.
+};
+
 /** Settings related to the difficulty of the game */
 struct DifficultySettings {
 	uint8_t competitor_start_time; ///< Unused value, used to load old savegames.
 	uint8_t competitor_intelligence; ///< Unused value, used to load old savegames.
+	uint8_t line_reverse_mode; ///< Unused value, used to load old savegames.
 
 	uint8_t max_no_competitors; ///< the number of competitors (AIs)
 	uint16_t competitors_interval; ///< the interval (in minutes) between adding competitors
@@ -164,7 +172,7 @@ struct DifficultySettings {
 	GenworldMaxHeight terrain_type; ///< the mountainousness of the landscape
 	uint8_t quantity_sea_lakes; ///< the amount of seas/lakes
 	bool economy; ///< how volatile is the economy
-	bool line_reverse_mode; ///< reversing at stations or not
+	TrainFlipReversingAllowed train_flip_reverse_allowed; ///< which stations can the train reverse at?
 	bool disasters; ///< are disasters enabled
 	uint8_t town_council_tolerance; ///< minimum required town ratings to be allowed to demolish stuff
 	bool infinite_money; ///< whether spending money despite negative balance is allowed

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -16,6 +16,8 @@ uint8_t _old_diff_level;                                 ///< Old difficulty lev
 static void DifficultyNoiseChange(int32_t new_value);
 static void MaxNoAIsChange(int32_t new_value);
 
+static constexpr std::initializer_list<std::string_view> _train_flip_reverse_allowed{"all"sv, "end of line only"sv, "none"sv};
+
 static const SettingVariant _difficulty_settings_table[] = {
 [post-amble]
 };
@@ -23,6 +25,7 @@ static const SettingVariant _difficulty_settings_table[] = {
 SDTG_VAR   =   SDTG_VAR($name,              $type, SettingFlags({$flags}), $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
 SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        SettingFlags({$flags}), $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to,        $cat, $extra, $startup),
 SDT_VAR    =   SDT_VAR (GameSettings, $var, $type, SettingFlags({$flags}), $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $range_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, SettingFlags({$flags}), $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $str_cb, $help_cb, $val_cb, $def_cb, $from, $to, $load, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert(ConvertEnumClass($max) <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -259,9 +262,21 @@ strhelp  = STR_CONFIG_SETTING_RECESSIONS_HELPTEXT
 [SDT_BOOL]
 var      = difficulty.line_reverse_mode
 from     = SLV_97
+to       = SLV_DRIVE_BACKWARDS
 def      = false
-str      = STR_CONFIG_SETTING_TRAIN_REVERSING
-strhelp  = STR_CONFIG_SETTING_TRAIN_REVERSING_HELPTEXT
+
+[SDT_OMANY]
+var      = difficulty.train_flip_reverse_allowed
+type     = SLE_UINT8
+from     = SLV_DRIVE_BACKWARDS
+flags    = SettingFlag::GuiDropdown
+def      = TrainFlipReversingAllowed::All
+min      = TrainFlipReversingAllowed::All
+max      = TrainFlipReversingAllowed::None
+full     = _train_flip_reverse_allowed
+str      = STR_CONFIG_SETTING_TRAIN_FLIP_REVERSE
+strhelp  = STR_CONFIG_SETTING_TRAIN_FLIP_REVERSE_HELPTEXT
+strval   = STR_CONFIG_SETTING_TRAIN_FLIP_REVERSE_ALL
 
 [SDT_BOOL]
 var      = difficulty.disasters

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -416,7 +416,8 @@ int Train::GetCurrentMaxSpeed() const
 
 	for (const Train *u = this; u != nullptr; u = u->Next()) {
 		if (_settings_game.vehicle.train_acceleration_model == AM_REALISTIC && u->track == TRACK_BIT_DEPOT) {
-			max_speed = std::min(max_speed, 61);
+			constexpr int DEPOT_SPEED_LIMIT = 61;
+			max_speed = std::min(max_speed, DEPOT_SPEED_LIMIT);
 			break;
 		}
 
@@ -427,6 +428,13 @@ int Train::GetCurrentMaxSpeed() const
 	}
 
 	max_speed = std::min<int>(max_speed, this->current_order.GetMaxSpeed());
+
+	/* If the train is going backwards, without a leading cab, restrict its speed. */
+	if (!moving_front->CanLeadTrain()) {
+		constexpr int BACKWARDS_NO_CAB_SPEED_LIMIT = 32;
+		max_speed = std::min<int>(max_speed, BACKWARDS_NO_CAB_SPEED_LIMIT);
+	}
+
 	return std::min<int>(max_speed, this->gcache.cached_max_track_speed);
 }
 
@@ -2018,7 +2026,7 @@ static void ReverseTrainDirection(Train *consist)
 	TileIndex crossing = TrainApproachingCrossingTile(moving_front);
 
 	/* Check if we should back up or flip the train. */
-	if (consist->Last()->CanLeadTrain()) {
+	if (consist->Last()->CanLeadTrain() || _settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::None) {
 		/* The train will back up. */
 		consist->vehicle_flags.Flip(VehicleFlag::DrivingBackwards);
 
@@ -3017,7 +3025,7 @@ bool TryPathReserve(Train *consist, bool mark_as_stuck, bool first_tile_okay)
 static bool CheckReverseTrain(const Train *consist)
 {
 	const Train *moving_front = consist->GetMovingFront();
-	if (_settings_game.difficulty.line_reverse_mode != 0 ||
+	if (_settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::EndOfLineOnly ||
 			moving_front->track == TRACK_BIT_DEPOT || moving_front->track == TRACK_BIT_WORMHOLE ||
 			!(moving_front->GetMovingDirection() & 1)) {
 		return false;


### PR DESCRIPTION
## Motivation / Problem

Step 3 for #15379, for players who want a challenge.

## Description

Change the `Disallow train reversing in stations` setting to `Allow trains to flip when reversing` and add a third value which prohibits trains from magic flipping anywhere.

Trains without a cab on the rear will back up at a reduced speed of 32 km/h, or 20 mph.

## Limitations

* I have also considered a per-order flag to force a train to back up. That would give more granular control, but also clutter up the order GUI further. I propose going with this PR for now, and adding per-order control later if desired.
* Setting conversion uses the same savegame version as in #15379, so anyone who plays a nightly between that was merged and when this gets merged won't have their setting updated automatically. I can add another saveload version if desired. 🙂 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
