### PR TITLE
Fix #15428: [Fluidsynth] treat configured synth.gain as maximum instead of hardcoded value

### DIFF
--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -26,6 +26,7 @@ static struct {
 	fluid_synth_t *synth; ///< FluidSynth synthesizer handle
 	fluid_player_t *player; ///< FluidSynth MIDI player handle
 	std::mutex synth_mutex; ///< Guard mutex for synth access
+	double max_gain; ///< Default max gain.
 } _midi; ///< Metadata about the midi we're playing.
 
 /** Factory for the FluidSynth driver. */
@@ -137,6 +138,14 @@ std::optional<std::string_view> MusicDriver_FluidSynth::Start(const StringList &
 		if (sfont_id == FLUID_FAILED) return "Could not open sound font";
 	}
 
+	/* Treat a configured synth gain as the maximum gain to use. */
+	if (fluid_settings_getnum(_midi.settings, "synth.gain", &_midi.max_gain) != FLUID_OK) {
+		if (fluid_settings_getnum_default(_midi.settings, "synth.gain", &_midi.max_gain) != FLUID_OK) {
+			/* No synth.gain value present for some reason, use FluidSynth's default value. */
+			_midi.max_gain = 0.2;
+		}
+	}
+
 	_midi.player = nullptr;
 
 	return std::nullopt;
@@ -217,11 +226,8 @@ void MusicDriver_FluidSynth::SetVolume(uint8_t vol)
 	std::lock_guard<std::mutex> lock{_midi.synth_mutex};
 	if (_midi.settings == nullptr) return;
 
-	/* Allowed range of synth.gain is 0.0 to 10.0 */
-	/* fluidsynth's default gain is 0.2, so use this as "full
-	 * volume". Set gain using OpenTTD's volume, as a number between 0
-	 * and 0.2. */
-	double gain = (1.0 * vol) / (128.0 * 5.0);
+	/* Set gain using OpenTTD's volume, as a number between 0 and max_gain. */
+	double gain = (1.0 * vol) / 128.0 * _midi.max_gain;
 	if (fluid_settings_setnum(_midi.settings, "synth.gain", gain) != FLUID_OK) {
 		Debug(driver, 0, "Could not set volume");
 	}


### PR DESCRIPTION

<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #15428, to set music volume, OpenTTD always scales `synth.gain` based on FluidSynth's default value of 0.2 (obfuscated as `1 / 5.0`), and the user's configured `synth.gain` is ignored.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, read `synth.gain` on start up and treat it as the maximum gain value. OpenTTD's internal volume will be scaled from 0 to this gain, instead of being hardcoded to scale from 0 to 0.2.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
