### PR TITLE
Codechange: make SwitchMode a scoped enum

### DIFF
--- a/src/ai/ai_instance.cpp
+++ b/src/ai/ai_instance.cpp
@@ -66,7 +66,7 @@ void AIInstance::Died()
 	if (_game_mode == GameMode::Menu) return;
 
 	/* Don't show errors while loading savegame. They will be shown at end of loading anyway. */
-	if (_switch_mode != SM_NONE) return;
+	if (_switch_mode != SwitchMode::None) return;
 
 	ShowScriptDebugWindow(_current_company);
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -468,7 +468,7 @@ static bool ConLoad(std::span<std::string_view> argv)
 	const FiosItem *item = _console_file_list_savegame.FindItem(file);
 	if (item != nullptr) {
 		if (item->type.abstract == AbstractFileType::Savegame) {
-			_switch_mode = SM_LOAD_GAME;
+			_switch_mode = SwitchMode::LoadGame;
 			_file_to_saveload.Set(*item);
 		} else {
 			IConsolePrint(CC_ERROR, "'{}' is not a savegame.", file);
@@ -495,7 +495,7 @@ static bool ConLoadScenario(std::span<std::string_view> argv)
 	const FiosItem *item = _console_file_list_scenario.FindItem(file);
 	if (item != nullptr) {
 		if (item->type.abstract == AbstractFileType::Scenario) {
-			_switch_mode = SM_LOAD_GAME;
+			_switch_mode = SwitchMode::LoadGame;
 			_file_to_saveload.Set(*item);
 		} else {
 			IConsolePrint(CC_ERROR, "'{}' is not a scenario.", file);
@@ -522,7 +522,7 @@ static bool ConLoadHeightmap(std::span<std::string_view> argv)
 	const FiosItem *item = _console_file_list_heightmap.FindItem(file);
 	if (item != nullptr) {
 		if (item->type.abstract == AbstractFileType::Heightmap) {
-			_switch_mode = SM_START_HEIGHTMAP;
+			_switch_mode = SwitchMode::StartHeightmap;
 			_file_to_saveload.Set(*item);
 		} else {
 			IConsolePrint(CC_ERROR, "'{}' is not a heightmap.", file);
@@ -1392,7 +1392,7 @@ static bool ConRestart(std::span<std::string_view> argv)
 	} else {
 		_settings_game.game_creation.map_x = Map::LogX();
 		_settings_game.game_creation.map_y = Map::LogY();
-		_switch_mode = SM_RESTARTGAME;
+		_switch_mode = SwitchMode::RestartGame;
 	}
 
 	return true;
@@ -1415,7 +1415,7 @@ static bool ConReload(std::span<std::string_view> argv)
 	/* Use a switch-mode to prevent copying over newgame settings to active settings. */
 	_settings_game.game_creation.map_x = Map::LogX();
 	_settings_game.game_creation.map_y = Map::LogY();
-	_switch_mode = SM_RELOADGAME;
+	_switch_mode = SwitchMode::ReloadGame;
 	return true;
 }
 
@@ -1930,7 +1930,7 @@ static bool ConPart(std::span<std::string_view> argv)
 		return false;
 	}
 
-	_switch_mode = SM_MENU;
+	_switch_mode = SwitchMode::Menu;
 	return true;
 }
 

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -360,13 +360,13 @@ private:
 	static void SaveGameConfirmationCallback(Window *, bool confirmed)
 	{
 		/* File name has already been written to _file_to_saveload */
-		if (confirmed) _switch_mode = SM_SAVE_GAME;
+		if (confirmed) _switch_mode = SwitchMode::SaveGame;
 	}
 
 	static void SaveHeightmapConfirmationCallback(Window *, bool confirmed)
 	{
 		/* File name has already been written to _file_to_saveload */
-		if (confirmed) _switch_mode = SM_SAVE_HEIGHTMAP;
+		if (confirmed) _switch_mode = SwitchMode::SaveHeightmap;
 	}
 
 	static void DeleteFileConfirmationCallback(Window *window, bool confirmed)
@@ -718,7 +718,7 @@ public:
 					this->Close();
 					LoadTownData();
 				} else if (!_load_check_data.HasNewGrfs() || _load_check_data.grf_compatibility != GRFListCompatibility::NotFound || _settings_client.gui.UserIsAllowedToChangeNewGRFs()) {
-					_switch_mode = (_game_mode == GameMode::Editor) ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
+					_switch_mode = (_game_mode == GameMode::Editor) ? SwitchMode::LoadScenario : SwitchMode::LoadGame;
 					ClearErrorMessages();
 					this->Close();
 				}
@@ -853,7 +853,7 @@ public:
 					ShowQuery(GetEncodedString(STR_SAVELOAD_OVERWRITE_TITLE), GetEncodedString(STR_SAVELOAD_OVERWRITE_WARNING),
 							this, SaveLoadWindow::SaveGameConfirmationCallback);
 				} else {
-					_switch_mode = SM_SAVE_GAME;
+					_switch_mode = SwitchMode::SaveGame;
 				}
 			} else {
 				_file_to_saveload.name = FiosMakeHeightmapName(this->filename_editbox.text.GetText());
@@ -861,7 +861,7 @@ public:
 					ShowQuery(GetEncodedString(STR_SAVELOAD_OVERWRITE_TITLE), GetEncodedString(STR_SAVELOAD_OVERWRITE_WARNING),
 							this, SaveLoadWindow::SaveHeightmapConfirmationCallback);
 				} else {
-					_switch_mode = SM_SAVE_HEIGHTMAP;
+					_switch_mode = SwitchMode::SaveHeightmap;
 				}
 			}
 

