### PR TITLE
Fix #8686: Allow selecting town name generator in scenario editor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -531,6 +531,8 @@ add_files(
     town_type.h
     townname.cpp
     townname_func.h
+    townname_gui.cpp
+    townname_gui.h
     townname_type.h
     track_func.h
     track_type.h

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -27,7 +27,7 @@
 #include "saveload/saveload.h"
 #include "progress.h"
 #include "error.h"
-#include "newgrf_townname.h"
+#include "townname_gui.h"
 #include "townname_type.h"
 #include "video/video_driver.hpp"
 #include "ai/ai_gui.hpp"
@@ -38,8 +38,6 @@
 #include "widgets/genworld_widget.h"
 
 #include "table/strings.h"
-
-#include "dropdown_common_type.h"
 
 #include "safeguards.h"
 
@@ -359,34 +357,6 @@ static DropDownList BuildMapsizeDropDown()
 	return list;
 }
 
-static DropDownList BuildTownNameDropDown()
-{
-	DropDownList list;
-
-	/* Add and sort newgrf townnames generators */
-	const auto &grf_names = GetGRFTownNameList();
-	for (uint i = 0; i < grf_names.size(); i++) {
-		list.push_back(MakeDropDownListStringItem(grf_names[i], BUILTIN_TOWNNAME_GENERATOR_COUNT + i));
-	}
-	std::sort(list.begin(), list.end(), DropDownListStringItem::NatSortFunc);
-
-	size_t newgrf_size = list.size();
-	/* Insert newgrf_names at the top of the list */
-	if (newgrf_size > 0) {
-		list.push_back(MakeDropDownListDividerItem()); // separator line
-		newgrf_size++;
-	}
-
-	/* Add and sort original townnames generators */
-	for (uint i = 0; i < BUILTIN_TOWNNAME_GENERATOR_COUNT; i++) {
-		list.push_back(MakeDropDownListStringItem(STR_MAPGEN_TOWN_NAME_ORIGINAL_ENGLISH + i, i));
-	}
-	std::sort(list.begin() + newgrf_size, list.end(), DropDownListStringItem::NatSortFunc);
-
-	return list;
-}
-
-
 static const StringID _max_height[]  = {STR_TERRAIN_TYPE_VERY_FLAT, STR_TERRAIN_TYPE_FLAT, STR_TERRAIN_TYPE_HILLY, STR_TERRAIN_TYPE_MOUNTAINOUS, STR_TERRAIN_TYPE_ALPINIST, STR_TERRAIN_TYPE_CUSTOM};
 static const StringID _sea_lakes[]   = {STR_SEA_LEVEL_VERY_LOW, STR_SEA_LEVEL_LOW, STR_SEA_LEVEL_MEDIUM, STR_SEA_LEVEL_HIGH, STR_SEA_LEVEL_CUSTOM};
 static const StringID _rivers[]      = {STR_RIVERS_NONE, STR_RIVERS_FEW, STR_RIVERS_MODERATE, STR_RIVERS_LOT};
@@ -452,11 +422,7 @@ struct GenerateLandscapeWindow : public Window {
 				return GetString(_num_towns[_settings_newgame.difficulty.number_towns]);
 
 			case WID_GL_TOWNNAME_DROPDOWN: {
-				uint gen = _settings_newgame.game_creation.town_name;
-				StringID name = gen < BUILTIN_TOWNNAME_GENERATOR_COUNT ?
-						STR_MAPGEN_TOWN_NAME_ORIGINAL_ENGLISH + gen :
-						GetGRFTownNameName(gen - BUILTIN_TOWNNAME_GENERATOR_COUNT);
-				return GetString(name);
+				return GetString(GetTownNameGeneratorName(_settings_newgame.game_creation.town_name));
 			}
 
 			case WID_GL_INDUSTRY_PULLDOWN:

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1632,8 +1632,6 @@ static void FinaliseBadges()
 	AddBadgeClassesToConfiguration();
 }
 
