### PR TITLE
Cleanup: Remove unused GameOptionsWindowNumber::GameSettings

### DIFF
--- a/bin/game/compat_15.nut
+++ b/bin/game/compat_15.nut
@@ -17,7 +17,7 @@ GSWindow.WN_GAME_OPTIONS_GS <- GSWindow.GameOptionsWindowNumber.GS;
 GSWindow.WN_GAME_OPTIONS_ABOUT <- GSWindow.GameOptionsWindowNumber.About;
 GSWindow.WN_GAME_OPTIONS_NEWGRF_STATE <- GSWindow.GameOptionsWindowNumber.NewGRFState;
 GSWindow.WN_GAME_OPTIONS_GAME_OPTIONS <- GSWindow.GameOptionsWindowNumber.GameOptions;
-GSWindow.WN_GAME_OPTIONS_GAME_SETTINGS <- GSWindow.GameOptionsWindowNumber.GameSettings;
+GSWindow.WN_GAME_OPTIONS_GAME_SETTINGS <- GSWindow.GameOptionsWindowNumber.GameOptions;
 GSWindow.WN_QUERY_STRING <- GSWindow.QueryStringWindowNumber.Default;
 GSWindow.WN_QUERY_STRING_SIGN <- GSWindow.QueryStringWindowNumber.Sign;
 GSWindow.WN_CONFIRM_POPUP_QUERY <- GSWindow.ConfirmPopupQueryWindowNumber.Default;

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1641,14 +1641,12 @@ public:
 			case WID_BS_DRAG_SIGNALS_DENSITY_DECREASE:
 				if (_settings_client.gui.drag_signals_density > 1) {
 					_settings_client.gui.drag_signals_density--;
-					SetWindowDirty(WindowClass::GameOptions, GameOptionsWindowNumber::GameSettings);
 				}
 				break;
 
 			case WID_BS_DRAG_SIGNALS_DENSITY_INCREASE:
 				if (_settings_client.gui.drag_signals_density < 20) {
 					_settings_client.gui.drag_signals_density++;
-					SetWindowDirty(WindowClass::GameOptions, GameOptionsWindowNumber::GameSettings);
 				}
 				break;
 

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -30,7 +30,6 @@ enum class GameOptionsWindowNumber : uint8_t {
 	About, ///< About window.
 	NewGRFState, ///< NewGRF settings.
 	GameOptions, ///< Game options.
-	GameSettings, ///< Game settings.
 };
 
 /** Window numbers for QueryString windows. */
@@ -643,7 +642,6 @@ enum class WindowClass : uint16_t {
 	 *   - #GameOptionsWindowNumber::About = #AboutWidgets
 	 *   - #GameOptionsWindowNumber::NewGRFState = #NewGRFStateWidgets
 	 *   - #GameOptionsWindowNumber::GameOptions = #GameOptionsWidgets
-	 *   - #GameOptionsWindowNumber::GameSettings = #GameSettingsWidgets
 	 */
 	GameOptions,
 


### PR DESCRIPTION
## Motivation / Problem

GameOptionsWindowNumber::GameSettings is unused since #13242.

## Description

Remove GameOptionsWindowNumber::GameSettings.
Remove associated redundant SetWindowDirty calls, these have no effect and no window dirty call is required here.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
