### PR TITLE
Change: test fonts for eligibility before adding as fallback

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -31,12 +31,15 @@ FontCacheSettings _fcsettings;
  * Try loading a font with any fontcache factory.
  * @param fs Font size to load.
  * @param fonttype Font type requested.
+ * @param search Set if searching for the font.
+ * @param font_name Font name to load.
+ * @param os_handle Font handle to load.
  * @return FontCache of the font if loaded, or nullptr.
  */
-/* static */ std::unique_ptr<FontCache> FontProviderManager::LoadFont(FontSize fs, FontType fonttype)
+/* static */ std::unique_ptr<FontCache> FontProviderManager::LoadFont(FontSize fs, FontType fonttype, bool search, const std::string &font_name, const std::any &os_handle)
 {
 	for (auto &provider : FontProviderManager::GetProviders()) {
-		auto fc = provider->LoadFont(fs, fonttype);
+		auto fc = provider->LoadFont(fs, fonttype, search, font_name, os_handle);
 		if (fc != nullptr) return fc;
 	}
 
@@ -97,7 +100,7 @@ int GetCharacterHeight(FontSize size)
 {
 	for (FontSize fs = FS_BEGIN; fs != FS_END; fs++) {
 		if (FontCache::Get(fs) != nullptr) continue;
-		FontCache::Register(FontProviderManager::LoadFont(fs, FontType::Sprite));
+		FontCache::Register(FontProviderManager::LoadFont(fs, FontType::Sprite, false, {}, {}));
 	}
 }
 
@@ -207,7 +210,7 @@ static std::string GetDefaultTruetypeFontFile([[maybe_unused]] FontSize fs)
  * @param fs Font size.
  * @return If configured, the font name to use, or the path of the default TrueType font if sprites are not preferred.
  */
-std::string GetFontCacheFontName(FontSize fs)
+static std::string GetFontCacheFontName(FontSize fs)
 {
 	const FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
 	if (!settings->font.empty()) return settings->font;
@@ -259,7 +262,12 @@ std::string GetFontCacheFontName(FontSize fs)
 			FontCache::caches[fs] = std::move(FontCache::caches[fs]->parent);
 		}
 
-		FontCache::Register(FontProviderManager::LoadFont(fs, FontType::TrueType));
+		FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
+
+		std::string font_name = GetFontCacheFontName(fs);
+		if (font_name.empty()) continue;
+
+		FontCache::Register(FontProviderManager::LoadFont(fs, FontType::TrueType, true, font_name, settings->os_handle));
 	}
 }
 

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -247,6 +247,33 @@ static std::string GetFontCacheFontName(FontSize fs)
 }
 
 /**
+ * Test a fallback font, with optional OS-specific handle, for specific glyphs.
+ * @param fontsizes The fontsizes the font will be used for.
+ * @param glyphs Glyphs to search for.
+ * @param name Name of font to test.
+ * @param os_handle OS-specific handle or data of font.
+ * @return true iff the font can be used.
+ */
+/* static */ bool FontCache::TryFallback(FontSizes, const std::set<char32_t> &glyphs, const std::string &name, const std::any &os_handle)
+{
+	/* Load the font without registering it. The font size does not matter. */
+	auto fc = FontProviderManager::LoadFont(FS_NORMAL, FontType::TrueType, false, name, os_handle);
+	if (fc == nullptr) return false;
+
+	size_t matching_chars = 0;
+	for (const char32_t &c : glyphs) {
+		if (fc->MapCharToGlyph(c, false) != 0) ++matching_chars;
+	}
+
+	if (matching_chars < glyphs.size()) {
+		Debug(fontcache, 1, "Font \"{}\" misses {} glyphs", name, glyphs.size() - matching_chars);
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * (Re)initialize the font cache related things, i.e. load the non-sprite fonts.
  * @param fontsizes Font sizes to be initialised.
  */

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -46,16 +46,14 @@ FontCacheSettings _fcsettings;
 /**
  * We would like to have a fallback font as the current one
  * doesn't contain all characters we need.
- * This function must set all fonts of settings.
- * @param settings the settings to overwrite the fontname of.
  * @param language_isocode the language, e.g. en_GB.
  * @param callback The function to call to check for missing glyphs.
  * @return true if a font has been set, false otherwise.
  */
-/* static */ bool FontProviderManager::FindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback)
+/* static */ bool FontProviderManager::FindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback)
 {
 	return std::ranges::any_of(FontProviderManager::GetProviders(),
-		[&](auto *provider) { return provider->FindFallbackFont(settings, language_isocode, callback); });
+		[&](auto *provider) { return provider->FindFallbackFont(language_isocode, callback); });
 }
 
 int FontCache::GetDefaultFontHeight(FontSize fs)
@@ -157,7 +155,7 @@ void SetFont(FontSize fontsize, const std::string &font, uint size)
  */
 static bool IsDefaultFont(const FontCacheSubSetting &setting)
 {
-	return setting.font.empty() && setting.os_handle == nullptr;
+	return setting.font.empty() && !setting.os_handle.has_value();
 }
 
 /**
@@ -229,6 +227,20 @@ std::string GetFontCacheFontName(FontSize fs)
 
 	fc->parent = std::move(FontCache::caches[fs]);
 	FontCache::caches[fs] = std::move(fc);
+}
+
+/**
+ * Add a fallback font, with optional OS-specific handle.
+ * @param fontsizes Fontsizes to add fallback to.
+ * @param name Name of font to add.
+ * @param os_handle OS-specific handle or data of font.
+ */
+/* static */ void FontCache::AddFallback(FontSizes fontsizes, std::string_view name, const std::any &os_handle)
+{
+	for (FontSize fs : fontsizes) {
+		GetFontCacheSubSetting(fs)->font = name;
+		GetFontCacheSubSetting(fs)->os_handle = os_handle;
+	}
 }
 
 /**

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -221,7 +221,6 @@ inline FontCacheSubSetting *GetFontCacheSubSetting(FontSize fs)
 }
 
 uint GetFontCacheFontSize(FontSize fs);
-std::string GetFontCacheFontName(FontSize fs);
 
 bool GetFontAAState();
 void SetFont(FontSize fontsize, const std::string &font, uint size);
@@ -250,9 +249,12 @@ public:
 	 * Try loading a font with this factory.
 	 * @param fs Font size to load.
 	 * @param fonttype Font type requested.
+	 * @param search Set if searching for the font.
+	 * @param font_name Font name to load.
+	 * @param os_handle Font handle to load.
 	 * @return FontCache of the font if loaded, or nullptr.
 	 */
