### PR TITLE
Codechange: use EnumBitSet for used_colours

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -620,15 +620,15 @@ private:
 
 	void ShowColourDropDownMenu(uint32_t widget)
 	{
-		uint32_t used_colours = 0;
+		EnumBitSet<Colours, uint16_t, COLOUR_END> used_colours{};
 		const Livery *livery, *default_livery = nullptr;
 		bool primary = widget == WID_SCL_PRI_COL_DROPDOWN;
-		uint8_t default_col = 0;
+		Colours default_col{};
 
 		/* Disallow other company colours for the primary colour */
 		if (this->livery_class < LC_GROUP_RAIL && HasBit(this->sel, LS_DEFAULT) && primary) {
 			for (const Company *c : Company::Iterate()) {
-				if (c->index != _local_company) SetBit(used_colours, c->colour);
+				if (c->index != _local_company) used_colours.Set(c->colour);
 			}
 		}
 
@@ -661,10 +661,10 @@ private:
 			list.push_back(std::make_unique<DropDownListColourItem<>>(default_col, false));
 		}
 		for (Colours colour = COLOUR_BEGIN; colour != COLOUR_END; colour++) {
-			list.push_back(std::make_unique<DropDownListColourItem<>>(colour, HasBit(used_colours, colour)));
+			list.push_back(std::make_unique<DropDownListColourItem<>>(colour, used_colours.Test(colour)));
 		}
 
-		uint8_t sel;
+		Colours sel;
 		if (default_livery == nullptr || livery->in_use.Test(primary ? Livery::Flag::Primary : Livery::Flag::Secondary)) {
 			sel = primary ? livery->colour1 : livery->colour2;
 		} else {


### PR DESCRIPTION
## Motivation / Problem

`used_colours` implements its own bitset functionality using `SetBit`/`HasBit`, why not use `EnumBitSet` instead?


## Description

Use an `EnumBitSet` instead `SetBit`/`HasBit`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
