### PR TITLE
Fix #15664, 568c7bb2: regression in aircraft movement

### DIFF
--- a/src/direction_func.h
+++ b/src/direction_func.h
@@ -71,7 +71,7 @@ inline DirDiff DirDifference(Direction d0, Direction d1)
 	assert(IsValidDirection(d1));
 	/* Cast to uint so compiler can use bitmask. If the difference is negative
 	 * and we used int instead of uint, further "+ 8" would have to be added. */
-	return static_cast<DirDiff>((to_underlying(d0) - to_underlying(d1)) % 8);
+	return static_cast<DirDiff>(static_cast<uint>(to_underlying(d0) - to_underlying(d1)) % 8);
 }
 
 /**
@@ -88,7 +88,7 @@ inline DirDiff DirDifference(Direction d0, Direction d1)
 inline DirDiff ChangeDirDiff(DirDiff d, DirDiff delta)
 {
 	/* Cast to uint so compiler can use bitmask. Result can never be negative. */
-	return static_cast<DirDiff>((to_underlying(d) + to_underlying(delta)) % 8);
+	return static_cast<DirDiff>(static_cast<uint>(to_underlying(d) + to_underlying(delta)) % 8);
 }
 
 /**
@@ -115,7 +115,7 @@ inline Direction ChangeDir(Direction d, DirDiff delta)
 {
 	assert(IsValidDirection(d));
 	/* Cast to uint so compiler can use bitmask. Result can never be negative. */
-	return static_cast<Direction>((to_underlying(d) + to_underlying(delta)) % 8);
+	return static_cast<Direction>(static_cast<uint>(to_underlying(d) + to_underlying(delta)) % 8);
 }
 
 
@@ -143,7 +143,7 @@ inline DiagDirDiff DiagDirDifference(DiagDirection d0, DiagDirection d1)
 	assert(IsValidDiagDirection(d0));
 	assert(IsValidDiagDirection(d1));
 	/* Cast to uint so compiler can use bitmask. Result can never be negative. */
-	return static_cast<DiagDirDiff>((to_underlying(d0) - to_underlying(d1)) % 4);
+	return static_cast<DiagDirDiff>(static_cast<uint>(to_underlying(d0) - to_underlying(d1)) % 4);
 }
 
 /**
@@ -160,7 +160,7 @@ inline DiagDirection ChangeDiagDir(DiagDirection d, DiagDirDiff delta)
 {
 	assert(IsValidDiagDirection(d));
 	/* Cast to uint so compiler can use bitmask. Result can never be negative. */
-	return static_cast<DiagDirection>((to_underlying(d) + to_underlying(delta)) % 4);
+	return static_cast<DiagDirection>(static_cast<uint>(to_underlying(d) + to_underlying(delta)) % 4);
 }
 
 /**


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #15664, various helpers handling `DirDiff` were broken by removal of casts to uint.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Reinstate the casts with `static_cast<uint>()`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
