### PR TITLE
Codefix: clean up confusion between Track and Trackdir

### DIFF
--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -891,10 +891,10 @@ static Trackdir RoadFindPathToDest(RoadVehicle *v, TileIndex tile, DiagDirection
 
 	TrackStatus ts = GetTileTrackStatus(tile, TRANSPORT_ROAD, GetRoadTramType(v->roadtype));
 
-	/* Replaces the given track with INVALID_TRACK when there is red signal for that track. */
-	auto FilterRedSignal = [&ts](auto track) {
-		if (HasBit(ts.signals, track)) return INVALID_TRACKDIR;
-		return static_cast<Trackdir>(track);
+	/* Replaces the given trackdir with INVALID_TRACKDIR when there is red signal for that trackdir. */
+	auto FilterRedSignal = [&ts](Trackdir trackdir) {
+		if (HasBit(ts.signals, trackdir)) return INVALID_TRACKDIR;
+		return trackdir;
 	};
 
 	if (IsTileType(tile, TileType::Road)) {
@@ -959,7 +959,7 @@ static Trackdir RoadFindPathToDest(RoadVehicle *v, TileIndex tile, DiagDirection
 
 	if (v->dest_tile == INVALID_TILE) {
 		/* We've got no destination, pick a random track */
-		return FilterRedSignal(PickRandomBit(ts.trackdirs));
+		return FilterRedSignal(static_cast<Trackdir>(PickRandomBit(ts.trackdirs)));
 	}
 
 	/* Only one track to choose between? */
@@ -968,7 +968,7 @@ static Trackdir RoadFindPathToDest(RoadVehicle *v, TileIndex tile, DiagDirection
 			/* Vehicle expected a choice here, invalidate its path. */
 			v->path.clear();
 		}
-		return FilterRedSignal(FindFirstBit(ts.trackdirs));
+		return FilterRedSignal(static_cast<Trackdir>(FindFirstBit(ts.trackdirs)));
 	}
 
 	/* Attempt to follow cached path. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

In `RoadFindPathToDest()` there is a helper function called `FilterRedSignal` that is documented as filtering a `Track` and returning `INVALID_TRACK`.

However, it actually deals with `Trackdir` and returns `INVALID_TRACKDIR`.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Correct the documentation and use correct types for `FilterRedSignal()`

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
