### PR TITLE
Fix: No reliability loss while vehicle is stopped in a depot

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1326,6 +1326,9 @@ void CheckVehicleBreakdown(Vehicle *v)
 	/* With Reduced breakdowns, vehicles (un)loading at stations don't lose reliability. */
 	if (_settings_game.difficulty.vehicle_breakdowns == VehicleBreakdowns::Reduced && v->current_order.IsType(OT_LOADING)) return;
 
+	/* If vehicle is stopped in a depot, it doesn't lose reliability. */
+	if (v->IsStoppedInDepot()) return;
+
 	/* Decrease reliability. */
 	int rel, rel_old;
 	v->reliability = rel = std::max((rel_old = v->reliability) - v->reliability_spd_dec, 0);


### PR DESCRIPTION
## Motivation / Problem

Vehicles sitting in a depot lose reliability, only to be serviced the moment they leave the depot and brought up to their max reliability.

Nothing is hurt by this, except it makes the UI a bit confusing to see a vehicle have low reliability just because it's been stopped in the depot for a while.

## Description

Let's make vehicles in a depot not lose reliability. There is no gameplay effect to this change.

#15456 fixed this but the contributor had Git problems and deleted their entire repo, so I can't push to that PR.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