-extern void InitGRFTownGeneratorNames();
-
 /** Finish loading NewGRFs and execute needed post-processing */
 static void AfterLoadGRFs()
 {

--- a/src/newgrf_townname.h
+++ b/src/newgrf_townname.h
@@ -44,6 +44,7 @@ GRFTownName *AddGRFTownName(uint32_t grfid);
 GRFTownName *GetGRFTownName(uint32_t grfid);
 void DelGRFTownName(uint32_t grfid);
 void CleanUpGRFTownNames();
+void InitGRFTownGeneratorNames();
 uint32_t GetGRFTownNameId(uint16_t gen);
 uint16_t GetGRFTownNameType(uint16_t gen);
 StringID GetGRFTownNameName(uint16_t gen);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -19,5 +19,6 @@ add_test_files(
     test_script_admin.cpp
     test_window_desc.cpp
     tilearea.cpp
+    townname_gui.cpp
     utf8.cpp
 )

--- a/src/tests/townname_gui.cpp
+++ b/src/tests/townname_gui.cpp
@@ -1,0 +1,102 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file townname_gui.cpp Test town name GUI helpers. */
+
+#include "../stdafx.h"
+
+#include "../3rdparty/catch2/catch.hpp"
+
+#include "mock_environment.h"
+
+#include "../fileio_func.h"
+#include "../newgrf_townname.h"
+#include "../strings_func.h"
+#include "../townname_gui.h"
+
+#include "../table/strings.h"
+
+#include "../safeguards.h"
+
+class TownNameGuiTestsFixture {
+private:
+	MockEnvironment &mock = MockEnvironment::Instance();
+
+	static void InitializeLanguage()
+	{
+		static bool initialized = false;
+		if (initialized) return;
+
+		DeterminePaths("openttd_test.exe", true);
+		InitializeLanguagePacks();
+
+		initialized = true;
+	}
+
+public:
+	TownNameGuiTestsFixture()
+	{
+		InitializeLanguage();
+		CleanUpGRFTownNames();
+		InitGRFTownGeneratorNames();
+	}
+
+	~TownNameGuiTestsFixture()
+	{
+		CleanUpGRFTownNames();
+		InitGRFTownGeneratorNames();
+	}
+};
+
+TEST_CASE_METHOD(TownNameGuiTestsFixture, "TownNameDropDown - built-in generators")
+{
+	DropDownList list = BuildTownNameDropDown();
+
+	REQUIRE(list.size() == BUILTIN_TOWNNAME_GENERATOR_COUNT);
+
+	std::set<int> values;
+	for (const auto &item : list) {
+		CHECK(item->Selectable());
+		values.insert(item->result);
+	}
+
+	for (uint i = 0; i < BUILTIN_TOWNNAME_GENERATOR_COUNT; i++) {
+		CHECK(values.contains(i));
+		CHECK(GetTownNameGeneratorName(i) == STR_MAPGEN_TOWN_NAME_ORIGINAL_ENGLISH + i);
+	}
+}
+
+TEST_CASE_METHOD(TownNameGuiTestsFixture, "TownNameDropDown - NewGRF generators")
+{
+	GRFTownName *townname = AddGRFTownName(0x12345678);
+	townname->styles.emplace_back(STR_MAPGEN_TOWN_NAME_FRENCH, 0);
+	townname->styles.emplace_back(STR_MAPGEN_TOWN_NAME_DANISH, 1);
+	InitGRFTownGeneratorNames();
+
+	CHECK(GetTownNameGeneratorName(BUILTIN_TOWNNAME_GENERATOR_COUNT) == STR_MAPGEN_TOWN_NAME_FRENCH);
+	CHECK(GetTownNameGeneratorName(BUILTIN_TOWNNAME_GENERATOR_COUNT + 1) == STR_MAPGEN_TOWN_NAME_DANISH);
+
+	DropDownList list = BuildTownNameDropDown();
+
+	REQUIRE(list.size() == BUILTIN_TOWNNAME_GENERATOR_COUNT + 3);
+
+	CHECK(list[0]->Selectable());
+	CHECK(list[0]->result >= static_cast<int>(BUILTIN_TOWNNAME_GENERATOR_COUNT));
+	CHECK(list[1]->Selectable());
+	CHECK(list[1]->result >= static_cast<int>(BUILTIN_TOWNNAME_GENERATOR_COUNT));
+	CHECK(!list[2]->Selectable());
+
+	std::set<int> builtin_values;
+	for (auto it = std::next(list.begin(), 3); it != list.end(); ++it) {
+		CHECK((*it)->Selectable());
+		builtin_values.insert((*it)->result);
+	}
+
+	for (uint i = 0; i < BUILTIN_TOWNNAME_GENERATOR_COUNT; i++) {
+		CHECK(builtin_values.contains(i));
+	}
+}

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -32,6 +32,7 @@
 #include "querystring_gui.h"
 #include "window_func.h"
 #include "townname_func.h"
+#include "townname_gui.h"
 #include "core/backup_type.hpp"
 #include "core/geometry_func.hpp"
 #include "core/string_consumer.hpp"
@@ -1097,6 +1098,12 @@ static constexpr std::initializer_list<NWidgetPart> _nested_found_town_widgets =
 			NWidget(WWT_LABEL, Colours::Invalid), SetStringTip(STR_FOUND_TOWN_NAME_TITLE),
 			NWidget(WWT_EDITBOX, Colours::Grey, WID_TF_TOWN_NAME_EDITBOX), SetStringTip(STR_FOUND_TOWN_NAME_EDITOR_TITLE, STR_FOUND_TOWN_NAME_EDITOR_TOOLTIP), SetFill(1, 0),
 			NWidget(WWT_PUSHTXTBTN, Colours::Grey, WID_TF_TOWN_NAME_RANDOM), SetStringTip(STR_FOUND_TOWN_NAME_RANDOM_BUTTON, STR_FOUND_TOWN_NAME_RANDOM_TOOLTIP), SetFill(1, 0),
+			NWidget(NWID_SELECTION, Colours::Invalid, WID_TF_TOWN_NAME_GENERATOR_SEL),
+				NWidget(NWID_VERTICAL), SetPIP(0, WidgetDimensions::unscaled.vsep_normal, 0),
+					NWidget(WWT_LABEL, Colours::Invalid), SetStringTip(STR_MAPGEN_TOWN_NAME_LABEL, STR_MAPGEN_TOWN_NAME_DROPDOWN_TOOLTIP),
+					NWidget(WWT_DROPDOWN, Colours::Grey, WID_TF_TOWN_NAME_DROPDOWN), SetToolTip(STR_MAPGEN_TOWN_NAME_DROPDOWN_TOOLTIP), SetFill(1, 0),
+				EndContainer(),
+			EndContainer(),
 
 			/* Town size selection. */
 			NWidget(WWT_LABEL, Colours::Invalid), SetStringTip(STR_FOUND_TOWN_INITIAL_SIZE_TITLE),
@@ -1177,6 +1184,7 @@ public:
 		if (_game_mode == GameMode::Editor) return;
 
 		this->GetWidget<NWidgetStacked>(WID_TF_TOWN_ACTION_SEL)->SetDisplayedPlane(SZSP_HORIZONTAL);
+		this->GetWidget<NWidgetStacked>(WID_TF_TOWN_NAME_GENERATOR_SEL)->SetDisplayedPlane(SZSP_HORIZONTAL);
 		this->GetWidget<NWidgetStacked>(WID_TF_TOWN_EXPAND_SEL)->SetDisplayedPlane(SZSP_HORIZONTAL);
 		this->GetWidget<NWidgetStacked>(WID_TF_SIZE_SEL)->SetDisplayedPlane(SZSP_VERTICAL);
 		if (_settings_game.economy.found_town != TF_CUSTOM_LAYOUT) {
@@ -1184,6 +1192,29 @@ public:
 		} else {
 			this->GetWidget<NWidgetStacked>(WID_TF_ROAD_LAYOUT_SEL)->SetDisplayedPlane(0);
 		}
+	}
+
+	std::string GetWidgetString(WidgetID widget, StringID stringid) const override
+	{
+		switch (widget) {
+			case WID_TF_TOWN_NAME_DROPDOWN:
+				return GetString(GetTownNameGeneratorName(_settings_game.game_creation.town_name));
+
+			default:
+				return this->Window::GetWidgetString(widget, stringid);
+		}
+	}
+
+	std::string GetGeneratedTownName() const
+	{
+		return this->townnamevalid ? GetTownName(&this->params, this->townnameparts) : std::string{};
+	}
+
+	bool HasCustomTownName() const
+	{
+		std::string current_name{this->townname_editbox.text.GetText()};
+		if (!this->townnamevalid) return !current_name.empty();
+		return current_name != this->GetGeneratedTownName();
 	}
 
 	void RandomTownName()
