### PR TITLE
Fix: Use tile of leading vehicle when calculating too-short station loading penalty

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1597,7 +1597,7 @@ static void UpdateLoadUnloadTicks(Vehicle *front, const Station *st, int ticks)
 {
 	if (front->type == VEH_TRAIN && _settings_game.order.station_length_loading_penalty) {
 		/* Each platform tile is worth 2 rail vehicles. */
-		int overhang = front->GetGroundVehicleCache()->cached_total_length - st->GetPlatformLength(front->tile) * TILE_SIZE;
+		int overhang = front->GetGroundVehicleCache()->cached_total_length - st->GetPlatformLength(front->GetMovingFront()->tile) * TILE_SIZE;
 		if (overhang > 0) {
 			ticks <<= 1;
 			ticks += (overhang * ticks) / 8;


### PR DESCRIPTION
## Motivation / Problem

When a train is too long for a station and is driving backwards, the engine will not be on the station tile, and will cause an assert.

<img width="1020" height="786" alt="image" src="https://github.com/user-attachments/assets/81eb6c55-debf-4664-908b-833e5f5159ba" />


## Description

Don't use the engine's tile, but the tile of the moving front.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
