### PR TITLE
Codechange: detangle InitializeRailGui vs InitializeRailGUI vs InitializeRoadGui vs InitializeRoadGUI

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -115,9 +115,10 @@ Money Company::GetMaxLoan() const
  * Sets the local company and updates the settings that are set on a
  * per-company basis to reflect the core's state in the GUI.
  * @param new_company the new company
+ * @param switching_game Whether we are switching the game, e.g. a new game or loading a game.
  * @pre Company::IsValidID(new_company) || new_company == COMPANY_SPECTATOR || new_company == OWNER_NONE
  */
-void SetLocalCompany(CompanyID new_company)
+void SetLocalCompany(CompanyID new_company, bool switching_game)
 {
 	/* company could also be COMPANY_SPECTATOR or OWNER_NONE */
 	assert(Company::IsValidID(new_company) || new_company == COMPANY_SPECTATOR || new_company == OWNER_NONE);
@@ -137,16 +138,21 @@ void SetLocalCompany(CompanyID new_company)
 		InvalidateWindowClassesData(WindowClass::VehicleView);
 		/* Delete any construction windows... */
 		CloseConstructionWindows();
+	}
+
+	if (switching_company || switching_game) {
 		/* Update the default rail based on most used */
 		SetDefaultRailGui();
 	}
 
