### PR TITLE
Fix #15399: Do not mark dependency content as an update.

### DIFF
--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -50,6 +50,13 @@ struct ContentInfo {
 		Invalid, ///< The content's invalid
 	};
 
+	/** For wich games the content is available. */
+	enum class Availability : uint8_t {
+		SavegamesOnly = 0, ///< Content only available for savegames.
+		NewGames = 1, ///< Content available for both savegames and new games.
+		Invalid = 0xFF, ///< The availability is unknown.
+	};
+
 	ContentType type = INVALID_CONTENT_TYPE; ///< Type of content
 	ContentID id = INVALID_CONTENT_ID;       ///< Unique (server side) ID for the content
 	uint32_t filesize = 0;                     ///< Size of the file
@@ -64,6 +71,7 @@ struct ContentInfo {
 	StringList tags;                         ///< Tags associated with the content
 	State state = State::Unselected;         ///< Whether the content info is selected (for download)
 	bool upgrade = false;                    ///< This item is an upgrade
+	ContentInfo::Availability availability = ContentInfo::Availability::Invalid; ///< @copydocs ContentInfo::Availability
 
 	bool IsSelected() const;
 	bool IsValid() const;

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -110,6 +110,8 @@ bool ClientNetworkContentSocketHandler::ReceiveServerInfo(Packet &p)
 	ci->tags.reserve(tag_count);
 	for (uint i = 0; i < tag_count; i++) ci->tags.push_back(p.Recv_string(NETWORK_CONTENT_TAG_LENGTH));
 
+	ci->availability = ContentInfo::Availability(p.Recv_uint8());
+
 	if (!ci->IsValid()) {
 		this->CloseConnection();
 		return false;
@@ -121,7 +123,7 @@ bool ClientNetworkContentSocketHandler::ReceiveServerInfo(Packet &p)
 			ci->state = ContentInfo::State::AlreadyHere;
 		} else {
 			ci->state = ContentInfo::State::Unselected;
-			if (proc(*ci, false)) ci->upgrade = true;
+			if ((ci->availability == ContentInfo::Availability::NewGames) && proc(*ci, false)) ci->upgrade = true;
 		}
 	} else {
 		ci->state = ContentInfo::State::Unselected;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
At first OpenTTD client fetches information about latest version of every content at BaNaNaS.
Then it fetches information for each dependency, when doing so it cannot distinguish between old versions and the latest one. Then because about a version it only knows the version as a string and the md5 sum it cannot guess which one is newer. So when only one of them is downloaded, then it thinks that the other one is an update.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
When fetching information about content also fetch the availability.
Then only mark the latest version as an update.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Needs https://github.com/OpenTTD/bananas-server/pull/425 to work.
I need an advice on how to store the content locally, so the local server could read it and I could test if it works.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
