### PR TITLE
Codechange: avoid magic numbers and generic types when drawing autorail

### DIFF
--- a/src/table/autorail.h
+++ b/src/table/autorail.h
@@ -19,10 +19,10 @@
 #define RED(c) -c
 
 /**
- * Table maps each of the six rail directions and tileh combinations to a sprite.
+ * Table maps each of the six rail directions and tileh combinations to a sprite offset.
  * Invalid entries are required to make sure that this array can be quickly accessed.
  */
-static const int _AutorailTilehSprite[][6] = {
+static const int _autorail_slope_sprite_offsets[][6] = {
 /* type   0        1        2        3        4        5 */
 	{       0,       8,      16,      25,      34,      42 }, // tileh = 0
 	{       5,      13, RED(22), RED(31),      35,      42 }, // tileh = 1

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -965,27 +965,26 @@ static const HighLightStyle _autorail_type[6][2] = {
  * Draws autorail highlights.
  *
  * @param *ti TileInfo Tile that is being drawn
- * @param autorail_type Offset into _AutorailTilehSprite[][]
+ * @param highlight_style Highlight to draw
  */
-static void DrawAutorailSelection(const TileInfo *ti, uint autorail_type)
+static void DrawAutorailSelection(const TileInfo *ti, HighLightStyle highlight_style)
 {
 	SpriteID image;
 	PaletteID pal;
-	int offset;
 
 	FoundationPart foundation_part = FOUNDATION_PART_NORMAL;
-	Slope autorail_tileh = RemoveHalftileSlope(ti->tileh);
+	Slope slope = RemoveHalftileSlope(ti->tileh);
 	if (IsHalftileSlope(ti->tileh)) {
-		static constexpr CornerIndexArray<uint> lower_rail = {5U, 2U, 4U, 3U};
+		static constexpr CornerIndexArray<HighLightStyle> lower_rail{HT_DIR_VR, HT_DIR_HU, HT_DIR_VL, HT_DIR_HL};
 		Corner halftile_corner = GetHalftileSlopeCorner(ti->tileh);
-		if (autorail_type != lower_rail[halftile_corner]) {
+		if ((highlight_style & HT_DIR_MASK) != lower_rail[halftile_corner]) {
 			foundation_part = FOUNDATION_PART_HALFTILE;
 			/* Here we draw the highlights of the "three-corners-raised"-slope. That looks ok to me. */
-			autorail_tileh = SlopeWithThreeCornersRaised(OppositeCorner(halftile_corner));
+			slope = SlopeWithThreeCornersRaised(OppositeCorner(halftile_corner));
 		}
 	}
 
-	offset = _AutorailTilehSprite[autorail_tileh][autorail_type];
+	int offset = _autorail_slope_sprite_offsets[slope][highlight_style & HT_DIR_MASK];
 	if (offset >= 0) {
 		image = SPR_AUTORAIL_BASE + offset;
 		pal = PAL_NONE;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`DrawAutorailSelection()` has a lookup table of magic numbers, and this is compared against a `uint` parameter.

However these values are actually values within the `HighLightStyle` enum.

Also the `uint` parameter being compared against is also a `HighLightStyle`, so...

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Replace `uint` parameter with `HighLightStyle` parameter, replace magic numbers with `HighLightStyle` values, and some minor tidying up.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
