### PR TITLE
Fix: MaxReliability order condition value not being clamped to <= 100

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -812,6 +812,7 @@ CommandCost CmdInsertOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 
 				case OrderConditionVariable::LoadPercentage:
 				case OrderConditionVariable::Reliability:
+				case OrderConditionVariable::MaxReliability:
 					if (new_order.GetConditionValue() > 100) return CMD_ERROR;
 					[[fallthrough]];
 
@@ -1312,6 +1313,7 @@ CommandCost CmdModifyOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 
 				case OrderConditionVariable::LoadPercentage:
 				case OrderConditionVariable::Reliability:
+				case OrderConditionVariable::MaxReliability:
 					if (data > 100) return CMD_ERROR;
 					break;
 
@@ -1397,6 +1399,7 @@ CommandCost CmdModifyOrder(DoCommandFlags flags, VehicleID veh, VehicleOrderID s
 
 					case OrderConditionVariable::LoadPercentage:
 					case OrderConditionVariable::Reliability:
+					case OrderConditionVariable::MaxReliability:
 						if (order->GetConditionValue() > 100) order->SetConditionValue(100);
 						[[fallthrough]];
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1343,6 +1343,7 @@ public:
 				break;
 
 			case OrderConditionVariable::Reliability:
+			case OrderConditionVariable::MaxReliability:
 			case OrderConditionVariable::LoadPercentage:
 				value = Clamp(*value, 0, 100);
 				break;


### PR DESCRIPTION
## Motivation / Problem

The order condition value for OrderConditionVariable::LoadPercentage and OrderConditionVariable::Reliability conditional orders is clamped to the range 0-100.
The other percentage condition: OrderConditionVariable::MaxReliability, does not clamp the order condition value.

## Description

Apply the clamping for OrderConditionVariable::MaxReliability.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
