### PR TITLE
Fix #15506: Avoid ternary signed/unsigned conversion when returning literal -1

### DIFF
--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -105,7 +105,9 @@
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
 
 	auto [res, veh_id, refit_capacity, refit_mail, cargo_capacities] = ::Command<Commands::BuildVehicle>::Do(DoCommandFlag::QueryCost, depot, engine_id, true, cargo, INVALID_CLIENT_ID);
-	return res.Succeeded() ? refit_capacity : -1;
+	if (res.Failed()) return -1;
+
+	return refit_capacity;
 }
 
 /* static */ VehicleID ScriptVehicle::CloneVehicle(TileIndex depot, VehicleID vehicle_id, bool share_orders)
@@ -154,7 +156,9 @@
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
 
 	auto [res, refit_capacity, refit_mail, cargo_capacities] = ::Command<Commands::RefitVehicle>::Do(DoCommandFlag::QueryCost, vehicle_id, cargo, 0, false, false, 0);
-	return res.Succeeded() ? refit_capacity : -1;
+	if (res.Failed()) return -1;
+
+	return refit_capacity;
 }
 
 /* static */ bool ScriptVehicle::RefitVehicle(VehicleID vehicle_id, CargoType cargo)


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Fix #15506 Implicit conversions of -1 to a uint when the intended return is literally -1.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Rewrite BuildVehicleWithRefit and GetRefitCapacity that avoids using ternary signed/unsigned conversion.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
I only verified that this fix works for the GetBuildWithRefitCapacity. I was unable to create a test case where GetRefitCapacity fails the command, but I assumed it is also bugged, so I fixed that too.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
