### PR TITLE
Codechange: let _dirkeys use an enum and EnumBitSet

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -32,7 +32,7 @@
 
 #include "safeguards.h"
 
-uint8_t _dirkeys;        ///< 1 = left, 2 = up, 4 = right, 8 = down
+DirectionKeys _dirkeys; ///< Pressed direction keys.
 bool _fullscreen;
 Support8bpp _support8bpp; ///< State of the support for 8bpp graphics.
 CursorVars _cursor;

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -48,7 +48,7 @@ void GameLoop();
 
 void CreateConsole();
 
-extern uint8_t _dirkeys;        ///< 1 = left, 2 = up, 4 = right, 8 = down
+extern DirectionKeys _dirkeys;
 extern bool _fullscreen;
 extern Support8bpp _support8bpp;
 extern CursorVars _cursor;

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -401,6 +401,15 @@ enum StringAlignment : uint8_t {
 };
 DECLARE_ENUM_AS_BIT_SET(StringAlignment)
 
+/** The four direction keys on a keyboard. */
+enum class DirectionKey {
+	Left, ///< Left
+	Up, ///< Up
+	Right, ///< Right
+	Down, ///< Down
+};
+using DirectionKeys = EnumBitSet<DirectionKey, uint8_t>; ///< Bitset of the direction keys.
+
 /** Colour for pixel/line drawing. */
 struct PixelColour {
 	uint8_t p; ///< Palette index.

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -468,11 +468,10 @@ void VideoDriver_Allegro::InputLoop()
 	this->fast_forward_key_pressed = key[KEY_TAB] && (key_shifts & KB_ALT_FLAG) == 0;
 
 	/* Determine which directional keys are down. */
-	_dirkeys =
-		(key[KEY_LEFT]  ? 1 : 0) |
-		(key[KEY_UP]    ? 2 : 0) |
-		(key[KEY_RIGHT] ? 4 : 0) |
-		(key[KEY_DOWN]  ? 8 : 0);
+	_dirkeys.Set(DirectionKey::Left, key[KEY_LEFT]);
+	_dirkeys.Set(DirectionKey::Up, key[KEY_UP]);
+	_dirkeys.Set(DirectionKey::Right, key[KEY_RIGHT]);
+	_dirkeys.Set(DirectionKey::Down, key[KEY_DOWN]);
 
 	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
 }

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -850,10 +850,10 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 - (BOOL)internalHandleKeycode:(unsigned short)keycode unicode:(char32_t)unicode pressed:(BOOL)down modifiers:(NSUInteger)modifiers
 {
 	switch (keycode) {
-		case QZ_UP:    SB(_dirkeys, 1, 1, down); break;
-		case QZ_DOWN:  SB(_dirkeys, 3, 1, down); break;
-		case QZ_LEFT:  SB(_dirkeys, 0, 1, down); break;
-		case QZ_RIGHT: SB(_dirkeys, 2, 1, down); break;
+		case QZ_UP: _dirkeys.Set(DirectionKey::Up, down); break;
+		case QZ_DOWN: _dirkeys.Set(DirectionKey::Down, down); break;
+		case QZ_LEFT: _dirkeys.Set(DirectionKey::Left, down); break;
+		case QZ_RIGHT: _dirkeys.Set(DirectionKey::Right, down); break;
 
 		case QZ_TAB:
 			_tab_is_down = down;

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -627,11 +627,10 @@ void VideoDriver_SDL_Base::InputLoop()
 	this->fast_forward_key_pressed = keys[SDL_SCANCODE_TAB] && (mod & KMOD_ALT) == 0;
 
 	/* Determine which directional keys are down. */
-	_dirkeys =
-		(keys[SDL_SCANCODE_LEFT]  ? 1 : 0) |
-		(keys[SDL_SCANCODE_UP]    ? 2 : 0) |
-		(keys[SDL_SCANCODE_RIGHT] ? 4 : 0) |
-		(keys[SDL_SCANCODE_DOWN]  ? 8 : 0);
+	_dirkeys.Set(DirectionKey::Left, keys[SDL_SCANCODE_LEFT]);
+	_dirkeys.Set(DirectionKey::Up, keys[SDL_SCANCODE_UP]);
+	_dirkeys.Set(DirectionKey::Right, keys[SDL_SCANCODE_RIGHT]);
+	_dirkeys.Set(DirectionKey::Down, keys[SDL_SCANCODE_DOWN]);
 
 	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
 }

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1006,13 +1006,12 @@ void VideoDriver_Win32Base::InputLoop()
 
 	/* Determine which directional keys are down. */
 	if (this->has_focus) {
-		_dirkeys =
-			(GetAsyncKeyState(VK_LEFT) < 0 ? 1 : 0) +
-			(GetAsyncKeyState(VK_UP) < 0 ? 2 : 0) +
-			(GetAsyncKeyState(VK_RIGHT) < 0 ? 4 : 0) +
-			(GetAsyncKeyState(VK_DOWN) < 0 ? 8 : 0);
+		_dirkeys.Set(DirectionKey::Left, GetAsyncKeyState(VK_LEFT));
+		_dirkeys.Set(DirectionKey::Up, GetAsyncKeyState(VK_UP));
+		_dirkeys.Set(DirectionKey::Right, GetAsyncKeyState(VK_RIGHT));
+		_dirkeys.Set(DirectionKey::Down, GetAsyncKeyState(VK_DOWN));
 	} else {
-		_dirkeys = 0;
+		_dirkeys.Reset();
 	}
 
 	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2862,7 +2862,7 @@ static void HandleKeyScrolling()
 	 * Check that any of the dirkeys is pressed and that the focused window
 	 * doesn't have an edit-box as focused widget.
 	 */
-	if (_dirkeys && !EditBoxInGlobalFocus()) {
+	if (_dirkeys.Any() && !EditBoxInGlobalFocus()) {
 		int factor = _shift_pressed ? 50 : 10;
 
 		if (_game_mode != GM_MENU && _game_mode != GM_BOOTSTRAP) {
@@ -2871,7 +2871,7 @@ static void HandleKeyScrolling()
 			main_window->viewport->CancelFollow(*main_window);
 		}
 
-		ScrollMainViewport(scrollamt[_dirkeys][0] * factor, scrollamt[_dirkeys][1] * factor);
+		ScrollMainViewport(scrollamt[_dirkeys.base()][0] * factor, scrollamt[_dirkeys.base()][1] * factor);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

Magic numbers used for `_dirkeys`.


## Description

Move the magic numbers into an `enum` and `EnumBitSet`.


## Limitations

Not actually tested on some platforms.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
