### PR TITLE
Codechange: make CanalFeatureFlag a scoped enum and use EnumBitSet for flags

### DIFF
--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -39,10 +39,17 @@ enum CanalFeature : uint8_t {
 	CF_END,
 };
 
+/** Flags controlling the display of canals. */
+enum CanalFeatureFlag : uint8_t {
+	HasFlatSprite = 0, ///< Additional flat ground sprite in the beginning.
+};
+/** CanalFeatureFlag bitmask. */
+using CanalFeatureFlags = EnumBitSet<CanalFeatureFlag, uint8_t>;
+
 /** Canal properties local to the NewGRF */
 struct CanalProperties {
-	CanalCallbackMasks callback_mask;  ///< Bitmask of canal callbacks that have to be called.
-	uint8_t flags;          ///< Flags controlling display.
+	CanalCallbackMasks callback_mask; ///< Bitmask of canal callbacks that have to be called.
+	CanalFeatureFlags flags; ///< Flags controlling display.
 };
 
 /** Stages of loading all NewGRFs. */

--- a/src/newgrf/newgrf_act0_canals.cpp
+++ b/src/newgrf/newgrf_act0_canals.cpp
@@ -40,7 +40,7 @@ static ChangeInfoResult CanalChangeInfo(uint first, uint last, int prop, ByteRea
 				break;
 
 			case 0x09:
-				cp->flags = buf.ReadByte();
+				cp->flags = CanalFeatureFlags{buf.ReadByte()};
 				break;
 
 			default:

--- a/src/newgrf_canal.h
+++ b/src/newgrf_canal.h
@@ -14,17 +14,12 @@
 #include "newgrf_callbacks.h"
 #include "tile_type.h"
 
-/** Flags controlling the display of canals. */
-enum CanalFeatureFlag : uint8_t {
-	CFF_HAS_FLAT_SPRITE = 0, ///< Additional flat ground sprite in the beginning.
-};
-
 /** Information about a water feature. */
 struct WaterFeature {
 	const SpriteGroup *group = nullptr; ///< Sprite group to start resolving.
 	const GRFFile *grffile = nullptr; ///< NewGRF where 'group' belongs to.
-	CanalCallbackMasks callback_mask = {}; ///< Bitmask of canal callbacks that have to be called.
-	uint8_t flags = 0; ///< Flags controlling display.
+	CanalCallbackMasks callback_mask{}; ///< Bitmask of canal callbacks that have to be called.
+	CanalFeatureFlags flags{}; ///< Flags controlling display.
 };
 
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -823,7 +823,7 @@ static void DrawSeaWater(TileIndex)
 static void DrawCanalWater(TileIndex tile)
 {
 	SpriteID image = SPR_FLAT_WATER_TILE;
-	if (HasBit(_water_feature[CF_WATERSLOPE].flags, CFF_HAS_FLAT_SPRITE)) {
+	if (_water_feature[CF_WATERSLOPE].flags.Test(CanalFeatureFlag::HasFlatSprite)) {
 		/* First water slope sprite is flat water. */
 		image = GetCanalSprite(CF_WATERSLOPE, tile);
 		if (image == 0) image = SPR_FLAT_WATER_TILE;
@@ -873,7 +873,7 @@ static void DrawWaterLock(const TileInfo *ti)
 	if (water_base == 0) {
 		/* Use default sprites. */
 		water_base = SPR_CANALS_BASE;
-	} else if (HasBit(_water_feature[CF_WATERSLOPE].flags, CFF_HAS_FLAT_SPRITE)) {
+	} else if (_water_feature[CF_WATERSLOPE].flags.Test(CanalFeatureFlag::HasFlatSprite)) {
 		/* NewGRF supplies a flat sprite as first sprite. */
 		if (image == SPR_FLAT_WATER_TILE) {
 			image = water_base;
@@ -915,7 +915,7 @@ static void DrawRiverWater(const TileInfo *ti)
 	uint     offset = 0;
 	uint     edges_offset = 0;
 
-	if (ti->tileh != SLOPE_FLAT || HasBit(_water_feature[CF_RIVER_SLOPE].flags, CFF_HAS_FLAT_SPRITE)) {
+	if (ti->tileh != SLOPE_FLAT || _water_feature[CF_RIVER_SLOPE].flags.Test(CanalFeatureFlag::HasFlatSprite)) {
 		image = GetCanalSprite(CF_RIVER_SLOPE, ti->tile);
 		if (image == 0) {
 			switch (ti->tileh) {
@@ -927,7 +927,7 @@ static void DrawRiverWater(const TileInfo *ti)
 			}
 		} else {
 			/* Flag bit 0 indicates that the first sprite is flat water. */
-			offset = HasBit(_water_feature[CF_RIVER_SLOPE].flags, CFF_HAS_FLAT_SPRITE) ? 1 : 0;
+			offset = _water_feature[CF_RIVER_SLOPE].flags.Test(CanalFeatureFlag::HasFlatSprite) ? 1 : 0;
 
 			switch (ti->tileh) {
 				case SLOPE_SE:              edges_offset += 12; break;


### PR DESCRIPTION
## Motivation / Problem

Our endeavour to improve type safety.


## Description

* Make the `CanalFeatureFlag` a scoped enumeration.
* Make a `CanalFeatureFlags` using `EnumBitSet`.
* Use `CanalFeatureFlags` over raw `uint8_t`.


## Limitations

Moving more types to newgrf.h.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