@@ -1198,6 +1229,21 @@ public:
 		UpdateOSKOriginalText(this, WID_TF_TOWN_NAME_EDITBOX);
 
 		this->SetWidgetDirty(WID_TF_TOWN_NAME_EDITBOX);
+	}
+
+	void SetTownNameGenerator(uint gen)
+	{
+		bool keep_custom_name = this->HasCustomTownName();
+		_settings_game.game_creation.town_name = ClampTo<uint8_t>(gen);
+		this->params = TownNameParams(_settings_game.game_creation.town_name);
+
+		if (keep_custom_name) {
+			this->SetWidgetDirty(WID_TF_TOWN_NAME_EDITBOX);
+		} else {
+			this->RandomTownName();
+		}
+
+		this->SetWidgetDirty(WID_TF_TOWN_NAME_DROPDOWN);
 	}
 
 	void UpdateButtons(bool check_availability)
@@ -1228,13 +1274,7 @@ public:
 	{
 		std::string name;
 
-		if (!this->townnamevalid) {
-			name = this->townname_editbox.text.GetText();
-		} else {
-			/* If user changed the name, send it */
-			std::string original_name = GetTownName(&this->params, this->townnameparts);
-			if (original_name != this->townname_editbox.text.GetText()) name = this->townname_editbox.text.GetText();
-		}
+		if (!this->townnamevalid || this->HasCustomTownName()) name = this->townname_editbox.text.GetText();
 
 		bool success = Command<Commands::FoundTown>::Post(errstr, cc,
 				tile, this->town_size, this->city, this->town_layout, random, townnameparts, name);
@@ -1257,6 +1297,10 @@ public:
 			case WID_TF_TOWN_NAME_RANDOM:
 				this->RandomTownName();
 				this->SetFocusedWidget(WID_TF_TOWN_NAME_EDITBOX);
+				break;
+
+			case WID_TF_TOWN_NAME_DROPDOWN:
+				if (_game_mode == GameMode::Editor) ShowDropDownList(this, BuildTownNameDropDown(), _settings_game.game_creation.town_name, WID_TF_TOWN_NAME_DROPDOWN);
 				break;
 
 			case WID_TF_MANY_RANDOM_TOWNS: {
@@ -1304,6 +1348,18 @@ public:
 				if (_game_mode == GameMode::Editor) _settings_game.economy.town_layout = this->town_layout;
 
 				this->UpdateButtons(false);
+				break;
+		}
+	}
+
+	void OnDropdownSelect(WidgetID widget, int index, int) override
+	{
+		switch (widget) {
+			case WID_TF_TOWN_NAME_DROPDOWN:
+				if (_game_mode == GameMode::Editor) this->SetTownNameGenerator(index);
+				break;
+
+			default:
 				break;
 		}
 	}

