### PR TITLE
Codechange: simplify LookupWithBuildOnSlopes in script_road.cpp.

### DIFF
--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -268,21 +268,15 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<RoadPartOrient
 
 	/* The slope is not steep. Furthermore lots of slopes are generally the
 	 * same but are only rotated. So to reduce the amount of lookup work that
-	 * needs to be done the data is made uniform. This means rotating the
-	 * existing parts and updating the slope. */
-	static const ::Slope base_slopes[] = {
-		SLOPE_FLAT, SLOPE_W,   SLOPE_W,   SLOPE_SW,
-		SLOPE_W,    SLOPE_EW,  SLOPE_SW,  SLOPE_WSE,
-		SLOPE_W,    SLOPE_SW,  SLOPE_EW,  SLOPE_WSE,
-		SLOPE_SW,   SLOPE_WSE, SLOPE_WSE};
+	 * needs to be done the data is made uniform.
+	 * This means rotating the existing parts. */
 	static const uint8_t base_rotates[] = {0, 0, 1, 0, 2, 0, 1, 0, 3, 3, 2, 3, 2, 2, 1};
 
-	if (slope >= (::Slope)lengthof(base_slopes)) {
+	if (slope >= SLOPE_ELEVATED) {
 		/* This slope is an invalid slope, so ignore it. */
 		return -1;
 	}
 	uint8_t base_rotate = base_rotates[slope];
-	slope = base_slopes[slope];
 
 	/* Some slopes don't need rotating, so return early when we know we do
 	 * not need to rotate. */
@@ -292,19 +286,18 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<RoadPartOrient
 			return 1;
 
 		case SLOPE_EW:
+		case SLOPE_NS:
 		case SLOPE_WSE:
+		case SLOPE_NWS:
+		case SLOPE_SEN:
+		case SLOPE_ENW:
 			/* A slope similar to a SLOPE_EW or SLOPE_WSE will always cause
 			 * foundations which makes them accessible from all sides. */
 			return 1;
 
-		case SLOPE_W:
-		case SLOPE_SW:
+		default:
 			/* A slope for which we need perform some calculations. */
 			break;
-
-		default:
-			/* An invalid slope. */
-			return -1;
 	}
 
 	/* Now perform the actual rotation. */
@@ -324,64 +317,59 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<RoadPartOrient
 		existing_roadbits.Set(NeighbourToRoadBits(neighbour));
 	}
 
