### PR TITLE
Feature: Add Ogg Opus to music player

### DIFF
--- a/docs/obm_format.txt
+++ b/docs/obm_format.txt
@@ -94,6 +94,15 @@ ezy_9 =
 [names]
 THEME_SONG.GM = Tycoon DELUXE Theme
 
+; The formats section is optional. When it is omitted, files are treated
+; as Standard MIDI, except ".opus" and ".ogg" files which are treated as
+; Ogg Opus audio. Use this section when you want to make the format explicit.
+; Supported values:
+;   midi - Standard MIDI file
+;   opus - Ogg Opus audio file
+[formats]
+theme = midi
+
 ; If you are loading music from the DOS version "cat" format, specify
 ; which index into the file the song has.
 [catindex]

--- a/src/base_media_music.h
+++ b/src/base_media_music.h
@@ -29,6 +29,7 @@ std::optional<std::vector<uint8_t>> GetMusicCatEntryData(const std::string &file
 enum MusicTrackType : uint8_t {
 	MTT_STANDARDMIDI, ///< Standard MIDI file
 	MTT_MPSMIDI,      ///< MPS GM driver MIDI format (contained in a CAT file)
+	MTT_OPUS,         ///< Ogg Opus audio file
 };
 
 /** Metadata about a music track. */

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -77,6 +77,27 @@ static const std::string_view _music_file_names[] = {
 /** Make sure we aren't messing things up. */
 static_assert(lengthof(_music_file_names) == NUM_SONGS_AVAILABLE);
 
+/**
+ * Determine the track type for a music file.
+ * @param filename Music file to inspect.
+ * @param format Optional explicit format item from the music set.
+ * @return Track type, or std::nullopt if the explicit format is invalid.
+ */
+static std::optional<MusicTrackType> GetMusicTrackType(std::string_view filename, const IniItem *format)
+{
+	if (format != nullptr && format->value.has_value() && !format->value->empty()) {
+		if (StrEqualsIgnoreCase(*format->value, "midi") || StrEqualsIgnoreCase(*format->value, "standardmidi") || StrEqualsIgnoreCase(*format->value, "standard_midi")) return MTT_STANDARDMIDI;
+		if (StrEqualsIgnoreCase(*format->value, "opus") || StrEqualsIgnoreCase(*format->value, "ogg_opus") || StrEqualsIgnoreCase(*format->value, "oggopus")) return MTT_OPUS;
+
+		Debug(grf, 0, "Invalid base music set song format: {}", *format->value);
+		return std::nullopt;
+	}
+
+	if (StrEndsWithIgnoreCase(filename, ".opus") || StrEndsWithIgnoreCase(filename, ".ogg")) return MTT_OPUS;
+
+	return MTT_STANDARDMIDI;
+}
+
 /** @copydoc BaseSet::GetFilenames */
 template <>
 /* static */ std::span<const std::string_view> BaseSet<MusicSet>::GetFilenames()
@@ -123,6 +144,7 @@ bool MusicSet::FillSetDetails(const IniFile &ini, const std::string &path, const
 		this->num_available = 0;
 		const IniGroup *names = ini.GetGroup("names");
 		const IniGroup *catindex = ini.GetGroup("catindex");
+		const IniGroup *formats = ini.GetGroup("formats");
 		const IniGroup *timingtrim = ini.GetGroup("timingtrim");
 		uint tracknr = 1;
 		for (uint i = 0; i < lengthof(this->songinfo); i++) {
@@ -150,7 +172,10 @@ bool MusicSet::FillSetDetails(const IniFile &ini, const std::string &path, const
 				}
 				this->songinfo[i].songname = *songname;
 			} else {
-				this->songinfo[i].filetype = MTT_STANDARDMIDI;
+				const IniItem *format = formats != nullptr ? formats->GetItem(_music_file_names[i]) : nullptr;
+				auto filetype = GetMusicTrackType(filename, format);
+				if (!filetype.has_value()) continue;
+				this->songinfo[i].filetype = *filetype;
 			}
 
 			std::string_view trimmed_filename{filename};
@@ -173,7 +198,7 @@ bool MusicSet::FillSetDetails(const IniFile &ini, const std::string &path, const
 				}
 			}
 
-			if (this->songinfo[i].filetype == MTT_STANDARDMIDI) {
+			if (this->songinfo[i].filetype != MTT_MPSMIDI) {
 				if (item != nullptr && item->value.has_value() && !item->value->empty()) {
 					this->songinfo[i].songname = item->value.value();
 				} else {

--- a/src/music/CMakeLists.txt
+++ b/src/music/CMakeLists.txt
@@ -48,4 +48,6 @@ add_files(
     music_driver.hpp
     null_m.cpp
     null_m.h
+    sampled_music.cpp
+    sampled_music.h
 )

--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -172,6 +172,7 @@ void MusicDriver_FluidSynth::PlaySong(const MusicSongInfo &song)
 	std::string filename = MidiFile::GetSMFFile(song);
 
 	this->StopSong();
+	MxSetMusicSource(RenderMusicStream);
 
 	if (filename.empty()) {
 		return;

--- a/src/music/sampled_music.cpp
+++ b/src/music/sampled_music.cpp
@@ -1,0 +1,302 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file sampled_music.cpp Playback for sampled music tracks. */
+
+#include "../stdafx.h"
+
+#include "sampled_music.h"
+
+#include "../debug.h"
+#include "../fileio_func.h"
+#include "../mixer.h"
+
+#include "../safeguards.h"
+
+bool MusicTrackUsesSampledPlayback(MusicTrackType filetype)
+{
+	return filetype == MTT_OPUS;
+}
+
+#ifdef WITH_OPUSFILE
+
+#include "../misc/autorelease.hpp"
+
+#include <mutex>
+#include <opusfile.h>
+
+static constexpr uint32_t OPUS_SAMPLE_RATE = 48000; ///< OpusFile always decodes at 48 kHz.
+static constexpr size_t OPUS_DECODE_BUFFER_FRAMES = 5760; ///< 120 ms at 48 kHz.
+
+struct OpusFileSource {
+	std::optional<FileHandle> file;
+	long start = 0;
+	size_t size = 0;
+
+	FILE *GetFile()
+	{
+		return static_cast<FILE *>(*this->file);
+	}
+};
+
+static int OpusRead(void *stream, unsigned char *ptr, int nbytes)
+{
+	OpusFileSource *source = static_cast<OpusFileSource *>(stream);
+	FILE *file = source->GetFile();
+
+	long current_pos = ftell(file);
+	if (current_pos < source->start) return 0;
+
+	size_t relative_pos = static_cast<size_t>(current_pos - source->start);
+	if (relative_pos >= source->size) return 0;
+
+	size_t remaining = source->size - relative_pos;
+	size_t bytes_to_read = std::min<size_t>(static_cast<size_t>(nbytes), remaining);
+	return static_cast<int>(fread(ptr, 1, bytes_to_read, file));
+}
+
+static int OpusSeek(void *stream, opus_int64 offset, int whence)
+{
+	OpusFileSource *source = static_cast<OpusFileSource *>(stream);
+	FILE *file = source->GetFile();
+
+	opus_int64 target = 0;
+	switch (whence) {
+		case SEEK_SET:
+			target = offset;
+			break;
+
+		case SEEK_CUR: {
+			long current_pos = ftell(file);
+			if (current_pos < 0) return -1;
+			target = current_pos - source->start + offset;
+			break;
+		}
+
+		case SEEK_END:
+			target = static_cast<opus_int64>(source->size) + offset;
+			break;
+
+		default:
+			return -1;
+	}
+
+	if (target < 0 || static_cast<uint64_t>(target) > source->size) return -1;
+	return fseek(file, source->start + static_cast<long>(target), SEEK_SET);
+}
+
+static opus_int64 OpusTell(void *stream)
+{
+	OpusFileSource *source = static_cast<OpusFileSource *>(stream);
+	long current_pos = ftell(source->GetFile());
+	if (current_pos < source->start) return -1;
+	return current_pos - source->start;
+}
+
+static int OpusClose(void *)
+{
+	return 0;
+}
+
+static const OpusFileCallbacks _opus_callbacks = {
+	OpusRead,
+	OpusSeek,
+	OpusTell,
+	OpusClose,
+};
+
+struct SampledMusicPlayback {
+	std::mutex mutex;
+
+	std::unique_ptr<OpusFileSource> source;
+	AutoRelease<OggOpusFile, op_free> opus;
+
+	std::vector<int16_t> decode_buffer{};
+	size_t decoded_frames = 0;
+	size_t decoded_pos = 0;
+	uint32_t frac_pos = 0;
+	uint32_t frac_speed = 0;
+
+	uint8_t volume = 127;
+	bool loop = false;
+	bool playing = false;
+	bool stream_active = false;
+};
+
+static SampledMusicPlayback _sampled_music;
+
+static bool RefillDecodeBuffer()
+{
+	size_t remaining_frames = _sampled_music.decoded_pos < _sampled_music.decoded_frames ? _sampled_music.decoded_frames - _sampled_music.decoded_pos : 0;
+	if (remaining_frames != 0 && _sampled_music.decoded_pos != 0) {
+		std::copy_n(_sampled_music.decode_buffer.data() + _sampled_music.decoded_pos * 2, remaining_frames * 2, _sampled_music.decode_buffer.data());
+	}
+	_sampled_music.decoded_frames = remaining_frames;
+	_sampled_music.decoded_pos = 0;
+
+	while (_sampled_music.decoded_frames < 2 && _sampled_music.playing) {
+		int16_t *target = _sampled_music.decode_buffer.data() + _sampled_music.decoded_frames * 2;
+		int values_available = static_cast<int>(_sampled_music.decode_buffer.size() - _sampled_music.decoded_frames * 2);
+		int read = op_read_stereo(_sampled_music.opus.get(), target, values_available);
+
+		if (read == 0) {
+			if (_sampled_music.loop && op_pcm_seek(_sampled_music.opus.get(), 0) == 0) continue;
+			_sampled_music.playing = false;
+			break;
+		}
+
+		if (read < 0) {
+			_sampled_music.playing = false;
+			break;
+		}
+
+		_sampled_music.decoded_frames += read;
+	}
+
+	return _sampled_music.decoded_frames - _sampled_music.decoded_pos >= 2;
+}
+
+static int16_t InterpolateSample(int16_t current, int16_t next, uint32_t frac)
+{
+	int sample = (static_cast<int>(current) * static_cast<int>(0x10000 - frac) + static_cast<int>(next) * static_cast<int>(frac)) >> 16;
+	return static_cast<int16_t>(sample);
+}
+
+static int16_t ScaleSample(int16_t sample, uint8_t volume)
+{
+	if (volume == 127) return sample;
+	return static_cast<int16_t>(static_cast<int>(sample) * volume / 127);
+}
+
+static void RenderSampledMusic(int16_t *buffer, size_t samples)
+{
+	std::unique_lock<std::mutex> lock{_sampled_music.mutex, std::try_to_lock};
+	if (!lock.owns_lock() || !_sampled_music.playing || _sampled_music.opus == nullptr) return;
+
+	for (size_t out = 0; out < samples; out++) {
+		if (_sampled_music.decoded_pos + 1 >= _sampled_music.decoded_frames && !RefillDecodeBuffer()) return;
+
+		const int16_t *current = _sampled_music.decode_buffer.data() + _sampled_music.decoded_pos * 2;
+		const int16_t *next = current + 2;
+
+		buffer[out * 2] = ScaleSample(InterpolateSample(current[0], next[0], _sampled_music.frac_pos), _sampled_music.volume);
+		buffer[out * 2 + 1] = ScaleSample(InterpolateSample(current[1], next[1], _sampled_music.frac_pos), _sampled_music.volume);
+
+		_sampled_music.frac_pos += _sampled_music.frac_speed;
+		_sampled_music.decoded_pos += _sampled_music.frac_pos >> 16;
+		_sampled_music.frac_pos &= 0xffff;
+	}
+}
+
+void StopSampledMusic()
+{
+	bool stream_active = false;
+	{
+		std::lock_guard<std::mutex> lock{_sampled_music.mutex};
+		stream_active = _sampled_music.stream_active;
+	}
+
+	if (!stream_active) return;
+
+	MxSetMusicSource(nullptr);
+
+	std::lock_guard<std::mutex> lock{_sampled_music.mutex};
+	_sampled_music.opus.reset();
+	_sampled_music.source.reset();
+	_sampled_music.decode_buffer.clear();
+	_sampled_music.decoded_frames = 0;
+	_sampled_music.decoded_pos = 0;
+	_sampled_music.frac_pos = 0;
+	_sampled_music.frac_speed = 0;
+	_sampled_music.playing = false;
+	_sampled_music.stream_active = false;
+}
+
+bool PlaySampledMusic(const MusicSongInfo &song, uint8_t volume)
+{
+	if (song.filetype != MTT_OPUS) return false;
+
+	StopSampledMusic();
+
+	uint32_t mixer_rate = MxSetMusicSource(nullptr);
+
+	size_t file_size = 0;
+	auto file = FioFOpenFile(song.filename, "rb", Subdirectory::Baseset, &file_size);
+	if (!file.has_value()) {
+		Debug(driver, 0, "Could not open sampled music file '{}'", song.filename);
+		return false;
+	}
+
+	auto source = std::make_unique<OpusFileSource>();
+	source->file = std::move(file);
+	source->size = file_size;
+	source->start = ftell(source->GetFile());
+	if (source->start < 0) {
+		Debug(driver, 0, "Could not read sampled music file '{}'", song.filename);
+		return false;
+	}
+
+	int error = 0;
+	AutoRelease<OggOpusFile, op_free> opus{op_open_callbacks(source.get(), &_opus_callbacks, nullptr, 0, &error)};
+	if (error != 0 || opus == nullptr) {
+		Debug(driver, 0, "Could not open Ogg Opus music file '{}'", song.filename);
+		return false;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock{_sampled_music.mutex};
+		_sampled_music.source = std::move(source);
+		_sampled_music.opus = std::move(opus);
+		_sampled_music.decode_buffer.assign(OPUS_DECODE_BUFFER_FRAMES * 2, 0);
+		_sampled_music.decoded_frames = 0;
+		_sampled_music.decoded_pos = 0;
+		_sampled_music.frac_pos = 0;
+		_sampled_music.frac_speed = static_cast<uint32_t>((static_cast<uint64_t>(OPUS_SAMPLE_RATE) << 16) / mixer_rate);
+		_sampled_music.volume = volume;
+		_sampled_music.loop = song.loop;
+		_sampled_music.playing = true;
+		_sampled_music.stream_active = true;
+	}
+
+	MxSetMusicSource(RenderSampledMusic);
+	return true;
+}
+
+bool IsSampledMusicPlaying()
+{
+	std::lock_guard<std::mutex> lock{_sampled_music.mutex};
+	return _sampled_music.playing;
+}
+
+void SetSampledMusicVolume(uint8_t volume)
+{
+	std::lock_guard<std::mutex> lock{_sampled_music.mutex};
+	_sampled_music.volume = volume;
+}
+
+#else /* WITH_OPUSFILE */
+
+bool PlaySampledMusic(const MusicSongInfo &song, uint8_t)
+{
+	if (song.filetype == MTT_OPUS) Debug(driver, 0, "Ogg Opus music support is not available in this build");
+	return false;
+}
+
+void StopSampledMusic()
+{
+}
+
+bool IsSampledMusicPlaying()
+{
+	return false;
+}
+
+void SetSampledMusicVolume(uint8_t)
+{
+}
+
+#endif /* WITH_OPUSFILE */

--- a/src/music/sampled_music.h
+++ b/src/music/sampled_music.h
@@ -1,0 +1,22 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file sampled_music.h Playback for sampled music tracks. */
+
+#ifndef MUSIC_SAMPLED_MUSIC_H
+#define MUSIC_SAMPLED_MUSIC_H
+
+#include "../base_media_music.h"
+
+bool MusicTrackUsesSampledPlayback(MusicTrackType filetype);
+
+bool PlaySampledMusic(const MusicSongInfo &song, uint8_t volume);
+void StopSampledMusic();
+bool IsSampledMusicPlaying();
+void SetSampledMusicVolume(uint8_t volume);
+
+#endif /* MUSIC_SAMPLED_MUSIC_H */

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -12,6 +12,7 @@
 #include "base_media_base.h"
 #include "base_media_music.h"
 #include "music/music_driver.hpp"
+#include "music/sampled_music.h"
 #include "window_gui.h"
 #include "strings_func.h"
 #include "window_func.h"
@@ -241,6 +242,7 @@ void MusicSystem::Play()
 	/* Always set the playing flag, even if there is no music */
 	_settings_client.music.playing = true;
 	MusicDriver::GetInstance()->StopSong();
+	StopSampledMusic();
 	/* Make sure playlist_position is a valid index, if playlist has changed etc. */
 	this->ChangePlaylistPosition(0);
 
@@ -249,7 +251,11 @@ void MusicSystem::Play()
 
 	MusicSongInfo song = this->active_playlist[this->playlist_position];
 	if (_game_mode == GameMode::Menu && this->selected_playlist == PLCH_THEMEONLY) song.loop = true;
-	MusicDriver::GetInstance()->PlaySong(song);
+	if (MusicTrackUsesSampledPlayback(song.filetype)) {
+		PlaySampledMusic(song, _settings_client.music.music_vol);
+	} else {
+		MusicDriver::GetInstance()->PlaySong(song);
+	}
 
 	InvalidateWindowData(WindowClass::Music, 0);
 }
@@ -258,6 +264,7 @@ void MusicSystem::Play()
 void MusicSystem::Stop()
 {
 	MusicDriver::GetInstance()->StopSong();
+	StopSampledMusic();
 	_settings_client.music.playing = false;
 
 	InvalidateWindowData(WindowClass::Music, 0);
@@ -290,7 +297,11 @@ void MusicSystem::CheckStatus()
 	}
 	if (this->active_playlist.empty()) return;
 	/* If we were supposed to be playing, but music has stopped, move to next song */
-	if (this->IsPlaying() && !MusicDriver::GetInstance()->IsSongPlaying()) this->Next();
+	if (this->IsPlaying()) {
+		const MusicSongInfo &song = this->active_playlist[this->playlist_position];
+		bool song_playing = MusicTrackUsesSampledPlayback(song.filetype) ? IsSampledMusicPlaying() : MusicDriver::GetInstance()->IsSongPlaying();
+		if (!song_playing) this->Next();
+	}
 }
 
 /**
@@ -837,6 +848,7 @@ struct MusicWindow : public Window {
 				if (ClickSliderWidget(this->GetWidget<NWidgetBase>(widget)->GetCurrentRect(), pt, 0, INT8_MAX, 0, vol)) {
 					if (widget == WID_M_MUSIC_VOL) {
 						MusicDriver::GetInstance()->SetVolume(vol);
+						SetSampledMusicVolume(vol);
 					} else {
 						SetEffectVolume(vol);
 					}

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -12,6 +12,7 @@
 #include "base_media_base.h"
 #include "base_media_music.h"
 #include "music/music_driver.hpp"
+#include "music/sampled_music.h"
 #include "window_gui.h"
 #include "strings_func.h"
 #include "window_func.h"
@@ -230,6 +231,7 @@ void MusicSystem::Play()
 	/* Always set the playing flag, even if there is no music */
 	_settings_client.music.playing = true;
 	MusicDriver::GetInstance()->StopSong();
+	StopSampledMusic();
 	/* Make sure playlist_position is a valid index, if playlist has changed etc. */
 	this->ChangePlaylistPosition(0);
 
@@ -238,7 +240,11 @@ void MusicSystem::Play()
 
 	MusicSongInfo song = this->active_playlist[this->playlist_position];
 	if (_game_mode == GameMode::Menu && this->selected_playlist == PlaylistChoice::ThemeOnly) song.loop = true;
-	MusicDriver::GetInstance()->PlaySong(song);
+	if (MusicTrackUsesSampledPlayback(song.filetype)) {
+		PlaySampledMusic(song, _settings_client.music.music_vol);
+	} else {
+		MusicDriver::GetInstance()->PlaySong(song);
+	}
 
 	InvalidateWindowData(WindowClass::Music, 0);
 }
@@ -247,6 +253,7 @@ void MusicSystem::Play()
 void MusicSystem::Stop()
 {
 	MusicDriver::GetInstance()->StopSong();
+	StopSampledMusic();
 	_settings_client.music.playing = false;
 
 	InvalidateWindowData(WindowClass::Music, 0);
@@ -279,7 +286,11 @@ void MusicSystem::CheckStatus()
 	}
 	if (this->active_playlist.empty()) return;
 	/* If we were supposed to be playing, but music has stopped, move to next song */
-	if (this->IsPlaying() && !MusicDriver::GetInstance()->IsSongPlaying()) this->Next();
+	if (this->IsPlaying()) {
+		const MusicSongInfo &song = this->active_playlist[this->playlist_position];
+		bool song_playing = MusicTrackUsesSampledPlayback(song.filetype) ? IsSampledMusicPlaying() : MusicDriver::GetInstance()->IsSongPlaying();
+		if (!song_playing) this->Next();
+	}
 }
 
 /**
@@ -835,6 +846,7 @@ struct MusicWindow : public Window {
 				if (ClickSliderWidget(this->GetWidget<NWidgetBase>(widget)->GetCurrentRect(), pt, 0, INT8_MAX, 0, vol)) {
 					if (widget == WID_M_MUSIC_VOL) {
 						MusicDriver::GetInstance()->SetVolume(vol);
+						SetSampledMusicVolume(vol);
 					} else {
 						SetEffectVolume(vol);
 					}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -43,6 +43,7 @@
 #include "rev.h"
 #include "video/video_driver.hpp"
 #include "music/music_driver.hpp"
+#include "music/sampled_music.h"
 #include "gui.h"
 #include "mixer.h"
 #include "newgrf_config.h"
@@ -1111,6 +1112,7 @@ struct GameOptionsWindow : Window {
 				if (ClickSliderWidget(this->GetWidget<NWidgetBase>(widget)->GetCurrentRect(), pt, 0, INT8_MAX, 0, vol)) {
 					if (widget == WID_GO_BASE_MUSIC_VOLUME) {
 						MusicDriver::GetInstance()->SetVolume(vol);
+						SetSampledMusicVolume(vol);
 					} else {
 						SetEffectVolume(vol);
 					}

--- a/test_content/ttd-opus/README.md
+++ b/test_content/ttd-opus/README.md
@@ -1,0 +1,26 @@
+# Sample TTD Opus music set
+
+This directory is only a template for the Ogg Opus music playback path. It does
+not contain music files.
+
+The workflow for making a real pack is:
+
+```sh
+mkdir -p my-opus-pack
+ffmpeg -i "source-track.ogg" -c:a libopus -b:a 160k my-opus-pack/track_01.opus
+md5sum my-opus-pack/track_01.opus
+```
+
+Then edit `ttd_opus.obm`:
+
+- put the `.opus` filenames into `[files]`
+- mark those playlist slots as `opus` in `[formats]`
+- add display names in `[names]`
+- paste the matching MD5 hashes into `[md5s]`
+
+To try the pack, place the completed folder in an OpenTTD baseset directory and
+start OpenTTD with:
+
+```sh
+openttd -M sample_opus
+```

--- a/test_content/ttd-opus/ttd_opus.obm
+++ b/test_content/ttd-opus/ttd_opus.obm
@@ -1,0 +1,59 @@
+; Sample Ogg Opus music-set metadata for OpenTTD.
+;
+; This file intentionally does not ship any music. Replace the placeholder
+; filenames and MD5 values with the files from your own Ogg Opus soundtrack.
+
+[metadata]
+name        = sample_opus
+shortname   = SOPU
+version     = 1
+description = Sample OpenTTD music set using Ogg Opus tracks.
+
+[files]
+theme = track_01.opus
+old_0 = track_02.opus
+old_1 =
+old_2 =
+old_3 =
+old_4 =
+old_5 =
+old_6 =
+old_7 =
+old_8 =
+old_9 =
+new_0 =
+new_1 =
+new_2 =
+new_3 =
+new_4 =
+new_5 =
+new_6 =
+new_7 =
+new_8 =
+new_9 =
+ezy_0 =
+ezy_1 =
+ezy_2 =
+ezy_3 =
+ezy_4 =
+ezy_5 =
+ezy_6 =
+ezy_7 =
+ezy_8 =
+ezy_9 =
+
+[formats]
+theme = opus
+old_0 = opus
+
+[names]
+track_01.opus = Sample Opus Theme
+track_02.opus = Sample Opus Track
+
+[md5s]
+; Replace these values with `md5sum track_01.opus track_02.opus`.
+track_01.opus = 00000000000000000000000000000000
+track_02.opus = 00000000000000000000000000000000
+
+[origin]
+default = Add your own Ogg Opus files next to this sample .obm.


### PR DESCRIPTION








## Motivation / Problem

The music in sessions used to be basically MIDI-only and i always wanted to have the 2014 TT Soundtrack version ingame. This adds a small music path next to the MIDI oath so base music tracks can also be played as Ogg Opus through libopusfile and fed straight into the existing PCM mixer.


## Description

The .obm loader now understands an optional [formats] section per playlist slot. If that section is missing tracks still default to MIDI, while .opus and .ogg filenames are treated as Ogg Opus. CAT/MPS MIDI stays on the old path. The music window and game options now route play, stop, status checks, and volume changes to either MIDI or sampled playback depending on the selected track.

There is also test_content/ttd-opus for quick manual testing. this test pack uses Ogg Opus files plus a ttd_opus.obm with names formats, and MD5s. It is test content for this branch, not a distributable music pack.

Workflow for setting up another playlist: first encode the source files to Ogg Opus, for example ffmpeg -i input.ogg -c:a libopus -b:a 160k track_01.opus. Put the .opus files and an .obm in the same baseset folder. Fill [files] with the OpenTTD playlist slots, set the same filled slots to opus in [formats], add display names in [names], and paste md5sum values for the .opus files into [md5s]. Copy the folder into a baseset directory and start it with openttd -M <set-name>.

## Limitations


None so far

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
