### PR TITLE
Fix: Allow recalculation of reserved paths to find depots

### DIFF
--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -671,7 +671,12 @@ FindDepotData YapfTrainFindNearestDepot(const Train *v, int max_penalty)
 {
 	const Train *moving_back = v->GetMovingBack();
 
-	PBSTileInfo origin = FollowTrainReservation(v);
+	/* Use the train current position instead of end of PBS reservation, depots might be along the currently reserved path. */
+	PBSTileInfo origin;
+	origin.tile = v->tile;
+	origin.trackdir = v->GetVehicleTrackdir();
+	origin.okay = true;
+
 	TileIndex last_tile = moving_back->tile;
 	Trackdir td_rev = ReverseTrackdir(moving_back->GetVehicleTrackdir());
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -4257,6 +4257,10 @@ static void CheckIfTrainNeedsService(Train *v)
 	v->current_order.MakeGoToDepot(depot, OrderDepotTypeFlag::Service, OrderNonStopFlag::NonStop, OrderDepotActionFlag::NearestDepot);
 	v->dest_tile = tfdd.tile;
 	SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);
+
+	/* Trigger a path re-reservation, because the destination changed. */
+	if (!v->flags.Test(VehicleRailFlag::Stuck)) FreeTrainTrackReservation(v);
+	TryPathReserve(v);
 }
 
 /** Calendar day handler. */

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2656,9 +2656,17 @@ CommandCost Vehicle::SendToDepot(DoCommandFlags flags, DepotCommandFlags command
 		if (!command.Test(DepotCommandFlag::Service)) this->current_order.SetDepotActionType(OrderDepotActionFlag::Halt);
 		InvalidateWindowData(WC_VEHICLE_VIEW, this->index);
 
-		/* If there is no depot in front and the train is not already reversing, reverse automatically (trains only) */
-		if (this->type == VEH_TRAIN && (closest_depot.reverse ^ Train::From(this)->flags.Test(VehicleRailFlag::Reversing))) {
-			Command<Commands::ReverseTrainDirection>::Do(DoCommandFlag::Execute, this->index, false);
+		/* Handle some train only behaviours */
+		if (this->type == VEH_TRAIN) {
+			Train *v = Train::From(this);
+			if (closest_depot.reverse ^ v->flags.Test(VehicleRailFlag::Reversing)) {
+				/* If there is no depot in front and the train is not already reversing, reverse automatically. */
+				Command<Commands::ReverseTrainDirection>::Do(flags, this->index, false);
+			} else if (flags.Test(DoCommandFlag::Execute)) {
+				/* Otherwise, trigger a path re-reservation, because the destination changed. */
+				if (!v->flags.Test(VehicleRailFlag::Stuck)) FreeTrainTrackReservation(v);
+				TryPathReserve(v);
+			}
 		}
 
 		if (this->type == VEH_AIRCRAFT) {


### PR DESCRIPTION
## Motivation / Problem

When sent to a depot, if trains are using reserved paths because of path-based signalling they can't find a depot before the next signal.

<img width="1262" height="717" alt="image" src="https://github.com/user-attachments/assets/64ad7f53-88c2-45f7-be27-48bf0b6dc616" />

## Description

Change the send to depot pathfinding to work from the current position of a train rather than working from the end of the reserved section, and change the go to depot command and servicing to trigger a re-reservation of paths based on the new route.

<img width="1725" height="980" alt="image" src="https://github.com/user-attachments/assets/ab2aa8ee-655a-462b-abf2-420e7813d0e1" />

<img width="1725" height="980" alt="image" src="https://github.com/user-attachments/assets/5f9b787e-f2ee-4f6d-b6c2-c1d344b0ad28" />

## Limitations

Changes servicing pathfinding, which could possibly break some track layouts?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
