### PR TITLE
Fix: Dedicated server signal handling for SIGTERM/SIGINT/SIGQUIT

### DIFF
--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -32,11 +32,13 @@
 #	include <signal.h>
 #	define STDIN 0  /* file descriptor for standard input */
 
+/** Dedicated exit requested. */
+std::atomic<bool> _dedicated_exit_requested;
+
 /* Signal handlers */
 static void DedicatedSignalHandler(int sig)
 {
-	if (_game_mode == GM_NORMAL && _settings_client.gui.autosave_on_exit) DoExitSave();
-	_exit_game = true;
+	_dedicated_exit_requested = true;
 	signal(sig, DedicatedSignalHandler);
 }
 #endif
@@ -220,5 +222,12 @@ void VideoDriver_Dedicated::MainLoop()
 
 		this->Tick();
 		this->SleepTillNextTick();
+
+#if defined(UNIX)
+		if (_dedicated_exit_requested) {
+			if (_game_mode == GM_NORMAL && _settings_client.gui.autosave_on_exit) DoExitSave();
+			_exit_game = true;
+		}
+#endif
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

Improper handling of SIGTERM/SIGINT/SIGQUIT when running in dedicated mode and using _settings_client.gui.autosave_on_exit.
Previously a save was attempted from within the signal handler on whichever thread happened to receive the signal, which is not signal/async safe and is liable to produce inconsistent/broken saves if you're unlucky.

## Description

Just set an atomic flag from the signal handler and do the actual save from a sensible location instead.

## Limitations

Use of `signal(2)` means that the signal handling is still not completely watertight, but that's out of scope for this PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
