### PR TITLE
Change: Default setting to review orders excludes stopped vehicles

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1687,16 +1687,16 @@ CommandCost CmdOrderRefit(DoCommandFlags flags, VehicleID veh, VehicleOrderID or
  */
 void CheckOrders(const Vehicle *v)
 {
-	/* Does the user wants us to check things? */
-	if (_settings_client.gui.order_review_system == 0) return;
+	/* Does the user want us to check things? */
+	if (_settings_client.gui.order_review_system == OrderReviewSystem::Off) return;
 
-	/* Do nothing for crashed vehicles */
+	/* Ignore crashed vehicles. */
 	if (v->vehstatus.Test(VehState::Crashed)) return;
 
-	/* Do nothing for stopped vehicles if setting is '1' */
-	if (_settings_client.gui.order_review_system == 1 && v->vehstatus.Test(VehState::Stopped)) return;
+	/* Maybe ignore stopped vehicles. */
+	if (_settings_client.gui.order_review_system == OrderReviewSystem::ExcludeStopped && v->vehstatus.Test(VehState::Stopped)) return;
 
-	/* do nothing we we're not the first vehicle in a share-chain */
+	/* Do nothing if we're not the first vehicle in a share-chain. */
 	if (v->FirstShared() != v) return;
 
 	/* Only check every 20 days, so that we don't flood the message log */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -178,6 +178,13 @@ struct DifficultySettings {
 	bool infinite_money; ///< whether spending money despite negative balance is allowed
 };
 
+/** Possible values for the `order_review_system` setting. */
+enum class OrderReviewSystem : uint8_t {
+	Off, ///< Do not review orders.
+	ExcludeStopped, ///< Review orders of vehicles which are not stopped in a depot, or manually by the player.
+	All, ///< Review orders of all vehicles.
+};
+
 /** Settings relating to viewport/smallmap scrolling. */
 enum class ViewportScrollMode : uint8_t {
 	ViewportRMBFixed, ///< Viewport moves with mouse movement on holding right mouse button, cursor position is fixed.
@@ -206,7 +213,7 @@ enum class OskActivation : uint8_t {
 struct GUISettings {
 	bool sg_full_load_any; ///< new full load calculation, any cargo must be full read from pre v93 savegames
 	bool lost_vehicle_warn; ///< if a vehicle can't find its destination, show a warning
-	uint8_t order_review_system; ///< perform order reviews on vehicles
+	OrderReviewSystem order_review_system; ///< perform order reviews on vehicles
 	bool vehicle_income_warn; ///< if a vehicle isn't generating income, show a warning
 	bool old_vehicle_warn; ///< if a vehicle is getting old, show a warning
 	bool show_finances; ///< show finances at end of year

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -17,6 +17,7 @@ static void InvalidateNewGRFChangeWindows(int32_t new_value);
 static void ZoomMinMaxChanged(int32_t new_value);
 static void SpriteZoomMinChanged(int32_t new_value);
 
+static constexpr std::initializer_list<std::string_view> _order_review_system{"off"sv, "exclude stopped"sv, "all"sv};
 static constexpr std::initializer_list<std::string_view> _osk_activation{"disabled"sv, "double"sv, "single"sv, "immediately"sv};
 static constexpr std::initializer_list<std::string_view> _savegame_date{"long"sv, "short"sv, "iso"sv};
 static constexpr std::initializer_list<std::string_view> _right_click_close{"no"sv, "yes"sv, "except sticky"sv};
@@ -585,9 +586,10 @@ cat      = SC_BASIC
 var      = gui.order_review_system
 type     = SLE_UINT8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
-def      = 2
-min      = 0
-max      = 2
+def      = OrderReviewSystem::ExcludeStopped
+min      = OrderReviewSystem::Off
+max      = OrderReviewSystem::All
+full     = _order_review_system
 str      = STR_CONFIG_SETTING_ORDER_REVIEW
 strhelp  = STR_CONFIG_SETTING_ORDER_REVIEW_HELPTEXT
 strval   = STR_CONFIG_SETTING_ORDER_REVIEW_OFF


### PR DESCRIPTION
## Motivation / Problem

#15564 describes excessive messages about vehicles in depots getting warnings about too few orders.

## Description

We have a setting already to fix this, but its default is for all vehicles, and players may not know there's an option to change it.

Let's change the default to exclude stopped vehicles.

While I'm here, I've updated the setting to use enum class values and store a named value in the config file, and renamed "No" to "None" to match our typical wording. 🙂 

## Limitations

[94% of players](https://survey.openttd.org/summaries/2026/q1/15#game.settings.gui.order_review_system) use the current default. This could also be interpreted as evidence that they don't know it can be changed, and we should change the default. In general, players tend to use default settings so this data does not necessarily reflect what players want.

As with all default settings, this only applies to new installations of the game (new players or a new computer), so existing players will not see any change.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
