### PR TITLE
Fix: incorrect language IDs passed to TranslateTTDPatchCodes

### DIFF
--- a/src/newgrf/newgrf_actb.cpp
+++ b/src/newgrf/newgrf_actb.cpp
@@ -11,6 +11,7 @@
 #include "../debug.h"
 #include "newgrf_bytereader.h"
 #include "newgrf_internal.h"
+#include "../language.h"
 
 #include "table/strings.h"
 
@@ -98,7 +99,7 @@ static void GRFLoadError(ByteReader &buf)
 		if (buf.HasData()) {
 			std::string_view message = buf.ReadString();
 
-			error.custom_message = TranslateTTDPatchCodes(_cur_gps.grffile->grfid, lang, true, message, SCC_RAW_STRING_POINTER);
+			error.custom_message = TranslateTTDPatchCodes(_cur_gps.grffile->grfid, _current_language->newgrflangid, true, message, SCC_RAW_STRING_POINTER);
 		} else {
 			GrfMsg(7, "GRFLoadError: No custom message supplied.");
 			error.custom_message.clear();
@@ -110,7 +111,7 @@ static void GRFLoadError(ByteReader &buf)
 	if (buf.HasData()) {
 		std::string_view data = buf.ReadString();
 
-		error.data = TranslateTTDPatchCodes(_cur_gps.grffile->grfid, lang, true, data);
+		error.data = TranslateTTDPatchCodes(_cur_gps.grffile->grfid, _current_language->newgrflangid, true, data);
 	} else {
 		GrfMsg(7, "GRFLoadError: No message data supplied.");
 		error.data.clear();


### PR DESCRIPTION
## Motivation / Problem

In some cases `TranslateTTDPatchCodes` is called with incorrect language IDs when using a NewGRF with GRF versions lower than 7.

With GRF versions < 7 the language is a bitmask, with GRF versions >= 7 it is an identifier. In the problematic cases the language provided by the NewGRF is passed as-is to `TranslateTTDPatchCodes`.

Note that this likely has little effect as it's used by `TranslateTTDPatchCodes` for determining genders/cases, which would require substrings that seem not to be available in these contexts. However, if you want to change to stricter typing it's better to solve it correctly than to cast willy-nilly.


## Description

In the error message handling the NewGRF language is used directly, but before that it's checking whether this string is valid for the current language. So, what you actually want in this context is using the current language.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
