### PR TITLE
Add: callback to control reversing behaviour

### DIFF
--- a/src/ground_vehicle.cpp
+++ b/src/ground_vehicle.cpp
@@ -68,6 +68,12 @@ void GroundVehicle<T, Type>::PowerChanged()
 		SetWindowWidgetDirty(WC_VEHICLE_VIEW, this->index, WID_VV_START_STOP);
 	}
 
+	/* If the consist is going backwards, without a leading cab, restrict its speed. */
+	if (!v->GetMovingFront()->CanLeadConsist()) {
+		constexpr int BACKWARDS_NO_CAB_SPEED_LIMIT = 32;
+		max_track_speed = std::min<int>(max_track_speed, BACKWARDS_NO_CAB_SPEED_LIMIT);
+	}
+
 	this->gcache.cached_max_track_speed = max_track_speed;
 }
 

--- a/src/ground_vehicle.hpp
+++ b/src/ground_vehicle.hpp
@@ -77,6 +77,7 @@ enum GroundVehicleFlags : uint8_t {
  * virtual int         GetDisplayMaxSpeed() const = 0;
  * virtual uint16_t      GetMaxTrackSpeed() const = 0;
  * virtual bool        TileMayHaveSlopedTrack() const = 0;
+ * virtual bool CanLeadConsist() const = 0;
  */
 template <class T, VehicleType Type>
 struct GroundVehicle : public SpecializedVehicle<T, Type> {
@@ -335,23 +336,6 @@ struct GroundVehicle : public SpecializedVehicle<T, Type> {
 	 * @return True if the engine is the rear part of a dualheaded engine.
 	 */
 	inline bool IsRearDualheaded() const { return this->IsMultiheaded() && !this->IsEngine(); }
-
-	/**
-	 * Check if this vehicle can lead a train.
-	 * @return \c true iff this vehicle can lead a train.
-	 */
-	inline bool CanLeadTrain() const
-	{
-		/* NewGRFs can allow unpowered wagons to lead trains. */
-		if (this->GetEngine()->info.extra_flags.Test(ExtraEngineFlag::HasCab)) return true;
-
-		/* This might be an articulated engine. */
-		if (this->IsArticulatedPart()) {
-			return this->GetFirstEnginePart()->IsEngine();
-		}
-
-		return this->IsEngine() || this->IsRearDualheaded();
-	}
 
 	/**
 	 * Update the GUI variant of the current speed of the vehicle.

--- a/src/newgrf_callbacks.h
+++ b/src/newgrf_callbacks.h
@@ -293,6 +293,9 @@ enum CallbackID : uint16_t {
 	 * for each defined cargo after all NewGRFs are loaded.
 	 */
 	CBID_VEHICLE_CUSTOM_REFIT            = 0x0163, // 15 bit callback
+
+	/** Called to determine if a consist can travel in reverse. */
+	CBID_VEHICLE_ALLOW_DENY_REVERSE = 0x164,
 };
 
 /**

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -619,7 +619,7 @@ bool YapfTrainCheckReverse(const Train *v)
 	int reverse_penalty = 0;
 
 	/* Consider whether the train might back up at reduced speed. */
-	if (_settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::None && !v->Last()->CanLeadTrain()) {
+	if (_settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::None && !v->Last()->CanLeadConsist()) {
 		constexpr int DRIVING_BACKWARDS_PENALTY = 100 * YAPF_TILE_LENGTH;
 
 		if (!v->vehicle_flags.Test(VehicleFlag::DrivingBackwards)) {

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -146,6 +146,12 @@ struct RoadVehicle final : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 	int UpdateSpeed();
 	void SetDestTile(TileIndex tile) override;
 
+	/**
+	 * Check if this vehicle can lead a consist.
+	 * @return \c true iff this vehicle can lead a consist.
+	 */
+	inline bool CanLeadConsist() const { return this->IsFrontEngine(); }
+
 protected: // These functions should not be called outside acceleration code.
 
 	/**

--- a/src/train.h
+++ b/src/train.h
@@ -196,6 +196,12 @@ struct Train final : public GroundVehicle<Train, VEH_TRAIN> {
 		return GetRailTypeInfo(GetRailType(this->tile))->acceleration_type;
 	}
 
+	/**
+	 * Check if this vehicle can lead a consist.
+	 * @return \c true iff this vehicle can lead a consist.
+	 */
+	bool CanLeadConsist() const;
+
 protected: // These functions should not be called outside acceleration code.
 
 	/**

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -430,7 +430,7 @@ int Train::GetCurrentMaxSpeed() const
 	max_speed = std::min<int>(max_speed, this->current_order.GetMaxSpeed());
 
 	/* If the train is going backwards, without a leading cab, restrict its speed. */
-	if (!moving_front->CanLeadTrain()) {
+	if (!moving_front->CanLeadConsist()) {
 		constexpr int BACKWARDS_NO_CAB_SPEED_LIMIT = 32;
 		max_speed = std::min<int>(max_speed, BACKWARDS_NO_CAB_SPEED_LIMIT);
 	}
@@ -2026,7 +2026,7 @@ static void ReverseTrainDirection(Train *consist)
 	TileIndex crossing = TrainApproachingCrossingTile(moving_front);
 
 	/* Check if we should back up or flip the train. */
-	if (consist->vehicle_flags.Test(VehicleFlag::DrivingBackwards) || _settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::None || consist->Last()->CanLeadTrain()) {
+	if (consist->vehicle_flags.Test(VehicleFlag::DrivingBackwards) || _settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::None || consist->Last()->CanLeadConsist()) {
 		/* The train will back up. */
 		consist->vehicle_flags.Flip(VehicleFlag::DrivingBackwards);
 
@@ -4184,6 +4184,21 @@ Money Train::GetRunningCost() const
 	} while ((v = v->GetNextVehicle()) != nullptr);
 
 	return cost;
+}
+
+/**
+ * Check if this vehicle can lead a consist.
+ * @return \c true iff this vehicle can lead a consist.
+ */
+bool Train::CanLeadConsist() const
+{
+	/* This might be an articulated engine. */
+	const Train *v = this->GetFirstEnginePart();
+
+	/* NewGRFs can allow unpowered wagons to lead trains. */
+	if (v->GetEngine()->info.extra_flags.Test(ExtraEngineFlag::HasCab)) return true;
+
+	return v->IsEngine() || v->IsRearDualheaded();
 }
 
 /**

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -429,12 +429,6 @@ int Train::GetCurrentMaxSpeed() const
 
 	max_speed = std::min<int>(max_speed, this->current_order.GetMaxSpeed());
 
-	/* If the train is going backwards, without a leading cab, restrict its speed. */
-	if (!moving_front->CanLeadConsist()) {
-		constexpr int BACKWARDS_NO_CAB_SPEED_LIMIT = 32;
-		max_speed = std::min<int>(max_speed, BACKWARDS_NO_CAB_SPEED_LIMIT);
-	}
-
 	return std::min<int>(max_speed, this->gcache.cached_max_track_speed);
 }
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -4192,7 +4192,12 @@ bool Train::CanLeadConsist() const
 	/* NewGRFs can allow unpowered wagons to lead trains. */
 	if (v->GetEngine()->info.extra_flags.Test(ExtraEngineFlag::HasCab)) return true;
 
-	return v->IsEngine() || v->IsRearDualheaded();
+	uint16_t callback = GetVehicleCallback(CBID_VEHICLE_ALLOW_DENY_REVERSE, 0, 0, v->engine_type, v, {});
+	switch (callback) {
+		case 0: return false;
+		case 1: return true;
+		default: return v->IsEngine() || v->IsRearDualheaded();
+	}
 }
 
 /**


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Requests to allow more dynamic control of train reversing.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add a callback to allow runtime control.

Callback 0x146 is called on the last vehicle of a train to test if it can lead the train. For articulated parts, only the "primary" leading part is considered.
- 0 = vehicle cannot lead train
- 1 = vehicle can lead train
- failed = default behaviour applies (can reverse if the part is an engine)

The callback is NOT called if the flag HasCab is set.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

This changes the existing behaviour which tests the HasCab flag the last part of the vehicle in the train, even if that part is the last part of an articulated vehicle. Now the first part of an articulated vehicle is checked.

Makes it difficult to create an API for AIs to test if a particular engine type can lead a train in reverse, as it's no longer a static property.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
