### PR TITLE
Codechange: [CI] Use unprivileged env to build preview

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -2,21 +2,10 @@ name: Preview build
 
 on:
   workflow_call:
-    secrets:
-      PREVIEW_CLOUDFLARE_API_TOKEN:
-        description: API token to upload a preview to Cloudflare Pages
-        required: true
-      PREVIEW_CLOUDFLARE_ACCOUNT_ID:
-        description: Account ID to upload a preview to Cloudflare Pages
-        required: true
 
 jobs:
   preview:
     name: Build preview
-
-    environment:
-      name: preview
-      url: https://preview.openttd.org/pr${{ github.event.pull_request.number }}/
 
     runs-on: ubuntu-latest
     container:
@@ -97,16 +86,14 @@ jobs:
         cp build/openttd.js public/
         cp build/openttd.wasm public/
 
-        # Ensure we use the latest version of npm; the one we get with current
-        # emscripten doesn't allow running "npx wrangler" as root.
-        # Current emscripten can't install npm>=10.0.0 because node is too old.
-        npm install -g npm@9
+        mkdir pr
+        echo ${{ github.event.pull_request.number }} > ./pr/number
 
-    - name: Publish preview
-      uses: cloudflare/pages-action@v1
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
       with:
-        apiToken: ${{ secrets.PREVIEW_CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.PREVIEW_CLOUDFLARE_ACCOUNT_ID }}
-        projectName: ${{ vars.PREVIEW_CLOUDFLARE_PROJECT_NAME }}
-        directory: public
-        branch: pr${{ github.event.pull_request.number }}
+        name: pr${{ github.event.pull_request.number }}
+        path: |
+          public
+          pr
+        retention-days: 1

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -1,0 +1,51 @@
+name: Preview publish
+
+on:
+  workflow_run:
+    workflows:
+    - Preview
+    types:
+    - completed
+
+jobs:
+  preview:
+    name: Publish preview
+
+    environment:
+      name: preview
+      url: https://preview.openttd.org/pr${{ steps.pr.outputs.number }}/
+
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        run-id: ${{github.event.workflow_run.id }}
+
+    - name: Get PR number
+      id: pr
+      run: |
+        echo "number=$(cat pr/number)" >> $GITHUB_OUTPUT
+
+    - name: Publish preview
+      uses: cloudflare/wrangler-action@v3
+      with:
+        apiToken: ${{ secrets.PREVIEW_CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.PREVIEW_CLOUDFLARE_ACCOUNT_ID }}
+        command: pages deploy public --project-name=${{ vars.PREVIEW_CLOUDFLARE_PROJECT_NAME }} --branch pr${{ steps.pr.outputs.number }}
+
+    - name: Report status
+      if: always()
+      run: |
+        curl -L \
+        -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+        -H "X-GitHub-Api-Version: 2026-03-10" \
+        https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }} \
+        -d '{"state":"${{ job.status }}","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}","context":"Publish preview"}'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,7 @@
 name: Preview
 
 on:
-  pull_request_target:
+  pull_request:
     types:
     - labeled
     - synchronize


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
A message from @TrueBrain:
>I disabled "Preview" in OpenTTD repo. There is some nastiness going around on GitHub, where people create a PR which tries to exfil repo secrets. Now although CI isn't starting with approval, for `pull_request_target` this is bypassed, and it always runs. The `preview.yml` uses this, so I disabled it.
>If it is still useful, someone needs to take a look at this, to ensure that evil people can't exfil secrets with it 🙁
>https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ and further details what is happening, and that it is intended.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I followed the instructions in the link:
* replaced `pull_request_target` with `pull_request` so `preview.yml` and `preview-build.yml` run unprivileged.
* upload artifacts at the end of `preview-build.yml` so a privileged workflow can retrieve them later.
* introduced a new workflow triggered on `workflow_run` when `Preview` is completed to do the actual publishing.

When looking at `cloudflare/pages-action` documentation I noticed it was deprecated so I migrated to `cloudflare/wrangler-action` (but this change is completely untested and I can un-migrate if required).

### Things to do before re-enabling previews once this PR is merged
* remove `preview` label from all open PRs.
* be sure a PR is up-to-date with master before adding `preview` label.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
It was painful to test `workflow_run` because the workflow needs to be in default branch, but I tested everything except `Publish preview` step (lacking secrets in my fork).
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
