### PR TITLE
Codechange: Use enum class for GenWorldProgress

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -337,9 +337,9 @@ void GenerateClearTile()
 	i = Map::ScaleBySize(GB(Random(), 0, 10) + 0x400);
 	gi = Map::ScaleBySize(GB(Random(), 0, 7) + 0x80);
 
-	SetGeneratingWorldProgress(GWP_ROUGH_ROCKY, gi + i);
+	SetGeneratingWorldProgress(GenWorldProgress::RoughAndRocks, gi + i);
 	do {
-		IncreaseGeneratingWorldProgress(GWP_ROUGH_ROCKY);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::RoughAndRocks);
 		tile = RandomTile();
 		if (IsTileType(tile, TileType::Clear) && !IsClearGround(tile, ClearGround::Desert)) SetClearGroundDensity(tile, ClearGround::Rough, 3);
 	} while (--i);
@@ -350,7 +350,7 @@ void GenerateClearTile()
 		uint32_t r = Random();
 		tile = RandomTileSeed(r);
 
-		IncreaseGeneratingWorldProgress(GWP_ROUGH_ROCKY);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::RoughAndRocks);
 		if (IsTileType(tile, TileType::Clear)) {
 			uint j = GB(r, 16, 4) + 5;
 			for (;;) {

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -105,13 +105,13 @@ static void _GenerateWorld()
 		if (_network_dedicated) Debug(net, 3, "Generating map, please wait...");
 		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
 		_random.SetSeed(_settings_game.game_creation.generation_seed);
-		SetGeneratingWorldProgress(GWP_MAP_INIT, 2);
+		SetGeneratingWorldProgress(GenWorldProgress::Init, 2);
 		SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WC_MAIN_WINDOW, 0);
 		ScriptObject::InitializeRandomizers();
 
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 
-		IncreaseGeneratingWorldProgress(GWP_MAP_INIT);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::Init);
 		/* Must start economy early because of the costs. */
 		StartupEconomy();
 		if (!CheckTownRoadTypes()) {
@@ -127,7 +127,7 @@ static void _GenerateWorld()
 		}
 
 		if (!landscape_generated) {
-			SetGeneratingWorldProgress(GWP_OBJECT, 1);
+			SetGeneratingWorldProgress(GenWorldProgress::Objects, 1);
 
 			/* Make sure the tiles at the north border are void tiles if needed. */
 			if (_settings_game.construction.freeform_edges) {
@@ -140,7 +140,7 @@ static void _GenerateWorld()
 
 			ConvertGroundTilesIntoWaterTiles();
 			Map::CountLandTiles();
-			IncreaseGeneratingWorldProgress(GWP_OBJECT);
+			IncreaseGeneratingWorldProgress(GenWorldProgress::Objects);
 
 			_settings_game.game_creation.snow_line_height = DEF_SNOWLINE_HEIGHT;
 		} else {
@@ -160,11 +160,11 @@ static void _GenerateWorld()
 		}
 
 		/* These are probably pointless when inside the scenario editor. */
-		SetGeneratingWorldProgress(GWP_GAME_INIT, 3);
+		SetGeneratingWorldProgress(GenWorldProgress::GameInit, 3);
 		StartupCompanies();
-		IncreaseGeneratingWorldProgress(GWP_GAME_INIT);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::GameInit);
 		StartupEngines();
-		IncreaseGeneratingWorldProgress(GWP_GAME_INIT);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::GameInit);
 		StartupDisasters();
 		_generating_world = false;
 
