### PR TITLE
Add: Allow precisely erasing rocks in scenario editor

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3082,7 +3082,7 @@ STR_TREES_MODE_FOREST_LG_TOOLTIP                                :{BLACK}Plant la
 
 # Land generation window (SE)
 STR_TERRAFORM_TOOLBAR_LAND_GENERATION_CAPTION                   :{WHITE}Land Generation
-STR_TERRAFORM_TOOLTIP_PLACE_ROCKY_AREAS_ON_LANDSCAPE            :{BLACK}Place rocky areas on landscape
+STR_TERRAFORM_TOOLTIP_PLACE_ROCKY_AREAS_ON_LANDSCAPE            :{BLACK}Place rocky areas on landscape.{}Ctrl+Click to remove rocky areas
 STR_TERRAFORM_TOOLTIP_DEFINE_DESERT_AREA                        :{BLACK}Define desert area.{}Ctrl+Click to remove desert area
 STR_TERRAFORM_TOOLTIP_INCREASE_SIZE_OF_LAND_AREA                :{BLACK}Increase area of land to lower/raise
 STR_TERRAFORM_TOOLTIP_DECREASE_SIZE_OF_LAND_AREA                :{BLACK}Decrease area of land to lower/raise

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -80,8 +80,9 @@ static void GenerateDesertArea(TileIndex end, TileIndex start)
  * Scenario editor command that generates rocky areas.
  * @param end The end tile of the map drag.
  * @param start The start tile of the map drag.
+ * @param remove If true, remove rocks instead of placing them.
  */
-static void GenerateRockyArea(TileIndex end, TileIndex start)
+static void GenerateRockyArea(TileIndex end, TileIndex start, bool remove)
 {
 	if (_game_mode != GM_EDITOR) return;
 
@@ -92,10 +93,19 @@ static void GenerateRockyArea(TileIndex end, TileIndex start)
 		switch (GetTileType(tile)) {
 			case TileType::Trees:
 				if (GetTreeGround(tile) == TreeGround::Shore) continue;
-				[[fallthrough]];
+				if (!remove) {
+					MakeClear(tile, ClearGround::Rocks, 3);
+				}
+				break;
 
 			case TileType::Clear:
-				MakeClear(tile, ClearGround::Rocks, 3);
+				if (remove) {
+					if (GetClearGround(tile) == ClearGround::Rocks) {
+						MakeClear(tile, ClearGround::Grass, 3);
+					}
+				} else {
+					MakeClear(tile, ClearGround::Rocks, 3);
+				}
 				break;
 
 			default:
@@ -140,7 +150,7 @@ bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_t
 			Command<Commands::LevelLand>::Post(STR_ERROR_CAN_T_LEVEL_LAND_HERE, CcTerraform, end_tile, start_tile, _ctrl_pressed, LM_LEVEL);
 			break;
 		case DDSP_CREATE_ROCKS:
-			GenerateRockyArea(end_tile, start_tile);
+			GenerateRockyArea(end_tile, start_tile, _ctrl_pressed);
 			break;
 		case DDSP_CREATE_DESERT:
 			GenerateDesertArea(end_tile, start_tile);
@@ -703,6 +713,20 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 					break;
 			}
 		}
+	}
+
+	EventState OnCTRLStateChange() override
+	{
+		switch (this->last_user_action) {
+			case WID_ETT_PLACE_ROCKS:
+			case WID_ETT_PLACE_DESERT:
+				if (this->IsWidgetLowered(this->last_user_action)) {
+					SetSelectionRed(_ctrl_pressed);
+					return ES_HANDLED;
+				}
+				break;
+		}
+		return ES_NOT_HANDLED;
 	}
 
 	void OnPlaceObjectAbort() override


### PR DESCRIPTION
## Motivation / Problem

Many tools in the game allow holding Ctrl to precisely erase just that thing, including the scenario editor's desert placer, but not the scenario editor's rock placer. It seems useful to not have to be extra-careful with the dynamite tool.

## Description

When holding Ctrl:
- The "Place rocky areas" tool will precisely erase rocks instead of placing them.
- The "Place rocky areas" and "Define desert area" tools will highlight the cursor red.

## Limitations

Mirrors placement in that snow/desert is not respected and must be fixed up by the tile loop.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
