### PR TITLE
Codechange: make GameMode a scoped enum

### DIFF
--- a/src/ai/ai_config.cpp
+++ b/src/ai/ai_config.cpp
@@ -21,7 +21,7 @@
 {
 	assert(company < MAX_COMPANIES);
 
-	if (source == ScriptSettingSource::Default && _game_mode == GM_MENU) source = ScriptSettingSource::ForceNewGame;
+	if (source == ScriptSettingSource::Default && _game_mode == GameMode::Menu) source = ScriptSettingSource::ForceNewGame;
 
 	if (source == ScriptSettingSource::Default) {
 		Company *c = Company::GetIfValid(company);

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -155,7 +155,7 @@ struct AIConfigWindow : public Window {
 	 */
 	static bool IsEditable(CompanyID slot)
 	{
-		if (_game_mode != GM_NORMAL) {
+		if (_game_mode != GameMode::Normal) {
 			return slot > 0 && slot < MAX_COMPANIES;
 		}
 		return slot < MAX_COMPANIES && !Company::IsValidID(slot);
@@ -168,7 +168,7 @@ struct AIConfigWindow : public Window {
 	 */
 	std::string GetSlotText(CompanyID cid) const
 	{
-		if ((_game_mode != GM_NORMAL && cid == 0) || (_game_mode == GM_NORMAL && Company::IsValidHumanID(cid))) return GetString(STR_AI_CONFIG_HUMAN_PLAYER);
+		if ((_game_mode != GameMode::Normal && cid == 0) || (_game_mode == GameMode::Normal && Company::IsValidHumanID(cid))) return GetString(STR_AI_CONFIG_HUMAN_PLAYER);
 		if (const AIInfo *info = AIConfig::GetConfig(cid)->GetInfo(); info != nullptr) return info->GetName();
 		return GetString(STR_AI_CONFIG_RANDOM_AI);
 	}
@@ -193,7 +193,7 @@ struct AIConfigWindow : public Window {
 			case WID_AIC_LIST: {
 				Rect tr = r.Shrink(WidgetDimensions::scaled.matrix);
 				int max_slot = GetGameSettings().difficulty.max_no_competitors;
-				if (_game_mode == GM_NORMAL) {
+				if (_game_mode == GameMode::Normal) {
 					for (const Company *c : Company::Iterate()) {
 						if (c->is_ai) max_slot--;
 					}

--- a/src/ai/ai_instance.cpp
+++ b/src/ai/ai_instance.cpp
@@ -63,7 +63,7 @@ void AIInstance::Died()
 	ScriptInstance::Died();
 
 	/* Intro is not supposed to use AI, but it may have 'dummy' AI which instant dies. */
-	if (_game_mode == GM_MENU) return;
+	if (_game_mode == GameMode::Menu) return;
 
 	/* Don't show errors while loading savegame. They will be shown at end of loading anyway. */
 	if (_switch_mode != SM_NONE) return;

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -53,7 +53,7 @@ void AIScannerInfo::RegisterAPI(class Squirrel &engine)
 
 AIInfo *AIScannerInfo::SelectRandomAI() const
 {
-	if (_game_mode == GM_MENU) {
+	if (_game_mode == GameMode::Menu) {
 		Debug(script, 0, "The intro game should not use AI, loading 'dummy' AI.");
 		return this->info_dummy.get();
 	}

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -190,7 +190,7 @@ struct BuildAirToolbarWindow : Window {
 	 */
 	static EventState AirportToolbarGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GM_NORMAL) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
 		Window *w = ShowBuildAirToolbar();
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);

--- a/src/autoslope.h
+++ b/src/autoslope.h
@@ -66,7 +66,7 @@ inline bool AutoslopeEnabled()
 {
 	return (_settings_game.construction.autoslope &&
 	        (_current_company < MAX_COMPANIES ||
-	         (_current_company == OWNER_NONE && _game_mode == GM_EDITOR)));
+	         (_current_company == OWNER_NONE && _game_mode == GameMode::Editor)));
 }
 
 #endif /* AUTOSLOPE_H */

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -165,7 +165,7 @@ public:
 		BaseGraphics::FindSets();
 
 		/* And continue going into the menu. */
-		_game_mode = GM_MENU;
+		_game_mode = GameMode::Menu;
 
 		/* _exit_game is used to break out of the outer video driver's MainLoop. */
 		_exit_game = true;
@@ -373,7 +373,7 @@ bool HandleBootstrap()
 	if (!_network_available) goto failure;
 
 	/* First tell the game we're bootstrapping. */
-	_game_mode = GM_BOOTSTRAP;
+	_game_mode = GameMode::Bootstrap;
 
 #if defined(__EMSCRIPTEN__)
 	new BootstrapEmscripten();
@@ -402,16 +402,16 @@ bool HandleBootstrap()
 	VideoDriver::GetInstance()->MainLoop();
 
 	/* _exit_game is used to get out of the video driver's main loop.
-	 * In case GM_BOOTSTRAP is still set we did not exit it via the
+	 * In case GameMode::Bootstrap is still set we did not exit it via the
 	 * "download complete" event, so it was a manual exit. Obey it. */
-	_exit_game = _game_mode == GM_BOOTSTRAP;
+	_exit_game = _game_mode == GameMode::Bootstrap;
 	if (_exit_game) return false;
 
 	/* Try to probe the graphics. Should work this time. */
 	if (!BaseGraphics::SetSet(nullptr)) goto failure;
 
 	/* Finally we can continue heading for the menu. */
-	_game_mode = GM_MENU;
+	_game_mode = GameMode::Menu;
 	return true;
 #endif
 

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -142,13 +142,13 @@ private:
 	{
 		/* If the bridge has no meaningful speed limit, don't display it. */
 		if (bridge_data.spec->speed == UINT16_MAX) {
-			return _game_mode == GM_EDITOR
+			return _game_mode == GameMode::Editor
 				? GetString(STR_SELECT_BRIDGE_INFO_NAME, bridge_data.spec->material)
 				: GetString(STR_SELECT_BRIDGE_INFO_NAME_COST, bridge_data.spec->material, bridge_data.cost);
 		}
 
 		uint64_t packed_velocity = PackVelocity(bridge_data.spec->speed, static_cast<VehicleType>(this->transport_type));
-		return _game_mode == GM_EDITOR
+		return _game_mode == GameMode::Editor
 			? GetString(STR_SELECT_BRIDGE_INFO_NAME_MAX_SPEED, bridge_data.spec->material, packed_velocity)
 			: GetString(STR_SELECT_BRIDGE_INFO_NAME_MAX_SPEED_COST, bridge_data.spec->material, packed_velocity, bridge_data.cost);
 	}

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -286,7 +286,7 @@ static void TileLoop_Clear(TileIndex tile)
 		case ClearGround::Grass:
 			if (GetClearDensity(tile) == 3) return;
 
-			if (_game_mode != GM_EDITOR) {
+			if (_game_mode != GameMode::Editor) {
 				if (GetClearCounter(tile) < 7) {
 					AddClearCounter(tile, 1);
 					return;
@@ -302,7 +302,7 @@ static void TileLoop_Clear(TileIndex tile)
 		case ClearGround::Fields:
 			UpdateFences(tile);
 
-			if (_game_mode == GM_EDITOR) return;
+			if (_game_mode == GameMode::Editor) return;
 
 			if (GetClearCounter(tile) < 7) {
 				AddClearCounter(tile, 1);

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -151,7 +151,7 @@ bool IsCommandAllowedWhilePaused(Commands cmd)
 	static_assert(std::size(command_type_lookup) == to_underlying(CommandType::End));
 
 	assert(IsValidCommand(cmd));
-	return _game_mode == GM_EDITOR || command_type_lookup[to_underlying(_command_table[cmd].type)] <= _settings_game.construction.command_pause_level;
+	return _game_mode == GameMode::Editor || command_type_lookup[to_underlying(_command_table[cmd].type)] <= _settings_game.construction.command_pause_level;
 }
 
 /**
@@ -240,7 +240,7 @@ void CommandHelperBase::InternalPostResult(CommandCost &res, TileIndex tile, boo
 		}
 	} else if (estimate_only) {
 		ShowEstimatedCostOrIncome(res.GetCost(), x, y);
-	} else if (!only_sending && tile != 0 && IsLocalCompany() && _game_mode != GM_EDITOR) {
+	} else if (!only_sending && tile != 0 && IsLocalCompany() && _game_mode != GameMode::Editor) {
 		/* Only show the cost animation when we did actually
 		 * execute the command, i.e. we're not sending it to
 		 * the server, when it has cost the local company
@@ -276,7 +276,7 @@ bool CommandHelperBase::InternalExecutePrepTest(CommandFlags cmd_flags, Backup<C
 	/* If the company isn't valid it may only do server command or start a new company!
 	 * The server will ditch any server commands a client sends to it, so effectively
 	 * this guards the server from executing functions for an invalid company. */
-	if (_game_mode == GM_NORMAL && !exec_as_spectator && !Company::IsValidID(_current_company) && !(_current_company == OWNER_DEITY && cmd_flags.Test(CommandFlag::Deity))) {
+	if (_game_mode == GameMode::Normal && !exec_as_spectator && !Company::IsValidID(_current_company) && !(_current_company == OWNER_DEITY && cmd_flags.Test(CommandFlag::Deity))) {
 		return false;
 	}
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -649,7 +649,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid(
 
 /** Start a new competitor company if possible. */
 TimeoutTimer<TimerGameTick> _new_competitor_timeout({ TimerGameTick::Priority::CompetitorTimeout, 0 }, []() {
-	if (_game_mode == GM_MENU || !AI::CanStartNew()) return;
+	if (_game_mode == GameMode::Menu || !AI::CanStartNew()) return;
 	if (_networking && Company::GetNumItems() >= _settings_client.network.max_companies) return;
 	if (_settings_game.difficulty.competitors_interval == 0) return;
 
@@ -762,7 +762,7 @@ static void HandleBankruptcyTakeover(Company *c)
 /** Called every tick for updating some company info. */
 void OnTick_Companies()
 {
-	if (_game_mode == GM_EDITOR) return;
+	if (_game_mode == GameMode::Editor) return;
 
 	Company *c = Company::GetIfValid(_cur_company_tick_index);
 	if (c != nullptr) {
@@ -770,7 +770,7 @@ void OnTick_Companies()
 		if (c->bankrupt_asked.Any()) HandleBankruptcyTakeover(c);
 	}
 
-	if (_new_competitor_timeout.HasFired() && _game_mode != GM_MENU && AI::CanStartNew()) {
+	if (_new_competitor_timeout.HasFired() && _game_mode != GameMode::Menu && AI::CanStartNew()) {
 		int32_t timeout = _settings_game.difficulty.competitors_interval * 60 * Ticks::TICKS_PER_SECOND;
 		/* If the interval is zero, start as many competitors as needed then check every ~10 minutes if a company went bankrupt and needs replacing. */
 		if (timeout == 0) {

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -235,7 +235,7 @@ static ConsoleHookResult ConHookServerOrNoNetwork(bool echo)
 static ConsoleHookResult ConHookNewGRFDeveloperTool(bool echo)
 {
 	if (_settings_client.gui.newgrf_developer_tools) {
-		if (_game_mode == GM_MENU) {
+		if (_game_mode == GameMode::Menu) {
 			if (echo) IConsolePrint(CC_ERROR, "This command is only available in-game and in the editor.");
 			return ConsoleHookResult::Disallow;
 		}
@@ -271,7 +271,7 @@ static bool ConResetEnginePool(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (_game_mode == GM_MENU) {
+	if (_game_mode == GameMode::Menu) {
 		IConsolePrint(CC_ERROR, "This command is only available in-game and in the editor.");
 		return true;
 	}
@@ -839,7 +839,7 @@ static bool ConPauseGame(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (_game_mode == GM_MENU) {
+	if (_game_mode == GameMode::Menu) {
 		IConsolePrint(CC_ERROR, "This command is only available in-game and in the editor.");
 		return true;
 	}
@@ -862,7 +862,7 @@ static bool ConUnpauseGame(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (_game_mode == GM_MENU) {
+	if (_game_mode == GameMode::Menu) {
 		IConsolePrint(CC_ERROR, "This command is only available in-game and in the editor.");
 		return true;
 	}
@@ -1503,7 +1503,7 @@ static bool ConStartAI(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (_game_mode != GM_NORMAL) {
+	if (_game_mode != GameMode::Normal) {
 		IConsolePrint(CC_ERROR, "AIs can only be managed in a game.");
 		return true;
 	}
@@ -1577,7 +1577,7 @@ static bool ConReloadAI(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (_game_mode != GM_NORMAL) {
+	if (_game_mode != GameMode::Normal) {
 		IConsolePrint(CC_ERROR, "AIs can only be managed in a game.");
 		return true;
 	}
@@ -1621,7 +1621,7 @@ static bool ConStopAI(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (_game_mode != GM_NORMAL) {
+	if (_game_mode != GameMode::Normal) {
 		IConsolePrint(CC_ERROR, "AIs can only be managed in a game.");
 		return true;
 	}
@@ -1909,7 +1909,7 @@ static bool ConExit(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (_game_mode == GM_NORMAL && _settings_client.gui.autosave_on_exit) DoExitSave();
+	if (_game_mode == GameMode::Normal && _settings_client.gui.autosave_on_exit) DoExitSave();
 
 	_exit_game = true;
 	return true;
@@ -1923,7 +1923,7 @@ static bool ConPart(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (_game_mode != GM_NORMAL) return false;
+	if (_game_mode != GameMode::Normal) return false;
 
 	if (_network_dedicated) {
 		IConsolePrint(CC_ERROR, "A dedicated server can not leave the game.");

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -259,7 +259,7 @@ bool CrashLog::WriteScreenshot()
  */
 void CrashLog::SendSurvey() const
 {
-	if (_game_mode == GM_NORMAL) {
+	if (_game_mode == GameMode::Normal) {
 		_survey.Transmit(NetworkSurveyHandler::Reason::Crash, true);
 	}
 }

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -109,7 +109,7 @@ struct BuildDocksToolbarWindow : Window {
 
 	void Close([[maybe_unused]] int data = 0) override
 	{
-		if (_game_mode == GM_NORMAL && this->IsWidgetLowered(WID_DT_STATION)) SetViewportCatchmentStation(nullptr, true);
+		if (_game_mode == GameMode::Normal && this->IsWidgetLowered(WID_DT_STATION)) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) CloseWindowById(WindowClass::ScenarioGenerateLandscape, 0, false);
 		this->Window::Close();
 	}
@@ -133,7 +133,7 @@ struct BuildDocksToolbarWindow : Window {
 			CloseWindowById(WindowClass::BuildDepot, TRANSPORT_WATER);
 		}
 
-		if (_game_mode != GM_EDITOR) {
+		if (_game_mode != GameMode::Editor) {
 			if (!can_build) {
 				/* Show in the tooltip why this button is disabled. */
 				this->GetWidget<NWidgetCore>(WID_DT_DEPOT)->SetToolTip(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE);
@@ -151,7 +151,7 @@ struct BuildDocksToolbarWindow : Window {
 	{
 		switch (widget) {
 			case WID_DT_CANAL: // Build canal button
-				if (_game_mode == GM_EDITOR) {
+				if (_game_mode == GameMode::Editor) {
 					HandlePlacePushButton(this, WID_DT_CANAL, SPR_CURSOR_CANAL, HT_RECT);
 				} else {
 					HandlePlacePushButton(this, WID_DT_CANAL, SPR_CURSOR_CANAL, HT_RECT | HT_DIAGONAL);
@@ -179,7 +179,7 @@ struct BuildDocksToolbarWindow : Window {
 				break;
 
 			case WID_DT_RIVER: // Build river button (in scenario editor)
-				if (_game_mode != GM_EDITOR) return;
+				if (_game_mode != GameMode::Editor) return;
 				HandlePlacePushButton(this, WID_DT_RIVER, SPR_CURSOR_RIVER, HT_RECT | HT_DIAGONAL);
 				break;
 
@@ -263,7 +263,7 @@ struct BuildDocksToolbarWindow : Window {
 					GUIPlaceProcDragXY(select_proc, start_tile, end_tile);
 					break;
 				case DDSP_CREATE_WATER:
-					if (_game_mode == GM_EDITOR) {
+					if (_game_mode == GameMode::Editor) {
 						Command<Commands::BuildCanal>::Post(STR_ERROR_CAN_T_BUILD_CANALS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, _ctrl_pressed ? WaterClass::Sea : WaterClass::Canal, false);
 					} else {
 						Command<Commands::BuildCanal>::Post(STR_ERROR_CAN_T_BUILD_CANALS, CcPlaySound_CONSTRUCTION_WATER, end_tile, start_tile, WaterClass::Canal, _ctrl_pressed);
@@ -280,7 +280,7 @@ struct BuildDocksToolbarWindow : Window {
 
 	void OnPlaceObjectAbort() override
 	{
-		if (_game_mode != GM_EDITOR && this->IsWidgetLowered(WID_DT_STATION)) SetViewportCatchmentStation(nullptr, true);
+		if (_game_mode != GameMode::Editor && this->IsWidgetLowered(WID_DT_STATION)) SetViewportCatchmentStation(nullptr, true);
 
 		this->RaiseButtons();
 
@@ -316,7 +316,7 @@ struct BuildDocksToolbarWindow : Window {
 	 */
 	static EventState DockToolbarGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GM_NORMAL) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
 		Window *w = ShowBuildDocksToolbar();
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1889,7 +1889,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 	 * if _settings_client.gui.loading_indicators == 1, _local_company must be the owner or must be a spectator to show ind., so 1 > 0
 	 * if _settings_client.gui.loading_indicators == 0, do not display indicators ... 0 is never greater than anything
 	 */
-	if (_game_mode != GM_MENU && (_settings_client.gui.loading_indicators > (uint)(front->owner != _local_company && _local_company != COMPANY_SPECTATOR))) {
+	if (_game_mode != GameMode::Menu && (_settings_client.gui.loading_indicators > (uint)(front->owner != _local_company && _local_company != COMPANY_SPECTATOR))) {
 		StringID percent_up_down = STR_NULL;
 		int percent = CalcPercentVehicleFilled(front, &percent_up_down);
 		if (front->fill_percent_te_id == INVALID_TE_ID) {

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -78,7 +78,7 @@ static uint ScaleByInverseCargoScale(uint num, bool town)
 inline uint ScaleByCargoScale(uint num, bool town)
 {
 	/* Don't bother scaling in the menu, especially since settings don't exist when starting OpenTTD and trying to read them crashes the game. */
-	if (_game_mode == GM_MENU) return num;
+	if (_game_mode == GameMode::Menu) return num;
 
 	if (num == 0) return num;
 

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -335,7 +335,7 @@ void ShowErrorMessage(EncodedString &&summary_msg, EncodedString &&detailed_msg,
 
 	bool is_critical = wl == WarningLevel::Critical;
 
-	if (_game_mode == GM_BOOTSTRAP) return;
+	if (_game_mode == GameMode::Bootstrap) return;
 	if (_settings_client.gui.errmsg_duration == 0 && !is_critical) return;
 
 	ErrorMessageData data(std::move(summary_msg), std::move(detailed_msg), is_critical, x, y, std::move(extra_msg), company);

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -206,7 +206,7 @@ static std::string FiosMakeFilename(const std::string *path, std::string_view na
  */
 std::string FiosMakeSavegameName(std::string_view name)
 {
-	std::string_view extension = (_game_mode == GM_EDITOR) ? ".scn" : ".sav";
+	std::string_view extension = (_game_mode == GameMode::Editor) ? ".scn" : ".sav";
 
 	return FiosMakeFilename(_fios_path, name, extension);
 }

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -457,7 +457,7 @@ public:
 
 		/* pause is only used in single-player, non-editor mode, non-menu mode. It
 		 * will be unpaused in the WE_DESTROY event handler. */
-		if (_game_mode != GM_MENU && !_networking && _game_mode != GM_EDITOR) {
+		if (_game_mode != GameMode::Menu && !_networking && _game_mode != GameMode::Editor) {
 			Command<Commands::Pause>::Post(PauseMode::SaveLoad, true);
 		}
 		SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WindowClass::MainWindow, 0);
@@ -500,7 +500,7 @@ public:
 	void Close([[maybe_unused]] int data = 0) override
 	{
 		/* pause is only used in single-player, non-editor mode, non menu mode */
-		if (!_networking && _game_mode != GM_EDITOR && _game_mode != GM_MENU) {
+		if (!_networking && _game_mode != GameMode::Editor && _game_mode != GameMode::Menu) {
 			Command<Commands::Pause>::Post(PauseMode::SaveLoad, false);
 		}
 		this->Window::Close();
@@ -718,7 +718,7 @@ public:
 					this->Close();
 					LoadTownData();
 				} else if (!_load_check_data.HasNewGrfs() || _load_check_data.grf_compatibility != GRFListCompatibility::NotFound || _settings_client.gui.UserIsAllowedToChangeNewGRFs()) {
-					_switch_mode = (_game_mode == GM_EDITOR) ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
+					_switch_mode = (_game_mode == GameMode::Editor) ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
 					ClearErrorMessages();
 					this->Close();
 				}
@@ -866,7 +866,7 @@ public:
 			}
 
 			/* In the editor set up the vehicle engines correctly (date might have changed) */
-			if (_game_mode == GM_EDITOR) StartupEngines();
+			if (_game_mode == GameMode::Editor) StartupEngines();
 		}
 	}
 

--- a/src/game/game_config.cpp
+++ b/src/game/game_config.cpp
@@ -17,7 +17,7 @@
 
 /* static */ GameConfig *GameConfig::GetConfig(ScriptSettingSource source)
 {
-	if (source == ScriptSettingSource::Default && _game_mode == GM_MENU) source = ScriptSettingSource::ForceNewGame;
+	if (source == ScriptSettingSource::Default && _game_mode == GameMode::Menu) source = ScriptSettingSource::ForceNewGame;
 
 	auto &config = (source == ScriptSettingSource::ForceNewGame) ? _settings_newgame.script_config.game : _settings_game.script_config.game;
 	if (config == nullptr) config = std::make_unique<GameConfig>();

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -72,7 +72,7 @@
 	if (Game::instance != nullptr) return;
 
 	/* Don't start GameScripts in intro */
-	if (_game_mode == GM_MENU) return;
+	if (_game_mode == GameMode::Menu) return;
 
 	/* Clients shouldn't start GameScripts */
 	if (_networking && !_network_server) return;

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -158,7 +158,7 @@ struct GSConfigWindow : public Window {
 	 */
 	static bool IsEditable()
 	{
-		return _game_mode != GM_NORMAL || Game::GetInstance() != nullptr;
+		return _game_mode != GameMode::Normal || Game::GetInstance() != nullptr;
 	}
 
 	/**
@@ -235,7 +235,7 @@ struct GSConfigWindow : public Window {
 		switch (widget) {
 			case WID_GSC_GSLIST: {
 				this->InvalidateData();
-				if (click_count > 1 && _game_mode != GM_NORMAL) ShowScriptListWindow(OWNER_DEITY, _ctrl_pressed);
+				if (click_count > 1 && _game_mode != GameMode::Normal) ShowScriptListWindow(OWNER_DEITY, _ctrl_pressed);
 				break;
 			}
 
@@ -339,7 +339,7 @@ struct GSConfigWindow : public Window {
 			}
 
 			case WID_GSC_RESET:
-				this->gs_config->ResetEditableSettings(_game_mode == GM_MENU);
+				this->gs_config->ResetEditableSettings(_game_mode == GameMode::Menu);
 				this->SetDirty();
 				break;
 		}
@@ -392,7 +392,7 @@ struct GSConfigWindow : public Window {
 	{
 		if (!gui_scope) return;
 
-		this->SetWidgetDisabledState(WID_GSC_CHANGE, (_game_mode == GM_NORMAL) || !IsEditable());
+		this->SetWidgetDisabledState(WID_GSC_CHANGE, (_game_mode == GameMode::Normal) || !IsEditable());
 
 		const GameConfig *config = GameConfig::GetConfig();
 		this->SetWidgetDisabledState(WID_GSC_OPEN_URL, config->GetInfo() == nullptr || config->GetInfo()->GetURL().empty());
@@ -406,8 +406,8 @@ struct GSConfigWindow : public Window {
 private:
 	bool IsEditableItem(const ScriptConfigItem &config_item) const
 	{
-		return _game_mode == GM_MENU
-			|| _game_mode == GM_EDITOR
+		return _game_mode == GameMode::Menu
+			|| _game_mode == GameMode::Editor
 			|| config_item.flags.Test(ScriptConfigFlag::InGame)
 			|| _settings_client.gui.ai_developer_tools;
 	}
@@ -415,7 +415,7 @@ private:
 	void SetValue(int value)
 	{
 		const ScriptConfigItem &config_item = *this->visible_settings[this->clicked_row];
-		if (_game_mode == GM_NORMAL && !config_item.flags.Test(ScriptConfigFlag::InGame)) return;
+		if (_game_mode == GameMode::Normal && !config_item.flags.Test(ScriptConfigFlag::InGame)) return;
 		this->gs_config->SetSetting(config_item.name, value);
 		this->SetDirty();
 	}

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -11,6 +11,7 @@
 #define GAMELOG_INTERNAL_H
 
 #include "gamelog.h"
+#include "openttd.h"
 #include "landscape_type.h"
 
 /**
@@ -45,13 +46,21 @@ struct LoggedChange {
 	GamelogChangeType ct{};
 };
 
+/** Log element for the change of the game mode and landscape. */
 struct LoggedChangeMode : LoggedChange {
+	/** Constructor for savegame loading. */
 	LoggedChangeMode() : LoggedChange(GLCT_MODE) {}
-	LoggedChangeMode(uint8_t mode, LandscapeType landscape) :
+
+	/**
+	 * Create the log for changing the game mode.
+	 * @param mode The new GameMode.
+	 * @param landscape The new landscape.
+	 */
+	LoggedChangeMode(GameMode mode, LandscapeType landscape) :
 		LoggedChange(GLCT_MODE), mode(mode), landscape(landscape) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint8_t mode = 0; ///< new game mode - Editor x Game
+	GameMode mode{}; ///< new game mode - Editor x Game
 	LandscapeType landscape{}; ///< landscape (temperate, arctic, ...)
 };
 

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -136,7 +136,7 @@ static void _GenerateWorld()
 			}
 
 			/* Make the map the height of the setting */
-			if (_game_mode != GM_MENU) FlatEmptyWorld(_settings_game.game_creation.se_flat_world_height);
+			if (_game_mode != GameMode::Menu) FlatEmptyWorld(_settings_game.game_creation.se_flat_world_height);
 
 			ConvertGroundTilesIntoWaterTiles();
 			Map::CountLandTiles();
@@ -148,7 +148,7 @@ static void _GenerateWorld()
 			Map::CountLandTiles();
 
 			/* Only generate towns, tree and industries in newgame mode. */
-			if (_game_mode != GM_EDITOR) {
+			if (_game_mode != GameMode::Editor) {
 				if (!GenerateTowns(_settings_game.economy.town_layout)) {
 					HandleGeneratingWorldAbortion();
 					return;
@@ -181,7 +181,7 @@ static void _GenerateWorld()
 				IncreaseGeneratingWorldProgress(GenWorldProgress::RunTileLoop);
 			}
 
-			if (_game_mode != GM_EDITOR) {
+			if (_game_mode != GameMode::Editor) {
 				if (Game::GetInstance() != nullptr) {
 					SetGeneratingWorldProgress(GenWorldProgress::GameScript, 2500);
 					_generating_world = true;
@@ -201,7 +201,7 @@ static void _GenerateWorld()
 		cur_company.Trash();
 		_current_company = _local_company = GenWorldInfo::lc;
 		/* Show all vital windows again, because we have hidden them. */
-		if (_game_mode != GM_MENU) ShowVitalWindows();
+		if (_game_mode != GameMode::Menu) ShowVitalWindows();
 
 		SetGeneratingWorldProgress(GenWorldProgress::GameStart, 1);
 		/* Call any callback */
@@ -278,7 +278,7 @@ bool IsGeneratingWorldAborted()
 void HandleGeneratingWorldAbortion()
 {
 	/* Clean up - in SE create an empty map, otherwise, go to intro menu */
-	_switch_mode = (_game_mode == GM_EDITOR) ? SM_EDITOR : SM_MENU;
+	_switch_mode = (_game_mode == GameMode::Editor) ? SM_EDITOR : SM_MENU;
 
 	if (GenWorldInfo::abortp != nullptr) GenWorldInfo::abortp();
 
@@ -312,7 +312,7 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 	if (_settings_game.construction.map_height_limit == 0) {
 		uint estimated_height = 0;
 
-		if (GenWorldInfo::mode == GWM_EMPTY && _game_mode != GM_MENU) {
+		if (GenWorldInfo::mode == GWM_EMPTY && _game_mode != GameMode::Menu) {
 			estimated_height = _settings_game.game_creation.se_flat_world_height;
 		} else if (GenWorldInfo::mode == GWM_HEIGHTMAP) {
 			estimated_height = _settings_game.game_creation.heightmap_height;

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -336,8 +336,8 @@ static void StartGeneratingLandscape(GenerateLandscapeWindowMode mode)
 
 	SndConfirmBeep();
 	switch (mode) {
-		case GLWM_GENERATE:  _switch_mode = (_game_mode == GM_EDITOR) ? SM_GENRANDLAND    : SM_NEWGAME;         break;
-		case GLWM_HEIGHTMAP: _switch_mode = (_game_mode == GM_EDITOR) ? SM_LOAD_HEIGHTMAP : SM_START_HEIGHTMAP; break;
+		case GLWM_GENERATE: _switch_mode = (_game_mode == GameMode::Editor) ? SM_GENRANDLAND : SM_NEWGAME; break;
+		case GLWM_HEIGHTMAP: _switch_mode = (_game_mode == GameMode::Editor) ? SM_LOAD_HEIGHTMAP : SM_START_HEIGHTMAP; break;
 		case GLWM_SCENARIO:  _switch_mode = SM_EDITOR; break;
 		default: NOT_REACHED();
 	}
@@ -416,8 +416,8 @@ struct GenerateLandscapeWindow : public Window {
 		this->mode = this->window_number;
 
 		/* Disable town and industry in SE */
-		this->SetWidgetDisabledState(WID_GL_TOWN_PULLDOWN,     _game_mode == GM_EDITOR);
-		this->SetWidgetDisabledState(WID_GL_INDUSTRY_PULLDOWN, _game_mode == GM_EDITOR);
+		this->SetWidgetDisabledState(WID_GL_TOWN_PULLDOWN, _game_mode == GameMode::Editor);
+		this->SetWidgetDisabledState(WID_GL_INDUSTRY_PULLDOWN, _game_mode == GameMode::Editor);
 
 		/* In case the map_height_limit is changed, clamp heightmap_height and custom_terrain_type. */
 		_settings_newgame.game_creation.heightmap_height = Clamp(_settings_newgame.game_creation.heightmap_height, MIN_HEIGHTMAP_HEIGHT, GetMapHeightLimit());
@@ -443,7 +443,7 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_DESERT_COVERAGE_TEXT: return GetString(STR_MAPGEN_DESERT_COVERAGE_TEXT, _settings_newgame.game_creation.desert_coverage);
 
 			case WID_GL_TOWN_PULLDOWN:
-				if (_game_mode == GM_EDITOR) {
+				if (_game_mode == GameMode::Editor) {
 					return GetString(STR_CONFIG_SETTING_OFF);
 				}
 				if (_settings_newgame.difficulty.number_towns == CUSTOM_TOWN_NUMBER_DIFFICULTY) {
@@ -460,7 +460,7 @@ struct GenerateLandscapeWindow : public Window {
 			}
 
 			case WID_GL_INDUSTRY_PULLDOWN:
-				if (_game_mode == GM_EDITOR) {
+				if (_game_mode == GameMode::Editor) {
 					return GetString(STR_CONFIG_SETTING_OFF);
 				}
 				if (_settings_newgame.difficulty.industry_density == IndustryDensity::Custom) {
@@ -895,7 +895,7 @@ struct GenerateLandscapeWindow : public Window {
 				break;
 
 			case WID_GL_TOWNNAME_DROPDOWN: // Town names
-				if (_game_mode == GM_MENU || Town::GetNumItems() == 0) {
+				if (_game_mode == GameMode::Menu || Town::GetNumItems() == 0) {
 					_settings_newgame.game_creation.town_name = index;
 					SetWindowDirty(WindowClass::GameOptions, GameOptionsWindowNumber::GameOptions);
 				}

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -141,7 +141,7 @@ struct EndGameWindow : EndGameHighScoreBaseWindow {
 	void Close([[maybe_unused]] int data = 0) override
 	{
 		if (!_networking) Command<Commands::Pause>::Post(PauseMode::Normal, false); // unpause
-		if (_game_mode != GM_MENU && !_exit_game) ShowHighscoreTable(this->window_number, this->rank);
+		if (_game_mode != GameMode::Menu && !_exit_game) ShowHighscoreTable(this->window_number, this->rank);
 		this->EndGameHighScoreBaseWindow::Close();
 	}
 
@@ -177,7 +177,7 @@ struct HighScoreWindow : EndGameHighScoreBaseWindow {
 		if (!_networking && !this->game_paused_by_player) Command<Commands::Pause>::Post(PauseMode::Normal, true);
 
 		/* Close all always on-top windows to get a clean screen */
-		if (_game_mode != GM_MENU) HideVitalWindows();
+		if (_game_mode != GameMode::Menu) HideVitalWindows();
 
 		MarkWholeScreenDirty();
 		this->window_number = difficulty; // show highscore chart for difficulty...
@@ -187,7 +187,7 @@ struct HighScoreWindow : EndGameHighScoreBaseWindow {
 
 	void Close([[maybe_unused]] int data = 0) override
 	{
-		if (_game_mode != GM_MENU && !_exit_game) ShowVitalWindows();
+		if (_game_mode != GameMode::Menu && !_exit_game) ShowVitalWindows();
 
 		if (!_networking && !this->game_paused_by_player) Command<Commands::Pause>::Post(PauseMode::Normal, false); // unpause
 

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -497,7 +497,7 @@ static CommandCost ClearTile_Industry(TileIndex tile, DoCommandFlags flags)
 	 * with magic_bulldozer cheat you can destroy industries
 	 * (area around OILRIG is water, so water shouldn't flood it
 	 */
-	if ((_current_company != OWNER_WATER && _game_mode != GM_EDITOR &&
+	if ((_current_company != OWNER_WATER && _game_mode != GameMode::Editor &&
 			!_cheats.magic_bulldozer.value) ||
 			flags.Test(DoCommandFlag::Auto) ||
 			(_current_company == OWNER_WATER &&
@@ -850,7 +850,7 @@ static void TileLoop_Industry(TileIndex tile)
 		return;
 	}
 
-	if (_game_mode == GM_EDITOR) return;
+	if (_game_mode == GameMode::Editor) return;
 
 	if (TransportIndustryGoods(tile) && !TriggerIndustryAnimation(Industry::GetByTile(tile), IndustryAnimationTrigger::CargoDistributed)) {
 		uint newgfx = GetIndustryTileSpec(GetIndustryGfx(tile))->anim_production;
@@ -1243,7 +1243,7 @@ void OnTick_Industry()
 		}
 	}
 
-	if (_game_mode == GM_EDITOR) return;
+	if (_game_mode == GameMode::Editor) return;
 
 	for (Industry *i : Industry::Iterate()) {
 		ProduceIndustryGoods(i);
@@ -1308,7 +1308,7 @@ static bool CheckScaledDistanceFromEdge(TileIndex tile, uint maxdist)
  */
 static CommandCost CheckNewIndustry_OilRefinery(TileIndex tile)
 {
-	if (_game_mode == GM_EDITOR) return CommandCost();
+	if (_game_mode == GameMode::Editor) return CommandCost();
 
 	if (CheckScaledDistanceFromEdge(TileAddXY(tile, 1, 1), _settings_game.game_creation.oil_refinery_limit)) return CommandCost();
 
@@ -1324,7 +1324,7 @@ extern bool _ignore_industry_restrictions;
  */
 static CommandCost CheckNewIndustry_OilRig(TileIndex tile)
 {
-	if (_game_mode == GM_EDITOR && _ignore_industry_restrictions) return CommandCost();
+	if (_game_mode == GameMode::Editor && _ignore_industry_restrictions) return CommandCost();
 
 	if (TileHeight(tile) == 0 &&
 			CheckScaledDistanceFromEdge(TileAddXY(tile, 1, 1), _settings_game.game_creation.oil_refinery_limit)) return CommandCost();
@@ -1812,7 +1812,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	i->ctlflags = {};
 
 	i->construction_date = TimerGameCalendar::date;
-	i->construction_type = (_game_mode == GM_EDITOR) ? IndustryConstructionType::ScenarioEditor :
+	i->construction_type = (_game_mode == GameMode::Editor) ? IndustryConstructionType::ScenarioEditor :
 			(_generating_world ? IndustryConstructionType::MapGeneration : IndustryConstructionType::Gameplay);
 
 	/* Adding 1 here makes it conform to specs of var44 of varaction2 for industries
@@ -2072,11 +2072,11 @@ CommandCost CmdBuildIndustry(DoCommandFlags flags, TileIndex tile, IndustryType 
 
 	/* If the setting for raw-material industries is not on, you cannot build raw-material industries.
 	 * Raw material industries are industries that do not accept cargo (at least for now) */
-	if (_game_mode != GM_EDITOR && _current_company != OWNER_DEITY && _settings_game.construction.raw_industry_construction == 0 && indspec->IsRawIndustry()) {
+	if (_game_mode != GameMode::Editor && _current_company != OWNER_DEITY && _settings_game.construction.raw_industry_construction == 0 && indspec->IsRawIndustry()) {
 		return CMD_ERROR;
 	}
 
-	if (_game_mode != GM_EDITOR && GetIndustryProbabilityCallback(it, _current_company == OWNER_DEITY ? IndustryAvailabilityCallType::RandomCreation : IndustryAvailabilityCallType::UserCreation, 1) == 0) {
+	if (_game_mode != GameMode::Editor && GetIndustryProbabilityCallback(it, _current_company == OWNER_DEITY ? IndustryAvailabilityCallType::RandomCreation : IndustryAvailabilityCallType::UserCreation, 1) == 0) {
 		return CMD_ERROR;
 	}
 
@@ -2089,7 +2089,7 @@ CommandCost CmdBuildIndustry(DoCommandFlags flags, TileIndex tile, IndustryType 
 	const bool deity_prospect = _current_company == OWNER_DEITY && !fund;
 
 	Industry *ind = nullptr;
-	if (deity_prospect || (_game_mode != GM_EDITOR && _current_company != OWNER_DEITY && _settings_game.construction.raw_industry_construction == 2 && indspec->IsRawIndustry())) {
+	if (deity_prospect || (_game_mode != GameMode::Editor && _current_company != OWNER_DEITY && _settings_game.construction.raw_industry_construction == 2 && indspec->IsRawIndustry())) {
 		if (flags.Test(DoCommandFlag::Execute)) {
 			/* Prospecting has a chance to fail, however we cannot guarantee that something can
 			 * be built on the map, so the chance gets lower when the map is fuller, but there
@@ -2138,7 +2138,7 @@ CommandCost CmdBuildIndustry(DoCommandFlags flags, TileIndex tile, IndustryType 
 		if (ret.Failed()) return ret;
 	}
 
-	if (flags.Test(DoCommandFlag::Execute) && ind != nullptr && _game_mode != GM_EDITOR) {
+	if (flags.Test(DoCommandFlag::Execute) && ind != nullptr && _game_mode != GameMode::Editor) {
 		AdvertiseIndustryOpening(ind);
 	}
 
@@ -2308,7 +2308,7 @@ static uint32_t GetScaledIndustryGenerationProbability(IndustryType it, std::opt
 
 	uint32_t chance = ind_spc->appear_creation[to_underlying(_settings_game.game_creation.landscape)];
 	if (!ind_spc->enabled || ind_spc->layouts.empty() ||
-			(_game_mode != GM_EDITOR && _settings_game.difficulty.industry_density == IndustryDensity::FundedOnly) ||
+			(_game_mode != GameMode::Editor && _settings_game.difficulty.industry_density == IndustryDensity::FundedOnly) ||
 			(chance = GetIndustryProbabilityCallback(it, IndustryAvailabilityCallType::MapGeneration, chance)) == 0) {
 		*force_at_least_one = false;
 		return 0;
@@ -2318,7 +2318,7 @@ static uint32_t GetScaledIndustryGenerationProbability(IndustryType it, std::opt
 		 * For simplicity we scale in both cases, though scaling the probabilities of all industries has no effect. */
 		chance = (ind_spc->check_proc == IndustryCheck::Refinery || ind_spc->check_proc == IndustryCheck::OilRig) ? Map::ScaleBySize1D(chance) : Map::ScaleBySize(chance);
 
-		*force_at_least_one = (chance > 0) && !ind_spc->behaviour.Test(IndustryBehaviour::NoBuildMapCreation) && (_game_mode != GM_EDITOR);
+		*force_at_least_one = (chance > 0) && !ind_spc->behaviour.Test(IndustryBehaviour::NoBuildMapCreation) && (_game_mode != GameMode::Editor);
 		return chance;
 	}
 }
@@ -2367,7 +2367,7 @@ static uint GetNumberOfIndustries()
 	};
 
 	assert(lengthof(numof_industry_table) == to_underlying(IndustryDensity::End));
-	IndustryDensity density = (_game_mode != GM_EDITOR) ? _settings_game.difficulty.industry_density : IndustryDensity::VeryLow;
+	IndustryDensity density = (_game_mode != GameMode::Editor) ? _settings_game.difficulty.industry_density : IndustryDensity::VeryLow;
 
 	if (density == IndustryDensity::Custom) return std::min<uint>(IndustryPool::MAX_SIZE, _settings_game.game_creation.custom_industry_number);
 
@@ -2486,7 +2486,7 @@ static IndustryGenerationProbabilities GetScaledProbabilities(bool water)
  */
 void GenerateIndustries()
 {
-	if (_game_mode != GM_EDITOR && _settings_game.difficulty.industry_density == IndustryDensity::FundedOnly) return; // No industries in the game.
+	if (_game_mode != GameMode::Editor && _settings_game.difficulty.industry_density == IndustryDensity::FundedOnly) return; // No industries in the game.
 
 	/* Get the probabilities for all industries. This is done first as we need the total of
 	 * both land and water for scaling later. */

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -311,7 +311,7 @@ class BuildIndustryWindow : public Window {
 
 	void UpdateAvailability()
 	{
-		this->enabled = this->selected_type != IT_INVALID && (_game_mode == GM_EDITOR || GetIndustryProbabilityCallback(this->selected_type, IndustryAvailabilityCallType::UserCreation, 1) > 0);
+		this->enabled = this->selected_type != IT_INVALID && (_game_mode == GameMode::Editor || GetIndustryProbabilityCallback(this->selected_type, IndustryAvailabilityCallType::UserCreation, 1) > 0);
 	}
 
 	void SetupArrays()
@@ -328,7 +328,7 @@ class BuildIndustryWindow : public Window {
 				/* Rule is that editor mode loads all industries.
 				 * In game mode, all non raw industries are loaded too
 				 * and raw ones are loaded only when setting allows it */
-				if (_game_mode != GM_EDITOR && indsp->IsRawIndustry() && _settings_game.construction.raw_industry_construction == 0) {
+				if (_game_mode != GameMode::Editor && indsp->IsRawIndustry() && _settings_game.construction.raw_industry_construction == 0) {
 					/* Unselect if the industry is no longer in the list */
 					if (this->selected_type == ind) this->selected_type = IT_INVALID;
 					continue;
@@ -389,7 +389,7 @@ public:
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_DPI_SCROLLBAR);
 		/* Show scenario editor tools in editor. */
-		if (_game_mode != GM_EDITOR) {
+		if (_game_mode != GameMode::Editor) {
 			this->GetWidget<NWidgetStacked>(WID_DPI_SCENARIO_EDITOR_PANE)->SetDisplayedPlane(SZSP_HORIZONTAL);
 		}
 		this->FinishInitNested(0);
@@ -426,7 +426,7 @@ public:
 
 			case WID_DPI_INFOPANEL: {
 				/* Extra line for cost outside of editor. */
-				int height = 2 + (_game_mode == GM_EDITOR ? 0 : 1);
+				int height = 2 + (_game_mode == GameMode::Editor ? 0 : 1);
 				uint extra_lines_req = 0;
 				uint extra_lines_prd = 0;
 				uint extra_lines_newgrf = 0;
@@ -487,7 +487,7 @@ public:
 			case WID_DPI_FUND_WIDGET:
 				/* Raw industries might be prospected. Show this fact by changing the string
 				 * In Editor, you just build, while ingame, or you fund or you prospect */
-				if (_game_mode == GM_EDITOR) {
+				if (_game_mode == GameMode::Editor) {
 					/* We've chosen many random industries but no industries have been specified */
 					return GetString(STR_FUND_INDUSTRY_BUILD_NEW_INDUSTRY);
 				}
@@ -555,7 +555,7 @@ public:
 
 				const IndustrySpec *indsp = GetIndustrySpec(this->selected_type);
 
-				if (_game_mode != GM_EDITOR) {
+				if (_game_mode != GameMode::Editor) {
 					DrawString(ir, GetString(STR_FUND_INDUSTRY_INDUSTRY_BUILD_COST, indsp->GetConstructionCost()));
 					ir.top += GetCharacterHeight(FontSize::Normal);
 				}
@@ -632,7 +632,7 @@ public:
 	{
 		switch (widget) {
 			case WID_DPI_CREATE_RANDOM_INDUSTRIES_WIDGET: {
-				assert(_game_mode == GM_EDITOR);
+				assert(_game_mode == GameMode::Editor);
 				this->HandleButtonClick(WID_DPI_CREATE_RANDOM_INDUSTRIES_WIDGET);
 				ShowQuery(
 					GetEncodedString(STR_FUND_INDUSTRY_MANY_RANDOM_INDUSTRIES_CAPTION),
@@ -642,7 +642,7 @@ public:
 			}
 
 			case WID_DPI_REMOVE_ALL_INDUSTRIES_WIDGET: {
-				assert(_game_mode == GM_EDITOR);
+				assert(_game_mode == GameMode::Editor);
 				this->HandleButtonClick(WID_DPI_REMOVE_ALL_INDUSTRIES_WIDGET);
 				ShowQuery(
 					GetEncodedString(STR_FUND_INDUSTRY_REMOVE_ALL_INDUSTRIES_CAPTION),
@@ -662,7 +662,7 @@ public:
 					this->SetDirty();
 
 					if (_thd.GetCallbackWnd() == this &&
-							((_game_mode != GM_EDITOR && _settings_game.construction.raw_industry_construction == 2 && indsp != nullptr && indsp->IsRawIndustry()) || !this->enabled)) {
+							((_game_mode != GameMode::Editor && _settings_game.construction.raw_industry_construction == 2 && indsp != nullptr && indsp->IsRawIndustry()) || !this->enabled)) {
 						/* Reset the button state if going to prospecting or "build many industries" */
 						this->RaiseButtons();
 						ResetObjectToPlace();
@@ -680,7 +680,7 @@ public:
 
 			case WID_DPI_FUND_WIDGET: {
 				if (this->selected_type != IT_INVALID) {
-					if (_game_mode != GM_EDITOR && _settings_game.construction.raw_industry_construction == 2 && GetIndustrySpec(this->selected_type)->IsRawIndustry()) {
+					if (_game_mode != GameMode::Editor && _settings_game.construction.raw_industry_construction == 2 && GetIndustrySpec(this->selected_type)->IsRawIndustry()) {
 						Command<Commands::BuildIndustry>::Post(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY, TileIndex{}, this->selected_type, 0, false, InteractiveRandom());
 						this->HandleButtonClick(WID_DPI_FUND_WIDGET);
 					} else {
@@ -706,7 +706,7 @@ public:
 		uint32_t seed = InteractiveRandom();
 		uint32_t layout_index = InteractiveRandomRange((uint32_t)indsp->layouts.size());
 
-		if (_game_mode == GM_EDITOR) {
+		if (_game_mode == GameMode::Editor) {
 			/* Show error if no town exists at all */
 			if (Town::GetNumItems() == 0) {
 				ShowErrorMessage(GetEncodedString(STR_ERROR_CAN_T_BUILD_HERE, indsp->name),
@@ -728,7 +728,7 @@ public:
 	}
 
 	const IntervalTimer<TimerWindow> update_interval = {std::chrono::seconds(3), [this](auto) {
-		if (_game_mode == GM_EDITOR) return;
+		if (_game_mode == GameMode::Editor) return;
 		if (this->selected_type == IT_INVALID) return;
 
 		bool enabled = this->enabled;
@@ -765,7 +765,7 @@ public:
 
 void ShowBuildIndustryWindow()
 {
-	if (_game_mode != GM_EDITOR && !Company::IsValidID(_local_company)) return;
+	if (_game_mode != GameMode::Editor && !Company::IsValidID(_local_company)) return;
 	if (BringWindowToFrontById(WindowClass::BuildIndustry, 0)) return;
 	new BuildIndustryWindow();
 }
@@ -776,7 +776,7 @@ static inline bool IsProductionAlterable(const Industry *i)
 {
 	const IndustrySpec *is = GetIndustrySpec(i->type);
 	bool has_prod = std::any_of(std::begin(is->production_rate), std::end(is->production_rate), [](auto rate) { return rate != 0; });
-	return ((_game_mode == GM_EDITOR || _cheats.setup_prod.value) &&
+	return ((_game_mode == GameMode::Editor || _cheats.setup_prod.value) &&
 			(has_prod || is->IsRawIndustry()) &&
 			!_networking);
 }

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -433,7 +433,7 @@ void AskExitToGameMenu()
 {
 	ShowQuery(
 		GetEncodedString(STR_ABANDON_GAME_CAPTION),
-		GetEncodedString((_game_mode != GM_EDITOR) ? STR_ABANDON_GAME_QUERY : STR_ABANDON_SCENARIO_QUERY),
+		GetEncodedString((_game_mode != GameMode::Editor) ? STR_ABANDON_GAME_QUERY : STR_ABANDON_SCENARIO_QUERY),
 		nullptr,
 		AskExitToGameMenuCallback,
 		true

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -143,7 +143,7 @@ void ZoomInOrOutToCursorWindow(bool in, Window *w)
 {
 	assert(w != nullptr);
 
-	if (_game_mode != GM_MENU) {
+	if (_game_mode != GameMode::Menu) {
 		if ((in && w->viewport->zoom <= _settings_client.gui.zoom_min) || (!in && w->viewport->zoom >= _settings_client.gui.zoom_max)) return;
 
 		Point pt = GetTileZoomCenterWindow(in, w);
@@ -157,7 +157,7 @@ void ZoomInOrOutToCursorWindow(bool in, Window *w)
 
 void FixTitleGameZoom(int zoom_adjust)
 {
-	if (_game_mode != GM_MENU) return;
+	if (_game_mode != GameMode::Menu) return;
 
 	Viewport &vp = *GetMainWindow()->viewport;
 
@@ -256,7 +256,7 @@ struct MainWindow : Window
 	void OnPaint() override
 	{
 		this->DrawWidgets();
-		if (_game_mode == GM_MENU) {
+		if (_game_mode == GameMode::Menu) {
 			static const std::initializer_list<SpriteID> title_sprites = {SPR_OTTD_O, SPR_OTTD_P, SPR_OTTD_E, SPR_OTTD_N, SPR_OTTD_T, SPR_OTTD_T, SPR_OTTD_D};
 			uint letter_spacing = ScaleGUITrad(10);
 			int name_width = static_cast<int>(std::size(title_sprites) - 1) * letter_spacing;
@@ -292,7 +292,7 @@ struct MainWindow : Window
 		switch (hotkey) {
 			case GHK_ABANDON:
 				/* No point returning from the main menu to itself */
-				if (_game_mode == GM_MENU) return ES_HANDLED;
+				if (_game_mode == GameMode::Menu) return ES_HANDLED;
 				if (_settings_client.gui.autosave_on_exit) {
 					DoExitSave();
 					_switch_mode = SM_MENU;
@@ -318,7 +318,7 @@ struct MainWindow : Window
 				return ES_HANDLED;
 		}
 
-		if (_game_mode == GM_MENU) return ES_NOT_HANDLED;
+		if (_game_mode == GameMode::Menu) return ES_NOT_HANDLED;
 
 		switch (hotkey) {
 			case GHK_CENTER:
@@ -566,12 +566,12 @@ void SetupColoursAndInitialWindow()
 	/* XXX: these are not done */
 	switch (_game_mode) {
 		default: NOT_REACHED();
-		case GM_MENU:
+		case GameMode::Menu:
 			ShowSelectGameWindow();
 			break;
 
-		case GM_NORMAL:
-		case GM_EDITOR:
+		case GameMode::Normal:
+		case GameMode::Editor:
 			ShowVitalWindows();
 			break;
 	}
@@ -585,7 +585,7 @@ void ShowVitalWindows()
 	AllocateToolbar();
 
 	/* Status bad only for normal games */
-	if (_game_mode == GM_EDITOR) return;
+	if (_game_mode == GameMode::Editor) return;
 
 	ShowStatusBar();
 }

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -150,7 +150,7 @@ void MusicSystem::ChangePlaylist(PlaylistChoices pl)
 
 	if (pl != PLCH_THEMEONLY) _settings_client.music.playlist = pl;
 
-	if (_game_mode != GM_MENU || pl == PLCH_THEMEONLY) {
+	if (_game_mode != GameMode::Menu || pl == PLCH_THEMEONLY) {
 		this->selected_playlist = pl;
 		this->active_playlist = this->standard_playlists[this->selected_playlist];
 		this->playlist_position = 0;
@@ -248,7 +248,7 @@ void MusicSystem::Play()
 	if (this->active_playlist.empty()) return;
 
 	MusicSongInfo song = this->active_playlist[this->playlist_position];
-	if (_game_mode == GM_MENU && this->selected_playlist == PLCH_THEMEONLY) song.loop = true;
+	if (_game_mode == GameMode::Menu && this->selected_playlist == PLCH_THEMEONLY) song.loop = true;
 	MusicDriver::GetInstance()->PlaySong(song);
 
 	InvalidateWindowData(WindowClass::Music, 0);
@@ -284,9 +284,9 @@ void MusicSystem::Prev()
 /** Check that music is playing if it should, and that appropriate playlist is active for game/main menu */
 void MusicSystem::CheckStatus()
 {
-	if ((_game_mode == GM_MENU) != (this->selected_playlist == PLCH_THEMEONLY)) {
+	if ((_game_mode == GameMode::Menu) != (this->selected_playlist == PLCH_THEMEONLY)) {
 		/* Make sure the theme-only playlist is active when on the title screen, and not during gameplay */
-		this->ChangePlaylist((_game_mode == GM_MENU) ? PLCH_THEMEONLY : (PlaylistChoices)_settings_client.music.playlist);
+		this->ChangePlaylist((_game_mode == GameMode::Menu) ? PLCH_THEMEONLY : (PlaylistChoices)_settings_client.music.playlist);
 	}
 	if (this->active_playlist.empty()) return;
 	/* If we were supposed to be playing, but music has stopped, move to next song */
@@ -699,12 +699,12 @@ struct MusicWindow : public Window {
 		this->SetWidgetsDisabledState(BaseMusic::GetUsedSet()->num_available == 0, WID_M_STOP, WID_M_PLAY);
 		/* Disable most music control widgets if there is no music, or we are in the intro menu. */
 		this->SetWidgetsDisabledState(
-			BaseMusic::GetUsedSet()->num_available == 0 || _game_mode == GM_MENU,
+			BaseMusic::GetUsedSet()->num_available == 0 || _game_mode == GameMode::Menu,
 			WID_M_PREV, WID_M_NEXT, WID_M_SHUFFLE,
 			WID_M_ALL, WID_M_OLD, WID_M_NEW, WID_M_EZY, WID_M_CUSTOM1, WID_M_CUSTOM2
 			);
 		/* Also disable programme button in the intro menu (not in game; it is desirable to allow change of music set.) */
-		this->SetWidgetsDisabledState(_game_mode == GM_MENU, WID_M_PROGRAMME);
+		this->SetWidgetsDisabledState(_game_mode == GameMode::Menu, WID_M_PROGRAMME);
 	}
 
 	void UpdateWidgetSize(WidgetID widget, Dimension &size, [[maybe_unused]] const Dimension &padding, [[maybe_unused]] Dimension &fill, [[maybe_unused]] Dimension &resize) override

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -820,7 +820,7 @@ bool NetworkClientConnectGame(std::string_view connection_string, CompanyID defa
 	_network_join.company = join_as;
 	_network_join.server_password = join_server_password;
 
-	if (_game_mode == GM_MENU) {
+	if (_game_mode == GameMode::Menu) {
 		/* From the menu we can immediately continue with the actual join. */
 		NetworkClientJoinGame();
 	} else {

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -185,7 +185,7 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 
 	CloseWindowById(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
-	if (_game_mode != GM_MENU) _switch_mode = SM_MENU;
+	if (_game_mode != GameMode::Menu) _switch_mode = SM_MENU;
 	_networking = false;
 }
 
@@ -863,7 +863,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapDone(Packet &)
 	/* Set the abstract filetype. This is read during savegame load. */
 	_file_to_saveload.SetMode(FIOS_TYPE_FILE, SaveLoadOperation::Load);
 
-	bool load_success = SafeLoad({}, SaveLoadOperation::Load, DetailedFileType::GameFile, GM_NORMAL, Subdirectory::None, this->savegame);
+	bool load_success = SafeLoad({}, SaveLoadOperation::Load, DetailedFileType::GameFile, GameMode::Normal, Subdirectory::None, this->savegame);
 	this->savegame = nullptr;
 
 	/* Long savegame loads shouldn't affect the lag calculation! */

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -488,7 +488,7 @@ bool GetGlobalVariable(uint8_t param, uint32_t *value, const GRFFile *grffile)
 			return true;
 
 		case 0x12: // Game mode
-			*value = _game_mode;
+			*value = to_underlying(_game_mode);
 			return true;
 
 		/* case 0x13: // Tile refresh offset to left    not implemented */

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -47,7 +47,7 @@
 void ShowNewGRFError()
 {
 	/* Do not show errors when entering the main screen */
-	if (_game_mode == GM_MENU) return;
+	if (_game_mode == GameMode::Menu) return;
 
 	for (const auto &c : _grfconfig) {
 		/* Only show Fatal and Error level messages */

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -604,7 +604,7 @@ bool CanDeleteHouse(TileIndex tile)
 
 	/* Humans are always allowed to remove buildings, as is water and disasters and
 	 * anyone using the scenario editor. */
-	if (Company::IsValidHumanID(_current_company) || _current_company == OWNER_WATER || _current_company == OWNER_NONE || _game_mode == GM_EDITOR || _generating_world) {
+	if (Company::IsValidHumanID(_current_company) || _current_company == OWNER_WATER || _current_company == OWNER_NONE || _game_mode == GameMode::Editor || _generating_world) {
 		return true;
 	}
 

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -78,7 +78,7 @@ size_t ObjectSpec::Count()
 bool ObjectSpec::IsEverAvailable() const
 {
 	return this->IsEnabled() && this->climate.Test(_settings_game.game_creation.landscape) &&
-			!this->flags.Test((_game_mode != GM_EDITOR && !_generating_world) ? ObjectFlag::OnlyInScenedit : ObjectFlag::OnlyInGame);
+			!this->flags.Test((_game_mode != GameMode::Editor && !_generating_world) ? ObjectFlag::OnlyInScenedit : ObjectFlag::OnlyInGame);
 }
 
 /**

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -916,7 +916,7 @@ std::string NewsItem::GetStatusText() const
  */
 void AddNewsItem(EncodedString &&headline, NewsType type, NewsStyle style, NewsFlags flags, NewsReference ref1, NewsReference ref2, std::unique_ptr<NewsAllocatedData> &&data, AdviceType advice_type)
 {
-	if (_game_mode == GM_MENU) return;
+	if (_game_mode == GameMode::Menu) return;
 
 	/* Create new news item node */
 	_news.emplace_front(std::move(headline), type, style, flags, ref1, ref2, std::move(data), advice_type);

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -213,11 +213,11 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 
 	if (type >= ObjectSpec::Count()) return CMD_ERROR;
 	const ObjectSpec *spec = ObjectSpec::Get(type);
-	if (_game_mode == GM_NORMAL && !spec->IsAvailable() && !_generating_world) return CMD_ERROR;
-	if ((_game_mode == GM_EDITOR || _generating_world) && !spec->WasEverAvailable()) return CMD_ERROR;
+	if (_game_mode == GameMode::Normal && !spec->IsAvailable() && !_generating_world) return CMD_ERROR;
+	if ((_game_mode == GameMode::Editor || _generating_world) && !spec->WasEverAvailable()) return CMD_ERROR;
 
-	if (spec->flags.Test(ObjectFlag::OnlyInScenedit) && ((!_generating_world && _game_mode != GM_EDITOR) || _current_company != OWNER_NONE)) return CMD_ERROR;
-	if (spec->flags.Test(ObjectFlag::OnlyInGame) && (_generating_world || _game_mode != GM_NORMAL || _current_company > MAX_COMPANIES)) return CMD_ERROR;
+	if (spec->flags.Test(ObjectFlag::OnlyInScenedit) && ((!_generating_world && _game_mode != GameMode::Editor) || _current_company != OWNER_NONE)) return CMD_ERROR;
+	if (spec->flags.Test(ObjectFlag::OnlyInGame) && (_generating_world || _game_mode != GameMode::Normal || _current_company > MAX_COMPANIES)) return CMD_ERROR;
 	if (view >= spec->views) return CMD_ERROR;
 
 	if (!Object::CanAllocateItem()) return CommandCost(STR_ERROR_TOO_MANY_OBJECTS);
@@ -564,7 +564,7 @@ static CommandCost ClearTile_Object(TileIndex tile, DoCommandFlags flags)
 		} else if (!spec->flags.Test(ObjectFlag::Autoremove) && flags.Test(DoCommandFlag::Auto)) {
 			/* No automatic removal by overbuilding stuff. */
 			return CommandCost(type == OBJECT_HQ ? STR_ERROR_COMPANY_HEADQUARTERS_IN : STR_ERROR_OBJECT_IN_THE_WAY);
-		} else if (_game_mode == GM_EDITOR) {
+		} else if (_game_mode == GameMode::Editor) {
 			/* No further limitations for the editor. */
 		} else if (GetTileOwner(tile) == OWNER_NONE) {
 			/* Owned by nobody and unremovable, so we can only remove it with brute force! */

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -369,7 +369,7 @@ public:
 	 */
 	static EventState BuildObjectGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode == GM_MENU) return ES_NOT_HANDLED;
+		if (_game_mode == GameMode::Menu) return ES_NOT_HANDLED;
 		Window *w = ShowBuildObjectPicker();
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -309,7 +309,7 @@ static void ShutdownGame()
 	PoolBase::Clean(PT_ALL);
 
 	/* No NewGRFs were loaded when it was still bootstrapping. */
-	if (_game_mode != GM_BOOTSTRAP) ResetNewGRFData();
+	if (_game_mode != GameMode::Bootstrap) ResetNewGRFData();
 
 	FontCache::UninitializeFontCaches();
 }
@@ -320,7 +320,7 @@ static void ShutdownGame()
  */
 static void LoadIntroGame(bool load_newgrfs = true)
 {
-	_game_mode = GM_MENU;
+	_game_mode = GameMode::Menu;
 
 	if (load_newgrfs) ResetGRFConfig(false);
 
@@ -513,7 +513,7 @@ int openttd_main(std::span<std::string_view> arguments)
 	extern bool _dedicated_forks;
 	_dedicated_forks = false;
 
-	_game_mode = GM_MENU;
+	_game_mode = GameMode::Menu;
 	_switch_mode = SM_MENU;
 
 	auto options = CreateOptions();
@@ -812,7 +812,7 @@ int openttd_main(std::span<std::string_view> arguments)
 
 void HandleExitGameRequest()
 {
-	if (_game_mode == GM_MENU || _game_mode == GM_BOOTSTRAP) { // do not ask to quit on the main screen
+	if (_game_mode == GameMode::Menu || _game_mode == GameMode::Bootstrap) { // do not ask to quit on the main screen
 		_exit_game = true;
 	} else if (_settings_client.gui.autosave_on_exit) {
 		DoExitSave();
@@ -895,7 +895,7 @@ static void MakeNewGameDone()
 
 static void MakeNewGame(bool from_heightmap, bool reset_settings)
 {
-	_game_mode = GM_NORMAL;
+	_game_mode = GameMode::Normal;
 	if (!from_heightmap) {
 		/* "reload" command needs to know what mode we were in. */
 		_file_to_saveload.SetMode(FIOS_TYPE_INVALID, SaveLoadOperation::Invalid);
@@ -914,7 +914,7 @@ static void MakeNewEditorWorldDone()
 
 static void MakeNewEditorWorld()
 {
-	_game_mode = GM_EDITOR;
+	_game_mode = GameMode::Editor;
 	/* "reload" command needs to know what mode we were in. */
 	_file_to_saveload.SetMode(FIOS_TYPE_INVALID, SaveLoadOperation::Invalid);
 
@@ -947,7 +947,7 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 	SaveLoadResult result = (lf == nullptr) ? SaveOrLoad(filename, fop, dft, subdir) : LoadWithFilter(std::move(lf));
 	if (result == SaveLoadResult::Ok) return true;
 
-	if (_network_dedicated && ogm == GM_MENU) {
+	if (_network_dedicated && ogm == GameMode::Menu) {
 		/*
 		 * If we are a dedicated server *and* we just were in the menu, then we
 		 * are loading the first savegame. If that fails, not starting the
@@ -985,8 +985,8 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 
 	switch (ogm) {
 		default:
-		case GM_MENU:   LoadIntroGame();      break;
-		case GM_EDITOR: MakeNewEditorWorld(); break;
+		case GameMode::Menu: LoadIntroGame(); break;
+		case GameMode::Editor: MakeNewEditorWorld(); break;
 	}
 	return false;
 }
@@ -994,12 +994,12 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 static void UpdateSocialIntegration(GameMode game_mode)
 {
 	switch (game_mode) {
-		case GM_BOOTSTRAP:
-		case GM_MENU:
+		case GameMode::Bootstrap:
+		case GameMode::Menu:
 			SocialIntegration::EventEnterMainMenu();
 			break;
 
-		case GM_NORMAL:
+		case GameMode::Normal:
 			if (_networking) {
 				SocialIntegration::EventEnterMultiplayer(Map::SizeX(), Map::SizeY());
 			} else {
@@ -1007,7 +1007,7 @@ static void UpdateSocialIntegration(GameMode game_mode)
 			}
 			break;
 
-		case GM_EDITOR:
+		case GameMode::Editor:
 			SocialIntegration::EventEnterScenarioEditor(Map::SizeX(), Map::SizeY());
 			break;
 	}
@@ -1051,7 +1051,7 @@ void SwitchToMode(SwitchMode new_mode)
 	if (new_mode != SM_SAVE_GAME) ChangeAutosaveFrequency(true);
 
 	/* Transmit the survey if we were in normal-mode and not saving. It always means we leaving the current game. */
-	if (_game_mode == GM_NORMAL && new_mode != SM_SAVE_GAME) _survey.Transmit(NetworkSurveyHandler::Reason::Leave);
+	if (_game_mode == GameMode::Normal && new_mode != SM_SAVE_GAME) _survey.Transmit(NetworkSurveyHandler::Reason::Leave);
 
 	/* Keep track when we last switch mode. Used for survey, to know how long someone was in a game. */
 	if (new_mode != SM_SAVE_GAME) {
@@ -1064,18 +1064,18 @@ void SwitchToMode(SwitchMode new_mode)
 			MakeNewEditorWorld();
 			GenerateSavegameId();
 
-			UpdateSocialIntegration(GM_EDITOR);
+			UpdateSocialIntegration(GameMode::Editor);
 			break;
 
 		case SM_RELOADGAME: // Reload with what-ever started the game
 			if (_file_to_saveload.ftype.abstract == AbstractFileType::Savegame || _file_to_saveload.ftype.abstract == AbstractFileType::Scenario) {
 				/* Reload current savegame/scenario */
-				_switch_mode = _game_mode == GM_EDITOR ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
+				_switch_mode = _game_mode == GameMode::Editor ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
 				SwitchToMode(_switch_mode);
 				break;
 			} else if (_file_to_saveload.ftype.abstract == AbstractFileType::Heightmap) {
 				/* Restart current heightmap */
-				_switch_mode = _game_mode == GM_EDITOR ? SM_LOAD_HEIGHTMAP : SM_RESTART_HEIGHTMAP;
+				_switch_mode = _game_mode == GameMode::Editor ? SM_LOAD_HEIGHTMAP : SM_RESTART_HEIGHTMAP;
 				SwitchToMode(_switch_mode);
 				break;
 			}
@@ -1083,7 +1083,7 @@ void SwitchToMode(SwitchMode new_mode)
 			MakeNewGame(false, new_mode == SM_NEWGAME);
 			GenerateSavegameId();
 
-			UpdateSocialIntegration(GM_NORMAL);
+			UpdateSocialIntegration(GameMode::Normal);
 			break;
 
 		case SM_RESTARTGAME: // Restart --> 'Random game' with current settings
@@ -1091,14 +1091,14 @@ void SwitchToMode(SwitchMode new_mode)
 			MakeNewGame(false, new_mode == SM_NEWGAME);
 			GenerateSavegameId();
 
-			UpdateSocialIntegration(GM_NORMAL);
+			UpdateSocialIntegration(GameMode::Normal);
 			break;
 
 		case SM_LOAD_GAME: { // Load game, Play Scenario
 			ResetGRFConfig(true);
 			ResetWindowSystem();
 
-			if (!SafeLoad(_file_to_saveload.name, _file_to_saveload.file_op, _file_to_saveload.ftype.detailed, GM_NORMAL, Subdirectory::None)) {
+			if (!SafeLoad(_file_to_saveload.name, _file_to_saveload.file_op, _file_to_saveload.ftype.detailed, GameMode::Normal, Subdirectory::None)) {
 				ShowErrorMessage(GetSaveLoadErrorType(), GetSaveLoadErrorMessage(), WarningLevel::Critical);
 			} else {
 				if (_file_to_saveload.ftype.abstract == AbstractFileType::Scenario) {
@@ -1109,7 +1109,7 @@ void SwitchToMode(SwitchMode new_mode)
 				Command<Commands::Pause>::Post(PauseMode::SaveLoad, false);
 			}
 
-			UpdateSocialIntegration(GM_NORMAL);
+			UpdateSocialIntegration(GameMode::Normal);
 			break;
 		}
 
@@ -1118,23 +1118,23 @@ void SwitchToMode(SwitchMode new_mode)
 			MakeNewGame(true, new_mode == SM_START_HEIGHTMAP);
 			GenerateSavegameId();
 
-			UpdateSocialIntegration(GM_NORMAL);
+			UpdateSocialIntegration(GameMode::Normal);
 			break;
 
 		case SM_LOAD_HEIGHTMAP: // Load heightmap from scenario editor
 			SetLocalCompany(OWNER_NONE);
 
-			_game_mode = GM_EDITOR;
+			_game_mode = GameMode::Editor;
 
 			GenerateWorld(GWM_HEIGHTMAP, 1 << _settings_game.game_creation.map_x, 1 << _settings_game.game_creation.map_y);
 			GenerateSavegameId();
 			MarkWholeScreenDirty();
 
-			UpdateSocialIntegration(GM_EDITOR);
+			UpdateSocialIntegration(GameMode::Editor);
 			break;
 
 		case SM_LOAD_SCENARIO: { // Load scenario from scenario editor
-			if (SafeLoad(_file_to_saveload.name, _file_to_saveload.file_op, _file_to_saveload.ftype.detailed, GM_EDITOR, Subdirectory::None)) {
+			if (SafeLoad(_file_to_saveload.name, _file_to_saveload.file_op, _file_to_saveload.ftype.detailed, GameMode::Editor, Subdirectory::None)) {
 				SetLocalCompany(OWNER_NONE);
 				GenerateSavegameId();
 				_settings_newgame.game_creation.starting_year = TimerGameCalendar::year;
@@ -1144,7 +1144,7 @@ void SwitchToMode(SwitchMode new_mode)
 				ShowErrorMessage(GetSaveLoadErrorType(), GetSaveLoadErrorMessage(), WarningLevel::Critical);
 			}
 
-			UpdateSocialIntegration(GM_EDITOR);
+			UpdateSocialIntegration(GameMode::Editor);
 			break;
 		}
 
@@ -1170,7 +1170,7 @@ void SwitchToMode(SwitchMode new_mode)
 				}
 			}
 
-			UpdateSocialIntegration(GM_MENU);
+			UpdateSocialIntegration(GameMode::Menu);
 			break;
 
 		case SM_SAVE_GAME: // Save game.
@@ -1223,7 +1223,7 @@ void StateGameLoop()
 
 		if (!HasModalProgress()) UpdateLandscapingLimits();
 #ifndef DEBUG_DUMP_COMMANDS
-		if (_game_mode == GM_NORMAL) Game::GameLoop();
+		if (_game_mode == GameMode::Normal) Game::GameLoop();
 #endif
 		return;
 	}
@@ -1231,7 +1231,7 @@ void StateGameLoop()
 	PerformanceMeasurer framerate(PFE_GAMELOOP);
 	PerformanceAccumulator::Reset(PFE_GL_LANDSCAPE);
 
-	if (_game_mode == GM_EDITOR) {
+	if (_game_mode == GameMode::Editor) {
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 		RunTileLoop();
 		CallVehicleTicks();
@@ -1332,7 +1332,7 @@ bool RequestNewGRFScan(NewGRFScanCallback *callback)
 
 void GameLoop()
 {
-	if (_game_mode == GM_BOOTSTRAP) {
+	if (_game_mode == GameMode::Bootstrap) {
 		/* Check for UDP stuff */
 		if (_network_available) NetworkBackgroundLoop();
 		return;
@@ -1348,7 +1348,7 @@ void GameLoop()
 
 	ProcessAsyncSaveFinish();
 
-	if (_game_mode == GM_NORMAL) {
+	if (_game_mode == GameMode::Normal) {
 		static auto last_time = std::chrono::steady_clock::now();
 		auto now = std::chrono::steady_clock::now();
 		auto delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_time);

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -15,11 +15,11 @@
 #include "core/enum_type.hpp"
 
 /** Mode which defines the state of the game. */
-enum GameMode : uint8_t {
-	GM_MENU,
-	GM_NORMAL,
-	GM_EDITOR,
-	GM_BOOTSTRAP
+enum class GameMode : uint8_t {
+	Menu, ///< In the main menu.
+	Normal, ///< Playing a game.
+	Editor, ///< In the scenario editor.
+	Bootstrap, ///< In the content bootstrap process.
 };
 
 /** Mode which defines what mode we're switching to. */

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1877,7 +1877,7 @@ uint16_t GetServiceIntervalClamped(int interval, bool ispercent)
 	if (ispercent) return Clamp(interval, MIN_SERVINT_PERCENT, MAX_SERVINT_PERCENT);
 
 	/* Service intervals are in minutes. */
-	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) return Clamp(interval, MIN_SERVINT_MINUTES, MAX_SERVINT_MINUTES);
+	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu)) return Clamp(interval, MIN_SERVINT_MINUTES, MAX_SERVINT_MINUTES);
 
 	/* Service intervals are in days. */
 	return Clamp(interval, MIN_SERVINT_DAYS, MAX_SERVINT_DAYS);

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -400,7 +400,7 @@ void PickerWindow::DrawWidget(const Rect &r, WidgetID widget) const
 
 				GrfSpecFeature feature = this->callbacks.GetFeature();
 				/* Houses have recolours but not related to the company colour and other items depend on gamemode. */
-				PaletteID palette = _game_mode != GM_NORMAL || feature == GrfSpecFeature::Houses ? PAL_NONE : GetCompanyPalette(_local_company);
+				PaletteID palette = _game_mode != GameMode::Normal || feature == GrfSpecFeature::Houses ? PAL_NONE : GetCompanyPalette(_local_company);
 				DrawBadgeColumn({0, by, ir.Width() - 1, ir.Height() - 1}, 0, this->badge_classes, this->callbacks.GetTypeBadges(item.class_index, item.index), feature, std::nullopt, palette);
 
 				if (this->callbacks.saved.contains(this->callbacks.sel_collection)) {
@@ -565,7 +565,7 @@ void PickerWindow::OnClick(Point pt, WidgetID widget, int)
 		default:
 			if (IsInsideMM(widget, this->badge_filters.first, this->badge_filters.second)) {
 				/* Houses have recolours but not related to the company colour and other items depend on gamemode. */
-				PaletteID palette = _game_mode != GM_NORMAL || this->callbacks.GetFeature() == GrfSpecFeature::Houses ? PAL_NONE : GetCompanyPalette(_local_company);
+				PaletteID palette = _game_mode != GameMode::Normal || this->callbacks.GetFeature() == GrfSpecFeature::Houses ? PAL_NONE : GetCompanyPalette(_local_company);
 				ShowDropDownList(this, this->GetWidget<NWidgetBadgeFilter>(widget)->GetDropDownList(palette), -1, widget, 0, DropDownOption::Filterable);
 			}
 			break;

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -2358,7 +2358,7 @@ static void DrawTrackBits(TileInfo *ti, TrackBits track)
 	}
 
 	/* PBS debugging, draw reserved tracks darker */
-	if (_game_mode != GM_MENU && _settings_client.gui.show_track_reservation) {
+	if (_game_mode != GameMode::Menu && _settings_client.gui.show_track_reservation) {
 		/* Get reservation, but mask track on halftile slope */
 		TrackBits pbs = GetRailReservationTrackBits(ti->tile) & track;
 		if (pbs & TRACK_BIT_X) {
@@ -2396,7 +2396,7 @@ static void DrawTrackBits(TileInfo *ti, TrackBits track)
 		}
 		DrawGroundSprite(image, pal, &(_halftile_sub_sprite[halftile_corner]));
 
-		if (_game_mode != GM_MENU && _settings_client.gui.show_track_reservation && HasReservedTracks(ti->tile, CornerToTrackBits(halftile_corner))) {
+		if (_game_mode != GameMode::Menu && _settings_client.gui.show_track_reservation && HasReservedTracks(ti->tile, CornerToTrackBits(halftile_corner))) {
 			static const uint8_t _corner_to_track_sprite[] = {3, 1, 2, 0};
 			DrawGroundSprite(_corner_to_track_sprite[halftile_corner] + rti->base_sprites.single_n, PALETTE_CRASH, nullptr, 0, -(int)TILE_HEIGHT);
 		}
@@ -2536,7 +2536,7 @@ static void DrawTile_Rail(TileInfo *ti)
 			}
 		} else {
 			/* PBS debugging, draw reserved tracks darker */
-			if (_game_mode != GM_MENU && _settings_client.gui.show_track_reservation && HasDepotReservation(ti->tile)) {
+			if (_game_mode != GameMode::Menu && _settings_client.gui.show_track_reservation && HasDepotReservation(ti->tile)) {
 				switch (GetRailDepotDirection(ti->tile)) {
 					case DIAGDIR_NE:
 						if (!IsInvisibilitySet(TO_BUILDINGS)) break;

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -873,7 +873,7 @@ struct BuildRailToolbarWindow : Window {
 	 */
 	static EventState RailToolbarGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GM_NORMAL) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
 		Window *w = ShowBuildRailToolbar(_last_built_railtype);
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);
@@ -1418,7 +1418,7 @@ public:
 	 */
 	static EventState BuildRailStationGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode == GM_MENU) return ES_NOT_HANDLED;
+		if (_game_mode == GameMode::Menu) return ES_NOT_HANDLED;
 		Window *w = ShowStationBuilder(FindWindowById(WindowClass::BuildToolbar, TRANSPORT_RAIL));
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -122,7 +122,7 @@ RoadBits CleanUpRoadBits(const TileIndex tile, RoadBits org_rb)
  */
 bool HasRoadTypeAvail(const CompanyID company, RoadType roadtype)
 {
-	if (company == OWNER_DEITY || company == OWNER_TOWN || _game_mode == GM_EDITOR || _generating_world) {
+	if (company == OWNER_DEITY || company == OWNER_TOWN || _game_mode == GameMode::Editor || _generating_world) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(roadtype);
 		if (rti->label == 0) return false;
 

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -254,7 +254,7 @@ static Foundation GetRoadFoundation(Slope tileh, RoadBits bits);
  */
 CommandCost CheckAllowRemoveRoad(TileIndex tile, RoadBits remove, Owner owner, RoadTramType rtt, DoCommandFlags flags, bool town_check)
 {
-	if (_game_mode == GM_EDITOR || remove.None()) return CommandCost();
+	if (_game_mode == GameMode::Editor || remove.None()) return CommandCost();
 
 	/* Water can always flood and towns can always remove "normal" road pieces.
 	 * Towns are not be allowed to remove non "normal" road pieces, like tram
@@ -1787,7 +1787,7 @@ static void DrawTile_Road(TileInfo *ti)
 			DrawRoadOverlays(ti, pal, road_rti, tram_rti, to_underlying(axis), to_underlying(axis));
 
 			/* Draw rail/PBS overlay */
-			bool draw_pbs = _game_mode != GM_MENU && _settings_client.gui.show_track_reservation && HasCrossingReservation(ti->tile);
+			bool draw_pbs = _game_mode != GameMode::Menu && _settings_client.gui.show_track_reservation && HasCrossingReservation(ti->tile);
 			if (rti->UsesOverlay()) {
 				pal = draw_pbs ? PALETTE_CRASH : PAL_NONE;
 				SpriteID rail = GetCustomRailSprite(rti, ti->tile, RailSpriteType::Crossing) + to_underlying(axis);

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -367,7 +367,7 @@ struct BuildRoadToolbarWindow : Window {
 
 	void Close([[maybe_unused]] int data = 0) override
 	{
-		if (_game_mode == GM_NORMAL && (this->IsWidgetLowered(WID_ROT_BUS_STATION) || this->IsWidgetLowered(WID_ROT_TRUCK_STATION))) SetViewportCatchmentStation(nullptr, true);
+		if (_game_mode == GameMode::Normal && (this->IsWidgetLowered(WID_ROT_BUS_STATION) || this->IsWidgetLowered(WID_ROT_TRUCK_STATION))) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) CloseWindowById(WindowClass::ScenarioGenerateLandscape, 0, false);
 		this->Window::Close();
 	}
@@ -402,7 +402,7 @@ struct BuildRoadToolbarWindow : Window {
 			CloseWindowById(WindowClass::BuildWaypoint, TRANSPORT_ROAD);
 		}
 
-		if (_game_mode != GM_EDITOR) {
+		if (_game_mode != GameMode::Editor) {
 			if (!can_build) {
 				/* Show in the tooltip why this button is disabled. */
 				this->GetWidget<NWidgetCore>(WID_ROT_DEPOT)->SetToolTip(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE);
@@ -425,7 +425,7 @@ struct BuildRoadToolbarWindow : Window {
 		this->GetWidget<NWidgetCore>(WID_ROT_ROAD_X)->SetSprite(rti->gui_sprites.build_x_road);
 		this->GetWidget<NWidgetCore>(WID_ROT_ROAD_Y)->SetSprite(rti->gui_sprites.build_y_road);
 		this->GetWidget<NWidgetCore>(WID_ROT_AUTOROAD)->SetSprite(rti->gui_sprites.auto_road);
-		if (_game_mode != GM_EDITOR) {
+		if (_game_mode != GameMode::Editor) {
 			this->GetWidget<NWidgetCore>(WID_ROT_DEPOT)->SetSprite(rti->gui_sprites.build_depot);
 		}
 		this->GetWidget<NWidgetCore>(WID_ROT_CONVERT_ROAD)->SetSprite(rti->gui_sprites.convert_road);
@@ -710,7 +710,7 @@ struct BuildRoadToolbarWindow : Window {
 
 	void OnPlaceObjectAbort() override
 	{
-		if (_game_mode != GM_EDITOR && (this->IsWidgetLowered(WID_ROT_BUS_STATION) || this->IsWidgetLowered(WID_ROT_TRUCK_STATION))) SetViewportCatchmentStation(nullptr, true);
+		if (_game_mode != GameMode::Editor && (this->IsWidgetLowered(WID_ROT_BUS_STATION) || this->IsWidgetLowered(WID_ROT_TRUCK_STATION))) SetViewportCatchmentStation(nullptr, true);
 
 		this->RaiseButtons();
 		this->SetWidgetDisabledState(WID_ROT_REMOVE, true);
@@ -874,7 +874,7 @@ struct BuildRoadToolbarWindow : Window {
 
 	void OnRealtimeTick([[maybe_unused]] uint delta_ms) override
 	{
-		if (_game_mode == GM_NORMAL && this->IsWidgetLowered(WID_ROT_BUILD_WAYPOINT)) CheckRedrawRoadWaypointCoverage(this);
+		if (_game_mode == GameMode::Normal && this->IsWidgetLowered(WID_ROT_BUILD_WAYPOINT)) CheckRedrawRoadWaypointCoverage(this);
 	}
 
 	/**
@@ -888,11 +888,11 @@ struct BuildRoadToolbarWindow : Window {
 	{
 		Window *w = nullptr;
 		switch (_game_mode) {
-			case GM_NORMAL:
+			case GameMode::Normal:
 				w = ShowBuildRoadToolbar(last_build);
 				break;
 
-			case GM_EDITOR:
+			case GameMode::Editor:
 				if (!GetRoadTypes(true).Any(GetMaskForRoadTramType(rtt))) return ES_NOT_HANDLED;
 				w = ShowBuildRoadScenToolbar(last_build);
 				break;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -827,7 +827,7 @@ bool AfterLoadGame()
 	ClearOldOrders();
 
 	/* make sure there is a town in the game */
-	if (_game_mode == GM_NORMAL && Town::GetNumItems() == 0) {
+	if (_game_mode == GameMode::Normal && Town::GetNumItems() == 0) {
 		SetSaveLoadError(STR_ERROR_NO_TOWN_IN_SCENARIO);
 		/* Restore the signals */
 		ResetSignalHandlers();

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -92,7 +92,7 @@ struct AIPLChunkHandler : ChunkHandler {
 			_ai_saveload_version = -1;
 			SlObject(nullptr, slt);
 
-			if (_game_mode == GM_MENU || (_networking && !_network_server)) {
+			if (_game_mode == GameMode::Menu || (_networking && !_network_server)) {
 				if (Company::IsValidAiID(index)) {
 					SlObject(nullptr, _ai_running_desc);
 					AIInstance::LoadEmpty();

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -66,7 +66,7 @@ struct GSDTChunkHandler : ChunkHandler {
 		_game_saveload_version = -1;
 		SlObject(nullptr, slt);
 
-		if (_game_mode == GM_MENU || (_networking && !_network_server)) {
+		if (_game_mode == GameMode::Menu || (_networking && !_network_server)) {
 			GameInstance::LoadEmpty();
 			if (SlIterateArray() != -1) SlErrorCorrupt("Too many GameScript configs");
 			return;

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -124,7 +124,7 @@ struct NGRFChunkHandler : ChunkHandler {
 	{
 		this->LoadCommon(_grfconfig);
 
-		if (_game_mode == GM_MENU) {
+		if (_game_mode == GameMode::Menu) {
 			/* Intro game must not have NewGRF. */
 			if (!_grfconfig.empty()) SlErrorCorrupt("The intro game must not use NewGRF");
 

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -144,7 +144,7 @@ static std::string_view MakeScreenshotName(std::string_view default_fn, std::str
 	bool generate = _screenshot_name.empty();
 
 	if (generate) {
-		if (_game_mode == GM_EDITOR || _game_mode == GM_MENU || _local_company == COMPANY_SPECTATOR) {
+		if (_game_mode == GameMode::Editor || _game_mode == GameMode::Menu || _local_company == COMPANY_SPECTATOR) {
 			_screenshot_name = default_fn;
 		} else {
 			_screenshot_name = GenerateDefaultSaveName();

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -85,7 +85,7 @@ public:
 		message.reserve(1024);
 		format_append(message, "Graphics set: {} ({})\n", BaseGraphics::GetUsedSet()->name, fmt::join(BaseGraphics::GetUsedSet()->version, "."));
 		message += "NewGRFs:\n";
-		if (_game_mode != GM_MENU) {
+		if (_game_mode != GameMode::Menu) {
 			for (const auto &c : _grfconfig) {
 				format_append(message, "{:08X} {} {}\n", std::byteswap(c->ident.grfid), FormatArrayAsHex(c->ident.md5sum), c->filename);
 			}

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -174,7 +174,7 @@ struct ScriptListWindow : public Window {
 			std::advance(it, this->selected);
 			GetConfig(this->slot)->Change(it->second->GetName(), it->second->GetVersion());
 		}
-		if (_game_mode == GM_EDITOR) {
+		if (_game_mode == GameMode::Editor) {
 			if (this->slot == OWNER_DEITY) {
 				if (Game::GetInstance() != nullptr) Game::ResetInstance();
 				Game::StartNew();
@@ -229,7 +229,7 @@ struct ScriptListWindow : public Window {
 	 */
 	void OnInvalidateData([[maybe_unused]] int data = 0, [[maybe_unused]] bool gui_scope = true) override
 	{
-		if (_game_mode == GM_NORMAL && Company::IsValidID(this->slot)) {
+		if (_game_mode == GameMode::Normal && Company::IsValidID(this->slot)) {
 			this->Close();
 			return;
 		}
@@ -477,7 +477,7 @@ struct ScriptSettingsWindow : public Window {
 			}
 
 			case WID_SCRS_RESET:
-				this->script_config->ResetEditableSettings(_game_mode == GM_MENU || ((this->slot != OWNER_DEITY) && !Company::IsValidID(this->slot)));
+				this->script_config->ResetEditableSettings(_game_mode == GameMode::Menu || ((this->slot != OWNER_DEITY) && !Company::IsValidID(this->slot)));
 				this->SetDirty();
 				break;
 		}
@@ -538,8 +538,8 @@ struct ScriptSettingsWindow : public Window {
 private:
 	bool IsEditableItem(const ScriptConfigItem &config_item) const
 	{
-		return _game_mode == GM_MENU
-			|| _game_mode == GM_EDITOR
+		return _game_mode == GameMode::Menu
+			|| _game_mode == GameMode::Editor
 			|| ((this->slot != OWNER_DEITY) && !Company::IsValidID(this->slot))
 			|| config_item.flags.Test(ScriptConfigFlag::InGame)
 			|| _settings_client.gui.ai_developer_tools;
@@ -548,7 +548,7 @@ private:
 	void SetValue(int value)
 	{
 		const ScriptConfigItem &config_item = *this->visible_settings[this->clicked_row];
-		if (_game_mode == GM_NORMAL && ((this->slot == OWNER_DEITY) || Company::IsValidID(this->slot)) && !config_item.flags.Test(ScriptConfigFlag::InGame)) return;
+		if (_game_mode == GameMode::Normal && ((this->slot == OWNER_DEITY) || Company::IsValidID(this->slot)) && !config_item.flags.Test(ScriptConfigFlag::InGame)) return;
 		this->script_config->SetSetting(config_item.name, value);
 		this->SetDirty();
 	}
@@ -1164,7 +1164,7 @@ struct ScriptDebugWindow : public Window {
 	 */
 	static EventState ScriptDebugGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GM_NORMAL) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
 		Window *w = ShowScriptDebugWindow(CompanyID::Invalid());
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -246,7 +246,7 @@ bool SettingEntry::UpdateFilterState(SettingFilter &filter, bool force_visible)
 const void *ResolveObject(const GameSettings *settings_ptr, const IntSettingDesc *sd)
 {
 	if (sd->flags.Test(SettingFlag::PerCompany)) {
-		if (Company::IsValidID(_local_company) && _game_mode != GM_MENU) {
+		if (Company::IsValidID(_local_company) && _game_mode != GameMode::Menu) {
 			return &Company::Get(_local_company)->settings;
 		}
 		return &_settings_client.company;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -896,12 +896,12 @@ bool SettingDesc::IsEditable(bool do_command) const
 {
 	if (!do_command && !this->flags.Test(SettingFlag::NoNetworkSync) && _networking && !_network_server && !this->flags.Test(SettingFlag::PerCompany)) return false;
 	if (do_command && this->flags.Test(SettingFlag::NoNetworkSync)) return false;
-	if (this->flags.Test(SettingFlag::NetworkOnly) && !_networking && _game_mode != GM_MENU) return false;
+	if (this->flags.Test(SettingFlag::NetworkOnly) && !_networking && _game_mode != GameMode::Menu) return false;
 	if (this->flags.Test(SettingFlag::NoNetwork) && _networking) return false;
 	if (this->flags.Test(SettingFlag::NewgameOnly) &&
-			(_game_mode == GM_NORMAL ||
-			(_game_mode == GM_EDITOR && !this->flags.Test(SettingFlag::SceneditToo)))) return false;
-	if (this->flags.Test(SettingFlag::SceneditOnly) && _game_mode != GM_EDITOR) return false;
+			(_game_mode == GameMode::Normal ||
+			(_game_mode == GameMode::Editor && !this->flags.Test(SettingFlag::SceneditToo)))) return false;
+	if (this->flags.Test(SettingFlag::SceneditOnly) && _game_mode != GameMode::Editor) return false;
 	return true;
 }
 
@@ -1824,7 +1824,7 @@ bool SetSettingValue(const IntSettingDesc *sd, int32_t value, bool force_newgame
 {
 	const IntSettingDesc *setting = sd->AsIntSetting();
 	if (setting->flags.Test(SettingFlag::PerCompany)) {
-		if (Company::IsValidID(_local_company) && _game_mode != GM_MENU) {
+		if (Company::IsValidID(_local_company) && _game_mode != GameMode::Menu) {
 			return Command<Commands::ChangeCompanySetting>::Post(setting->GetName(), value);
 		}
 
@@ -1837,7 +1837,7 @@ bool SetSettingValue(const IntSettingDesc *sd, int32_t value, bool force_newgame
 	 * of settings because changing a company-based setting in a game also
 	 * changes its defaults. At least that is the convention we have chosen */
 	if (setting->flags.Test(SettingFlag::NoNetworkSync)) {
-		if (_game_mode != GM_MENU) {
+		if (_game_mode != GameMode::Menu) {
 			setting->ChangeValue(&_settings_newgame, value);
 		}
 		setting->ChangeValue(&GetGameSettings(), value);
@@ -1906,7 +1906,7 @@ bool SetSettingValue(const StringSettingDesc *sd, std::string_view value, bool f
 		value = {};
 	}
 
-	const void *object = (_game_mode == GM_MENU || force_newgame) ? &_settings_newgame : &_settings_game;
+	const void *object = (_game_mode == GameMode::Menu || force_newgame) ? &_settings_newgame : &_settings_game;
 	sd->AsStringSetting()->ChangeValue(object, std::string{value});
 	return true;
 }
@@ -1983,7 +1983,7 @@ void IConsoleGetSetting(std::string_view name, bool force_newgame)
 		return;
 	}
 
-	const void *object = (_game_mode == GM_MENU || force_newgame) ? &_settings_newgame : &_settings_game;
+	const void *object = (_game_mode == GameMode::Menu || force_newgame) ? &_settings_newgame : &_settings_game;
 
 	if (sd->IsStringSetting()) {
 		IConsolePrint(CC_INFO, "Current value for '{}' is '{}'.", sd->GetName(), sd->AsStringSetting()->Read(object));

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -477,7 +477,7 @@ struct GameOptionsWindow : Window {
 		switch (widget) {
 			case WID_GO_CURRENCY_DROPDOWN: { // Setup currencies dropdown
 				*selected_index = this->opt->locale.currency;
-				uint64_t disabled = _game_mode == GM_MENU ? 0LL : ~GetMaskOfAllowedCurrencies();
+				uint64_t disabled = _game_mode == GameMode::Menu ? 0LL : ~GetMaskOfAllowedCurrencies();
 
 				/* Add non-custom currencies; sorted naturally */
 				for (const CurrencySpec &currency : _currency_specs) {
@@ -581,8 +581,8 @@ struct GameOptionsWindow : Window {
 
 			case WID_GO_TYPE_DROPDOWN:
 				list.push_back(MakeDropDownListStringItem(STR_CONFIG_SETTING_TYPE_DROPDOWN_ALL, ST_ALL));
-				list.push_back(MakeDropDownListStringItem(_game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_INGAME, ST_GAME));
-				list.push_back(MakeDropDownListStringItem(_game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_INGAME, ST_COMPANY));
+				list.push_back(MakeDropDownListStringItem(_game_mode == GameMode::Menu ? STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_INGAME, ST_GAME));
+				list.push_back(MakeDropDownListStringItem(_game_mode == GameMode::Menu ? STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_INGAME, ST_COMPANY));
 				list.push_back(MakeDropDownListStringItem(STR_CONFIG_SETTING_TYPE_DROPDOWN_CLIENT, ST_CLIENT));
 				break;
 		}
@@ -641,10 +641,10 @@ struct GameOptionsWindow : Window {
 
 			case WID_GO_TYPE_DROPDOWN:
 				switch (this->filter.type) {
-					case ST_GAME:    return GetString(_game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_INGAME);
-					case ST_COMPANY: return GetString(_game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_INGAME);
-					case ST_CLIENT:  return GetString(STR_CONFIG_SETTING_TYPE_DROPDOWN_CLIENT);
-					default:         return GetString(STR_CONFIG_SETTING_TYPE_DROPDOWN_ALL);
+					case ST_GAME: return GetString(_game_mode == GameMode::Menu ? STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_INGAME);
+					case ST_COMPANY: return GetString(_game_mode == GameMode::Menu ? STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_INGAME);
+					case ST_CLIENT: return GetString(STR_CONFIG_SETTING_TYPE_DROPDOWN_CLIENT);
+					default: return GetString(STR_CONFIG_SETTING_TYPE_DROPDOWN_ALL);
 				}
 				break;
 
@@ -725,9 +725,9 @@ struct GameOptionsWindow : Window {
 					Rect tr = r;
 					std::string str;
 					switch (sd->GetType()) {
-						case ST_COMPANY: str = GetString(STR_CONFIG_SETTING_TYPE, _game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_COMPANY_MENU : STR_CONFIG_SETTING_TYPE_COMPANY_INGAME); break;
-						case ST_CLIENT:  str = GetString(STR_CONFIG_SETTING_TYPE, STR_CONFIG_SETTING_TYPE_CLIENT); break;
-						case ST_GAME:    str = GetString(STR_CONFIG_SETTING_TYPE, _game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_GAME_MENU : STR_CONFIG_SETTING_TYPE_GAME_INGAME); break;
+						case ST_COMPANY: str = GetString(STR_CONFIG_SETTING_TYPE, _game_mode == GameMode::Menu ? STR_CONFIG_SETTING_TYPE_COMPANY_MENU : STR_CONFIG_SETTING_TYPE_COMPANY_INGAME); break;
+						case ST_CLIENT: str = GetString(STR_CONFIG_SETTING_TYPE, STR_CONFIG_SETTING_TYPE_CLIENT); break;
+						case ST_GAME: str = GetString(STR_CONFIG_SETTING_TYPE, _game_mode == GameMode::Menu ? STR_CONFIG_SETTING_TYPE_GAME_MENU : STR_CONFIG_SETTING_TYPE_GAME_INGAME); break;
 						default: NOT_REACHED();
 					}
 					DrawString(tr, str);
@@ -1100,8 +1100,8 @@ struct GameOptionsWindow : Window {
 				if (used_set == nullptr || !used_set->IsConfigurable()) break;
 				GRFConfig &extra_cfg = used_set->GetOrCreateExtraConfig();
 				if (extra_cfg.param.empty()) extra_cfg.SetParameterDefaults();
-				OpenGRFParameterWindow(true, extra_cfg, _game_mode == GM_MENU);
-				if (_game_mode == GM_MENU) this->reload = true;
+				OpenGRFParameterWindow(true, extra_cfg, _game_mode == GameMode::Menu);
+				if (_game_mode == GameMode::Menu) this->reload = true;
 				break;
 			}
 
@@ -1462,7 +1462,7 @@ struct GameOptionsWindow : Window {
 			}
 
 			case WID_GO_BASE_GRF_DROPDOWN:
-				if (_game_mode == GM_MENU) {
+				if (_game_mode == GameMode::Menu) {
 					CloseWindowByClass(WindowClass::NewGRFParameters);
 					auto set = BaseGraphics::GetSet(index);
 					BaseGraphics::SetSet(set);
@@ -1558,7 +1558,7 @@ struct GameOptionsWindow : Window {
 		this->SetWidgetDisabledState(WID_GO_GUI_FONT_AA, _fcsettings.prefer_sprite);
 #endif /* HAS_TRUETYPE_FONT */
 
-		this->SetWidgetDisabledState(WID_GO_BASE_GRF_DROPDOWN, _game_mode != GM_MENU);
+		this->SetWidgetDisabledState(WID_GO_BASE_GRF_DROPDOWN, _game_mode != GameMode::Menu);
 
 		this->SetWidgetDisabledState(WID_GO_BASE_GRF_PARAMETERS, BaseGraphics::GetUsedSet() == nullptr || !BaseGraphics::GetUsedSet()->IsConfigurable());
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -87,13 +87,13 @@ SettingTable _win32_settings{ _win32_settings_table };
 /** Switch setting title depending on wallclock setting. @copydoc IntSettingDesc::GetTitleCallback */
 static StringID SettingTitleWallclock(const IntSettingDesc &sd)
 {
-	return TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU) ? sd.str + 1 : sd.str;
+	return TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu) ? sd.str + 1 : sd.str;
 }
 
 /** Switch setting help depending on wallclock setting. @copydoc IntSettingDesc::GetHelpCallback */
 static StringID SettingHelpWallclock(const IntSettingDesc &sd)
 {
-	return TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU) ? sd.str_help + 1 : sd.str_help;
+	return TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu) ? sd.str_help + 1 : sd.str_help;
 }
 
 /** Setting values for velocity unit localisation. @copydoc IntSettingDesc::GetValueParamsCallback */
@@ -104,7 +104,7 @@ static std::pair<StringParameter, StringParameter> SettingsValueVelocityUnit([[m
 		case 0: val = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_IMPERIAL; break;
 		case 1: val = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_METRIC; break;
 		case 2: val = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_SI; break;
-		case 3: val = TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU) ? STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_GAMEUNITS_SECS : STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_GAMEUNITS_DAYS; break;
+		case 3: val = TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu) ? STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_GAMEUNITS_SECS : STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_GAMEUNITS_DAYS; break;
 		case 4: val = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_KNOTS; break;
 		default: NOT_REACHED();
 	}
@@ -121,7 +121,7 @@ static std::pair<StringParameter, StringParameter> SettingsValueAbsolute(const I
 static std::pair<StringParameter, StringParameter> ServiceIntervalSettingsValueText(const IntSettingDesc &sd, int32_t value)
 {
 	VehicleDefaultSettings *vds;
-	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
+	if (_game_mode == GameMode::Menu || !Company::IsValidID(_current_company)) {
 		vds = &_settings_client.company.vehicle;
 	} else {
 		vds = &Company::Get(_current_company)->settings.vehicle;
@@ -132,7 +132,7 @@ static std::pair<StringParameter, StringParameter> ServiceIntervalSettingsValueT
 		str = sd.str_val + 3;
 	} else if (vds->servint_ispercent) {
 		str = sd.str_val + 2;
-	} else if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
+	} else if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu)) {
 		str = sd.str_val + 1;
 	} else {
 		str = sd.str_val;
@@ -143,13 +143,13 @@ static std::pair<StringParameter, StringParameter> ServiceIntervalSettingsValueT
 /** Reposition the main toolbar as the setting changed. */
 static void v_PositionMainToolbar(int32_t)
 {
-	if (_game_mode != GM_MENU) PositionMainToolbar(nullptr);
+	if (_game_mode != GameMode::Menu) PositionMainToolbar(nullptr);
 }
 
 /** Reposition the statusbar as the setting changed. */
 static void v_PositionStatusbar(int32_t)
 {
-	if (_game_mode != GM_MENU) {
+	if (_game_mode != GameMode::Menu) {
 		PositionStatusbar(nullptr);
 		PositionNewsMessage(nullptr);
 		PositionNetworkChatWindow(nullptr);
@@ -196,7 +196,7 @@ static void UpdateAllServiceInterval(int32_t new_value)
 {
 	bool update_vehicles;
 	VehicleDefaultSettings *vds;
-	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
+	if (_game_mode == GameMode::Menu || !Company::IsValidID(_current_company)) {
 		vds = &_settings_client.company.vehicle;
 		update_vehicles = false;
 	} else {
@@ -210,7 +210,7 @@ static void UpdateAllServiceInterval(int32_t new_value)
 		vds->servint_roadveh  = DEF_SERVINT_PERCENT;
 		vds->servint_aircraft = DEF_SERVINT_PERCENT;
 		vds->servint_ships    = DEF_SERVINT_PERCENT;
-	} else if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
+	} else if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu)) {
 		/* Service intervals are in minutes. */
 		vds->servint_trains   = DEF_SERVINT_MINUTES_TRAINS;
 		vds->servint_roadveh  = DEF_SERVINT_MINUTES_ROADVEH;
@@ -240,7 +240,7 @@ static void UpdateAllServiceInterval(int32_t new_value)
 static bool CanUpdateServiceInterval(VehicleType, int32_t &new_value)
 {
 	VehicleDefaultSettings *vds;
-	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
+	if (_game_mode == GameMode::Menu || !Company::IsValidID(_current_company)) {
 		vds = &_settings_client.company.vehicle;
 	} else {
 		vds = &Company::Get(_current_company)->settings.vehicle;
@@ -253,7 +253,7 @@ static bool CanUpdateServiceInterval(VehicleType, int32_t &new_value)
 
 static void UpdateServiceInterval(VehicleType type, int32_t new_value)
 {
-	if (_game_mode != GM_MENU && Company::IsValidID(_current_company)) {
+	if (_game_mode != GameMode::Menu && Company::IsValidID(_current_company)) {
 		for (Vehicle *v : Vehicle::Iterate()) {
 			if (v->owner == _current_company && v->type == type && v->IsPrimaryVehicle() && !v->ServiceIntervalIsCustom()) {
 				v->SetServiceInterval(new_value);
@@ -273,7 +273,7 @@ static void UpdateServiceInterval(VehicleType type, int32_t new_value)
 static int32_t GetDefaultServiceInterval(const IntSettingDesc &sd, VehicleType type)
 {
 	VehicleDefaultSettings *vds;
-	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
+	if (_game_mode == GameMode::Menu || !Company::IsValidID(_current_company)) {
 		vds = &_settings_client.company.vehicle;
 	} else {
 		vds = &Company::Get(_current_company)->settings.vehicle;
@@ -281,7 +281,7 @@ static int32_t GetDefaultServiceInterval(const IntSettingDesc &sd, VehicleType t
 
 	if (vds->servint_ispercent) return DEF_SERVINT_PERCENT;
 
-	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
+	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu)) {
 		switch (type) {
 			case VehicleType::Train: return DEF_SERVINT_MINUTES_TRAINS;
 			case VehicleType::Road: return DEF_SERVINT_MINUTES_ROADVEH;
@@ -297,7 +297,7 @@ static int32_t GetDefaultServiceInterval(const IntSettingDesc &sd, VehicleType t
 static std::tuple<int32_t, uint32_t> GetServiceIntervalRange(const IntSettingDesc &)
 {
 	VehicleDefaultSettings *vds;
-	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
+	if (_game_mode == GameMode::Menu || !Company::IsValidID(_current_company)) {
 		vds = &_settings_client.company.vehicle;
 	} else {
 		vds = &Company::Get(_current_company)->settings.vehicle;
@@ -305,7 +305,7 @@ static std::tuple<int32_t, uint32_t> GetServiceIntervalRange(const IntSettingDes
 
 	if (vds->servint_ispercent) return { MIN_SERVINT_PERCENT, MAX_SERVINT_PERCENT };
 
-	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) {
+	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu)) {
 		return { MIN_SERVINT_MINUTES, MAX_SERVINT_MINUTES };
 	}
 
@@ -386,7 +386,7 @@ static void AircraftRangeChanged(int32_t)
 
 static void TownFoundingChanged(int32_t)
 {
-	if (_game_mode != GM_EDITOR && _settings_game.economy.found_town == TF_FORBIDDEN) {
+	if (_game_mode != GameMode::Editor && _settings_game.economy.found_town == TF_FORBIDDEN) {
 		CloseWindowById(WindowClass::FoundTown, 0);
 	} else {
 		InvalidateWindowData(WindowClass::FoundTown, 0);
@@ -430,7 +430,7 @@ static void InvalidateCompanyLiveryWindow(int32_t)
 
 static void DifficultyNoiseChange(int32_t)
 {
-	if (_game_mode == GM_NORMAL) {
+	if (_game_mode == GameMode::Normal) {
 		UpdateAirportsNoise();
 		if (_settings_game.economy.station_noise_level) {
 			InvalidateWindowClassesData(WindowClass::TownView, 0);
@@ -455,7 +455,7 @@ static void MaxNoAIsChange(int32_t)
  */
 static bool CheckRoadSide(int32_t &)
 {
-	return _game_mode == GM_MENU || !RoadVehiclesAreBuilt();
+	return _game_mode == GameMode::Menu || !RoadVehiclesAreBuilt();
 }
 
 /**
@@ -474,7 +474,7 @@ static std::optional<uint32_t> ConvertLandscape(std::string_view value)
 
 static bool CheckFreeformEdges(int32_t &new_value)
 {
-	if (_game_mode == GM_MENU) return true;
+	if (_game_mode == GameMode::Menu) return true;
 	if (new_value != 0) {
 		for (Ship *s : Ship::Iterate()) {
 			/* Check if there is a ship on the northern border. */
@@ -521,7 +521,7 @@ static bool CheckFreeformEdges(int32_t &new_value)
 
 static void UpdateFreeformEdges(int32_t new_value)
 {
-	if (_game_mode == GM_MENU) return;
+	if (_game_mode == GameMode::Menu) return;
 
 	if (new_value != 0) {
 		for (uint x = 0; x < Map::SizeX(); x++) MakeVoid(TileXY(x, 0));
@@ -547,7 +547,7 @@ static void UpdateFreeformEdges(int32_t new_value)
  */
 static bool CheckDynamicEngines([[maybe_unused]] int32_t &value)
 {
-	if (_game_mode == GM_MENU) return true;
+	if (_game_mode == GameMode::Menu) return true;
 
 	if (!EngineOverrideManager::ResetToCurrentNewGRFConfig()) {
 		ShowErrorMessage(GetEncodedString(STR_CONFIG_SETTING_DYNAMIC_ENGINES_EXISTING_VEHICLES), {}, WarningLevel::Error);
@@ -559,8 +559,8 @@ static bool CheckDynamicEngines([[maybe_unused]] int32_t &value)
 
 static bool CheckMaxHeightLevel(int32_t &new_value)
 {
-	if (_game_mode == GM_NORMAL) return false;
-	if (_game_mode != GM_EDITOR) return true;
+	if (_game_mode == GameMode::Normal) return false;
+	if (_game_mode != GameMode::Editor) return true;
 
 	/* Check if at least one mountain on the map is higher than the new value.
 	 * If yes, disallow the change. */
@@ -628,7 +628,7 @@ static void ChangeTimekeepingUnits()
 	InvalidateWindowClassesData(WindowClass::GameOptions, 0);
 
 	/* It is possible to change these units in Scenario Editor. We must set the economy date appropriately. */
-	if (_game_mode == GM_EDITOR) {
+	if (_game_mode == GameMode::Editor) {
 		TimerGameEconomy::Date new_economy_date;
 		TimerGameEconomy::DateFract new_economy_date_fract;
 
@@ -669,7 +669,7 @@ static void ChangeMinutesPerYear(int32_t new_value)
 		}
 
 		/* Override the setting with the clamped value. */
-		if (_game_mode == GM_MENU) {
+		if (_game_mode == GameMode::Menu) {
 			_settings_newgame.economy.minutes_per_calendar_year = clamped;
 		} else {
 			_settings_game.economy.minutes_per_calendar_year = clamped;
@@ -679,7 +679,7 @@ static void ChangeMinutesPerYear(int32_t new_value)
 	/* If the setting value is not the default, force the game to use wallclock timekeeping units.
 	 * This can only happen in the menu, since the pre_cb ensures this setting can only be changed there, or if we're already using wallclock units.
 	 */
-	if (_game_mode == GM_MENU && (_settings_newgame.economy.minutes_per_calendar_year != CalendarTime::DEF_MINUTES_PER_YEAR)) {
+	if (_game_mode == GameMode::Menu && (_settings_newgame.economy.minutes_per_calendar_year != CalendarTime::DEF_MINUTES_PER_YEAR)) {
 		if (_settings_newgame.economy.timekeeping_units != TimekeepingUnits::Wallclock) {
 			_settings_newgame.economy.timekeeping_units = TimekeepingUnits::Wallclock;
 			ChangeTimekeepingUnits();
@@ -691,7 +691,7 @@ static void ChangeMinutesPerYear(int32_t new_value)
 static std::tuple<int32_t, uint32_t> GetMinutesPerYearRange(const IntSettingDesc &)
 {
 	/* Allow a non-default value only if using Wallclock timekeeping units. */
-	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU)) return { CalendarTime::FROZEN_MINUTES_PER_YEAR, CalendarTime::MAX_MINUTES_PER_YEAR };
+	if (TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu)) return { CalendarTime::FROZEN_MINUTES_PER_YEAR, CalendarTime::MAX_MINUTES_PER_YEAR };
 
 	return { CalendarTime::DEF_MINUTES_PER_YEAR, CalendarTime::DEF_MINUTES_PER_YEAR };
 }

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -721,7 +721,7 @@ extern VehicleDefaultSettings _old_vds;
  */
 inline GameSettings &GetGameSettings()
 {
-	return (_game_mode == GM_MENU) ? _settings_newgame : _settings_game;
+	return (_game_mode == GameMode::Menu) ? _settings_newgame : _settings_game;
 }
 
 #endif /* SETTINGS_TYPE_H */

--- a/src/signs.cpp
+++ b/src/signs.cpp
@@ -61,6 +61,6 @@ void UpdateAllSignVirtCoords()
  */
 bool CompanyCanEditSign(const Sign *si)
 {
-	if (si->owner == OWNER_DEITY && _current_company != OWNER_DEITY && _game_mode != GM_EDITOR) return false;
+	if (si->owner == OWNER_DEITY && _current_company != OWNER_DEITY && _game_mode != GameMode::Editor) return false;
 	return true;
 }

--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -45,7 +45,7 @@ std::tuple<CommandCost, SignID> CmdPlaceSign(DoCommandFlags flags, TileIndex til
 		int x = TileX(tile) * TILE_SIZE;
 		int y = TileY(tile) * TILE_SIZE;
 
-		Sign *si = Sign::Create(_game_mode == GM_EDITOR ? OWNER_DEITY : _current_company, x, y, GetSlopePixelZ(x, y), text);
+		Sign *si = Sign::Create(_game_mode == GameMode::Editor ? OWNER_DEITY : _current_company, x, y, GetSlopePixelZ(x, y), text);
 
 		si->UpdateVirtCoord();
 		InvalidateWindowData(WindowClass::SignList, 0, 0);
@@ -79,7 +79,7 @@ CommandCost CmdRenameSign(DoCommandFlags flags, SignID sign_id, const std::strin
 			/* Assign the new one */
 			si->name = text;
 			if (text_colour != Colours::Invalid) si->text_colour = text_colour;
-			if (_game_mode != GM_EDITOR) si->owner = _current_company;
+			if (_game_mode != GameMode::Editor) si->owner = _current_company;
 
 			si->UpdateVirtCoord();
 			InvalidateWindowData(WindowClass::SignList, 0, 1);
@@ -119,7 +119,7 @@ CommandCost CmdMoveSign(DoCommandFlags flags, SignID sign_id, TileIndex tile)
 		si->x = x;
 		si->y = y;
 		si->z = GetSlopePixelZ(x, y);
-		if (_game_mode != GM_EDITOR) si->owner = _current_company;
+		if (_game_mode != GameMode::Editor) si->owner = _current_company;
 
 		si->UpdateVirtCoord();
 	}

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -125,7 +125,7 @@ struct SignList {
 	void FilterSignList()
 	{
 		this->signs.Filter(&SignNameFilter, this->string_filter);
-		if (_game_mode != GM_EDITOR) this->signs.Filter(&OwnerDeityFilter, this->string_filter);
+		if (_game_mode != GameMode::Editor) this->signs.Filter(&OwnerDeityFilter, this->string_filter);
 		if (!_display_opt.Test(DisplayOption::ShowCompetitorSigns)) {
 			this->signs.Filter(&OwnerVisibilityFilter, this->string_filter);
 		}
@@ -322,7 +322,7 @@ struct SignListWindow : Window, SignList {
 	 */
 	static EventState SignListGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode == GM_MENU) return ES_NOT_HANDLED;
+		if (_game_mode == GameMode::Menu) return ES_NOT_HANDLED;
 		Window *w = ShowSignList();
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);
@@ -418,7 +418,7 @@ struct SignWindow : Window, SignList {
 
 		this->InitNested(QueryStringWindowNumber::Sign);
 
-		if (_game_mode != GameMode::GM_EDITOR) {
+		if (_game_mode != GameMode::Editor) {
 			this->GetWidget<NWidgetStacked>(WID_QES_COLOUR_PANE)->SetDisplayedPlane(SZSP_VERTICAL);
 			this->ReInit();
 		}
@@ -630,7 +630,7 @@ void HandleClickOnSign(const Sign *si)
 	/* If we can't edit the sign, don't even open the rename GUI. */
 	if (!CompanyCanEditSign(si)) return;
 
-	if (_ctrl_pressed && (si->owner == _local_company || (si->owner == OWNER_DEITY && _game_mode == GM_EDITOR))) {
+	if (_ctrl_pressed && (si->owner == _local_company || (si->owner == OWNER_DEITY && _game_mode == GameMode::Editor))) {
 		RenameSign(si->index, "", Colours::Invalid);
 		return;
 	}

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3445,7 +3445,7 @@ static void DrawTile_Station(TileInfo *ti)
 			DrawGroundSprite(image, PAL_NONE);
 			DrawGroundSprite(ground + overlay_offset, PAL_NONE);
 
-			if (_game_mode != GM_MENU && _settings_client.gui.show_track_reservation && HasStationReservation(ti->tile)) {
+			if (_game_mode != GameMode::Menu && _settings_client.gui.show_track_reservation && HasStationReservation(ti->tile)) {
 				SpriteID overlay = GetCustomRailSprite(rti, ti->tile, RailSpriteType::Overlay);
 				DrawGroundSprite(overlay + overlay_offset, PALETTE_CRASH);
 			}
@@ -3455,7 +3455,7 @@ static void DrawTile_Station(TileInfo *ti)
 			DrawGroundSprite(image, GroundSpritePaletteTransform(image, pal, palette));
 
 			/* PBS debugging, draw reserved tracks darker */
-			if (_game_mode != GM_MENU && _settings_client.gui.show_track_reservation && HasStationRail(ti->tile) && HasStationReservation(ti->tile)) {
+			if (_game_mode != GameMode::Menu && _settings_client.gui.show_track_reservation && HasStationRail(ti->tile) && HasStationReservation(ti->tile)) {
 				DrawGroundSprite(GetRailStationAxis(ti->tile) == Axis::X ? rti->base_sprites.single_x : rti->base_sprites.single_y, PALETTE_CRASH);
 			}
 		}
@@ -4361,7 +4361,7 @@ static void StationHandleSmallTick(BaseStation *st)
 
 void OnTick_Station()
 {
-	if (_game_mode == GM_EDITOR) return;
+	if (_game_mode == GameMode::Editor) return;
 
 	for (BaseStation *st : BaseStation::Iterate()) {
 		StationHandleSmallTick(st);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1579,7 +1579,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 				}
 
 				case SCC_UNITS_DAYS_OR_SECONDS: { // {UNITS_DAYS_OR_SECONDS}
-					uint8_t realtime = TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU);
+					uint8_t realtime = TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu);
 					const auto &x = _units_time_days_or_seconds[realtime];
 					auto tmp_params = MakeParameters(x.c.ToDisplay(args.GetNextParameter<int64_t>()), x.decimal_places);
 					FormatString(builder, GetStringPtr(x.s), tmp_params);
@@ -1587,7 +1587,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 				}
 
 				case SCC_UNITS_MONTHS_OR_MINUTES: { // {UNITS_MONTHS_OR_MINUTES}
-					uint8_t realtime = TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU);
+					uint8_t realtime = TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu);
 					const auto &x = _units_time_months_or_minutes[realtime];
 					auto tmp_params = MakeParameters(x.c.ToDisplay(args.GetNextParameter<int64_t>()), x.decimal_places);
 					FormatString(builder, GetStringPtr(x.s), tmp_params);
@@ -1595,7 +1595,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 				}
 
 				case SCC_UNITS_YEARS_OR_PERIODS: { // {UNITS_YEARS_OR_PERIODS}
-					uint8_t realtime = TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU);
+					uint8_t realtime = TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu);
 					const auto &x = _units_time_years_or_periods[realtime];
 					auto tmp_params = MakeParameters(x.c.ToDisplay(args.GetNextParameter<int64_t>()), x.decimal_places);
 					FormatString(builder, GetStringPtr(x.s), tmp_params);
@@ -1603,7 +1603,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 				}
 
 				case SCC_UNITS_YEARS_OR_MINUTES: { // {UNITS_YEARS_OR_MINUTES}
-					uint8_t realtime = TimerGameEconomy::UsingWallclockUnits(_game_mode == GM_MENU);
+					uint8_t realtime = TimerGameEconomy::UsingWallclockUnits(_game_mode == GameMode::Menu);
 					const auto &x = _units_time_years_or_minutes[realtime];
 					auto tmp_params = MakeParameters(x.c.ToDisplay(args.GetNextParameter<int64_t>()), x.decimal_places);
 					FormatString(builder, GetStringPtr(x.s), tmp_params);

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -342,7 +342,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_MINUTES_PER_YEAR
 strhelp  = STR_CONFIG_SETTING_MINUTES_PER_YEAR_HELPTEXT
 strval   = STR_CONFIG_SETTING_MINUTES_PER_YEAR_VALUE
-pre_cb   = [](auto) { return _game_mode == GM_MENU || _settings_game.economy.timekeeping_units == TimekeepingUnits::Wallclock; }
+pre_cb   = [](auto) { return _game_mode == GameMode::Menu || _settings_game.economy.timekeeping_units == TimekeepingUnits::Wallclock; }
 post_cb  = ChangeMinutesPerYear
 range_cb = GetMinutesPerYearRange
 cat      = SC_BASIC

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -255,7 +255,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlags flags,
 
 			/* Check tiletype-specific things, and add extra-cost */
 			Backup<bool> old_generating_world(_generating_world);
-			if (_game_mode == GM_EDITOR) old_generating_world.Change(true); // used to create green terraformed land
+			if (_game_mode == GameMode::Editor) old_generating_world.Change(true); // used to create green terraformed land
 			DoCommandFlags tile_flags = flags | DoCommandFlag::Auto | DoCommandFlag::ForceClearTile;
 			if (pass == 0) {
 				tile_flags.Reset(DoCommandFlag::Execute);

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -62,7 +62,7 @@ void CcTerraform(Commands, const CommandCost &result, Money, TileIndex tile)
  */
 static void GenerateDesertArea(TileIndex end, TileIndex start)
 {
-	if (_game_mode != GM_EDITOR) return;
+	if (_game_mode != GameMode::Editor) return;
 
 	Backup<bool> old_generating_world(_generating_world, true);
 
@@ -83,7 +83,7 @@ static void GenerateDesertArea(TileIndex end, TileIndex start)
  */
 static void GenerateRockyArea(TileIndex end, TileIndex start)
 {
-	if (_game_mode != GM_EDITOR) return;
+	if (_game_mode != GameMode::Editor) return;
 
 	bool success = false;
 	TileArea ta(start, end);
@@ -307,7 +307,7 @@ struct TerraformToolbarWindow : Window {
 	 */
 	static EventState TerraformToolbarGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GM_NORMAL) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
 		Window *w = ShowTerraformToolbar(nullptr);
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);
@@ -727,7 +727,7 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 	 */
 	static EventState TerraformToolbarEditorGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GM_EDITOR) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Editor) return ES_NOT_HANDLED;
 		Window *w = ShowEditorTerraformToolbar();
 		if (w == nullptr) return ES_NOT_HANDLED;
 		return w->OnHotkey(hotkey);

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -41,7 +41,7 @@ static std::vector<TextEffect> _text_effects; ///< Text effects are stored there
 /* Text Effects */
 TextEffectID AddTextEffect(EncodedString &&msg, int center, int y, uint8_t duration, TextEffectMode mode)
 {
-	if (_game_mode == GM_MENU) return INVALID_TE_ID;
+	if (_game_mode == GameMode::Menu) return INVALID_TE_ID;
 
 	auto it = std::ranges::find_if(_text_effects, [](const TextEffect &te) { return !te.IsValid(); });
 	if (it == std::end(_text_effects)) {
@@ -90,7 +90,7 @@ void RemoveTextEffect(TextEffectID te_id)
 
 /** Slowly move text effects upwards. */
 const IntervalTimer<TimerWindow> move_all_text_effects_interval = {std::chrono::milliseconds(30), [](uint count) {
-	if (_pause_mode.Any() && _game_mode != GM_EDITOR && _settings_game.construction.command_pause_level <= CommandPauseLevel::NoConstruction) return;
+	if (_pause_mode.Any() && _game_mode != GameMode::Editor && _settings_game.construction.command_pause_level <= CommandPauseLevel::NoConstruction) return;
 
 	for (TextEffect &te : _text_effects) {
 		if (!te.IsValid()) continue;

--- a/src/timer/timer_game_calendar.cpp
+++ b/src/timer/timer_game_calendar.cpp
@@ -93,7 +93,7 @@ void TimeoutTimer<TimerGameCalendar>::Elapsed(TimerGameCalendar::TElapsed trigge
 template <>
 bool TimerManager<TimerGameCalendar>::Elapsed(TimerGameCalendar::TElapsed)
 {
-	if (_game_mode == GM_MENU) return false;
+	if (_game_mode == GameMode::Menu) return false;
 
 	/* If calendar day progress is frozen, don't try to advance time. */
 	if (_settings_game.economy.minutes_per_calendar_year == CalendarTime::FROZEN_MINUTES_PER_YEAR) return false;

--- a/src/timer/timer_game_economy.cpp
+++ b/src/timer/timer_game_economy.cpp
@@ -121,7 +121,7 @@ void TimeoutTimer<TimerGameEconomy>::Elapsed(TimerGameEconomy::TElapsed trigger)
 template <>
 bool TimerManager<TimerGameEconomy>::Elapsed(TimerGameEconomy::TElapsed)
 {
-	if (_game_mode == GM_MENU) return false;
+	if (_game_mode == GameMode::Menu) return false;
 
 	TimerGameEconomy::date_fract++;
 	if (TimerGameEconomy::date_fract < Ticks::DAY_TICKS) return true;

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -284,7 +284,7 @@ static CallBackFunction ToolbarOptionsClick(Window *w)
 		list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_GAMESCRIPT_SETTINGS, OptionMenuEntries::GameScriptSettings));
 	}
 	list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_NEWGRF_SETTINGS, OptionMenuEntries::NewGRFSettings));
-	if (_game_mode != GM_EDITOR && !_networking) {
+	if (_game_mode != GameMode::Editor && !_networking) {
 		list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_SANDBOX_OPTIONS, OptionMenuEntries::SandboxOptions));
 	}
 	list.push_back(MakeDropDownListStringItem(STR_SETTINGS_MENU_TRANSPARENCY_OPTIONS, OptionMenuEntries::Transparencies));
@@ -405,7 +405,7 @@ static CallBackFunction ToolbarScenSaveOrLoad(Window *w)
  */
 static CallBackFunction MenuClickSaveLoad(int index = 0)
 {
-	if (_game_mode == GM_EDITOR) {
+	if (_game_mode == GameMode::Editor) {
 		switch (SaveLoadEditorMenuEntries(index)) {
 			case SaveLoadEditorMenuEntries::SaveScenario: ShowSaveLoadDialog(AbstractFileType::Scenario, SaveLoadOperation::Save); break;
 			case SaveLoadEditorMenuEntries::LoadScenario: ShowSaveLoadDialog(AbstractFileType::Scenario, SaveLoadOperation::Load); break;
@@ -868,7 +868,7 @@ static CallBackFunction MenuClickShowAir(int index)
 static CallBackFunction ToolbarZoomInClick(Window *w)
 {
 	if (DoZoomInOutWindow(ZOOM_IN, GetMainWindow())) {
-		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (WidgetID)WID_TE_ZOOM_IN : (WidgetID)WID_TN_ZOOM_IN);
+		w->HandleButtonClick((_game_mode == GameMode::Editor) ? (WidgetID)WID_TE_ZOOM_IN : (WidgetID)WID_TN_ZOOM_IN);
 	}
 	return CallBackFunction::None;
 }
@@ -878,7 +878,7 @@ static CallBackFunction ToolbarZoomInClick(Window *w)
 static CallBackFunction ToolbarZoomOutClick(Window *w)
 {
 	if (DoZoomInOutWindow(ZOOM_OUT, GetMainWindow())) {
-		w->HandleButtonClick((_game_mode == GM_EDITOR) ? (WidgetID)WID_TE_ZOOM_OUT : (WidgetID)WID_TN_ZOOM_OUT);
+		w->HandleButtonClick((_game_mode == GameMode::Editor) ? (WidgetID)WID_TE_ZOOM_OUT : (WidgetID)WID_TN_ZOOM_OUT);
 	}
 	return CallBackFunction::None;
 }
@@ -1028,7 +1028,7 @@ static CallBackFunction MenuClickForest(int index)
 
 static CallBackFunction ToolbarMusicClick(Window *w)
 {
-	PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (WidgetID)WID_TE_MUSIC_SOUND : (WidgetID)WID_TN_MUSIC_SOUND, {STR_TOOLBAR_SOUND_MUSIC});
+	PopupMainToolbarMenu(w, _game_mode == GameMode::Editor ? (WidgetID)WID_TE_MUSIC_SOUND : (WidgetID)WID_TN_MUSIC_SOUND, {STR_TOOLBAR_SOUND_MUSIC});
 	return CallBackFunction::None;
 }
 
@@ -1083,13 +1083,13 @@ static CallBackFunction PlaceLandBlockInfo()
 static CallBackFunction ToolbarHelpClick(Window *w)
 {
 	if (_settings_client.gui.newgrf_developer_tools) {
-		PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
+		PopupMainToolbarMenu(w, _game_mode == GameMode::Editor ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
 				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
 				STR_ABOUT_MENU_SCREENSHOT, STR_ABOUT_MENU_SHOW_FRAMERATE, STR_ABOUT_MENU_ABOUT_OPENTTD,
 				STR_ABOUT_MENU_SPRITE_ALIGNER, STR_ABOUT_MENU_TOGGLE_BOUNDING_BOXES, STR_ABOUT_MENU_TOGGLE_DIRTY_BLOCKS,
 				STR_ABOUT_MENU_TOGGLE_WIDGET_OUTLINES});
 	} else {
-		PopupMainToolbarMenu(w, _game_mode == GM_EDITOR ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
+		PopupMainToolbarMenu(w, _game_mode == GameMode::Editor ? (WidgetID)WID_TE_HELP : (WidgetID)WID_TN_HELP, {STR_ABOUT_MENU_LAND_BLOCK_INFO,
 				STR_ABOUT_MENU_HELP, STR_NULL, STR_ABOUT_MENU_TOGGLE_CONSOLE, STR_ABOUT_MENU_AI_DEBUG,
 				STR_ABOUT_MENU_SCREENSHOT, STR_ABOUT_MENU_SHOW_FRAMERATE, STR_ABOUT_MENU_ABOUT_OPENTTD});
 	}
@@ -1199,7 +1199,7 @@ static CallBackFunction ToolbarSwitchClick(Window *w)
 	}
 
 	w->ReInit();
-	w->SetWidgetLoweredState(_game_mode == GM_EDITOR ? (WidgetID)WID_TE_SWITCH_BAR : (WidgetID)WID_TN_SWITCH_BAR, _toolbar_mode == ToolbarMode::Lower);
+	w->SetWidgetLoweredState(_game_mode == GameMode::Editor ? (WidgetID)WID_TE_SWITCH_BAR : (WidgetID)WID_TN_SWITCH_BAR, _toolbar_mode == ToolbarMode::Lower);
 	SndClickBeep();
 	return CallBackFunction::None;
 }
@@ -2036,7 +2036,7 @@ struct MainToolbarWindow : Window {
 
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
-		if (_game_mode != GM_MENU && !this->IsWidgetDisabled(widget)) _toolbar_button_procs[widget](this);
+		if (_game_mode != GameMode::Menu && !this->IsWidgetDisabled(widget)) _toolbar_button_procs[widget](this);
 	}
 
 	void OnDropdownSelect(WidgetID widget, int index, int) override
@@ -2425,7 +2425,7 @@ struct ScenarioEditorToolbarWindow : Window {
 
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
 	{
-		if (_game_mode == GM_MENU) return;
+		if (_game_mode == GameMode::Menu) return;
 		CallBackFunction cbf = _scen_toolbar_button_procs[widget](this);
 		if (cbf != CallBackFunction::None) _last_started_action = cbf;
 	}
@@ -2622,7 +2622,7 @@ void AllocateToolbar()
 	_last_built_roadtype = ROADTYPE_ROAD;
 	_last_built_tramtype = ROADTYPE_TRAM;
 
-	if (_game_mode == GM_EDITOR) {
+	if (_game_mode == GameMode::Editor) {
 		new ScenarioEditorToolbarWindow(_toolb_scen_desc);
 	} else {
 		new MainToolbarWindow(_toolb_normal_desc);

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -908,7 +908,7 @@ static void TownTickHandler(Town *t)
 /** Iterate through all towns and call their tick handler. */
 void OnTick_Town()
 {
-	if (_game_mode == GM_EDITOR) return;
+	if (_game_mode == GameMode::Editor) return;
 
 	for (Town *t : Town::Iterate()) {
 		TownTickHandler(t);
@@ -1834,7 +1834,7 @@ static bool GrowTownAtRoad(Town *t, TileIndex tile, TownExpandModes modes)
 			/* Don't allow building over roads of other cities */
 			if (IsRoadOwner(tile, RoadTramType::Road, OWNER_TOWN) && Town::GetByTile(tile) != t) {
 				return false;
-			} else if (IsRoadOwner(tile, RoadTramType::Road, OWNER_NONE) && _game_mode == GM_EDITOR) {
+			} else if (IsRoadOwner(tile, RoadTramType::Road, OWNER_NONE) && _game_mode == GameMode::Editor) {
 				/* If we are in the SE, and this road-piece has no town owner yet, it just found an
 				 * owner :) (happy happy happy road now) */
 				SetRoadOwner(tile, RoadTramType::Road, OWNER_TOWN);
@@ -2063,7 +2063,7 @@ static void DoCreateTown(Town *t, TileIndex tile, uint32_t townnameparts, TownSi
 	int x = (int)size * 16 + 3;
 	if (size == TSZ_RANDOM) x = (Random() & 0xF) + 8;
 	/* Don't create huge cities when founding town in-game */
-	if (city && (!manual || _game_mode == GM_EDITOR)) x *= _settings_game.economy.initial_city_size;
+	if (city && (!manual || _game_mode == GameMode::Editor)) x *= _settings_game.economy.initial_city_size;
 
 	t->cache.num_houses += x;
 	UpdateTownRadius(t);
@@ -2175,7 +2175,7 @@ std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlags flags, TileIn
 	if (layout >= NUM_TLS) return { CMD_ERROR, 0, TownID::Invalid() };
 
 	/* Some things are allowed only in the scenario editor and for game scripts. */
-	if (_game_mode != GM_EDITOR && _current_company != OWNER_DEITY) {
+	if (_game_mode != GameMode::Editor && _current_company != OWNER_DEITY) {
 		if (_settings_game.economy.found_town == TF_FORBIDDEN) return { CMD_ERROR, 0, TownID::Invalid() };
 		if (size == TSZ_LARGE) return { CMD_ERROR, 0, TownID::Invalid() };
 		if (random_location) return { CMD_ERROR, 0, TownID::Invalid() };
@@ -2242,7 +2242,7 @@ std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlags flags, TileIn
 			t->UpdateVirtCoord();
 		}
 
-		if (_game_mode != GM_EDITOR) {
+		if (_game_mode != GameMode::Editor) {
 			/* 't' can't be nullptr since 'random' is false outside scenedit */
 			assert(!random_location);
 
@@ -2358,7 +2358,7 @@ HouseZones GetClimateMaskForLandscape()
  */
 static Town *CreateRandomTown(uint attempts, uint32_t townnameparts, TownSize size, bool city, TownLayout layout)
 {
-	assert(_game_mode == GM_EDITOR || _generating_world); // These are the preconditions for Commands::DeleteTown
+	assert(_game_mode == GameMode::Editor || _generating_world); // These are the preconditions for Commands::DeleteTown
 
 	if (!Town::CanAllocateItem()) return nullptr;
 
@@ -2471,7 +2471,7 @@ bool GenerateTowns(TownLayout layout, std::optional<uint> number)
 	}
 
 	/* If there are no towns at all and we are generating new game, bail out */
-	if (Town::GetNumItems() == 0 && _game_mode != GM_EDITOR) {
+	if (Town::GetNumItems() == 0 && _game_mode != GameMode::Editor) {
 		ShowErrorMessage(GetEncodedString(STR_ERROR_COULD_NOT_CREATE_TOWN), {}, WarningLevel::Critical);
 	}
 
@@ -2758,7 +2758,7 @@ static void BuildTownHouse(Town *t, TileIndex tile, const HouseSpec *hs, HouseID
 	uint8_t construction_counter = 0;
 	uint8_t construction_stage = 0;
 
-	if (_generating_world || _game_mode == GM_EDITOR || house_completed) {
+	if (_generating_world || _game_mode == GameMode::Editor || house_completed) {
 		uint32_t construction_random = Random();
 
 		construction_stage = TOWN_HOUSE_COMPLETED;
@@ -2865,7 +2865,7 @@ static bool TryBuildTownHouse(Town *t, TileIndex tile, TownExpandModes modes)
 
 		const HouseSpec *hs = HouseSpec::Get(house);
 
-		if (!_generating_world && _game_mode != GM_EDITOR && hs->extra_flags.Test(HouseExtraFlag::BuildingIsHistorical)) {
+		if (!_generating_world && _game_mode != GameMode::Editor && hs->extra_flags.Test(HouseExtraFlag::BuildingIsHistorical)) {
 			continue;
 		}
 
@@ -2925,7 +2925,7 @@ static bool TryBuildTownHouse(Town *t, TileIndex tile, TownExpandModes modes)
  */
 CommandCost CmdPlaceHouse(DoCommandFlags flags, TileIndex tile, HouseID house, bool is_protected, bool replace)
 {
-	if (_game_mode != GM_EDITOR && _settings_game.economy.place_houses == PlaceHouses::Forbidden) return CMD_ERROR;
+	if (_game_mode != GameMode::Editor && _settings_game.economy.place_houses == PlaceHouses::Forbidden) return CMD_ERROR;
 
 	if (Town::GetNumItems() == 0) return CommandCost(STR_ERROR_MUST_FOUND_TOWN_FIRST);
 
@@ -2994,7 +2994,7 @@ CommandCost CmdPlaceHouseArea(DoCommandFlags flags, TileIndex tile, TileIndex st
 {
 	if (start_tile >= Map::Size()) return CMD_ERROR;
 
-	if (_game_mode != GM_EDITOR && _settings_game.economy.place_houses == PlaceHouses::Forbidden) return CMD_ERROR;
+	if (_game_mode != GameMode::Editor && _settings_game.economy.place_houses == PlaceHouses::Forbidden) return CMD_ERROR;
 
 	if (Town::GetNumItems() == 0) return CommandCost(STR_ERROR_MUST_FOUND_TOWN_FIRST);
 
@@ -3289,7 +3289,7 @@ CommandCost CmdTownRating(DoCommandFlags flags, TownID town_id, CompanyID compan
  */
 CommandCost CmdExpandTown(DoCommandFlags flags, TownID town_id, uint32_t grow_amount, TownExpandModes modes)
 {
-	if (_game_mode != GM_EDITOR && _current_company != OWNER_DEITY) return CMD_ERROR;
+	if (_game_mode != GameMode::Editor && _current_company != OWNER_DEITY) return CMD_ERROR;
 	if (modes.None()) return CMD_ERROR;
 	Town *t = Town::GetIfValid(town_id);
 	if (t == nullptr) return CMD_ERROR;
@@ -3327,7 +3327,7 @@ CommandCost CmdExpandTown(DoCommandFlags flags, TownID town_id, uint32_t grow_am
  */
 CommandCost CmdDeleteTown(DoCommandFlags flags, TownID town_id)
 {
-	if (_game_mode != GM_EDITOR && !_generating_world) return CMD_ERROR;
+	if (_game_mode != GameMode::Editor && !_generating_world) return CMD_ERROR;
 	Town *t = Town::GetIfValid(town_id);
 	if (t == nullptr) return CMD_ERROR;
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -683,7 +683,7 @@ static WindowDesc _town_editor_view_desc(
 
 void ShowTownViewWindow(TownID town)
 {
-	if (_game_mode == GM_EDITOR) {
+	if (_game_mode == GameMode::Editor) {
 		AllocateWindowDescFront<TownViewWindow>(_town_editor_view_desc, town);
 	} else {
 		AllocateWindowDescFront<TownViewWindow>(_town_game_view_desc, town);
@@ -872,7 +872,7 @@ public:
 					assert(t->xy != INVALID_TILE);
 
 					/* Draw rating icon. */
-					if (_game_mode == GM_EDITOR || !t->have_ratings.Test(_local_company)) {
+					if (_game_mode == GameMode::Editor || !t->have_ratings.Test(_local_company)) {
 						DrawSprite(SPR_TOWN_RATING_NA, PAL_NONE, icon_x, tr.top + (this->resize.step_height - icon_size.height) / 2);
 					} else {
 						SpriteID icon = SPR_TOWN_RATING_APPALLING;
@@ -1174,7 +1174,7 @@ public:
 
 	void OnInit() override
 	{
-		if (_game_mode == GM_EDITOR) return;
+		if (_game_mode == GameMode::Editor) return;
 
 		this->GetWidget<NWidgetStacked>(WID_TF_TOWN_ACTION_SEL)->SetDisplayedPlane(SZSP_HORIZONTAL);
 		this->GetWidget<NWidgetStacked>(WID_TF_TOWN_EXPAND_SEL)->SetDisplayedPlane(SZSP_HORIZONTAL);
@@ -1202,7 +1202,7 @@ public:
 
 	void UpdateButtons(bool check_availability)
 	{
-		if (check_availability && _game_mode != GM_EDITOR) {
+		if (check_availability && _game_mode != GameMode::Editor) {
 			if (_settings_game.economy.found_town != TF_CUSTOM_LAYOUT) this->town_layout = _settings_game.economy.town_layout;
 			this->ReInit();
 		}
@@ -1301,7 +1301,7 @@ public:
 
 				/* If we are in the editor, sync the settings of the current game to the chosen layout,
 				 * so that importing towns from file uses the selected layout. */
-				if (_game_mode == GM_EDITOR) _settings_game.economy.town_layout = this->town_layout;
+				if (_game_mode == GameMode::Editor) _settings_game.economy.town_layout = this->town_layout;
 
 				this->UpdateButtons(false);
 				break;
@@ -1357,7 +1357,7 @@ static WindowDesc _found_town_desc(
 
 void ShowFoundTownWindow()
 {
-	if (_game_mode != GM_EDITOR && !Company::IsValidID(_local_company)) return;
+	if (_game_mode != GameMode::Editor && !Company::IsValidID(_local_company)) return;
 	AllocateWindowDescFront<FoundTownWindow>(_found_town_desc, 0);
 }
 

--- a/src/transparency.h
+++ b/src/transparency.h
@@ -50,7 +50,7 @@ extern StationFacilities _facility_display_opt;
  */
 inline bool IsTransparencySet(TransparencyOption to)
 {
-	return (HasBit(_transparency_opt, to) && _game_mode != GM_MENU);
+	return (HasBit(_transparency_opt, to) && _game_mode != GameMode::Menu);
 }
 
 /**
@@ -62,7 +62,7 @@ inline bool IsTransparencySet(TransparencyOption to)
  */
 inline bool IsInvisibilitySet(TransparencyOption to)
 {
-	return (HasBit(_transparency_opt & _invisibility_opt, to) && _game_mode != GM_MENU);
+	return (HasBit(_transparency_opt & _invisibility_opt, to) && _game_mode != GameMode::Menu);
 }
 
 /**

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -372,7 +372,7 @@ void PlaceTreesRandomly()
 	uint8_t max_height = _settings_game.construction.map_height_limit;
 
 	i = Map::ScaleBySize(DEFAULT_TREE_STEPS);
-	if (_game_mode == GM_EDITOR) i /= EDITOR_TREE_DIV;
+	if (_game_mode == GameMode::Editor) i /= EDITOR_TREE_DIV;
 	do {
 		uint32_t r = Random();
 		TileIndex tile = RandomTileSeed(r);
@@ -402,7 +402,7 @@ void PlaceTreesRandomly()
 	/* place extra trees at rainforest area */
 	if (_settings_game.game_creation.landscape == LandscapeType::Tropic) {
 		i = Map::ScaleBySize(DEFAULT_RAINFOREST_TREE_STEPS);
-		if (_game_mode == GM_EDITOR) i /= EDITOR_TREE_DIV;
+		if (_game_mode == GameMode::Editor) i /= EDITOR_TREE_DIV;
 
 		do {
 			uint32_t r = Random();
@@ -431,7 +431,7 @@ void PlaceTreesRandomly()
  */
 uint PlaceTreeGroupAroundTile(TileIndex tile, TreeType treetype, uint radius, uint count, bool set_zone)
 {
-	assert(_game_mode == GM_EDITOR); // Due to InteractiveRandom being used in this function
+	assert(_game_mode == GameMode::Editor); // Due to InteractiveRandom being used in this function
 	assert(treetype < TREE_TOYLAND + TREE_COUNT_TOYLAND);
 	const bool allow_desert = treetype == TREE_CACTUS;
 	uint planted = 0;
@@ -520,7 +520,7 @@ CommandCost CmdPlantTree(DoCommandFlags flags, TileIndex tile, TileIndex start_t
 	/* Check the tree type within the current climate */
 	if (tree_to_plant != TREE_INVALID && !IsInsideBS(tree_to_plant, _tree_base_by_landscape[to_underlying(_settings_game.game_creation.landscape)], _tree_count_by_landscape[to_underlying(_settings_game.game_creation.landscape)])) return CMD_ERROR;
 
-	Company *c = (_game_mode != GM_EDITOR) ? Company::GetIfValid(_current_company) : nullptr;
+	Company *c = (_game_mode != GameMode::Editor) ? Company::GetIfValid(_current_company) : nullptr;
 	int limit = (c == nullptr ? INT32_MAX : GB(c->tree_limit, 16, 16));
 
 	std::unique_ptr<TileIterator> iter = TileIterator::Create(tile, start_tile, diagonal);
@@ -568,7 +568,7 @@ CommandCost CmdPlantTree(DoCommandFlags flags, TileIndex tile, TileIndex start_t
 						/* No cacti outside the desert */
 						(treetype == TREE_CACTUS && GetTropicZone(current_tile) != TropicZone::Desert) ||
 						/* No rainforest trees outside the rainforest, except in the editor mode where it makes those tiles rainforest tile */
-						(IsInsideMM(treetype, TREE_RAINFOREST, TREE_CACTUS) && GetTropicZone(current_tile) != TropicZone::Rainforest && _game_mode != GM_EDITOR) ||
+						(IsInsideMM(treetype, TREE_RAINFOREST, TREE_CACTUS) && GetTropicZone(current_tile) != TropicZone::Rainforest && _game_mode != GameMode::Editor) ||
 						/* And no subtropical trees in the desert/rainforest */
 						(IsInsideMM(treetype, TREE_SUB_TROPICAL, TREE_TOYLAND) && GetTropicZone(current_tile) != TropicZone::Normal))) {
 					msg = STR_ERROR_TREE_WRONG_TERRAIN_FOR_TREE_TYPE;
@@ -596,7 +596,7 @@ CommandCost CmdPlantTree(DoCommandFlags flags, TileIndex tile, TileIndex start_t
 					}
 				}
 
-				if (_game_mode != GM_EDITOR && Company::IsValidID(_current_company)) {
+				if (_game_mode != GameMode::Editor && Company::IsValidID(_current_company)) {
 					Town *t = ClosestTownFromTile(current_tile, _settings_game.economy.dist_local_authority);
 					if (t != nullptr) ChangeTownRating(t, RATING_TREE_UP_STEP, RATING_TREE_MAXIMUM, flags);
 				}
@@ -608,12 +608,12 @@ CommandCost CmdPlantTree(DoCommandFlags flags, TileIndex tile, TileIndex start_t
 					}
 
 					/* Plant full grown trees in scenario editor */
-					PlantTreesOnTile(current_tile, treetype, 0, _game_mode == GM_EDITOR ? TreeGrowthStage::Grown : TreeGrowthStage::Growing1);
+					PlantTreesOnTile(current_tile, treetype, 0, _game_mode == GameMode::Editor ? TreeGrowthStage::Grown : TreeGrowthStage::Growing1);
 					MarkTileDirtyByTile(current_tile);
 					if (c != nullptr) c->tree_limit -= 1 << 16;
 
 					/* When planting rainforest-trees, set tropiczone to rainforest in editor. */
-					if (_game_mode == GM_EDITOR && IsInsideMM(treetype, TREE_RAINFOREST, TREE_CACTUS)) {
+					if (_game_mode == GameMode::Editor && IsInsideMM(treetype, TREE_RAINFOREST, TREE_CACTUS)) {
 						SetTropicZone(current_tile, TropicZone::Rainforest);
 					}
 				}

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -146,7 +146,7 @@ public:
 
 		this->LowerWidget(WID_BT_MODE_NORMAL);
 		/* Show scenario editor tools in editor */
-		if (_game_mode != GM_EDITOR) {
+		if (_game_mode != GameMode::Editor) {
 			this->GetWidget<NWidgetStacked>(WID_BT_SE_PANE)->SetDisplayedPlane(SZSP_HORIZONTAL);
 		}
 		this->FinishInitNested(window_number);
@@ -191,13 +191,13 @@ public:
 				break;
 
 			case WID_BT_MODE_FOREST_SM:
-				assert(_game_mode == GM_EDITOR);
+				assert(_game_mode == GameMode::Editor);
 				this->mode = PM_FOREST_SM;
 				this->UpdateMode();
 				break;
 
 			case WID_BT_MODE_FOREST_LG:
-				assert(_game_mode == GM_EDITOR);
+				assert(_game_mode == GameMode::Editor);
 				this->mode = PM_FOREST_LG;
 				this->UpdateMode();
 				break;
@@ -214,7 +214,7 @@ public:
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
 	{
-		if (_game_mode != GM_EDITOR && this->mode == PM_NORMAL) {
+		if (_game_mode != GameMode::Editor && this->mode == PM_NORMAL) {
 			VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_PLANT_TREES);
 		} else {
 			VpStartDragging(DDSP_PLANT_TREES);
@@ -223,7 +223,7 @@ public:
 
 	void OnPlaceDrag(ViewportPlaceMethod select_method, [[maybe_unused]] ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt) override
 	{
-		if (_game_mode != GM_EDITOR && this->mode == PM_NORMAL) {
+		if (_game_mode != GameMode::Editor && this->mode == PM_NORMAL) {
 			VpSelectTilesWithMethod(pt.x, pt.y, select_method);
 		} else {
 			TileIndex tile = TileVirtXY(pt.x, pt.y);
@@ -238,7 +238,7 @@ public:
 
 	void OnPlaceMouseUp([[maybe_unused]] ViewportPlaceMethod select_method, ViewportDragDropSelectionProcess select_proc, [[maybe_unused]] Point pt, TileIndex start_tile, TileIndex end_tile) override
 	{
-		if (_game_mode != GM_EDITOR && this->mode == PM_NORMAL && pt.x != -1 && select_proc == DDSP_PLANT_TREES) {
+		if (_game_mode != GameMode::Editor && this->mode == PM_NORMAL && pt.x != -1 && select_proc == DDSP_PLANT_TREES) {
 			Command<Commands::PlantTree>::Post(STR_ERROR_CAN_T_PLANT_TREE_HERE, end_tile, start_tile, this->tree_to_plant, _ctrl_pressed);
 		}
 	}
@@ -320,6 +320,6 @@ static WindowDesc _build_trees_desc(
 
 void ShowBuildTreesToolbar()
 {
-	if (_game_mode != GM_EDITOR && !Company::IsValidID(_local_company)) return;
+	if (_game_mode != GameMode::Editor && !Company::IsValidID(_local_company)) return;
 	AllocateWindowDescFront<BuildTreesWindow>(_build_trees_desc, 0);
 }

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -430,7 +430,7 @@ CommandCost CmdBuildBridge(DoCommandFlags flags, TileIndex tile_end, TileIndex t
 			}
 
 			/* Do not replace town bridges with lower speed bridges, unless in scenario editor. */
-			if (IsTileOwner(tile_start, OWNER_TOWN) && _game_mode != GM_EDITOR) {
+			if (IsTileOwner(tile_start, OWNER_TOWN) && _game_mode != GameMode::Editor) {
 				Town *t = ClosestTownFromTile(tile_start, UINT_MAX);
 				if (t == nullptr) return CMD_ERROR;
 
@@ -814,7 +814,7 @@ CommandCost CmdBuildTunnel(DoCommandFlags flags, TileIndex start_tile, Transport
 static inline CommandCost CheckAllowRemoveTunnelBridge(TileIndex tile)
 {
 	/* Floods can remove anything as well as the scenario editor */
-	if (_current_company == OWNER_WATER || _game_mode == GM_EDITOR) return CommandCost();
+	if (_current_company == OWNER_WATER || _game_mode == GameMode::Editor) return CommandCost();
 
 	switch (GetTunnelBridgeTransportType(tile)) {
 		case TRANSPORT_ROAD: {
@@ -872,7 +872,7 @@ static CommandCost DoClearTunnel(TileIndex tile, DoCommandFlags flags)
 	_build_tunnel_endtile = endtile;
 
 	Town *t = nullptr;
-	if (IsTileOwner(tile, OWNER_TOWN) && _game_mode != GM_EDITOR) {
+	if (IsTileOwner(tile, OWNER_TOWN) && _game_mode != GameMode::Editor) {
 		t = ClosestTownFromTile(tile, UINT_MAX); // town penalty rating
 
 		/* Check if you are allowed to remove the tunnel owned by a town
@@ -883,7 +883,7 @@ static CommandCost DoClearTunnel(TileIndex tile, DoCommandFlags flags)
 
 	/* checks if the owner is town then decrease town rating by RATING_TUNNEL_BRIDGE_DOWN_STEP until
 	 * you have a "Poor" (0) town rating */
-	if (IsTileOwner(tile, OWNER_TOWN) && _game_mode != GM_EDITOR) {
+	if (IsTileOwner(tile, OWNER_TOWN) && _game_mode != GameMode::Editor) {
 		ChangeTownRating(t, RATING_TUNNEL_BRIDGE_DOWN_STEP, RATING_TUNNEL_BRIDGE_MINIMUM, flags);
 	}
 
@@ -953,7 +953,7 @@ static CommandCost DoClearBridge(TileIndex tile, DoCommandFlags flags)
 	TileIndexDiff delta = TileOffsByDiagDir(direction);
 
 	Town *t = nullptr;
-	if (IsTileOwner(tile, OWNER_TOWN) && _game_mode != GM_EDITOR) {
+	if (IsTileOwner(tile, OWNER_TOWN) && _game_mode != GameMode::Editor) {
 		t = ClosestTownFromTile(tile, UINT_MAX); // town penalty rating
 
 		/* Check if you are allowed to remove the bridge owned by a town
@@ -964,7 +964,7 @@ static CommandCost DoClearBridge(TileIndex tile, DoCommandFlags flags)
 
 	/* checks if the owner is town then decrease town rating by RATING_TUNNEL_BRIDGE_DOWN_STEP until
 	 * you have a "Poor" (0) town rating */
-	if (IsTileOwner(tile, OWNER_TOWN) && _game_mode != GM_EDITOR) {
+	if (IsTileOwner(tile, OWNER_TOWN) && _game_mode != GameMode::Editor) {
 		ChangeTownRating(t, RATING_TUNNEL_BRIDGE_DOWN_STEP, RATING_TUNNEL_BRIDGE_MINIMUM, flags);
 	}
 
@@ -1404,7 +1404,7 @@ static void DrawTile_TunnelBridge(TileInfo *ti)
 			}
 
 			/* PBS debugging, draw reserved tracks darker */
-			if (_game_mode != GM_MENU && _settings_client.gui.show_track_reservation && HasTunnelBridgeReservation(ti->tile)) {
+			if (_game_mode != GameMode::Menu && _settings_client.gui.show_track_reservation && HasTunnelBridgeReservation(ti->tile)) {
 				if (rti->UsesOverlay()) {
 					SpriteID overlay = GetCustomRailSprite(rti, ti->tile, RailSpriteType::Overlay);
 					DrawGroundSprite(overlay + RTO_X + to_underlying(DiagDirToAxis(tunnelbridge_direction)), PALETTE_CRASH);
@@ -1504,7 +1504,7 @@ static void DrawTile_TunnelBridge(TileInfo *ti)
 			}
 
 			/* PBS debugging, draw reserved tracks darker */
-			if (_game_mode != GM_MENU && _settings_client.gui.show_track_reservation && HasTunnelBridgeReservation(ti->tile)) {
+			if (_game_mode != GameMode::Menu && _settings_client.gui.show_track_reservation && HasTunnelBridgeReservation(ti->tile)) {
 				if (rti->UsesOverlay()) {
 					SpriteID overlay = GetCustomRailSprite(rti, ti->tile, RailSpriteType::Overlay);
 					if (HasBridgeFlatRamp(ti->tileh, DiagDirToAxis(tunnelbridge_direction))) {
@@ -1677,7 +1677,7 @@ void DrawBridgeMiddle(const TileInfo *ti, BridgePillarFlags blocked_pillars)
 			}
 		}
 
-		if (_game_mode != GM_MENU && _settings_client.gui.show_track_reservation && !IsInvisibilitySet(TO_BRIDGES) && HasTunnelBridgeReservation(rampnorth)) {
+		if (_game_mode != GameMode::Menu && _settings_client.gui.show_track_reservation && !IsInvisibilitySet(TO_BRIDGES) && HasTunnelBridgeReservation(rampnorth)) {
 			if (rti->UsesOverlay()) {
 				SpriteID overlay = GetCustomRailSprite(rti, rampnorth, RailSpriteType::Overlay, TCX_ON_BRIDGE);
 				AddSortableSpriteToDraw(overlay + RTO_X + to_underlying(axis), PALETTE_CRASH, ti->x, ti->y, bridge_z, {{}, {TILE_SIZE, TILE_SIZE, 0}, {}}, IsTransparencySet(TO_BRIDGES));

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -936,7 +936,7 @@ static void VehicleEnteredDepotThisTick(Vehicle *v)
  */
 void RunVehicleCalendarDayProc()
 {
-	if (_game_mode != GM_NORMAL) return;
+	if (_game_mode != GameMode::Normal) return;
 
 	/* Run the calendar day proc for every DAY_TICKS vehicle starting at TimerGameCalendar::date_fract. */
 	for (size_t i = TimerGameCalendar::date_fract; i < Vehicle::GetPoolSize(); i += Ticks::DAY_TICKS) {
@@ -953,7 +953,7 @@ void RunVehicleCalendarDayProc()
  */
 static void RunEconomyVehicleDayProc()
 {
-	if (_game_mode != GM_NORMAL) return;
+	if (_game_mode != GameMode::Normal) return;
 
 	/* Run the economy day proc for every DAY_TICKS vehicle starting at TimerGameEconomy::date_fract. */
 	for (size_t i = TimerGameEconomy::date_fract; i < Vehicle::GetPoolSize(); i += Ticks::DAY_TICKS) {
@@ -1318,7 +1318,7 @@ static const uint8_t _breakdown_chance[64] = {
 void CheckVehicleBreakdown(Vehicle *v)
 {
 	/* Vehicles in the menu don't break down. */
-	if (_game_mode == GM_MENU) return;
+	if (_game_mode == GameMode::Menu) return;
 
 	/* If both breakdowns and automatic servicing are disabled, we don't decrease reliability or break down. */
 	if (_settings_game.difficulty.vehicle_breakdowns == VehicleBreakdowns::None && _settings_game.order.no_servicing_if_no_breakdowns) return;

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -603,7 +603,7 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
  */
 - (void)cursorUpdate:(NSEvent *)event
 {
-	[ (_game_mode == GM_BOOTSTRAP ? [ NSCursor arrowCursor ] : [ NSCursor clearCocoaCursor ]) set ];
+	[ (_game_mode == GameMode::Bootstrap ? [ NSCursor arrowCursor ] : [ NSCursor clearCocoaCursor ]) set ];
 }
 
 - (void)viewWillMoveToWindow:(NSWindow *)win

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -225,7 +225,7 @@ void VideoDriver_Dedicated::MainLoop()
 
 #if defined(UNIX)
 		if (_dedicated_exit_requested) {
-			if (_game_mode == GM_NORMAL && _settings_client.gui.autosave_on_exit) DoExitSave();
+			if (_game_mode == GameMode::Normal && _settings_client.gui.autosave_on_exit) DoExitSave();
 			_exit_game = true;
 		}
 #endif

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -653,7 +653,7 @@ void VideoDriver_SDL_Base::LoopOnce()
 		/* In effect, the game ends here. As emscripten_set_main_loop() caused
 		 * the stack to be unwound, the code after MainLoop() in
 		 * openttd_main() is never executed. */
-		if (_game_mode == GM_BOOTSTRAP) {
+		if (_game_mode == GameMode::Bootstrap) {
 			EM_ASM(if (window["openttd_bootstrap_reload"]) openttd_bootstrap_reload());
 		} else {
 			EM_ASM(if (window["openttd_exit"]) openttd_exit());

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -138,7 +138,7 @@ void VideoDriver::Tick()
 			this->InputLoop();
 
 			/* Check if the fast-forward button is still pressed. */
-			if (fast_forward_key_pressed && !_networking && _game_mode != GM_MENU) {
+			if (fast_forward_key_pressed && !_networking && _game_mode != GameMode::Menu) {
 				ChangeGameSpeed(true);
 				this->fast_forward_via_key = true;
 			} else if (this->fast_forward_via_key) {
@@ -149,7 +149,7 @@ void VideoDriver::Tick()
 			::InputLoop();
 
 			/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
-			if (_game_mode == GM_BOOTSTRAP || _switch_mode == SM_NONE || HasModalProgress()) {
+			if (_game_mode == GameMode::Bootstrap || _switch_mode == SM_NONE || HasModalProgress()) {
 				::UpdateWindows();
 			}
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1447,9 +1447,9 @@ static void ViewportAddKdtreeSigns(DrawPixelInfo *dpi)
 	Rect search_rect{ dpi->left, dpi->top, dpi->left + dpi->width, dpi->top + dpi->height };
 	search_rect = ExpandRectWithViewportSignMargins(search_rect, dpi->zoom);
 
-	bool show_stations = _display_opt.Test(DisplayOption::ShowStationNames) && _game_mode != GM_MENU;
-	bool show_waypoints = _display_opt.Test(DisplayOption::ShowWaypointNames) && _game_mode != GM_MENU;
-	bool show_towns = _display_opt.Test(DisplayOption::ShowTownNames) && _game_mode != GM_MENU;
+	bool show_stations = _display_opt.Test(DisplayOption::ShowStationNames) && _game_mode != GameMode::Menu;
+	bool show_waypoints = _display_opt.Test(DisplayOption::ShowWaypointNames) && _game_mode != GameMode::Menu;
+	bool show_towns = _display_opt.Test(DisplayOption::ShowTownNames) && _game_mode != GameMode::Menu;
 	bool show_signs = _display_opt.Test(DisplayOption::ShowSigns) && !IsInvisibilitySet(TO_SIGNS);
 	bool show_competitors = _display_opt.Test(DisplayOption::ShowCompetitorSigns);
 
@@ -2286,7 +2286,7 @@ static bool CheckClickOnViewportSign(const Viewport &vp, int x, int y, const Vie
  */
 static bool CheckClickOnViewportSign(const Viewport &vp, int x, int y)
 {
-	if (_game_mode == GM_MENU) return false;
+	if (_game_mode == GameMode::Menu) return false;
 
 	x = ScaleByZoom(x - vp.left, vp.zoom) + vp.virtual_left;
 	y = ScaleByZoom(y - vp.top, vp.zoom) + vp.virtual_top;

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -501,7 +501,7 @@ CommandCost CmdBuildCanal(DoCommandFlags flags, TileIndex tile, TileIndex start_
 	if (start_tile >= Map::Size() || !IsValidWaterClass(wc)) return CMD_ERROR;
 
 	/* Outside of the editor you can only build canals, not oceans */
-	if (wc != WaterClass::Canal && _game_mode != GM_EDITOR) return CMD_ERROR;
+	if (wc != WaterClass::Canal && _game_mode != GameMode::Editor) return CMD_ERROR;
 
 	CommandCost cost(ExpensesType::Construction);
 
@@ -518,7 +518,7 @@ CommandCost CmdBuildCanal(DoCommandFlags flags, TileIndex tile, TileIndex start_
 		bool water = IsWaterTile(current_tile);
 
 		/* Outside the editor, prevent building canals over your own or OWNER_NONE owned canals */
-		if (water && IsCanal(current_tile) && _game_mode != GM_EDITOR && (IsTileOwner(current_tile, _current_company) || IsTileOwner(current_tile, OWNER_NONE))) continue;
+		if (water && IsCanal(current_tile) && _game_mode != GameMode::Editor && (IsTileOwner(current_tile, _current_company) || IsTileOwner(current_tile, OWNER_NONE))) continue;
 
 		ret = Command<Commands::LandscapeClear>::Do(flags, current_tile);
 		if (ret.Failed()) return ret;
@@ -537,7 +537,7 @@ CommandCost CmdBuildCanal(DoCommandFlags flags, TileIndex tile, TileIndex start_
 			switch (wc) {
 				case WaterClass::River:
 					MakeRiver(current_tile, Random());
-					if (_game_mode == GM_EDITOR) {
+					if (_game_mode == GameMode::Editor) {
 						/* Remove desert directly around the river tile. */
 						for (auto t : SpiralTileSequence(current_tile, RIVER_OFFSET_DESERT_DISTANCE)) {
 							if (GetTropicZone(t) == TropicZone::Desert) SetTropicZone(t, TropicZone::Normal);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2769,7 +2769,7 @@ void HandleTextInput(std::string_view str, bool marked, std::optional<size_t> ca
  */
 static void HandleAutoscroll()
 {
-	if (_game_mode == GM_MENU || HasModalProgress()) return;
+	if (_game_mode == GameMode::Menu || HasModalProgress()) return;
 	if (_settings_client.gui.auto_scrolling == VA_DISABLED) return;
 	if (_settings_client.gui.auto_scrolling == VA_MAIN_VIEWPORT_FULLSCREEN && !_fullscreen) return;
 
@@ -2821,7 +2821,7 @@ const std::chrono::milliseconds TIME_BETWEEN_DOUBLE_CLICK{500}; ///< Time betwee
 
 static void ScrollMainViewport(int x, int y)
 {
-	if (_game_mode != GM_MENU && _game_mode != GM_BOOTSTRAP) {
+	if (_game_mode != GameMode::Menu && _game_mode != GameMode::Bootstrap) {
 		Window *w = GetMainWindow();
 		w->viewport->dest_scrollpos_x += ScaleByZoom(x, w->viewport->zoom);
 		w->viewport->dest_scrollpos_y += ScaleByZoom(y, w->viewport->zoom);
@@ -2865,7 +2865,7 @@ static void HandleKeyScrolling()
 	if (_dirkeys.Any() && !EditBoxInGlobalFocus()) {
 		int factor = _shift_pressed ? 50 : 10;
 
-		if (_game_mode != GM_MENU && _game_mode != GM_BOOTSTRAP) {
+		if (_game_mode != GameMode::Menu && _game_mode != GameMode::Bootstrap) {
 			/* Key scrolling stops following a vehicle. */
 			Window *main_window = GetMainWindow();
 			main_window->viewport->CancelFollow(*main_window);
@@ -2904,7 +2904,7 @@ static void MouseLoop(MouseClick click, int mousewheel)
 	Viewport *vp = IsPtInWindowViewport(w, x, y);
 
 	/* Don't allow any action in a viewport if either in menu or when having a modal progress window */
-	if (vp != nullptr && (_game_mode == GM_MENU || HasModalProgress())) return;
+	if (vp != nullptr && (_game_mode == GameMode::Menu || HasModalProgress())) return;
 
 	if (mousewheel != 0) {
 		/* Send mousewheel event to window, unless we're scrolling a viewport or the map */


### PR DESCRIPTION
## Motivation / Problem

Our endeavour to migrate to scoped enums and improving documentation.


## Description

* Make `GameMode` a scoped enum and document the values.
* Make `LoggedChangeMode` use `GameMode` instead of `uint8_t`.
* Some alignment changes and an addition of `to_underlying`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
