### PR TITLE
Fix traffic side inconsistencies

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1660,12 +1660,12 @@ STR_CONFIG_SETTING_TREE_PLACER_NONE                             :None
 STR_CONFIG_SETTING_TREE_PLACER_ORIGINAL                         :Original
 STR_CONFIG_SETTING_TREE_PLACER_IMPROVED                         :Improved
 
-STR_CONFIG_SETTING_ROAD_SIDE                                    :Road vehicles: {STRING2}
-STR_CONFIG_SETTING_ROAD_SIDE_HELPTEXT                           :Choose the driving side
+STR_CONFIG_SETTING_ROAD_SIDE                                    :Road vehicle driving side: {STRING2}
+STR_CONFIG_SETTING_ROAD_SIDE_HELPTEXT                           :Choose the road vehicle driving side.{}This can also affect signal side and semaphore graphics.{}It may require reloading the game for a change to take full effect
 
 ###length 2
-STR_CONFIG_SETTING_ROAD_SIDE_LEFT                               :Drive on left
-STR_CONFIG_SETTING_ROAD_SIDE_RIGHT                              :Drive on right
+STR_CONFIG_SETTING_ROAD_SIDE_LEFT                               :Left
+STR_CONFIG_SETTING_ROAD_SIDE_RIGHT                              :Right
 
 STR_CONFIG_SETTING_HEIGHTMAP_ROTATION                           :Heightmap rotation: {STRING2}
 STR_CONFIG_SETTING_HEIGHTMAP_ROTATION_TOOLTIP                   :Choose which way the heightmap image is rotated to fit into the game world

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1660,12 +1660,12 @@ STR_CONFIG_SETTING_TREE_PLACER_NONE                             :None
 STR_CONFIG_SETTING_TREE_PLACER_ORIGINAL                         :Original
 STR_CONFIG_SETTING_TREE_PLACER_IMPROVED                         :Improved
 
-STR_CONFIG_SETTING_ROAD_SIDE                                    :Road vehicles: {STRING2}
-STR_CONFIG_SETTING_ROAD_SIDE_HELPTEXT                           :Choose the driving side
+STR_CONFIG_SETTING_ROAD_SIDE                                    :Driving side: {STRING2}
+STR_CONFIG_SETTING_ROAD_SIDE_HELPTEXT                           :Choose the driving side.{}This can also affect signal side and semaphore graphics.{}It may require reloading the game for a change to take full effect.
 
 ###length 2
-STR_CONFIG_SETTING_ROAD_SIDE_LEFT                               :Drive on left
-STR_CONFIG_SETTING_ROAD_SIDE_RIGHT                              :Drive on right
+STR_CONFIG_SETTING_ROAD_SIDE_LEFT                               :Left
+STR_CONFIG_SETTING_ROAD_SIDE_RIGHT                              :Right
 
 STR_CONFIG_SETTING_HEIGHTMAP_ROTATION                           :Heightmap rotation: {STRING2}
 STR_CONFIG_SETTING_HEIGHTMAP_ROTATION_TOOLTIP                   :Choose which way the heightmap image is rotated to fit into the game world

--- a/src/newgrf/newgrf_act7_9.cpp
+++ b/src/newgrf/newgrf_act7_9.cpp
@@ -24,6 +24,21 @@
 /** 32 * 8 = 256 flags. Apparently TTDPatch uses this many.. */
 static std::array<uint32_t, 8> _ttdpatch_flags;
 
+/**
+ * Checks whether the train signals are on the same side as the road vehicles are driving.
+ * This is a flag that can be checked by NewGRFs (TTDPatchFlags bit 0x3B).
+ * @return \c true iff the road vehicles drive on the same side as signals are drawn.
+ */
+static bool IsSignalSideOnTrafficSide()
+{
+	switch (_settings_game.construction.train_signal_side) {
+		case TrainSignalSide::RoadVehicleDrivingSide: return true;
+		case TrainSignalSide::Left: return _settings_game.vehicle.road_side == RoadVehicleDrivingSide::Left;
+		case TrainSignalSide::Right: return _settings_game.vehicle.road_side == RoadVehicleDrivingSide::Right;
+		default: NOT_REACHED();
+	}
+}
+
 /** Initialize the TTDPatch flags */
 void InitializePatchFlags()
 {
@@ -52,7 +67,7 @@ void InitializePatchFlags()
 	                   |                                                       (1U << 0x18)  // newrvs
 	                   |                                                       (1U << 0x19)  // newships
 	                   |                                                       (1U << 0x1A)  // newplanes
-	                   | ((_settings_game.construction.train_signal_side == TrainSignalSide::RoadVehicleDrivingSide ? 1U : 0U) << 0x1B)  // signalsontrafficside
+	                   |                  ((IsSignalSideOnTrafficSide() ? 1U : 0U) << 0x1B)  // signalsontrafficside
 	                   |       ((_settings_game.vehicle.disable_elrails ? 0U : 1U) << 0x1C); // electrifiedrailway
 
 	_ttdpatch_flags[2] =                                                       (1U << 0x01)  // loadallgraphics - obsolete

--- a/src/newgrf/newgrf_act7_9.cpp
+++ b/src/newgrf/newgrf_act7_9.cpp
@@ -24,6 +24,14 @@
 /** 32 * 8 = 256 flags. Apparently TTDPatch uses this many.. */
 static std::array<uint32_t, 8> _ttdpatch_flags;
 
+static bool GetSignalSideOnTrafficSide()
+{
+	return
+	    _settings_game.construction.train_signal_side == TrainSignalSide::RoadVehicleDrivingSide ||
+	    (_settings_game.construction.train_signal_side == TrainSignalSide::Left && _settings_game.vehicle.road_side == RoadVehicleDrivingSide::Left) ||
+	    (_settings_game.construction.train_signal_side == TrainSignalSide::Right && _settings_game.vehicle.road_side == RoadVehicleDrivingSide::Right);
+}
+
 /** Initialize the TTDPatch flags */
 void InitializePatchFlags()
 {
@@ -52,7 +60,7 @@ void InitializePatchFlags()
 	                   |                                                       (1U << 0x18)  // newrvs
 	                   |                                                       (1U << 0x19)  // newships
 	                   |                                                       (1U << 0x1A)  // newplanes
-	                   | ((_settings_game.construction.train_signal_side == TrainSignalSide::RoadVehicleDrivingSide ? 1U : 0U) << 0x1B)  // signalsontrafficside
+	                   |                 ((GetSignalSideOnTrafficSide() ? 1U : 0U) << 0x1B)  // signalsontrafficside
 	                   |       ((_settings_game.vehicle.disable_elrails ? 0U : 1U) << 0x1C); // electrifiedrailway
 
 	_ttdpatch_flags[2] =                                                       (1U << 0x01)  // loadallgraphics - obsolete


### PR DESCRIPTION
Resolves (partially) #15608 

Updates wording traffic side setting and help text to better reflect its effects.

Update `signals_on_traffic_side` value (for newgrfs) to also be true when signal side is not set to follow traffic side, but is _manually_ set to the traffic side (e.g. traffic side is set to _Drive on left_ and signal side is manually set to _On the left_ rather than to _On the driving side_)

NewGRFs can now make use of `signals_on_traffic_side` to display the correct graphics.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
