### PR TITLE
Codechange: split WindowNumberEnum into several scoped enumerations

### DIFF
--- a/bin/game/compat_15.nut
+++ b/bin/game/compat_15.nut
@@ -6,3 +6,24 @@
  */
 
 /* This file contains code to downgrade the API from 16 to 15. */
+
+/*
+ * These window/widget related enumerations have never been stable, but breaking anything using them
+ * is a really big ask when restructuring code. If in the future things are removed from the underlying
+ * enumerations, feel free to remove them from this compatibility script.
+ */
+GSWindow.WN_GAME_OPTIONS_AI <- GSWindow.GameOptionsWindowNumber.AI;
+GSWindow.WN_GAME_OPTIONS_GS <- GSWindow.GameOptionsWindowNumber.GS;
+GSWindow.WN_GAME_OPTIONS_ABOUT <- GSWindow.GameOptionsWindowNumber.About;
+GSWindow.WN_GAME_OPTIONS_NEWGRF_STATE <- GSWindow.GameOptionsWindowNumber.NewGRFState;
+GSWindow.WN_GAME_OPTIONS_GAME_OPTIONS <- GSWindow.GameOptionsWindowNumber.GameOptions;
+GSWindow.WN_GAME_OPTIONS_GAME_SETTINGS <- GSWindow.GameOptionsWindowNumber.GameSettings;
+GSWindow.WN_QUERY_STRING <- GSWindow.QueryStringWindowNumber.Default;
+GSWindow.WN_QUERY_STRING_SIGN <- GSWindow.QueryStringWindowNumber.Sign;
+GSWindow.WN_CONFIRM_POPUP_QUERY <- GSWindow.ConfirmPopupQueryWindowNumber.Default;
+GSWindow.WN_CONFIRM_POPUP_QUERY_BOOTSTRAP <- GSWindow.ConfirmPopupQueryWindowNumber.Bootstrap;
+GSWindow.WN_NETWORK_WINDOW_GAME <- GSWindow.NetworkWindowNumber.Game;
+GSWindow.WN_NETWORK_WINDOW_CONTENT_LIST <- GSWindow.NetworkWindowNumber.ContentList;
+GSWindow.WN_NETWORK_WINDOW_START <- GSWindow.NetworkWindowNumber.StartServer;
+GSWindow.WN_NETWORK_STATUS_WINDOW_JOIN <- GSWindow.NetworkStatusWindowNumber.Join;
+GSWindow.WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD <- GSWindow.NetworkStatusWindowNumber.ContentDownload;

--- a/cmake/scripts/GenerateWidget.cmake
+++ b/cmake/scripts/GenerateWidget.cmake
@@ -65,7 +65,8 @@ foreach(ENUM IN LISTS ENUM_LINES)
             endif()
 
             # Check for enum match
-            if("${LINE}" MATCHES "^	*enum *${ENUM_PATTERN}( *: *[^ ]*)? *\{")
+            if("${LINE}" MATCHES "^	*enum *(class)? *(${ENUM_PATTERN})( *: *[^ ]*)? *\{")
+                set(ENUM_NAME "${CMAKE_MATCH_2}")
                 # REGEX REPLACE does a REGEX MATCHALL and fails if an empty string is matched
                 string(REGEX MATCH "[^	]*" RESULT "${LINE}")
                 string(REPLACE "${RESULT}" "" RM_INDENT "${LINE}")
@@ -111,9 +112,9 @@ foreach(ENUM IN LISTS ENUM_LINES)
                     if(CMAKE_MATCH_3)
                         # CMAKE_MATCH_3 contains inline comment.
                         remove_invalid_links("${CMAKE_MATCH_3}")
-                        string(APPEND ${PLACE_HOLDER} "\n${ADD_INDENT}${CMAKE_MATCH_1}${CMAKE_MATCH_2}${SPACES} = ::${CMAKE_MATCH_2},${SPACES}${NO_INVALID_LINKS}")
+                        string(APPEND ${PLACE_HOLDER} "\n${ADD_INDENT}${CMAKE_MATCH_1}${CMAKE_MATCH_2}${SPACES} = to_underlying(::${ENUM_NAME}::${CMAKE_MATCH_2}),${SPACES}${NO_INVALID_LINKS}")
                     else()
-                        string(APPEND ${PLACE_HOLDER} "\n${ADD_INDENT}${CMAKE_MATCH_1}${CMAKE_MATCH_2}${SPACES} = ::${CMAKE_MATCH_2},")
+                        string(APPEND ${PLACE_HOLDER} "\n${ADD_INDENT}${CMAKE_MATCH_1}${CMAKE_MATCH_2}${SPACES} = to_underlying(::${ENUM_NAME}::${CMAKE_MATCH_2}),")
                     endif()
                 elseif("${LINE}" STREQUAL "")
                     string(APPEND ${PLACE_HOLDER} "\n")

--- a/cmake/scripts/SquirrelExport.cmake
+++ b/cmake/scripts/SquirrelExport.cmake
@@ -262,7 +262,7 @@ foreach(LINE IN LISTS SOURCE_LINES)
     endif()
 
     # We need to make specialized conversions for enums
-    if("${LINE}" MATCHES "^(\t*)enum ([^ ]*)")
+    if("${LINE}" MATCHES "^(\t*)enum *(class)? *([^ ]*)")
         math(EXPR CLS_LEVEL "${CLS_LEVEL} + 1")
 
         # Check if we want to publish this enum
