### PR TITLE
Codechange: use Direction helpers instead of direct masking

### DIFF
--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -472,7 +472,7 @@ inline int RoadVehicle::GetCurrentMaxSpeed() const
 			if (this->state <= RVSB_TRACKDIR_MASK && IsReversingRoadTrackdir((Trackdir)this->state)) {
 				max_speed = this->gcache.cached_max_track_speed / 2;
 				break;
-			} else if ((u->direction & 1) == 0) {
+			} else if (!IsDiagonalDirection(u->direction)) {
 				max_speed = this->gcache.cached_max_track_speed * 3 / 4;
 			}
 		}
@@ -823,7 +823,7 @@ static void RoadVehCheckOvertake(RoadVehicle *v, RoadVehicle *u)
 	if (v->HasArticulatedPart()) return;
 
 	/* Vehicles are not driving in same direction || direction is not a diagonal direction */
-	if (v->direction != u->direction || !(v->direction & 1)) return;
+	if (v->direction != u->direction || !IsDiagonalDirection(v->direction)) return;
 
 	/* Check if vehicle is in a road stop, depot, tunnel or bridge or not on a straight road */
 	if (v->state >= RVSB_IN_ROAD_STOP || !IsStraightRoadTrackdir((Trackdir)(v->state & RVSB_TRACKDIR_MASK))) return;

--- a/src/track_func.h
+++ b/src/track_func.h
@@ -723,7 +723,7 @@ inline DiagDirection VehicleExitDir(Direction direction, TrackBits track)
 	DiagDirection diagdir = DirToDiagDir(direction);
 
 	/* Determine the diagonal direction in which we will exit this tile */
-	if (!HasBit(direction, 0) && track != state_dir_table[diagdir]) {
+	if (!IsDiagonalDirection(direction) && track != state_dir_table[diagdir]) {
 		diagdir = ChangeDiagDir(diagdir, DIAGDIRDIFF_90LEFT);
 	}
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2404,8 +2404,7 @@ static bool CheckTrainStayInDepot(Train *v)
 	v->PlayLeaveStationSound();
 	SetWindowClassesDirty(WindowClass::TrainList);
 
-	v->track = TRACK_BIT_X;
-	if (v->direction & 2) v->track = TRACK_BIT_Y;
+	v->track = AxisToTrackBits(DiagDirToAxis(DirToDiagDir(v->direction)));
 
 	v->vehstatus.Reset(VehState::Hidden);
 	v->cur_speed = 0;
@@ -3030,7 +3029,7 @@ static bool CheckReverseTrain(const Train *consist)
 	const Train *moving_front = consist->GetMovingFront();
 	if (_settings_game.difficulty.train_flip_reverse_allowed == TrainFlipReversingAllowed::EndOfLineOnly ||
 			moving_front->track == TRACK_BIT_DEPOT || moving_front->track == TRACK_BIT_WORMHOLE ||
-			!(moving_front->GetMovingDirection() & 1)) {
+			!IsDiagonalDirection(moving_front->GetMovingDirection())) {
 		return false;
 	}
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2947,7 +2947,7 @@ void Vehicle::ShowVisualEffect() const
 			if (v->type == VehicleType::Train) effect_offset += (VEHICLE_LENGTH - Train::From(v)->gcache.cached_veh_length) / 2;
 
 			int x = _vehicle_smoke_pos[v->direction] * effect_offset;
-			int y = _vehicle_smoke_pos[(v->direction + 2) % 8] * effect_offset;
+			int y = _vehicle_smoke_pos[ChangeDir(v->direction, DIRDIFF_90RIGHT)] * effect_offset;
 
 			if (v->type == VehicleType::Train && Train::From(v)->flags.Test(VehicleRailFlag::Flipped)) {
 				x = -x;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -431,7 +431,7 @@ public:
 	 */
 	inline uint GetOldAdvanceSpeed(uint speed)
 	{
-		return (this->GetMovingDirection() & 1) ? speed : speed * 3 / 4;
+		return IsDiagonalDirection(this->GetMovingDirection()) ? speed : speed * 3 / 4;
 	}
 
 	/**
@@ -460,7 +460,7 @@ public:
 	 */
 	inline uint GetAdvanceDistance()
 	{
-		return (this->GetMovingDirection() & 1) ? TILE_AXIAL_DISTANCE : TILE_CORNER_DISTANCE * 2;
+		return IsDiagonalDirection(this->GetMovingDirection()) ? TILE_AXIAL_DISTANCE : TILE_CORNER_DISTANCE * 2;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Direct masking of `Direction` variables instead of using existing helpers, e.g. `IsDiagonalDirection()`

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `IsDiagonalDirection()` along with other helpers.
Reduces duplication.
Makes the intention clearer.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Double-negatives.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
