### PR TITLE
Fix: Vehicle's motion_counter increases when travelling backwards, making animations run backwards.

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1007,10 +1007,14 @@ void CallVehicleTicks()
 
 		assert(Vehicle::Get(vehicle_index) == v);
 
+		bool vehicle_flipped = false;
+
 		switch (v->type) {
 			default: break;
 
 			case VehicleType::Train:
+				vehicle_flipped = Train::From(v)->flags.Test(VehicleRailFlag::Flipped);
+				[[fallthrough]];
 			case VehicleType::Road:
 			case VehicleType::Aircraft:
 			case VehicleType::Ship: {
@@ -1033,8 +1037,8 @@ void CallVehicleTicks()
 				/* Do not play any sound when stopped */
 				if (front->vehstatus.Test(VehState::Stopped) && (front->type != VehicleType::Train || front->cur_speed == 0)) continue;
 
-				/* Update motion counter for animation purposes. */
-				v->motion_counter += front->cur_speed;
+				/* Update motion counter for animation purposes. Relative motion is negative (animations go backwards) if the vehicle is reversed xor reversing */
+				v->motion_counter += (v->IsDrivingBackwards() != vehicle_flipped) ? -front->cur_speed : front->cur_speed;
 
 				/* Check vehicle type specifics */
 				switch (v->type) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
Since #15391 trains have been able to go backwards, but now the motion_counter variable doesn't make sense for animated vehicle motion, so steam locomotives from many sets were moonwalking.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This fix is to increase motion_counter when vehicles are moving forward and decrease it when they move in reverse. For trains that flip at the end of the line, the behaviour is unchanged.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
* Doesn't seem to impact sounds but I've only tested a few NewGRFs briefly. I don't see why the logic would need to change there.
* There's a potential regression in any NewGRF that offers a flippable animated locomotive but handles reordering the animation frames when flipped for itself. I would be very surprised if there are any of those in the wild.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
