### PR TITLE
Add: Setting to disable aircraft range limit

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -615,7 +615,7 @@ void UpdateAircraftCache(Aircraft *v, bool update_range)
 
 	/* Update aircraft range. */
 	if (update_range) {
-		v->acache.cached_max_range = GetVehicleProperty(v, PROP_AIRCRAFT_RANGE, AircraftVehInfo(v->engine_type)->max_range);
+		v->acache.cached_max_range = Engine::Get(v->engine_type)->GetRange();
 		/* Squared it now so we don't have to do it later all the time. */
 		v->acache.cached_max_range_sqr = v->acache.cached_max_range * v->acache.cached_max_range;
 	}

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -455,6 +455,7 @@ TimerGameCalendar::Date Engine::GetLifeLengthInDays() const
  */
 uint16_t Engine::GetRange() const
 {
+	if (!_settings_game.vehicle.aircraft_range) return 0;
 	switch (this->type) {
 		case VEH_AIRCRAFT:
 			return GetEngineProperty(this->index, PROP_AIRCRAFT_RANGE, this->VehInfo<AircraftVehicleInfo>().max_range);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1905,6 +1905,9 @@ STR_CONFIG_SETTING_STATION_LENGTH_LOADING_PENALTY_HELPTEXT      :When enabled, t
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS                             :Enable wagon speed limits: {STRING2}
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT                    :When enabled, also use speed limits of wagons for deciding the maximum speed of a train
 
+STR_CONFIG_SETTING_AIRCRAFT_RANGE                               :Enable aircraft maximum range: {STRING2}
+STR_CONFIG_SETTING_AIRCRAFT_RANGE_HELPTEXT                      :When enabled, NewGRFs will be able to limit maximum range of aircraft
+
 STR_CONFIG_SETTING_DISABLE_ELRAILS                              :Disable electric rails: {STRING2}
 STR_CONFIG_SETTING_DISABLE_ELRAILS_HELPTEXT                     :Enabling this setting disables the requirement to electrify tracks to make electric engines run on them
 

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -731,6 +731,7 @@ SettingsContainer &GetSettingsTree()
 				physics->Add(new SettingEntry("vehicle.roadveh_slope_steepness"));
 				physics->Add(new SettingEntry("vehicle.smoke_amount"));
 				physics->Add(new SettingEntry("vehicle.plane_speed"));
+				physics->Add(new SettingEntry("vehicle.aircraft_range"));
 			}
 
 			SettingsPage *routing = vehicles->Add(new SettingsPage(STR_CONFIG_SETTING_VEHICLES_ROUTING));

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -50,6 +50,8 @@
 #include "void_map.h"
 #include "station_func.h"
 #include "station_base.h"
+#include "aircraft.h"
+#include "aircraft_cmd.h"
 
 #include "table/strings.h"
 #include "table/settings.h"
@@ -361,6 +363,24 @@ static void RoadVehSlopeSteepnessChanged(int32_t)
 {
 	for (RoadVehicle *rv : RoadVehicle::Iterate()) {
 		if (rv->IsFrontEngine()) rv->CargoChanged();
+	}
+}
+
+/**
+ * This function updates the aircraft cache when the aircraft range setting is changed.
+ */
+static void AircraftRangeChanged(int32_t)
+{
+	for (Aircraft *v : Aircraft::Iterate()) {
+		v->acache.cached_max_range = Engine::Get(v->engine_type)->GetRange();
+		v->acache.cached_max_range_sqr = v->acache.cached_max_range * v->acache.cached_max_range;
+
+		/* Reset destination is too far state */
+		if (v->flags.Test(VehicleAirFlag::DestinationTooFar)) {
+			v->flags.Reset(VehicleAirFlag::DestinationTooFar);
+			SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);
+			DeleteVehicleNews(v->index, AdviceType::AircraftDestinationTooFar);
+		}
 	}
 }
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -562,6 +562,7 @@ struct VehicleSettings {
 	uint8_t extend_vehicle_life;              ///< extend vehicle life by this many years
 	uint8_t road_side;                        ///< the side of the road vehicles drive on
 	uint8_t  plane_crashes;                    ///< number of plane crashes, 0 = none, 1 = reduced, 2 = normal
+	bool aircraft_range; ///< enable range limits for aircraft
 };
 
 /** Settings related to the economy. */

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -21,6 +21,7 @@ static bool CheckRoadSide(int32_t &new_value);
 static bool CheckDynamicEngines(int32_t &new_value);
 static void StationCatchmentChanged(int32_t new_value);
 static void MaxVehiclesChanged(int32_t new_value);
+static void AircraftRangeChanged(int32_t new_value);
 
 static const SettingVariant _game_settings_table[] = {
 [post-amble]
@@ -354,6 +355,15 @@ str      = STR_CONFIG_SETTING_PLANE_CRASHES
 strhelp  = STR_CONFIG_SETTING_PLANE_CRASHES_HELPTEXT
 strval   = STR_CONFIG_SETTING_PLANE_CRASHES_NONE
 cat      = SC_BASIC
+
+[SDT_BOOL]
+var      = vehicle.aircraft_range
+flags    = SettingFlag::NoNetwork
+def      = true
+str      = STR_CONFIG_SETTING_AIRCRAFT_RANGE
+strhelp  = STR_CONFIG_SETTING_AIRCRAFT_RANGE_HELPTEXT
+post_cb  = AircraftRangeChanged
+cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = vehicle.extend_vehicle_life


### PR DESCRIPTION

## Motivation / Problem

Aircraft NewGRFs often add range limits to their aircraft, sometimes with no parameter to turn them off. While it can be argued that this should remain the responsibility of the NewGRF, other similar settings have been part of the game all along. 

Take wagon speed limits for example. Like aircraft range, this property is not present in the vanilla vehicles and is only added by NewGRF vehicle sets. But the game has had a setting to disable these for a very long time, and NewGRFs are not expected to include a parameter to disable the speed limits.

Conversely, aircraft range limits are forced on the player if the NewGRF supplies that property. It is up to the NewGRF author to include a parameter to disable them, and has led to various "rangeless" variants of aircraft NewGRFs for sets that don't have this option.

The reason for wanting to disable range limits is because the ranges simply may not make sense given the map size. There is no fixed scale in OpenTTD, so a large map can represent a relatively small area of the real world, which can easily be crossed by jet airliners. This PR is aimed at players who play large and realistic maps, who do not want to make fuel stops for what should be a short-haul flight.

There has been discussion in the past about adjusting ranges as a fraction of the map size rather than fixed tile limits, but that is beyond the scope of this PR.


## Description

This PR adds a setting to disable the range limit for aircraft, ignoring the range property provided by the NewGRF.

It also includes a function to clear the aircraft cache, so aircraft already existing on the map will be affected by the setting change.


## Limitations

Adds another setting to a game with too many settings already.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
