### PR TITLE
Add: Support automatic detection of data from Atari's Transport Tycoon Deluxe re-release

### DIFF
--- a/docs/directory_structure.md
+++ b/docs/directory_structure.md
@@ -38,6 +38,17 @@ your operating system:
 
     It includes the OpenTTD files (grf+lng) and it will work as long as they
     are not touched
+7. The Atari Transport Tycoon Deluxe directory, if installed (path may vary)
+
+    This refers to the `CD` folder within the Transport Tycoon Deluxe
+    installation folder (2026 Atari re-release). OpenTTD detects the presence
+    of this folder based upon the contents of the `installpath.ini` file located
+    in:
+    - Windows: `%APPDATA%\Atari\Transport Tycoon Deluxe`
+    - macOS: `~/Library/Application Support/Atari/Transport Tycoon Deluxe`
+    - Linux: `$XDG_DATA_HOME/Atari/Transport Tycoon Deluxe`
+
+    This is used only for the loading of base sets (graphics, sound, music).
 
 Different types of data or extensions go into different subdirectories of the
 chosen main OpenTTD directory:

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -167,6 +167,9 @@ std::string FioGetDirectory(Searchpath sp, Subdirectory subdir)
 	assert(subdir < Subdirectory::End);
 	assert(sp < Searchpath::End);
 
+	/* For official TTD directory, don't include the subdirectory. */
+	if (sp == Searchpath::TransportTycoonDeluxeDir && subdir == Subdirectory::Baseset) return _searchpaths[sp];
+
 	return fmt::format("{}{}", _searchpaths[sp], _subdirs[subdir]);
 }
 
@@ -197,7 +200,7 @@ static std::optional<FileHandle> FioFOpenFileSp(std::string_view filename, std::
 	if (subdir == Subdirectory::None) {
 		buf = filename;
 	} else {
-		buf = fmt::format("{}{}{}", _searchpaths[sp], _subdirs[subdir], filename);
+		buf = fmt::format("{}{}", FioGetDirectory(sp, subdir), filename);
 	}
 
 	auto f = FileHandle::Open(buf, mode);
@@ -871,6 +874,50 @@ extern void CocoaSetApplicationBundleDir();
 #else
 	_searchpaths[Searchpath::ApplicationBundleDir].clear();
 #endif
+
+	/* Look for Atari release of Transport Tycoon Deluxe for original data files */
+	std::string config_file_path;
+	const std::string atari_ini_filename = "Atari/Transport Tycoon Deluxe/installpath.ini";
+
+	_searchpaths[Searchpath::TransportTycoonDeluxeDir].clear();
+
+#ifdef WITH_COCOA
+extern std::string CocoaGetAppSupportDir();
+	config_file_path = CocoaGetAppSupportDir();
+
+	if (!config_file_path.empty()) {
+		AppendPathSeparator(config_file_path);
+		config_file_path += atari_ini_filename;
+	}
+#else
+	config_file_path = GetHomeDir();
+
+	if (!config_file_path.empty()) {
+		AppendPathSeparator(config_file_path);
+		config_file_path += ".local/share/";
+		config_file_path += atari_ini_filename;
+	}
+#endif
+
+	if (!config_file_path.empty()) {
+		size_t installpath_len;
+		std::unique_ptr<char[]> installpath = ReadFileToMem(config_file_path, installpath_len, MAX_PATH);
+
+		if (installpath != nullptr && installpath_len > 0) {
+			std::string ttd_path = installpath.get();
+			AppendPathSeparator(ttd_path);
+
+#ifdef WITH_COCOA
+			/* The path provided is to the TTD.app/Contents/MacOS folder */
+			ttd_path += "../Resources/";
+#endif
+
+			ttd_path += "CD";
+			AppendPathSeparator(ttd_path);
+
+			if (FileExists(ttd_path)) _searchpaths[Searchpath::TransportTycoonDeluxeDir] = ttd_path;
+		}
+	}
 }
 #endif /* defined(_WIN32) */
 

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -121,6 +121,7 @@ enum class Searchpath : uint8_t {
 	BinaryDir, ///< Search in the directory where the binary resides.
 	InstallationDir, ///< Search in the installation directory.
 	ApplicationBundleDir, ///< Search within the application bundle.
+	TransportTycoonDeluxeDir, ///< Search within the Transport Tycoon Deluxe data directory (if installed).
 	AutodownloadDir, ///< Search within the autodownload directory.
 	AutodownloadPersonalDir,///< Search within the autodownload directory located in the personal directory.
 	AutodownloadPersonalDirXdg, ///< Search within the autodownload directory located in the personal directory (XDG variant).

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -139,6 +139,17 @@ void CocoaSetApplicationBundleDir()
 }
 
 /**
+ * Returns the path to the user's Application Support folder.
+ */
+std::string CocoaGetAppSupportDir()
+{
+	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+	NSString *appSupportPath = [paths firstObject];
+
+	return [appSupportPath UTF8String];
+}
+
+/**
  * Setup autorelease for the application pool.
  *
  * These are called from main() to prevent a _NSAutoreleaseNoPool error when

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -322,6 +322,25 @@ void DetermineBasePaths(std::string_view exe)
 
 	_searchpaths[Searchpath::InstallationDir].clear();
 	_searchpaths[Searchpath::ApplicationBundleDir].clear();
+	_searchpaths[Searchpath::TransportTycoonDeluxeDir].clear();
+
+	if (SUCCEEDED(SHGetFolderPath(nullptr, CSIDL_APPDATA, nullptr, SHGFP_TYPE_CURRENT, path))) {
+		std::string config_file_path(FS2OTTD(path));
+		AppendPathSeparator(config_file_path);
+		config_file_path += "Atari\\Transport Tycoon Deluxe\\installpath.ini";
+
+		size_t installpath_len;
+		std::unique_ptr<char[]> installpath = ReadFileToMem(config_file_path, installpath_len, MAX_PATH);
+
+		if (installpath != nullptr && installpath_len > 0) {
+			std::string ttd_path = installpath.get();
+			AppendPathSeparator(ttd_path);
+			ttd_path += "CD";
+			AppendPathSeparator(ttd_path);
+
+			if (FileExists(ttd_path)) _searchpaths[Searchpath::TransportTycoonDeluxeDir] = ttd_path;
+		}
+	}
 }
 
 


### PR DESCRIPTION
Initial support for detection of the Atari TTD data files. Windows only at the moment, but I'll push changes for Linux and macOS soon.

## Motivation / Problem

People may acquire TTD and OpenTTD on Steam or GOG together, so it would be nice to make it easier for OpenTTD players to play with the original game data if they wish.

## Description

Atari have added support to TTD to write their game location to an `installpath.ini` file in their AppData/Application Support folder. (Note that this is currently only in a beta branch and is not yet in the public release version.) We can use this to identify where the game data is stored.

## Limitations

This does rely on the user running TTD at least once, but it then at least avoids any need to attempt to query Steam/GOG for install locations.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
