### PR TITLE
Codechange: directly use _current_language->newgrflangid instead of maintaining a separate variable for two functions

### DIFF
--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -74,7 +74,6 @@ struct GRFTextEntry {
 
 
 static TypedIndexContainer<std::vector<GRFTextEntry>, StringIndexInTab> _grf_text;
-static uint8_t _current_lang_id = GRFLX_ENGLISH;  ///< by default, english is used.
 
 /**
  * Get the mapping from the NewGRF supplied ID to OpenTTD's internal ID.
@@ -614,7 +613,7 @@ std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextList &text_
 
 	/* Search the list of lang-strings of this stringid for current lang */
 	for (const auto &text : text_list) {
-		if (text.langid == _current_lang_id) return text.text;
+		if (text.langid == _current_language->newgrflangid) return text.text;
 
 		/* If the current string is English or American, set it as the
 		 * fallback language if the specific language isn't available. */
@@ -656,23 +655,10 @@ std::string_view GetGRFStringPtr(StringIndexInTab stringid)
 	return GetStringPtr(_grf_text[stringid].def_string);
 }
 
-/**
- * Equivalence Setter function between game and newgrf langID.
- * This function will adjust _currentLangID as to what is the LangID
- * of the current language set by the user.
- * This function is called after the user changed language,
- * from strings.cpp:ReadLanguagePack
- * @param language_id iso code of current selection
- */
-void SetCurrentGrfLangID(uint8_t language_id)
-{
-	_current_lang_id = language_id;
-}
-
 bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version)
 {
 	if (grf_version < 7) {
-		switch (_current_lang_id) {
+		switch (_current_language->newgrflangid) {
 			case GRFLX_GERMAN:  return (lang_id & GRFLB_GERMAN)  != 0;
 			case GRFLX_FRENCH:  return (lang_id & GRFLB_FRENCH)  != 0;
 			case GRFLX_SPANISH: return (lang_id & GRFLB_SPANISH) != 0;
@@ -680,7 +666,7 @@ bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version)
 		}
 	}
 
-	return (lang_id == _current_lang_id || lang_id == GRFLX_UNSPECIFIED);
+	return (lang_id == _current_language->newgrflangid || lang_id == GRFLX_UNSPECIFIED);
 }
 
 /**

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -20,7 +20,6 @@ std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextList &text_
 std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextWrapper &text);
 std::string_view GetGRFStringPtr(StringIndexInTab stringid);
 void CleanUpStrings();
-void SetCurrentGrfLangID(uint8_t language_id);
 std::string TranslateTTDPatchCodes(uint32_t grfid, uint8_t language_id, bool allow_newlines, std::string_view str, StringControlCode byte80 = SCC_NEWGRF_PRINT_WORD_STRING_ID);
 void AddGRFTextToList(GRFTextList &list, uint8_t langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add);
 void AddGRFTextToList(GRFTextWrapper &list, uint8_t langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2105,7 +2105,6 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 	_current_language = lang;
 	_current_text_dir = (TextDirection)_current_language->text_dir;
 	_config_language_file = FS2OTTD(_current_language->file.filename().native());
-	SetCurrentGrfLangID(_current_language->newgrflangid);
 	_langpack.list_separator = GetString(STR_LIST_SEPARATOR);
 	_langpack.ellipsis = GetString(STR_TRUNCATION_ELLIPSIS);
 


### PR DESCRIPTION
## Motivation / Problem

We maintain two 'global' variables for the currently used language:
* `_current_language->newgrflangid`
* `_current_lang_id`


## Description

Drop `_current_lang_id` in favour of `_current_language->newgrflangid`, and remove the unneeded setter function.


## Limitations

Could use some `enum` love, but that's another PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
