### PR TITLE
Fix: Typo in Hungarian town name suffix ("kak" -> "lak")

### DIFF
--- a/src/table/townname.h
+++ b/src/table/townname.h
@@ -2450,7 +2450,7 @@ static const std::string_view _name_hungarian_3[] = {
 	"fa",
 	"f\u00f6ld",
 	"hegyes",
-	"kak",
+	"lak",
 	"kereszt",
 	"k\u00fcrt",
 	"lad\u00e1ny",


### PR DESCRIPTION
## Motivation / Problem

While playing with Hungarian town names I found some of the town names amusing, having the "kak" suffix, as is it is very similar to Hungarian word for excrement "kaka" or "kaki". However later I realized it might be a misspelling of a legitimate suffix "lak" meaning home or dwelling. While I could not find any town names with the "kak" suffix, here are some town names with the "lak" suffix: Abaújlak, Alsóújlak, Balatonújlak, Géderlak, Mezőlak, Nagylak, Ormándlak

## Description
Changed "kak" suffix to "lak"


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
