### PR TITLE
Codechange: make a scoped GRFLanguages

### DIFF
--- a/src/language.h
+++ b/src/language.h
@@ -14,6 +14,7 @@
 #include <unicode/coll.h>
 #endif /* WITH_ICU_I18N */
 #include "strings_type.h"
+#include "newgrf_text_type.h"
 #include <filesystem>
 
 static const uint8_t CASE_GENDER_LEN = 16; ///< The (maximum) length of a case/gender string.
@@ -49,7 +50,7 @@ struct LanguagePackHeader {
 	 *   http://msdn.microsoft.com/en-us/library/ms776294.aspx
 	 */
 	uint16_t winlangid = 0; ///< windows language id
-	uint8_t newgrflangid = 0; ///< newgrf language id
+	GRFLanguage newgrflangid{}; ///< newgrf language id
 	uint8_t num_genders = 0; ///< the number of genders of this language
 	uint8_t num_cases = 0; ///< the number of cases of this language
 	uint8_t pad[3] = {}; ///< pad header to be a multiple of 4
@@ -104,6 +105,6 @@ extern std::unique_ptr<icu::Collator> _current_collator;
 #endif /* WITH_ICU_I18N */
 
 bool ReadLanguagePack(const LanguageMetadata *lang);
-const LanguageMetadata *GetLanguage(uint8_t newgrflangid);
+const LanguageMetadata *GetLanguage(GRFLanguage newgrflangid);
 
 #endif /* LANGUAGE_H */

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -360,9 +360,8 @@ void ConvertTTDBasePrice(uint32_t base_pointer, std::string_view error_location,
  * @param language_id The (NewGRF) language ID to get the map for.
  * @return The LanguageMap, or nullptr if it couldn't be found.
  */
-/* static */ const LanguageMap *LanguageMap::GetLanguageMap(uint32_t grfid, uint8_t language_id)
+/* static */ const LanguageMap *LanguageMap::GetLanguageMap(uint32_t grfid, GRFLanguage language_id)
 {
-	/* LanguageID "MAX_LANG", i.e. 7F is any. This language can't have a gender/case mapping, but has to be handled gracefully. */
 	const GRFFile *grffile = GetFileByGRFID(grfid);
 	if (grffile == nullptr) return nullptr;
 

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -161,7 +161,7 @@ struct GRFFile {
 
 	std::array<CanalProperties, CF_END> canal_local_properties{}; ///< Canal properties as set by this NewGRF
 
-	std::unordered_map<uint8_t, LanguageMap> language_map{}; ///< Mappings related to the languages.
+	std::unordered_map<GRFLanguage, LanguageMap> language_map{}; ///< Mappings related to the languages.
 
 	int traininfo_vehicle_pitch = 0; ///< Vertical offset for drawing train images in depot GUI and vehicle details
 	uint traininfo_vehicle_width = 0; ///< Width (in pixels) of a 8/8 train vehicle in depot GUI and vehicle details

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -266,10 +266,10 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 			case 0x13:   // Gender translation table
 			case 0x14:   // Case translation table
 			case 0x15: { // Plural form translation
-				uint curidx = id; // The current index, i.e. language.
-				const LanguageMetadata *lang = curidx < MAX_LANG ? GetLanguage(curidx) : nullptr;
+				GRFLanguage langid = static_cast<GRFLanguage>(id); // The current index, i.e. language.
+				const LanguageMetadata *lang = langid < GRFLanguage::End ? GetLanguage(langid) : nullptr;
 				if (lang == nullptr) {
-					GrfMsg(1, "GlobalVarChangeInfo: Language {} is not known, ignoring", curidx);
+					GrfMsg(1, "GlobalVarChangeInfo: Language {} is not known, ignoring", langid);
 					/* Skip over the data. */
 					if (prop == 0x15) {
 						buf.ReadByte();
@@ -286,7 +286,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					if (plural_form >= LANGUAGE_MAX_PLURAL) {
 						GrfMsg(1, "GlobalVarChanceInfo: Plural form {} is out of range, ignoring", plural_form);
 					} else {
-						_cur_gps.grffile->language_map[curidx].plural_form = plural_form;
+						_cur_gps.grffile->language_map[langid].plural_form = plural_form;
 					}
 					break;
 				}
@@ -309,14 +309,14 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 						if (map.openttd_id >= MAX_NUM_GENDERS) {
 							GrfMsg(1, "GlobalVarChangeInfo: Gender name {} is not known, ignoring", StrMakeValid(name));
 						} else {
-							_cur_gps.grffile->language_map[curidx].gender_map.push_back(map);
+							_cur_gps.grffile->language_map[langid].gender_map.push_back(map);
 						}
 					} else {
 						map.openttd_id = lang->GetCaseIndex(name);
 						if (map.openttd_id >= MAX_NUM_CASES) {
 							GrfMsg(1, "GlobalVarChangeInfo: Case name {} is not known, ignoring", StrMakeValid(name));
 						} else {
-							_cur_gps.grffile->language_map[curidx].case_map.push_back(map);
+							_cur_gps.grffile->language_map[langid].case_map.push_back(map);
 						}
 					}
 					newgrf_id = buf.ReadByte();

--- a/src/newgrf/newgrf_act14.cpp
+++ b/src/newgrf/newgrf_act14.cpp
@@ -16,21 +16,21 @@
 #include "../safeguards.h"
 
 /** Callback function for 'INFO'->'NAME' to add a translation to the newgrf name. @copydoc TextHandler */
-static bool ChangeGRFName(uint8_t langid, std::string_view str)
+static bool ChangeGRFName(GRFLanguage langid, std::string_view str)
 {
 	AddGRFTextToList(_cur_gps.grfconfig->name, langid, _cur_gps.grfconfig->ident.grfid, false, str);
 	return true;
 }
 
 /** Callback function for 'INFO'->'DESC' to add a translation to the newgrf description. @copydoc TextHandler */
-static bool ChangeGRFDescription(uint8_t langid, std::string_view str)
+static bool ChangeGRFDescription(GRFLanguage langid, std::string_view str)
 {
 	AddGRFTextToList(_cur_gps.grfconfig->info, langid, _cur_gps.grfconfig->ident.grfid, true, str);
 	return true;
 }
 
 /** Callback function for 'INFO'->'URL_' to set the newgrf url. @copydoc TextHandler */
-static bool ChangeGRFURL(uint8_t langid, std::string_view str)
+static bool ChangeGRFURL(GRFLanguage langid, std::string_view str)
 {
 	AddGRFTextToList(_cur_gps.grfconfig->url, langid, _cur_gps.grfconfig->ident.grfid, false, str);
 	return true;
@@ -132,14 +132,14 @@ static bool ChangeGRFMinVersion(size_t len, ByteReader &buf)
 static GRFParameterInfo *_cur_parameter; ///< The parameter which info is currently changed by the newgrf.
 
 /** Callback function for 'INFO'->'PARAM'->param_num->'NAME' to set the name of a parameter. @copydoc TextHandler */
-static bool ChangeGRFParamName(uint8_t langid, std::string_view str)
+static bool ChangeGRFParamName(GRFLanguage langid, std::string_view str)
 {
 	AddGRFTextToList(_cur_parameter->name, langid, _cur_gps.grfconfig->ident.grfid, false, str);
 	return true;
 }
 
 /** Callback function for 'INFO'->'PARAM'->param_num->'DESC' to set the description of a parameter. @copydoc TextHandler */
-static bool ChangeGRFParamDescription(uint8_t langid, std::string_view str)
+static bool ChangeGRFParamDescription(GRFLanguage langid, std::string_view str)
 {
 	AddGRFTextToList(_cur_parameter->desc, langid, _cur_gps.grfconfig->ident.grfid, true, str);
 	return true;
@@ -237,7 +237,7 @@ using DataHandler = bool(*)(size_t len, ByteReader &buf);
  * @param str The actual text.
  * @return \c true iff the data could be processed.
  */
-using TextHandler = bool(*)(uint8_t langid, std::string_view str);
+using TextHandler = bool(*)(GRFLanguage langid, std::string_view str);
 
 /**
  * Callback for parsing branch nodes.
@@ -283,7 +283,7 @@ static bool ChangeGRFParamValueNames(ByteReader &buf)
 			continue;
 		}
 
-		uint8_t langid = buf.ReadByte();
+		GRFLanguage langid = static_cast<GRFLanguage>(buf.ReadByte());
 		std::string_view name_string = buf.ReadString();
 
 		auto it = std::ranges::lower_bound(_cur_parameter->value_names, id, std::less{}, &GRFParameterInfo::ValueName::first);
@@ -429,7 +429,7 @@ static bool HandleNode(uint8_t type, uint32_t id, ByteReader &buf, std::span<con
 
 		bool operator()(const TextHandler &handler)
 		{
-			uint8_t langid = buf.ReadByte();
+			GRFLanguage langid = static_cast<GRFLanguage>(buf.ReadByte());
 			return handler(langid, buf.ReadString());
 		}
 

--- a/src/newgrf/newgrf_act8.cpp
+++ b/src/newgrf/newgrf_act8.cpp
@@ -34,11 +34,11 @@ static void ScanInfo(ByteReader &buf)
 	/* GRF IDs starting with 0xFF are reserved for internal TTDPatch use */
 	if (GB(grfid, 0, 8) == 0xFF) _cur_gps.grfconfig->flags.Set(GRFConfigFlag::System);
 
-	AddGRFTextToList(_cur_gps.grfconfig->name, 0x7F, grfid, false, name);
+	AddGRFTextToList(_cur_gps.grfconfig->name, GRFLanguage::Unspecified, grfid, false, name);
 
 	if (buf.HasData()) {
 		std::string_view info = buf.ReadString();
-		AddGRFTextToList(_cur_gps.grfconfig->info, 0x7F, grfid, true, info);
+		AddGRFTextToList(_cur_gps.grfconfig->info, GRFLanguage::Unspecified, grfid, true, info);
 	}
 
 	/* GrfLoadingStage::FileScan only looks for the action 8, so we can skip the rest of the file */

--- a/src/newgrf/newgrf_actf.cpp
+++ b/src/newgrf/newgrf_actf.cpp
@@ -50,7 +50,7 @@ static void FeatureTownName(ByteReader &buf)
 
 			std::string_view name = buf.ReadString();
 
-			GrfMsg(6, "FeatureTownName: lang 0x{:X} (new_scheme: {}) -> '{}'", lang, new_scheme, TranslateTTDPatchCodes(grfid, 0, false, name));
+			GrfMsg(6, "FeatureTownName: lang 0x{:X} (new_scheme: {}) -> '{}'", lang, new_scheme, TranslateTTDPatchCodes(grfid, GRFLanguage::Fallback, false, name));
 
 			style = AddGRFString(grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 
@@ -88,7 +88,7 @@ static void FeatureTownName(ByteReader &buf)
 				GrfMsg(6, "FeatureTownName: part {}, text {}, uses intermediate definition 0x{:02X} (with probability {})", partnum, textnum, ref_id, part.prob & 0x7F);
 			} else {
 				std::string_view text = buf.ReadString();
-				part.text = TranslateTTDPatchCodes(grfid, 0, false, text);
+				part.text = TranslateTTDPatchCodes(grfid, GRFLanguage::Fallback, false, text);
 				GrfMsg(6, "FeatureTownName: part {}, text {}, '{}' (with probability {})", partnum, textnum, part.text, part.prob);
 			}
 			partlist.maxprob += GB(part.prob, 0, 7);

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -50,15 +50,6 @@ enum GRFBaseLanguages : uint8_t {
 	GRFLB_GENERIC     = 0x80,
 };
 
-enum GRFExtendedLanguages : uint8_t {
-	GRFLX_AMERICAN    = 0x00,
-	GRFLX_ENGLISH     = 0x01,
-	GRFLX_GERMAN      = 0x02,
-	GRFLX_FRENCH      = 0x03,
-	GRFLX_SPANISH     = 0x04,
-	GRFLX_UNSPECIFIED = 0x7F,
-};
-
 
 /**
  * Holder of the above structure.
@@ -233,7 +224,7 @@ struct UnmappedChoiceList {
  * @param byte80         The control code to use as replacement for the 0x80-value.
  * @return The translated string.
  */
-std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool allow_newlines, std::string_view str, StringControlCode byte80)
+std::string TranslateTTDPatchCodes(uint32_t grfid, GRFLanguage language_id, bool allow_newlines, std::string_view str, StringControlCode byte80)
 {
 	/* Empty input string? Nothing to do here. */
 	if (str.empty()) return {};
@@ -474,7 +465,7 @@ string_end:
  * @param langid The The language of the new text.
  * @param text_to_add The text to add to the list.
  */
-static void AddGRFTextToList(GRFTextList &list, uint8_t langid, std::string_view text_to_add)
+static void AddGRFTextToList(GRFTextList &list, GRFLanguage langid, std::string_view text_to_add)
 {
 	/* Loop through all languages and see if we can replace a string */
 	for (auto &text : list) {
@@ -497,7 +488,7 @@ static void AddGRFTextToList(GRFTextList &list, uint8_t langid, std::string_view
  * @param text_to_add The text to add to the list.
  * @note All text-codes will be translated.
  */
-void AddGRFTextToList(GRFTextList &list, uint8_t langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add)
+void AddGRFTextToList(GRFTextList &list, GRFLanguage langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add)
 {
 	AddGRFTextToList(list, langid, TranslateTTDPatchCodes(grfid, langid, allow_newlines, text_to_add));
 }
@@ -511,7 +502,7 @@ void AddGRFTextToList(GRFTextList &list, uint8_t langid, uint32_t grfid, bool al
  * @param text_to_add The text to add to the list.
  * @note All text-codes will be translated.
  */
-void AddGRFTextToList(GRFTextWrapper &list, uint8_t langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add)
+void AddGRFTextToList(GRFTextWrapper &list, GRFLanguage langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add)
 {
 	if (list == nullptr) list = std::make_shared<GRFTextList>();
 	AddGRFTextToList(*list, langid, grfid, allow_newlines, text_to_add);
@@ -526,7 +517,7 @@ void AddGRFTextToList(GRFTextWrapper &list, uint8_t langid, uint32_t grfid, bool
 void AddGRFTextToList(GRFTextWrapper &list, std::string_view text_to_add)
 {
 	if (list == nullptr) list = std::make_shared<GRFTextList>();
-	AddGRFTextToList(*list, GRFLX_UNSPECIFIED, text_to_add);
+	AddGRFTextToList(*list, GRFLanguage::Unspecified, text_to_add);
 }
 
 /**
@@ -539,7 +530,7 @@ void AddGRFTextToList(GRFTextWrapper &list, std::string_view text_to_add)
  * @param def_string The fallback string if a translation for this string isn't available.
  * @return The OpenTTD internal string identifier.
  */
-static StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid_to_add, bool allow_newlines, std::string_view text_to_add, StringID def_string)
+static StringID AddGRFString(uint32_t grfid, GRFStringID stringid, GRFLanguage langid_to_add, bool allow_newlines, std::string_view text_to_add, StringID def_string)
 {
 	auto it = std::ranges::find_if(_grf_text, [&grfid, &stringid](const GRFTextEntry &grf_text) { return grf_text.grfid == grfid && grf_text.stringid == stringid; });
 	if (it == std::end(_grf_text)) {
@@ -575,7 +566,7 @@ static StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langi
  */
 StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid_to_add, bool new_scheme, bool allow_newlines, std::string_view text_to_add, StringID def_string)
 {
-	if (new_scheme) return AddGRFString(grfid, stringid, langid_to_add, allow_newlines, text_to_add, def_string);
+	if (new_scheme) return AddGRFString(grfid, stringid, static_cast<GRFLanguage>(langid_to_add), allow_newlines, text_to_add, def_string);
 
 	/* When working with the old language scheme (grf_version is less than 7) and
 	 * English or American is among the set bits, simply add it as English in
@@ -583,12 +574,12 @@ StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid_to_ad
 	 * If English is set, it is pretty safe to assume the translations are not
 	 * actually translated.
 	 */
-	if (langid_to_add & (GRFLB_AMERICAN | GRFLB_ENGLISH)) return AddGRFString(grfid, stringid, GRFLX_ENGLISH, allow_newlines, text_to_add, def_string);
+	if (langid_to_add & (GRFLB_AMERICAN | GRFLB_ENGLISH)) return AddGRFString(grfid, stringid, GRFLanguage::English, allow_newlines, text_to_add, def_string);
 
 	StringID ret = STR_EMPTY;
-	if (langid_to_add & GRFLB_GERMAN) ret = AddGRFString(grfid, stringid, GRFLX_GERMAN, allow_newlines, text_to_add, def_string);
-	if (langid_to_add & GRFLB_FRENCH) ret = AddGRFString(grfid, stringid, GRFLX_FRENCH, allow_newlines, text_to_add, def_string);
-	if (langid_to_add & GRFLB_SPANISH) ret = AddGRFString(grfid, stringid, GRFLX_SPANISH, allow_newlines, text_to_add, def_string);
+	if (langid_to_add & GRFLB_GERMAN) ret = AddGRFString(grfid, stringid, GRFLanguage::German, allow_newlines, text_to_add, def_string);
+	if (langid_to_add & GRFLB_FRENCH) ret = AddGRFString(grfid, stringid, GRFLanguage::French, allow_newlines, text_to_add, def_string);
+	if (langid_to_add & GRFLB_SPANISH) ret = AddGRFString(grfid, stringid, GRFLanguage::Spanish, allow_newlines, text_to_add, def_string);
 	return ret;
 }
 
@@ -628,7 +619,7 @@ std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextList &text_
 
 		/* If the current string is English or American, set it as the
 		 * fallback language if the specific language isn't available. */
-		if (text.langid == GRFLX_UNSPECIFIED || (!default_text.has_value() && (text.langid == GRFLX_ENGLISH || text.langid == GRFLX_AMERICAN))) {
+		if (text.langid == GRFLanguage::Unspecified || (!default_text.has_value() && (text.langid == GRFLanguage::English || text.langid == GRFLanguage::American))) {
 			default_text = text.text;
 		}
 	}
@@ -670,14 +661,15 @@ bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version)
 {
 	if (grf_version < 7) {
 		switch (_current_language->newgrflangid) {
-			case GRFLX_GERMAN:  return (lang_id & GRFLB_GERMAN)  != 0;
-			case GRFLX_FRENCH:  return (lang_id & GRFLB_FRENCH)  != 0;
-			case GRFLX_SPANISH: return (lang_id & GRFLB_SPANISH) != 0;
+			case GRFLanguage::German: return (lang_id & GRFLB_GERMAN) != 0;
+			case GRFLanguage::French: return (lang_id & GRFLB_FRENCH) != 0;
+			case GRFLanguage::Spanish: return (lang_id & GRFLB_SPANISH) != 0;
 			default:            return (lang_id & (GRFLB_ENGLISH | GRFLB_AMERICAN)) != 0;
 		}
 	}
 
-	return (lang_id == _current_language->newgrflangid || lang_id == GRFLX_UNSPECIFIED);
+	GRFLanguage new_lang = static_cast<GRFLanguage>(lang_id);
+	return new_lang == _current_language->newgrflangid || new_lang == GRFLanguage::Unspecified;
 }
 
 /**

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -36,19 +36,8 @@
 
 #include "safeguards.h"
 
-/**
- * Explains the newgrf shift bit positioning.
- * the grf base will not be used in order to find the string, but rather for
- * jumping from standard langID scheme to the new one.
- */
-enum GRFBaseLanguages : uint8_t {
-	GRFLB_AMERICAN    = 0x01,
-	GRFLB_ENGLISH     = 0x02,
-	GRFLB_GERMAN      = 0x04,
-	GRFLB_FRENCH      = 0x08,
-	GRFLB_SPANISH     = 0x10,
-	GRFLB_GENERIC     = 0x80,
-};
+/** The bitmask of the old GRF languages, which are conveniently the same as the first few GRFLanguages. */
+using OldGRFLanguages = EnumBitSet<GRFLanguage, uint8_t>;
 
 
 /**
@@ -568,18 +557,20 @@ StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid_to_ad
 {
 	if (new_scheme) return AddGRFString(grfid, stringid, static_cast<GRFLanguage>(langid_to_add), allow_newlines, text_to_add, def_string);
 
+	OldGRFLanguages old_lang{langid_to_add};
+
 	/* When working with the old language scheme (grf_version is less than 7) and
 	 * English or American is among the set bits, simply add it as English in
 	 * the new scheme, i.e. as langid = 1.
 	 * If English is set, it is pretty safe to assume the translations are not
 	 * actually translated.
 	 */
-	if (langid_to_add & (GRFLB_AMERICAN | GRFLB_ENGLISH)) return AddGRFString(grfid, stringid, GRFLanguage::English, allow_newlines, text_to_add, def_string);
+	if (old_lang.Any({GRFLanguage::American, GRFLanguage::English})) return AddGRFString(grfid, stringid, GRFLanguage::English, allow_newlines, text_to_add, def_string);
 
 	StringID ret = STR_EMPTY;
-	if (langid_to_add & GRFLB_GERMAN) ret = AddGRFString(grfid, stringid, GRFLanguage::German, allow_newlines, text_to_add, def_string);
-	if (langid_to_add & GRFLB_FRENCH) ret = AddGRFString(grfid, stringid, GRFLanguage::French, allow_newlines, text_to_add, def_string);
-	if (langid_to_add & GRFLB_SPANISH) ret = AddGRFString(grfid, stringid, GRFLanguage::Spanish, allow_newlines, text_to_add, def_string);
+	for (GRFLanguage lang: {GRFLanguage::German, GRFLanguage::French, GRFLanguage::Spanish}) {
+		if (old_lang.Test(lang)) ret = AddGRFString(grfid, stringid, lang, allow_newlines, text_to_add, def_string);
+	}
 	return ret;
 }
 
@@ -660,11 +651,12 @@ std::string_view GetGRFStringPtr(StringIndexInTab stringid)
 bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version)
 {
 	if (grf_version < 7) {
+		OldGRFLanguages old_lang{lang_id};
 		switch (_current_language->newgrflangid) {
-			case GRFLanguage::German: return (lang_id & GRFLB_GERMAN) != 0;
-			case GRFLanguage::French: return (lang_id & GRFLB_FRENCH) != 0;
-			case GRFLanguage::Spanish: return (lang_id & GRFLB_SPANISH) != 0;
-			default:            return (lang_id & (GRFLB_ENGLISH | GRFLB_AMERICAN)) != 0;
+			case GRFLanguage::German: return old_lang.Test(GRFLanguage::German);
+			case GRFLanguage::French: return old_lang.Test(GRFLanguage::French);
+			case GRFLanguage::Spanish: return old_lang.Test(GRFLanguage::Spanish);
+			default: return old_lang.Any({GRFLanguage::American, GRFLanguage::English});
 		}
 	}
 

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -20,9 +20,9 @@ std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextList &text_
 std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextWrapper &text);
 std::string_view GetGRFStringPtr(StringIndexInTab stringid);
 void CleanUpStrings();
-std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool allow_newlines, std::string_view str, StringControlCode byte80 = SCC_NEWGRF_PRINT_WORD_STRING_ID);
-void AddGRFTextToList(GRFTextList &list, uint8_t langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add);
-void AddGRFTextToList(GRFTextWrapper &list, uint8_t langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add);
+std::string TranslateTTDPatchCodes(uint32_t grfid, GRFLanguage language_id, bool allow_newlines, std::string_view str, StringControlCode byte80 = SCC_NEWGRF_PRINT_WORD_STRING_ID);
+void AddGRFTextToList(GRFTextList &list, GRFLanguage langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add);
+void AddGRFTextToList(GRFTextWrapper &list, GRFLanguage langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add);
 void AddGRFTextToList(GRFTextWrapper &list, std::string_view text_to_add);
 
 bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version);

--- a/src/newgrf_text_type.h
+++ b/src/newgrf_text_type.h
@@ -20,9 +20,23 @@ static constexpr GRFStringID GRFSTR_MISC_GRF_TEXT{0xD000}; ///< Miscellaneous GR
 /** This character (thorn) indicates a unicode string to NFO. */
 static const char32_t NFO_UTF8_IDENTIFIER = 0x00DE;
 
+/** Incomplete enumeration of the (New)GRF languages. */
+enum class GRFLanguage : uint8_t {
+	American = 0, ///< American (English US)
+	English = 1, ///< English (English UK)
+	German = 2, ///< German
+	French = 3, ///< French
+	Spanish = 4, ///< Spanish
+
+	Unspecified = 0x7F, ///< No specific language.
+	End = 0x7F, ///< End marker of the valid languages.
+
+	Fallback = American, ///< Default fallback language.
+};
+
 /** A GRF text with associated language ID. */
 struct GRFText {
-	uint8_t langid;      ///< The language associated with this GRFText.
+	GRFLanguage langid; ///< The language associated with this GRFText.
 	std::string text; ///< The actual (translated) text.
 };
 
@@ -51,7 +65,7 @@ struct LanguageMap {
 
 	int GetMapping(int newgrf_id, bool gender) const;
 	int GetReverseMapping(int openttd_id, bool gender) const;
-	static const LanguageMap *GetLanguageMap(uint32_t grfid, uint8_t language_id);
+	static const LanguageMap *GetLanguageMap(uint32_t grfid, GRFLanguage language_id);
 };
 
 #endif /* NEWGRF_TEXT_TYPE_H */

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -143,7 +143,7 @@ void FileStringReader::HandlePragma(std::string_view str, LanguagePackHeader &la
 		if (langid >= 0x7F || langid < 0) {
 			FatalError("Invalid grflangid {}", langid);
 		}
-		lang.newgrflangid = static_cast<uint8_t>(langid);
+		lang.newgrflangid = static_cast<GRFLanguage>(langid);
 	} else if (name == "gender") {
 		if (this->master) FatalError("Genders are not allowed in the base translation.");
 		for (;;) {

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2026,7 +2026,7 @@ bool LanguagePackHeader::IsValid() const
 	       this->version      == TO_LE32(LANGUAGE_PACK_VERSION) &&
 	       this->plural_form  <  LANGUAGE_MAX_PLURAL &&
 	       this->text_dir     <= 1 &&
-	       this->newgrflangid < MAX_LANG &&
+	       this->newgrflangid < GRFLanguage::End &&
 	       this->num_genders  < MAX_NUM_GENDERS &&
 	       this->num_cases    < MAX_NUM_CASES &&
 	       StrValid(this->name) &&
@@ -2187,7 +2187,7 @@ std::optional<std::string> GetCurrentLocale(const char *param);
  * @param newgrflangid NewGRF languages ID to check.
  * @return The language's metadata, or nullptr if it is not known.
  */
-const LanguageMetadata *GetLanguage(uint8_t newgrflangid)
+const LanguageMetadata *GetLanguage(GRFLanguage newgrflangid)
 {
 	for (const LanguageMetadata &lang : _languages) {
 		if (newgrflangid == lang.newgrflangid) return &lang;

--- a/src/strings_type.h
+++ b/src/strings_type.h
@@ -20,7 +20,6 @@
 typedef uint32_t StringID;
 static const StringID INVALID_STRING_ID = 0xFFFF; ///< Constant representing an invalid string (16bit in case it is used in savegames)
 static const int MAX_CHAR_LENGTH        = 4;      ///< Max. length of UTF-8 encoded unicode character
-static const uint MAX_LANG              = 0x7F;   ///< Maximum number of languages supported by the game, and the NewGRF specs
 
 /** Directions a text can go to */
 enum TextDirection : uint8_t {


### PR DESCRIPTION
## Motivation / Problem

Our endeavour to make enumerations scoped.

But also that it's often highly unclear which of the 'language IDs' is meant.
* The pre v7 language id bitmask.
* The v7+ language id.
* The internal language id.
* Or a mix of GRF version <7 and >= 7 language id.


## Description

The internal language id and v7+ language id are the same. These become `GRFLanguage`, for which only the few values that are needed for OpenTTD's logic are added.

The pre v7 language id bitmask becomes `OldGRFLanguages`, which is an `EnumBitSet` of `GRFLanguage`.

When it's unclear which one it is, it remains `uint8_t` and an extra parameter for the GRF version is required.

`MAX_LANG` is moved to `GRFLanguage` as `End` marker.


## Limitations

Might the 'fallback' language need to be changed to English (UK)? As that's internally our main fallback language?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