--- a/src/townname_gui.cpp
+++ b/src/townname_gui.cpp
@@ -1,0 +1,53 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file townname_gui.cpp GUI helpers for town name generators. */
+
+#include "stdafx.h"
+#include "townname_gui.h"
+
+#include "dropdown_common_type.h"
+#include "dropdown_func.h"
+#include "newgrf_townname.h"
+
+#include "table/strings.h"
+
+#include "safeguards.h"
+
+DropDownList BuildTownNameDropDown()
+{
+	DropDownList list;
+
+	/* Add and sort NewGRF townname generators. */
+	const auto &grf_names = GetGRFTownNameList();
+	for (uint i = 0; i < grf_names.size(); i++) {
+		list.push_back(MakeDropDownListStringItem(grf_names[i], BUILTIN_TOWNNAME_GENERATOR_COUNT + i));
+	}
+	std::sort(list.begin(), list.end(), DropDownListStringItem::NatSortFunc);
+
+	size_t newgrf_size = list.size();
+	/* Insert a separator after NewGRF town names. */
+	if (newgrf_size > 0) {
+		list.push_back(MakeDropDownListDividerItem());
+		newgrf_size++;
+	}
+
+	/* Add and sort built-in townname generators. */
+	for (uint i = 0; i < BUILTIN_TOWNNAME_GENERATOR_COUNT; i++) {
+		list.push_back(MakeDropDownListStringItem(STR_MAPGEN_TOWN_NAME_ORIGINAL_ENGLISH + i, i));
+	}
+	std::sort(list.begin() + newgrf_size, list.end(), DropDownListStringItem::NatSortFunc);
+
+	return list;
+}
+
+StringID GetTownNameGeneratorName(uint gen)
+{
+	return gen < BUILTIN_TOWNNAME_GENERATOR_COUNT ?
+			STR_MAPGEN_TOWN_NAME_ORIGINAL_ENGLISH + gen :
+			GetGRFTownNameName(gen - BUILTIN_TOWNNAME_GENERATOR_COUNT);
+}

