### PR TITLE
Fix: Condition for whether to change driving direction or flip on train reverse

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2026,7 +2026,7 @@ static void ReverseTrainDirection(Train *consist)
 	TileIndex crossing = TrainApproachingCrossingTile(moving_front);
 
 	/* Check if we should back up or flip the train. */
-	if (consist->Last()->CanLeadTrain() || _settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::None) {
+	if (consist->vehicle_flags.Test(VehicleFlag::DrivingBackwards) || _settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::None || consist->Last()->CanLeadTrain()) {
 		/* The train will back up. */
 		consist->vehicle_flags.Flip(VehicleFlag::DrivingBackwards);
 


### PR DESCRIPTION
## Motivation / Problem

If a train is already driving backwards then reversing should always result in driving forwards instead of flipping the train.

See also: https://github.com/OpenTTD/OpenTTD/pull/15391#issuecomment-4270098959

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
