### PR TITLE
Fix sort order of engines defined in overriding NewGRFs

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -180,6 +180,7 @@ static std::map<uint32_t, uint32_t> _grf_id_overrides;
 /**
  * Get the override for a NewGRF
  * @param source_grfid The grfID which wants to override another NewGRF.
+ * @return The grfID of the overridden NewGRF if present, or INVALID_GRFID.
  */
 uint32_t GetNewGRFOverride(uint32_t source_grfid)
 {

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -178,6 +178,20 @@ void DisableStaticNewGRFInfluencingNonStaticNewGRFs(GRFConfig &c)
 static std::map<uint32_t, uint32_t> _grf_id_overrides;
 
 /**
+ * Get the override for a NewGRF
+ * @param source_grfid The grfID which wants to override another NewGRF.
+ */
+uint32_t GetNewGRFOverride(uint32_t source_grfid)
+{
+	auto found = _grf_id_overrides.find(source_grfid);
+	if (found != std::end(_grf_id_overrides)) {
+		return found->second;
+	}
+	return INVALID_GRFID;
+}
+
+
+/**
  * Set the override for a NewGRF
  * @param source_grfid The grfID which wants to override another NewGRF.
  * @param target_grfid The grfID which is being overridden.

--- a/src/newgrf/newgrf_internal.h
+++ b/src/newgrf/newgrf_internal.h
@@ -221,6 +221,7 @@ extern GRFLineToSpriteOverride _grf_line_to_action6_sprite_override;
 
 extern GrfMiscBits _misc_grf_features;
 
+uint32_t GetNewGRFOverride(uint32_t source_grfid);
 void SetNewGRFOverride(uint32_t source_grfid, uint32_t target_grfid);
 GRFFile *GetCurrentGRFOverride();
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -25,6 +25,7 @@
 #include "newgrf_railtype.h"
 #include "newgrf_roadtype.h"
 #include "ship.h"
+#include "newgrf/newgrf_internal.h"
 
 #include "safeguards.h"
 
@@ -1394,8 +1395,16 @@ void CommitVehicleListOrderChanges()
 		Engine *engine_source = Engine::Get(source);
 		if (engine_source->grf_prop.local_id == loc.target) continue;
 
-		EngineID target = _engine_mngr.GetID(engine_source->type, loc.target, engine_source->grf_prop.grfid);
-		if (target == EngineID::Invalid()) continue;
+		EngineID target = _engine_mngr.GetID(engine_source->type, loc.target, engine_source->GetGRFID());
+		if (target == EngineID::Invalid()) {
+			auto override_grfid = GetNewGRFOverride(engine_source->GetGRFID());
+			if (override_grfid != INVALID_GRFID)
+				target = _engine_mngr.GetID(engine_source->type, loc.target, override_grfid);
+			if (target == EngineID::Invalid()) {
+				GrfMsg(6, "ListOrderChange: invalid target {} of GRFID {:x}", loc.target, std::byteswap(engine_source->GetGRFID()));
+				continue;
+			}
+		}
 
 		auto it_source = std::ranges::find(ordering, source);
 		auto it_target = std::ranges::find(ordering, target);

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -25,6 +25,7 @@
 #include "newgrf_railtype.h"
 #include "newgrf_roadtype.h"
 #include "ship.h"
+#include "newgrf/newgrf_internal.h"
 
 #include "safeguards.h"
 
@@ -1393,8 +1394,16 @@ void CommitVehicleListOrderChanges()
 		Engine *engine_source = Engine::Get(source);
 		if (engine_source->grf_prop.local_id == loc.target) continue;
 
-		EngineID target = _engine_mngr.GetID(engine_source->type, loc.target, engine_source->grf_prop.grfid);
-		if (target == EngineID::Invalid()) continue;
+		EngineID target = _engine_mngr.GetID(engine_source->type, loc.target, engine_source->GetGRFID());
+		if (target == EngineID::Invalid()) {
+			auto override_grfid = GetNewGRFOverride(engine_source->GetGRFID());
+			if (override_grfid != INVALID_GRFID)
+				target = _engine_mngr.GetID(engine_source->type, loc.target, override_grfid);
+			if (target == EngineID::Invalid()) {
+				GrfMsg(6, "ListOrderChange: invalid target {} of GRFID {:x}", loc.target, std::byteswap(engine_source->GetGRFID()));
+				continue;
+			}
+		}
 
 		auto it_source = std::ranges::find(ordering, source);
 		auto it_target = std::ranges::find(ordering, target);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The change of engine pool in 15.0 broke sorting across NewGRFs, which was working in 14.0 (#15556). This is a feature I'm using for my 2cc Narrow Gauge in NML add-on of the 2cc Trains in NML set.

Let's suppose we have a base NewGRF, and an add-on NewGRF that both fixes the base NewGRF engines and also add new engines. The add-on NewGRF defines a sort order with both the engines of the base NewGRF and the add-on ones. In OpenTTD 15, the sort ignores the add-on engines and puts them at inconsistent locations. This is because the current code logic always assumes the engines in `sort` come from the same NewGRF, which is not true in case of an engine override.

## Description

The `CommitVehicleListOrderChanges` function uses insertion sort to put the engines at their target location. The target location is a *local* engine ID. This *local* engine ID needs to be translated to a global engine ID. However, the current code always assume the target engine comes from the same NewGRF as the source engine, which may not be the case for engine overrides.

I added a fallback so that if the local ID is not found for the source NewGRF, the engine manager is queried again using the GRF ID of the overriden GRF. To do so, I had to add a new function to get the overridden GRF ID for a given GRF ID, an info which is available in the `newgrf_internals.h` but not exposed (only a setter is exposed).

## Limitations

This now works on my particular case, but I have not tested more complex scenarii with multiple NewGRFs having multiple or cascading overrides. I also think that the `GetNewGRFOverride` relies on private data that may not be accessible at all time, but since the sort order is computed at the NewGRF load stage I think the mapping table is always there?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
