### PR TITLE
Update: doxygen version to 1.17.0.

### DIFF
--- a/.github/install-doxygen/action.yml
+++ b/.github/install-doxygen/action.yml
@@ -8,7 +8,7 @@ runs:
       echo "::group::Downloading"
       # Download currently (at the time of creation this action) latest version of Doxygen
       # because version in ubuntu repository (1.9.8) is outdated and buggy.
-      wget -O doxygen.tar.gz "https://github.com/doxygen/doxygen/releases/download/Release_1_16_1/doxygen-1.16.1.linux.bin.tar.gz"
+      wget -O doxygen.tar.gz "https://github.com/doxygen/doxygen/releases/download/Release_1_17_0/doxygen-1.17.0.linux.bin.tar.gz"
       echo "::endgroup::"
 
       echo "::group::Unpacking"

--- a/src/os/macosx/macos.h
+++ b/src/os/macosx/macos.h
@@ -10,7 +10,6 @@
 #ifndef MACOS_H
 #define MACOS_H
 
-/** Helper function displaying a message the best possible way. */
 void ShowMacDialog(std::string_view title, std::string_view message, std::string_view button_label);
 
 std::tuple<int, int, int> GetMacOSVersion();


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
There is a new version of doxygen with multiple bugs fixed. (https://www.doxygen.nl/manual/changelog.html#log_1_17_0)

In multiple places in the code, where function is defined to match prototype the `[[maybe_unused]]` is used mainly because of doxygen. For example:
```cpp 
static int GetSlopePixelZ_Void([[maybe_unused]] TileIndex tile, uint x, uint y, [[maybe_unused]] bool ground_vehicle)
```

With doxygen 1.17.0 and a simple change in doxygen comments for prototypes e.g.
```diff
- * @param tile The queries tile for the Z coordinate.
- * @param x World X coordinate in tile "units".
- * @param y World Y coordinate in tile "units".
- * @param ground_vehicle Whether to get the Z coordinate of the ground vehicle, or the ground.
+ * @param 1 The queries tile for the Z coordinate.
+ * @param 2 World X coordinate in tile "units".
+ * @param 3 World Y coordinate in tile "units".
+ * @param 4 Whether to get the Z coordinate of the ground vehicle, or the ground.
```
the `[[maybe_unused]]` statements could be removed.
```cpp
static int GetSlopePixelZ_Void(TileIndex, uint x, uint y, bool)
```

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Update version of doxygen used by workflows from 1.16.1 to 1.17.0.

Due to https://github.com/doxygen/doxygen/issues/12120 removes the doxygen comment for ShowMacDialog from header file, as it is already documented in the source one. That change is not necessary to pass docs checker but it is better not to add new warnings.

Fixes 0 doxygen warnings, adds 0 doxygen warnings.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Purpose of this pull request is to allow more simple documentation for currently undocumented parts of code, not the ones that are already documented.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