@@ -280,7 +280,10 @@ foreach(LINE IN LISTS SOURCE_LINES)
         endif()
 
         set(IN_ENUM TRUE)
-        list(APPEND ENUMS "${CLS}::${CMAKE_MATCH_2}")
+        if(CMAKE_MATCH_2 STREQUAL "class")
+            set(IN_SCOPED_ENUM TRUE)
+        endif()
+        list(APPEND ENUMS "${CLS}::${CMAKE_MATCH_3}")
         continue()
     endif()
 
@@ -289,6 +292,7 @@ foreach(LINE IN LISTS SOURCE_LINES)
         math(EXPR CLS_LEVEL "${CLS_LEVEL} - 1")
         if(CLS_LEVEL)
             unset(IN_ENUM)
+            unset(IN_SCOPED_ENUM)
             continue()
         endif()
 
@@ -365,9 +369,33 @@ foreach(LINE IN LISTS SOURCE_LINES)
         string(APPEND SQUIRREL_EXPORT "\n")
 
         # Enum values
+
+        macro(add_scoped_enum_end_if_needed)
+            if(CURRENT_ENUM_NAME)
+                unset(CURRENT_ENUM_NAME)
+                string(APPEND SQUIRREL_EXPORT "\n\tSQ${API_CLS}.AddScopedEnumEnd(engine);\n")
+            endif()
+        endmacro()
+
+        set(CURRENT_ENUM_NAME 0)
         foreach(ENUM_VALUE IN LISTS ENUM_VALUES)
+            if(ENUM_VALUE MATCHES "::")
+                string(REGEX REPLACE ".*:" "" ENUM_VALUE_NAME "${ENUM_VALUE}")
+                string(REGEX MATCH "::(.*)::" ENUM_NAME "${ENUM_VALUE}")
+                set(ENUM_NAME ${CMAKE_MATCH_1})
+                if(CURRENT_ENUM_NAME STREQUAL ENUM_NAME)
+                else()
+                    add_scoped_enum_end_if_needed()
+                    string(APPEND SQUIRREL_EXPORT "\n\tSQ${API_CLS}.AddScopedEnumBegin(engine, \"${ENUM_NAME}\");")
+                    set(CURRENT_ENUM_NAME ${ENUM_NAME})
+                endif()
+                string(APPEND SQUIRREL_EXPORT "\n\tSQ${API_CLS}.DefSQConst(engine, to_underlying(${ENUM_VALUE}), \"${ENUM_VALUE_NAME}\");")
+                continue()
+            endif()
+            add_scoped_enum_end_if_needed()
             string(APPEND SQUIRREL_EXPORT "\n\tSQ${API_CLS}.DefSQConst(engine, ${CLS}::${ENUM_VALUE}, \"${ENUM_VALUE}\");")
         endforeach()
+        add_scoped_enum_end_if_needed()
 
         # Const values
         foreach(CONST_VALUE IN LISTS CONST_VALUES)
@@ -440,11 +468,16 @@ foreach(LINE IN LISTS SOURCE_LINES)
 
     # Add enums
     if(IN_ENUM)
-        string(REGEX MATCH "([^,\t ]+)" ENUM_VALUE "${LINE}")
-        list(APPEND ENUM_VALUES "${ENUM_VALUE}")
-
         # Check if this a special error enum
         list(GET ENUMS -1 ENUM)
