### PR TITLE
Codefix: make scoped-named enum actually scoped

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -216,7 +216,7 @@ static bool CMSATree(TileIndex tile)
 }
 
 /** Station types a station could be named after. */
-enum StationNaming : uint8_t {
+enum class StationNaming : uint8_t {
 	Rail, ///< Railway station.
 	Road, ///< Truck or bus stop.
 	Airport, ///< Airport for fixed wing aircraft.

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2820,7 +2820,7 @@ static bool IsBridgeAboveVehicle(const Vehicle *v)
 
 
 /** Models for spawning visual effects. */
-enum VisualEffectSpawnModel : uint8_t {
+enum class VisualEffectSpawnModel : uint8_t {
 	None = 0, ///< No visual effect
 	Steam, ///< Steam model
 	Diesel, ///< Diesel model


### PR DESCRIPTION
## Motivation / Problem

Incomplete scoped enum conversions.


## Description

Add some `class`.


## Limitations

None?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
