### PR TITLE
Codechange: make WindowPosition a scoped enum

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -84,7 +84,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_ai_config_widgets = 
 
 /** Window definition for the configure AI window. */
 static WindowDesc _ai_config_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	{},
 	_nested_ai_config_widgets

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -215,8 +215,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_air_toolbar_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the air toolbar. */
 static WindowDesc _air_toolbar_desc(
-	WDP_MANUAL, "toolbar_air", 0, 0,
+	WindowPosition::Manual, "toolbar_air", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_air_toolbar_widgets,
@@ -625,8 +626,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_airport_widget
 	EndContainer(),
 };
 
+/** Window definition for the airport build window. */
 static WindowDesc _build_airport_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_airport_widgets

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -760,8 +760,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_replace_rail_vehicle
 	EndContainer(),
 };
 
+/** Window definition for the replace rail vehicle window. */
 static WindowDesc _replace_rail_vehicle_desc(
-	WDP_AUTO, "replace_vehicle_train", 500, 140,
+	WindowPosition::Automatic, "replace_vehicle_train", 500, 140,
 	WC_REPLACE_VEHICLE, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_replace_rail_vehicle_widgets
@@ -818,8 +819,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_replace_road_vehicle
 	EndContainer(),
 };
 
+/** Window definition for the replace road vehicle window. */
 static WindowDesc _replace_road_vehicle_desc(
-	WDP_AUTO, "replace_vehicle_road", 500, 140,
+	WindowPosition::Automatic, "replace_vehicle_road", 500, 140,
 	WC_REPLACE_VEHICLE, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_replace_road_vehicle_widgets
@@ -872,8 +874,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_replace_vehicle_widg
 	EndContainer(),
 };
 
