### PR TITLE
Codechange: Remove goto jumps from TrainController

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3436,7 +3436,14 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 							v->wait_counter = 0;
 							return false;
 						}
-						goto reverse_train_direction;
+
+						if (reverse) {
+							v->wait_counter = 0;
+							v->cur_speed = 0;
+							v->subspeed = 0;
+							ReverseTrainDirection(v);
+						}
+						return false;
 					} else {
 						TryReserveRailTrack(gp.new_tile, TrackBitsToTrack(chosen_track), false);
 					}
@@ -3610,16 +3617,6 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 	if (direction_changed) first->tcache.cached_max_curve_speed = first->GetCurveSpeedLimit();
 
 	return true;
-
-reverse_train_direction:
-	if (reverse) {
-		v->wait_counter = 0;
-		v->cur_speed = 0;
-		v->subspeed = 0;
-		ReverseTrainDirection(v);
-	}
-
-	return false;
 }
 
 static bool IsRailStationPlatformOccupied(TileIndex tile)

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3333,9 +3333,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 					if (v->IsFrontEngine() && !TrainCheckIfLineEnds(v, reverse)) return false;
 
 					auto vets = VehicleEnterTile(v, gp.new_tile, gp.x, gp.y);
-					if (vets.Test(VehicleEnterTileState::CannotEnter)) {
-						goto invalid_rail;
-					}
+					assert(!vets.Test(VehicleEnterTileState::CannotEnter));
 					if (vets.Test(VehicleEnterTileState::EnteredStation)) {
 						/* The new position is the end of the platform */
 						TrainEnterStation(v, GetStationIndex(gp.new_tile));
@@ -3363,11 +3361,10 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 					bits &= ~TrackCrossesTracks(FindFirstTrack(v->track));
 				}
 
-				if (bits == TRACK_BIT_NONE) goto invalid_rail;
+				assert(bits != TRACK_BIT_NONE);
 
-				/* Check if the new tile constrains tracks that are compatible
-				 * with the current train, if not, bail out. */
-				if (!CheckCompatibleRail(v, gp.new_tile)) goto invalid_rail;
+				/* The new tile must contain tracks that are compatible with the current train. */
+				assert(CheckCompatibleRail(v, gp.new_tile));
 
 				TrackBits chosen_track;
 				if (prev == nullptr) {
@@ -3490,9 +3487,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 
 				/* Call the landscape function and tell it that the vehicle entered the tile */
 				auto vets = VehicleEnterTile(v, gp.new_tile, gp.x, gp.y);
-				if (vets.Test(VehicleEnterTileState::CannotEnter)) {
-					goto invalid_rail;
-				}
+				assert(!vets.Test(VehicleEnterTileState::CannotEnter));
 
 				if (!vets.Test(VehicleEnterTileState::EnteredWormhole)) {
 					Track track = FindFirstTrack(chosen_track);
@@ -3615,10 +3610,6 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 	if (direction_changed) first->tcache.cached_max_curve_speed = first->GetCurveSpeedLimit();
 
 	return true;
-
-invalid_rail:
-	/* We've reached end of line?? */
-	if (prev != nullptr) FatalError("Disconnecting train");
 
 reverse_train_direction:
 	if (reverse) {


### PR DESCRIPTION
## Motivation / Problem

TrainController uses two `goto` jumps, which are not good coding practice. I'm tired of seeing "Disconnecting train" errors while debugging my backwards-trains PR rebase and wishing it was a nice assertion that told me exactly what went wrong.

## Description

Convert `goto invalid_rail` to assertions.

While I'm there, remove the other jump in TrainController, `goto reverse_train_direction`. It's only called from one place, so I just moved the code there.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
