### PR TITLE
Fix: improve appearance of toolbars and main menu images/text

### DIFF
--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -90,6 +90,7 @@ void GfxScroll(int left, int top, int width, int height, int xo, int yo);
 
 Dimension GetSpriteSize(SpriteID sprid, Point *offset = nullptr, ZoomLevel zoom = _gui_zoom);
 Dimension GetScaledSpriteSize(SpriteID sprid); /* widget.cpp */
+Dimension GetSquareScaledSpriteSize(SpriteID sprid); /* widget.cpp */
 void DrawSpriteViewport(SpriteID img, PaletteID pal, int x, int y, const SubSprite *sub = nullptr);
 void DrawSprite(SpriteID img, PaletteID pal, int x, int y, const SubSprite *sub = nullptr, ZoomLevel zoom = _gui_zoom);
 void DrawSpriteIgnorePadding(SpriteID img, PaletteID pal, const Rect &r, StringAlignment align); /* widget.cpp */

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -8,7 +8,9 @@
 /** @file toolbar_gui.cpp Code related to the (main) toolbar. */
 
 #include "stdafx.h"
+#include "core/geometry_func.hpp"
 #include "gui.h"
+#include "spritecache.h"
 #include "window_gui.h"
 #include "window_func.h"
 #include "viewport_func.h"
@@ -2175,45 +2177,63 @@ struct MainToolbarWindow : Window {
 	}};
 };
 