+
+        string(REGEX MATCH "([^,\t ]+)" ENUM_VALUE "${LINE}")
+        if(IN_SCOPED_ENUM)
+            list(APPEND ENUM_VALUES "${ENUM}::${ENUM_VALUE}")
+        else()
+            list(APPEND ENUM_VALUES "${ENUM_VALUE}")
+        endif()
+
         if("${ENUM}" MATCHES ".*::ErrorMessages")
             # syntax:
             # enum ErrorMessages {

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -100,7 +100,7 @@ struct AIConfigWindow : public Window {
 
 	AIConfigWindow() : Window(_ai_config_desc)
 	{
-		this->InitNested(WN_GAME_OPTIONS_AI); // Initializes 'this->line_height' as a side effect.
+		this->InitNested(GameOptionsWindowNumber::AI); // Initializes 'this->line_height' as a side effect.
 		this->vscroll = this->GetScrollbar(WID_AIC_SCROLLBAR);
 		this->selected_slot = CompanyID::Invalid();
 		NWidgetCore *nwi = this->GetWidget<NWidgetCore>(WID_AIC_LIST);

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -201,7 +201,7 @@ public:
 	/** Start listening to the content client events. */
 	BootstrapAskForDownloadWindow() : Window(_bootstrap_query_desc)
 	{
-		this->InitNested(WN_CONFIRM_POPUP_QUERY_BOOTSTRAP);
+		this->InitNested(ConfirmPopupQueryWindowNumber::Bootstrap);
 		_network_content_client.AddCallback(this);
 	}
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -880,7 +880,7 @@ CommandCost CmdCompanyCtrl(DoCommandFlags flags, CompanyCtrlAction cca, CompanyI
 			NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
 
 			/* Delete multiplayer progress bar */
-			CloseWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+			CloseWindowById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 
 			Company *c = DoStartupNewCompany(false);
 

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -104,7 +104,7 @@ struct GSConfigWindow : public Window {
 
 		this->CreateNestedTree(); // Initializes 'this->line_height' as a side effect.
 		this->vscroll = this->GetScrollbar(WID_GSC_SCROLLBAR);
-		this->FinishInitNested(WN_GAME_OPTIONS_GS);
+		this->FinishInitNested(GameOptionsWindowNumber::GS);
 		this->OnInvalidateData(0);
 
 		this->RebuildVisibleSettings();

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -897,7 +897,7 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_TOWNNAME_DROPDOWN: // Town names
 				if (_game_mode == GM_MENU || Town::GetNumItems() == 0) {
 					_settings_newgame.game_creation.town_name = index;
-					SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GAME_OPTIONS);
+					SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::GameOptions);
 				}
 				break;
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -417,7 +417,7 @@ struct AboutWindow : public Window {
 
 	AboutWindow() : Window(_about_desc)
 	{
-		this->InitNested(WN_GAME_OPTIONS_ABOUT);
+		this->InitNested(GameOptionsWindowNumber::About);
 
 		this->text_position = this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->pos_y + this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->current_y;
 	}
@@ -920,7 +920,7 @@ struct QueryStringWindow : public Window
 		this->CreateNestedTree();
 		this->GetWidget<NWidgetStacked>(WID_QS_DEFAULT_SEL)->SetDisplayedPlane((this->flags.Test(QueryStringFlag::EnableDefault)) ? 0 : SZSP_NONE);
 		this->GetWidget<NWidgetStacked>(WID_QS_MOVE_SEL)->SetDisplayedPlane((this->flags.Test(QueryStringFlag::EnableMove)) ? 0 : SZSP_NONE);
-		this->FinishInitNested(WN_QUERY_STRING);
+		this->FinishInitNested(QueryStringWindowNumber::Default);
 
 		this->parent = parent;
 
@@ -1091,7 +1091,7 @@ struct QueryWindow : public Window {
 		this->parent = parent;
 
 		this->CreateNestedTree();
-		this->FinishInitNested(WN_CONFIRM_POPUP_QUERY);
+		this->FinishInitNested(ConfirmPopupQueryWindowNumber::Default);
 	}
 
 	void Close([[maybe_unused]] int data = 0) override

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -175,7 +175,7 @@ void MusicSystem::ChangeMusicSet(const std::string &set_name)
 	this->BuildPlaylists();
 	this->ChangePlaylist(this->selected_playlist);
 
-	InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GAME_OPTIONS, 0, true);
+	InvalidateWindowData(WC_GAME_OPTIONS, GameOptionsWindowNumber::GameOptions, 0, true);
 	InvalidateWindowData(WC_MUSIC_TRACK_SELECTION, 0, 1, true);
 	InvalidateWindowData(WC_MUSIC_WINDOW, 0, 1, true);
 }

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1048,7 +1048,7 @@ void NetworkDisconnect(bool close_admins)
 		}
 	}
 
-	CloseWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+	CloseWindowById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 
 	NetworkClose(close_admins);
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -153,7 +153,7 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 		this->CloseConnection(res);
 		_networking = false;
 
-		CloseWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+		CloseWindowById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 		return;
 	}
 
@@ -183,7 +183,7 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 		ClientNetworkEmergencySave();
 	}
 
-	CloseWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+	CloseWindowById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 
 	if (_game_mode != GM_MENU) _switch_mode = SM_MENU;
 	_networking = false;
@@ -292,7 +292,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
 	my_client->status = STATUS_JOIN;
 	Debug(net, 9, "Client::join_status = Authorizing");
 	_network_join_status = NetworkJoinStatus::Authorizing;
-	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientJoin);
 	p->Send_string(GetNetworkRevisionString());
