### PR TITLE
Fix depot maintenance scaling for rail and road depots

### DIFF
--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -235,7 +235,10 @@ static const uint TUNNELBRIDGE_TRACKBIT_FACTOR = 4;
 /** Multiplier for how many regular track bits a level crossing counts. */
 static const uint LEVELCROSSING_TRACKBIT_FACTOR = 2;
 /** Multiplier for how many regular track bits a road depot counts. */
-static const uint ROAD_DEPOT_TRACKBIT_FACTOR = 2;
+// Depot infrastructure contribution factor.
+// Increased to ensure depot maintenance is visible under the current cost formula,
+// which uses scaling and integer division that can round small values to zero.
+static const uint ROAD_DEPOT_TRACKBIT_FACTOR = 64;
 /** Multiplier for how many regular track bits a bay stop counts. */
 static const uint ROAD_STOP_TRACKBIT_FACTOR = 2;
 /** Multiplier for how many regular tiles a lock counts. */

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -43,6 +43,11 @@
 /** Helper type for lists/vectors of trains */
 typedef std::vector<Train *> TrainList;
 
+// Depot infrastructure contribution factor.
+// Increased to ensure depot maintenance is visible under the current cost formula,
+// which uses scaling and integer division that can round small values to zero.
+static constexpr uint RAIL_DEPOT_TRACKBIT_FACTOR = 64;
+
 RailTypeInfo _railtypes[RAILTYPE_END];
 std::vector<RailType> _sorted_railtypes; ///< Sorted list of rail types.
 RailTypes _railtypes_hidden_mask;
@@ -1010,8 +1015,9 @@ CommandCost CmdBuildTrainDepot(DoCommandFlags flags, TileIndex tile, RailType ra
 
 			MakeRailDepot(tile, _current_company, d->index, dir, railtype);
 			MakeDefaultName(d);
-
-			Company::Get(_current_company)->infrastructure.rail[railtype]++;
+			//updated to make it so company incurs mainance fee by constant amount when building depot
+			//per bug request
+			Company::Get(_current_company)->infrastructure.rail[railtype] += RAIL_DEPOT_TRACKBIT_FACTOR;
 			DirtyCompanyInfrastructureWindows(_current_company);
 		}
 
@@ -1774,8 +1780,9 @@ static CommandCost RemoveTrainDepot(TileIndex tile, DoCommandFlags flags)
 			v = GetTrainForReservation(tile, DiagDirToDiagTrack(dir));
 			if (v != nullptr) FreeTrainTrackReservation(v);
 		}
+		//updated the infrastructure cost if removed by constant amount, per request of bug
 
-		Company::Get(owner)->infrastructure.rail[GetRailType(tile)]--;
+		Company::Get(owner)->infrastructure.rail[GetRailType(tile)] -= RAIL_DEPOT_TRACKBIT_FACTOR;
 		DirtyCompanyInfrastructureWindows(owner);
 
 		delete Depot::GetByTile(tile);