+/** Window definition for the replace ship/aircraft window. */
 static WindowDesc _replace_vehicle_desc(
-	WDP_AUTO, "replace_vehicle", 456, 118,
+	WindowPosition::Automatic, "replace_vehicle", 456, 118,
 	WC_REPLACE_VEHICLE, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_replace_vehicle_widgets

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -42,7 +42,7 @@ static constexpr std::initializer_list<NWidgetPart> _background_widgets = {
  * Window description for the background window to prevent smearing.
  */
 static WindowDesc _background_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_background_widgets
@@ -78,7 +78,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_bootstrap_errmsg_wid
 
 /** Window description for the error window. */
 static WindowDesc _bootstrap_errmsg_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_BOOTSTRAP, WC_NONE,
 	{WindowDefaultFlag::Modal, WindowDefaultFlag::NoClose},
 	_nested_bootstrap_errmsg_widgets
@@ -135,7 +135,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_bootstrap_download_s
 
 /** Window description for the download window */
 static WindowDesc _bootstrap_download_status_window_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	{WindowDefaultFlag::Modal, WindowDefaultFlag::NoClose},
 	_nested_bootstrap_download_status_window_widgets
@@ -187,7 +187,7 @@ static constexpr std::initializer_list<NWidgetPart> _bootstrap_query_widgets = {
 
 /** The window description for the query. */
 static WindowDesc _bootstrap_query_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_CONFIRM_POPUP_QUERY, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_bootstrap_query_widgets

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -350,7 +350,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_bridge_widgets
 
 /** Window definition for the rail bridge selection window. */
 static WindowDesc _build_bridge_desc(
-	WDP_AUTO, "build_bridge", 200, 114,
+	WindowPosition::Automatic, "build_bridge", 200, 114,
 	WC_BUILD_BRIDGE, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_bridge_widgets

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -2009,8 +2009,9 @@ struct BuildVehicleWindow : Window {
 	}};
 };
 
+/** Window definition for the build vehicle window. */
 static WindowDesc _build_vehicle_desc(
-	WDP_AUTO, "build_vehicle", 240, 268,
+	WindowPosition::Automatic, "build_vehicle", 240, 268,
 	WC_BUILD_VEHICLE, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_vehicle_widgets,

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -641,7 +641,7 @@ struct CheatWindow : Window {
 
 /** Window description of the cheats GUI. */
 static WindowDesc _cheats_desc(
-	WDP_AUTO, "cheats", 0, 0,
+	WindowPosition::Automatic, "cheats", 0, 0,
 	WC_CHEATS, WC_NONE,
 	{},
 	_nested_cheat_widgets

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -564,8 +564,9 @@ struct CompanyFinancesWindow : Window {
 /** First conservative estimate of the maximum amount of money */
 Money CompanyFinancesWindow::max_money = INT32_MAX;
 
+/** Window definition for the company finances window. */
 static WindowDesc _company_finances_desc(
-	WDP_AUTO, "company_finances", 0, 0,
+	WindowPosition::Automatic, "company_finances", 0, 0,
 	WC_FINANCES, WC_NONE,
 	{},
 	_nested_company_finances_widgets
@@ -1116,8 +1117,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_select_company_liver
 	EndContainer(),
 };
 
+/** Window definition for the company livery configuration window. */
 static WindowDesc _select_company_livery_desc(
-	WDP_AUTO, "company_colour_scheme", 0, 0,
+	WindowPosition::Automatic, "company_colour_scheme", 0, 0,
 	WC_COMPANY_COLOUR, WC_NONE,
 	{},
 	_nested_select_company_livery_widgets
@@ -1539,7 +1541,7 @@ public:
 
 /** Company manager face selection window description */
 static WindowDesc _select_company_manager_face_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_COMPANY_MANAGER_FACE, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_select_company_manager_face_widgets
@@ -1845,8 +1847,9 @@ struct CompanyInfrastructureWindow : Window
 	}
 };
 
+/** Window definition for the company infrastructure statistics window. */
 static WindowDesc _company_infrastructure_desc(
-	WDP_AUTO, "company_infrastructure", 0, 0,
+	WindowPosition::Automatic, "company_infrastructure", 0, 0,
 	WC_COMPANY_INFRASTRUCTURE, WC_NONE,
 	{},
 	_nested_company_infrastructure_widgets
@@ -2326,8 +2329,9 @@ struct CompanyWindow : Window
 	}
 };
 
+/** Window definition for the company window. */
 static WindowDesc _company_desc(
-	WDP_AUTO, "company", 0, 0,
+	WindowPosition::Automatic, "company", 0, 0,
 	WC_COMPANY, WC_NONE,
 	{},
 	_nested_company_widgets
@@ -2457,8 +2461,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_buy_company_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the window to buy a company. */
 static WindowDesc _buy_company_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_BUY_COMPANY, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_buy_company_widgets

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -137,8 +137,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_console_window_widge
 	NWidget(WWT_EMPTY, Colours::Invalid, WID_C_BACKGROUND), SetResize(1, 1),
 };
 
+/** Window definition for the console window. */
 static WindowDesc _console_window_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_CONSOLE, WC_NONE,
 	{},
 	_nested_console_window_widgets

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -196,7 +196,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_set_date_widgets = {
 
 /** Description of the date setting window. */
 static WindowDesc _set_date_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_SET_DATE, WC_NONE,
 	{},
 	_nested_set_date_widgets

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -86,29 +86,33 @@ static constexpr std::initializer_list<NWidgetPart> _nested_train_depot_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the train depot window. */
 static WindowDesc _train_depot_desc(
-	WDP_AUTO, "depot_train", 362, 123,
+	WindowPosition::Automatic, "depot_train", 362, 123,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	{},
 	_nested_train_depot_widgets
 );
 
+/** Window definition for the road depot window. */
 static WindowDesc _road_depot_desc(
-	WDP_AUTO, "depot_roadveh", 316, 97,
+	WindowPosition::Automatic, "depot_roadveh", 316, 97,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	{},
 	_nested_train_depot_widgets
 );
 
+/** Window definition for the ship depot window. */
 static WindowDesc _ship_depot_desc(
-	WDP_AUTO, "depot_ship", 306, 99,
+	WindowPosition::Automatic, "depot_ship", 306, 99,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	{},
 	_nested_train_depot_widgets
 );
 
+/** Window definition for the aircraft depot window. */
 static WindowDesc _aircraft_depot_desc(
-	WDP_AUTO, "depot_aircraft", 332, 99,
+	WindowPosition::Automatic, "depot_aircraft", 332, 99,
 	WC_VEHICLE_DEPOT, WC_NONE,
 	{},
 	_nested_train_depot_widgets

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -356,8 +356,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_docks_toolbar_
 	EndContainer(),
 };
 
+/** Window definition for the water/docks toolbar. */
 static WindowDesc _build_docks_toolbar_desc(
-	WDP_MANUAL, "toolbar_water", 0, 0,
+	WindowPosition::Manual, "toolbar_water", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_docks_toolbar_widgets,
@@ -401,7 +402,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_docks_scen_too
 
 /** Window definition for the build docks in scenario editor window. */
 static WindowDesc _build_docks_scen_toolbar_desc(
-	WDP_AUTO, "toolbar_water_scen", 0, 0,
+	WindowPosition::Automatic, "toolbar_water_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_docks_scen_toolbar_widgets
@@ -502,8 +503,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_dock_station_w
 	EndContainer(),
 };
 
+/** Window definition for the dock building window. */
 static WindowDesc _build_dock_station_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_dock_station_widgets
@@ -597,8 +599,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_docks_depot_wi
 	EndContainer(),
 };
 
+/** Window definition for the ship depot window. */
 static WindowDesc _build_docks_depot_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_docks_depot_widgets

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -115,7 +115,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_dropdown_menu_widget
 
 /** Window description for dropdown menus. */
 static WindowDesc _dropdown_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_DROPDOWN_MENU, WC_NONE,
 	{},
 	_nested_dropdown_menu_widgets

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -271,8 +271,9 @@ struct EnginePreviewWindow : Window {
 	}
 };
 
+/** Window definition for the engine preview window. */
 static WindowDesc _engine_preview_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_ENGINE_PREVIEW, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_engine_preview_widgets

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -43,8 +43,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_errmsg_widgets = {
 	EndContainer(),
 };
 
+/** Window definition for the error message window. */
 static WindowDesc _errmsg_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	{},
 	_nested_errmsg_widgets
@@ -63,8 +64,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_errmsg_face_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the error message with company president face window. */
 static WindowDesc _errmsg_face_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_ERRMSG, WC_NONE,
 	{},
 	_nested_errmsg_face_widgets

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -982,7 +982,7 @@ public:
 
 /** Load game/scenario */
 static WindowDesc _load_dialog_desc(
-	WDP_CENTER, "load_game", 500, 294,
+	WindowPosition::Center, "load_game", 500, 294,
 	WC_SAVELOAD, WC_NONE,
 	{},
 	_nested_load_dialog_widgets
@@ -990,7 +990,7 @@ static WindowDesc _load_dialog_desc(
 
 /** Load heightmap */
 static WindowDesc _load_heightmap_dialog_desc(
-	WDP_CENTER, "load_heightmap", 257, 320,
+	WindowPosition::Center, "load_heightmap", 257, 320,
 	WC_SAVELOAD, WC_NONE,
 	{},
 	_nested_load_heightmap_dialog_widgets
@@ -998,7 +998,7 @@ static WindowDesc _load_heightmap_dialog_desc(
 
 /** Load town data */
 static WindowDesc _load_town_data_dialog_desc(
-	WDP_CENTER, "load_town_data", 257, 320,
+	WindowPosition::Center, "load_town_data", 257, 320,
 	WC_SAVELOAD, WC_NONE,
 	{},
 	_nested_load_town_data_dialog_widgets
@@ -1006,7 +1006,7 @@ static WindowDesc _load_town_data_dialog_desc(
 
 /** Save game/scenario */
 static WindowDesc _save_dialog_desc(
-	WDP_CENTER, "save_game", 500, 294,
+	WindowPosition::Center, "save_game", 500, 294,
 	WC_SAVELOAD, WC_NONE,
 	{},
 	_nested_save_dialog_widgets

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -719,8 +719,9 @@ struct FramerateWindow : Window {
 	}
 };
 
+/** Window definition for the frame rate window. */
 static WindowDesc _framerate_display_desc(
-	WDP_AUTO, "framerate_display", 0, 0,
+	WindowPosition::Automatic, "framerate_display", 0, 0,
 	WC_FRAMERATE_DISPLAY, WC_NONE,
 	{},
 	_framerate_window_widgets
@@ -1014,8 +1015,9 @@ struct FrametimeGraphWindow : Window {
 	}
 };
 
+/** Window definition for the frame rate graph window. */
 static WindowDesc _frametime_graph_window_desc(
-	WDP_AUTO, "frametime_graph", 140, 90,
+	WindowPosition::Automatic, "frametime_graph", 140, 90,
 	WC_FRAMETIME_GRAPH, WC_NONE,
 	{},
 	_frametime_graph_window_widgets

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -77,7 +77,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_gs_config_widgets = 
 
 /** Window definition for the configure GS window. */
 static WindowDesc _gs_config_desc(
-	WDP_CENTER, "settings_gs_config", 500, 350,
+	WindowPosition::Center, "settings_gs_config", 500, 350,
 	WC_GAME_OPTIONS, WC_NONE,
 	{},
 	_nested_gs_config_widgets

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1016,15 +1016,17 @@ struct GenerateLandscapeWindow : public Window {
 	}
 };
 
+/** Window definition for the landscape generation window. */
 static WindowDesc _generate_landscape_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	{},
 	_nested_generate_landscape_widgets
 );
 
+/** Window definition for the heightmap configuration window. */
 static WindowDesc _heightmap_load_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	{},
 	_nested_heightmap_load_widgets
@@ -1323,8 +1325,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_create_scenario_widg
 	EndContainer(),
 };
 
+/** Window definition for the create scenario window. */
 static WindowDesc _create_scenario_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_GENERATE_LANDSCAPE, WC_NONE,
 	{},
 	_nested_create_scenario_widgets
@@ -1349,8 +1352,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_generate_progress_wi
 };
 
 
+/** Window definition for the map generation progress window. */
 static WindowDesc _generate_progress_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_MODAL_PROGRESS, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_nested_generate_progress_widgets

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -296,8 +296,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_goals_list_widgets =
 	EndContainer(),
 };
 
+/** Window definition for the goal listing window. */
 static WindowDesc _goals_list_desc(
-	WDP_AUTO, "list_goals", 500, 127,
+	WindowPosition::Automatic, "list_goals", 500, 127,
 	WC_GOALS_LIST, WC_NONE,
 	{},
 	_nested_goals_list_widgets
@@ -437,27 +438,28 @@ static constexpr auto _nested_goal_question_widgets_info     = NestedGoalWidgets
 static constexpr auto _nested_goal_question_widgets_warning  = NestedGoalWidgets<Colours::Yellow,     Colours::Yellow,     STR_GOAL_QUESTION_CAPTION_WARNING>::widgetparts;
 static constexpr auto _nested_goal_question_widgets_error    = NestedGoalWidgets<Colours::Red,        Colours::Yellow,     STR_GOAL_QUESTION_CAPTION_ERROR>::widgetparts;
 
+/** Window definitions for the goal question windows. */
 static WindowDesc _goal_question_list_desc[] = {
 	{
-		WDP_CENTER, {}, 0, 0,
+		WindowPosition::Center, {}, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WindowDefaultFlag::Construction,
 		_nested_goal_question_widgets_question,
 	},
 	{
-		WDP_CENTER, {}, 0, 0,
+		WindowPosition::Center, {}, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WindowDefaultFlag::Construction,
 		_nested_goal_question_widgets_info,
 	},
 	{
-		WDP_CENTER, {}, 0, 0,
+		WindowPosition::Center, {}, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WindowDefaultFlag::Construction,
 		_nested_goal_question_widgets_warning,
 	},
 	{
-		WDP_CENTER, {}, 0, 0,
+		WindowPosition::Center, {}, 0, 0,
 		WC_GOAL_QUESTION, WC_NONE,
 		WindowDefaultFlag::Construction,
 		_nested_goal_question_widgets_error,

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -145,8 +145,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_graph_legend_widgets
 	EndContainer(),
 };
 
+/** Window definition for the graph legend window. */
 static WindowDesc _graph_legend_desc(
-	WDP_AUTO, "graph_legend", 0, 0,
+	WindowPosition::Automatic, "graph_legend", 0, 0,
 	WC_GRAPH_LEGEND, WC_NONE,
 	{},
 	_nested_graph_legend_widgets
@@ -961,8 +962,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_operating_profit_wid
 	EndContainer(),
 };
 
+/** Window definition for the operating profit graph window. */
 static WindowDesc _operating_profit_desc(
-	WDP_AUTO, "graph_operating_profit", 0, 0,
+	WindowPosition::Automatic, "graph_operating_profit", 0, 0,
 	WC_OPERATING_PROFIT, WC_NONE,
 	{},
 	_nested_operating_profit_widgets
@@ -1014,8 +1016,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_income_graph_widgets
 	EndContainer(),
 };
 
+/** Window definition for the income graph window. */
 static WindowDesc _income_graph_desc(
-	WDP_AUTO, "graph_income", 0, 0,
+	WindowPosition::Automatic, "graph_income", 0, 0,
 	WC_INCOME_GRAPH, WC_NONE,
 	{},
 	_nested_income_graph_widgets
@@ -1065,8 +1068,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_delivered_cargo_grap
 	EndContainer(),
 };
 
+/** Window definition for the delivered cargo graph window. */
 static WindowDesc _delivered_cargo_graph_desc(
-	WDP_AUTO, "graph_delivered_cargo", 0, 0,
+	WindowPosition::Automatic, "graph_delivered_cargo", 0, 0,
 	WC_DELIVERED_CARGO, WC_NONE,
 	{},
 	_nested_delivered_cargo_graph_widgets
@@ -1123,8 +1127,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_performance_history_
 	EndContainer(),
 };
 
+/** Window definition for the performance history graph window. */
 static WindowDesc _performance_history_desc(
-	WDP_AUTO, "graph_performance", 0, 0,
+	WindowPosition::Automatic, "graph_performance", 0, 0,
 	WC_PERFORMANCE_HISTORY, WC_NONE,
 	{},
 	_nested_performance_history_widgets
@@ -1174,8 +1179,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_company_value_graph_
 	EndContainer(),
 };
 
+/** Window definition for the company value graph window. */
 static WindowDesc _company_value_graph_desc(
-	WDP_AUTO, "graph_company_value", 0, 0,
+	WindowPosition::Automatic, "graph_company_value", 0, 0,
 	WC_COMPANY_VALUE, WC_NONE,
 	{},
 	_nested_company_value_graph_widgets
@@ -1462,8 +1468,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_cargo_payment_rates_
 	EndContainer(),
 };
 
+/** Window definition for the cargo payment rates graph window. */
 static WindowDesc _cargo_payment_rates_desc(
-	WDP_AUTO, "graph_cargo_payment_rates", 0, 0,
+	WindowPosition::Automatic, "graph_cargo_payment_rates", 0, 0,
 	WC_PAYMENT_RATES, WC_NONE,
 	{},
 	_nested_cargo_payment_rates_widgets
@@ -1866,8 +1873,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_industry_production_
 	EndContainer(),
 };
 
+/** Window definition for the industry production graph window. */
 static WindowDesc _industry_production_desc(
-	WDP_AUTO, "graph_industry_production", 0, 0,
+	WindowPosition::Automatic, "graph_industry_production", 0, 0,
 	WC_INDUSTRY_PRODUCTION, WC_INDUSTRY_VIEW,
 	{},
 	_nested_industry_production_widgets
@@ -2029,8 +2037,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_town_cargo_graph_wid
 	EndContainer(),
 };
 
+/** Window definition for the town cargo graph window. */
 static WindowDesc _town_cargo_graph_desc(
-	WDP_AUTO, "graph_town_cargo", 0, 0,
+	WindowPosition::Automatic, "graph_town_cargo", 0, 0,
 	WC_TOWN_CARGO_GRAPH, WC_TOWN_VIEW,
 	{},
 	_nested_town_cargo_graph_widgets
@@ -2092,8 +2101,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_performance_rating_d
 	NWidgetFunction(MakePerformanceDetailPanels),
 };
 
+/** Window definition for the performance rating details window. */
 static WindowDesc _performance_rating_detail_desc(
-	WDP_AUTO, "league_details", 0, 0,
+	WindowPosition::Automatic, "league_details", 0, 0,
 	WC_PERFORMANCE_DETAIL, WC_NONE,
 	{},
 	_nested_performance_rating_detail_widgets

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1190,27 +1190,28 @@ public:
 
 };
 
+/** Window definitions for the vehicle group windows. */
 static WindowDesc _vehicle_group_desc[] = {
 	{
-		WDP_AUTO, "list_groups_train", 525, 246,
+		WindowPosition::Automatic, "list_groups_train", 525, 246,
 		WC_TRAINS_LIST, WC_NONE,
 		{},
 		_nested_group_widgets
 	},
 	{
-		WDP_AUTO, "list_groups_roadveh", 460, 246,
+		WindowPosition::Automatic, "list_groups_roadveh", 460, 246,
 		WC_ROADVEH_LIST, WC_NONE,
 		{},
 		_nested_group_widgets
 	},
 	{
-		WDP_AUTO, "list_groups_ship", 460, 246,
+		WindowPosition::Automatic, "list_groups_ship", 460, 246,
 		WC_SHIPS_LIST, WC_NONE,
 		{},
 		_nested_group_widgets
 	},
 	{
-		WDP_AUTO, "list_groups_aircraft", 460, 246,
+		WindowPosition::Automatic, "list_groups_aircraft", 460, 246,
 		WC_AIRCRAFT_LIST, WC_NONE,
 		{},
 		_nested_group_widgets

--- a/src/help_gui.cpp
+++ b/src/help_gui.cpp
@@ -202,8 +202,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_helpwin_widgets = {
 	EndContainer(),
 };
 
+/** Window definition for the help window. */
 static WindowDesc _helpwin_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_HELPWIN, WC_NONE,
 	{},
 	_nested_helpwin_widgets

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -225,15 +225,17 @@ static constexpr std::initializer_list<NWidgetPart> _nested_highscore_widgets = 
 	NWidget(WWT_PANEL, Colours::Brown, WID_H_BACKGROUND), SetResize(1, 1), EndContainer(),
 };
 
+/** Window definition for the highscore window. */
 static WindowDesc _highscore_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_HIGHSCORE, WC_NONE,
 	{},
 	_nested_highscore_widgets
 );
 
+/** Window definition for the endgame window. */
 static WindowDesc _endgame_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_ENDSCREEN, WC_NONE,
 	{},
 	_nested_highscore_widgets

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -291,7 +291,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_industry_widge
 
 /** Window definition of the dynamic place industries gui */
 static WindowDesc _build_industry_desc(
-	WDP_AUTO, "build_industry", 170, 212,
+	WindowPosition::Automatic, "build_industry", 170, 212,
 	WC_BUILD_INDUSTRY, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_industry_widgets
@@ -1222,7 +1222,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_industry_view_widget
 
 /** Window definition of the view industry gui */
 static WindowDesc _industry_view_desc(
-	WDP_AUTO, "view_industry", 260, 120,
+	WindowPosition::Automatic, "view_industry", 260, 120,
 	WC_INDUSTRY_VIEW, WC_NONE,
 	{},
 	_nested_industry_view_widgets
@@ -1916,7 +1916,7 @@ CargoType IndustryDirectoryWindow::produced_cargo_filter = CargoFilterCriteria::
 
 /** Window definition of the industry directory gui */
 static WindowDesc _industry_directory_desc(
-	WDP_AUTO, "list_industries", 428, 190,
+	WindowPosition::Automatic, "list_industries", 428, 190,
 	WC_INDUSTRY_DIRECTORY, WC_NONE,
 	{},
 	_nested_industry_directory_widgets,
@@ -1955,7 +1955,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_industry_cargoes_wid
 
 /** Window description for the industry cargoes window. */
 static WindowDesc _industry_cargoes_desc(
-	WDP_AUTO, "industry_cargoes", 300, 210,
+	WindowPosition::Automatic, "industry_cargoes", 300, 210,
 	WC_INDUSTRY_CARGOES, WC_NONE,
 	{},
 	_nested_industry_cargoes_widgets

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -388,8 +388,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_select_game_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the select game window. */
 static WindowDesc _select_game_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_SELECT_GAME, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_nested_select_game_widgets

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -191,8 +191,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_performance_league_w
 	EndContainer(),
 };
 
+/** Window definition for the performance league window. */
 static WindowDesc _performance_league_desc(
-	WDP_AUTO, "performance_league", 0, 0,
+	WindowPosition::Automatic, "performance_league", 0, 0,
 	WC_COMPANY_LEAGUE, WC_NONE,
 	{},
 	_nested_performance_league_widgets
@@ -427,8 +428,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_script_league_widget
 	EndContainer(),
 };
 
+/** Window definition for the script league window. */
 static WindowDesc _script_league_desc(
-	WDP_AUTO, "script_league", 0, 0,
+	WindowPosition::Automatic, "script_league", 0, 0,
 	WC_COMPANY_LEAGUE, WC_NONE,
 	{},
 	_nested_script_league_widgets

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -532,8 +532,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_linkgraph_legend_wid
 static_assert(WID_LGL_SATURATION_LAST - WID_LGL_SATURATION_FIRST ==
 		lengthof(LinkGraphOverlay::LINK_COLOURS[0]) - 1);
 
+/** Window definition for the linkgraph toolbar. */
 static WindowDesc _linkgraph_legend_desc(
-	WDP_AUTO, "toolbar_linkgraph", 0, 0,
+	WindowPosition::Automatic, "toolbar_linkgraph", 0, 0,
 	WC_LINKGRAPH_LEGEND, WC_NONE,
 	{},
 	_nested_linkgraph_legend_widgets

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -525,8 +525,9 @@ struct MainWindow : Window
 	}};
 };
 
+/** Window definition for the main window. */
 static WindowDesc _main_window_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_MAIN_WINDOW, WC_NONE,
 	WindowDefaultFlag::NoClose,
 	_nested_main_window_widgets,

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -54,8 +54,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_land_info_widgets = 
 	NWidget(WWT_PANEL, Colours::Grey, WID_LI_BACKGROUND), EndContainer(),
 };
 
+/** Window definition for the land information window. */
 static WindowDesc _land_info_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_LAND_INFO, WC_NONE,
 	{},
 	_nested_land_info_widgets
@@ -333,8 +334,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_about_widgets = {
 	EndContainer(),
 };
 
+/** Window definition for the about window. */
 static WindowDesc _about_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	{},
 	_nested_about_widgets
@@ -589,8 +591,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_tooltips_widgets = {
 	NWidget(WWT_EMPTY, Colours::Invalid, WID_TT_BACKGROUND),
 };
 
+/** Window definition for the tool tip window. */
 static WindowDesc _tool_tips_desc(
-	WDP_MANUAL, {}, 0, 0, // Coordinates and sizes are not used,
+	WindowPosition::Manual, {}, 0, 0, // Coordinates and sizes are not used,
 	WC_TOOLTIPS, WC_NONE,
 	{WindowDefaultFlag::NoFocus, WindowDefaultFlag::NoClose},
 	_nested_tooltips_widgets
@@ -1039,8 +1042,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_query_string_widgets
 	EndContainer(),
 };
 
+/** Window definition for the string query window. */
 static WindowDesc _query_string_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	{},
 	_nested_query_string_widgets
@@ -1188,8 +1192,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_query_widgets = {
 	EndContainer(),
 };
 
+/** Window definition for the query window. */
 static WindowDesc _query_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_CONFIRM_POPUP_QUERY, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_query_widgets

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -670,8 +670,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_music_track_selectio
 	EndContainer(),
 };
 
+/** Window definition for the music track selection window. */
 static WindowDesc _music_track_selection_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_MUSIC_TRACK_SELECTION, WC_NONE,
 	{},
 	_nested_music_track_selection_widgets
@@ -929,8 +930,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_music_window_widgets
 	EndContainer(),
 };
 
+/** Window definition for the music window. */
 static WindowDesc _music_window_desc(
-	WDP_AUTO, "music", 0, 0,
+	WindowPosition::Automatic, "music", 0, 0,
 	WC_MUSIC_WINDOW, WC_NONE,
 	{},
 	_nested_music_window_widgets

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -429,7 +429,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_chat_window_widgets 
 
 /** The description of the chat window. */
 static WindowDesc _chat_window_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_SEND_NETWORK_MSG, WC_NONE,
 	{},
 	_nested_chat_window_widgets

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -113,7 +113,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_network_content_down
 
 /** Window description for the download window */
 static WindowDesc _network_content_download_status_window_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_network_content_download_status_window_widgets
@@ -1119,7 +1119,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_network_content_list
 
 /** Window description of the content list */
 static WindowDesc _network_content_list_desc(
-	WDP_CENTER, "list_content", 630, 460,
+	WindowPosition::Center, "list_content", 630, 460,
 	WC_NETWORK_WINDOW, WC_NONE,
 	{},
 	_nested_network_content_list_widgets

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -952,7 +952,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_network_game_widgets
 
 /** Description of the NetworkGameWindow. */
 static WindowDesc _network_game_window_desc(
-	WDP_CENTER, "list_servers", 1000, 730,
+	WindowPosition::Center, "list_servers", 1000, 730,
 	WC_NETWORK_WINDOW, WC_NONE,
 	{},
 	_nested_network_game_widgets
@@ -1229,7 +1229,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_network_start_server
 
 /** Description of the NetworkStartServerWindow. */
 static WindowDesc _network_start_server_window_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_NETWORK_WINDOW, WC_NONE,
 	{},
 	_nested_network_start_server_window_widgets
@@ -1306,7 +1306,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_client_list_widgets 
 
 /** Description of the NetworkClientListWindow. */
 static WindowDesc _client_list_desc(
-	WDP_AUTO, "list_clients", 220, 300,
+	WindowPosition::Automatic, "list_clients", 220, 300,
 	WC_CLIENT_LIST, WC_NONE,
 	{},
 	_nested_client_list_widgets
@@ -2208,7 +2208,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_network_join_status_
 
 /** Description of the NetworkJoinStatusWindow. */
 static WindowDesc _network_join_status_window_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_network_join_status_window_widgets
@@ -2330,7 +2330,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_network_ask_relay_wi
 
 /** Description of the NetworkAskRelayWindow. */
 static WindowDesc _network_ask_relay_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_NETWORK_ASK_RELAY, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_network_ask_relay_widgets
@@ -2435,7 +2435,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_network_ask_survey_w
 
 /** Description of the NetworkAskSurveyWindow. */
 static WindowDesc _network_ask_survey_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_NETWORK_ASK_SURVEY, WC_NONE,
 	WindowDefaultFlag::Modal,
 	_nested_network_ask_survey_widgets

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -678,15 +678,17 @@ static constexpr std::initializer_list<NWidgetPart> _nested_newgrf_inspect_widge
 	EndContainer(),
 };
 
+/** Window definition for the NewGRF chain inspection window. */
 static WindowDesc _newgrf_inspect_chain_desc(
-	WDP_AUTO, "newgrf_inspect_chain", 400, 300,
+	WindowPosition::Automatic, "newgrf_inspect_chain", 400, 300,
 	WC_NEWGRF_INSPECT, WC_NONE,
 	{},
 	_nested_newgrf_inspect_chain_widgets
 );
 
+/** Window definition for the NewGRF inspection window. */
 static WindowDesc _newgrf_inspect_desc(
-	WDP_AUTO, "newgrf_inspect", 400, 300,
+	WindowPosition::Automatic, "newgrf_inspect", 400, 300,
 	WC_NEWGRF_INSPECT, WC_NONE,
 	{},
 	_nested_newgrf_inspect_widgets
@@ -1185,8 +1187,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_sprite_aligner_widge
 	EndContainer(),
 };
 
+/** Window definition for the sprite aligner window. */
 static WindowDesc _sprite_aligner_desc(
-	WDP_AUTO, "sprite_aligner", 400, 300,
+	WindowPosition::Automatic, "sprite_aligner", 400, 300,
 	WC_SPRITE_ALIGNER, WC_NONE,
 	{},
 	_nested_sprite_aligner_widgets

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -533,7 +533,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_newgrf_parameter_wid
 
 /** Window definition for the change grf parameters window */
 static WindowDesc _newgrf_parameters_desc(
-	WDP_CENTER, "settings_newgrf_config", 500, 208,
+	WindowPosition::Center, "settings_newgrf_config", 500, 208,
 	WC_GRF_PARAMETERS, WC_NONE,
 	{},
 	_nested_newgrf_parameter_widgets
@@ -1906,7 +1906,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_newgrf_widgets = {
 
 /** Window definition of the manage newgrfs window. */
 static WindowDesc _newgrf_desc(
-	WDP_CENTER, "settings_newgrf", 300, 263,
+	WindowPosition::Center, "settings_newgrf", 300, 263,
 	WC_GAME_OPTIONS, WC_NONE,
 	{},
 	_nested_newgrf_widgets
@@ -1997,7 +1997,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_save_preset_widgets 
 
 /** Window description of the preset save window. */
 static WindowDesc _save_preset_desc(
-	WDP_CENTER, "save_preset", 140, 110,
+	WindowPosition::Center, "save_preset", 140, 110,
 	WC_SAVE_PRESET, WC_GAME_OPTIONS,
 	WindowDefaultFlag::Modal,
 	_nested_save_preset_widgets
@@ -2138,7 +2138,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_scan_progress_widget
 
 /** Description of the widgets and other settings of the window. */
 static WindowDesc _scan_progress_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_MODAL_PROGRESS, WC_NONE,
 	{},
 	_nested_scan_progress_widgets

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -126,8 +126,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_normal_news_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the normal news window. */
 static WindowDesc _normal_news_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_normal_news_widgets
@@ -174,8 +175,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_vehicle_news_widgets
 	EndContainer(),
 };
 
+/** Window definition for the vehicle news window. */
 static WindowDesc _vehicle_news_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_vehicle_news_widgets
@@ -219,8 +221,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_company_news_widgets
 	EndContainer(),
 };
 
+/** Window definition for the company news window. */
 static WindowDesc _company_news_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_company_news_widgets
@@ -253,8 +256,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_thin_news_widgets = 
 	EndContainer(),
 };
 
+/** Window definition for the thin news window. */
 static WindowDesc _thin_news_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_thin_news_widgets
@@ -291,8 +295,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_small_news_widgets =
 	EndContainer(),
 };
 
+/** Window definition for the small news window. */
 static WindowDesc _small_news_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_NEWS_WINDOW, WC_NONE,
 	{},
 	_nested_small_news_widgets
@@ -1309,8 +1314,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_message_history = {
 	EndContainer(),
 };
 
+/** Window definition for the news message history window. */
 static WindowDesc _message_history_desc(
-	WDP_AUTO, "list_news", 400, 140,
+	WindowPosition::Automatic, "list_news", 400, 140,
 	WC_MESSAGE_HISTORY, WC_NONE,
 	{},
 	_nested_message_history

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -408,8 +408,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_object_widgets
 	EndContainer(),
 };
 
+/** Window definition for the build object window. */
 static WindowDesc _build_object_desc(
-	WDP_AUTO, "build_object", 0, 0,
+	WindowPosition::Automatic, "build_object", 0, 0,
 	WC_BUILD_OBJECT, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_object_widgets,

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1642,8 +1642,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_orders_train_widgets
 	EndContainer(),
 };
 
+/** Window definition for the train orders window. */
 static WindowDesc _orders_train_desc(
-	WDP_AUTO, "view_vehicle_orders_train", 384, 100,
+	WindowPosition::Automatic, "view_vehicle_orders_train", 384, 100,
 	WC_VEHICLE_ORDERS, WC_VEHICLE_VIEW,
 	WindowDefaultFlag::Construction,
 	_nested_orders_train_widgets,
@@ -1715,8 +1716,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_orders_widgets = {
 	EndContainer(),
 };
 
+/** Window definition for the orders window for road vehicles, ships and aircraft. */
 static WindowDesc _orders_desc(
-	WDP_AUTO, "view_vehicle_orders", 384, 100,
+	WindowPosition::Automatic, "view_vehicle_orders", 384, 100,
 	WC_VEHICLE_ORDERS, WC_VEHICLE_VIEW,
 	WindowDefaultFlag::Construction,
 	_nested_orders_widgets,
@@ -1742,8 +1744,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_other_orders_widgets
 	EndContainer(),
 };
 
+/** Window definition for the orders window for other companies. */
 static WindowDesc _other_orders_desc(
-	WDP_AUTO, "view_vehicle_orders_competitor", 384, 86,
+	WindowPosition::Automatic, "view_vehicle_orders_competitor", 384, 86,
 	WC_VEHICLE_ORDERS, WC_VEHICLE_VIEW,
 	WindowDefaultFlag::Construction,
 	_nested_other_orders_widgets,

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -338,8 +338,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_osk_widgets = {
 	EndContainer(),
 };
 
+/** Window definition for the on screen keyboard window. */
 static WindowDesc _osk_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_OSK, WC_NONE,
 	{},
 	_nested_osk_widgets

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -942,8 +942,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_rail_widgets =
 	EndContainer(),
 };
 
+/** Window definition for the rail toolbar. */
 static WindowDesc _build_rail_desc(
-	WDP_MANUAL, "toolbar_rail", 0, 0,
+	WindowPosition::Manual, "toolbar_rail", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_rail_widgets,
@@ -1483,7 +1484,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_station_builder_widg
 
 /** High level window description of the station-build window (default & newGRF) */
 static WindowDesc _station_builder_desc(
-	WDP_AUTO, "build_station_rail", 0, 0,
+	WindowPosition::Automatic, "build_station_rail", 0, 0,
 	WC_BUILD_STATION, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_station_builder_widgets,
@@ -1741,7 +1742,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_signal_builder_widge
 
 /** Signal selection window description */
 static WindowDesc _signal_builder_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_BUILD_SIGNAL, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_signal_builder_widgets
@@ -1822,8 +1823,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_depot_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the build rail depot window. */
 static WindowDesc _build_depot_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_depot_widgets
@@ -1942,8 +1944,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_waypoint_widge
 	EndContainer(),
 };
 
+/** Window definition for the build rail waypoint window. */
 static WindowDesc _build_waypoint_desc(
-	WDP_AUTO, "build_waypoint", 0, 0,
+	WindowPosition::Automatic, "build_waypoint", 0, 0,
 	WC_BUILD_WAYPOINT, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_waypoint_widgets,

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -994,8 +994,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_road_widgets =
 	EndContainer(),
 };
 
+/** Window definition for the road toolbar. */
 static WindowDesc _build_road_desc(
-	WDP_MANUAL, "toolbar_road", 0, 0,
+	WindowPosition::Manual, "toolbar_road", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_road_widgets,
@@ -1039,8 +1040,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_tramway_widget
 	EndContainer(),
 };
 
+/** Window definition for the tram toolbar. */
 static WindowDesc _build_tramway_desc(
-	WDP_MANUAL, "toolbar_tramway", 0, 0,
+	WindowPosition::Manual, "toolbar_tramway", 0, 0,
 	WC_BUILD_TOOLBAR, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_tramway_widgets,
@@ -1097,8 +1099,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_road_scen_widg
 	EndContainer(),
 };
 
+/** Window definition for the road toolbar of the scenario editor. */
 static WindowDesc _build_road_scen_desc(
-	WDP_AUTO, "toolbar_road_scen", 0, 0,
+	WindowPosition::Automatic, "toolbar_road_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_road_scen_widgets,
@@ -1134,8 +1137,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_tramway_scen_w
 	EndContainer(),
 };
 
+/** Window definition for the tram toolbar of the scenario editor. */
 static WindowDesc _build_tramway_scen_desc(
-	WDP_AUTO, "toolbar_tram_scen", 0, 0,
+	WindowPosition::Automatic, "toolbar_tram_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_tramway_scen_widgets,
@@ -1232,8 +1236,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_road_depot_wid
 	EndContainer(),
 };
 
+/** Window definition for the build road depot window. */
 static WindowDesc _build_road_depot_desc(
-	WDP_AUTO, {}, 0, 0,
+	WindowPosition::Automatic, {}, 0, 0,
 	WC_BUILD_DEPOT, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_road_depot_widgets
@@ -1629,8 +1634,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_road_station_picker_
 	EndContainer(),
 };
 
+/** Window definition for the build road station window. */
 static WindowDesc _road_station_picker_desc(
-	WDP_AUTO, "build_station_road", 0, 0,
+	WindowPosition::Automatic, "build_station_road", 0, 0,
 	WC_BUS_STATION, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_road_station_picker_widgets,
@@ -1669,8 +1675,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_tram_station_picker_
 	EndContainer(),
 };
 
+/** Window definition for the build tram station window. */
 static WindowDesc _tram_station_picker_desc(
-	WDP_AUTO, "build_station_tram", 0, 0,
+	WindowPosition::Automatic, "build_station_tram", 0, 0,
 	WC_BUS_STATION, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_tram_station_picker_widgets,
@@ -1791,8 +1798,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_road_waypoint_
 	EndContainer(),
 };
 
+/** Window definition for the build road waypoint window. */
 static WindowDesc _build_road_waypoint_desc(
-	WDP_AUTO, "build_road_waypoint", 0, 0,
+	WindowPosition::Automatic, "build_road_waypoint", 0, 0,
 	WC_BUILD_WAYPOINT, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_road_waypoint_widgets,

--- a/src/screenshot_gui.cpp
+++ b/src/screenshot_gui.cpp
@@ -64,8 +64,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_screenshot = {
 	EndContainer(),
 };
 
+/** Window definition for the screenshot window. */
 static WindowDesc _screenshot_window_desc(
-	WDP_AUTO, "take_a_screenshot", 200, 100,
+	WindowPosition::Automatic, "take_a_screenshot", 200, 100,
 	WC_SCREENSHOT, WC_NONE,
 	{},
 	_nested_screenshot

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -264,7 +264,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_script_list_widgets 
 
 /** Window definition for the ai list window. */
 static WindowDesc _script_list_desc(
-	WDP_CENTER, "settings_script_list", 200, 234,
+	WindowPosition::Center, "settings_script_list", 200, 234,
 	WC_SCRIPT_LIST, WC_NONE,
 	{},
 	_nested_script_list_widgets
@@ -575,7 +575,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_script_settings_widg
 
 /** Window definition for the Script settings window. */
 static WindowDesc _script_settings_desc(
-	WDP_CENTER, "settings_script", 500, 208,
+	WindowPosition::Center, "settings_script", 500, 208,
 	WC_SCRIPT_SETTINGS, WC_NONE,
 	{},
 	_nested_script_settings_widgets
@@ -1252,7 +1252,7 @@ EndContainer(),
 
 /** Window definition for the Script debug window. */
 static WindowDesc _script_debug_desc(
-	WDP_AUTO, "script_debug", 600, 450,
+	WindowPosition::Automatic, "script_debug", 600, 450,
 	WC_SCRIPT_DEBUG, WC_NONE,
 	{},
 	_nested_script_debug_widgets,

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1852,8 +1852,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_game_options_widgets
 	EndContainer(),
 };
 
+/** Window definition for the game options window. */
 static WindowDesc _game_options_desc(
-	WDP_CENTER, "game_options", 0, 0,
+	WindowPosition::Center, "game_options", 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	{},
 	_nested_game_options_widgets
@@ -2195,8 +2196,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_cust_currency_widget
 	EndContainer(),
 };
 
+/** Window definition for the custom currency window. */
 static WindowDesc _cust_currency_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_CUSTOM_CURRENCY, WC_NONE,
 	{},
 	_nested_cust_currency_widgets

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -360,8 +360,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_sign_list_widgets = 
 	EndContainer(),
 };
 
+/** Window definition for the sign list window. */
 static WindowDesc _sign_list_desc(
-	WDP_AUTO, "list_signs", 358, 138,
+	WindowPosition::Automatic, "list_signs", 358, 138,
 	WC_SIGN_LIST, WC_NONE,
 	{},
 	_nested_sign_list_widgets,
@@ -612,8 +613,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_query_sign_edit_widg
 	EndContainer(),
 };
 
+/** Window definition for the sign editor window. */
 static WindowDesc _query_sign_edit_desc(
-	WDP_CENTER, {}, 0, 0,
+	WindowPosition::Center, {}, 0, 0,
 	WC_QUERY_STRING, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_query_sign_edit_widgets

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -2058,8 +2058,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_smallmap_widgets = {
 	EndContainer(),
 };
 
+/** Window definition for the smallmap window. */
 static WindowDesc _smallmap_desc(
-	WDP_AUTO, "smallmap", 484, 314,
+	WindowPosition::Automatic, "smallmap", 484, 314,
 	WC_SMALLMAP, WC_NONE,
 	{},
 	_nested_smallmap_widgets

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -796,8 +796,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_company_stations_wid
 	EndContainer(),
 };
 
+/** Window definition for the company stations window. */
 static WindowDesc _company_stations_desc(
-	WDP_AUTO, "list_stations", 358, 162,
+	WindowPosition::Automatic, "list_stations", 358, 162,
 	WC_STATION_LIST, WC_NONE,
 	{},
 	_nested_company_stations_widgets
@@ -2174,8 +2175,9 @@ struct StationViewWindow : public Window {
 	}
 };
 
+/** Window definition for the station view window. */
 static WindowDesc _station_view_desc(
-	WDP_AUTO, "view_station", 249, 117,
+	WindowPosition::Automatic, "view_station", 249, 117,
 	WC_STATION_VIEW, WC_NONE,
 	{},
 	_nested_station_view_widgets
@@ -2427,8 +2429,9 @@ struct SelectStationWindow : Window {
 	}
 };
 
+/** Window definition for the station selection window for (distant) joining. */
 static WindowDesc _select_station_desc(
-	WDP_AUTO, "build_station_join", 200, 180,
+	WindowPosition::Automatic, "build_station_join", 200, 180,
 	WC_SELECT_STATION, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_select_station_widgets

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -218,8 +218,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_main_status_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the main status bar. */
 static WindowDesc _main_status_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_STATUS_BAR, WC_NONE,
 	{WindowDefaultFlag::NoFocus, WindowDefaultFlag::NoClose},
 	_nested_main_status_widgets

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -961,15 +961,17 @@ static constexpr std::initializer_list<NWidgetPart> _nested_story_book_widgets =
 	EndContainer(),
 };
 
+/** Window definition for the story book window. */
 static WindowDesc _story_book_desc(
-	WDP_AUTO, "view_story", 400, 300,
+	WindowPosition::Automatic, "view_story", 400, 300,
 	WC_STORY_BOOK, WC_NONE,
 	{},
 	_nested_story_book_widgets
 );
 
+/** Window definition for the game script window. */
 static WindowDesc _story_book_gs_desc(
-	WDP_CENTER, "view_story_gs", 400, 300,
+	WindowPosition::Center, "view_story_gs", 400, 300,
 	WC_STORY_BOOK, WC_NONE,
 	{},
 	_nested_story_book_widgets

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -279,8 +279,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_subsidies_list_widge
 	EndContainer(),
 };
 
+/** Window definition for the subsidies window. */
 static WindowDesc _subsidies_list_desc(
-	WDP_AUTO, "list_subsidies", 500, 127,
+	WindowPosition::Automatic, "list_subsidies", 500, 127,
 	WC_SUBSIDIES_LIST, WC_NONE,
 	{},
 	_nested_subsidies_list_widgets

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -356,8 +356,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_terraform_widgets = 
 	EndContainer(),
 };
 
+/** Window definition for the landscaping toolbar. */
 static WindowDesc _terraform_desc(
-	WDP_MANUAL, "toolbar_landscape", 0, 0,
+	WindowPosition::Manual, "toolbar_landscape", 0, 0,
 	WC_SCEN_LAND_GEN, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_terraform_widgets,
@@ -735,8 +736,9 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 	}, TerraformToolbarEditorGlobalHotkeys};
 };
 
+/** Window definition for the landscaping toolbar for he scenario editor. */
 static WindowDesc _scen_edit_land_gen_desc(
-	WDP_AUTO, "toolbar_landscape_scen", 0, 0,
+	WindowPosition::Automatic, "toolbar_landscape_scen", 0, 0,
 	WC_SCEN_LAND_GEN, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_scen_edit_land_gen_widgets,

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -77,7 +77,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_textfile_widgets = {
 
 /** Window definition for the textfile window */
 static WindowDesc _textfile_desc(
-	WDP_CENTER, "textfile", 630, 460,
+	WindowPosition::Center, "textfile", 630, 460,
 	WC_TEXTFILE, WC_NONE,
 	{},
 	_nested_textfile_widgets

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -842,8 +842,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_timetable_widgets = 
 	EndContainer(),
 };
 
+/** Window definition for the timetable window. */
 static WindowDesc _timetable_desc(
-	WDP_AUTO, "view_vehicle_timetable", 400, 130,
+	WindowPosition::Automatic, "view_vehicle_timetable", 400, 130,
 	WC_VEHICLE_TIMETABLE, WC_VEHICLE_VIEW,
 	WindowDefaultFlag::Construction,
 	_nested_timetable_widgets

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2256,8 +2256,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_toolbar_normal_widge
 	NWidgetFunction(MakeMainToolbar),
 };
 
+/** Window definition for the normal (top) toolbar. */
 static WindowDesc _toolb_normal_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
 	{WindowDefaultFlag::NoFocus, WindowDefaultFlag::NoClose},
 	_nested_toolbar_normal_widgets,
@@ -2599,8 +2600,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_toolb_scen_widgets =
 	NWidgetFunction(MakeScenarioToolbar),
 };
 
+/** Window definition for the scenario editor (top) toolbar window. */
 static WindowDesc _toolb_scen_desc(
-	WDP_MANUAL, {}, 0, 0,
+	WindowPosition::Manual, {}, 0, 0,
 	WC_MAIN_TOOLBAR, WC_NONE,
 	{WindowDefaultFlag::NoFocus, WindowDefaultFlag::NoClose},
 	_nested_toolb_scen_widgets,

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -330,8 +330,9 @@ public:
 	}
 };
 
+/** Window definition for the town authority window. */
 static WindowDesc _town_authority_desc(
-	WDP_AUTO, "view_town_authority", 317, 222,
+	WindowPosition::Automatic, "view_town_authority", 317, 222,
 	WC_TOWN_AUTHORITY, WC_NONE,
 	{},
 	_nested_town_authority_widgets
@@ -636,8 +637,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_town_game_view_widge
 	EndContainer(),
 };
 
+/** Window definition for the town view window. */
 static WindowDesc _town_game_view_desc(
-	WDP_AUTO, "view_town", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
+	WindowPosition::Automatic, "view_town", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
 	WC_TOWN_VIEW, WC_NONE,
 	{},
 	_nested_town_game_view_widgets
@@ -671,8 +673,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_town_editor_view_wid
 	EndContainer(),
 };
 
+/** Window definition for the town view window of the scenario edtior. */
 static WindowDesc _town_editor_view_desc(
-	WDP_AUTO, "view_town_scen", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
+	WindowPosition::Automatic, "view_town_scen", 260, TownViewWindow::WID_TV_HEIGHT_NORMAL,
 	WC_TOWN_VIEW, WC_NONE,
 	{},
 	_nested_town_editor_view_widgets
@@ -1043,8 +1046,9 @@ const std::initializer_list<GUITownList::SortFunction * const> TownDirectoryWind
 	&TownRatingSorter,
 };
 
+/** Window definition for the town directory window. */
 static WindowDesc _town_directory_desc(
-	WDP_AUTO, "list_towns", 208, 202,
+	WindowPosition::Automatic, "list_towns", 208, 202,
 	WC_TOWN_DIRECTORY, WC_NONE,
 	{},
 	_nested_town_directory_widgets,
@@ -1344,8 +1348,9 @@ public:
 	}
 };
 
+/** Window definition for the town funding window. */
 static WindowDesc _found_town_desc(
-	WDP_AUTO, "build_town", 160, 162,
+	WindowPosition::Automatic, "build_town", 160, 162,
 	WC_FOUND_TOWN, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_found_town_widgets
@@ -1867,8 +1872,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_house_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the house building window. */
 static WindowDesc _build_house_desc(
-	WDP_AUTO, "build_house", 0, 0,
+	WindowPosition::Automatic, "build_house", 0, 0,
 	WC_BUILD_HOUSE, WC_BUILD_TOOLBAR,
 	WindowDefaultFlag::Construction,
 	_nested_build_house_widgets,

--- a/src/transparency_gui.cpp
+++ b/src/transparency_gui.cpp
@@ -149,8 +149,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_transparency_widgets
 	EndContainer(),
 };
 
+/** Window definition for the transparency toolbar window. */
 static WindowDesc _transparency_desc(
-	WDP_MANUAL, "toolbar_transparency", 0, 0,
+	WindowPosition::Manual, "toolbar_transparency", 0, 0,
 	WC_TRANSPARENCY_TOOLBAR, WC_NONE,
 	{},
 	_nested_transparency_widgets

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -310,8 +310,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_build_trees_widgets 
 	EndContainer(),
 };
 
+/** Window definition for the tree building window. */
 static WindowDesc _build_trees_desc(
-	WDP_AUTO, "build_tree", 0, 0,
+	WindowPosition::Automatic, "build_tree", 0, 0,
 	WC_BUILD_TREES, WC_NONE,
 	WindowDefaultFlag::Construction,
 	_nested_build_trees_widgets

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1340,8 +1340,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_vehicle_refit_widget
 	EndContainer(),
 };
 
+/** Window definition for the vehicle refit window. */
 static WindowDesc _vehicle_refit_desc(
-	WDP_AUTO, "view_vehicle_refit", 240, 174,
+	WindowPosition::Automatic, "view_vehicle_refit", 240, 174,
 	WC_VEHICLE_REFIT, WC_VEHICLE_VIEW,
 	WindowDefaultFlag::Construction,
 	_nested_vehicle_refit_widgets
@@ -2278,27 +2279,28 @@ public:
 	}
 };
 
+/** Window definitions for the vehicle list windows. */
 static WindowDesc _vehicle_list_desc[] = {
 	{
-		WDP_AUTO, "list_vehicles_train", 325, 246,
+		WindowPosition::Automatic, "list_vehicles_train", 325, 246,
 		WC_TRAINS_LIST, WC_NONE,
 		{},
 		_nested_vehicle_list
 	},
 	{
-		WDP_AUTO, "list_vehicles_roadveh", 260, 246,
+		WindowPosition::Automatic, "list_vehicles_roadveh", 260, 246,
 		WC_ROADVEH_LIST, WC_NONE,
 		{},
 		_nested_vehicle_list
 	},
 	{
-		WDP_AUTO, "list_vehicles_ship", 260, 246,
+		WindowPosition::Automatic, "list_vehicles_ship", 260, 246,
 		WC_SHIPS_LIST, WC_NONE,
 		{},
 		_nested_vehicle_list
 	},
 	{
-		WDP_AUTO, "list_vehicles_aircraft", 260, 246,
+		WindowPosition::Automatic, "list_vehicles_aircraft", 260, 246,
 		WC_AIRCRAFT_LIST, WC_NONE,
 		{},
 		_nested_vehicle_list
@@ -2831,7 +2833,7 @@ struct VehicleDetailsWindow : Window {
 
 /** Vehicle details window descriptor. */
 static WindowDesc _train_vehicle_details_desc(
-	WDP_AUTO, "view_vehicle_details_train", 405, 178,
+	WindowPosition::Automatic, "view_vehicle_details_train", 405, 178,
 	WC_VEHICLE_DETAILS, WC_VEHICLE_VIEW,
 	{},
 	_nested_train_vehicle_details_widgets
@@ -2839,7 +2841,7 @@ static WindowDesc _train_vehicle_details_desc(
 
 /** Vehicle details window descriptor for other vehicles than a train. */
 static WindowDesc _nontrain_vehicle_details_desc(
-	WDP_AUTO, "view_vehicle_details", 405, 113,
+	WindowPosition::Automatic, "view_vehicle_details", 405, 113,
 	WC_VEHICLE_DETAILS, WC_VEHICLE_VIEW,
 	{},
 	_nested_nontrain_vehicle_details_widgets
@@ -3469,7 +3471,7 @@ public:
 
 /** Vehicle view window descriptor for all vehicles but trains. */
 static WindowDesc _vehicle_view_desc(
-	WDP_AUTO, "view_vehicle", 250, 116,
+	WindowPosition::Automatic, "view_vehicle", 250, 116,
 	WC_VEHICLE_VIEW, WC_NONE,
 	{},
 	_nested_vehicle_view_widgets,
@@ -3481,7 +3483,7 @@ static WindowDesc _vehicle_view_desc(
  *  default_height are different for train view.
  */
 static WindowDesc _train_view_desc(
-	WDP_AUTO, "view_vehicle_train", 250, 134,
+	WindowPosition::Automatic, "view_vehicle_train", 250, 134,
 	WC_VEHICLE_VIEW, WC_NONE,
 	{},
 	_nested_vehicle_view_widgets,

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -146,8 +146,9 @@ public:
 	}
 };
 
+/** Window definition for the extra viewport window. */
 static WindowDesc _extra_viewport_desc(
-	WDP_AUTO, "extra_viewport", 300, 268,
+	WindowPosition::Automatic, "extra_viewport", 300, 268,
 	WC_EXTRA_VIEWPORT, WC_NONE,
 	{},
 	_nested_extra_viewport_widgets

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -219,7 +219,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_waypoint_view_widget
 
 /** The description of the waypoint view. */
 static WindowDesc _waypoint_view_desc(
-	WDP_AUTO, "view_waypoint", 260, 118,
+	WindowPosition::Automatic, "view_waypoint", 260, 118,
 	WC_WAYPOINT_VIEW, WC_NONE,
 	{},
 	_nested_waypoint_view_widgets

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1435,7 +1435,7 @@ void Window::InitializeData(WindowNumber window_number)
 	/* Set up window properties; some of them are needed to set up smallest size below */
 	this->window_class = this->window_desc.cls;
 	this->SetWhiteBorder();
-	if (this->window_desc.default_pos == WDP_CENTER) this->flags.Set(WindowFlag::Centred);
+	if (this->window_desc.default_pos == WindowPosition::Center) this->flags.Set(WindowFlag::Centred);
 	this->owner = INVALID_OWNER;
 	this->nested_focus = nullptr;
 	this->window_number = window_number;
@@ -1775,18 +1775,18 @@ static Point LocalGetWindowPlacement(const WindowDesc &desc, int16_t sm_width, i
 	}
 
 	switch (desc.default_pos) {
-		case WDP_ALIGN_TOOLBAR: // Align to the toolbar
+		case WindowPosition::AlignToolbar: // Align to the toolbar
 			return GetToolbarAlignedWindowPosition(default_width);
 
-		case WDP_AUTO: // Find a good automatic position for the window
+		case WindowPosition::Automatic: // Find a good automatic position for the window
 			return GetAutoPlacePosition(default_width, default_height);
 
-		case WDP_CENTER: // Centre the window horizontally
+		case WindowPosition::Center: // Centre the window horizontally
 			pt.x = (_screen.width - default_width) / 2;
 			pt.y = (_screen.height - default_height) / 2;
 			break;
 
-		case WDP_MANUAL:
+		case WindowPosition::Manual:
 			pt.x = 0;
 			pt.y = 0;
 			break;

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -139,11 +139,11 @@ extern Window *_focused_window;
 
 
 /** How do we the window to be placed? */
-enum WindowPosition : uint8_t {
-	WDP_MANUAL,        ///< Manually align the window (so no automatic location finding)
-	WDP_AUTO,          ///< Find a place automatically
-	WDP_CENTER,        ///< Center the window
-	WDP_ALIGN_TOOLBAR, ///< Align toward the toolbar
+enum class WindowPosition : uint8_t {
+	Manual, ///< Manually align the window (so no automatic location finding)
+	Automatic, ///< Find a place automatically
+	Center, ///< Center the window
+	AlignToolbar, ///< Align toward the toolbar
 };
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Our scoped enum and documentation pushes.


## Description

Make `WindowPosition` a scoped enum.
Document all the `WindowDesc` instances, as doxygen flags them as new members. This fixes 110 warnings.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