-	virtual std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const = 0;
+	virtual std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype, bool search, const std::string &font_name, const std::any &os_handle) const = 0;
 
 	/**
 	 * We would like to have a fallback font as the current one
@@ -266,7 +268,7 @@ public:
 
 class FontProviderManager : ProviderManager<FontCacheFactory> {
 public:
-	static std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype);
+	static std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype, bool search, const std::string &font_name, const std::any &os_handle = {});
 	static bool FindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback);
 };
 

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -50,6 +50,8 @@ public:
 
 	static void AddFallback(FontSizes fontsizes, std::string_view name, const std::any &os_handle = {});
 
+	static bool TryFallback(FontSizes fontsizes, const std::set<char32_t> &glyphs, const std::string &name, const std::any &os_handle = {});
+
 	/**
 	 * Get the FontSize of the font.
 	 * @return The FontSize.

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -10,6 +10,7 @@
 #ifndef FONTCACHE_H
 #define FONTCACHE_H
 
+#include <any>
 #include "gfx_type.h"
 #include "provider_manager.h"
 #include "spritecache_type.h"
@@ -46,6 +47,8 @@ public:
 	static const int DEFAULT_FONT_ASCENDER[FS_END];
 
 	static int GetDefaultFontHeight(FontSize fs);
+
+	static void AddFallback(FontSizes fontsizes, std::string_view name, const std::any &os_handle = {});
 
 	/**
 	 * Get the FontSize of the font.
@@ -186,7 +189,7 @@ struct FontCacheSubSetting {
 	std::string font; ///< The name of the font, or path to the font.
 	uint size;        ///< The (requested) size of the font.
 
-	const void *os_handle = nullptr; ///< Optional native OS font info. Only valid during font search.
+	std::any os_handle; ///< Optional native OS font info.
 };
 
 /** Settings for the four different fonts. */
@@ -254,19 +257,17 @@ public:
 	/**
 	 * We would like to have a fallback font as the current one
 	 * doesn't contain all characters we need.
-	 * This function must set all fonts of settings.
-	 * @param settings The settings to overwrite the fontname of.
 	 * @param language_isocode The language, e.g. en_GB.
 	 * @param callback The function to call to check for missing glyphs.
-	 * @return \c true if a font has been set, false otherwise.
+	 * @return \c true if a font has been set, \c false otherwise.
 	 */
-	virtual bool FindFallbackFont(struct FontCacheSettings *settings, const std::string &language_isocode, class MissingGlyphSearcher *callback) const = 0;
+	virtual bool FindFallbackFont(const std::string &language_isocode, class MissingGlyphSearcher *callback) const = 0;
 };
 
 class FontProviderManager : ProviderManager<FontCacheFactory> {
 public:
 	static std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype);
-	static bool FindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback);
+	static bool FindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback);
 };
 
 /* Implemented in spritefontcache.cpp */

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -242,7 +242,9 @@ public:
 
 		/* If font is an absolute path to a ttf, try loading that first. */
 		int32_t index = 0;
-		if (settings->os_handle != nullptr) index = *static_cast<const int32_t *>(settings->os_handle);
+		if (auto ptr = std::any_cast<int32_t>(&settings->os_handle)) {
+			index = *ptr;
+		}
 		FT_Error error = FT_New_Face(_ft_library, font.c_str(), index, &face);
 
 		if (error != FT_Err_Ok) {
@@ -266,10 +268,10 @@ public:
 		return LoadFont(fs, face, font, GetFontCacheFontSize(fs));
 	}
 
-	bool FindFallbackFont(struct FontCacheSettings *settings, const std::string &language_isocode, class MissingGlyphSearcher *callback) const override
+	bool FindFallbackFont(const std::string &language_isocode, class MissingGlyphSearcher *callback) const override
 	{
 #ifdef WITH_FONTCONFIG
-		if (FontConfigFindFallbackFont(settings, language_isocode, callback)) return true;
+		if (FontConfigFindFallbackFont(language_isocode, callback)) return true;
 #endif /* WITH_FONTCONFIG */
 
 		return false;

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -220,14 +220,9 @@ public:
 		_ft_library = nullptr;
 	}
 
