### PR TITLE
Codechange: remove unused path in DrawSortButton and simplify calling

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -432,7 +432,7 @@ public:
 	{
 		switch (widget) {
 			case WID_RV_SORT_ASCENDING_DESCENDING:
-				this->DrawSortButtonState(WID_RV_SORT_ASCENDING_DESCENDING, this->descending_sort_order ? SBS_DOWN : SBS_UP);
+				this->DrawSortButton(WID_RV_SORT_ASCENDING_DESCENDING, this->descending_sort_order);
 				break;
 
 			case WID_RV_INFO_TAB: {

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -241,7 +241,7 @@ public:
 	{
 		switch (widget) {
 			case WID_BBS_DROPDOWN_ORDER:
-				this->DrawSortButtonState(widget, this->bridges.IsDescSortOrder() ? SBS_DOWN : SBS_UP);
+				this->DrawSortButton(widget, this->bridges.IsDescSortOrder());
 				break;
 
 			case WID_BBS_BRIDGE_LIST: {

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1928,7 +1928,7 @@ struct BuildVehicleWindow : Window {
 				break;
 
 			case WID_BV_SORT_ASCENDING_DESCENDING:
-				this->DrawSortButtonState(WID_BV_SORT_ASCENDING_DESCENDING, this->descending_sort_order ? SBS_DOWN : SBS_UP);
+				this->DrawSortButton(WID_BV_SORT_ASCENDING_DESCENDING, this->descending_sort_order);
 				break;
 		}
 	}

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -512,7 +512,7 @@ public:
 			case WID_SL_SORT_BYNAME:
 			case WID_SL_SORT_BYDATE:
 				if ((_savegame_sorter == SavegameSorter::Name) == (widget == WID_SL_SORT_BYNAME)) {
-					this->DrawSortButtonState(widget, _savegame_sorter_ascending ? SBS_UP : SBS_DOWN);
+					this->DrawSortButton(widget, !_savegame_sorter_ascending);
 				}
 				break;
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -697,7 +697,7 @@ public:
 			}
 
 			case WID_GL_SORT_BY_ORDER:
-				this->DrawSortButtonState(WID_GL_SORT_BY_ORDER, this->vehgroups.IsDescSortOrder() ? SBS_DOWN : SBS_UP);
+				this->DrawSortButton(WID_GL_SORT_BY_ORDER, this->vehgroups.IsDescSortOrder());
 				break;
 
 			case WID_GL_LIST_VEHICLE:

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1694,7 +1694,7 @@ public:
 	{
 		switch (widget) {
 			case WID_ID_DROPDOWN_ORDER:
-				this->DrawSortButtonState(widget, this->industries.IsDescSortOrder() ? SBS_DOWN : SBS_UP);
+				this->DrawSortButton(widget, this->industries.IsDescSortOrder());
 				break;
 
 			case WID_ID_INDUSTRY_LIST: {

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -643,19 +643,12 @@ public:
 
 	void OnPaint() override
 	{
-		const SortButtonState arrow = this->content.IsDescSortOrder() ? SBS_DOWN : SBS_UP;
-
 		if (this->content.NeedRebuild()) {
 			this->BuildContentList();
 		}
 
 		this->DrawWidgets();
-
-		switch (this->content.SortType()) {
-			case WID_NCL_CHECKBOX - WID_NCL_CHECKBOX: this->DrawSortButtonState(WID_NCL_CHECKBOX, arrow); break;
-			case WID_NCL_TYPE     - WID_NCL_CHECKBOX: this->DrawSortButtonState(WID_NCL_TYPE,     arrow); break;
-			case WID_NCL_NAME     - WID_NCL_CHECKBOX: this->DrawSortButtonState(WID_NCL_NAME,     arrow); break;
-		}
+		this->DrawSortButton(this->content.SortType() + WID_NCL_CHECKBOX, this->content.IsDescSortOrder());
 	}
 
 	/**

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -565,7 +565,7 @@ public:
 			case WID_NG_DATE:
 			case WID_NG_YEARS:
 			case WID_NG_INFO:
-				if (widget - WID_NG_NAME == this->servers.SortType()) this->DrawSortButtonState(widget, this->servers.IsDescSortOrder() ? SBS_DOWN : SBS_UP);
+				if (widget - WID_NG_NAME == this->servers.SortType()) this->DrawSortButton(widget, this->servers.IsDescSortOrder());
 				break;
 		}
 	}

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -499,7 +499,7 @@ public:
 		switch (widget) {
 			case WID_STL_SORTBY:
 				/* draw arrow pointing up/down for ascending/descending sorting */
-				this->DrawSortButtonState(WID_STL_SORTBY, this->stations.IsDescSortOrder() ? SBS_DOWN : SBS_UP);
+				this->DrawSortButton(WID_STL_SORTBY, this->stations.IsDescSortOrder());
 				break;
 
 			case WID_STL_LIST: {
@@ -1475,7 +1475,7 @@ struct StationViewWindow : public Window {
 			}
 
 			/* Draw arrow pointing up/down for ascending/descending sorting */
-			this->DrawSortButtonState(WID_SV_SORT_ORDER, sort_orders[1] == SO_ASCENDING ? SBS_UP : SBS_DOWN);
+			this->DrawSortButton(WID_SV_SORT_ORDER, sort_orders[1] != SO_ASCENDING);
 
 			int pos = this->vscroll->GetPosition();
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -847,7 +847,7 @@ public:
 	{
 		switch (widget) {
 			case WID_TD_SORT_ORDER:
-				this->DrawSortButtonState(widget, this->towns.IsDescSortOrder() ? SBS_DOWN : SBS_UP);
+				this->DrawSortButton(widget, this->towns.IsDescSortOrder());
 				break;
 
 			case WID_TD_LIST: {

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2069,7 +2069,7 @@ public:
 		switch (widget) {
 			case WID_VL_SORT_ORDER:
 				/* draw arrow pointing up/down for ascending/descending sorting */
-				this->DrawSortButtonState(widget, this->vehgroups.IsDescSortOrder() ? SBS_DOWN : SBS_UP);
+				this->DrawSortButton(widget, this->vehgroups.IsDescSortOrder());
 				break;
 
 			case WID_VL_LIST:

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -813,19 +813,17 @@ void Window::DrawWidgets() const
 /**
  * Draw a sort button's up or down arrow symbol.
  * @param widget Sort button widget
- * @param state State of sort button
+ * @param descending Draw the button for sorting descending.
  */
-void Window::DrawSortButtonState(WidgetID widget, SortButtonState state) const
+void Window::DrawSortButton(WidgetID widget, bool descending) const
 {
-	if (state == SBS_OFF) return;
-
 	assert(!this->widget_lookup.empty());
 	Rect r = this->GetWidget<NWidgetBase>(widget)->GetCurrentRect();
 
 	/* Sort button uses the same sprites as vertical scrollbar */
 	Dimension dim = NWidgetScrollbar::GetVerticalDimension();
 
-	DrawSpriteIgnorePadding(state == SBS_DOWN ? SPR_ARROW_DOWN : SPR_ARROW_UP, PAL_NONE, r.WithWidth(dim.width, _current_text_dir == TD_LTR), SA_CENTER);
+	DrawSpriteIgnorePadding(descending ? SPR_ARROW_DOWN : SPR_ARROW_UP, PAL_NONE, r.WithWidth(dim.width, _current_text_dir == TD_LTR), SA_CENTER);
 }
 
 /**

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -217,13 +217,6 @@ struct ResizeInfo {
 	uint step_height; ///< Step-size of height resize changes
 };
 
-/** State of a sort direction button. */
-enum SortButtonState : uint8_t {
-	SBS_OFF,  ///< Do not sort (with this button).
-	SBS_DOWN, ///< Sort ascending.
-	SBS_UP,   ///< Sort descending.
-};
-
 /**
  * Window flags.
  */
@@ -549,7 +542,7 @@ public:
 
 	void DrawWidgets() const;
 	void DrawViewport() const;
-	void DrawSortButtonState(WidgetID widget, SortButtonState state) const;
+	void DrawSortButton(WidgetID widget, bool descending) const;
 	static int SortButtonWidth();
 
 	Window *FindChildWindow(WindowClass wc = WindowClass::Invalid) const;


### PR DESCRIPTION
## Motivation / Problem

Initially scoped enums, but then seeing all the callers and thinking... this can be so much simpler once noticing that one of the enum values is not even used.

Since `SPS_OFF` isn't actually used (yes, `DrawSortButtonState` has support for it but nothing uses is), it devolves into a boolean.

Of the 14 times it's called, it is using ` ? SBS_DOWN : SBS_UP`, the two others are ` ? SBS_UP : SBS_DOWN`.


## Description

Remove the `SPS_OFF` special case, remove the whole enum and replace it with a boolean. Finally rename `DrawSortButtonState` to just `DrawSortButton`.

Finally, simplify `NetworkContentListWindow::OnPaint` as the complete switch is just a very obtuse way of directly calling it for one of the three sort types.


## Limitations

One could think what would happen if one wants to use `SPS_OFF`, and consider just not calling the `DrawSortButton` function.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