@@ -2908,6 +2915,8 @@ static void GetTileDesc_Rail(TileIndex tile, TileDesc &td)
 /** @copydoc ChangeTileOwnerProc */
 static void ChangeTileOwner_Rail(TileIndex tile, Owner old_owner, Owner new_owner)
 {
+	//Added another branch to transfer. Made it so it would consistenly reduce the maintance fee if 
+	//depot transfered, maintance fee would update with scale
 	if (!IsTileOwner(tile, old_owner)) return;
 
 	if (new_owner != INVALID_OWNER) {
@@ -2917,6 +2926,8 @@ static void ChangeTileOwner_Rail(TileIndex tile, Owner old_owner, Owner new_owne
 			TrackBits bits = GetTrackBits(tile);
 			num_pieces = CountBits(bits);
 			if (TracksOverlap(bits)) num_pieces *= num_pieces;
+		} else if (IsRailDepotTile(tile)) {
+			num_pieces = RAIL_DEPOT_TRACKBIT_FACTOR;
 		}
 		RailType rt = GetRailType(tile);
 		Company::Get(old_owner)->infrastructure.rail[rt] -= num_pieces;

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -48,6 +48,8 @@
 
 #include "safeguards.h"
 
+//static constexpr uint ROAD_DEPOT_TRACKBIT_FACTOR = 64;
+
 /** Helper type for lists/vectors of road vehicles */
 typedef std::vector<RoadVehicle *> RoadVehicleList;
 
@@ -1181,6 +1183,8 @@ CommandCost CmdBuildRoadDepot(DoCommandFlags flags, TileIndex tile, RoadType rt,
 			MakeDefaultName(dep);
 
 			/* A road depot has two road bits. */
+			//updated to make it so company incurs mainance fee by constant amount when building depot
+			//per bug request
 			UpdateCompanyRoadInfrastructure(rt, _current_company, ROAD_DEPOT_TRACKBIT_FACTOR);
 		}
 
@@ -1193,6 +1197,7 @@ CommandCost CmdBuildRoadDepot(DoCommandFlags flags, TileIndex tile, RoadType rt,
 
 static CommandCost RemoveRoadDepot(TileIndex tile, DoCommandFlags flags)
 {
+	
 	if (_current_company != OWNER_WATER) {
 		CommandCost ret = CheckTileOwnership(tile);
 		if (ret.Failed()) return ret;
@@ -1207,6 +1212,7 @@ static CommandCost RemoveRoadDepot(TileIndex tile, DoCommandFlags flags)
 			/* A road depot has two road bits. */
 			RoadType rt = GetRoadTypeRoad(tile);
 			if (rt == INVALID_ROADTYPE) rt = GetRoadTypeTram(tile);
+			//updated the infrastructure cost if removed by constant amount, per request of bug
 			c->infrastructure.road[rt] -= ROAD_DEPOT_TRACKBIT_FACTOR;
 			DirtyCompanyInfrastructureWindows(c->index);
 		}
@@ -2323,6 +2329,7 @@ static VehicleEnterTileStates VehicleEnterTile_Road(Vehicle *v, TileIndex tile, 
 /** @copydoc ChangeTileOwnerProc */
 static void ChangeTileOwner_Road(TileIndex tile, Owner old_owner, Owner new_owner)
 {
+	//updated current branch to change the infrastructure maintance by constant amount if ownership changed for both owners
 	if (IsRoadDepot(tile)) {
 		if (GetTileOwner(tile) == old_owner) {
 			if (new_owner == INVALID_OWNER) {
@@ -2331,8 +2338,8 @@ static void ChangeTileOwner_Road(TileIndex tile, Owner old_owner, Owner new_owne
 				/* A road depot has two road bits. No need to dirty windows here, we'll redraw the whole screen anyway. */
 				RoadType rt = GetRoadTypeRoad(tile);
 				if (rt == INVALID_ROADTYPE) rt = GetRoadTypeTram(tile);
-				Company::Get(old_owner)->infrastructure.road[rt] -= 2;
-				Company::Get(new_owner)->infrastructure.road[rt] += 2;
+				Company::Get(old_owner)->infrastructure.road[rt] -= ROAD_DEPOT_TRACKBIT_FACTOR;
+				Company::Get(new_owner)->infrastructure.road[rt] += ROAD_DEPOT_TRACKBIT_FACTOR;
 
 				SetTileOwner(tile, new_owner);
 				for (RoadTramType rtt : _roadtramtypes) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem


This addresses issue #14666.

Train and road depots contributed very small values to infrastructure counts, which often resulted in maintenance being rounded down to zero due to scaling and integer division in the cost formula. As a result, these depots appeared to have no maintenance cost, unlike ship depots, creating unrealisitc and inconsistent gameplay behavior.



## Description


This change increases the infrastructure contribution of rail and road depots to ensure that even a single depot incurs a visible maintenance cost.
Additions:
Introduced and increased depot contribution factors for rail and road depots
Updated build, removal, and ownership transfer logic to consistently use these factors
Ensured infrastructure accounting remains consistant across all code relation areas
This improves consistency with ship depots and makes maintenance behavior more realistic for players.



## Limitations


The fix adds depot factor values rather than changing the maintenance formula. As a result, the maintenance amount depends on the chosen factor and scaling behavior. Very small configurations may still result in minimal costs depending on total infrastructure, but the issue of depots appearing completely free is resolved. Further tuning of depot contribution factors could be explored to better match gameplay realisms.



## Checklist for review

The bug fix is important enough to be backported? No
This PR touches english.txt or translations? No
This PR affects the GS/AI API? No
This PR affects the NewGRF API? No