### PR TITLE
Change: [NewGRF] Ensure modflags bit 8 respects old behavior when train is driving backwards

### DIFF
--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -740,7 +740,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 
 				if (powered && has_power) SetBit(modflags, 5);
 				if (powered && !has_power) SetBit(modflags, 6);
-				if (t->flags.Test(VehicleRailFlag::Reversed)) SetBit(modflags, 8);
+				if (t->flags.Test(VehicleRailFlag::Reversed) ^ v->vehicle_flags.Test(VehicleFlag::DrivingBackwards)) SetBit(modflags, 8); // old newgrfs relied on this to provide sprites for driving backwards we no longer want that
 			}
 			if (v->vehicle_flags.Test(VehicleFlag::CargoUnloading)) SetBit(modflags, 1);
 			if (v->vehicle_flags.Test(VehicleFlag::BuiltAsPrototype)) SetBit(modflags, 10);

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -741,7 +741,9 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 
 				if (powered && has_power) SetBit(modflags, 5);
 				if (powered && !has_power) SetBit(modflags, 6);
-				if (t->flags.Test(VehicleRailFlag::Reversed)) SetBit(modflags, 8);
+				/* Before trains could drive backwards, many NewGRFs faked this effect by swapping sprites when the Reversed flag was set.
+				 * To maintain their intended behaviour, only pass them the Reversed flag if the vehicle is not driving backwards. */
+				if (t->flags.Test(VehicleRailFlag::Reversed) != t->IsDrivingBackwards()) SetBit(modflags, 8);
 			}
 			if (v->vehicle_flags.Test(VehicleFlag::CargoUnloading)) SetBit(modflags, 1);
 			if (v->vehicle_flags.Test(VehicleFlag::BuiltAsPrototype)) SetBit(modflags, 10);


### PR DESCRIPTION
## Motivation / Problem

#15379 made it so that trains with engines on both sides can drive backwards, but introduced an issue for trains using var FE/modflags bit 8. The trains using the variable would still be set meaning that the NewGRF would provide sprites as if the train had flipped "magically" that would result in sprites not fit for purpose being showed.


## Description

We XOR the states of the DrivingBackward and Reversed flags since that will change only when the trains "magically" flips. 

## Limitations

It's not magic, lights will be as if trains were going forward just like other vehicles not implementing the new variable.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
