### PR TITLE
Fix #15216: Buying area fails or succeeds in entirety, not partially

### DIFF
--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -407,7 +407,9 @@ CommandCost CmdBuildObjectArea(DoCommandFlags flags, TileIndex tile, TileIndex s
 	Money money = GetAvailableMoneyForCommand();
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 	CommandCost last_error = CMD_ERROR;
-	bool had_success = false;
+	bool had_success = true;
+	std::vector<TileIndex> valid_tiles;
+	Money total_cost = 0;
 
 	const Company *c = Company::GetIfValid(_current_company);
 	int limit = (c == nullptr ? INT32_MAX : GB(c->build_object_limit, 16, 16));
@@ -425,17 +427,23 @@ CommandCost CmdBuildObjectArea(DoCommandFlags flags, TileIndex tile, TileIndex s
 			continue;
 		}
 
-		had_success = true;
-		if (flags.Test(DoCommandFlag::Execute)) {
-			money -= ret.GetCost();
-
-			/* If we run out of money, stop building. */
-			if (ret.GetCost() > 0 && money < 0) break;
-			Command<Commands::BuildObject>::Do(flags, t, type, view);
-		}
+		total_cost += ret.GetCost();
 		cost.AddCost(ret.GetCost());
+		valid_tiles.push_back(t);
 	}
 
+	/* Check if there are insufficient funds to prevent partial building. */
+	if (total_cost > money) {
+		had_success = false;
+		return CommandCostWithParam(STR_ERROR_NOT_ENOUGH_CASH_REQUIRES_CURRENCY, total_cost);
+	}
+
+	if (flags.Test(DoCommandFlag::Execute)) {
+		/* Build tiles that passed first pass. */
+		for (size_t i = 0; i < valid_tiles.size(); i++) {
+			Command<Commands::BuildObject>::Do(flags, valid_tiles[i], type, view);
+		}
+	}
 	return had_success ? cost : last_error;
 }
 


### PR DESCRIPTION
Commit message: Fix #15216: Buying area fails or succeeds in entirety, not partially

## Motivation / Problem

Fixes land area buying partially without any error message, detailed more and issued in #15216. 

## Description

Instead of only having one pass that builds until there are insufficient funds, implement a two pass system. The first pass checks for limits, adds valid tiles to a container, and adds the running cost to a local variable. Between the first pass and second pass, check that the current money amount is sufficient in affording the summed cost of buying the area, returning failure immediately if its not the case. Second pass proceeds to build if failure never happens.

## Limitations

Similar limitations as #15224. This PR is only meant to address the partial build paired with the absence of an error message when buying land. 

It is worth nothing that this solution uses additional memory using a vector of TileIndex. If using an iterator instead of a container in second pass, we would need to check limitations again. On the other hand, using a container of pointers would cost more memory than a vector of TileIndex since in c++, a pointer is 8 bytes on a 64-bit system, while TileIndex, compatible with int32 would be 4 bytes to my understanding. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