+/** Sprites to use for the different toolbar buttons */
+static constexpr std::tuple<WidgetID, WidgetType, SpriteID> _toolbar_button_sprites[] = {
+	{WID_TN_PAUSE,        WWT_IMGBTN,     SPR_IMG_PAUSE},
+	{WID_TN_FAST_FORWARD, WWT_IMGBTN,     SPR_IMG_FASTFORWARD},
+	{WID_TN_SETTINGS,     WWT_IMGBTN,     SPR_IMG_SETTINGS},
+	{WID_TN_SAVE,         WWT_IMGBTN_2,   SPR_IMG_SAVE},
+	{WID_TN_SMALL_MAP,    WWT_IMGBTN,     SPR_IMG_SMALLMAP},
+	{WID_TN_TOWNS,        WWT_IMGBTN,     SPR_IMG_TOWN},
+	{WID_TN_SUBSIDIES,    WWT_IMGBTN,     SPR_IMG_SUBSIDIES},
+	{WID_TN_STATIONS,     WWT_IMGBTN,     SPR_IMG_COMPANY_LIST},
+	{WID_TN_FINANCES,     WWT_IMGBTN,     SPR_IMG_COMPANY_FINANCE},
+	{WID_TN_COMPANIES,    WWT_IMGBTN,     SPR_IMG_COMPANY_GENERAL},
+	{WID_TN_STORY,        WWT_IMGBTN,     SPR_IMG_STORY_BOOK},
+	{WID_TN_GOAL,         WWT_IMGBTN,     SPR_IMG_GOAL},
+	{WID_TN_GRAPHS,       WWT_IMGBTN,     SPR_IMG_GRAPHS},
+	{WID_TN_LEAGUE,       WWT_IMGBTN,     SPR_IMG_COMPANY_LEAGUE},
+	{WID_TN_INDUSTRIES,   WWT_IMGBTN,     SPR_IMG_INDUSTRY},
+	{WID_TN_TRAINS,       WWT_IMGBTN,     SPR_IMG_TRAINLIST},
+	{WID_TN_ROADVEHS,     WWT_IMGBTN,     SPR_IMG_TRUCKLIST},
+	{WID_TN_SHIPS,        WWT_IMGBTN,     SPR_IMG_SHIPLIST},
+	{WID_TN_AIRCRAFT,     WWT_IMGBTN,     SPR_IMG_AIRPLANESLIST},
+	{WID_TN_ZOOM_IN,      WWT_PUSHIMGBTN, SPR_IMG_ZOOMIN},
+	{WID_TN_ZOOM_OUT,     WWT_PUSHIMGBTN, SPR_IMG_ZOOMOUT},
+	{WID_TN_RAILS,        WWT_IMGBTN,     SPR_IMG_BUILDRAIL},
+	{WID_TN_ROADS,        WWT_IMGBTN,     SPR_IMG_BUILDROAD},
+	{WID_TN_TRAMS,        WWT_IMGBTN,     SPR_IMG_BUILDTRAMS},
+	{WID_TN_WATER,        WWT_IMGBTN,     SPR_IMG_BUILDWATER},
+	{WID_TN_AIR,          WWT_IMGBTN,     SPR_IMG_BUILDAIR},
+	{WID_TN_LANDSCAPE,    WWT_IMGBTN,     SPR_IMG_LANDSCAPING},
+	{WID_TN_MUSIC_SOUND,  WWT_IMGBTN,     SPR_IMG_MUSIC},
+	{WID_TN_MESSAGES,     WWT_IMGBTN,     SPR_IMG_MESSAGES},
+	{WID_TN_HELP,         WWT_IMGBTN,     SPR_IMG_QUERY},
+	{WID_TN_SWITCH_BAR,   WWT_IMGBTN,     SPR_IMG_SWITCH_TOOLBAR},
+};
+
+/**
+ * Get maximal square size of a toolbar image.
+ * @return maximal toolbar image size.
+ */
+Dimension GetToolbarMaximalImageSize()
+{
+	Dimension d{};
+	for (const auto &[widget, tp, sprite] : _toolbar_button_sprites) {
+		if (!SpriteExists(sprite)) continue;
+		d = maxdim(d, GetSquareScaledSpriteSize(sprite));
+	}
+	return d;
+}
+
+/**
+ * Make widgets for the main toolbar.
+ * @return widgets for the main toolbar.
+ */
 static std::unique_ptr<NWidgetBase> MakeMainToolbar()
 {
-	/** Sprites to use for the different toolbar buttons */
-	static const std::tuple<WidgetID, WidgetType, SpriteID> toolbar_button_sprites[] = {
-		{WID_TN_PAUSE,        WWT_IMGBTN,     SPR_IMG_PAUSE},
-		{WID_TN_FAST_FORWARD, WWT_IMGBTN,     SPR_IMG_FASTFORWARD},
-		{WID_TN_SETTINGS,     WWT_IMGBTN,     SPR_IMG_SETTINGS},
-		{WID_TN_SAVE,         WWT_IMGBTN_2,   SPR_IMG_SAVE},
-		{WID_TN_SMALL_MAP,    WWT_IMGBTN,     SPR_IMG_SMALLMAP},
-		{WID_TN_TOWNS,        WWT_IMGBTN,     SPR_IMG_TOWN},
-		{WID_TN_SUBSIDIES,    WWT_IMGBTN,     SPR_IMG_SUBSIDIES},
-		{WID_TN_STATIONS,     WWT_IMGBTN,     SPR_IMG_COMPANY_LIST},
-		{WID_TN_FINANCES,     WWT_IMGBTN,     SPR_IMG_COMPANY_FINANCE},
-		{WID_TN_COMPANIES,    WWT_IMGBTN,     SPR_IMG_COMPANY_GENERAL},
-		{WID_TN_STORY,        WWT_IMGBTN,     SPR_IMG_STORY_BOOK},
-		{WID_TN_GOAL,         WWT_IMGBTN,     SPR_IMG_GOAL},
-		{WID_TN_GRAPHS,       WWT_IMGBTN,     SPR_IMG_GRAPHS},
-		{WID_TN_LEAGUE,       WWT_IMGBTN,     SPR_IMG_COMPANY_LEAGUE},
-		{WID_TN_INDUSTRIES,   WWT_IMGBTN,     SPR_IMG_INDUSTRY},
-		{WID_TN_TRAINS,       WWT_IMGBTN,     SPR_IMG_TRAINLIST},
-		{WID_TN_ROADVEHS,     WWT_IMGBTN,     SPR_IMG_TRUCKLIST},
-		{WID_TN_SHIPS,        WWT_IMGBTN,     SPR_IMG_SHIPLIST},
-		{WID_TN_AIRCRAFT,     WWT_IMGBTN,     SPR_IMG_AIRPLANESLIST},
-		{WID_TN_ZOOM_IN,      WWT_PUSHIMGBTN, SPR_IMG_ZOOMIN},
-		{WID_TN_ZOOM_OUT,     WWT_PUSHIMGBTN, SPR_IMG_ZOOMOUT},
-		{WID_TN_RAILS,        WWT_IMGBTN,     SPR_IMG_BUILDRAIL},
-		{WID_TN_ROADS,        WWT_IMGBTN,     SPR_IMG_BUILDROAD},
-		{WID_TN_TRAMS,        WWT_IMGBTN,     SPR_IMG_BUILDTRAMS},
-		{WID_TN_WATER,        WWT_IMGBTN,     SPR_IMG_BUILDWATER},
-		{WID_TN_AIR,          WWT_IMGBTN,     SPR_IMG_BUILDAIR},
-		{WID_TN_LANDSCAPE,    WWT_IMGBTN,     SPR_IMG_LANDSCAPING},
-		{WID_TN_MUSIC_SOUND,  WWT_IMGBTN,     SPR_IMG_MUSIC},
-		{WID_TN_MESSAGES,     WWT_IMGBTN,     SPR_IMG_MESSAGES},
-		{WID_TN_HELP,         WWT_IMGBTN,     SPR_IMG_QUERY},
-		{WID_TN_SWITCH_BAR,   WWT_IMGBTN,     SPR_IMG_SWITCH_TOOLBAR},
-	};
-
 	auto hor = std::make_unique<NWidgetMainToolbarContainer>();
-	for (const auto &[widget, tp, sprite] : toolbar_button_sprites) {
+	for (const auto &[widget, tp, sprite] : _toolbar_button_sprites) {
 		switch (widget) {
 			case WID_TN_SMALL_MAP:
 			case WID_TN_FINANCES:
@@ -2225,7 +2245,7 @@ static std::unique_ptr<NWidgetBase> MakeMainToolbar()
 				break;
 		}
 		auto leaf = std::make_unique<NWidgetLeaf>(tp, COLOUR_GREY, widget, WidgetData{.sprite = sprite}, STR_TOOLBAR_TOOLTIP_PAUSE_GAME + widget);
-		leaf->SetMinimalSize(20, 20);
+		leaf->SetToolbarMinimalSize(1);
 		hor->Add(std::move(leaf));
 	}
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -386,7 +386,7 @@ static inline void DrawImageTextButtons(const Rect &r, Colours colour, bool clic
 	DrawFrameRect(r, colour, clicked ? FrameFlag::Lowered : FrameFlags{});
 
 	bool rtl = _current_text_dir == TD_RTL;
-	int image_width = img != 0 ? GetScaledSpriteSize(img).width : 0;
+	int image_width = img != 0 ? std::max<int>(GetSquareScaledSpriteSize(img).width, r.Shrink(WidgetDimensions::scaled.framerect).Height()) : 0;
 	Rect r_img = r.Shrink(WidgetDimensions::scaled.framerect).WithWidth(image_width, rtl);
 	Rect r_text = r.Shrink(WidgetDimensions::scaled.framerect).Indent(image_width + WidgetDimensions::scaled.hsep_wide, rtl);
 
@@ -2912,7 +2912,7 @@ void NWidgetLeaf::SetupSmallestSize(Window *w)
 		case WWT_IMGTEXTBTN:
 		case WWT_PUSHIMGTEXTBTN: {
 			padding = {WidgetDimensions::scaled.framerect.Horizontal(), WidgetDimensions::scaled.framerect.Vertical()};
-			Dimension di = GetScaledSpriteSize(this->widget_data.sprite);
+			Dimension di = GetSquareScaledSpriteSize(this->widget_data.sprite);
 			Dimension dt = GetStringBoundingBox(GetStringForWidget(w, this), this->text_size);
 			Dimension d2{
 				padding.width + 2 * (di.width + WidgetDimensions::scaled.hsep_wide) + dt.width,

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -77,6 +77,22 @@ Dimension GetScaledSpriteSize(SpriteID sprid)
 }
 
 /**
+ * Scale sprite size for GUI, as a square.
+ * Offset is ignored.
+ * @param sprid The sprite to get the size from.
+ * @return The square scaled dimension of the sprite.
+ */
+Dimension GetSquareScaledSpriteSize(SpriteID sprid)
+{
+	Dimension d = GetScaledSpriteSize(sprid);
+	uint x = std::max(d.width, d.height);
+	return {x, x};
+}
+
+static Dimension _toolbar_image_size{}; ///< Cached dimension of maximal toolbar sprite size.
+extern Dimension GetToolbarMaximalImageSize();
+
+/**
  * Set up pre-scaled versions of Widget Dimensions.
  */
 void SetupWidgetDimensions()
@@ -110,6 +126,8 @@ void SetupWidgetDimensions()
 	WidgetDimensions::scaled.hsep_normal  = ScaleGUITrad(WidgetDimensions::unscaled.hsep_normal);
 	WidgetDimensions::scaled.hsep_wide    = ScaleGUITrad(WidgetDimensions::unscaled.hsep_wide);
 	WidgetDimensions::scaled.hsep_indent  = ScaleGUITrad(WidgetDimensions::unscaled.hsep_indent);
+
+	_toolbar_image_size = GetToolbarMaximalImageSize();
 }
 
 /**
@@ -1014,6 +1032,10 @@ void NWidgetResizeBase::AdjustPaddingForZoom()
 	if (!this->absolute) {
 		this->min_x = ScaleGUITrad(this->uz_min_x);
 		this->min_y = std::max(ScaleGUITrad(this->uz_min_y), this->uz_text_lines * GetCharacterHeight(this->uz_text_size) + ScaleGUITrad(this->uz_text_spacing));
+		if (this->toolbar_size > 0) {
+			this->min_x = std::max(this->min_x, this->toolbar_size * _toolbar_image_size.width + WidgetDimensions::scaled.imgbtn.Horizontal());
+			this->min_y = std::max(this->min_y, _toolbar_image_size.height + WidgetDimensions::scaled.imgbtn.Vertical());
+		}
 	}
 	NWidgetBase::AdjustPaddingForZoom();
 }
@@ -1027,6 +1049,15 @@ void NWidgetResizeBase::SetMinimalSize(uint min_x, uint min_y)
 {
 	this->uz_min_x = std::max(this->uz_min_x, min_x);
 	this->uz_min_y = std::max(this->uz_min_y, min_y);
+}
+
+/**
+ * Set minimal size of the widget in toolbar-icon-relative width.
+ * @param toolbar_size Toolbar button size of the widget.
+ */
+void NWidgetResizeBase::SetToolbarMinimalSize(uint8_t toolbar_size)
+{
+	this->toolbar_size = toolbar_size;
 }
 
 /**
@@ -3161,6 +3192,14 @@ void ApplyNWidgetPartAttribute(const NWidgetPart &nwid, NWidgetBase *dest)
 			if (nwrb == nullptr) [[unlikely]] throw std::runtime_error("WPT_MINTEXTLINES requires NWidgetResizeBase");
 			assert(nwid.u.text_lines.size >= FS_BEGIN && nwid.u.text_lines.size < FS_END);
 			nwrb->SetMinimalTextLines(nwid.u.text_lines.lines, nwid.u.text_lines.spacing, nwid.u.text_lines.size);
+			break;
+		}
+
+		case WPT_TOOLBARSIZE: {
+			NWidgetResizeBase *nwrb = dynamic_cast<NWidgetResizeBase *>(dest);
+			if (nwrb == nullptr) [[unlikely]] throw std::runtime_error("WPT_TOOLBARSIZE requires NWidgetResizeBase");
+			assert(nwid.u.xy.x >= 0);
+			nwrb->SetToolbarMinimalSize(nwid.u.xy.x);
 			break;
 		}
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1027,8 +1027,6 @@ void NWidgetResizeBase::SetMinimalSize(uint min_x, uint min_y)
 {
 	this->uz_min_x = std::max(this->uz_min_x, min_x);
 	this->uz_min_y = std::max(this->uz_min_y, min_y);
-	this->min_x = ScaleGUITrad(this->uz_min_x);
-	this->min_y = std::max(ScaleGUITrad(this->uz_min_y), this->uz_text_lines * GetCharacterHeight(this->uz_text_size) + ScaleGUITrad(this->uz_text_spacing));
 }
 
 /**
@@ -1054,7 +1052,6 @@ void NWidgetResizeBase::SetMinimalTextLines(uint8_t min_lines, uint8_t spacing, 
 	this->uz_text_lines = min_lines;
 	this->uz_text_spacing = spacing;
 	this->uz_text_size = size;
-	this->min_y = std::max(ScaleGUITrad(this->uz_min_y), this->uz_text_lines * GetCharacterHeight(this->uz_text_size) + ScaleGUITrad(this->uz_text_spacing));
 }
 
 /**

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -90,6 +90,7 @@ enum WidgetType : uint8_t {
 	WPT_ALIGNMENT,    ///< Widget part for specifying text/image alignment.
 	WPT_SCROLLBAR,    ///< Widget part for attaching a scrollbar.
 	WPT_ASPECT,       ///< Widget part for specifying aspect ratio.
+	WPT_TOOLBARSIZE,  ///< Widget part for specifying minimal size in terms of toolbar images.
 	WPT_ATTRIBUTE_END, ///< End marker for attribute NWidgetPart types.
 
 	WPT_FUNCTION, ///< Widget part for calling a user function.
@@ -326,6 +327,7 @@ public:
 	void SetMinimalSize(uint min_x, uint min_y);
 	void SetMinimalSizeAbsolute(uint min_x, uint min_y);
 	void SetMinimalTextLines(uint8_t min_lines, uint8_t spacing, FontSize size);
+	void SetToolbarMinimalSize(uint8_t toolbar_size);
 	void SetFill(uint fill_x, uint fill_y);
 	void SetResize(uint resize_x, uint resize_y);
 	void SetAspect(float ratio, AspectFlags flags = AspectFlag::ResizeX);
@@ -347,6 +349,7 @@ public:
 	uint8_t uz_text_lines = 0; ///< 'Unscaled' text lines, stored for resize calculation.
 	uint8_t uz_text_spacing = 0; ///< 'Unscaled' text padding, stored for resize calculation.
 	FontSize uz_text_size{}; ///< 'Unscaled' font size, stored for resize calculation.
+	uint8_t toolbar_size = 0; ///< Minimal size in terms of toolbar images.
 };
 
 /** Nested widget flags that affect display and interaction with 'real' widgets. */
@@ -1205,7 +1208,7 @@ constexpr NWidgetPart SetToolbarSpacerMinimalSize()
  */
 constexpr NWidgetPart SetToolbarMinimalSize(int width)
 {
-	return NWidgetPart{WPT_MINSIZE, Point{20 * width + 2, 22}};
+	return NWidgetPart{WPT_TOOLBARSIZE, Point{width, 1}};
 }
 
 /**

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1821,6 +1821,7 @@ void Window::CreateNestedTree()
  */
 void Window::FinishInitNested(WindowNumber window_number)
 {
+	this->nested_root->AdjustPaddingForZoom();
 	this->InitializeData(window_number);
 	this->ApplyDefaults();
 	Point pt = this->OnInitialPosition(this->nested_root->smallest_x, this->nested_root->smallest_y, window_number);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The images used on the main menu are highly dependent on the baseset used, and currently rely on all images being the same size.

This unfortunately doesn't hold for all basesets, most notably the original TTD baseset, and this results in the text of the main menu not being aligned neatly.

Part of the issue is that the method to set button size relative to toolbar button sizes uses a hardcoded pixel size value, which may not actually match the loaded baseset.

This is noticeable when using a graphics set such as "aBase" or "biggui", which use larger than intended toolbar icons, but only for some toolbar icons, resulting in a weird mix of sizes.

<img width="354" height="657" alt="ttdmenubefore" src="https://github.com/user-attachments/assets/bb0721e0-4f8c-4089-b3fc-ef179c12bdd5" />
<img width="722" height="1105" alt="abasemenubefore" src="https://github.com/user-attachments/assets/1b3cf411-afb5-4952-baad-8714a1d5044d" />
<img width="2407" height="214" alt="abasetoolbarbefore" src="https://github.com/user-attachments/assets/b12e60d4-af18-4110-93e7-edd0b24820dc" />

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

These issues are resolved by making toolbar-button-sizes relative to the largest normal toolbar icon, instead of the hardcoded 20 pixels, and then forcing the image part of image-text buttons to be square, based on toolbar button sizing.

This is not 100% ideal for image-text buttons, but there are currently no other users of this widget type so it's mostly fine.

It's still not really recommended to use larger icons than designed, as it will always cause inconsistency with NewGRF addons which are generally designed for the default button size.

<img width="354" height="657" alt="ttdmenuafter" src="https://github.com/user-attachments/assets/599b9088-1ecc-4ccb-abe0-02ce1a16ea7e" />
<img width="722" height="1105" alt="abasemenuafter" src="https://github.com/user-attachments/assets/19bf6f2f-c0ac-478d-9abc-bb9bd1d01df1" />
<img width="2407" height="214" alt="abasetoolbarafter" src="https://github.com/user-attachments/assets/77dc8291-c42b-4b39-be21-e20b3826df8e" />

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