@@ -788,7 +788,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerWaitForMap(Packet
 	Debug(net, 9, "Client::join_status = Waiting");
 	_network_join_status = NetworkJoinStatus::Waiting;
 	_network_join_waiting = p.Recv_uint8();
-	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -812,7 +812,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapBegin(Packet &
 
 	Debug(net, 9, "Client::join_status = Downloading");
 	_network_join_status = NetworkJoinStatus::Downloading;
-	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -823,7 +823,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapSize(Packet &p
 	if (this->savegame == nullptr) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 
 	_network_join_bytes_total = p.Recv_uint32();
-	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 
 	Debug(net, 9, "Client::ReceiveServerMapSize(): bytes_total={}", _network_join_bytes_total);
 
@@ -839,7 +839,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapData(Packet &p
 	this->savegame->AddPacket(p);
 
 	_network_join_bytes = static_cast<uint32_t>(this->savegame->buffer.size());
-	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -853,7 +853,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapDone(Packet &)
 
 	Debug(net, 9, "Client::join_status = Processing");
 	_network_join_status = NetworkJoinStatus::Processing;
-	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 
 	this->savegame->Reset();
 

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -467,7 +467,7 @@ bool ClientNetworkContentSocketHandler::ReceiveServerContent(Packet &p)
 			return fwrite(buffer.data(), 1, buffer.size(), *this->cur_file);
 		};
 		if (to_read != 0 && p.TransferOut(write_to_disk) != to_read) {
-			CloseWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD);
+			CloseWindowById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::ContentDownload);
 			ShowErrorMessage(
 				GetEncodedString(STR_CONTENT_ERROR_COULD_NOT_DOWNLOAD),
 				GetEncodedString(STR_CONTENT_ERROR_COULD_NOT_DOWNLOAD_FILE_NOT_WRITABLE),
@@ -502,7 +502,7 @@ bool ClientNetworkContentSocketHandler::BeforeDownload()
 		std::string filename = GetFullFilename(*this->cur_info, true);
 		if (filename.empty() || !(this->cur_file = FileHandle::Open(filename, "wb")).has_value()) {
 			/* Unless that fails of course... */
-			CloseWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD);
+			CloseWindowById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::ContentDownload);
 			ShowErrorMessage(
 				GetEncodedString(STR_CONTENT_ERROR_COULD_NOT_DOWNLOAD),
 				GetEncodedString(STR_CONTENT_ERROR_COULD_NOT_DOWNLOAD_FILE_NOT_WRITABLE),

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -124,7 +124,7 @@ BaseNetworkContentDownloadStatusWindow::BaseNetworkContentDownloadStatusWindow(W
 	_network_content_client.AddCallback(this);
 	_network_content_client.DownloadSelectedContent(this->total_files, this->total_bytes);
 
-	this->InitNested(WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD);
+	this->InitNested(NetworkStatusWindowNumber::ContentDownload);
 }
 
 void BaseNetworkContentDownloadStatusWindow::Close([[maybe_unused]] int data)
@@ -210,7 +210,7 @@ public:
 	 */
 	NetworkContentDownloadStatusWindow() : BaseNetworkContentDownloadStatusWindow(_network_content_download_status_window_desc)
 	{
-		this->parent = FindWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_CONTENT_LIST);
+		this->parent = FindWindowById(WC_NETWORK_WINDOW, NetworkWindowNumber::ContentList);
 	}
 
 	void Close([[maybe_unused]] int data = 0) override
@@ -264,17 +264,17 @@ public:
 
 				case ContentType::BaseGraphics:
 					BaseGraphics::FindSets();
-					SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GAME_OPTIONS);
+					SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::GameOptions);
 					break;
 
 				case ContentType::BaseSounds:
 					BaseSounds::FindSets();
-					SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GAME_OPTIONS);
+					SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::GameOptions);
 					break;
 
 				case ContentType::BaseMusic:
 					BaseMusic::FindSets();
-					SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GAME_OPTIONS);
+					SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::GameOptions);
 					break;
 
 				case ContentType::NewGRF:
@@ -293,7 +293,7 @@ public:
 		}
 
 		/* Always invalidate the download window; tell it we are going to be gone */
-		InvalidateWindowData(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_CONTENT_LIST, 2);
+		InvalidateWindowData(WC_NETWORK_WINDOW, NetworkWindowNumber::ContentList, 2);
 
 		this->BaseNetworkContentDownloadStatusWindow::Close();
 	}
@@ -307,7 +307,7 @@ public:
 			} else {
 				/* If downloading succeeded, close the online content window. This will close
 				 * the current window as well. */
-				CloseWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_CONTENT_LIST);
+				CloseWindowById(WC_NETWORK_WINDOW, NetworkWindowNumber::ContentList);
 			}
 		}
 	}
@@ -564,7 +564,7 @@ public:
 	{
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_NCL_SCROLLBAR);
-		this->FinishInitNested(WN_NETWORK_WINDOW_CONTENT_LIST);
+		this->FinishInitNested(NetworkWindowNumber::ContentList);
 
 		this->GetWidget<NWidgetStacked>(WID_NCL_SEL_ALL_UPDATE)->SetDisplayedPlane(select_all);
 
@@ -870,7 +870,7 @@ public:
 				break;
 
 			case WID_NCL_DOWNLOAD:
-				if (BringWindowToFrontById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD) == nullptr) new NetworkContentDownloadStatusWindow();
+				if (BringWindowToFrontById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::ContentDownload) == nullptr) new NetworkContentDownloadStatusWindow();
 				break;
 
 			case WID_NCL_SEARCH_EXTERNAL:
@@ -1005,7 +1005,7 @@ public:
 		}
 
 		/* If data == 2 then the status window caused this OnInvalidate */
-		this->SetWidgetDisabledState(WID_NCL_DOWNLOAD, this->filesize_sum == 0 || (FindWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD) != nullptr && data != 2));
+		this->SetWidgetDisabledState(WID_NCL_DOWNLOAD, this->filesize_sum == 0 || (FindWindowById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::ContentDownload) != nullptr && data != 2));
 		this->SetWidgetDisabledState(WID_NCL_UNSELECT, this->filesize_sum == 0);
 		this->SetWidgetDisabledState(WID_NCL_SELECT_ALL, !show_select_all);
 		this->SetWidgetDisabledState(WID_NCL_SELECT_UPDATE, !show_select_upgrade || !this->filter_data.string_filter.IsEmpty());
@@ -1149,7 +1149,7 @@ void ShowNetworkContentListWindow(ContentVector *cv, ContentType type1, ContentT
 		_network_content_client.RequestContentList(cv, true);
 	}
 
