### PR TITLE
Codefix: Station/waypoint viewport rect handling in QueryStringWindow::OnPlaceObjectAbort

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -992,14 +992,19 @@ struct QueryStringWindow : public Window
 		}
 	}
 
+private:
+	/** Clear parent window station/waypoint viewport rect. */
+	void ClearViewportRect()
+	{
+		if (this->parent->window_class == WC_STATION_VIEW) SetViewportStationRect(Station::Get(this->parent->window_number), false);
+		if (this->parent->window_class == WC_WAYPOINT_VIEW) SetViewportWaypointRect(Waypoint::Get(this->parent->window_number), false);
+	}
+
+public:
 	void OnPlaceObjectAbort() override
 	{
-		if (Station::IsExpected(Station::Get(this->parent->window_number))) {
-			/* this is a station */
-			SetViewportStationRect(Station::Get(this->parent->window_number), false);
-		} else {
-			/* this is a waypoint */
-			SetViewportWaypointRect(Waypoint::Get(this->parent->window_number), false);
+		if (this->parent != nullptr) {
+			this->ClearViewportRect();
 		}
 
 		this->RaiseButtons();
@@ -1008,8 +1013,7 @@ struct QueryStringWindow : public Window
 	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (this->parent != nullptr) {
-			if (this->parent->window_class == WC_STATION_VIEW) SetViewportStationRect(Station::Get(this->parent->window_number), false);
-			if (this->parent->window_class == WC_WAYPOINT_VIEW) SetViewportWaypointRect(Waypoint::Get(this->parent->window_number), false);
+			this->ClearViewportRect();
 
 			if (!this->editbox.handled) {
 				Window *parent = this->parent;


### PR DESCRIPTION
## Motivation / Problem

In OnPlaceObjectAbort in the rename station/waypoint window when using the move tool `Station::IsExpected(Station::Get(this->parent->window_number))` is technically UB for waypoints, because Station::Get returns a station pointer which points to a waypoint.

OnPlaceObjectAbort also assumes that `this->parent` is non-null, which is potentially problematic when `Close` can set it to nullptr.

## Description

De-duplicate viewport rect clearing behaviour between OnPlaceObjectAbort and Close, in favour of the better implementation in Close.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
