### PR TITLE
Codefix: explicitly delete unwanted indexers

### DIFF
--- a/src/core/convertible_through_base.hpp
+++ b/src/core/convertible_through_base.hpp
@@ -37,12 +37,16 @@ concept ConvertibleThroughBaseOrTo = std::is_convertible_v<T, TTo> || Convertibl
 template <typename Container, typename Index>
 class TypedIndexContainer : public Container {
 public:
+	Container::reference at(size_t pos) = delete;
 	Container::reference at(const Index &pos) { return this->Container::at(pos.base()); }
 
+	Container::const_reference at(size_t pos) const = delete;
 	Container::const_reference at(const Index &pos) const { return this->Container::at(pos.base()); }
 
+	Container::reference operator[](size_t pos) = delete;
 	Container::reference operator[](const Index &pos) { return this->Container::operator[](pos.base()); }
 
+	Container::const_reference operator[](size_t pos) const = delete;
 	Container::const_reference operator[](const Index &pos) const { return this->Container::operator[](pos.base()); }
 };
 

--- a/src/core/enum_type.hpp
+++ b/src/core/enum_type.hpp
@@ -246,12 +246,16 @@ public:
 template <typename Container, typename Index>
 class EnumClassIndexContainer : public Container {
 public:
+	Container::reference at(size_t pos) = delete;
 	Container::reference at(const Index &pos) { return this->Container::at(to_underlying(pos)); }
 
+	Container::const_reference at(size_t pos) const = delete;
 	Container::const_reference at(const Index &pos) const { return this->Container::at(to_underlying(pos)); }
 
+	Container::reference operator[](size_t pos) = delete;
 	Container::reference operator[](const Index &pos) { return this->Container::operator[](to_underlying(pos)); }
 
+	Container::const_reference operator[](size_t pos) const = delete;
 	Container::const_reference operator[](const Index &pos) const { return this->Container::operator[](to_underlying(pos)); }
 };
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

1d10e8ee6 & 736ed61c removed `size_t` indexers to prevent using the wrong type as an indexer, however there are cases with implicit conversion can creep in.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead, re-add the `size_t` indexers, but explicitly `delete` them.

Prevents typed-indexers being used via implicit conversion, as the compiler will complain about ambiguous meaning.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This doesn't actually affect anything right now but I noticed it when migrating to more typed-indexed containers.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