--- a/src/game/game_instance.cpp
+++ b/src/game/game_instance.cpp
@@ -70,7 +70,7 @@ void GameInstance::Died()
 	ScriptInstance::Died();
 
 	/* Don't show errors while loading savegame. They will be shown at end of loading anyway. */
-	if (_switch_mode != SM_NONE) return;
+	if (_switch_mode != SwitchMode::None) return;
 
 	ShowScriptDebugWindow(OWNER_DEITY);
 

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -278,7 +278,7 @@ bool IsGeneratingWorldAborted()
 void HandleGeneratingWorldAbortion()
 {
 	/* Clean up - in SE create an empty map, otherwise, go to intro menu */
-	_switch_mode = (_game_mode == GameMode::Editor) ? SM_EDITOR : SM_MENU;
+	_switch_mode = (_game_mode == GameMode::Editor) ? SwitchMode::Editor : SwitchMode::Menu;
 
 	if (GenWorldInfo::abortp != nullptr) GenWorldInfo::abortp();
 

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -336,9 +336,9 @@ static void StartGeneratingLandscape(GenerateLandscapeWindowMode mode)
 
 	SndConfirmBeep();
 	switch (mode) {
-		case GLWM_GENERATE: _switch_mode = (_game_mode == GameMode::Editor) ? SM_GENRANDLAND : SM_NEWGAME; break;
-		case GLWM_HEIGHTMAP: _switch_mode = (_game_mode == GameMode::Editor) ? SM_LOAD_HEIGHTMAP : SM_START_HEIGHTMAP; break;
-		case GLWM_SCENARIO:  _switch_mode = SM_EDITOR; break;
+		case GLWM_GENERATE: _switch_mode = (_game_mode == GameMode::Editor) ? SwitchMode::GenerateRandomLand : SwitchMode::NewGame; break;
+		case GLWM_HEIGHTMAP: _switch_mode = (_game_mode == GameMode::Editor) ? SwitchMode::LoadHeightmap : SwitchMode::StartHeightmap; break;
+		case GLWM_SCENARIO: _switch_mode = SwitchMode::Editor; break;
 		default: NOT_REACHED();
 	}
 }

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -47,7 +47,7 @@ DrawPixelInfo _screen;
 bool _screen_disable_anim = false;   ///< Disable palette animation (important for 32bpp-anim blitter during giant screenshot)
 std::atomic<bool> _exit_game;
 GameMode _game_mode;
