### PR TITLE
Fix: Finding nearest train depot when driving backwards

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2251,7 +2251,7 @@ static FindDepotData FindClosestTrainDepot(Train *v, int max_distance)
 {
 	assert(!v->vehstatus.Test(VehState::Crashed));
 
-	return YapfTrainFindNearestDepot(v->GetMovingFront(), max_distance);
+	return YapfTrainFindNearestDepot(v, max_distance);
 }
 
 ClosestDepot Train::FindClosestDepot()


### PR DESCRIPTION
## Motivation / Problem

Failure to find nearest depot when driving backwards due to incorrect use of Vehicle::MovingFront.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
