### PR TITLE
Codechange: typedef for EnumClassIndexContainer with std::array

### DIFF
--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -192,7 +192,7 @@ struct CargoSpec {
 	static IterateWrapper Iterate(size_t from = 0) { return IterateWrapper(from); }
 
 	/** List of cargo specs for each Town Product Effect. */
-	static inline EnumClassIndexContainer<std::array<std::vector<const CargoSpec *>, to_underlying(TownProductionEffect::End)>, TownProductionEffect> town_production_cargoes{};
+	static inline EnumIndexArray<std::vector<const CargoSpec *>, TownProductionEffect, TownProductionEffect::End> town_production_cargoes{};
 
 private:
 	static CargoSpec array[NUM_CARGO]; ///< Array holding all CargoSpecs

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -84,7 +84,7 @@ inline constexpr CommandInfo CommandFromTrait() noexcept { return { T::name, T::
 
 template <typename T, T... i>
 inline constexpr auto MakeCommandsFromTraits(std::integer_sequence<T, i...>) noexcept {
-	return EnumClassIndexContainer<std::array<CommandInfo, sizeof...(i)>, Commands>{{{ CommandFromTrait<CommandTraits<static_cast<Commands>(i)>>()... }}};
+	return EnumIndexArray<CommandInfo, Commands, static_cast<Commands>(sizeof...(i))>{{{ CommandFromTrait<CommandTraits<static_cast<Commands>(i)>>()... }}};
 }
 
 /**

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -470,7 +470,7 @@ bad_town_name:;
 }
 
 /** Sorting weights for the company colours. */
-static const EnumClassIndexContainer<std::array<uint8_t, to_underlying(Colours::End)>, Colours> _colour_sort{2, 2, 3, 2, 3, 2, 3, 2, 3, 2, 2, 2, 3, 1, 1, 1};
+static const EnumIndexArray<uint8_t, Colours, Colours::End> _colour_sort{2, 2, 3, 2, 3, 2, 3, 2, 3, 2, 2, 2, 3, 1, 1, 1};
 /** Similar colours, so we can try to prevent same coloured companies. */
 static const std::initializer_list<Colours> _similar_colour[to_underlying(Colours::End)] = {
 	{Colours::Blue, Colours::LightBlue }, // Colours::DarkBlue

--- a/src/core/enum_type.hpp
+++ b/src/core/enum_type.hpp
@@ -259,4 +259,13 @@ public:
 	Container::const_reference operator[](const Index &pos) const { return this->Container::operator[](to_underlying(pos)); }
 };
 
+/**
+ * A typedef for EnumClassIndexContainer using std::array as the backing container type.
+ * @tparam T std::array value type.
+ * @tparam Index The enum class to use for indexing.
+ * @tparam N The std::array size.
+ */
+template <typename T, typename Index, Index N>
+using EnumIndexArray = EnumClassIndexContainer<std::array<T, to_underlying(N)>, Index>;
+
 #endif /* ENUM_TYPE_HPP */

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -88,7 +88,7 @@ typedef std::vector<Industry *> SmallIndustryList;
 /**
  * Score info, values used for computing the detailed performance rating.
  */
-const EnumClassIndexContainer<std::array<ScoreInfo, to_underlying(ScoreID::End)>, ScoreID> _score_info = {
+const EnumIndexArray<ScoreInfo, ScoreID, ScoreID::End> _score_info = {
 	ScoreInfo(100, 120), // ScoreID::Vehicles
 	ScoreInfo(100, 80), // ScoreID::Stations
 	ScoreInfo(100, 10000), // ScoreID::MinProfit
@@ -101,7 +101,7 @@ const EnumClassIndexContainer<std::array<ScoreInfo, to_underlying(ScoreID::End)>
 	ScoreInfo(0, 0), // ScoreID::Total
 };
 
-TypedIndexContainer<std::array<EnumClassIndexContainer<std::array<int64_t, to_underlying(ScoreID::End)>, ScoreID>, MAX_COMPANIES>, CompanyID> _score_part;
+TypedIndexContainer<std::array<EnumIndexArray<int64_t, ScoreID, ScoreID::End>, MAX_COMPANIES>, CompanyID> _score_part;
 Economy _economy;
 Prices _price;
 static PriceMultipliers _price_base_multiplier;

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -22,8 +22,8 @@
 void ResetPriceBaseMultipliers();
 void SetPriceBaseMultiplier(Price price, int factor);
 
-extern const EnumClassIndexContainer<std::array<ScoreInfo, to_underlying(ScoreID::End)>, ScoreID> _score_info;
-extern TypedIndexContainer<std::array<EnumClassIndexContainer<std::array<int64_t, to_underlying(ScoreID::End)>, ScoreID>, MAX_COMPANIES>, CompanyID> _score_part;
+extern const EnumIndexArray<ScoreInfo, ScoreID, ScoreID::End> _score_info;
+extern TypedIndexContainer<std::array<EnumIndexArray<int64_t, ScoreID, ScoreID::End>, MAX_COMPANIES>, CompanyID> _score_part;
 extern Economy _economy;
 /** Prices and also the fractional part. */
 extern Prices _price;

--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -168,8 +168,8 @@ enum class Price : uint8_t {
 };
 DECLARE_INCREMENT_DECREMENT_OPERATORS(Price)
 
-using Prices = EnumClassIndexContainer<std::array<Money,to_underlying(Price::End)>, Price>; ///< Prices of everything. @see Price
-using PriceMultipliers = EnumClassIndexContainer<std::array<int8_t, to_underlying(Price::End)>, Price>;
+using Prices = EnumIndexArray<Money, Price, Price::End>; ///< Prices of everything. @see Price
+using PriceMultipliers = EnumIndexArray<int8_t, Price, Price::End>;
 
 /** Types of expenses. */
 enum ExpensesType : uint8_t {

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -36,7 +36,7 @@ extern std::string _config_file;
 extern std::string _highscore_file;
 
 /** Subdirectory names. */
-static const EnumClassIndexContainer<std::array<std::string_view, to_underlying(Subdirectory::End)>, Subdirectory> _subdirs = {
+static const EnumIndexArray<std::string_view, Subdirectory, Subdirectory::End> _subdirs = {
 	"",
 	"save" PATHSEP,
 	"save" PATHSEP "autosave" PATHSEP,
@@ -62,12 +62,12 @@ static const EnumClassIndexContainer<std::array<std::string_view, to_underlying(
  * An empty string tells that there is no such path for the
  * current operating system.
  */
-EnumClassIndexContainer<std::array<std::string, to_underlying(Searchpath::End)>, Searchpath> _searchpaths;
+EnumIndexArray<std::string, Searchpath, Searchpath::End> _searchpaths;
 std::vector<Searchpath> _valid_searchpaths;
 /** List of tar files found in each subdirectory. */
-EnumClassIndexContainer<std::array<TarList, to_underlying(Subdirectory::End)>, Subdirectory> _tar_list;
+EnumIndexArray<TarList, Subdirectory, Subdirectory::End> _tar_list;
 /** List of files within tar files found in each subdirectory. */
-EnumClassIndexContainer<std::array<TarFileList, to_underlying(Subdirectory::End)>, Subdirectory> _tar_filelist;
+EnumIndexArray<TarFileList, Subdirectory, Subdirectory::End> _tar_filelist;
 
 /**
  * Checks whether the given search path is a valid search path

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -303,7 +303,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_save_dialog_widgets 
 };
 
 /** Text colours of #DetailedFileType fios entries in the window. */
-static const EnumClassIndexContainer<std::array<TextColour, to_underlying(DetailedFileType::End)>, DetailedFileType> _fios_colours = {
+static const EnumIndexArray<TextColour, DetailedFileType, DetailedFileType::End> _fios_colours = {
 	TC_LIGHT_BROWN, // DetailedFileType::OldGameFile
 	TC_ORANGE, // DetailedFileType::GameFile
 	TC_YELLOW, // DetailedFileType::HeightmapBmp

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -21,9 +21,9 @@
 #include "safeguards.h"
 
 /** Default unscaled heights for the different sizes of fonts. */
-/* static */ const EnumClassIndexContainer<std::array<int, to_underlying(FontSize::End)>, FontSize> FontCache::DEFAULT_FONT_HEIGHT{10, 6, 18, 10};
+/* static */ const EnumIndexArray<int, FontSize, FontSize::End> FontCache::DEFAULT_FONT_HEIGHT{10, 6, 18, 10};
 /** Default unscaled ascenders for the different sizes of fonts. */
-/* static */ const EnumClassIndexContainer<std::array<int, to_underlying(FontSize::End)>, FontSize> FontCache::DEFAULT_FONT_ASCENDER{8, 5, 15, 8};
+/* static */ const EnumIndexArray<int, FontSize, FontSize::End> FontCache::DEFAULT_FONT_ASCENDER{8, 5, 15, 8};
 
 FontCacheSettings _fcsettings;
 
@@ -91,7 +91,7 @@ int GetCharacterHeight(FontSize size)
 }
 
 
-/* static */ EnumClassIndexContainer<std::array<std::unique_ptr<FontCache>, to_underlying(FontSize::End)>, FontSize> FontCache::caches{};
+/* static */ EnumIndexArray<std::unique_ptr<FontCache>, FontSize, FontSize::End> FontCache::caches{};
 
 /**
  * Initialise font caches with the base sprite font cache for all sizes.

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -22,7 +22,7 @@ static const GlyphID SPRITE_GLYPH = 1U << 30;
 /** Font cache for basic fonts. */
 class FontCache {
 protected:
-	static EnumClassIndexContainer<std::array<std::unique_ptr<FontCache>, to_underlying(FontSize::End)>, FontSize> caches; ///< All the font caches.
+	static EnumIndexArray<std::unique_ptr<FontCache>, FontSize, FontSize::End> caches; ///< All the font caches.
 	std::unique_ptr<FontCache> parent; ///< The parent of this font cache.
 	const FontSize fs; ///< The size of the font.
 	int height = 0; ///< The height of the font.
@@ -42,9 +42,9 @@ public:
 	static void ClearFontCaches(FontSizes fontsizes);
 
 	/** Default unscaled font heights. */
-	static const EnumClassIndexContainer<std::array<int, to_underlying(FontSize::End)>, FontSize> DEFAULT_FONT_HEIGHT;
+	static const EnumIndexArray<int, FontSize, FontSize::End> DEFAULT_FONT_HEIGHT;
 	/** Default unscaled font ascenders. */
-	static const EnumClassIndexContainer<std::array<int, to_underlying(FontSize::End)>, FontSize> DEFAULT_FONT_ASCENDER;
+	static const EnumIndexArray<int, FontSize, FontSize::End> DEFAULT_FONT_ASCENDER;
 
 	static int GetDefaultFontHeight(FontSize fs);
 

--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -33,7 +33,7 @@ static int ScaleFontTrad(int value)
 	return UnScaleByZoom(value * ZOOM_BASE, _font_zoom);
 }
 
-static EnumClassIndexContainer<std::array<std::unordered_map<char32_t, SpriteID>, to_underlying(FontSize::End)>, FontSize> _char_maps{}; ///< Glyph map for each font size.
+static EnumIndexArray<std::unordered_map<char32_t, SpriteID>, FontSize, FontSize::End> _char_maps{}; ///< Glyph map for each font size.
 
 /**
  * Get SpriteID associated with a character.

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -51,7 +51,7 @@ SwitchMode _switch_mode;  ///< The next mainloop command.
 PauseModes _pause_mode;
 GameSessionStats _game_session_stats; ///< Statistics about the current session.
 
-static EnumClassIndexContainer<std::array<std::array<uint8_t, 244>, to_underlying(FontSize::End)>, FontSize> _stringwidth_table; ///< Cache containing width of often used characters. @see GetCharacterWidth()
+static EnumIndexArray<std::array<uint8_t, 244>, FontSize, FontSize::End> _stringwidth_table; ///< Cache containing width of often used characters. @see GetCharacterWidth()
 DrawPixelInfo *_cur_dpi;
 
 static void GfxMainBlitterViewport(const Sprite *sprite, int x, int y, BlitterMode mode, const SubSprite *sub = nullptr, SpriteID sprite_id = SPR_CURSOR_MOUSE);

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -38,7 +38,7 @@
 std::unique_ptr<Layouter::LineCache> Layouter::linecache;
 
 /** Cache of Font instances. */
-EnumClassIndexContainer<std::array<Layouter::FontColourMap, to_underlying(FontSize::End)>, FontSize> Layouter::fonts;
+EnumIndexArray<Layouter::FontColourMap, FontSize, FontSize::End> Layouter::fonts;
 
 
 /**

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -279,7 +279,7 @@ private:
 	static LineCacheItem &GetCachedParagraphLayout(std::string_view str, const FontState &state);
 
 	using FontColourMap = std::map<TextColour, std::unique_ptr<Font>>;
-	static EnumClassIndexContainer<std::array<FontColourMap, to_underlying(FontSize::End)>, FontSize> fonts; ///< The colour mapping of each of the fonts.
+	static EnumIndexArray<FontColourMap, FontSize, FontSize::End> fonts; ///< The colour mapping of each of the fonts.
 public:
 	static Font *GetFont(FontSize size, TextColour colour);
 

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -66,7 +66,7 @@ extern const TileTypeProcs
  * @ingroup TileCallbackGroup
  * @see TileType
  */
-const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::MaxSize)>, TileType> _tile_type_procs = {
+const EnumIndexArray<const TileTypeProcs *, TileType, TileType::MaxSize> _tile_type_procs = {
 	&_tile_type_clear_procs, // Callback functions for TileType::Clear tiles
 	&_tile_type_rail_procs, // Callback functions for TileType::Railway tiles
 	&_tile_type_road_procs, // Callback functions for TileType::Road tiles

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -167,7 +167,7 @@ constexpr UnpackDispatchT MakeUnpackNetworkCommand(std::index_sequence<i...>) no
 template <typename T, T... i, size_t... j>
 inline constexpr auto MakeDispatchTable(std::integer_sequence<T, i...>, std::index_sequence<j...>) noexcept
 {
-	return EnumClassIndexContainer<std::array<CommandDispatch, sizeof...(i)>, Commands>{{{ { &SanitizeCmdStrings<static_cast<Commands>(i)>, &NetworkReplaceCommandClientId<static_cast<Commands>(i)>, MakeUnpackNetworkCommand<static_cast<Commands>(i)>(std::make_index_sequence<_callback_tuple_size>{}) }... }}};
+	return EnumIndexArray<CommandDispatch, Commands, static_cast<Commands>(sizeof...(i))>{{{ { &SanitizeCmdStrings<static_cast<Commands>(i)>, &NetworkReplaceCommandClientId<static_cast<Commands>(i)>, MakeUnpackNetworkCommand<static_cast<Commands>(i)>(std::make_index_sequence<_callback_tuple_size>{}) }... }}};
 }
 /** Command dispatch table. */
 static constexpr auto _cmd_dispatch = MakeDispatchTable(std::make_integer_sequence<std::underlying_type_t<Commands>, to_underlying(Commands::End)>{}, std::make_index_sequence<_callback_tuple_size>{});

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -55,7 +55,7 @@ using AdminID = PoolID<uint8_t, struct AdminIDTag, 16, 0xFF>;
 /** Simple calculated statistics of a company */
 struct NetworkCompanyStats {
 	/** Array indexed by NetworkVehicleType. */
-	using NetworkVehicleTypeArray = EnumClassIndexContainer<std::array<uint16_t, to_underlying(NetworkVehicleType::End)>, NetworkVehicleType>;
+	using NetworkVehicleTypeArray = EnumIndexArray<uint16_t, NetworkVehicleType, NetworkVehicleType::End>;
 	NetworkVehicleTypeArray num_vehicle; ///< How many vehicles are there of this type?
 	NetworkVehicleTypeArray num_station; ///< How many stations are there of this type?
 };

--- a/src/newgrf/newgrf_act0.cpp
+++ b/src/newgrf/newgrf_act0.cpp
@@ -164,7 +164,7 @@ struct InvokeGrfChangeInfoHandler {
 	using Invoker = ChangeInfoResult(*)(uint first, uint last, int prop, ByteReader &buf, GrfLoadingStage stage);
 
 	/** List of invoke handlers for each feature. */
-	static constexpr EnumClassIndexContainer<std::array<Invoker, to_underlying(GrfSpecFeature::End)>, GrfSpecFeature> funcs { // Must be listed in feature order.
+	static constexpr EnumIndexArray<Invoker, GrfSpecFeature, GrfSpecFeature::End> funcs { // Must be listed in feature order.
 		Invoke<GrfSpecFeature::Trains>,       Invoke<GrfSpecFeature::RoadVehicles>,  Invoke<GrfSpecFeature::Ships>,         Invoke<GrfSpecFeature::Aircraft>,
 		Invoke<GrfSpecFeature::Stations>,     Invoke<GrfSpecFeature::Canals>,        Invoke<GrfSpecFeature::Bridges>,       Invoke<GrfSpecFeature::Houses>,
 		Invoke<GrfSpecFeature::GlobalVar>,    Invoke<GrfSpecFeature::IndustryTiles>, Invoke<GrfSpecFeature::Industries>,    Invoke<GrfSpecFeature::Cargoes>,

--- a/src/newgrf_badge_config.cpp
+++ b/src/newgrf_badge_config.cpp
@@ -24,13 +24,13 @@ class BadgeClassConfig {
 public:
 	static inline const BadgeClassConfigItem EMPTY_CONFIG_ITEM{};
 
-	EnumClassIndexContainer<std::array<std::vector<BadgeClassConfigItem>, to_underlying(GrfSpecFeature::End)>, GrfSpecFeature> features = {};
+	EnumIndexArray<std::vector<BadgeClassConfigItem>, GrfSpecFeature, GrfSpecFeature::End> features = {};
 
 	static constexpr GrfSpecFeatures CONFIGURABLE_FEATURES = {
 		GrfSpecFeature::Trains, GrfSpecFeature::RoadVehicles, GrfSpecFeature::Ships, GrfSpecFeature::Aircraft, GrfSpecFeature::Stations, GrfSpecFeature::Houses, GrfSpecFeature::Objects, GrfSpecFeature::RoadStops,
 	};
 
-	static inline const EnumClassIndexContainer<std::array<std::string_view, to_underlying(GrfSpecFeature::End)>, GrfSpecFeature> sections = {
+	static inline const EnumIndexArray<std::string_view, GrfSpecFeature, GrfSpecFeature::End> sections = {
 		"badges_trains", // GrfSpecFeature::Trains
 		"badges_roadvehicles", // GrfSpecFeature::RoadVehicles
 		"badges_ships", // GrfSpecFeature::Ships

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -258,7 +258,7 @@ static inline const NIHelper &GetFeatureHelper(uint window_number)
 /** Window used for inspecting NewGRFs. */
 struct NewGRFInspectWindow : Window {
 	/** The value for the variable 60 parameters. */
-	static inline EnumClassIndexContainer<std::array<std::array<uint32_t, 0x20>, to_underlying(GrfSpecFeature::FakeEnd)>, GrfSpecFeature> var60params{};
+	static inline EnumIndexArray<std::array<uint32_t, 0x20>, GrfSpecFeature, GrfSpecFeature::FakeEnd> var60params{};
 
 	/** GRFID of the caller of this window, 0 if it has no caller. */
 	uint32_t caller_grfid = 0;

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -86,7 +86,7 @@ struct GenericCallback {
 typedef std::list<GenericCallback> GenericCallbackList;
 
 /** Generic callbacks for each feature. */
-static EnumClassIndexContainer<std::array<GenericCallbackList, to_underlying(GrfSpecFeature::End)>, GrfSpecFeature> _gcl{};
+static EnumIndexArray<GenericCallbackList, GrfSpecFeature, GrfSpecFeature::End> _gcl{};
 
 
 /**

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -126,7 +126,7 @@ std::optional<std::string> GetClipboardContents()
  */
 void CocoaSetApplicationBundleDir()
 {
-	extern EnumClassIndexContainer<std::array<std::string, to_underlying(Searchpath::End)>, Searchpath> _searchpaths;
+	extern EnumIndexArray<std::string, Searchpath, Searchpath::End> _searchpaths;
 
 	char tmp[MAXPATHLEN];
 	CFAutoRelease<CFURLRef> url(CFBundleCopyResourcesDirectoryURL(CFBundleGetMainBundle()));

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -24,7 +24,7 @@
 /** Cached current locale. */
 static CFAutoRelease<CFLocaleRef> _osx_locale;
 /** CoreText cache for font information, cleared when OTTD changes fonts. */
-static EnumClassIndexContainer<std::array<CFAutoRelease<CTFontRef>, to_underlying(FontSize::End)>, FontSize> _font_cache;
+static EnumIndexArray<CFAutoRelease<CTFontRef>, FontSize, FontSize::End> _font_cache;
 
 
 /**

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -29,7 +29,7 @@
 
 
 /** Uniscribe cache for internal font information, cleared when OTTD changes fonts. */
-static EnumClassIndexContainer<std::array<SCRIPT_CACHE, to_underlying(FontSize::End)>, FontSize> _script_cache;
+static EnumIndexArray<SCRIPT_CACHE, FontSize, FontSize::End> _script_cache;
 
 /**
  * Contains all information about a run of characters. A run are consecutive

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -248,7 +248,7 @@ extern std::string _config_file;
 
 void DetermineBasePaths(std::string_view exe)
 {
-	extern EnumClassIndexContainer<std::array<std::string, to_underlying(Searchpath::End)>, Searchpath> _searchpaths;
+	extern EnumIndexArray<std::string, Searchpath, Searchpath::End> _searchpaths;
 
 	wchar_t path[MAX_PATH];
 #ifdef WITH_PERSONAL_DIR

--- a/src/rail.h
+++ b/src/rail.h
@@ -262,12 +262,12 @@ public:
 	/**
 	 * NewGRF providing the Action3 for the railtype. nullptr if not available.
 	 */
-	EnumClassIndexContainer<std::array<const GRFFile *, to_underlying(RailSpriteType::End)>, RailSpriteType> grffile{};
+	EnumIndexArray<const GRFFile *, RailSpriteType, RailSpriteType::End> grffile{};
 
 	/**
 	 * Sprite groups for resolving sprites
 	 */
-	EnumClassIndexContainer<std::array<const SpriteGroup *, to_underlying(RailSpriteType::End)>, RailSpriteType> group{};
+	EnumIndexArray<const SpriteGroup *, RailSpriteType, RailSpriteType::End> group{};
 
 	std::vector<BadgeID> badges;
 

--- a/src/road.h
+++ b/src/road.h
@@ -158,12 +158,12 @@ public:
 	/**
 	 * NewGRF providing the Action3 for the roadtype. nullptr if not available.
 	 */
-	EnumClassIndexContainer<std::array<const GRFFile *, to_underlying(RoadSpriteType::End)>, RoadSpriteType> grffile{};
+	EnumIndexArray<const GRFFile *, RoadSpriteType, RoadSpriteType::End> grffile{};
 
 	/**
 	 * Sprite groups for resolving sprites
 	 */
-	EnumClassIndexContainer<std::array<const SpriteGroup *, to_underlying(RoadSpriteType::End)>, RoadSpriteType> group{};
+	EnumIndexArray<const SpriteGroup *, RoadSpriteType, RoadSpriteType::End> group{};
 
 	std::vector<BadgeID> badges;
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2451,8 +2451,8 @@ static CommandCost RemoveGenericRoadStop(DoCommandFlags flags, const TileArea &r
 
 		/* Save information on to-be-restored roads before the stop is removed. */
 		RoadBits road_bits{};
-		EnumClassIndexContainer<std::array<RoadType, to_underlying(RoadTramType::End)>, RoadTramType> road_type{INVALID_ROADTYPE, INVALID_ROADTYPE};
-		EnumClassIndexContainer<std::array<Owner, to_underlying(RoadTramType::End)>, RoadTramType> road_owner{OWNER_NONE, OWNER_NONE};
+		EnumIndexArray<RoadType, RoadTramType, RoadTramType::End> road_type{INVALID_ROADTYPE, INVALID_ROADTYPE};
+		EnumIndexArray<Owner, RoadTramType, RoadTramType::End> road_owner{OWNER_NONE, OWNER_NONE};
 		if (IsDriveThroughStopTile(cur_tile)) {
 			for (RoadTramType rtt : ROADTRAMTYPES_ALL) {
 				road_type[rtt] = GetRoadType(cur_tile, rtt);

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -721,7 +721,7 @@ static const NIFeature _nif_roadstop = {
 };
 
 /** Table with all NIFeatures. */
-static const EnumClassIndexContainer<std::array<const NIFeature *, to_underlying(GrfSpecFeature::FakeEnd)>, GrfSpecFeature> _nifeatures{
+static const EnumIndexArray<const NIFeature *, GrfSpecFeature, GrfSpecFeature::FakeEnd> _nifeatures{
 	&_nif_vehicle, // GrfSpecFeature::Trains
 	&_nif_vehicle, // GrfSpecFeature::RoadVehicles
 	&_nif_vehicle, // GrfSpecFeature::Ships

--- a/src/table/pricebase.h
+++ b/src/table/pricebase.h
@@ -7,7 +7,7 @@
 
 /** @file pricebase.h Table of all default price bases. */
 
-static const EnumClassIndexContainer<std::array<PriceBaseSpec, to_underlying(Price::End)>, Price> _price_base_specs = {
+static const EnumIndexArray<PriceBaseSpec, Price, Price::End> _price_base_specs = {
 	PriceBaseSpec(100, PCAT_NONE, GrfSpecFeature::End, Price::Invalid), // Price::StationValue
 	PriceBaseSpec(100, PCAT_CONSTRUCTION, GrfSpecFeature::End, Price::Invalid), // Price::BuildRail
 	PriceBaseSpec(95, PCAT_CONSTRUCTION, GrfSpecFeature::End, Price::Invalid), // Price::BuildRoad

--- a/src/table/roadveh_movement.h
+++ b/src/table/roadveh_movement.h
@@ -1479,7 +1479,7 @@ static const RoadDriveEntry * const _road_tram_drive_data[] = {
 };
 
 /** Road drive data for all \c RoadTramTypes */
-static const EnumClassIndexContainer<std::array<const RoadDriveEntry * const *, to_underlying(RoadTramType::End)>, RoadTramType> _road_drive_data{
+static const EnumIndexArray<const RoadDriveEntry * const *, RoadTramType, RoadTramType::End> _road_drive_data{
 	_road_road_drive_data,
 	_road_tram_drive_data,
 };

--- a/src/tar_type.h
+++ b/src/tar_type.h
@@ -21,7 +21,7 @@ struct TarFileListEntry {
 
 using TarList = std::map<std::string, std::string, std::less<>>; ///< Map of tar file to tar directory.
 using TarFileList = std::map<std::string, TarFileListEntry, std::less<>> ;
-extern EnumClassIndexContainer<std::array<TarList, to_underlying(Subdirectory::End)>, Subdirectory> _tar_list;
-extern EnumClassIndexContainer<std::array<TarFileList, to_underlying(Subdirectory::End)>, Subdirectory> _tar_filelist;
+extern EnumIndexArray<TarList, Subdirectory, Subdirectory::End> _tar_list;
+extern EnumIndexArray<TarFileList, Subdirectory, Subdirectory::End> _tar_filelist;
 
 #endif /* TAR_TYPE_H */

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -228,7 +228,7 @@ struct TileTypeProcs {
 	CheckBuildAboveProc *check_build_above_proc = nullptr; ///< Called to check whether a bridge can be build above.
 };
 
-extern const EnumClassIndexContainer<std::array<const TileTypeProcs *, to_underlying(TileType::MaxSize)>, TileType> _tile_type_procs;
+extern const EnumIndexArray<const TileTypeProcs *, TileType, TileType::MaxSize> _tile_type_procs;
 
 TrackStatus GetTileTrackStatus(TileIndex tile, TransportType mode, RoadTramType sub_mode, DiagDirection side = INVALID_DIAGDIR);
 VehicleEnterTileStates VehicleEnterTile(Vehicle *v, TileIndex tile, int x, int y);

--- a/src/town.h
+++ b/src/town.h
@@ -129,8 +129,8 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	SuppliedCargoes supplied{}; ///< Cargo statistics about supplied cargo.
 	AcceptedCargoes accepted{}; ///< Cargo statistics about accepted cargo.
-	EnumClassIndexContainer<std::array<TransportedCargoStat<uint16_t>, to_underlying(TownAcceptanceEffect::End)>, TownAcceptanceEffect> received{}; ///< Cargo statistics about received cargotypes.
-	EnumClassIndexContainer<std::array<uint32_t, to_underlying(TownAcceptanceEffect::End)>, TownAcceptanceEffect> goal{}; ///< Amount of cargo required for the town to grow.
+	EnumIndexArray<TransportedCargoStat<uint16_t>, TownAcceptanceEffect, TownAcceptanceEffect::End> received{}; ///< Cargo statistics about received cargotypes.
+	EnumIndexArray<uint32_t, TownAcceptanceEffect, TownAcceptanceEffect::End> goal{}; ///< Amount of cargo required for the town to grow.
 	ValidHistoryMask valid_history = 0; ///< Mask of valid history records.
 
 	EncodedString text{}; ///< General text with additional information.

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -96,6 +96,6 @@ using VehicleRandomTriggers = EnumBitSet<VehicleRandomTrigger, uint8_t>;
  * @tparam Tend the number of elements in the array.
  */
 template <typename T, VehicleType Tend = VehicleType::CompanyEnd>
-using VehicleTypeIndexArray = EnumClassIndexContainer<std::array<T, to_underlying(Tend)>, VehicleType>;
+using VehicleTypeIndexArray = EnumIndexArray<T, VehicleType, Tend>;
 
 #endif /* VEHICLE_TYPE_H */


### PR DESCRIPTION
## Motivation / Problem

All uses of EnumClassIndexContainer are with std::array.
EnumClassIndexContainer types are overly long and cumbersome.

## Description

Add a typedef for the simple case (all current uses). This also allows otherwise unnecessary calls to to_underlying to be removed in most cases.

## Limitations

TypedIndexContainer is less of a problem and could be done in a different PR if need be.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
