### PR TITLE
Codechange: use reference over pointer for RemoveFirstTrack(dir)

### DIFF
--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -447,7 +447,7 @@ no_entry_cost: // jump here at the beginning if the node has no parent (it is th
 							td = Trackdir::Invalid;
 							break;
 						}
-						td = RemoveFirstTrackdir(&ft.new_td_bits);
+						td = RemoveFirstTrackdir(ft.new_td_bits);
 						/* If this is a safe waiting position we're done searching for it */
 						if (IsSafeWaitingPosition(v, t, td, true, _settings_game.pf.forbid_90_deg)) break;
 					}

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1218,7 +1218,7 @@ static bool AdvanceSignalAutoFill(TileIndex &tile, Trackdir &trackdir, bool remo
 	if (trackdirbits.None()) return false;
 
 	/* Get the first track dir */
-	trackdir = RemoveFirstTrackdir(&trackdirbits);
+	trackdir = RemoveFirstTrackdir(trackdirbits);
 
 	/* Any left? It's a junction so we stop */
 	if (trackdirbits.Any()) return false;

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -210,7 +210,7 @@ inline void SetTrackReservation(Tile t, TrackBits b)
 {
 	assert(IsPlainRailTile(t));
 	assert(!TracksOverlap(b));
-	Track track = RemoveFirstTrack(&b);
+	Track track = RemoveFirstTrack(b);
 	SB(t.m2(), 8, 3, IsValidTrack(track) ? to_underlying(track) + 1 : 0);
 	AssignBit(t.m2(), 11, b.Any());
 }

--- a/src/track_func.h
+++ b/src/track_func.h
@@ -103,13 +103,13 @@ inline TrackdirBits TrackdirToTrackdirBits(Trackdir trackdir)
  * @return The first Track from the TrackBits value
  * @see FindFirstTrack
  */
-inline Track RemoveFirstTrack(TrackBits *tracks)
+inline Track RemoveFirstTrack(TrackBits &tracks)
 {
-	if (tracks->None()) return Track::Invalid;
+	if (tracks.None()) return Track::Invalid;
 
-	assert(!tracks->Any({Track::Wormhole, Track::Depot}));
-	Track first = tracks->GetNthSetBit(0).value();
-	tracks->Reset(first);
+	assert(!tracks.Any({Track::Wormhole, Track::Depot}));
+	Track first = tracks.GetNthSetBit(0).value();
+	tracks.Reset(first);
 	return first;
 }
 
@@ -127,13 +127,13 @@ inline Track RemoveFirstTrack(TrackBits *tracks)
  * @return The first Trackdir from the TrackdirBits value
  * @see FindFirstTrackdir
  */
-inline Trackdir RemoveFirstTrackdir(TrackdirBits *trackdirs)
+inline Trackdir RemoveFirstTrackdir(TrackdirBits &trackdirs)
 {
-	if (trackdirs->None() || *trackdirs == INVALID_TRACKDIR_BIT) return Trackdir::Invalid;
+	if (trackdirs.None() || trackdirs == INVALID_TRACKDIR_BIT) return Trackdir::Invalid;
 
-	assert(!trackdirs->Any({Trackdir::RvRev_NE, Trackdir::RvRev_SE, Trackdir::RvRev_SW, Trackdir::RvRev_NW}));
-	Trackdir first = trackdirs->GetNthSetBit(0).value();
-	trackdirs->Reset(first);
+	assert(!trackdirs.Any({Trackdir::RvRev_NE, Trackdir::RvRev_SE, Trackdir::RvRev_SW, Trackdir::RvRev_NW}));
+	Trackdir first = trackdirs.GetNthSetBit(0).value();
+	trackdirs.Reset(first);
 	return first;
 }
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2498,7 +2498,7 @@ void FreeTrainTrackReservation(const Train *consist)
 	while (ft.Follow(tile, td)) {
 		tile = ft.new_tile;
 		TrackdirBits bits = ft.new_td_bits & TrackBitsToTrackdirBits(GetReservedTrackbits(tile));
-		td = RemoveFirstTrackdir(&bits);
+		td = RemoveFirstTrackdir(bits);
 		assert(bits.None());
 
 		if (!IsValidTrackdir(td)) break;


### PR DESCRIPTION
## Motivation / Problem

Use references over pointers to show the intent that you never expect `nullptr`.


## Description

Convert `RemoveFirstTrack` and `RemoveFirstTrackdir`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