-	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
+	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype, bool search, const std::string &font_name, const std::any &os_handle) const override
 	{
 		if (fonttype != FontType::TrueType) return nullptr;
-
-		FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
-
-		std::string font = GetFontCacheFontName(fs);
-		if (font.empty()) return nullptr;
 
 		if (_ft_library == nullptr) {
 			if (FT_Init_FreeType(&_ft_library) != FT_Err_Ok) {
@@ -242,22 +237,22 @@ public:
 
 		/* If font is an absolute path to a ttf, try loading that first. */
 		int32_t index = 0;
-		if (auto ptr = std::any_cast<int32_t>(&settings->os_handle)) {
+		if (auto ptr = std::any_cast<int32_t>(&os_handle)) {
 			index = *ptr;
 		}
-		FT_Error error = FT_New_Face(_ft_library, font.c_str(), index, &face);
+		FT_Error error = FT_New_Face(_ft_library, font_name.c_str(), index, &face);
 
 		if (error != FT_Err_Ok) {
 			/* Check if font is a relative filename in one of our search-paths. */
-			std::string full_font = FioFindFullPath(BASE_DIR, font);
+			std::string full_font = FioFindFullPath(BASE_DIR, font_name);
 			if (!full_font.empty()) {
 				error = FT_New_Face(_ft_library, full_font.c_str(), 0, &face);
 			}
 		}
 
 #ifdef WITH_FONTCONFIG
-		/* Try loading based on font face name (OS-wide fonts). */
-		if (error != FT_Err_Ok) error = GetFontByFaceName(font, &face);
+		/* If allowed to search, try loading based on font face name (OS-wide fonts). */
+		if (error != FT_Err_Ok && search) error = GetFontByFaceName(font_name, &face);
 #endif /* WITH_FONTCONFIG */
 
 		if (error != FT_Err_Ok) {
@@ -265,7 +260,7 @@ public:
 			return nullptr;
 		}
 
-		return LoadFont(fs, face, font, GetFontCacheFontSize(fs));
+		return LoadFont(fs, face, font_name, GetFontCacheFontSize(fs));
 	}
 
 	bool FindFallbackFont(const std::string &language_isocode, class MissingGlyphSearcher *callback) const override

--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -159,7 +159,7 @@ class SpriteFontCacheFactory : public FontCacheFactory {
 public:
 	SpriteFontCacheFactory() : FontCacheFactory("sprite", "Sprite font provider") {}
 
-	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
+	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype, bool, const std::string &, const std::any &) const override
 	{
 		if (fonttype != FontType::Sprite) return nullptr;
 

--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -166,7 +166,7 @@ public:
 		return std::make_unique<SpriteFontCache>(fs);
 	}
 
-	bool FindFallbackFont(struct FontCacheSettings *, const std::string &, class MissingGlyphSearcher *) const override
+	bool FindFallbackFont(const std::string &, class MissingGlyphSearcher *) const override
 	{
 		return false;
 	}

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -215,7 +215,7 @@ public:
 			* something, no matter the name. As such, we can't use it to check for existence.
 			* We instead query the list of all font descriptors that match the given name which
 			* does not do this stupid name fallback. */
-			CFAutoRelease<CTFontDescriptorRef> name_desc(CTFontDescriptorCreateWithNameAndSize(font_name.get(), 0.0));
+			CFAutoRelease<CTFontDescriptorRef> name_desc(CTFontDescriptorCreateWithNameAndSize(name.get(), 0.0));
 			CFAutoRelease<CFSetRef> mandatory_attribs(CFSetCreate(kCFAllocatorDefault, const_cast<const void **>(reinterpret_cast<const void * const *>(&kCTFontNameAttribute)), 1, &kCFTypeSetCallBacks));
 			CFAutoRelease<CFArrayRef> descs(CTFontDescriptorCreateMatchingFontDescriptors(name_desc.get(), mandatory_attribs.get()));
 
@@ -298,10 +298,10 @@ public:
 				if (name.starts_with(".") || name.starts_with("LastResort")) continue;
 
 				/* Save result. */
-				FontCache::AddFallback(callback->missing_fontsizes, name);
-				if (!callback->FindMissingGlyphs()) {
+				result = FontCache::TryFallback(callback->missing_fontsizes, callback->missing_glyphs, std::string{name});
+				if (result) {
+					FontCache::AddFallback(callback->missing_fontsizes, name);
 					Debug(fontcache, 2, "CT-Font for {}: {}", language_isocode, name);
-					result = true;
 					break;
 				}
 			}
@@ -310,11 +310,12 @@ public:
 		if (!result) {
 			/* For some OS versions, the font 'Arial Unicode MS' does not report all languages it
 			 * supports. If we didn't find any other font, just try it, maybe we get lucky. */
-			FontCache::AddFallback(callback->missing_fontsizes, "Arial Unicode MS");
-			result = !callback->FindMissingGlyphs();
+			result = FontCache::TryFallback(callback->missing_fontsizes, callback->missing_glyphs, "Arial Unicode MS");
+			if (result) {
+				FontCache::AddFallback(callback->missing_fontsizes, "Arial Unicode MS");
+			}
 		}
 
-		callback->FindMissingGlyphs();
 		return result;
 	}
 

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -200,24 +200,22 @@ class CoreTextFontCacheFactory : public FontCacheFactory {
 public:
 	CoreTextFontCacheFactory() : FontCacheFactory("coretext", "CoreText font loader") {}
 
-	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
+	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype, bool search, const std::string &font_name, const std::any &) const override
 	{
 		if (fonttype != FontType::TrueType) return nullptr;
 
-		std::string font = GetFontCacheFontName(fs);
-		if (font.empty()) return nullptr;
-
 		/* Might be a font file name, try load it. */
-		CFAutoRelease<CTFontDescriptorRef> font_ref(LoadFontFromFile(font));
-		if (!font_ref) {
-			ShowInfo("Unable to load file '{}' for {} font, using default OS font selection instead", font, FontSizeToName(fs));
-			CFAutoRelease<CFStringRef> name(CFStringCreateWithCString(kCFAllocatorDefault, font.c_str(), kCFStringEncodingUTF8));
+		CFAutoRelease<CTFontDescriptorRef> font_ref(LoadFontFromFile(font_name));
+		if (!font_ref) ShowInfo("Unable to load file '{}' for {} font, using default OS font selection instead", font_name, FontSizeToName(fs));
+
+		if (!font_ref && search) {
+			CFAutoRelease<CFStringRef> name(CFStringCreateWithCString(kCFAllocatorDefault, font_name.c_str(), kCFStringEncodingUTF8));
 
 			/* Simply creating the font using CTFontCreateWithNameAndSize will *always* return
 			* something, no matter the name. As such, we can't use it to check for existence.
 			* We instead query the list of all font descriptors that match the given name which
 			* does not do this stupid name fallback. */
-			CFAutoRelease<CTFontDescriptorRef> name_desc(CTFontDescriptorCreateWithNameAndSize(name.get(), 0.0));
+			CFAutoRelease<CTFontDescriptorRef> name_desc(CTFontDescriptorCreateWithNameAndSize(font_name.get(), 0.0));
 			CFAutoRelease<CFSetRef> mandatory_attribs(CFSetCreate(kCFAllocatorDefault, const_cast<const void **>(reinterpret_cast<const void * const *>(&kCTFontNameAttribute)), 1, &kCFTypeSetCallBacks));
 			CFAutoRelease<CFArrayRef> descs(CTFontDescriptorCreateMatchingFontDescriptors(name_desc.get(), mandatory_attribs.get()));
 
@@ -229,7 +227,7 @@ public:
 		}
 
 		if (!font_ref) {
-			ShowInfo("Unable to use '{}' for {} font, using sprite font instead", font, FontSizeToName(fs));
+			ShowInfo("Unable to use '{}' for {} font, using sprite font instead", font_name, FontSizeToName(fs));
 			return nullptr;
 		}
 

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -236,7 +236,7 @@ public:
 		return std::make_unique<CoreTextFontCache>(fs, std::move(font_ref), GetFontCacheFontSize(fs));
 	}
 
-	bool FindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback) const override
+	bool FindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback) const override
 	{
 		/* Determine fallback font using CoreText. This uses the language isocode
 		 * to find a suitable font. CoreText is available from 10.5 onwards. */
@@ -282,7 +282,7 @@ public:
 				/* Skip bold fonts (especially Arial Bold, which looks worse than regular Arial). */
 				if (symbolic_traits & kCTFontBoldTrait) continue;
 				/* Select monospaced fonts if asked for. */
-				if (((symbolic_traits & kCTFontMonoSpaceTrait) == kCTFontMonoSpaceTrait) != callback->Monospace()) continue;
+				if (((symbolic_traits & kCTFontMonoSpaceTrait) == kCTFontMonoSpaceTrait) != callback->missing_fontsizes.Test(FS_MONO)) continue;
 
 				/* Get font name. */
 				char buffer[128];
@@ -300,7 +300,7 @@ public:
 				if (name.starts_with(".") || name.starts_with("LastResort")) continue;
 
 				/* Save result. */
-				callback->SetFontNames(settings, name);
+				FontCache::AddFallback(callback->missing_fontsizes, name);
 				if (!callback->FindMissingGlyphs()) {
 					Debug(fontcache, 2, "CT-Font for {}: {}", language_isocode, name);
 					result = true;
@@ -312,7 +312,7 @@ public:
 		if (!result) {
 			/* For some OS versions, the font 'Arial Unicode MS' does not report all languages it
 			 * supports. If we didn't find any other font, just try it, maybe we get lucky. */
-			callback->SetFontNames(settings, "Arial Unicode MS");
+			FontCache::AddFallback(callback->missing_fontsizes, "Arial Unicode MS");
 			result = !callback->FindMissingGlyphs();
 		}
 

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -139,7 +139,13 @@ static int GetPreferredWeightDistance(int weight)
 	return 0;
 }
 
-bool FontConfigFindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback)
+/**
+ * Use FontConfig to find a fallback font.
+ * @param language_isocode The language, e.g. en_GB.
+ * @param callback The function to call to check for missing glyphs.
+ * @return \c true if a font has been set, \c false otherwise.
+ */
+bool FontConfigFindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback)
 {
 	bool ret = false;
 
@@ -174,7 +180,7 @@ bool FontConfigFindFallbackFont(FontCacheSettings *settings, const std::string &
 		/* Get a font with the right spacing .*/
 		int value = 0;
 		FcPatternGetInteger(font, FC_SPACING, 0, &value);
-		if (callback->Monospace() != (value == FC_MONO) && value != FC_DUAL) continue;
+		if (callback->missing_fontsizes.Test(FS_MONO) != (value == FC_MONO) && value != FC_DUAL) continue;
 
 		/* Do not use those that explicitly say they're slanted. */
 		FcPatternGetInteger(font, FC_SLANT, 0, &value);
@@ -190,7 +196,7 @@ bool FontConfigFindFallbackFont(FontCacheSettings *settings, const std::string &
 		res = FcPatternGetInteger(font, FC_INDEX, 0, &index);
 		if (res != FcResultMatch) continue;
 
-		callback->SetFontNames(settings, FromFcString(file), &index);
+		FontCache::AddFallback(callback->missing_fontsizes, FromFcString(file), index);
 
 		bool missing = callback->FindMissingGlyphs();
 		Debug(fontcache, 1, "Font \"{}\" misses{} glyphs", FromFcString(file), missing ? "" : " no");
@@ -204,7 +210,7 @@ bool FontConfigFindFallbackFont(FontCacheSettings *settings, const std::string &
 
 	if (best_font == nullptr) return false;
 
-	callback->SetFontNames(settings, best_font, &best_index);
-	FontCache::LoadFontCaches(callback->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
+	FontCache::AddFallback(callback->missing_fontsizes, best_font, best_index);
+	FontCache::LoadFontCaches(callback->missing_fontsizes);
 	return true;
 }

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -162,7 +162,7 @@ bool FontConfigFindFallbackFont(const std::string &language_isocode, MissingGlyp
 	/* First create a pattern to match the wanted language. */
 	auto pat = AutoRelease<FcPattern, FcPatternDestroy>(FcNameParse(ToFcString(lang)));
 	/* We only want to know these attributes. */
-	auto os = AutoRelease<FcObjectSet, FcObjectSetDestroy>(FcObjectSetBuild(FC_FILE, FC_INDEX, FC_SPACING, FC_SLANT, FC_WEIGHT, nullptr));
+	auto os = AutoRelease<FcObjectSet, FcObjectSetDestroy>(FcObjectSetBuild(FC_FILE, FC_INDEX, FC_SPACING, FC_SLANT, FC_WEIGHT, FC_CHARSET, nullptr));
 	/* Get the list of filenames matching the wanted language. */
 	auto fs = AutoRelease<FcFontSet, FcFontSetDestroy>(FcFontList(nullptr, pat.get(), os.get()));
 
@@ -191,21 +191,28 @@ bool FontConfigFindFallbackFont(const std::string &language_isocode, MissingGlyp
 		int weight = GetPreferredWeightDistance(value);
 		if (best_weight != -1 && weight > best_weight) continue;
 
+		/* Test the font for matching glyphs. This is essentially the same as
+		 * calling TryFallback() but avoids having to reopen the font, etc. */
+		size_t matching_chars = 0;
+		FcCharSet *charset;
+		FcPatternGetCharSet(font, FC_CHARSET, 0, &charset);
+		for (const char32_t &c : callback->missing_glyphs) {
+			if (FcCharSetHasChar(charset, c)) ++matching_chars;
+		}
+
+		if (matching_chars < callback->missing_glyphs.size()) {
+			Debug(fontcache, 1, "Font \"{}\" misses {} glyphs", FromFcString(file), callback->missing_glyphs.size() - matching_chars);
+			continue;
+		}
+
 		/* Possible match based on attributes, get index. */
 		int32_t index;
 		res = FcPatternGetInteger(font, FC_INDEX, 0, &index);
 		if (res != FcResultMatch) continue;
 
-		FontCache::AddFallback(callback->missing_fontsizes, FromFcString(file), index);
-
-		bool missing = callback->FindMissingGlyphs();
-		Debug(fontcache, 1, "Font \"{}\" misses{} glyphs", FromFcString(file), missing ? "" : " no");
-
-		if (!missing) {
-			best_weight = weight;
-			best_font = FromFcString(file);
-			best_index = index;
-		}
+		best_weight = weight;
+		best_font = FromFcString(file);
+		best_index = index;
 	}
 
 	if (best_font == nullptr) return false;

--- a/src/os/unix/font_unix.h
+++ b/src/os/unix/font_unix.h
@@ -19,7 +19,7 @@
 
 FT_Error GetFontByFaceName(std::string_view font_name, FT_Face *face);
 
-bool FontConfigFindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback);
+bool FontConfigFindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback);
 
 #endif /* WITH_FONTCONFIG */
 

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -76,8 +76,9 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	char font_name[MAX_PATH];
 	convert_from_fs(logfont->elfFullName, font_name);
 
+	if (!FontCache::TryFallback(info->callback->missing_fontsizes, info->callback->missing_glyphs, font_name, logfont->elfLogFont)) return 1;
+
 	FontCache::AddFallback(info->callback->missing_fontsizes, font_name, logfont->elfLogFont);
-	if (info->callback->FindMissingGlyphs()) return 1;
 	Debug(fontcache, 1, "Fallback font: {}", font_name);
 	return 0; // stop enumerating
 }

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -31,7 +31,6 @@
 #include "../../safeguards.h"
 
 struct EFCParam {
-	FontCacheSettings *settings;
 	LOCALESIGNATURE  locale;
 	MissingGlyphSearcher *callback;
 	std::vector<std::wstring> fonts;
@@ -58,7 +57,7 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	/* Don't use SYMBOL fonts */
 	if (logfont->elfLogFont.lfCharSet == SYMBOL_CHARSET) return 1;
 	/* Use monospaced fonts when asked for it. */
-	if (info->callback->Monospace() && (logfont->elfLogFont.lfPitchAndFamily & (FF_MODERN | FIXED_PITCH)) != (FF_MODERN | FIXED_PITCH)) return 1;
+	if (info->callback->missing_fontsizes.Test(FS_MONO) && (logfont->elfLogFont.lfPitchAndFamily & (FF_MODERN | FIXED_PITCH)) != (FF_MODERN | FIXED_PITCH)) return 1;
 
 	/* The font has to have at least one of the supported locales to be usable. */
 	auto check_bitfields = [&]() {
@@ -77,7 +76,7 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	char font_name[MAX_PATH];
 	convert_from_fs(logfont->elfFullName, font_name);
 
-	info->callback->SetFontNames(info->settings, font_name, &logfont->elfLogFont);
+	FontCache::AddFallback(info->callback->missing_fontsizes, font_name, logfont->elfLogFont);
 	if (info->callback->FindMissingGlyphs()) return 1;
 	Debug(fontcache, 1, "Fallback font: {}", font_name);
 	return 0; // stop enumerating
@@ -287,8 +286,8 @@ public:
 
 		/* If a GDI font description is present, e.g. from the automatic font
 		 * fallback search, use it. Otherwise, try to resolve it by font name. */
-		if (settings->os_handle != nullptr) {
-			logfont = *(const LOGFONT *)settings->os_handle;
+		if (auto ptr = std::any_cast<LOGFONT>(&settings->os_handle)) {
+			logfont = *ptr;
 		} else if (font.find('.') != std::string::npos) {
 			/* Might be a font file name, try load it. */
 			if (!TryLoadFontFromFile(font, logfont)) {
@@ -304,7 +303,7 @@ public:
 		return LoadWin32Font(fs, logfont, GetFontCacheFontSize(fs), font);
 	}
 
-	bool FindFallbackFont(FontCacheSettings *settings, const std::string &language_isocode, MissingGlyphSearcher *callback) const override
+	bool FindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback) const override
 	{
 		Debug(fontcache, 1, "Trying fallback fonts");
 		EFCParam langInfo;
@@ -314,7 +313,6 @@ public:
 			Debug(fontcache, 1, "Can't get locale info for fallback font (isocode={})", language_isocode);
 			return false;
 		}
-		langInfo.settings = settings;
 		langInfo.callback = callback;
 
 		LOGFONT font;

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -269,14 +269,9 @@ class Win32FontCacheFactory : FontCacheFactory {
 public:
 	Win32FontCacheFactory() : FontCacheFactory("win32", "Win32 font loader") {}
 
-	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype) const override
+	std::unique_ptr<FontCache> LoadFont(FontSize fs, FontType fonttype, bool search, const std::string &font_name, const std::any &os_handle) const override
 	{
 		if (fonttype != FontType::TrueType) return nullptr;
-
-		FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
-
-		std::string font = GetFontCacheFontName(fs);
-		if (font.empty()) return nullptr;
 
 		LOGFONT logfont{};
 		logfont.lfPitchAndFamily = fs == FS_MONO ? FIXED_PITCH : VARIABLE_PITCH;
@@ -286,21 +281,22 @@ public:
 
 		/* If a GDI font description is present, e.g. from the automatic font
 		 * fallback search, use it. Otherwise, try to resolve it by font name. */
-		if (auto ptr = std::any_cast<LOGFONT>(&settings->os_handle)) {
+		if (auto ptr = std::any_cast<LOGFONT>(&os_handle)) {
 			logfont = *ptr;
-		} else if (font.find('.') != std::string::npos) {
+		} else if (font_name.find('.') != std::string::npos) {
 			/* Might be a font file name, try load it. */
-			if (!TryLoadFontFromFile(font, logfont)) {
-				ShowInfo("Unable to load file '{}' for {} font, using default windows font selection instead", font, FontSizeToName(fs));
+			if (!TryLoadFontFromFile(font_name, logfont)) {
+				ShowInfo("Unable to load file '{}' for {} font, using default windows font selection instead", font_name, FontSizeToName(fs));
+				if (!search) return nullptr;
 			}
 		}
 
 		if (logfont.lfFaceName[0] == 0) {
-			logfont.lfWeight = StrContainsIgnoreCase(font, " bold") ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
-			convert_to_fs(font, logfont.lfFaceName);
+			logfont.lfWeight = StrContainsIgnoreCase(font_name, " bold") ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
+			convert_to_fs(font_name, logfont.lfFaceName);
 		}
 
-		return LoadWin32Font(fs, logfont, GetFontCacheFontSize(fs), font);
+		return LoadWin32Font(fs, logfont, GetFontCacheFontSize(fs), font_name);
 	}
 
 	bool FindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback) const override

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2306,40 +2306,40 @@ std::string_view GetCurrentLanguageIsoCode()
 	return _langpack.langpack->isocode;
 }
 
-/**
- * Check whether there are glyphs missing in the current language.
- * @return If glyphs are missing, return \c true, else return \c false.
- */
-bool MissingGlyphSearcher::FindMissingGlyphs()
+void BaseStringMissingGlyphSearcher::DetermineRequiredGlyphs(FontSizes fontsizes)
 {
-	FontCache::LoadFontCaches(this->fontsizes);
+	this->missing_fontsizes.Reset();
+	this->missing_glyphs.clear();
 
 	this->Reset();
 	for (auto text = this->NextString(); text.has_value(); text = this->NextString()) {
-		FontSize size = this->DefaultSize();
-		FontCache *fc = FontCache::Get(size);
+		FontSize fs = this->DefaultSize();
+		FontCache *fc = FontCache::Get(fs);
 		for (char32_t c : Utf8View(*text)) {
 			if (c >= SCC_FIRST_FONT && c <= SCC_LAST_FONT) {
-				size = (FontSize)(c - SCC_FIRST_FONT);
-				fc = FontCache::Get(size);
-			} else if (!IsInsideMM(c, SCC_SPRITE_START, SCC_SPRITE_END) && IsPrintable(c) && !IsTextDirectionChar(c) && fc->MapCharToGlyph(c, false) == 0) {
-				/* The character is printable, but not in the normal font. This is the case we were testing for. */
-				Debug(fontcache, 0, "Font is missing glyphs to display char 0x{:X} in {} font size", static_cast<uint32_t>(c), FontSizeToName(size));
-
-				/* For now, assume all fontsizes need searching if any are missing. */
-				this->missing_fontsizes = this->fontsizes;
-
-				return true;
+				fs = (FontSize)(c - SCC_FIRST_FONT);
+				fc = FontCache::Get(fs);
+				continue;
 			}
+
+			if (!fontsizes.Test(fs)) continue;
+			if (!IsPrintable(c) || IsTextDirectionChar(c)) continue;
+			if (IsInsideMM(c, SCC_SPRITE_START, SCC_SPRITE_END)) continue;
+			if (fc->MapCharToGlyph(c, false) != 0) continue;
+
+			this->missing_fontsizes.Set(fs);
+			this->missing_glyphs.insert(c);
 		}
 	}
-	return false;
 }
 
 /** Helper for searching through the language pack. */
-class LanguagePackGlyphSearcher : public MissingGlyphSearcher {
+class LanguagePackGlyphSearcher : public BaseStringMissingGlyphSearcher {
 public:
-	LanguagePackGlyphSearcher() : MissingGlyphSearcher(FONTSIZES_REQUIRED) {}
+	/**
+	 * Create this language pack glyph searcher.
+	 */
+	LanguagePackGlyphSearcher() : BaseStringMissingGlyphSearcher(FONTSIZES_REQUIRED) {}
 
 private:
 	uint i; ///< Iterator for the primary language tables.
@@ -2388,7 +2388,12 @@ void CheckForMissingGlyphs(MissingGlyphSearcher *searcher)
 {
 	static LanguagePackGlyphSearcher pack_searcher;
 	if (searcher == nullptr) searcher = &pack_searcher;
-	bool bad_font = searcher->FindMissingGlyphs();
+
+	FontCache::LoadFontCaches(searcher->fontsizes);
+
+	searcher->DetermineRequiredGlyphs(searcher->fontsizes);
+	bool bad_font = searcher->missing_fontsizes.Any();
+
 #if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
 	if (bad_font) {
 		/* We found an unprintable character... lets try whether we can find
@@ -2397,6 +2402,9 @@ void CheckForMissingGlyphs(MissingGlyphSearcher *searcher)
 		FontCacheSettings backup = _fcsettings;
 
 		bad_font = !FontProviderManager::FindFallbackFont(_langpack.langpack->isocode, searcher);
+		if (!bad_font) {
+			FontCache::LoadFontCaches(searcher->missing_fontsizes);
+		}
 
 		_fcsettings = std::move(backup);
 
@@ -2409,13 +2417,6 @@ void CheckForMissingGlyphs(MissingGlyphSearcher *searcher)
 			builder.PutUtf8(SCC_YELLOW);
 			builder.Put("The current font is missing some of the characters used in the texts for this language. Using system fallback font instead.");
 			ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, std::move(err_str)), {}, WL_WARNING);
-		}
-
-		if (bad_font) {
-			/* Our fallback font does miss characters too, so keep the
-			 * user chosen font as that is more likely to be any good than
-			 * the wild guess we made */
-			FontCache::LoadFontCaches(searcher->fontsizes);
 		}
 	}
 #endif
@@ -2432,12 +2433,12 @@ void CheckForMissingGlyphs(MissingGlyphSearcher *searcher)
 		ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, std::move(err_str)), {}, WL_WARNING);
 
 		/* Reset the font width */
-		LoadStringWidthTable(searcher->fontsizes);
+		LoadStringWidthTable(searcher->missing_fontsizes);
 		return;
 	}
 
 	/* Update the font with cache */
-	LoadStringWidthTable(searcher->fontsizes);
+	LoadStringWidthTable(searcher->missing_fontsizes);
 
 #if !(defined(WITH_ICU_I18N) && defined(WITH_HARFBUZZ)) && !defined(WITH_UNISCRIBE) && !defined(WITH_COCOA)
 	/*

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2312,7 +2312,7 @@ std::string_view GetCurrentLanguageIsoCode()
  */
 bool MissingGlyphSearcher::FindMissingGlyphs()
 {
-	FontCache::LoadFontCaches(this->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
+	FontCache::LoadFontCaches(this->fontsizes);
 
 	this->Reset();
 	for (auto text = this->NextString(); text.has_value(); text = this->NextString()) {
@@ -2325,6 +2325,10 @@ bool MissingGlyphSearcher::FindMissingGlyphs()
 			} else if (!IsInsideMM(c, SCC_SPRITE_START, SCC_SPRITE_END) && IsPrintable(c) && !IsTextDirectionChar(c) && fc->MapCharToGlyph(c, false) == 0) {
 				/* The character is printable, but not in the normal font. This is the case we were testing for. */
 				Debug(fontcache, 0, "Font is missing glyphs to display char 0x{:X} in {} font size", static_cast<uint32_t>(c), FontSizeToName(size));
+
+				/* For now, assume all fontsizes need searching if any are missing. */
+				this->missing_fontsizes = this->fontsizes;
+
 				return true;
 			}
 		}
@@ -2334,6 +2338,10 @@ bool MissingGlyphSearcher::FindMissingGlyphs()
 
 /** Helper for searching through the language pack. */
 class LanguagePackGlyphSearcher : public MissingGlyphSearcher {
+public:
+	LanguagePackGlyphSearcher() : MissingGlyphSearcher(FONTSIZES_REQUIRED) {}
+
+private:
 	uint i; ///< Iterator for the primary language tables.
 	uint j; ///< Iterator for the secondary language tables.
 
@@ -2362,24 +2370,6 @@ class LanguagePackGlyphSearcher : public MissingGlyphSearcher {
 
 		return ret;
 	}
-
-	bool Monospace() override
-	{
-		return false;
-	}
-
-	void SetFontNames([[maybe_unused]] FontCacheSettings *settings, [[maybe_unused]] std::string_view font_name, [[maybe_unused]] const void *os_data) override
-	{
-#if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
-		settings->small.font = font_name;
-		settings->medium.font = font_name;
-		settings->large.font = font_name;
-
-		settings->small.os_handle = os_data;
-		settings->medium.os_handle = os_data;
-		settings->large.os_handle = os_data;
-#endif
-	}
 };
 
 /**
@@ -2406,10 +2396,7 @@ void CheckForMissingGlyphs(MissingGlyphSearcher *searcher)
 		bool any_font_configured = !_fcsettings.medium.font.empty();
 		FontCacheSettings backup = _fcsettings;
 
-		_fcsettings.mono.os_handle = nullptr;
-		_fcsettings.medium.os_handle = nullptr;
-
-		bad_font = !FontProviderManager::FindFallbackFont(&_fcsettings, _langpack.langpack->isocode, searcher);
+		bad_font = !FontProviderManager::FindFallbackFont(_langpack.langpack->isocode, searcher);
 
 		_fcsettings = std::move(backup);
 
@@ -2428,7 +2415,7 @@ void CheckForMissingGlyphs(MissingGlyphSearcher *searcher)
 			/* Our fallback font does miss characters too, so keep the
 			 * user chosen font as that is more likely to be any good than
 			 * the wild guess we made */
-			FontCache::LoadFontCaches(searcher->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
+			FontCache::LoadFontCaches(searcher->fontsizes);
 		}
 	}
 #endif
@@ -2445,12 +2432,12 @@ void CheckForMissingGlyphs(MissingGlyphSearcher *searcher)
 		ShowErrorMessage(GetEncodedString(STR_JUST_RAW_STRING, std::move(err_str)), {}, WL_WARNING);
 
 		/* Reset the font width */
-		LoadStringWidthTable(searcher->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
+		LoadStringWidthTable(searcher->fontsizes);
 		return;
 	}
 
 	/* Update the font with cache */
-	LoadStringWidthTable(searcher->Monospace() ? FontSizes{FS_MONO} : FONTSIZES_REQUIRED);
+	LoadStringWidthTable(searcher->fontsizes);
 
 #if !(defined(WITH_ICU_I18N) && defined(WITH_HARFBUZZ)) && !defined(WITH_UNISCRIBE) && !defined(WITH_COCOA)
 	/*

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -167,6 +167,25 @@ public:
 
 	const FontSizes fontsizes; ///< Font sizes this searcher will try to find.
 	FontSizes missing_fontsizes{}; ///< Font sizes to actually search for.
+	std::set<char32_t> missing_glyphs{}; ///< Glyphs to search for.
+
+	/**
+	 * Determine set of glyphs required for the current language.
+	 * @param fontsizes Font sizes to test.
+	 **/
+	virtual void DetermineRequiredGlyphs(FontSizes fontsizes) = 0;
+};
+
+/** Base for missing glyph searchers that look for missing glyphs in strings. */
+class BaseStringMissingGlyphSearcher : public MissingGlyphSearcher {
+public:
+	/**
+	 * Create this string glyph searcher.
+	 * @param fontsizes Font sizes to consider.
+	 */
+	BaseStringMissingGlyphSearcher(FontSizes fontsizes) : MissingGlyphSearcher(fontsizes) {}
+
+	void DetermineRequiredGlyphs(FontSizes fontsizes) override;
 
 	/**
 	 * Get the next string to search through.
@@ -184,10 +203,8 @@ public:
 	 * Reset the search, i.e. begin from the beginning again.
 	 */
 	virtual void Reset() = 0;
-
-	bool FindMissingGlyphs();
 };
 
-void CheckForMissingGlyphs(MissingGlyphSearcher *search = nullptr);
+void CheckForMissingGlyphs(MissingGlyphSearcher *searcher = nullptr);
 
 #endif /* STRINGS_FUNC_H */

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -156,8 +156,17 @@ EncodedString GetEncodedString(StringID string, const Args&... args)
  */
 class MissingGlyphSearcher {
 public:
+	/**
+	 * Create this glyph searcher.
+	 * @param fontsizes Font sizes to consider.
+	 */
+	MissingGlyphSearcher(FontSizes fontsizes) : fontsizes(fontsizes) {}
+
 	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~MissingGlyphSearcher() = default;
+
+	const FontSizes fontsizes; ///< Font sizes this searcher will try to find.
+	FontSizes missing_fontsizes{}; ///< Font sizes to actually search for.
 
 	/**
 	 * Get the next string to search through.
@@ -175,20 +184,6 @@ public:
 	 * Reset the search, i.e. begin from the beginning again.
 	 */
 	virtual void Reset() = 0;
-
-	/**
-	 * Whether to search for a monospace font or not.
-	 * @return True if searching for monospace.
-	 */
-	virtual bool Monospace() = 0;
-
-	/**
-	 * Set the right font names.
-	 * @param settings  The settings to modify.
-	 * @param font_name The new font name.
-	 * @param os_data Opaque pointer to OS-specific data.
-	 */
-	virtual void SetFontNames(struct FontCacheSettings *settings, std::string_view font_name, const void *os_data = nullptr) = 0;
 
 	bool FindMissingGlyphs();
 };

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -83,7 +83,7 @@ static WindowDesc _textfile_desc(
 	_nested_textfile_widgets
 );
 
-TextfileWindow::TextfileWindow(Window *parent, TextfileType file_type) : Window(_textfile_desc), MissingGlyphSearcher(FS_MONO), file_type(file_type)
+TextfileWindow::TextfileWindow(Window *parent, TextfileType file_type) : Window(_textfile_desc), BaseStringMissingGlyphSearcher(FS_MONO), file_type(file_type)
 {
 	/* Init of nested tree is deferred.
 	 * TextfileWindow::ConstructWindow must be called by the inheriting window. */

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -83,7 +83,7 @@ static WindowDesc _textfile_desc(
 	_nested_textfile_widgets
 );
 
-TextfileWindow::TextfileWindow(Window *parent, TextfileType file_type) : Window(_textfile_desc), file_type(file_type)
+TextfileWindow::TextfileWindow(Window *parent, TextfileType file_type) : Window(_textfile_desc), MissingGlyphSearcher(FS_MONO), file_type(file_type)
 {
 	/* Init of nested tree is deferred.
 	 * TextfileWindow::ConstructWindow must be called by the inheriting window. */
@@ -752,19 +752,6 @@ bool TextfileWindow::IsTextWrapped() const
 	if (this->search_iterator >= this->lines.size()) return std::nullopt;
 
 	return this->lines[this->search_iterator++].text;
-}
-
-/* virtual */ bool TextfileWindow::Monospace()
-{
-	return true;
-}
-
-/* virtual */ void TextfileWindow::SetFontNames([[maybe_unused]] FontCacheSettings *settings, [[maybe_unused]] std::string_view font_name, [[maybe_unused]] const void *os_data)
-{
-#if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
-	settings->mono.font = font_name;
-	settings->mono.os_handle = os_data;
-#endif
 }
 
 #if defined(WITH_ZLIB)

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -38,8 +38,6 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 	void Reset() override;
 	FontSize DefaultSize() override;
 	std::optional<std::string_view> NextString() override;
-	bool Monospace() override;
-	void SetFontNames(FontCacheSettings *settings, std::string_view font_name, const void *os_data) override;
 	void ScrollToLine(size_t line);
 	bool IsTextWrapped() const;
 

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -19,7 +19,7 @@
 std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, std::string_view filename);
 
 /** Window for displaying a textfile */
-struct TextfileWindow : public Window, MissingGlyphSearcher {
+struct TextfileWindow : public Window, BaseStringMissingGlyphSearcher {
 	TextfileType file_type{}; ///< Type of textfile to view.
 	Scrollbar *vscroll = nullptr; ///< Vertical scrollbar.
 	Scrollbar *hscroll = nullptr; ///< Horizontal scrollbar.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When testing if a fallback font is suitable for use, the fontcache system is reset, and the language files rescanned to see if there are any missing glyphs. This happens for each potential font.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, keep a list of required glyphs up front, and temporarily load each font to test it for required glyphs.

The fontcache is only reloaded once at the end if a fallback font is found.

This is based on code that was present in the side-by-side font cache changes, though reworked a bit.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

On Windows, scanning and opening fonts can be quite slow. This may or may not improve it.

Has not been tested on Windows or Mac OS.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