@@ -174,20 +174,20 @@ static void _GenerateWorld()
 		if (GenWorldInfo::mode != GWM_EMPTY) {
 			uint i;
 
-			SetGeneratingWorldProgress(GWP_RUNTILELOOP, 0x500);
+			SetGeneratingWorldProgress(GenWorldProgress::RunTileLoop, 0x500);
 			for (i = 0; i < 0x500; i++) {
 				RunTileLoop();
 				TimerGameTick::counter++;
-				IncreaseGeneratingWorldProgress(GWP_RUNTILELOOP);
+				IncreaseGeneratingWorldProgress(GenWorldProgress::RunTileLoop);
 			}
 
 			if (_game_mode != GM_EDITOR) {
 				if (Game::GetInstance() != nullptr) {
-					SetGeneratingWorldProgress(GWP_RUNSCRIPT, 2500);
+					SetGeneratingWorldProgress(GenWorldProgress::GameScript, 2500);
 					_generating_world = true;
 					for (i = 0; i < 2500; i++) {
 						Game::GameLoop();
-						IncreaseGeneratingWorldProgress(GWP_RUNSCRIPT);
+						IncreaseGeneratingWorldProgress(GenWorldProgress::GameScript);
 						if (Game::GetInstance()->IsSleeping()) break;
 					}
 					_generating_world = false;
@@ -203,10 +203,10 @@ static void _GenerateWorld()
 		/* Show all vital windows again, because we have hidden them. */
 		if (_game_mode != GM_MENU) ShowVitalWindows();
 
-		SetGeneratingWorldProgress(GWP_GAME_START, 1);
+		SetGeneratingWorldProgress(GenWorldProgress::GameStart, 1);
 		/* Call any callback */
 		if (GenWorldInfo::proc != nullptr) GenWorldInfo::proc();
-		IncreaseGeneratingWorldProgress(GWP_GAME_START);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::GameStart);
 
 		CleanupGeneration();
 

--- a/src/genworld.h
+++ b/src/genworld.h
@@ -56,22 +56,23 @@ typedef void GWDoneProc();  ///< Procedure called when the genworld process fini
 typedef void GWAbortProc(); ///< Called when genworld is aborted
 
 /** Current stage of world generation process */
-enum GenWorldProgress : uint8_t {
-	GWP_MAP_INIT,    ///< Initialize/allocate the map, start economy
-	GWP_LANDSCAPE,   ///< Create the landscape
-	GWP_RIVER,       ///< Create the rivers
-	GWP_ROUGH_ROCKY, ///< Make rough and rocky areas
-	GWP_TOWN,        ///< Generate towns
-	GWP_LAND_INDUSTRY, ///< Generate industries
-	GWP_WATER_INDUSTRY, ///< Generate industries
-	GWP_OBJECT,      ///< Generate objects (radio tower, light houses)
-	GWP_TREE,        ///< Generate trees
-	GWP_GAME_INIT,   ///< Initialize the game
-	GWP_RUNTILELOOP, ///< Runs the tile loop 1280 times to make snow etc
-	GWP_RUNSCRIPT,   ///< Runs the game script at most 2500 times, or when ever the script sleeps
-	GWP_GAME_START,  ///< Really prepare to start the game
-	GWP_CLASS_COUNT
+enum class GenWorldProgress : uint8_t {
+	Init, ///< Initialize/allocate the map, start economy.
+	Landscape, ///< Create the landscape.
+	Rivers, ///< Create the rivers.
+	RoughAndRocks, ///< Make rough and rocky areas.
+	Towns, ///< Generate towns.
+	LandIndustries, ///< Generate industries.
+	WaterIndustries, ///< Generate industries.
+	Objects, ///< Generate objects (radio tower, light houses).
+	Trees, ///< Generate trees.
+	GameInit, ///< Initialize the game.
+	RunTileLoop, ///< Runs the tile loop 1280 times to make snow etc.
+	GameScript, ///< Runs the game script at most 2500 times, or when ever the script sleeps.
+	GameStart, ///< Really prepare to start the game.
+	End, ///< End marker.
 };
+DECLARE_ENUM_AS_SEQUENTIAL(GenWorldProgress)
 
 /* genworld.cpp */
 void GenerateWorldSetCallback(GWDoneProc *proc);

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1367,7 +1367,8 @@ struct GenWorldStatus {
 	static inline uint total;
 };
 
-static const StringID _generation_class_table[]  = {
+/** Strings used for the steps of the world generation progress bar. */
+static const EnumIndexArray<StringID, GenWorldProgress, GenWorldProgress::End> _generation_class_table = {
 	STR_GENERATION_WORLD_GENERATION,
 	STR_GENERATION_LANDSCAPE_GENERATION,
 	STR_GENERATION_RIVER_GENERATION,
@@ -1382,8 +1383,6 @@ static const StringID _generation_class_table[]  = {
 	STR_GENERATION_PREPARING_SCRIPT,
 	STR_GENERATION_PREPARING_GAME
 };
-static_assert(lengthof(_generation_class_table) == GWP_CLASS_COUNT);
-
 
 static void AbortGeneratingWorldCallback(Window *, bool confirmed)
 {
@@ -1428,8 +1427,8 @@ struct GenerateProgressWindow : public Window {
 			}
 
 			case WID_GP_PROGRESS_TEXT:
-				for (uint i = 0; i < GWP_CLASS_COUNT; i++) {
-					size.width = std::max(size.width, GetStringBoundingBox(_generation_class_table[i]).width + padding.width);
+				for (StringID str : _generation_class_table) {
+					size.width = std::max(size.width, GetStringBoundingBox(str).width + padding.width);
 				}
 				size.height = GetCharacterHeight(FontSize::Normal) * 2 + WidgetDimensions::scaled.vsep_normal;
 				break;
@@ -1482,8 +1481,8 @@ void ShowGenerateWorldProgress()
 static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uint total)
 {
 	static const int percent_table[] = {0, 5, 14, 17, 20, 40, 55, 60, 65, 80, 85, 95, 99, 100 };
-	static_assert(lengthof(percent_table) == GWP_CLASS_COUNT + 1);
-	assert(cls < GWP_CLASS_COUNT);
+	static_assert(lengthof(percent_table) == to_underlying(GenWorldProgress::End) + 1);
+	assert(cls < GenWorldProgress::End);
 
 	/* Check if we really are generating the world.
 	 * For example, placing trees via the SE also calls this function, but
@@ -1504,11 +1503,11 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 		GenWorldStatus::cls     = _generation_class_table[cls];
 		GenWorldStatus::current = progress;
 		GenWorldStatus::total   = total;
-		GenWorldStatus::percent = percent_table[cls];
+		GenWorldStatus::percent = percent_table[to_underlying(cls)];
 	}
 
 	/* Percentage is about the number of completed tasks, so 'current - 1' */
-	GenWorldStatus::percent = percent_table[cls] + (percent_table[cls + 1] - percent_table[cls]) * (GenWorldStatus::current == 0 ? 0 : GenWorldStatus::current - 1) / GenWorldStatus::total;
+	GenWorldStatus::percent = percent_table[to_underlying(cls)] + (percent_table[to_underlying(cls) + 1] - percent_table[to_underlying(cls)]) * (GenWorldStatus::current == 0 ? 0 : GenWorldStatus::current - 1) / GenWorldStatus::total;
 
 	if (_network_dedicated) {
 		static uint last_percent = 0;

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2403,7 +2403,7 @@ static void PlaceInitialIndustry(IndustryType type, bool water, bool try_hard)
 {
 	AutoRestoreBackup cur_company(_current_company, OWNER_NONE);
 
-	IncreaseGeneratingWorldProgress(water ? GWP_WATER_INDUSTRY : GWP_LAND_INDUSTRY);
+	IncreaseGeneratingWorldProgress(water ? GenWorldProgress::WaterIndustries : GenWorldProgress::LandIndustries);
 	PlaceIndustry(type, IndustryAvailabilityCallType::MapGeneration, try_hard);
 }
 
@@ -2510,7 +2510,7 @@ void GenerateIndustries()
 			total_amount = p.num_forced;
 		}
 
-		SetGeneratingWorldProgress(water ? GWP_WATER_INDUSTRY : GWP_LAND_INDUSTRY, total_amount);
+		SetGeneratingWorldProgress(water ? GenWorldProgress::WaterIndustries : GenWorldProgress::LandIndustries, total_amount);
 
 		/* Try to build one industry per type independent of any probabilities */
 		for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -986,7 +986,7 @@ static void CreateDesertOrRainForest(uint desert_tropic_line)
 	uint update_freq = Map::Size() / 4;
 
 	for (const auto tile : Map::Iterate()) {
-		if ((tile % update_freq) == 0) IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+		if ((tile % update_freq) == 0) IncreaseGeneratingWorldProgress(GenWorldProgress::Landscape);
 
 		if (!IsValidTile(tile)) continue;
 
@@ -1000,13 +1000,13 @@ static void CreateDesertOrRainForest(uint desert_tropic_line)
 	}
 
 	for (uint i = 0; i != TILE_UPDATE_FREQUENCY; i++) {
-		if ((i % 64) == 0) IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+		if ((i % 64) == 0) IncreaseGeneratingWorldProgress(GenWorldProgress::Landscape);
 
 		RunTileLoop();
 	}
 
 	for (const auto tile : Map::Iterate()) {
-		if ((tile % update_freq) == 0) IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+		if ((tile % update_freq) == 0) IncreaseGeneratingWorldProgress(GenWorldProgress::Landscape);
 
 		if (!IsValidTile(tile)) continue;
 
@@ -1471,11 +1471,11 @@ static void CreateRivers()
 
 	uint wells = Map::ScaleBySize(4 << _settings_game.game_creation.amount_of_rivers);
 	const uint num_short_rivers = wells - std::max(1u, wells / 10);
-	SetGeneratingWorldProgress(GWP_RIVER, wells + TILE_UPDATE_FREQUENCY / 64); // Include the tile loop calls below.
+	SetGeneratingWorldProgress(GenWorldProgress::Rivers, wells + TILE_UPDATE_FREQUENCY / 64); // Include the tile loop calls below.
 
 	/* Try to create long rivers. */
 	for (; wells > num_short_rivers; wells--) {
-		IncreaseGeneratingWorldProgress(GWP_RIVER);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::Rivers);
 		bool done = false;
 		for (int tries = 0; tries < 512; tries++) {
 			for (auto t : SpiralTileSequence(RandomTile(), 8)) {
@@ -1490,7 +1490,7 @@ static void CreateRivers()
 
 	/* Try to create short rivers. */
 	for (; wells != 0; wells--) {
-		IncreaseGeneratingWorldProgress(GWP_RIVER);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::Rivers);
 		bool done = false;
 		for (int tries = 0; tries < 128; tries++) {
 			for (auto t : SpiralTileSequence(RandomTile(), 8)) {
@@ -1508,7 +1508,7 @@ static void CreateRivers()
 
 	/* Run tile loop to update the ground density. */
 	for (uint i = 0; i != TILE_UPDATE_FREQUENCY; i++) {
-		if (i % 64 == 0) IncreaseGeneratingWorldProgress(GWP_RIVER);
+		if (i % 64 == 0) IncreaseGeneratingWorldProgress(GenWorldProgress::Rivers);
 		RunTileLoop();
 	}
 }
@@ -1626,16 +1626,16 @@ bool GenerateLandscape(uint8_t mode)
 	uint steps = (_settings_game.game_creation.landscape == LandscapeType::Tropic) ? GLS_TROPIC : GLS_OTHER;
 
 	if (mode == GWM_HEIGHTMAP) {
-		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_HEIGHTMAP);
+		SetGeneratingWorldProgress(GenWorldProgress::Landscape, steps + GLS_HEIGHTMAP);
 		if (!LoadHeightmap(_file_to_saveload.ftype.detailed, _file_to_saveload.name)) {
 			return false;
 		}
-		IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::Landscape);
 	} else if (_settings_game.game_creation.land_generator == LG_TERRAGENESIS) {
-		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_TERRAGENESIS);
+		SetGeneratingWorldProgress(GenWorldProgress::Landscape, steps + GLS_TERRAGENESIS);
 		GenerateTerrainPerlin();
 	} else {
-		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_ORIGINAL);
+		SetGeneratingWorldProgress(GenWorldProgress::Landscape, steps + GLS_ORIGINAL);
 		if (_settings_game.construction.freeform_edges) {
 			for (uint x = 0; x < Map::SizeX(); x++) MakeVoid(TileXY(x, 0));
 			for (uint y = 0; y < Map::SizeY(); y++) MakeVoid(TileXY(0, y));
@@ -1693,11 +1693,11 @@ bool GenerateLandscape(uint8_t mode)
 	 * it allows screen redraw. Drawing of broken slopes crashes the game */
 	FixSlopes();
 	MarkWholeScreenDirty();
-	IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+	IncreaseGeneratingWorldProgress(GenWorldProgress::Landscape);
 
 	ConvertGroundTilesIntoWaterTiles();
 	MarkWholeScreenDirty();
-	IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+	IncreaseGeneratingWorldProgress(GenWorldProgress::Landscape);
 
 	switch (_settings_game.game_creation.landscape) {
 		case LandscapeType::Arctic:

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -875,7 +875,7 @@ static bool TryBuildTransmitter()
 void GenerateObjects()
 {
 	/* Set a guestimate on how much we progress */
-	SetGeneratingWorldProgress(GWP_OBJECT, (uint)ObjectSpec::Count());
+	SetGeneratingWorldProgress(GenWorldProgress::Objects, static_cast<uint>(ObjectSpec::Count()));
 
 	/* Determine number of water tiles at map border needed for freeform_edges */
 	uint num_water_tiles = 0;
@@ -930,7 +930,7 @@ void GenerateObjects()
 				}
 				break;
 		}
-		IncreaseGeneratingWorldProgress(GWP_OBJECT);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::Objects);
 	}
 }
 

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -1061,11 +1061,11 @@ void GenerateTerrainPerlin()
 
 	HeightMapGenerate();
 
-	IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+	IncreaseGeneratingWorldProgress(GenWorldProgress::Landscape);
 
 	HeightMapNormalize();
 
-	IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+	IncreaseGeneratingWorldProgress(GenWorldProgress::Landscape);
 
 	/* First make sure the tiles at the north border are void tiles if needed. */
 	if (_settings_game.construction.freeform_edges) {

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2433,7 +2433,7 @@ bool GenerateTowns(TownLayout layout, std::optional<uint> number)
 	uint32_t townnameparts;
 	TownNames town_names;
 
-	SetGeneratingWorldProgress(GWP_TOWN, total);
+	SetGeneratingWorldProgress(GenWorldProgress::Towns, total);
 
 	/* Pre-populate the town names list with the names of any towns already on the map */
 	for (const Town *town : Town::Iterate()) {
@@ -2449,7 +2449,7 @@ bool GenerateTowns(TownLayout layout, std::optional<uint> number)
 	 * We would not like the system to lock up just because the user wanted 100 cities on a 64*64 map, would we? */
 	do {
 		bool city = (_settings_game.economy.larger_towns != 0 && ((city_random_offset + current_number) % _settings_game.economy.larger_towns) == 0);
-		IncreaseGeneratingWorldProgress(GWP_TOWN);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::Towns);
 		/* Get a unique name for the town. */
 		if (!GenerateTownName(_random, &townnameparts, &town_names)) continue;
 		/* try 20 times to create a random-sized town for the first loop. */

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -311,7 +311,7 @@ static void PlaceTreeGroups(uint num_groups)
 		CreateRandomStarShapedPolygon(GROVE_RADIUS, grove);
 
 		for (uint i = 0; i < DEFAULT_TREE_STEPS; i++) {
-			IncreaseGeneratingWorldProgress(GWP_TREE);
+			IncreaseGeneratingWorldProgress(GenWorldProgress::Trees);
 
 			uint32_t r = Random();
 			int x = GB(r, 0, 5) - GROVE_RADIUS;
@@ -377,7 +377,7 @@ void PlaceTreesRandomly()
 		uint32_t r = Random();
 		TileIndex tile = RandomTileSeed(r);
 
-		IncreaseGeneratingWorldProgress(GWP_TREE);
+		IncreaseGeneratingWorldProgress(GenWorldProgress::Trees);
 
 		if (CanPlantTreesOnTile(tile, true)) {
 			PlaceTree(tile, r);
@@ -408,7 +408,7 @@ void PlaceTreesRandomly()
 			uint32_t r = Random();
 			TileIndex tile = RandomTileSeed(r);
 
-			IncreaseGeneratingWorldProgress(GWP_TREE);
+			IncreaseGeneratingWorldProgress(GenWorldProgress::Trees);
 
 			if (GetTropicZone(tile) == TropicZone::Rainforest && CanPlantTreesOnTile(tile, false)) {
 				PlaceTree(tile, r);
@@ -493,7 +493,7 @@ void GenerateTrees()
 	total *= i;
 	uint num_groups = (_settings_game.game_creation.landscape != LandscapeType::Toyland) ? Map::ScaleBySize(GB(Random(), 0, 5) + 25) : 0;
 	total += num_groups * DEFAULT_TREE_STEPS;
-	SetGeneratingWorldProgress(GWP_TREE, total);
+	SetGeneratingWorldProgress(GenWorldProgress::Trees, total);
 
 	if (num_groups != 0) PlaceTreeGroups(num_groups);
 


### PR DESCRIPTION
## Motivation / Problem

We are slowly converting enums to enum classes.

## Description

Convert GenWorldProgress to an enum class.

## Limitations

~~Lots of casting in `genworld_gui.cpp`, do we have a way to allow arithmetic operators for enum classes?~~ Resolved.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