-	CloseWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_CONTENT_LIST);
+	CloseWindowById(WC_NETWORK_WINDOW, NetworkWindowNumber::ContentList);
 	new NetworkContentListWindow(_network_content_list_desc, cv != nullptr, types);
 #else
 	ShowErrorMessage(

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -65,7 +65,7 @@ static CompanyID _admin_company_id = CompanyID::Invalid(); ///< For what company
  */
 void UpdateNetworkGameWindow()
 {
-	InvalidateWindowData(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_GAME, 0);
+	InvalidateWindowData(WC_NETWORK_WINDOW, NetworkWindowNumber::Game, 0);
 }
 
 /**
@@ -449,7 +449,7 @@ public:
 	{
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_NG_SCROLLBAR);
-		this->FinishInitNested(WN_NETWORK_WINDOW_GAME);
+		this->FinishInitNested(NetworkWindowNumber::Game);
 
 		this->querystrings[WID_NG_CLIENT] = &this->name_editbox;
 		this->name_editbox.text.Assign(_settings_client.network.client_name);
@@ -962,7 +962,7 @@ static WindowDesc _network_game_window_desc(
 void ShowNetworkGameWindow()
 {
 	static bool first = true;
-	CloseWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_START);
+	CloseWindowById(WC_NETWORK_WINDOW, NetworkWindowNumber::StartServer);
 
 	/* Only show once */
 	if (first) {
@@ -987,7 +987,7 @@ struct NetworkStartServerWindow : public Window {
 	 */
 	NetworkStartServerWindow(WindowDesc &desc) : Window(desc), name_editbox(NETWORK_NAME_LENGTH)
 	{
-		this->InitNested(WN_NETWORK_WINDOW_START);
+		this->InitNested(NetworkWindowNumber::StartServer);
 
 		this->querystrings[WID_NSS_GAMENAME] = &this->name_editbox;
 		this->name_editbox.text.Assign(_settings_client.network.server_name);
@@ -1240,7 +1240,7 @@ static void ShowNetworkStartServerWindow()
 {
 	if (!NetworkValidateOurClientName()) return;
 
-	CloseWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_GAME);
+	CloseWindowById(WC_NETWORK_WINDOW, NetworkWindowNumber::Game);
 
 	new NetworkStartServerWindow(_network_start_server_window_desc);
 }
@@ -2092,8 +2092,8 @@ struct NetworkJoinStatusWindow : Window {
 	 */
 	NetworkJoinStatusWindow(WindowDesc &desc) : Window(desc)
 	{
-		this->parent = FindWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_GAME);
-		this->InitNested(WN_NETWORK_STATUS_WINDOW_JOIN);
+		this->parent = FindWindowById(WC_NETWORK_WINDOW, NetworkWindowNumber::Game);
+		this->InitNested(NetworkStatusWindowNumber::Join);
 	}
 
 	void DrawWidget(const Rect &r, WidgetID widget) const override
@@ -2217,7 +2217,7 @@ static WindowDesc _network_join_status_window_desc(
 /** Open the window showing the status of joining the server. */
 void ShowJoinStatusWindow()
 {
-	CloseWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
+	CloseWindowById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join);
 	new NetworkJoinStatusWindow(_network_join_status_window_desc);
 }
 
@@ -2227,7 +2227,7 @@ void ShowJoinStatusWindow()
  */
 void ShowNetworkNeedPassword(std::shared_ptr<NetworkAuthenticationPasswordRequest> request)
 {
-	NetworkJoinStatusWindow *w = dynamic_cast<NetworkJoinStatusWindow *>(FindWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN));
+	NetworkJoinStatusWindow *w = dynamic_cast<NetworkJoinStatusWindow *>(FindWindowById(WC_NETWORK_STATUS_WINDOW, NetworkStatusWindowNumber::Join));
 	if (w == nullptr) return;
 	w->request = std::move(request);
 

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -193,7 +193,7 @@ void GRFConfig::SetValue(const GRFParameterInfo &info, uint32_t value)
 		SB(this->param[info.param_nr], info.first_bit, info.num_bit, value);
 	}
 
-	SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_NEWGRF_STATE);
+	SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::NewGRFState);
 }
 
 /**
@@ -567,7 +567,7 @@ void DoScanNewGRFFiles(NewGRFScanCallback *callback)
 
 	/* Yes... these are the NewGRF windows */
 	InvalidateWindowClassesData(WC_SAVELOAD, 0, true);
-	InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_NEWGRF_STATE, GOID_NEWGRF_RESCANNED, true);
+	InvalidateWindowData(WC_GAME_OPTIONS, GameOptionsWindowNumber::NewGRFState, GOID_NEWGRF_RESCANNED, true);
 	if (!_exit_game && callback != nullptr) callback->OnNewGRFsScanned();
 
 	CloseWindowByClass(WC_MODAL_PROGRESS);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -335,7 +335,7 @@ struct NewGRFParametersWindow : public Window {
 				if (this->editable && !this->action14present && !this->grf_config.param.empty()) {
 					this->grf_config.param.pop_back();
 					this->InvalidateData();
-					SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_NEWGRF_STATE);
+					SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::NewGRFState);
 				}
 				break;
 
@@ -343,7 +343,7 @@ struct NewGRFParametersWindow : public Window {
 				if (this->editable && !this->action14present && this->grf_config.param.size() < this->grf_config.num_valid_params) {
 					this->grf_config.param.emplace_back(0);
 					this->InvalidateData();
-					SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_NEWGRF_STATE);
+					SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::NewGRFState);
 				}
 				break;
 
