### PR TITLE
Add: Allow placing/erasing rough terrain in scenario editor

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3095,6 +3095,7 @@ STR_TREES_MODE_FOREST_LG_TOOLTIP                                :{BLACK}Plant la
 # Land generation window (SE)
 STR_TERRAFORM_TOOLBAR_LAND_GENERATION_CAPTION                   :{WHITE}Land Generation
 STR_TERRAFORM_TOOLTIP_PLACE_ROCKY_AREAS_ON_LANDSCAPE            :{BLACK}Place rocky areas on landscape.{}Ctrl+Click to remove rocky areas
+STR_TERRAFORM_TOOLTIP_PLACE_ROUGH_AREAS_ON_LANDSCAPE            :{BLACK}Place rough areas on landscape.{}Ctrl+Click to remove rough areas
 STR_TERRAFORM_TOOLTIP_DEFINE_DESERT_AREA                        :{BLACK}Define desert area.{}Ctrl+Click to remove desert area
 STR_TERRAFORM_TOOLTIP_INCREASE_SIZE_OF_LAND_AREA                :{BLACK}Increase area of land to lower/raise
 STR_TERRAFORM_TOOLTIP_DECREASE_SIZE_OF_LAND_AREA                :{BLACK}Decrease area of land to lower/raise

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -119,6 +119,71 @@ static void GenerateRockyArea(TileIndex end, TileIndex start, bool remove)
 }
 
 /**
+ * Scenario editor command that generates rough land areas.
+ * @param end The end tile of the map drag.
+ * @param start The start tile of the map drag.
+ * @param remove If true, remove rough areas instead of placing them.
+ */
+static void GenerateRoughArea(TileIndex end, TileIndex start, bool remove)
+{
+	if (_game_mode != GameMode::Editor) return;
+
+	bool success = false;
+	TileArea ta(start, end);
+
+	for (TileIndex tile : ta) {
+		switch (GetTileType(tile)) {
+			case TileType::Trees: {
+				// Preserve snowline density underneath trees, so the tile loop
+				// doesn't have to come back and fix it later.
+				uint density = GetTreeDensity(tile);
+				if (remove) {
+					switch (GetTreeGround(tile)) {
+						case TreeGround::Rough:
+							SetTreeGroundDensity(tile, TreeGround::Grass, density);
+							break;
+						case TreeGround::RoughSnow:
+							SetTreeGroundDensity(tile, TreeGround::SnowOrDesert, density);
+							break;
+						default:
+							break;
+					}
+				} else {
+					switch (GetTreeGround(tile)) {
+						case TreeGround::Grass:
+							SetTreeGroundDensity(tile, TreeGround::Rough, density);
+							break;
+						case TreeGround::SnowOrDesert:
+							SetTreeGroundDensity(tile, TreeGround::RoughSnow, density);
+							break;
+						default:
+							break;
+					}
+				}
+				break;
+			}
+
+			case TileType::Clear:
+				if (remove) {
+					if (GetClearGround(tile) == ClearGround::Rough) {
+						SetClearGroundDensity(tile, ClearGround::Grass, 3);
+					}
+				} else {
+					SetClearGroundDensity(tile, ClearGround::Rough, 3);
+				}
+				break;
+
+			default:
+				continue;
+		}
+		MarkTileDirtyByTile(tile);
+		success = true;
+	}
+
+	if (success && _settings_client.sound.confirm) SndPlayTileFx(SND_1F_CONSTRUCTION_OTHER, end);
+}
+
+/**
  * A central place to handle all X_AND_Y dragged GUI functions.
  * @param proc       Procedure related to the dragging
  * @param start_tile Begin of the dragging
@@ -151,6 +216,9 @@ bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_t
 			break;
 		case DDSP_CREATE_ROCKS:
 			GenerateRockyArea(end_tile, start_tile, _ctrl_pressed);
+			break;
+		case DDSP_CREATE_ROUGH:
+			GenerateRoughArea(end_tile, start_tile, _ctrl_pressed);
 			break;
 		case DDSP_CREATE_DESERT:
 			GenerateDesertArea(end_tile, start_tile);
@@ -479,6 +547,8 @@ static constexpr std::initializer_list<NWidgetPart> _nested_scen_edit_land_gen_w
 										SetFill(0, 1), SetSpriteTip(SPR_IMG_LEVEL_LAND, STR_LANDSCAPING_LEVEL_LAND_TOOLTIP),
 			NWidget(WWT_IMGBTN, Colours::Grey, WID_ETT_PLACE_ROCKS), SetToolbarMinimalSize(1),
 										SetFill(0, 1), SetSpriteTip(SPR_IMG_ROCKS, STR_TERRAFORM_TOOLTIP_PLACE_ROCKY_AREAS_ON_LANDSCAPE),
+			NWidget(WWT_IMGBTN, Colours::Grey, WID_ETT_PLACE_ROUGH), SetToolbarMinimalSize(1),
+										SetFill(0, 1), SetSpriteTip(SPR_IMG_SHOW_COUNTOURS, STR_TERRAFORM_TOOLTIP_PLACE_ROUGH_AREAS_ON_LANDSCAPE),
 			NWidget(NWID_SELECTION, Colours::Invalid, WID_ETT_SHOW_PLACE_DESERT),
 				NWidget(WWT_IMGBTN, Colours::Grey, WID_ETT_PLACE_DESERT), SetToolbarMinimalSize(1),
 											SetFill(0, 1), SetSpriteTip(SPR_IMG_DESERT, STR_TERRAFORM_TOOLTIP_DEFINE_DESERT_AREA),
@@ -617,6 +687,11 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 				this->last_user_action = widget;
 				break;
 
+			case WID_ETT_PLACE_ROUGH: // Place rough land button
+				HandlePlacePushButton(this, WID_ETT_PLACE_ROUGH, SPR_CURSOR_ROCKY_AREA, HT_RECT);
+				this->last_user_action = widget;
+				break;
+
 			case WID_ETT_PLACE_DESERT: // Place desert button (in tropical climate)
 				HandlePlacePushButton(this, WID_ETT_PLACE_DESERT, SPR_CURSOR_DESERT, HT_RECT);
 				this->last_user_action = widget;
@@ -694,6 +769,10 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_ROCKS);
 				break;
 
+			case WID_ETT_PLACE_ROUGH: // Place rough land button
+				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_ROUGH);
+				break;
+
 			case WID_ETT_PLACE_DESERT: // Place desert button (in tropical climate)
 				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_DESERT);
 				break;
@@ -713,6 +792,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 			switch (select_proc) {
 				default: NOT_REACHED();
 				case DDSP_CREATE_ROCKS:
+				case DDSP_CREATE_ROUGH:
 				case DDSP_CREATE_DESERT:
 				case DDSP_RAISE_AND_LEVEL_AREA:
 				case DDSP_LOWER_AND_LEVEL_AREA:
@@ -729,6 +809,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 		switch (this->last_user_action) {
 			case WID_ETT_PLACE_ROCKS:
 			case WID_ETT_PLACE_DESERT:
+			case WID_ETT_PLACE_ROUGH:
 				if (this->IsWidgetLowered(this->last_user_action)) {
 					SetSelectionRed(_ctrl_pressed);
 					return ES_HANDLED;

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -119,6 +119,73 @@ static void GenerateRockyArea(TileIndex end, TileIndex start, bool remove)
 }
 
 /**
+ * Scenario editor command that generates rough land areas.
+ * @param end The end tile of the map drag.
+ * @param start The start tile of the map drag.
+ * @param remove If true, remove rough areas instead of placing them.
+ */
+static void PlaceRoughGround(TileIndex end, TileIndex start, bool remove)
+{
+	if (_game_mode != GameMode::Editor) return;
+
+	bool success = false;
+	TileArea ta(start, end);
+
+	for (TileIndex tile : ta) {
+		switch (GetTileType(tile)) {
+			case TileType::Trees: {
+				/* Preserve snowline density underneath trees, so the tile loop
+				 * doesn't have to come back and fix it later. */
+				uint density = GetTreeDensity(tile);
+				if (remove) {
+					switch (GetTreeGround(tile)) {
+						case TreeGround::Rough:
+							SetTreeGroundDensity(tile, TreeGround::Grass, density);
+							break;
+						case TreeGround::RoughSnow:
+							SetTreeGroundDensity(tile, TreeGround::SnowOrDesert, density);
+							break;
+						default:
+							continue;
+					}
+				} else {
+					switch (GetTreeGround(tile)) {
+						case TreeGround::Grass:
+							SetTreeGroundDensity(tile, TreeGround::Rough, density);
+							break;
+						case TreeGround::SnowOrDesert:
+							SetTreeGroundDensity(tile, TreeGround::RoughSnow, density);
+							break;
+						default:
+							continue;
+					}
+				}
+				break;
+			}
+
+			case TileType::Clear:
+				if (remove) {
+					if (GetClearGround(tile) == ClearGround::Rough) {
+						SetClearGroundDensity(tile, ClearGround::Grass, 3);
+					} else {
+						continue;
+					}
+				} else {
+					SetClearGroundDensity(tile, ClearGround::Rough, 3);
+				}
+				break;
+
+			default:
+				continue;
+		}
+		MarkTileDirtyByTile(tile);
+		success = true;
+	}
+
+	if (success && _settings_client.sound.confirm) SndPlayTileFx(SND_1F_CONSTRUCTION_OTHER, end);
+}
+
+/**
  * A central place to handle all X_AND_Y dragged GUI functions.
  * @param proc       Procedure related to the dragging
  * @param start_tile Begin of the dragging
@@ -151,6 +218,9 @@ bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_t
 			break;
 		case DDSP_CREATE_ROCKS:
 			GenerateRockyArea(end_tile, start_tile, _ctrl_pressed);
+			break;
+		case DDSP_CREATE_ROUGH:
+			PlaceRoughGround(end_tile, start_tile, _ctrl_pressed);
 			break;
 		case DDSP_CREATE_DESERT:
 			GenerateDesertArea(end_tile, start_tile);
@@ -479,6 +549,8 @@ static constexpr std::initializer_list<NWidgetPart> _nested_scen_edit_land_gen_w
 										SetFill(0, 1), SetSpriteTip(SPR_IMG_LEVEL_LAND, STR_LANDSCAPING_LEVEL_LAND_TOOLTIP),
 			NWidget(WWT_IMGBTN, Colours::Grey, WID_ETT_PLACE_ROCKS), SetToolbarMinimalSize(1),
 										SetFill(0, 1), SetSpriteTip(SPR_IMG_ROCKS, STR_TERRAFORM_TOOLTIP_PLACE_ROCKY_AREAS_ON_LANDSCAPE),
+			NWidget(WWT_IMGBTN, Colours::Grey, WID_ETT_PLACE_ROUGH), SetToolbarMinimalSize(1),
+										SetFill(0, 1), SetSpriteTip(SPR_IMG_SHOW_COUNTOURS, STR_TERRAFORM_TOOLTIP_PLACE_ROUGH_AREAS_ON_LANDSCAPE),
 			NWidget(NWID_SELECTION, Colours::Invalid, WID_ETT_SHOW_PLACE_DESERT),
 				NWidget(WWT_IMGBTN, Colours::Grey, WID_ETT_PLACE_DESERT), SetToolbarMinimalSize(1),
 											SetFill(0, 1), SetSpriteTip(SPR_IMG_DESERT, STR_TERRAFORM_TOOLTIP_DEFINE_DESERT_AREA),
@@ -617,6 +689,11 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 				this->last_user_action = widget;
 				break;
 
+			case WID_ETT_PLACE_ROUGH: // Place rough land button
+				HandlePlacePushButton(this, WID_ETT_PLACE_ROUGH, SPR_CURSOR_ROCKY_AREA, HT_RECT);
+				this->last_user_action = widget;
+				break;
+
 			case WID_ETT_PLACE_DESERT: // Place desert button (in tropical climate)
 				HandlePlacePushButton(this, WID_ETT_PLACE_DESERT, SPR_CURSOR_DESERT, HT_RECT);
 				this->last_user_action = widget;
@@ -694,6 +771,10 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_ROCKS);
 				break;
 
+			case WID_ETT_PLACE_ROUGH: // Place rough land button
+				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_ROUGH);
+				break;
+
 			case WID_ETT_PLACE_DESERT: // Place desert button (in tropical climate)
 				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_DESERT);
 				break;
@@ -713,6 +794,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 			switch (select_proc) {
 				default: NOT_REACHED();
 				case DDSP_CREATE_ROCKS:
+				case DDSP_CREATE_ROUGH:
 				case DDSP_CREATE_DESERT:
 				case DDSP_RAISE_AND_LEVEL_AREA:
 				case DDSP_LOWER_AND_LEVEL_AREA:
@@ -729,6 +811,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 		switch (this->last_user_action) {
 			case WID_ETT_PLACE_ROCKS:
 			case WID_ETT_PLACE_DESERT:
+			case WID_ETT_PLACE_ROUGH:
 				if (this->IsWidgetLowered(this->last_user_action)) {
 					SetSelectionRed(_ctrl_pressed);
 					return EventState::Handled;

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -123,6 +123,7 @@ enum ViewportDragDropSelectionProcess : uint8_t {
 	DDSP_LEVEL_AREA,           ///< Level area
 	DDSP_CREATE_DESERT,        ///< Fill area with desert
 	DDSP_CREATE_ROCKS,         ///< Fill area with rocks
+	DDSP_CREATE_ROUGH,         ///< Fill area with rough land
 	DDSP_CREATE_WATER,         ///< Create a canal
 	DDSP_CREATE_RIVER,         ///< Create rivers
 	DDSP_PLANT_TREES,          ///< Plant trees

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -125,6 +125,7 @@ enum ViewportDragDropSelectionProcess : uint8_t {
 	DDSP_LEVEL_AREA,           ///< Level area
 	DDSP_CREATE_DESERT,        ///< Fill area with desert
 	DDSP_CREATE_ROCKS,         ///< Fill area with rocks
+	DDSP_CREATE_ROUGH,         ///< Fill area with rough land
 	DDSP_CREATE_WATER,         ///< Create a canal
 	DDSP_CREATE_RIVER,         ///< Create rivers
 	DDSP_PLANT_TREES,          ///< Plant trees

--- a/src/widgets/terraform_widget.h
+++ b/src/widgets/terraform_widget.h
@@ -35,6 +35,7 @@ enum EditorTerraformToolbarWidgets : WidgetID {
 	WID_ETT_RAISE_LAND,                          ///< Raise land button.
 	WID_ETT_LEVEL_LAND,                          ///< Level land button.
 	WID_ETT_PLACE_ROCKS,                         ///< Place rocks button.
+	WID_ETT_PLACE_ROUGH,                         ///< Place rough land button.
 	WID_ETT_PLACE_DESERT,                        ///< Place desert button (in tropical climate).
 	WID_ETT_PLACE_OBJECT,                        ///< Place transmitter button.
 	WID_ETT_BUTTONS_END,                         ///< End of pushable buttons.


### PR DESCRIPTION
## Motivation / Problem

The scenario editor currently generates rough patches at some probability when the tile loop turns dirt to grass. If you want to place them, you have to bomb grass until it randomly turns rough; to remove rough patches, you have to bomb them a few tiles at a time until they randomly don't.

## Description

Adds a rough terrain tool to the scenario editor terraform GUI. Holding Ctrl removes rough terrain.

Handles adding and removing rough terrain on clear ground (including snow) and under trees, without modifying incompatible tiles (roads, houses, water, coast, &c.).

## Limitations

* Reuses `SPR_IMG_SHOW_COUNTOURS` for the icon.
* Permits placing rough tiles in desert areas, which are then erased by the tile loop.
  * Prevent placing?
  * Erase desert?
* Permits placing rough tiles in snow areas, which is mechanically permitted, but such tiles are not visually distinct.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
