### PR TITLE
map generation: map-level stracture 

### DIFF
--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -915,22 +915,19 @@ static void HeightMapTectonicMoves(BorderFlags water_borders)
 {
 	const int64_t water_percent = _settings_game.difficulty.quantity_sea_lakes != CUSTOM_SEA_LEVEL_NUMBER_DIFFICULTY ? _water_percent[_settings_game.difficulty.quantity_sea_lakes] : _settings_game.game_creation.custom_sea_level * WATER_PERCENT_FACTOR / 100;
 
-	const size_t n_points = 8;
+	const size_t n_points = 8; // number of random points
 	const size_t offset_NE = n_points;
 	const size_t offset_NW = n_points + 1;
 	const size_t offset_SE = n_points + 2;
 	const size_t offset_SW = n_points + 3;
 
-	const uint64_t h_scale = 1 << 16;
+	const uint64_t h_scale = 1 << 16; // scale for random generation
 	const uint64_t flag_skip = h_scale << 1;
 	const Height max_height = TGPGetMaxHeight();
 	const Height adjust_max = max_height/2;
 	const Height adjust_down = adjust_max*water_percent / WATER_PERCENT_FACTOR;
 
-	auto adj_normalize = [=] (uint64_t h) -> Height {
-		return (h*adjust_max) / h_scale - adjust_down;
-	};
-
+	// we have n_points random points and 4 map edges
 	uint64_t idw_h[n_points+4];
 	int idw_x[n_points+4];
 	int idw_y[n_points+4];
@@ -949,6 +946,7 @@ static void HeightMapTectonicMoves(BorderFlags water_borders)
 	Height peak = 0;
 	for (int y = 0; y <= (int)_height_map.size_y; y++) {
 		for (int x = 0; x <= (int)_height_map.size_x; x++) {
+			// adjust map edge points for current coordinates
 			idw_x[offset_NE] = 0;
 			idw_y[offset_NE] = y;
 
@@ -961,15 +959,16 @@ static void HeightMapTectonicMoves(BorderFlags water_borders)
 			idw_x[offset_SE] = x;
 			idw_y[offset_SE] = _height_map.size_y;
 
+			// calculate height using Inverse Distance Weighting
 			Height *h = &_height_map.height(x, y);
-			uint64_t sum_w = 0;
-			uint64_t sum_val = 0;
-			uint64_t adj_h;
+			uint64_t sum_w = 0; // weight sum for IDW algorithm
+			uint64_t sum_val = 0; // value sum for IDW algorithm
 			for (size_t i = 0; i < n_points+4; ++i) {
 				if (idw_h[i] == flag_skip) continue;
 				if (x == idw_x[i] && y == idw_y[i]) {
-					adj_h = idw_h[i];
-					goto height_tect_idw_cont;
+					sum_val = idw_h[i];
+					sum_w = 1;
+					break;
 				}
 				int dx = Delta(x, idw_x[i]);
 				int dy = Delta(y, idw_y[i]);
@@ -978,9 +977,9 @@ static void HeightMapTectonicMoves(BorderFlags water_borders)
 				sum_w +=  w;
 				sum_val += idw_h[i]*w;
 			}
-			adj_h = (sum_val / sum_w);
-		height_tect_idw_cont:
-			*h += adj_normalize(adj_h);
+			uint64_t adj_h = (sum_val / sum_w);
+
+			*h += (adj_h*adjust_max) / h_scale - adjust_down;
 			peak = std::max(peak, *h);
 		}
 	}

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -913,7 +913,30 @@ static void HeightMapSmoothSlopes(Height dh_max)
  */
 static void HeightMapTectonicMoves(BorderFlags water_borders)
 {
-	const int64_t water_percent = _settings_game.difficulty.quantity_sea_lakes != CUSTOM_SEA_LEVEL_NUMBER_DIFFICULTY ? _water_percent[_settings_game.difficulty.quantity_sea_lakes] : _settings_game.game_creation.custom_sea_level * WATER_PERCENT_FACTOR / 100;
+	int64_t water_percent = _settings_game.difficulty.quantity_sea_lakes != CUSTOM_SEA_LEVEL_NUMBER_DIFFICULTY ? _water_percent[_settings_game.difficulty.quantity_sea_lakes] : _settings_game.game_creation.custom_sea_level * WATER_PERCENT_FACTOR / 100;
+	// The graph of "% area below or at X height" for height maps generated
+	// by IDW is not linear, especially near the higher end. The
+	// water_percent value is for % area under water, not for point heights
+	// so we need to adjust it accordingly.
+	static const int water_percent_adjust[][2] = {
+		{0,    0},
+		{614,   614},
+		{778,   717},
+		{973,   819},
+		{1024,  1024}
+	};
+	for (size_t i = 1; i < std::size(water_percent_adjust); ++i) {
+		int percent_from_A = water_percent_adjust[i-1][0];
+		int percent_to_A = water_percent_adjust[i-1][1];
+		int percent_from_B = water_percent_adjust[i][0];
+		int percent_to_B = water_percent_adjust[i][1];
+		if (water_percent <= percent_from_B) {
+			int orig_interval = percent_from_B - percent_from_A;
+			int new_interval = percent_to_B - percent_to_A;
+			water_percent = percent_to_A + (water_percent - percent_from_A) * new_interval / orig_interval;
+			break;
+		}
+	}
 
 	const size_t n_points = 8; // number of random points
 	const size_t offset_NE = n_points;

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -907,6 +907,96 @@ static void HeightMapSmoothSlopes(Height dh_max)
 }
 
 /**
+ * Adjusts heights to achieve map-scale structure. This is done by generating a
+ * new height map from a few points (using Inverse Distance Weighting) and
+ * summing it with the existing height map.
+ */
+static void HeightMapTectonicMoves(BorderFlags water_borders)
+{
+	const int64_t water_percent = _settings_game.difficulty.quantity_sea_lakes != CUSTOM_SEA_LEVEL_NUMBER_DIFFICULTY ? _water_percent[_settings_game.difficulty.quantity_sea_lakes] : _settings_game.game_creation.custom_sea_level * WATER_PERCENT_FACTOR / 100;
+
+	const size_t n_points = 8;
+	const size_t offset_NE = n_points;
+	const size_t offset_NW = n_points + 1;
+	const size_t offset_SE = n_points + 2;
+	const size_t offset_SW = n_points + 3;
+
+	const uint64_t h_scale = 1 << 16;
+	const uint64_t flag_skip = h_scale << 1;
+	const Height max_height = TGPGetMaxHeight();
+	const Height adjust_max = max_height/2;
+	const Height adjust_down = adjust_max*water_percent / WATER_PERCENT_FACTOR;
+
+	auto adj_normalize = [=] (uint64_t h) -> Height {
+		return (h*adjust_max) / h_scale - adjust_down;
+	};
+
+	uint64_t idw_h[n_points+4];
+	int idw_x[n_points+4];
+	int idw_y[n_points+4];
+
+	for (size_t i = 0; i < n_points; ++i) {
+		idw_h[i] = RandomRange(h_scale);
+		idw_x[i] = RandomRange((_height_map.size_x*2)/3)+_height_map.size_x/6;
+		idw_y[i] = RandomRange((_height_map.size_y*2)/3)+_height_map.size_y/6;
+	}
+
+	idw_h[offset_NE] = water_borders.Test(BorderFlag::NorthEast) ? 0 : flag_skip;
+	idw_h[offset_NW] = water_borders.Test(BorderFlag::NorthWest) ? 0 : flag_skip;
+	idw_h[offset_SE] = water_borders.Test(BorderFlag::SouthEast) ? 0 : flag_skip;
+	idw_h[offset_SW] = water_borders.Test(BorderFlag::SouthWest) ? 0 : flag_skip;
+
+	Height peak = 0;
+	for (int y = 0; y <= (int)_height_map.size_y; y++) {
+		for (int x = 0; x <= (int)_height_map.size_x; x++) {
+			idw_x[offset_NE] = 0;
+			idw_y[offset_NE] = y;
+
+			idw_x[offset_NW] = x;
+			idw_y[offset_NW] = 0;
+
+			idw_x[offset_SW] = _height_map.size_x;
+			idw_y[offset_SW] = y;
+
+			idw_x[offset_SE] = x;
+			idw_y[offset_SE] = _height_map.size_y;
+
+			Height *h = &_height_map.height(x, y);
+			uint64_t sum_w = 0;
+			uint64_t sum_val = 0;
+			uint64_t adj_h;
+			for (size_t i = 0; i < n_points+4; ++i) {
+				if (idw_h[i] == flag_skip) continue;
+				if (x == idw_x[i] && y == idw_y[i]) {
+					adj_h = idw_h[i];
+					goto height_tect_idw_cont;
+				}
+				int dx = Delta(x, idw_x[i]);
+				int dy = Delta(y, idw_y[i]);
+				uint64_t w = (1LL<<32) / (dx*dx + dy*dy);
+
+				sum_w +=  w;
+				sum_val += idw_h[i]*w;
+			}
+			adj_h = (sum_val / sum_w);
+		height_tect_idw_cont:
+			*h += adj_normalize(adj_h);
+			peak = std::max(peak, *h);
+		}
+	}
+	// normalize for maximum height
+	if (peak > max_height) {
+		for (int y = 0; y <= (int)_height_map.size_y; y++) {
+			for (int x = 0; x <= (int)_height_map.size_x; x++) {
+				Height *h = &_height_map.height(x, y);
+				*h = (*h) * (int64_t)max_height / (int64_t)peak;
+			}
+		}
+	}
+}
+
+
+/**
  * Height map terraform post processing:
  *  - water level adjusting
  *  - coast Smoothing
@@ -935,6 +1025,9 @@ static void HeightMapNormalize()
 	if (_settings_game.game_creation.variety > 0) {
 		HeightMapCurves(_settings_game.game_creation.variety);
 	}
+
+	HeightMapTectonicMoves(water_borders);
+	HeightMapSmoothSlopes(roughness);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Something about the map generation has been bothering me for a while. Maps - the bigger ones especially - have no overall shape. It doesn't look very different between any two places.

## Description

This generates a height map from a few random points with random heights (using IDW) and sums it with the existing height map, to give the map an overall shape.

## Limitations

This is currently a proof of concept, I'd like to gather some opinions and/or advice. It does reflect configuration (land/water borders, height, amount of water) to a reasonable degree (for a proof of concept). It sometimes leaves very regular curves too visible. Should be solvable with some added noise, as I wrote it's a proof of concept.

Yes, obviously this should have a setting toggle of some sort if it ever makes it into master.

I will screenshot some maps tomorrow.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
