### PR TITLE
Fix: Fix viewport snap back on stop following vehicle (#15520)

### DIFF
--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -3849,5 +3849,7 @@ void ViewportData::CancelFollow(const Window &viewport_window)
 		if (vehicle_window != nullptr) vehicle_window->RaiseWidgetWhenLowered(WID_VV_LOCATION);
 	}
 
+	this->dest_scrollpos_x = this->scrollpos_x;
+	this->dest_scrollpos_y = this->scrollpos_y;
 	this->follow_vehicle = VehicleID::Invalid();
 }


### PR DESCRIPTION
## Motivation / Problem

As described in #15520: When following a vehicle, if you stop following by using the arrow keys to move the viewport the view would snap back to the position where the vehicle was when following was started. Instead it should move smoothly from the vehicle's current position.

Similar bug also occurred when using panning when the mouse is near the edge of the viewport. When following a vehicle, moving the mouse to the edge of the viewport would cause the view to snap back to the position when following was started, before scrolling.

## Description

In a viewport `dest_scrollpos_x` and `dest_scrollpos_y` weren't updated when following a vehicle, so set them to the current position before setting vehicle target for following to invalid.

Fixes #15520

## Limitations

None(?)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
