### PR TITLE
Fix #14624: Don't apply linkgraph days-to-seconds migration on fresh …

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1400,7 +1400,7 @@ void LoadFromConfig(bool startup)
 
 	/* Load basic settings only during bootstrap, load other settings not during bootstrap */
 	if (!startup) {
-		if (generic_version < IFV_LINKGRAPH_SECONDS) {
+		if (generic_version < IFV_LINKGRAPH_SECONDS && generic_ini.GetGroup("linkgraph") != nullptr) {
 			_settings_newgame.linkgraph.recalc_interval *= CalendarTime::SECONDS_PER_DAY;
 			_settings_newgame.linkgraph.recalc_time     *= CalendarTime::SECONDS_PER_DAY;
 		}


### PR DESCRIPTION
Closes #14624 

When the linkgraph logic executes which I am assuming is to manage older save files (Days to seconds) it multiplies the values described in the issue as well. Now there is an additional check for it if it is an old file it converts it into seconds, otherwise it is the defaults values.

