### PR TITLE
Update: Update changelog and bump release version for 15.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT BINARY_NAME)
 endif()
 
 project(${BINARY_NAME}
-    VERSION 15.2
+    VERSION 15.3
     LANGUAGES CXX
 )
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 ## 15.x
 
+### 15.3 (2026-04-04)
+
+- Fix: Conditional orders could require a maximum reliability over 100% (#15409)
+- Fix: Improve appearance of toolbars and main menu images/text with some non-default base sets (#15402)
+- Fix: [Script] IsBuildableRectangle for a 0x0 tile should return false (#15357)
+- Fix: Desync caused by train crashes (#15338)
+- Fix: Incorrect scroll bar capacity for train details window total cargo tab (#15329)
+- Fix #15310: Crash caused by a helicopter running out of fuel near map edge (#15311)
+
 ### 15.2 (2026-02-18)
 
 - Fix: Crashed zeppelin not blocking runway (#15281)


### PR DESCRIPTION
## Motivation / Problem

Let's release 15.3, to eliminate a desync and make the main menu look nicer (with some non-default base sets).

## Description

Update changelog with the PRs in #15417 (all previous were in 15.2).

Bump the release version.

Website PR: https://github.com/OpenTTD/website/pull/385

## Limitations



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
