### PR TITLE
Fix: Coordinate transformation for JSON town placement when anticlockwise

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -452,7 +452,7 @@ void LoadTownData()
 				break;
 			case HM_COUNTER_CLOCKWISE:
 				/* Tile coordinates are rotated and must be adjusted. */
-				target_tile = TileXY((1 - y_proportion * Map::MaxX()), x_proportion * Map::MaxY());
+				target_tile = TileXY((1 - y_proportion) * Map::MaxX(), x_proportion * Map::MaxY());
 				break;
 			default: NOT_REACHED();
 		}


### PR DESCRIPTION
## Motivation / Problem

Anticlockwise coordinate transformation in LoadTownData is incorrect due to misplaced brackets.
This resulted in negative x coordinates.
This could plausibly result in invalid tile coordinates and resulting problems if y was 0.

May be relevant to #15486.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
