### PR TITLE
Feature: Add default road/tram type setting

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -41,6 +41,7 @@
 #include "timer/timer_game_economy.h"
 #include "timer/timer_game_tick.h"
 #include "timer/timer_window.h"
+#include "road_gui.h"
 
 #include "widgets/statusbar_widget.h"
 
@@ -141,8 +142,9 @@ void SetLocalCompany(CompanyID new_company, bool switching_game)
 	}
 
 	if (switching_company || switching_game) {
-		/* Update the default rail based on most used */
+		/* Update the default rail and road types */
 		SetDefaultRailGui();
+		SetDefaultRoadGui();
 	}
 
 	if (!switching_game) {

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1805,12 +1805,12 @@ STR_CONFIG_SETTING_TIMETABLE_SHOW_ARRIVAL_DEPARTURE_HELPTEXT    :Display anticip
 STR_CONFIG_SETTING_QUICKGOTO                                    :Quick creation of vehicle orders: {STRING2}
 STR_CONFIG_SETTING_QUICKGOTO_HELPTEXT                           :Pre-select the 'goto cursor' when opening the orders window
 
-STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE                            :Default rail type (after new game/game load): {STRING2}
-STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_HELPTEXT                   :Rail type to select after starting or loading a game. 'first available' selects the oldest type of tracks, 'last available' selects the newest type of tracks, and 'most used' selects the type which is currently most in use
+STR_CONFIG_SETTING_DEFAULT_RAIL_ROAD_TYPE                       :Default rail, road, and tram type (after new game/game load): {STRING2}
+STR_CONFIG_SETTING_DEFAULT_RAIL_ROAD_TYPE_HELPTEXT              :Rail, road, and tram type to select after starting or loading a game. 'first available' selects the oldest type of tracks, 'last available' selects the newest type of tracks, and 'most used' selects the type which is currently most in use
 ###length 3
-STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_FIRST                      :First available
-STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_LAST                       :Last available
-STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_MOST_USED                  :Most used
+STR_CONFIG_SETTING_DEFAULT_RAIL_ROAD_TYPE_FIRST                 :First available
+STR_CONFIG_SETTING_DEFAULT_RAIL_ROAD_TYPE_LAST                  :Last available
+STR_CONFIG_SETTING_DEFAULT_RAIL_ROAD_TYPE_MOST_USED             :Most used
 
 STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION                       :Show path reservations for tracks: {STRING2}
 STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION_HELPTEXT              :Give reserved tracks a different colour to assist in problems with trains refusing to enter path-based blocks

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1989,8 +1989,8 @@ void SetDefaultRailGui()
 	if (_local_company == COMPANY_SPECTATOR || !Company::IsValidID(_local_company)) return;
 
 	RailType rt;
-	switch (_settings_client.gui.default_rail_type) {
-		case 2: {
+	switch (_settings_client.gui.default_rail_road_type) {
+		case DefaultRailRoadType::MostUsed: {
 			/* Find the most used rail type */
 			std::array<uint, RAILTYPE_END> count{};
 			for (const auto t : Map::Iterate()) {
@@ -2006,14 +2006,14 @@ void SetDefaultRailGui()
 			/* No rail, just get the first available one */
 			[[fallthrough]];
 		}
-		case 0: {
+		case DefaultRailRoadType::FirstAvailable: {
 			/* Use first available type */
 			std::vector<RailType>::const_iterator it = std::find_if(_sorted_railtypes.begin(), _sorted_railtypes.end(),
 					[](RailType r) { return HasRailTypeAvail(_local_company, r); });
 			rt = it != _sorted_railtypes.end() ? *it : RAILTYPE_BEGIN;
 			break;
 		}
-		case 1: {
+		case DefaultRailRoadType::LastAvailable: {
 			/* Use last available type */
 			std::vector<RailType>::const_reverse_iterator it = std::find_if(_sorted_railtypes.rbegin(), _sorted_railtypes.rend(),
 					[](RailType r){ return HasRailTypeAvail(_local_company, r); });

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1927,3 +1927,49 @@ DropDownList GetScenRoadTypeDropDownList(RoadTramTypes rtts)
 
 	return list;
 }
+
+/**
+ * Determine the default road type to use for a given RoadTramType.
+ * @param rtt Whether to find a road or tram type.
+ * @return The default RoadType based on the setting.
+ */
+static RoadType GetDefaultRoadType(RoadTramType rtt)
+{
+	const auto find_available = [rtt]<typename It>(It begin, It end) {
+		const RoadTypes mask = GetMaskForRoadTramType(rtt);
+		auto it = std::find_if(begin, end, [&](RoadType r) {
+			return HasRoadTypeAvail(_local_company, r) && mask.Test(r);
+		});
+		return it != end ? *it : ROADTYPE_BEGIN;
+	};
+
+	switch (_settings_client.gui.default_rail_road_type) {
+		case DefaultRailRoadType::MostUsed: {
+			const Company *c = Company::Get(_local_company);
+			std::array<uint, ROADTYPE_END> count{};
+			for (RoadType rt : GetMaskForRoadTramType(rtt)) {
+				count[rt] = c->infrastructure.road[rt];
+			}
+			auto best = static_cast<RoadType>(std::distance(std::begin(count), std::ranges::max_element(count)));
+			if (c->infrastructure.road[best] > 0) return best;
+
+			/* No tile of this kind has been built yet, fall through to first available. */
+			[[fallthrough]];
+		}
+		case DefaultRailRoadType::FirstAvailable:
+			return find_available(_sorted_roadtypes.begin(), _sorted_roadtypes.end());
+		case DefaultRailRoadType::LastAvailable:
+			return find_available(_sorted_roadtypes.rbegin(), _sorted_roadtypes.rend());
+		default:
+			NOT_REACHED();
+	}
+}
+
+/** Set the initial (default) road & tram type to use. */
+void SetDefaultRoadGui()
+{
+	if (_local_company == COMPANY_SPECTATOR || !Company::IsValidID(_local_company)) return;
+
+	_last_built_roadtype = GetDefaultRoadType(RoadTramType::Road);
+	_last_built_tramtype = GetDefaultRoadType(RoadTramType::Tram);
+}

--- a/src/road_gui.h
+++ b/src/road_gui.h
@@ -21,5 +21,6 @@ struct Window *ShowBuildRoadScenToolbar(RoadType roadtype);
 void ConnectRoadToStructure(TileIndex tile, DiagDirection direction);
 DropDownList GetRoadTypeDropDownList(RoadTramTypes rtts, bool for_replacement = false, bool all_option = false);
 DropDownList GetScenRoadTypeDropDownList(RoadTramTypes rtts);
+void SetDefaultRoadGui();
 
 #endif /* ROAD_GUI_H */

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -647,7 +647,7 @@ SettingsContainer &GetSettingsTree()
 			{
 				construction->Add(new SettingEntry("gui.link_terraform_toolbar"));
 				construction->Add(new SettingEntry("gui.persistent_buildingtools"));
-				construction->Add(new SettingEntry("gui.default_rail_type"));
+				construction->Add(new SettingEntry("gui.default_rail_road_type"));
 				construction->Add(new SettingEntry("gui.semaphore_build_before"));
 				construction->Add(new SettingEntry("gui.signal_gui_mode"));
 				construction->Add(new SettingEntry("gui.cycle_signal_types"));

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -176,11 +176,34 @@ enum IniFileVersion : uint32_t {
 	IFV_AUTOSAVE_RENAME,                                   ///< 5  PR#11143 Renamed values of autosave to be in minutes.
 	IFV_RIGHT_CLICK_CLOSE,                                 ///< 6  PR#10204 Add alternative right click to close windows setting.
 	IFV_REMOVE_GENERATION_SEED,                            ///< 7  PR#11927 Remove "generation_seed" from configuration.
+	IFV_DEFAULT_RAIL_ROAD,                                 ///< 8  PR#15585 Update default rail type setting to support road and tram tiles
 
 	IFV_MAX_VERSION,       ///< Highest possible ini-file version.
 };
 
 const uint16_t INIFILE_VERSION = (IniFileVersion)(IFV_MAX_VERSION - 1); ///< Current ini-file version of OpenTTD.
+
+/**
+ * Find whether a string was a valid int setting
+ *
+ * @param str the current value of the setting
+ * @param min the min value for the setting
+ * @param max the max value for the setting
+ * @return Either the parsed value, or nullopt if no value found within range.
+ */
+std::optional<int32_t> IntSettingDesc::ParseSingleValue(std::string_view str, int32_t min, uint32_t max)
+{
+	StringConsumer consumer{str};
+	/* The actual settings value might be int32 or uint32. Read as int64 and just cast away the high bits. */
+	auto value = consumer.TryReadIntegerBase<int64_t>(10);
+	/* check if it's an integer */
+	if (!value.has_value()) return std::nullopt;
+
+	if (value < min || value > max) {
+		return std::nullopt;
+	}
+	return value;
+}
 
 /**
  * Find the index value of a ONEofMANY type in a string
@@ -1447,6 +1470,11 @@ void LoadFromConfig(bool startup)
 		if (generic_version < IFV_RIGHT_CLICK_CLOSE && IsConversionNeeded(generic_ini, "gui", "right_mouse_wnd_close", "right_click_wnd_close", &old_item)) {
 			auto old_value = BoolSettingDesc::ParseSingleValue(*old_item->value);
 			_settings_client.gui.right_click_wnd_close = old_value.value_or(false) ? RightClickClose::Yes : RightClickClose::No;
+		}
+
+		if (generic_version < IFV_DEFAULT_RAIL_ROAD && IsConversionNeeded(generic_ini, "gui", "default_rail_type", "default_rail_road_type", &old_item)) {
+			auto old_value = IntSettingDesc::ParseSingleValue(*old_item->value, 0, 2);
+			_settings_client.gui.default_rail_road_type = static_cast<DefaultRailRoadType>(old_value.value_or(0));
 		}
 
 		_grfconfig_newgame = GRFLoadConfig(generic_ini, "newgrf", false);

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -288,6 +288,8 @@ struct IntSettingDesc : SettingDesc {
 	virtual int32_t ParseValue(std::string_view str) const;
 	std::string FormatValue(const void *object) const override;
 	void ParseValue(const IniItem *item, void *object) const override;
+	static std::optional<int32_t> ParseSingleValue(std::string_view str, int32_t min, uint32_t max);
+
 	bool IsSameValue(const IniItem *item, void *object) const override;
 	bool IsDefaultValue(void *object) const override;
 	void ResetToDefault(void *object) const override;

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -202,6 +202,13 @@ enum class OskActivation : uint8_t {
 	Immediately, ///< Focusing click already opens OSK.
 };
 
+/** How to select the default rail/road types */
+enum class DefaultRailRoadType : uint8_t {
+	FirstAvailable, ///< Use the first available to the player
+	LastAvailable, ///< Use the latest available to the player
+	MostUsed, ///< Use the most used by the company controlled by the player
+};
+
 /** Settings related to the GUI and other stuff that is not saved in the savegame. */
 struct GUISettings {
 	bool sg_full_load_any; ///< new full load calculation, any cargo must be full read from pre v93 savegames
@@ -226,7 +233,7 @@ struct GUISettings {
 	bool prefer_teamchat; ///< choose the chat message target with \<ENTER\>, true=all clients, false=your team
 	uint8_t advanced_vehicle_list; ///< use the "advanced" vehicle list
 	uint8_t loading_indicators; ///< show loading indicators
-	uint8_t default_rail_type; ///< the default rail type for the rail GUI
+	DefaultRailRoadType default_rail_road_type; ///< the default rail type for the rail/road/tram GUI
 	uint8_t toolbar_pos; ///< position of toolbars, 0=left, 1=center, 2=right
 	uint8_t statusbar_pos; ///< position of statusbar, 0=left, 1=center, 2=right
 	uint8_t window_snap_radius; ///< windows snap at each other if closer than this

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -20,6 +20,7 @@ static void SpriteZoomMinChanged(int32_t new_value);
 static constexpr std::initializer_list<std::string_view> _osk_activation{"disabled"sv, "double"sv, "single"sv, "immediately"sv};
 static constexpr std::initializer_list<std::string_view> _savegame_date{"long"sv, "short"sv, "iso"sv};
 static constexpr std::initializer_list<std::string_view> _right_click_close{"no"sv, "yes"sv, "except sticky"sv};
+static constexpr std::initializer_list<std::string_view> _default_rail_road_type{"first available"sv, "last available"sv, "most used"sv};
 
 static const SettingVariant _gui_settings_table[] = {
 [post-amble]
@@ -479,16 +480,17 @@ strval   = STR_CONFIG_SETTING_COMPANIES_OFF
 post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
-[SDTC_VAR]
-var      = gui.default_rail_type
+[SDTC_OMANY]
+var      = gui.default_rail_road_type
 type     = SLE_UINT8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
-def      = 0
-min      = 0
-max      = 2
-str      = STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE
-strhelp  = STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_HELPTEXT
-strval   = STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_FIRST
+def      = DefaultRailRoadType::FirstAvailable
+min      = DefaultRailRoadType::FirstAvailable
+max      = DefaultRailRoadType::MostUsed
+full     = _default_rail_road_type
+str      = STR_CONFIG_SETTING_DEFAULT_RAIL_ROAD_TYPE
+strhelp  = STR_CONFIG_SETTING_DEFAULT_RAIL_ROAD_TYPE_HELPTEXT
+strval   = STR_CONFIG_SETTING_DEFAULT_RAIL_ROAD_TYPE_FIRST
 cat      = SC_BASIC
 
 [SDTC_VAR]

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2618,10 +2618,6 @@ static WindowDesc _toolb_scen_desc(
 /** Allocate the toolbar. */
 void AllocateToolbar()
 {
-	/* Clean old GUI values; railtype is (re)set by rail_gui.cpp */
-	_last_built_roadtype = ROADTYPE_ROAD;
-	_last_built_tramtype = ROADTYPE_TRAM;
-
 	if (_game_mode == GameMode::Editor) {
 		new ScenarioEditorToolbarWindow(_toolb_scen_desc);
 	} else {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

- There was an existing setting for "Default rail type" which could be set to oldest/newest/most used, but this did not exist for road and tram.
- Since NRT was merged, we've had support for multiple road and tram types, so this feature should be carried over.
- Most used rail type was discovered by iterating over the entire map each time it was needed, but this information already exists in `CompanyInfrastructure`

## Description

- Adds a `Default rail, road & tram track types` setting with the same options as the existing rail types
  - Automatically migrates from old rail-only setting
- ~~Additionally, compute most used rail type from company infrastructure~~
  - Moving to its own PR

## Limitations

- DONE: I feel like having two settings for this is a bit of an anti-pattern. I would consider merging the two options as I would assume most users wanting one would want the other...
- DONE: `SetDefaultRailGui()` now runs twice on every load due to it being called by `InitializeRailGUI()` (not to be confused with `InitializeRailGui`, eek!) which runs on every load of a save. ~~I feel like this could be sorted out but I'm not familiar with the other things that function does.~~
  - Removed both `SetDefault*` functions from the `Initialize*` functions to avoid over-calling
- Done: I would prefer both of the `SetDefault*` functions to run inside of the `switching_company` block, but when loading a save after you were previously company ID `0` - ie, any singleplayer game, the function will not run. I feel like we should be invalidating `_local_company` at the start of the save loading process but just a thought.
  - `_local_company` and `_current_company` are both invalidated early in loading now.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