@@ -430,7 +430,7 @@ struct NewGRFParametersWindow : public Window {
 				if (!this->editable) break;
 				this->grf_config.SetParameterDefaults();
 				this->InvalidateData();
-				SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_NEWGRF_STATE);
+				SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::NewGRFState);
 				break;
 		}
 	}
@@ -641,7 +641,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		this->GetWidget<NWidgetStacked>(WID_NS_SHOW_REMOVE)->SetDisplayedPlane(this->editable ? 0 : 1);
 		this->GetWidget<NWidgetStacked>(WID_NS_SHOW_EDIT)->SetDisplayedPlane(this->editable ? 0 : (this->show_params ? 1 : SZSP_HORIZONTAL));
 		this->GetWidget<NWidgetStacked>(WID_NS_SHOW_APPLY)->SetDisplayedPlane(this->editable && this->execute ? 0 : SZSP_VERTICAL);
-		this->FinishInitNested(WN_GAME_OPTIONS_NEWGRF_STATE);
+		this->FinishInitNested(GameOptionsWindowNumber::NewGRFState);
 
 		this->querystrings[WID_NS_FILTER] = &this->filter_editbox;
 		this->filter_editbox.cancel_button = QueryString::ACTION_CLEAR;
@@ -2097,7 +2097,7 @@ struct SavePresetWindow : public Window {
 			}
 
 			case WID_SVP_SAVE: {
-				Window *w = FindWindowById(WC_GAME_OPTIONS, WN_GAME_OPTIONS_NEWGRF_STATE);
+				Window *w = FindWindowById(WC_GAME_OPTIONS, GameOptionsWindowNumber::NewGRFState);
 				if (w != nullptr) {
 					auto text = this->presetname_editbox.text.GetText();
 					if (!text.empty()) w->OnQueryTextFinished(std::string{text});

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1641,14 +1641,14 @@ public:
 			case WID_BS_DRAG_SIGNALS_DENSITY_DECREASE:
 				if (_settings_client.gui.drag_signals_density > 1) {
 					_settings_client.gui.drag_signals_density--;
-					SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GAME_SETTINGS);
+					SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::GameSettings);
 				}
 				break;
 
 			case WID_BS_DRAG_SIGNALS_DENSITY_INCREASE:
 				if (_settings_client.gui.drag_signals_density < 20) {
 					_settings_client.gui.drag_signals_density++;
-					SetWindowDirty(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GAME_SETTINGS);
+					SetWindowDirty(WC_GAME_OPTIONS, GameOptionsWindowNumber::GameSettings);
 				}
 				break;
 

--- a/src/script/api/script_window.hpp.in
+++ b/src/script/api/script_window.hpp.in
@@ -32,7 +32,7 @@ ${INCLUDES}
  */
 class ScriptWindow : public ScriptObject {
 public:
-	// @enum WindowNumberEnum ../../window_type.h@ENUM_WINDOWNUMBERENUM@
+	// @enum .*WindowNumber ../../window_type.h@ENUM_WINDOWNUMBERENUM@
 	// @endenum
 
 	// @enum WindowClass ../../window_type.h@ENUM_WINDOWCLASS@

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -186,7 +186,7 @@ struct ScriptListWindow : public Window {
 				}
 			}
 		}
-		InvalidateWindowData(WC_GAME_OPTIONS, this->slot == OWNER_DEITY ? WN_GAME_OPTIONS_GS : WN_GAME_OPTIONS_AI);
+		InvalidateWindowData(WC_GAME_OPTIONS, this->slot == OWNER_DEITY ? GameOptionsWindowNumber::GS : GameOptionsWindowNumber::AI);
 		InvalidateWindowClassesData(WC_SCRIPT_SETTINGS);
 		InvalidateWindowClassesData(WC_SCRIPT_DEBUG, -1);
 		CloseWindowByClass(WC_QUERY_STRING);

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -341,6 +341,21 @@ void Squirrel::AddClassEnd()
 	sq_pop(vm, 1);
 }
 
