### PR TITLE
Add: List 'Place object' in landscaping dropdown

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -525,6 +525,7 @@ STR_AIRCRAFT_MENU_AIRPORT_CONSTRUCTION                          :Airport constru
 STR_LANDSCAPING_MENU_LANDSCAPING                                :Landscaping
 STR_LANDSCAPING_MENU_PLANT_TREES                                :Plant trees
 STR_LANDSCAPING_MENU_PLACE_SIGN                                 :Place sign
+STR_LANDSCAPING_MENU_PLACE_OBJECT                               :Place object
 
 # Music menu
 STR_TOOLBAR_SOUND_MUSIC                                         :Sound/music

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -25,6 +25,8 @@
 #include "vehicle_func.h"
 #include "sound_func.h"
 #include "terraform_gui.h"
+#include "object.h"
+#include "newgrf_object.h"
 #include "strings_func.h"
 #include "company_func.h"
 #include "company_gui.h"
@@ -998,6 +1000,9 @@ static CallBackFunction ToolbarForestClick(Window *w)
 	list.push_back(MakeDropDownListIconItem(SPR_IMG_LANDSCAPING, PAL_NONE, STR_LANDSCAPING_MENU_LANDSCAPING, 0));
 	list.push_back(MakeDropDownListIconItem(SPR_IMG_PLANTTREES, PAL_NONE, STR_LANDSCAPING_MENU_PLANT_TREES, 1));
 	list.push_back(MakeDropDownListIconItem(SPR_IMG_SIGN, PAL_NONE, STR_LANDSCAPING_MENU_PLACE_SIGN, 2));
+	if (ObjectClass::GetUIClassCount() != 0) {
+		list.push_back(MakeDropDownListIconItem(SPR_IMG_TRANSMITTER, PAL_NONE, STR_LANDSCAPING_MENU_PLACE_OBJECT, 3));
+	}
 	ShowDropDownList(w, std::move(list), 0, WID_TN_LANDSCAPE, 100, GetToolbarDropDownOptions());
 	return CallBackFunction::None;
 }
@@ -1014,6 +1019,7 @@ static CallBackFunction MenuClickForest(int index)
 		case 0: ShowTerraformToolbar();  break;
 		case 1: ShowBuildTreesToolbar(); break;
 		case 2: return SelectSignTool();
+		case 3: ShowBuildObjectPicker(); break;
 	}
 	return CallBackFunction::None;
 }


### PR DESCRIPTION
## Motivation / Problem

Object placement is somewhat hidden as a feature, particularly since the button is entirely invisible without relevant NewGRFs. It'd be nice to get to it in fewer clicks.

There does exist a <kbd>Q P</kbd> chord to open the window quickly, but it's not discoverable.

## Description

Adds "Place object" to the landscaping dropdown directly, so it gets higher billing and is reachable in one fewer clicks. Hidden when irrelevant.

Default appearance is unchanged. Appearance with object NewGRFs:
<img width="288" height="248" alt="image" src="https://github.com/user-attachments/assets/f12af979-9920-44c7-a99d-e0bafc62d41e" />

## Limitations

* ~~Inconsistency between dropdown and tool window when no object NewGRFs are used. Solutions:~~
  * **Resolved:** Dropdown entry should be entirely absent without object NewGRFs
  * ~~Landscaping window button should be shaded instead of absent without object NewGRFs?~~
    * Doesn't explain why it's shaded
    * Is consistent with tram dropdown with shaded "None" if no relevant NewGRFs
  * ~~Nothing, inconsistency is fine?~~

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
