### PR TITLE
Feature: Move and resize windows with modifier keys.

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -650,6 +650,16 @@ static void DispatchLeftClickEvent(Window *w, int x, int y, int click_count)
 		}
 	}
 
+	if (_shift_pressed && _ctrl_pressed) {
+		/* ctrl shift click resizes windows */
+		StartWindowSizing(w, false);
+		return;
+	} else if (_shift_pressed) {
+		/* shift click moves windows */
+		StartWindowDrag(w);
+		return;
+	}
+
 	if (nw == nullptr) return; // exit if clicked outside of widgets
 
 	/* don't allow any interaction if the button has been disabled */


### PR DESCRIPTION
## Motivation / Problem

It's hard to aim for the title bar or resize widget when you want to quickly move and resize windows respectively. For many that might not be a problem, I play mostly on a laptop where screen space is limited and aiming for things with a touchpad is inconsistent.

## Description

This PR adds two abilities:

* Hold shift and click on a window to move it
* Hold shift+ctrl and click on a window to resize it

## Limitations

This is more of a proof of concept implementation. Looking for feedback to flesh this out more and end up with a more mergeable version.

1. This might clash with other hotkeys, through light testing I haven't stumbled on one yet though. If I were to use ctrl for moving for example this would clash with some widgets where holding ctrl and clicking them alters their behaviour.
2. It might be better to enable/disable/configure the functionality through an option. And maybe specify there which modifier keys would be used too.
3. Using it on viewport windows can feel a bit awkward. If for example you have a build tool active and hold shift and click the normal behaviour appears where you get a preview of building cost. If you don't have a tool active and shift click on the landscape you can move the window, if you don't have a tool active and shift click on a station the station window opens. None of these look too bad, but it's more that this behaviour is not intentional one way or another. It'd be better to be clear about what exactly should happen in each case and ensure the code properly does that.
4. There might be other general unintended consequences of this, I'm not proficient with the codebase at all to be aware.