### PR TITLE
Fix: Depot listing for trains arriving backwards with an articulated tail

### DIFF
--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -50,9 +50,8 @@ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine
 
 		if (type == VehicleType::Train) {
 			const Train *t = Train::From(v);
-			if (t->IsArticulatedPart()) continue;
 			if (wagons != nullptr && t->First()->IsFreeWagon()) {
-				if (individual_wagons || t->IsFreeWagon()) wagons->push_back(t);
+				if (!t->IsArticulatedPart() && (individual_wagons || t->IsFreeWagon())) wagons->push_back(t);
 				continue;
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

Trains driving backwards to arrive in a depot should be listed even when only partially inside.
However if the end of the train is an articulated part (i.e. the moving front is an articulated part) then it isn't listed in the depot.

Example save:
[Rev Depot Test, 1990-02-17.sav.zip](https://github.com/user-attachments/files/27145745/Rev.Depot.Test.1990-02-17.sav.zip)

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
