### PR TITLE
Codechange: Object's colour is actually a recolour offset

### DIFF
--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -340,7 +340,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 		case 0x46: return DistanceSquare(this->tile, t->xy);
 
 		/* Object colour */
-		case 0x47: return this->obj->colour;
+		case 0x47: return this->obj->recolour_offset;
 
 		/* Object view */
 		case 0x48: return this->obj->view;
@@ -449,7 +449,7 @@ uint16_t GetObjectCallback(CallbackID callback, uint32_t param1, uint32_t param2
  */
 static void DrawTileLayout(const TileInfo *ti, const DrawTileSpriteSpan &dts, const ObjectSpec *spec)
 {
-	PaletteID palette = (spec->flags.Test(ObjectFlag::Uses2CC) ? SPR_2CCMAP_BASE : PALETTE_RECOLOUR_START) + Object::GetByTile(ti->tile)->colour;
+	PaletteID palette = (spec->flags.Test(ObjectFlag::Uses2CC) ? SPR_2CCMAP_BASE : PALETTE_RECOLOUR_START) + Object::GetByTile(ti->tile)->recolour_offset;
 
 	SpriteID image = dts.ground.sprite;
 	PaletteID pal = dts.ground.pal;

--- a/src/object_base.h
+++ b/src/object_base.h
@@ -25,7 +25,7 @@ struct Object : ObjectPool::PoolItem<&_object_pool> {
 	Town *town = nullptr; ///< Town the object is built in
 	TileArea location{INVALID_TILE, 0, 0}; ///< Location of the object
 	TimerGameCalendar::Date build_date{}; ///< Date of construction
-	uint8_t colour = 0; ///< Colour of the object, for display purpose
+	uint8_t recolour_offset = 0; ///< Recolour offset of the object (basically the 2CC colour offset), for display purpose.
 	uint8_t view = 0; ///< The view setting for this object
 
 	Object(ObjectID index) : ObjectPool::PoolItem<&_object_pool>(index) {}

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -95,19 +95,19 @@ void BuildObject(ObjectType type, TileIndex tile, CompanyID owner, Town *town, u
 	/* If nothing owns the object, the colour will be random. Otherwise
 	 * get the colour from the company's livery settings. */
 	if (owner == OWNER_NONE) {
-		o->colour = Random();
+		o->recolour_offset = Random();
 	} else {
-		o->colour = Company::Get(owner)->GetCompanyRecolourOffset(LS_DEFAULT);
+		o->recolour_offset = Company::Get(owner)->GetCompanyRecolourOffset(LS_DEFAULT);
 	}
 
 	/* If the object wants only one colour, then give it that colour. */
-	if (!spec->flags.Test(ObjectFlag::Uses2CC)) o->colour &= 0xF;
+	if (!spec->flags.Test(ObjectFlag::Uses2CC)) o->recolour_offset &= 0xF;
 
 	if (spec->callback_mask.Test(ObjectCallbackMask::Colour)) {
-		uint16_t res = GetObjectCallback(CBID_OBJECT_COLOUR, o->colour, 0, spec, o, tile);
+		uint16_t res = GetObjectCallback(CBID_OBJECT_COLOUR, o->recolour_offset, 0, spec, o, tile);
 		if (res != CALLBACK_FAILED) {
 			if (res >= 0x100) ErrorUnknownCallbackResult(spec->grf_prop.grfid, CBID_OBJECT_COLOUR, res);
-			o->colour = GB(res, 0, 8);
+			o->recolour_offset = GB(res, 0, 8);
 		}
 	}
 
@@ -192,7 +192,7 @@ void UpdateObjectColours(const Company *c)
 		/* Using the object colour callback, so not using company colour. */
 		if (spec->callback_mask.Test(ObjectCallbackMask::Colour)) continue;
 
-		obj->colour = c->GetCompanyRecolourOffset(LS_DEFAULT, spec->flags.Test(ObjectFlag::Uses2CC));
+		obj->recolour_offset = c->GetCompanyRecolourOffset(LS_DEFAULT, spec->flags.Test(ObjectFlag::Uses2CC));
 	}
 }
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2596,7 +2596,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_148)) {
 		for (Object *o : Object::Iterate()) {
 			Owner owner = GetTileOwner(o->location.tile);
-			o->colour = (owner == OWNER_NONE) ? static_cast<Colours>(GB(Random(), 0, 4)) : Company::Get(owner)->livery[0].colour1;
+			o->recolour_offset = (owner == OWNER_NONE) ? GB(Random(), 0, 4) : to_underlying(Company::Get(owner)->livery[0].colour1);
 		}
 	}
 

--- a/src/saveload/object_sl.cpp
+++ b/src/saveload/object_sl.cpp
@@ -24,7 +24,7 @@ static const SaveLoad _object_desc[] = {
 	    SLE_VAR(Object, location.h,                 SLE_FILE_U8 | SLE_VAR_U16),
 	    SLE_REF(Object, town,                       REF_TOWN),
 	    SLE_VAR(Object, build_date,                 SLE_UINT32),
-	SLE_CONDVAR(Object, colour,                     SLE_UINT8,                  SLV_148, SL_MAX_VERSION),
+	SLE_CONDVARNAME(Object, recolour_offset, "colour", SLE_UINT8, SLV_148, SL_MAX_VERSION),
 	SLE_CONDVAR(Object, view,                       SLE_UINT8,                  SLV_155, SL_MAX_VERSION),
 	SLE_CONDVAR(Object, type,                       SLE_UINT16,                 SLV_186, SL_MAX_VERSION),
 };


### PR DESCRIPTION
## Motivation / Problem

The class for Object has a `colour`. This would imply that it's a `Colours`, after all... that's what the name implies. But it's not a `Colours` as it's a value up to 255 instead of 15. It's rather a `recolour_offset`.


## Description

Rename `colour` to `recolour_offset`.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
