### PR TITLE
Fix: Train reversing when partially in a depot

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1653,7 +1653,10 @@ static void UpdateStatusAfterSwap(Train *v, bool reverse = true)
 
 	/* Call the proper EnterTile function unless we are in a wormhole. */
 	if (v->track != TRACK_BIT_WORMHOLE) {
-		VehicleEnterTile(v, v->tile, v->x_pos, v->y_pos);
+		/* Do not call EnterTile for vehicles partially or totally in a depot. */
+		if (!IsRailDepotTile(v->tile)) {
+			VehicleEnterTile(v, v->tile, v->x_pos, v->y_pos);
+		}
 	} else {
 		/* VehicleEnterTile_TunnelBridge() sets TRACK_BIT_WORMHOLE when the vehicle
 		 * is on the last bit of the bridge head (frame == TILE_SIZE - 1).


### PR DESCRIPTION
## Motivation / Problem

Trains reversed (by flipping) when heading into and partially in a depot can result in the train vehicles separating and later assertion failures, etc.
Appears to be a side-effect of the change to Vehicle::direction reverse behaviour in UpdateStatusAfterSwap in 2b530751dddef5513f67fceb529384d9fa4d6f57.

The (non-wormhole path) call to VehicleEnterTile in UpdateStatusAfterSwap results can result in the `fract_coord_leave == fract_coord` leaving depot path in `VehicleEnterTile_Rail` being called, which clobbers subsequent parts of the train and breaks subsequent calls to ReverseTrainSwapVeh.

Save illustrating the problem.
[Depot Reversing Ltd.sav.zip](https://github.com/user-attachments/files/28476615/Depot.Reversing.Ltd.sav.zip)

## Description

The VehicleEnterTile in UpdateStatusAfterSwap is of no use for depot tiles, so just don't call it in this case.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