-SwitchMode _switch_mode;  ///< The next mainloop command.
+SwitchMode _switch_mode; ///< The next mainloop command.
 PauseModes _pause_mode;
 GameSessionStats _game_session_stats; ///< Statistics about the current session.
 

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -424,7 +424,7 @@ void AskExitGame()
 static void AskExitToGameMenuCallback(Window *, bool confirmed)
 {
 	if (confirmed) {
-		_switch_mode = SM_MENU;
+		_switch_mode = SwitchMode::Menu;
 		ClearErrorMessages();
 	}
 }

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -295,7 +295,7 @@ struct MainWindow : Window
 				if (_game_mode == GameMode::Menu) return ES_HANDLED;
 				if (_settings_client.gui.autosave_on_exit) {
 					DoExitSave();
-					_switch_mode = SM_MENU;
+					_switch_mode = SwitchMode::Menu;
 				} else {
 					AskExitToGameMenu();
 				}

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -40,7 +40,7 @@ NetworkRecvStatus NetworkGameSocketHandler::CloseConnection([[maybe_unused]] boo
 	/* Clients drop back to the main menu */
 	if (!_network_server && _networking) {
 		ClientNetworkEmergencySave();
-		_switch_mode = SM_MENU;
+		_switch_mode = SwitchMode::Menu;
 		_networking = false;
 		ShowErrorMessage(GetEncodedString(STR_NETWORK_ERROR_LOSTCONNECTION), {}, WarningLevel::Critical);
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -315,7 +315,7 @@ uint NetworkCalculateLag(const NetworkClientSocket *cs)
  */
 void ShowNetworkError(StringID error_string)
 {
-	_switch_mode = SM_MENU;
+	_switch_mode = SwitchMode::Menu;
 	ShowErrorMessage(GetEncodedString(error_string), {}, WarningLevel::Critical);
 }
 
@@ -829,7 +829,7 @@ bool NetworkClientConnectGame(std::string_view connection_string, CompanyID defa
 		 * load in the new. After all, there is little point in continuing to
 		 * play on a server if we are connecting to another one.
 		 */
-		_switch_mode = SM_JOIN_GAME;
+		_switch_mode = SwitchMode::JoinGame;
 	}
 	return true;
 }

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -185,7 +185,7 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 
 	CloseWindowById(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
-	if (_game_mode != GameMode::Menu) _switch_mode = SM_MENU;
+	if (_game_mode != GameMode::Menu) _switch_mode = SwitchMode::Menu;
 	_networking = false;
 }
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2178,7 +2178,7 @@ struct NetworkJoinStatusWindow : Window {
 	{
 		if (widget == WID_NJS_CANCELOK) { // Disconnect button
 			NetworkDisconnect();
-			SwitchToMode(SM_MENU);
+			SwitchToMode(SwitchMode::Menu);
 			ShowNetworkGameWindow();
 		}
 	}

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1877,15 +1877,15 @@ static void NetworkRestartMap()
 	switch (_file_to_saveload.ftype.abstract) {
 		case AbstractFileType::Savegame:
 		case AbstractFileType::Scenario:
-			_switch_mode = SM_LOAD_GAME;
+			_switch_mode = SwitchMode::LoadGame;
 			break;
 
 		case AbstractFileType::Heightmap:
-			_switch_mode = SM_START_HEIGHTMAP;
+			_switch_mode = SwitchMode::StartHeightmap;
 			break;
 
 		default:
-			_switch_mode = SM_NEWGAME;
+			_switch_mode = SwitchMode::NewGame;
 	}
 }
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -431,11 +431,11 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 		IConsoleCmdExec("exec scripts/autoexec.scr 0");
 
 		/* Make sure _settings is filled with _settings_newgame if we switch to a game directly */
-		if (_switch_mode != SM_NONE) MakeNewgameSettingsLive();
+		if (_switch_mode != SwitchMode::None) MakeNewgameSettingsLive();
 
 		if (_network_available && !connection_string.empty()) {
 			LoadIntroGame();
-			_switch_mode = SM_NONE;
+			_switch_mode = SwitchMode::None;
 
 			NetworkClientConnectGame(connection_string, COMPANY_NEW_COMPANY, join_server_password);
 		}
@@ -514,7 +514,7 @@ int openttd_main(std::span<std::string_view> arguments)
 	_dedicated_forks = false;
 
 	_game_mode = GameMode::Menu;
-	_switch_mode = SM_MENU;
+	_switch_mode = SwitchMode::Menu;
 
 	auto options = CreateOptions();
 	GetOptData mgo(arguments.subspan(1), options);
@@ -565,9 +565,9 @@ int openttd_main(std::span<std::string_view> arguments)
 		case 'e':
 			/* Allow for '-e' before or after '-g'. */
 			switch (_switch_mode) {
-				case SM_MENU: _switch_mode = SM_EDITOR; break;
-				case SM_LOAD_GAME: _switch_mode = SM_LOAD_SCENARIO; break;
-				case SM_START_HEIGHTMAP: _switch_mode = SM_LOAD_HEIGHTMAP; break;
+				case SwitchMode::Menu: _switch_mode = SwitchMode::Editor; break;
+				case SwitchMode::LoadGame: _switch_mode = SwitchMode::LoadScenario; break;
+				case SwitchMode::StartHeightmap: _switch_mode = SwitchMode::LoadHeightmap; break;
 				default: break;
 			}
 			break;
@@ -586,9 +586,9 @@ int openttd_main(std::span<std::string_view> arguments)
 
 				/* Allow for '-e' before or after '-g'. */
 				switch (ft.abstract) {
-					case AbstractFileType::Savegame: _switch_mode = (_switch_mode == SM_EDITOR ? SM_LOAD_SCENARIO : SM_LOAD_GAME); break;
-					case AbstractFileType::Scenario: _switch_mode = (_switch_mode == SM_EDITOR ? SM_LOAD_SCENARIO : SM_LOAD_GAME); break;
-					case AbstractFileType::Heightmap: _switch_mode = (_switch_mode == SM_EDITOR ? SM_LOAD_HEIGHTMAP : SM_START_HEIGHTMAP); break;
+					case AbstractFileType::Savegame: _switch_mode = (_switch_mode == SwitchMode::Editor ? SwitchMode::LoadScenario : SwitchMode::LoadGame); break;
+					case AbstractFileType::Scenario: _switch_mode = (_switch_mode == SwitchMode::Editor ? SwitchMode::LoadScenario : SwitchMode::LoadGame); break;
+					case AbstractFileType::Heightmap: _switch_mode = (_switch_mode == SwitchMode::Editor ? SwitchMode::LoadHeightmap : SwitchMode::StartHeightmap); break;
 					default: break;
 				}
 
@@ -596,7 +596,7 @@ int openttd_main(std::span<std::string_view> arguments)
 				break;
 			}
 