--- a/src/townname_gui.h
+++ b/src/townname_gui.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file townname_gui.h GUI helpers for town name generators. */
+
+#ifndef TOWNNAME_GUI_H
+#define TOWNNAME_GUI_H
+
+#include "dropdown_type.h"
+#include "strings_type.h"
+
+/**
+ * Build a list of town name generators for a dropdown widget.
+ * @return Dropdown list with NewGRF generators first, followed by built-in generators.
+ */
+DropDownList BuildTownNameDropDown();
+
+/**
+ * Get the display string for a town name generator.
+ * @param gen Town name generator index.
+ * @return String ID of the generator name.
+ */
+StringID GetTownNameGeneratorName(uint gen);
+
+#endif /* TOWNNAME_GUI_H */

--- a/src/widgets/town_widget.h
+++ b/src/widgets/town_widget.h
@@ -58,6 +58,8 @@ enum TownFoundingWidgets : WidgetID {
 	WID_TF_EXPAND_ALL_TOWNS,  ///< Make all towns grow slightly.
 	WID_TF_TOWN_NAME_EDITBOX, ///< Editor for the town name.
 	WID_TF_TOWN_NAME_RANDOM,  ///< Generate a random town name.
+	WID_TF_TOWN_NAME_GENERATOR_SEL, ///< Container of town name generator dropdown.
+	WID_TF_TOWN_NAME_DROPDOWN, ///< Select town name generator.
 	WID_TF_SIZE_SEL, ///< Container of town size buttons.
 	WID_TF_SIZE_SMALL,        ///< Selection for a small town.
 	WID_TF_SIZE_MEDIUM,       ///< Selection for a medium town.


### PR DESCRIPTION
## Context

Issue #8686, related to changes in PR #8566, reports that the scenario editor does not expose a way to choose the town name generator when manually placing towns.

The map generation window already allows selecting the town name generator. Without that option in the Town Generation window, if the current town name generator was, for example, English, the random button would only produce English-style names. If the player wanted French, German, NewGRF town names, etc., they had to change the generator somewhere else first. The Town Generation window itself had no dropdown for that choice.

## Description

This adds a town name generator dropdown to the scenario editor Town Generation window.

The dropdown-list construction was moved out of `genworld_gui.cpp` into `townname_gui.cpp/h` because the same built-in/NewGRF generator list is now needed by both the map generation window and the scenario editor Town Generation window. Keeping it in one shared helper avoids duplicating the sorting, divider, and generator-id mapping logic, so both UI paths continue to show the same town name generator list.

The new control is wrapped in the existing `NWID_SELECTION` / `NWidgetStacked` pattern used by nearby editor-only town controls, so it is hidden outside the scenario editor. When the selected generator changes, automatically generated town names are refreshed, but a manually typed town name is not overwritten.

## Testing

- Added tests for the shared town name generator dropdown-list construction
- Built and ran the OpenTTD test binary: all tests passed, 2275 assertions in 96 test cases
- Built the OpenTTD executable
- Manually checked the scenario editor Town Generation window
