### PR TITLE
Fix: town name language incorrectly decoded

### DIFF
--- a/src/newgrf/newgrf_actf.cpp
+++ b/src/newgrf/newgrf_actf.cpp
@@ -50,8 +50,7 @@ static void FeatureTownName(ByteReader &buf)
 
 			std::string_view name = buf.ReadString();
 
-			std::string lang_name = TranslateTTDPatchCodes(grfid, lang, false, name);
-			GrfMsg(6, "FeatureTownName: lang 0x{:X} -> '{}'", lang, lang_name);
+			GrfMsg(6, "FeatureTownName: lang 0x{:X} (new_scheme: {}) -> '{}'", lang, new_scheme, TranslateTTDPatchCodes(grfid, 0, false, name));
 
 			style = AddGRFString(grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 


### PR DESCRIPTION
## Motivation / Problem

`TranslateTTDPatchCodes` supports only GRF version >= 7, but can be passed GRF version < 7.


## Description

Instead of trying to properly decode the language, since this is for printing a debug message... use the fallback/default language. Just as is done for the part name later in the function (line 91/92). 

Moving the call the `TranslateTTDPatchCodes` to the `GrfMsg` 'call' means it won't be evaluated when the message isn't emitted any more.


## Limitations

Fixing the hardcoded `0` for default language is something for another PR that introduces an enumeration in the appropriate place.

`GRFLoadError` has a similar issue, but the solution is completely different. So that's also another PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