+void Squirrel::AddScopedEnumBegin(std::string_view enum_name)
+{
+	ScriptAllocatorScope alloc_scope(this);
+
+	sq_pushstring(this->vm, enum_name);
+	sq_newclass(this->vm, SQFalse);
+}
+
+void Squirrel::AddScopedEnumEnd()
+{
+	ScriptAllocatorScope alloc_scope(this);
+
+	sq_newslot(vm, -3, SQFalse);
+}
+
 bool Squirrel::MethodExists(HSQOBJECT instance, std::string_view method_name)
 {
 	assert(!this->crashed);

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -187,6 +187,17 @@ public:
 	void AddClassEnd();
 
 	/**
+	 * Adds an enum to the scope. Make sure to call AddScopedEnumEnd when you are done adding constants.
+	 * @param enum_name The name of the enum.
+	 */
+	void AddScopedEnumBegin(std::string_view enum_name);
+
+	/**
+	 * Finishes adding an enum to the scope. If this isn't called, no enum is really created.
+	 */
+	void AddScopedEnumEnd();
+
+	/**
 	 * Resume a VM when it was suspended via a throw.
 	 * @param suspend The number of opcodes that are allowed before suspending.
 	 * @return \c true iff the VM is still alive.

--- a/src/script/squirrel_class.hpp
+++ b/src/script/squirrel_class.hpp
@@ -123,6 +123,25 @@ public:
 	{
 		engine.AddClassEnd();
 	}
+
+	/**
+	 * Helper to start a scoped enumeration. Make sure to call #AddScopedEnumEnd when the enumeration is done.
+	 * @param engine The engine to add the enumeration to.
+	 * @param enum_name The name of the enumeration.
+	 */
+	void AddScopedEnumBegin(Squirrel &engine, std::string_view enum_name)
+	{
+		engine.AddScopedEnumBegin(enum_name);
+	}
+
+	/**
+	 * Helper to end a scoped enumeration.
+	 * @param engine The engine to end the enumeration in.
+	 */
+	void AddScopedEnumEnd(Squirrel &engine)
+	{
+		engine.AddScopedEnumEnd();
+	}
 };
 
 #endif /* SQUIRREL_CLASS_HPP */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -438,7 +438,7 @@ struct GameOptionsWindow : Window {
 		this->vscroll = this->GetScrollbar(WID_GO_SCROLLBAR);
 		this->vscroll_description = this->GetScrollbar(WID_GO_HELP_TEXT_SCROLL);
 		this->vscroll_description->SetCapacity(NUM_DESCRIPTION_LINES);
-		this->FinishInitNested(WN_GAME_OPTIONS_GAME_OPTIONS);
+		this->FinishInitNested(GameOptionsWindowNumber::GameOptions);
 
 		this->querystrings[WID_GO_FILTER] = &this->filter_editbox;
 		this->filter_editbox.cancel_button = QueryString::ACTION_CLEAR;

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -416,7 +416,7 @@ struct SignWindow : Window, SignList {
 		this->name_editbox.cancel_button = WID_QES_CANCEL;
 		this->name_editbox.ok_button = WID_QES_OK;
 
-		this->InitNested(WN_QUERY_STRING_SIGN);
+		this->InitNested(QueryStringWindowNumber::Sign);
 
 		if (_game_mode != GameMode::GM_EDITOR) {
 			this->GetWidget<NWidgetStacked>(WID_QES_COLOUR_PANE)->SetDisplayedPlane(SZSP_VERTICAL);
@@ -656,7 +656,7 @@ void ShowRenameSignWindow(const Sign *si)
  */
 void DeleteRenameSignWindow(SignID sign)
 {
-	SignWindow *w = dynamic_cast<SignWindow *>(FindWindowById(WC_QUERY_STRING, WN_QUERY_STRING_SIGN));
+	SignWindow *w = dynamic_cast<SignWindow *>(FindWindowById(WC_QUERY_STRING, QueryStringWindowNumber::Sign));
 
 	if (w != nullptr && w->cur_sign == sign) w->Close();
 }

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -187,7 +187,7 @@ void ChangeSoundSet(int index)
 		sound->priority = 0;
 	}
 
-	InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GAME_OPTIONS, 0, true);
+	InvalidateWindowData(WC_GAME_OPTIONS, GameOptionsWindowNumber::GameOptions, 0, true);
 }
 
 /**

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -23,27 +23,39 @@ using WidgetID = int;
 /** An invalid widget index. */
 static constexpr WidgetID INVALID_WIDGET = -1;
 
