### PR TITLE
Fix #15679: Train reversing when partially in a depot

### DIFF
--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -561,7 +561,7 @@ void AfterLoadVehiclesPhase2(bool part_of_load)
 }
 
 bool TrainController(Train *v, Vehicle *nomove, bool reverse = true); // From train_cmd.cpp
-void ReverseTrainSwapVeh(Train *v, int l, int r);
+void ReverseTrainSwapVehicles(Train *v);
 
 /** Fixup old train spacing. */
 void FixupTrainLengths()
@@ -595,9 +595,7 @@ void FixupTrainLengths()
 					u->force_proceed = TFP_SIGNAL;
 
 					/* Swap start<>end, start+1<>end-1, ... */
-					int r = CountVehiclesInChain(u) - 1; // number of vehicles - 1
-					int l = 0;
-					do ReverseTrainSwapVeh(u, l++, r--); while (l <= r);
+					ReverseTrainSwapVehicles(u);
 
 					/* We moved the first vehicle which is now the last. Move it back to the
 					 * original position as we will fix up the last vehicle later in the loop. */
@@ -612,9 +610,7 @@ void FixupTrainLengths()
 					}
 
 					/* Swap start<>end, start+1<>end-1, ... again. */
-					r = CountVehiclesInChain(u) - 1; // number of vehicles - 1
-					l = 0;
-					do ReverseTrainSwapVeh(u, l++, r--); while (l <= r);
+					ReverseTrainSwapVehicles(u);
 
 					u->force_proceed = old_tfp;
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1653,10 +1653,7 @@ static void UpdateStatusAfterSwap(Train *v, bool reverse = true)
 
 	/* Call the proper EnterTile function unless we are in a wormhole. */
 	if (v->track != TRACK_BIT_WORMHOLE) {
-		/* Do not call EnterTile for vehicles partially or totally in a depot. */
-		if (!IsRailDepotTile(v->tile)) {
-			VehicleEnterTile(v, v->tile, v->x_pos, v->y_pos);
-		}
+		VehicleEnterTile(v, v->tile, v->x_pos, v->y_pos);
 	} else {
 		/* VehicleEnterTile_TunnelBridge() sets TRACK_BIT_WORMHOLE when the vehicle
 		 * is on the last bit of the bridge head (frame == TILE_SIZE - 1).
@@ -1682,11 +1679,12 @@ static void UpdateStatusAfterSwap(Train *v, bool reverse = true)
 
 /**
  * Swap vehicles \a l and \a r in consist \a v, and reverse their direction.
+ * UpdateStatusAfterSwap calls should be made after all ReverseTrainSwapVeh calls have been completed.
  * @param v Consist to change.
  * @param l %Vehicle index in the consist of the first vehicle.
  * @param r %Vehicle index in the consist of the second vehicle.
  */
-void ReverseTrainSwapVeh(Train *v, int l, int r)
+static void ReverseTrainSwapVeh(Train *v, int l, int r)
 {
 	Train *a, *b;
 
@@ -1711,15 +1709,30 @@ void ReverseTrainSwapVeh(Train *v, int l, int r)
 		std::swap(a->z_pos, b->z_pos);
 
 		SwapTrainFlags(&a->gv_flags, &b->gv_flags);
-
-		UpdateStatusAfterSwap(a);
-		UpdateStatusAfterSwap(b);
 	} else {
 		/* Swap GVF_GOINGUP_BIT/GVF_GOINGDOWN_BIT.
 		 * This is a little bit redundant way, a->gv_flags will
 		 * be (re)set twice, but it reduces code duplication */
 		SwapTrainFlags(&a->gv_flags, &a->gv_flags);
-		UpdateStatusAfterSwap(a);
+	}
+}
+
+/**
+ * Swap vehicles in chain starting from \a v, and reverse their direction.
+ * @param v First vehicle in chain to change.
+ */
+void ReverseTrainSwapVehicles(Train *v)
+{
+	int r = CountVehiclesInChain(v) - 1;  // number of vehicles - 1
+
+	/* swap start<>end, start+1<>end-1, ... */
+	int l = 0;
+	do {
+		ReverseTrainSwapVeh(v, l++, r--);
+	} while (l <= r);
+
+	for (Train *u = v; u != nullptr; u = u->Next()) {
+		UpdateStatusAfterSwap(u);
 	}
 }
 
@@ -2048,15 +2061,10 @@ static void ReverseTrainDirection(Train *consist)
 		moving_front = consist->GetMovingFront();
 	} else {
 		/* The train will flip. */
-		int r = CountVehiclesInChain(consist) - 1;  // number of vehicles - 1
-
 		AdvanceWagonsBeforeSwap(moving_front);
 
 		/* swap start<>end, start+1<>end-1, ... */
-		int l = 0;
-		do {
-			ReverseTrainSwapVeh(consist, l++, r--);
-		} while (l <= r);
+		ReverseTrainSwapVehicles(consist);
 
 		AdvanceWagonsAfterSwap(moving_front);
 	}


### PR DESCRIPTION
## Motivation / Problem

#15679.
#15662 fixed the reversing out of depot case, but broke the reversing into depot case.

## Description

Defer UpdateStatusAfterSwap until after all swaps done.
Replace previous fix in #15662.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
