### PR TITLE
Fix: Display action limit error messages (#15223)

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -765,7 +765,9 @@ std::tuple<CommandCost, Money> CmdClearArea(DoCommandFlags flags, TileIndex tile
 			last_error = std::move(ret);
 
 			/* We may not clear more tiles. */
-			if (c != nullptr && GB(c->clear_limit, 16, 16) < 1) break;
+			if (c != nullptr && GB(c->clear_limit, 16, 16) < 1) {
+				return { CommandCost(STR_ERROR_CLEARING_LIMIT_REACHED), 0 };
+			}
 			continue;
 		}
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -418,7 +418,9 @@ CommandCost CmdBuildObjectArea(DoCommandFlags flags, TileIndex tile, TileIndex s
 		CommandCost ret = Command<Commands::BuildObject>::Do(DoCommandFlags{flags}.Reset(DoCommandFlag::Execute), t, type, view);
 
 		/* If we've reached the limit, stop building (or testing). */
-		if (c != nullptr && limit-- <= 0) break;
+		if (c != nullptr && limit-- <= 0) {
+			return CommandCost(STR_ERROR_BUILD_OBJECT_LIMIT_REACHED);
+		}
 
 		if (ret.Failed()) {
 			last_error = std::move(ret);

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -369,8 +369,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdLevelLand(DoCommandFlags flags, Til
 				 * completely off due to it basically counting terraforming double, so it being
 				 * cut off earlier might even give a better estimate in some cases. */
 				if (--limit <= 0) {
-					had_success = true;
-					break;
+					return { CommandCost(STR_ERROR_TERRAFORM_LIMIT_REACHED), 0, error_tile };
 				}
 			}
 

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -536,8 +536,7 @@ CommandCost CmdPlantTree(DoCommandFlags flags, TileIndex tile, TileIndex start_t
 
 				/* Test tree limit. */
 				if (--limit < 1) {
-					msg = STR_ERROR_TREE_PLANT_LIMIT_REACHED;
-					break;
+					return CommandCost(STR_ERROR_TREE_PLANT_LIMIT_REACHED);
 				}
 
 				if (flags.Test(DoCommandFlag::Execute)) {
@@ -577,8 +576,7 @@ CommandCost CmdPlantTree(DoCommandFlags flags, TileIndex tile, TileIndex start_t
 
 				/* Test tree limit. */
 				if (--limit < 1) {
-					msg = STR_ERROR_TREE_PLANT_LIMIT_REACHED;
-					break;
+					return CommandCost(STR_ERROR_TREE_PLANT_LIMIT_REACHED);
 				}
 
 				if (IsTileType(current_tile, TileType::Clear)) {


### PR DESCRIPTION
## Motivation / Problem

There are limits on some player actions (planting trees, placing objects/buying land, clearing tiles, terraforming), however the error message if you hit these limits isn't shown. Instead, the action just fails part-way, working from the top left.

There's no feedback to the player - it just silently fails.

## Description

Adjust the commands so they track if the limit would be reached, then fail and display the error message if it would be.

Fixes #15223

<img width="706" height="203" alt="image" src="https://github.com/user-attachments/assets/7aa9d4b3-5874-4ea0-bd4c-cb39e67392a3" />

## Limitations

Correct behaviour is unclear. Should the player action partially complete, or should it completely fail? Should the cost estimation (shift+action) show that the action will hit the limit, or should it show the estimated cost of the full action? Should all tools behave the same, or should they have behaviours which match failure for other causes (eg. running out of money)? For objects with placement restrictions, should it count where objects will actually be placed, or where placement will be attempted?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