-	/* ... and redraw the whole screen. */
-	MarkWholeScreenDirty();
-	InvalidateWindowClassesData(WindowClass::SignList, -1);
-	InvalidateWindowClassesData(WindowClass::GoalList);
-	InvalidateWindowClassesData(WindowClass::CompanyLivery, -1);
-	ResetVehicleColourMap();
+	if (!switching_game) {
+		/* ... and redraw the whole screen. */
+		MarkWholeScreenDirty();
+		InvalidateWindowClassesData(WindowClass::SignList, -1);
+		InvalidateWindowClassesData(WindowClass::GoalList);
+		InvalidateWindowClassesData(WindowClass::CompanyLivery, -1);
+		ResetVehicleColourMap();
+	}
 }
 
 /**

--- a/src/company_func.h
+++ b/src/company_func.h
@@ -18,7 +18,7 @@
 bool CheckTakeoverVehicleLimit(CompanyID cbig, CompanyID small);
 void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner);
 std::array<StringParameter, 2> GetParamsForOwnedBy(Owner owner, TileIndex tile);
-void SetLocalCompany(CompanyID new_company);
+void SetLocalCompany(CompanyID new_company, bool switching_game = false);
 void ShowBuyCompanyDialog(CompanyID company, bool hostile_takeover);
 void CompanyAdminUpdate(const Company *company);
 void CompanyAdminBankrupt(CompanyID company_id);

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -888,7 +888,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapDone(Packet &)
 	/* New company/spectator (invalid company) or company we want to join is not active
 	 * Switch local company to spectator and await the server's judgement */
 	if (_network_join.company == COMPANY_NEW_COMPANY || !Company::IsValidID(_network_join.company)) {
-		SetLocalCompany(COMPANY_SPECTATOR);
+		SetLocalCompany(COMPANY_SPECTATOR, true);
 
 		if (_network_join.company != COMPANY_SPECTATOR) {
 			/* We have arrived and ready to start playing; send a command to make a new company;
@@ -900,7 +900,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapDone(Packet &)
 		}
 	} else {
 		/* take control over an existing company */
-		SetLocalCompany(_network_join.company);
+		SetLocalCompany(_network_join.company, true);
 	}
 
 	SocialIntegration::EventEnterMultiplayer(Map::SizeX(), Map::SizeY());

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -884,7 +884,6 @@ static void MakeNewGameDone()
 	OnStartGame(false);
 
 	InitializeRailGUI();
-	InitializeRoadGUI();
 
 	if (_settings_client.gui.pause_on_newgame) Command<Commands::Pause>::Post(PauseMode::Normal, true);
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -845,7 +845,7 @@ static void OnStartGame(bool dedicated_server)
 {
 	/* Update the local company for a loaded game. It is either the first available company
 	 * or in the case of a dedicated server, a spectator */
-	SetLocalCompany(dedicated_server ? COMPANY_SPECTATOR : GetFirstPlayableCompanyID());
+	SetLocalCompany(dedicated_server ? COMPANY_SPECTATOR : GetFirstPlayableCompanyID(), true);
 
 	NetworkOnGameStart();
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -883,7 +883,7 @@ static void MakeNewGameDone()
 
 	OnStartGame(false);
 
-	InitializeRailGUI();
+	InitializeSignalGui();
 
 	if (_settings_client.gui.pause_on_newgame) Command<Commands::Pause>::Post(PauseMode::Normal, true);
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2056,7 +2056,7 @@ static const IntervalTimer<TimerGameCalendar> _check_reset_signal{{TimerGameCale
 /**
  * Resets the signal GUI.
  */
-void InitializeRailGUI()
+void InitializeSignalGui()
 {
 	_convert_signal_button = false;
 	_cur_signal_type = _settings_client.gui.default_signal_type;

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2025,8 +2025,6 @@ void SetDefaultRailGui()
 	}
 
 	_last_built_railtype = _cur_railtype = rt;
-	BuildRailToolbarWindow *w = dynamic_cast<BuildRailToolbarWindow *>(FindWindowById(WindowClass::BuildToolbar, TRANSPORT_RAIL));
-	if (w != nullptr) w->ModifyRailType(_cur_railtype);
 }
 
 /**

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2054,13 +2054,10 @@ static const IntervalTimer<TimerGameCalendar> _check_reset_signal{{TimerGameCale
 }};
 
 /**
- * Resets the rail GUI - sets default railtype to build
- * and resets the signal GUI
+ * Resets the signal GUI.
  */
 void InitializeRailGUI()
 {
-	SetDefaultRailGui();
-
 	_convert_signal_button = false;
 	_cur_signal_type = _settings_client.gui.default_signal_type;
 	ResetSignalVariant();

--- a/src/rail_gui.h
+++ b/src/rail_gui.h
@@ -16,7 +16,7 @@
 struct Window *ShowBuildRailToolbar(RailType railtype);
 void ReinitGuiAfterToggleElrail(bool disable);
 void ResetSignalVariant(int32_t = 0);
-void InitializeRailGUI();
+void InitializeSignalGui();
 DropDownList GetRailTypeDropDownList(bool for_replacement = false, bool all_option = false);
 void SetDefaultRailGui();
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1821,15 +1821,6 @@ void InitializeRoadGui()
 	_waypoint_gui.sel_type = 0;
 }
 
-/**
- * I really don't know why rail_gui.cpp has this too, shouldn't be included in the other one?
- */
-void InitializeRoadGUI()
-{
-	BuildRoadToolbarWindow *w = dynamic_cast<BuildRoadToolbarWindow *>(FindWindowById(WindowClass::BuildToolbar, TRANSPORT_ROAD));
-	if (w != nullptr) w->ModifyRoadType(_cur_roadtype);
-}
-
 DropDownList GetRoadTypeDropDownList(RoadTramTypes rtts, bool for_replacement, bool all_option)
 {
 	RoadTypes used_roadtypes;

--- a/src/road_gui.h
+++ b/src/road_gui.h
@@ -21,6 +21,5 @@ struct Window *ShowBuildRoadScenToolbar(RoadType roadtype);
 void ConnectRoadToStructure(TileIndex tile, DiagDirection direction);
 DropDownList GetRoadTypeDropDownList(RoadTramTypes rtts, bool for_replacement = false, bool all_option = false);
 DropDownList GetScenRoadTypeDropDownList(RoadTramTypes rtts);
-void InitializeRoadGUI();
 
 #endif /* ROAD_GUI_H */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1510,7 +1510,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_38)) _settings_game.vehicle.disable_elrails = false;
 	/* do the same as when elrails were enabled/disabled manually just now */
 	UpdateDisableElrailSettingState(_settings_game.vehicle.disable_elrails, false);
-	InitializeRailGUI();
+	InitializeSignalGui();
 
 	/* From version 53, the map array was changed for house tiles to allow
 	 * space for newhouses grf features. A new byte, m7, was also added. */


### PR DESCRIPTION
## Motivation / Problem

As per https://github.com/OpenTTD/OpenTTD/pull/15585#discussion_r3343721752 the behaviour/things that `InitializeRailGui`, `InitializeRailGUI`, `InitializeRoadGui` and `InitializeRoadGUI` are internally inconsistent and sometimes pointless.

`InitializeRailGui` (by-proxy) and `InitializeRoadGUI` call `ModifyRail/RoadType` on the toolbar. `InitializeRoadGUI` is called from essentially new game generation and `InitializeRailGui` is called after closing all construction toolbars. In other words: there won't be a toolbar opened, so  no need to update it.

There are multiple places that call `SetDefaultRailGui`, making for companion functions like `SetDefaultRoadGui` to be called in all the right places, because the paths leading to `SetDefaultRailGui` being called won't be logical for a `SetDefaultRoadGui` being called. Especially from `InitializeRailGUI`.
Given this is something that needs to be rerun when the local company changes, just use that function. However... `SetLocalCompany` does call `SetDefaultRailGui` on all calls because it checks whether the local company changed, which might not happen when loading a game.

Finally having a `InitializeRailGui` and `InitializeRailGUI` is super confusing and inconvenient, and the same holds for `InitializeRoadGui` and `InitializeRoadGUI`.


## Description

Don't update the toolbar, as it's not opened. The removes `InitializeRoadGUI` completely.

Only call `SetDefaultRailGui` from `SetLocalCompany` and make `SetLocalCompany` aware that a different game has been loaded, so it can call the required initialisation functions even though the company seems to be still the same. Also, run some tasks in `SetLocalCompany` only when we're not loading a new game, like marking the whole screen or some windows dirty when we know the whole UI is being reinitialised.

Although `InitializeRoadGUI` was already removed, there still is a `InitializeRailGUI` that somewhat shadows `InitializeRailGui`. Rename the former to `InitializeSignalGui` as it only handles the signal stuff.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
