### PR TITLE
Codechange: Make doxygen ignore some parts of code that it does not understand.

### DIFF
--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -19,13 +19,15 @@
 
 #include "../safeguards.h"
 
-/** Mapping to a string representation of the Reason enumeration. */
+#ifndef DOXYGEN_API
+/* Mapping to a string representation of the Reason enumeration. */
 NLOHMANN_JSON_SERIALIZE_ENUM(NetworkSurveyHandler::Reason, {
 	{NetworkSurveyHandler::Reason::Preview, "preview"},
 	{NetworkSurveyHandler::Reason::Leave, "leave"},
 	{NetworkSurveyHandler::Reason::Exit, "exit"},
 	{NetworkSurveyHandler::Reason::Crash, "crash"},
 })
+#endif /* DOXYGEN_API */
 
 NetworkSurveyHandler _survey = {};
 

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -79,6 +79,8 @@
 
 #include "safeguards.h"
 
+#ifndef DOXYGEN_API
+
 NLOHMANN_JSON_SERIALIZE_ENUM(GRFStatus, {
 	{GRFStatus::GCS_UNKNOWN, "unknown"},
 	{GRFStatus::GCS_DISABLED, "disabled"},
@@ -97,6 +99,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(SocialIntegrationPlugin::State, {
 	{SocialIntegrationPlugin::State::INVALID_SIGNATURE, "invalid_signature"},
 })
 
+#endif /* DOXYGEN_API */
 
 /** Lookup table to convert a VehicleType to a string. */
 static const std::string _vehicle_type_to_string[] = {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Docs checker fails in [#15426](https://github.com/OpenTTD/OpenTTD/pull/15426) because of this:
> /home/runner/work/OpenTTD/OpenTTD/src/survey.cpp:$: warning: Member NLOHMANN_JSON_SERIALIZE_ENUM(GRFStatus, { {GRFStatus::Unknown, "unknown"}, {GRFStatus::Disabled, "disabled"}, {GRFStatus::NotFound, "not found"}, {GRFStatus::Initialised, "initialised"}, {GRFStatus::Activated, "activated"}, }) NLOHMANN_JSON_SERIALIZE_ENUM(SocialIntegrationPlugin (function) of file survey.cpp is not documented.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Thats because doxygen did not expand macro, which is corect as in Doxyfile.in `EXPAND_ONLY_PREDEF` is set to `YES` and in `EXPAND_AS_DEFINED` is only `DEFINE_POOL_METHOD`.
If `NLOHMANN_JSON_SERIALIZE_ENUM` is added to `EXPAND_AS_DEFINED` too then doxygen will complain about undocumented nlohmann json's internal functions:
> /home/cyprian/openTTD/OpenTTD_SourceCode/src/network/network_survey.cpp:28: warning: Member from_json(const BasicJsonType &j, NetworkSurveyHandler::Reason &e) (function) of file network_survey.cpp is not documented.
> <from_json>:1: warning: parameters of member from_json are not documented
> /home/cyprian/openTTD/OpenTTD_SourceCode/src/network/network_survey.cpp:22: warning: parameters of member to_json are not documented
> /home/cyprian/openTTD/OpenTTD_SourceCode/src/survey.cpp:88: warning: Member to_json(BasicJsonType &j, const GRFStatus &e) (function) of file survey.cpp is not documented.
> /home/cyprian/openTTD/OpenTTD_SourceCode/src/survey.cpp:88: warning: Member from_json(const BasicJsonType &j, GRFStatus &e) (function) of file survey.cpp is not documented.
> /home/cyprian/openTTD/OpenTTD_SourceCode/src/survey.cpp:98: warning: Member to_json(BasicJsonType &j, const SocialIntegrationPlugin::State &e) (function) of file survey.cpp is not documented.
> /home/cyprian/openTTD/OpenTTD_SourceCode/src/survey.cpp:98: warning: Member from_json(const BasicJsonType &j, SocialIntegrationPlugin::State &e) (function) of file survey.cpp is not documented.
> <to_json>:1: warning: parameters of member to_json are not documented

as they aren't used in the OTTD's source code (except 3rdparty/nlohmann/json.hpp) it feels a bit strange to document them.

Therefore it is probably just better to hide that code from doxygen so it does not complain about it.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
It is a local solution to projectwise problem.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