-			_switch_mode = SM_NEWGAME;
+			_switch_mode = SwitchMode::NewGame;
 			/* Give a random map if no seed has been given */
 			if (scanner->generation_seed == GENERATE_NEW_SEED) {
 				scanner->generation_seed = InteractiveRandom();
@@ -1016,10 +1016,10 @@ static void UpdateSocialIntegration(GameMode game_mode)
 void SwitchToMode(SwitchMode new_mode)
 {
 	/* If we are saving something, the network stays in its current state */
-	if (new_mode != SM_SAVE_GAME) {
+	if (new_mode != SwitchMode::SaveGame) {
 		/* If the network is active, make it not-active */
 		if (_networking) {
-			if (_network_server && (new_mode == SM_LOAD_GAME || new_mode == SM_NEWGAME || new_mode == SM_RESTARTGAME)) {
+			if (_network_server && (new_mode == SwitchMode::LoadGame || new_mode == SwitchMode::NewGame || new_mode == SwitchMode::RestartGame)) {
 				NetworkReboot();
 			} else {
 				NetworkDisconnect();
@@ -1029,7 +1029,7 @@ void SwitchToMode(SwitchMode new_mode)
 		/* If we are a server, we restart the server */
 		if (_is_network_server) {
 			/* But not if we are going to the menu */
-			if (new_mode != SM_MENU) {
+			if (new_mode != SwitchMode::Menu) {
 				/* check if we should reload the config */
 				if (_settings_client.network.reload_cfg) {
 					LoadFromConfig();
@@ -1045,56 +1045,56 @@ void SwitchToMode(SwitchMode new_mode)
 	}
 
 	/* Make sure all AI controllers are gone at quitting game */
-	if (new_mode != SM_SAVE_GAME) AI::KillAll();
+	if (new_mode != SwitchMode::SaveGame) AI::KillAll();
 
 	/* When we change mode, reset the autosave. */
-	if (new_mode != SM_SAVE_GAME) ChangeAutosaveFrequency(true);
+	if (new_mode != SwitchMode::SaveGame) ChangeAutosaveFrequency(true);
 
 	/* Transmit the survey if we were in normal-mode and not saving. It always means we leaving the current game. */
-	if (_game_mode == GameMode::Normal && new_mode != SM_SAVE_GAME) _survey.Transmit(NetworkSurveyHandler::Reason::Leave);
+	if (_game_mode == GameMode::Normal && new_mode != SwitchMode::SaveGame) _survey.Transmit(NetworkSurveyHandler::Reason::Leave);
 
 	/* Keep track when we last switch mode. Used for survey, to know how long someone was in a game. */
-	if (new_mode != SM_SAVE_GAME) {
+	if (new_mode != SwitchMode::SaveGame) {
 		_game_session_stats.start_time = std::chrono::steady_clock::now();
 		_game_session_stats.savegame_size = std::nullopt;
 	}
 
 	switch (new_mode) {
-		case SM_EDITOR: // Switch to scenario editor
+		case SwitchMode::Editor: // Switch to scenario editor
 			MakeNewEditorWorld();
 			GenerateSavegameId();
 
 			UpdateSocialIntegration(GameMode::Editor);
 			break;
 
-		case SM_RELOADGAME: // Reload with what-ever started the game
+		case SwitchMode::ReloadGame: // Reload with what-ever started the game
 			if (_file_to_saveload.ftype.abstract == AbstractFileType::Savegame || _file_to_saveload.ftype.abstract == AbstractFileType::Scenario) {
 				/* Reload current savegame/scenario */
-				_switch_mode = _game_mode == GameMode::Editor ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
+				_switch_mode = _game_mode == GameMode::Editor ? SwitchMode::LoadScenario : SwitchMode::LoadGame;
 				SwitchToMode(_switch_mode);
 				break;
 			} else if (_file_to_saveload.ftype.abstract == AbstractFileType::Heightmap) {
 				/* Restart current heightmap */
-				_switch_mode = _game_mode == GameMode::Editor ? SM_LOAD_HEIGHTMAP : SM_RESTART_HEIGHTMAP;
+				_switch_mode = _game_mode == GameMode::Editor ? SwitchMode::LoadHeightmap : SwitchMode::RestartHeightmap;
 				SwitchToMode(_switch_mode);
 				break;
 			}
 
-			MakeNewGame(false, new_mode == SM_NEWGAME);
+			MakeNewGame(false, new_mode == SwitchMode::NewGame);
 			GenerateSavegameId();
 
 			UpdateSocialIntegration(GameMode::Normal);
 			break;
 
-		case SM_RESTARTGAME: // Restart --> 'Random game' with current settings
-		case SM_NEWGAME: // New Game --> 'Random game'
-			MakeNewGame(false, new_mode == SM_NEWGAME);
+		case SwitchMode::RestartGame: // Restart --> 'Random game' with current settings
+		case SwitchMode::NewGame: // New Game --> 'Random game'
+			MakeNewGame(false, new_mode == SwitchMode::NewGame);
 			GenerateSavegameId();
 
 			UpdateSocialIntegration(GameMode::Normal);
 			break;
 
-		case SM_LOAD_GAME: { // Load game, Play Scenario
+		case SwitchMode::LoadGame: { // Load game, Play Scenario
 			ResetGRFConfig(true);
 			ResetWindowSystem();
 
@@ -1113,15 +1113,15 @@ void SwitchToMode(SwitchMode new_mode)
 			break;
 		}
 
-		case SM_RESTART_HEIGHTMAP: // Load a heightmap and start a new game from it with current settings
-		case SM_START_HEIGHTMAP: // Load a heightmap and start a new game from it
-			MakeNewGame(true, new_mode == SM_START_HEIGHTMAP);
+		case SwitchMode::RestartHeightmap: // Load a heightmap and start a new game from it with current settings
+		case SwitchMode::StartHeightmap: // Load a heightmap and start a new game from it
+			MakeNewGame(true, new_mode == SwitchMode::StartHeightmap);
 			GenerateSavegameId();
 
 			UpdateSocialIntegration(GameMode::Normal);
 			break;
 
-		case SM_LOAD_HEIGHTMAP: // Load heightmap from scenario editor
+		case SwitchMode::LoadHeightmap: // Load heightmap from scenario editor
 			SetLocalCompany(OWNER_NONE);
 
 			_game_mode = GameMode::Editor;
@@ -1133,7 +1133,7 @@ void SwitchToMode(SwitchMode new_mode)
 			UpdateSocialIntegration(GameMode::Editor);
 			break;
 
-		case SM_LOAD_SCENARIO: { // Load scenario from scenario editor
+		case SwitchMode::LoadScenario: { // Load scenario from scenario editor
 			if (SafeLoad(_file_to_saveload.name, _file_to_saveload.file_op, _file_to_saveload.ftype.detailed, GameMode::Editor, Subdirectory::None)) {
 				SetLocalCompany(OWNER_NONE);
 				GenerateSavegameId();
@@ -1148,14 +1148,14 @@ void SwitchToMode(SwitchMode new_mode)
 			break;
 		}
 
-		case SM_JOIN_GAME: // Join a multiplayer game
+		case SwitchMode::JoinGame: // Join a multiplayer game
 			LoadIntroGame();
 			NetworkClientJoinGame();
 
 			SocialIntegration::EventJoiningMultiplayer();
 			break;
 
-		case SM_MENU: // Switch to game intro menu
+		case SwitchMode::Menu: // Switch to game intro menu
 			LoadIntroGame();
 			if (BaseSounds::ini_set.empty() && BaseSounds::GetUsedSet()->fallback && SoundDriver::GetInstance()->HasOutput()) {
 				ShowErrorMessage(GetEncodedString(STR_WARNING_FALLBACK_SOUNDSET), {}, WarningLevel::Critical);
@@ -1173,7 +1173,7 @@ void SwitchToMode(SwitchMode new_mode)
 			UpdateSocialIntegration(GameMode::Menu);
 			break;
 
-		case SM_SAVE_GAME: // Save game.
+		case SwitchMode::SaveGame: // Save game.
 			/* Make network saved games on pause compatible to singleplayer mode */
 			if (SaveOrLoad(_file_to_saveload.name, SaveLoadOperation::Save, DetailedFileType::GameFile, Subdirectory::None) != SaveLoadResult::Ok) {
 				ShowErrorMessage(GetSaveLoadErrorType(), GetSaveLoadErrorMessage(), WarningLevel::Error);
@@ -1182,12 +1182,12 @@ void SwitchToMode(SwitchMode new_mode)
 			}
 			break;
 
-		case SM_SAVE_HEIGHTMAP: // Save heightmap.
+		case SwitchMode::SaveHeightmap: // Save heightmap.
 			MakeHeightmapScreenshot(_file_to_saveload.name);
 			CloseWindowById(WindowClass::SaveLoad, 0);
 			break;
 
-		case SM_GENRANDLAND: // Generate random land within scenario editor
+		case SwitchMode::GenerateRandomLand: // Generate random land within scenario editor
 			SetLocalCompany(OWNER_NONE);
 			GenerateWorld(GWM_RANDOM, 1 << _settings_game.game_creation.map_x, 1 << _settings_game.game_creation.map_y);
 			/* XXX: set date */
@@ -1359,9 +1359,9 @@ void GameLoop()
 	}
 
 	/* switch game mode? */
-	if (_switch_mode != SM_NONE && !HasModalProgress()) {
+	if (_switch_mode != SwitchMode::None && !HasModalProgress()) {
 		SwitchToMode(_switch_mode);
-		_switch_mode = SM_NONE;
+		_switch_mode = SwitchMode::None;
 		if (_exit_game) return;
 	}
 

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -23,22 +23,22 @@ enum class GameMode : uint8_t {
 };
 
 /** Mode which defines what mode we're switching to. */
-enum SwitchMode : uint8_t {
-	SM_NONE,
-	SM_NEWGAME,           ///< New Game --> 'Random game'.
-	SM_RESTARTGAME,       ///< Restart --> 'Random game' with current settings.
-	SM_RELOADGAME,        ///< Reload the savegame / scenario / heightmap you started the game with.
-	SM_EDITOR,            ///< Switch to scenario editor.
-	SM_LOAD_GAME,         ///< Load game, Play Scenario.
-	SM_MENU,              ///< Switch to game intro menu.
-	SM_SAVE_GAME,         ///< Save game.
-	SM_SAVE_HEIGHTMAP,    ///< Save heightmap.
-	SM_GENRANDLAND,       ///< Generate random land within scenario editor.
-	SM_LOAD_SCENARIO,     ///< Load scenario from scenario editor.
-	SM_START_HEIGHTMAP,   ///< Load a heightmap and start a new game from it.
-	SM_LOAD_HEIGHTMAP,    ///< Load heightmap from scenario editor.
-	SM_RESTART_HEIGHTMAP, ///< Load a heightmap and start a new game from it with current settings.
-	SM_JOIN_GAME,         ///< Join a network game.
+enum class SwitchMode : uint8_t {
+	None, ///< Not switching game mode.
+	NewGame, ///< New Game --> 'Random game'.
+	RestartGame, ///< Restart --> 'Random game' with current settings.
+	ReloadGame, ///< Reload the savegame / scenario / heightmap you started the game with.
+	Editor, ///< Switch to scenario editor.
+	LoadGame, ///< Load game, Play Scenario.
+	Menu, ///< Switch to game intro menu.
+	SaveGame, ///< Save game.
+	SaveHeightmap, ///< Save heightmap.
+	GenerateRandomLand, ///< Generate random land within scenario editor.
+	LoadScenario, ///< Load scenario from scenario editor.
+	StartHeightmap, ///< Load a heightmap and start a new game from it.
+	LoadHeightmap, ///< Load heightmap from scenario editor.
+	RestartHeightmap, ///< Load a heightmap and start a new game from it with current settings.
+	JoinGame, ///< Join a network game.
 };
 
 /** Display Options */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -461,7 +461,7 @@ struct GameOptionsWindow : Window {
 	void Close([[maybe_unused]] int data = 0) override
 	{
 		CloseWindowById(WindowClass::CustomCurrenty, 0);
-		if (this->reload) _switch_mode = SM_MENU;
+		if (this->reload) _switch_mode = SwitchMode::Menu;
 		this->Window::Close();
 	}
 

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -207,8 +207,8 @@ void VideoDriver_Dedicated::MainLoop()
 	_network_dedicated = true;
 	_current_company = _local_company = COMPANY_SPECTATOR;
 
-	/* If SwitchMode is SM_LOAD_GAME / SM_START_HEIGHTMAP, it means that the user used the '-g' options */
-	if (_switch_mode != SM_LOAD_GAME && _switch_mode != SM_START_HEIGHTMAP) {
+	/* If SwitchMode is SwitchMode::LoadGame / SwitchMode::StartHeightmap, it means that the user used the '-g' options */
+	if (_switch_mode != SwitchMode::LoadGame && _switch_mode != SwitchMode::StartHeightmap) {
 		StartNewGameWithoutGUI(GENERATE_NEW_SEED);
 	}
 

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -149,7 +149,7 @@ void VideoDriver::Tick()
 			::InputLoop();
 
 			/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
-			if (_game_mode == GameMode::Bootstrap || _switch_mode == SM_NONE || HasModalProgress()) {
+			if (_game_mode == GameMode::Bootstrap || _switch_mode == SwitchMode::None || HasModalProgress()) {
 				::UpdateWindows();
 			}
 


### PR DESCRIPTION
## Motivation / Problem

Making enums scoped.


## Description

Make `SwitchMode` a scoped enum.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
