### PR TITLE
Change: Most used rail type takes ownership into account

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -137,6 +137,8 @@ void SetLocalCompany(CompanyID new_company)
 		InvalidateWindowClassesData(WC_VEHICLE_VIEW);
 		/* Delete any construction windows... */
 		CloseConstructionWindows();
+		/* Update the default rail based on most used */
+		SetDefaultRailGui();
 	}
 
 	/* ... and redraw the whole screen. */

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1983,7 +1983,7 @@ void ReinitGuiAfterToggleElrail(bool disable)
 }
 
 /** Set the initial (default) railtype to use */
-static void SetDefaultRailGui()
+void SetDefaultRailGui()
 {
 	if (_local_company == COMPANY_SPECTATOR || !Company::IsValidID(_local_company)) return;
 
@@ -1993,8 +1993,8 @@ static void SetDefaultRailGui()
 			/* Find the most used rail type */
 			std::array<uint, RAILTYPE_END> count{};
 			for (const auto t : Map::Iterate()) {
-				if (IsTileType(t, TileType::Railway) || IsLevelCrossingTile(t) || HasStationTileRail(t) ||
-						(IsTileType(t, TileType::TunnelBridge) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL)) {
+				if ((IsTileType(t, TileType::Railway) || IsLevelCrossingTile(t) || HasStationTileRail(t) ||
+						(IsTileType(t, TileType::TunnelBridge) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL)) && IsTileOwner(t, _local_company)) {
 					count[GetRailType(t)]++;
 				}
 			}

--- a/src/rail_gui.h
+++ b/src/rail_gui.h
@@ -18,6 +18,7 @@ void ReinitGuiAfterToggleElrail(bool disable);
 void ResetSignalVariant(int32_t = 0);
 void InitializeRailGUI();
 DropDownList GetRailTypeDropDownList(bool for_replacement = false, bool all_option = false);
+void SetDefaultRailGui();
 
 /** Settings for which signals are shown by the signal GUI. */
 enum SignalGUISettings : uint8_t {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The "Default Rail Type" setting has a "Most used" option. In multiplayer, this is global across all owners rather than scoped to the player's company.
Noted in issue #9721. 

## Description

This updates the behaviour to calculate the "most used" rail type for the current local company and re-calculate it when a new company is joined.

## Limitations

I think this solves the problem widely, but this is my first PR (yay) so I'm sure there's a path I'm missing.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
