### PR TITLE
Codechange: move calculating livery recolour offset to Livery

### DIFF
--- a/src/company_base.h
+++ b/src/company_base.h
@@ -192,8 +192,7 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 	 */
 	inline uint8_t GetCompanyRecolourOffset(LiveryScheme livery_scheme, bool use_secondary = true) const
 	{
-		const Livery &l = this->livery[livery_scheme];
-		return use_secondary ? l.colour1 + l.colour2 * 16 : l.colour1;
+		return this->livery[livery_scheme].GetRecolourOffset(use_secondary);
 	}
 
 	static void PostDestructor(size_t index);

--- a/src/livery.h
+++ b/src/livery.h
@@ -87,6 +87,16 @@ struct Livery {
 	Flags in_use{}; ///< Livery flags.
 	Colours colour1 = COLOUR_BEGIN; ///< First colour, for all vehicles.
 	Colours colour2 = COLOUR_BEGIN; ///< Second colour, for vehicles with 2CC support.
+
+	/**
+	 * Get offset for recolour palette.
+	 * @param use_secondary Specify whether to add secondary colour offset to the result.
+	 * @return The palette offset.
+	 */
+	inline uint8_t GetRecolourOffset(bool use_secondary = true) const
+	{
+		return use_secondary ? this->colour1 + this->colour2 * 16 : this->colour1;
+	}
 };
 
 void ResetCompanyLivery(Company *c);

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -506,7 +506,7 @@ void DrawNewObjectTileInGUI(int x, int y, const ObjectSpec *spec, uint8_t view)
 		/* Get the colours of our company! */
 		if (spec->flags.Test(ObjectFlag::Uses2CC)) {
 			const Livery &l = Company::Get(_local_company)->livery[0];
-			palette = SPR_2CCMAP_BASE + l.colour1 + l.colour2 * 16;
+			palette = SPR_2CCMAP_BASE + l.GetRecolourOffset();
 		} else {
 			palette = GetCompanyPalette(_local_company);
 		}

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2148,8 +2148,7 @@ static PaletteID GetEngineColourMap(EngineID engine_type, CompanyID company, Eng
 
 	const Livery *livery = GetEngineLivery(engine_type, company, parent_engine_type, v, _settings_client.gui.liveries);
 
-	map += livery->colour1;
-	if (twocc) map += livery->colour2 * 16;
+	map += livery->GetRecolourOffset(twocc);
 
 	/* Update cache */
 	if (v != nullptr) const_cast<Vehicle *>(v)->colourmap = map;


### PR DESCRIPTION
## Motivation / Problem

Calculating the livery recolour offset is duplicated.


## Description

Move the calculation to a single location.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
