### PR TITLE
Fix: Scenario editor random industry generation

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -604,6 +604,7 @@ public:
 		if (Town::GetNumItems() == 0) {
 			ShowErrorMessage(GetEncodedString(STR_ERROR_CAN_T_GENERATE_INDUSTRIES), GetEncodedString(STR_ERROR_MUST_FOUND_TOWN_FIRST), WL_INFO);
 		} else {
+			Map::CountLandTiles();
 			AutoRestoreBackup old_generating_world(_generating_world, true);
 			BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 			GenerateIndustries();


### PR DESCRIPTION
## Motivation / Problem

Since #10063, industry generation depends on the value of `Map::initial_land_count`, however this is generally not initialised to a meaningful value in the scenario editor.

## Description

Use ` Map::CountLandTiles` when generating industries in the scenario editor.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