-	switch (slope) {
-		case SLOPE_W:
-			/* A slope similar to a SLOPE_W. */
-			switch (new_roadbits.base()) {
-				case ROAD_N.base():
-				case ROAD_E.base():
-				case ROAD_S.base():
-					/* Cannot build anything with a turn from the low side. */
+	if (IsSlopeWithOneCornerRaised(slope)) {
+		/* A slope similar to a SLOPE_W. */
+		switch (new_roadbits.base()) {
+			case ROAD_N.base():
+			case ROAD_E.base():
+			case ROAD_S.base():
+				/* Cannot build anything with a turn from the low side. */
+				return 0;
+
+			case ROAD_X.base():
+			case ROAD_Y.base():
+				/* A 'sloped' tile is going to be build. */
+				if ((existing_roadbits | new_roadbits) != new_roadbits) {
+					/* There is already a foundation on the tile, or at least
+					 * another slope that is not compatible with the new one. */
 					return 0;
+				}
+				/* If the start is in the low part, it is automatically
+				 * building the second part too. */
+				return (start_roadbits.Any(ROAD_E) && !existing_roadbits.Any(ROAD_W)) ? 2 : 1;
 
-				case ROAD_X.base():
-				case ROAD_Y.base():
-					/* A 'sloped' tile is going to be build. */
-					if ((existing_roadbits | new_roadbits) != new_roadbits) {
-						/* There is already a foundation on the tile, or at least
-						 * another slope that is not compatible with the new one. */
-						return 0;
-					}
-					/* If the start is in the low part, it is automatically
-					 * building the second part too. */
-					return (start_roadbits.Any(ROAD_E) && !existing_roadbits.Any(ROAD_W)) ? 2 : 1;
+			default:
+				/* Roadbits causing a foundation are going to be build.
+				 * When the existing roadbits are slopes (the lower bits
+				 * are used), this cannot be done. */
+				if ((existing_roadbits | new_roadbits) == new_roadbits) return 1;
+				return existing_roadbits.Any(ROAD_E) ? 0 : 1;
+		}
+	} else {
+		/* A slope similar to a SLOPE_SW. */
+		switch (new_roadbits.base()) {
+			case ROAD_N.base():
+			case ROAD_E.base():
+				/* Cannot build anything with a turn from the low side. */
+				return 0;
 
-				default:
-					/* Roadbits causing a foundation are going to be build.
-					 * When the existing roadbits are slopes (the lower bits
-					 * are used), this cannot be done. */
-					if ((existing_roadbits | new_roadbits) == new_roadbits) return 1;
-					return existing_roadbits.Any(ROAD_E) ? 0 : 1;
-			}
-
-		case SLOPE_SW:
-			/* A slope similar to a SLOPE_SW. */
-			switch (new_roadbits.base()) {
-				case ROAD_N.base():
-				case ROAD_E.base():
-					/* Cannot build anything with a turn from the low side. */
+			case ROAD_X.base():
+				/* A 'sloped' tile is going to be build. */
+				if ((existing_roadbits | new_roadbits) != new_roadbits) {
+					/* There is already a foundation on the tile, or at least
+					 * another slope that is not compatible with the new one. */
 					return 0;
+				}
+				/* If the start is in the low part, it is automatically
+				 * building the second part too. */
+				return (start_roadbits.Test(RoadBit::NE) && !existing_roadbits.Test(RoadBit::SW)) ? 2 : 1;
 
-				case ROAD_X.base():
-					/* A 'sloped' tile is going to be build. */
-					if ((existing_roadbits | new_roadbits) != new_roadbits) {
-						/* There is already a foundation on the tile, or at least
-						 * another slope that is not compatible with the new one. */
-						return 0;
-					}
-					/* If the start is in the low part, it is automatically
-					 * building the second part too. */
-					return (start_roadbits.Test(RoadBit::NE) && !existing_roadbits.Test(RoadBit::SW)) ? 2 : 1;
-
-				default:
-					/* Roadbits causing a foundation are going to be build.
-					 * When the existing roadbits are slopes (the lower bits
-					 * are used), this cannot be done. */
-					return existing_roadbits.Test(RoadBit::NE) ? 0 : 1;
-			}
-
-		default:
-			NOT_REACHED();
+			default:
+				/* Roadbits causing a foundation are going to be build.
+				 * When the existing roadbits are slopes (the lower bits
+				 * are used), this cannot be done. */
+				return existing_roadbits.Test(RoadBit::NE) ? 0 : 1;
+		}
 	}
 }
 

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -308,7 +308,7 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<RoadPartOrient
 
 	/* Create roadbits out of the data for easier handling. */
 	RoadBits start_roadbits = NeighbourToRoadBits(start);
-	RoadBits new_roadbits = start_roadbits | NeighbourToRoadBits(end);
+	RoadBits new_roadbits = NeighbourToRoadBits(end).Set(start_roadbits);
 	RoadBits existing_roadbits{};
 	for (RoadPartOrientation neighbour : existing) {
 		for (int j = 0; j < base_rotate; j++) {
@@ -329,7 +329,7 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<RoadPartOrient
 			case ROAD_X.base():
 			case ROAD_Y.base():
 				/* A 'sloped' tile is going to be build. */
-				if ((existing_roadbits | new_roadbits) != new_roadbits) {
+				if (existing_roadbits.Any(new_roadbits.Flip())) {
 					/* There is already a foundation on the tile, or at least
 					 * another slope that is not compatible with the new one. */
 					return 0;
@@ -342,7 +342,7 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<RoadPartOrient
 				/* Roadbits causing a foundation are going to be build.
 				 * When the existing roadbits are slopes (the lower bits
 				 * are used), this cannot be done. */
-				if ((existing_roadbits | new_roadbits) == new_roadbits) return 1;
+				if (!existing_roadbits.Any(new_roadbits.Flip())) return 1;
 				return existing_roadbits.Any(ROAD_E) ? 0 : 1;
 		}
 	} else {
@@ -355,7 +355,7 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<RoadPartOrient
 
 			case ROAD_X.base():
 				/* A 'sloped' tile is going to be build. */
-				if ((existing_roadbits | new_roadbits) != new_roadbits) {
+				if (existing_roadbits.Any(new_roadbits.Flip())) {
 					/* There is already a foundation on the tile, or at least
 					 * another slope that is not compatible with the new one. */
 					return 0;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
LookupWithBuildOnSlopes uses strange helper lookup table to reduce the amount of lookup work.
However with use of helper function it is possible to reduce the amount of lines and make code clearer.

Named functions for bit sets better show the intentions than overloaded operators.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Remove one of the lookup tables and replace switch with an if else block that uses helper function instead of comparison.
Use named functions for RoadBits instead of overloaded operators.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
 - Replaces switch with if else which causes everything to be moved one tab to the left.
 - Second commit could have been handled in #15537 but wasn't.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