-/** %Window numbers. */
-enum WindowNumberEnum : uint8_t {
-	WN_GAME_OPTIONS_AI = 0,          ///< AI settings.
-	WN_GAME_OPTIONS_GS,              ///< GS settings.
-	WN_GAME_OPTIONS_ABOUT,           ///< About window.
-	WN_GAME_OPTIONS_NEWGRF_STATE,    ///< NewGRF settings.
-	WN_GAME_OPTIONS_GAME_OPTIONS,    ///< Game options.
-	WN_GAME_OPTIONS_GAME_SETTINGS,   ///< Game settings.
+/** Window numbers for GameOptions windows. */
+enum class GameOptionsWindowNumber : uint8_t {
+	AI, ///< AI settings.
+	GS, ///< GS settings.
+	About, ///< About window.
+	NewGRFState, ///< NewGRF settings.
+	GameOptions, ///< Game options.
+	GameSettings, ///< Game settings.
+};
 
-	WN_QUERY_STRING = 0,  ///< Query string.
-	WN_QUERY_STRING_SIGN, ///< Query string for signs.
+/** Window numbers for QueryString windows. */
+enum class QueryStringWindowNumber : uint8_t {
+	Default, ///< Query string.
+	Sign, ///< Query string for signs.
+};
 
-	WN_CONFIRM_POPUP_QUERY = 0,       ///< Query popup confirm.
-	WN_CONFIRM_POPUP_QUERY_BOOTSTRAP, ///< Query popup confirm for bootstrap.
+/** Window numbers for PopupQuery windows. */
+enum class ConfirmPopupQueryWindowNumber : uint8_t {
+	Default, ///< Query popup confirm.
+	Bootstrap, ///< Query popup confirm for bootstrap.
+};
 
-	WN_NETWORK_WINDOW_GAME = 0,     ///< Network game window.
-	WN_NETWORK_WINDOW_CONTENT_LIST, ///< Network content list.
-	WN_NETWORK_WINDOW_START,        ///< Network start server.
+/** Window numbers for network windows. */
+enum class NetworkWindowNumber : uint8_t {
+	Game, ///< Network game window.
+	ContentList, ///< Network content list.
+	StartServer, ///< Network start server.
+};
 
-	WN_NETWORK_STATUS_WINDOW_JOIN = 0,         ///< Network join status.
-	WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD, ///< Network content download status.
+/** Window number for network status windows. */
+enum class NetworkStatusWindowNumber : uint8_t {
+	Join, ///< Network join status.
+	ContentDownload, ///< Network content download status.
 };
 
 /** %Window classes. */
@@ -123,15 +135,15 @@ enum WindowClass : uint16_t {
 
 	/**
 	 * Query string window; %Window numbers:
-	 *   - #WN_QUERY_STRING = #QueryStringWidgets
-	 *   - #WN_QUERY_STRING_SIGN = #QueryEditSignWidgets
+	 *   - #QueryStringWindowNumber::Default = #QueryStringWidgets
+	 *   - #QueryStringWindowNumber::Sign = #QueryEditSignWidgets
 	 */
 	WC_QUERY_STRING,
 
 	/**
 	 * Popup with confirm question; %Window numbers:
-	 *   - #WN_CONFIRM_POPUP_QUERY = #QueryWidgets
-	 *   - #WN_CONFIRM_POPUP_QUERY_BOOTSTRAP = #BootstrapAskForDownloadWidgets
+	 *   - #ConfirmPopupQueryWindowNumber::Default = #QueryWidgets
+	 *   - #ConfirmPopupQueryWindowNumber::Bootstrap = #BootstrapAskForDownloadWidgets
 	 */
 	WC_CONFIRM_POPUP_QUERY,
 
@@ -477,9 +489,9 @@ enum WindowClass : uint16_t {
 
 	/**
 	 * Network window; %Window numbers:
-	 *   - #WN_NETWORK_WINDOW_GAME = #NetworkGameWidgets
-	 *   - #WN_NETWORK_WINDOW_CONTENT_LIST = #NetworkContentListWidgets
-	 *   - #WN_NETWORK_WINDOW_START = #NetworkStartServerWidgets
+	 *   - #NetworkWindowNumber::Game = #NetworkGameWidgets
+	 *   - #NetworkWindowNumber::ContentList = #NetworkContentListWidgets
+	 *   - #NetworkWindowNumber::StartServer = #NetworkStartServerWidgets
 	 */
 	WC_NETWORK_WINDOW,
 
@@ -491,8 +503,8 @@ enum WindowClass : uint16_t {
 
 	/**
 	 * Network status window; %Window numbers:
-	 *   - #WN_NETWORK_STATUS_WINDOW_JOIN = #NetworkJoinStatusWidgets
-	 *   - #WN_NETWORK_STATUS_WINDOW_CONTENT_DOWNLOAD = #NetworkContentDownloadStatusWidgets
+	 *   - #NetworkStatusWindowNumber::Join = #NetworkJoinStatusWidgets
+	 *   - #NetworkStatusWindowNumber::ContentDownload = #NetworkContentDownloadStatusWidgets
 	 */
 	WC_NETWORK_STATUS_WINDOW,
 
@@ -626,12 +638,12 @@ enum WindowClass : uint16_t {
 
 	/**
 	 * Game options window; %Window numbers:
-	 *   - #WN_GAME_OPTIONS_AI = #AIConfigWidgets
-	 *   - #WN_GAME_OPTIONS_GS = #GSConfigWidgets
-	 *   - #WN_GAME_OPTIONS_ABOUT = #AboutWidgets
-	 *   - #WN_GAME_OPTIONS_NEWGRF_STATE = #NewGRFStateWidgets
-	 *   - #WN_GAME_OPTIONS_GAME_OPTIONS = #GameOptionsWidgets
-	 *   - #WN_GAME_OPTIONS_GAME_SETTINGS = #GameSettingsWidgets
+	 *   - #GameOptionsWindowNumber::AI = #AIConfigWidgets
+	 *   - #GameOptionsWindowNumber::GS = #GSConfigWidgets
+	 *   - #GameOptionsWindowNumber::About = #AboutWidgets
+	 *   - #GameOptionsWindowNumber::NewGRFState = #NewGRFStateWidgets
+	 *   - #GameOptionsWindowNumber::GameOptions = #GameOptionsWidgets
+	 *   - #GameOptionsWindowNumber::GameSettings = #GameSettingsWidgets
 	 */
 	WC_GAME_OPTIONS,
 


### PR DESCRIPTION
## Motivation / Problem

There is a `WindowNumberEnum` that contains many enumerations for different window classes. However, it's not a complete enumeration. Why not have an scoped enumeration per window class?


## Description

Split `WindowNumberEnum` into five enumerations.

Add support for scoped enumerations to the Squirrel-codegen, and backward compatibility to these new enumerations. Although there are technically not necessary given we don't provide any warranty, but making `WindowClass` a scoped enumeration will definitely break all game scripts that make use of this. 
That makes the compat script warranted, even when we don't keep it forever. So, when a specific WindowNumber enumeration (value) gets removed in the future, it ought to be removed from the compat script as well. That'd be a warranted moment to break the script, as the window will then behave differently.

I've tested this with the tutorial GS, and that still seems to function.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
