### PR TITLE
Codechange: make EventState a scoped enum

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -186,13 +186,13 @@ struct BuildAirToolbarWindow : Window {
 	/**
 	 * Handler for global hotkeys of the BuildAirToolbarWindow.
 	 * @param hotkey Hotkey
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState AirportToolbarGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return EventState::NotHandled;
 		Window *w = ShowBuildAirToolbar();
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -266,9 +266,9 @@ public:
 			/* Build the requested bridge */
 			this->BuildBridge(this->bridges[i].index);
 			this->Close();
-			return ES_HANDLED;
+			return EventState::Handled;
 		}
-		return ES_NOT_HANDLED;
+		return EventState::NotHandled;
 	}
 
 	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -239,7 +239,7 @@ struct IConsoleWindow : Window
 
 	EventState OnKeyPress([[maybe_unused]] char32_t key, uint16_t keycode) override
 	{
-		if (_focused_window != this) return ES_NOT_HANDLED;
+		if (_focused_window != this) return EventState::NotHandled;
 
 		const int scroll_height = (this->height / this->line_height) - 1;
 		switch (keycode) {
@@ -311,12 +311,12 @@ struct IConsoleWindow : Window
 					IConsoleResetHistoryPos();
 					this->SetDirty();
 				} else {
-					return ES_NOT_HANDLED;
+					return EventState::NotHandled;
 				}
 				break;
 			}
 		}
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	void InsertTextString(WidgetID, std::string_view str, bool marked, std::optional<size_t> caret, std::optional<size_t> insert_location, std::optional<size_t> replacement_end) override

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -1148,10 +1148,10 @@ struct DepotWindow : Window {
 		if (this->sel != VehicleID::Invalid()) {
 			_cursor.vehchain = _ctrl_pressed;
 			this->SetWidgetDirty(WID_D_MATRIX);
-			return ES_HANDLED;
+			return EventState::Handled;
 		}
 
-		return ES_NOT_HANDLED;
+		return EventState::NotHandled;
 	}
 
 	/**

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -312,13 +312,13 @@ struct BuildDocksToolbarWindow : Window {
 	/**
 	 * Handler for global hotkeys of the BuildDocksToolbarWindow.
 	 * @param hotkey Hotkey
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState DockToolbarGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return EventState::NotHandled;
 		Window *w = ShowBuildDocksToolbar();
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -832,10 +832,10 @@ public:
 	{
 		if (keycode == WKC_ESC) {
 			this->Close();
-			return ES_HANDLED;
+			return EventState::Handled;
 		}
 
-		return ES_NOT_HANDLED;
+		return EventState::NotHandled;
 	}
 
 	void OnTimeout() override

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -88,7 +88,7 @@ struct EndGameHighScoreBaseWindow : Window {
 		/* All keys are 'handled' by this window but we want to make
 		 * sure that 'quit' still works correctly. Not handling the
 		 * quit key is enough so the main toolbar can handle it. */
-		if (IsQuitKey(keycode)) return ES_NOT_HANDLED;
+		if (IsQuitKey(keycode)) return EventState::NotHandled;
 
 		switch (keycode) {
 			/* Keys for telling we want to go on */
@@ -96,13 +96,13 @@ struct EndGameHighScoreBaseWindow : Window {
 			case WKC_ESC:
 			case WKC_SPACE:
 				this->Close();
-				return ES_HANDLED;
+				return EventState::Handled;
 
 			default:
 				/* We want to handle all keys; we don't want windows in
 				 * the background to open. Especially the ones that do
 				 * locate themselves based on the status-/toolbars. */
-				return ES_HANDLED;
+				return EventState::Handled;
 		}
 	}
 };

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -347,7 +347,7 @@ void HandleGlobalHotkeys([[maybe_unused]] char32_t key, uint16_t keycode)
 		if (list->global_hotkey_handler == nullptr) continue;
 
 		int hotkey = list->CheckMatch(keycode, true);
-		if (hotkey >= 0 && (list->global_hotkey_handler(hotkey) == ES_HANDLED)) return;
+		if (hotkey >= 0 && (list->global_hotkey_handler(hotkey) == EventState::Handled)) return;
 	}
 }
 

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -280,45 +280,45 @@ struct MainWindow : Window
 	{
 		if (hotkey == GHK_QUIT) {
 			HandleExitGameRequest();
-			return ES_HANDLED;
+			return EventState::Handled;
 		}
 
 		/* Disable all key shortcuts, except quit shortcuts when
 		 * generating the world, otherwise they create threading
 		 * problem during the generating, resulting in random
 		 * assertions that are hard to trigger and debug */
-		if (HasModalProgress()) return ES_NOT_HANDLED;
+		if (HasModalProgress()) return EventState::NotHandled;
 
 		switch (hotkey) {
 			case GHK_ABANDON:
 				/* No point returning from the main menu to itself */
-				if (_game_mode == GameMode::Menu) return ES_HANDLED;
+				if (_game_mode == GameMode::Menu) return EventState::Handled;
 				if (_settings_client.gui.autosave_on_exit) {
 					DoExitSave();
 					_switch_mode = SwitchMode::Menu;
 				} else {
 					AskExitToGameMenu();
 				}
-				return ES_HANDLED;
+				return EventState::Handled;
 
 			case GHK_CONSOLE:
 				IConsoleSwitch();
-				return ES_HANDLED;
+				return EventState::Handled;
 
 			case GHK_BOUNDING_BOXES:
 				ToggleBoundingBoxes();
-				return ES_HANDLED;
+				return EventState::Handled;
 
 			case GHK_DIRTY_BLOCKS:
 				ToggleDirtyBlocks();
-				return ES_HANDLED;
+				return EventState::Handled;
 
 			case GHK_WIDGET_OUTLINES:
 				ToggleWidgetOutlines();
-				return ES_HANDLED;
+				return EventState::Handled;
 		}
 
-		if (_game_mode == GameMode::Menu) return ES_NOT_HANDLED;
+		if (_game_mode == GameMode::Menu) return EventState::NotHandled;
 
 		switch (hotkey) {
 			case GHK_CENTER:
@@ -415,16 +415,16 @@ struct MainWindow : Window
 				break;
 
 			case GHK_CLOSE_NEWS: // close active news window
-				if (!HideActiveNewsMessage()) return ES_NOT_HANDLED;
+				if (!HideActiveNewsMessage()) return EventState::NotHandled;
 				break;
 
 			case GHK_CLOSE_ERROR: // close active error window
-				if (!HideActiveErrorMessage()) return ES_NOT_HANDLED;
+				if (!HideActiveErrorMessage()) return EventState::NotHandled;
 				break;
 
-			default: return ES_NOT_HANDLED;
+			default: return EventState::NotHandled;
 		}
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	void OnScroll(Point delta) override

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1174,9 +1174,9 @@ struct QueryWindow : public Window {
 
 			case WKC_ESC:
 				this->Close();
-				return ES_HANDLED;
+				return EventState::Handled;
 		}
-		return ES_NOT_HANDLED;
+		return EventState::NotHandled;
 	}
 };
 

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -382,10 +382,10 @@ struct NetworkChatWindow : public Window {
 
 	EventState OnKeyPress([[maybe_unused]] char32_t key, uint16_t keycode) override
 	{
-		EventState state = ES_NOT_HANDLED;
+		EventState state = EventState::NotHandled;
 		if (keycode == WKC_TAB) {
 			ChatTabCompletion();
-			state = ES_HANDLED;
+			state = EventState::Handled;
 		}
 		return state;
 	}

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -881,7 +881,7 @@ public:
 
 	EventState OnKeyPress([[maybe_unused]] char32_t key, uint16_t keycode) override
 	{
-		if (this->vscroll->UpdateListPositionOnKeyPress(this->list_pos, keycode) == ES_NOT_HANDLED) {
+		if (this->vscroll->UpdateListPositionOnKeyPress(this->list_pos, keycode) == EventState::NotHandled) {
 			switch (keycode) {
 				case WKC_SPACE:
 				case WKC_RETURN:
@@ -895,13 +895,13 @@ public:
 							this->content.ForceRebuild();
 							this->InvalidateData();
 						}
-						return ES_HANDLED;
+						return EventState::Handled;
 					}
 					/* space is pressed and filter is focused. */
 					[[fallthrough]];
 
 				default:
-					return ES_NOT_HANDLED;
+					return EventState::NotHandled;
 			}
 		}
 
@@ -910,7 +910,7 @@ public:
 				this->content.ForceRebuild();
 				this->InvalidateData();
 			}
-			return ES_HANDLED;
+			return EventState::Handled;
 		}
 
 		this->selected = this->content[this->list_pos];
@@ -924,7 +924,7 @@ public:
 
 		/* redraw window */
 		this->InvalidateData();
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	void OnEditboxChanged(WidgetID wid) override

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -789,11 +789,11 @@ public:
 
 	EventState OnKeyPress([[maybe_unused]] char32_t key, uint16_t keycode) override
 	{
-		EventState state = ES_NOT_HANDLED;
+		EventState state = EventState::NotHandled;
 
 		/* handle up, down, pageup, pagedown, home and end */
-		if (this->vscroll->UpdateListPositionOnKeyPress(this->list_pos, keycode) == ES_HANDLED) {
-			if (this->list_pos == SLP_INVALID) return ES_HANDLED;
+		if (this->vscroll->UpdateListPositionOnKeyPress(this->list_pos, keycode) == EventState::Handled) {
+			if (this->list_pos == SLP_INVALID) return EventState::Handled;
 
 			this->server = this->servers[this->list_pos];
 
@@ -802,7 +802,7 @@ public:
 
 			/* redraw window */
 			this->SetDirty();
-			return ES_HANDLED;
+			return EventState::Handled;
 		}
 
 		if (this->server != nullptr) {

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1293,9 +1293,9 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 	EventState OnKeyPress([[maybe_unused]] char32_t key, uint16_t keycode) override
 	{
-		if (!this->editable) return ES_NOT_HANDLED;
+		if (!this->editable) return EventState::NotHandled;
 
-		if (this->vscroll2->UpdateListPositionOnKeyPress(this->avail_pos, keycode) == ES_NOT_HANDLED) return ES_NOT_HANDLED;
+		if (this->vscroll2->UpdateListPositionOnKeyPress(this->avail_pos, keycode) == EventState::NotHandled) return EventState::NotHandled;
 
 		if (this->avail_pos >= 0) {
 			this->active_sel = nullptr;
@@ -1306,7 +1306,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 			this->InvalidateData(0);
 		}
 
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	void OnEditboxChanged(WidgetID widget) override

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -365,13 +365,13 @@ public:
 	/**
 	 * Handler for global hotkeys of the BuildObjectWindow.
 	 * @param hotkey Hotkey
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState BuildObjectGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode == GameMode::Menu) return ES_NOT_HANDLED;
+		if (_game_mode == GameMode::Menu) return EventState::NotHandled;
 		Window *w = ShowBuildObjectPicker();
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1434,7 +1434,7 @@ public:
 
 	EventState OnHotkey(int hotkey) override
 	{
-		if (this->vehicle->owner != _local_company) return ES_NOT_HANDLED;
+		if (this->vehicle->owner != _local_company) return EventState::NotHandled;
 
 		switch (hotkey) {
 			case OHK_SKIP:           this->OrderClick_Skip(); break;
@@ -1448,9 +1448,9 @@ public:
 			case OHK_TRANSFER:       this->OrderClick_Unload(OrderUnloadType::Transfer, true); break;
 			case OHK_NO_UNLOAD:      this->OrderClick_Unload(OrderUnloadType::NoUnload, true); break;
 			case OHK_NO_LOAD:        this->OrderClick_FullLoad(OrderLoadType::NoLoad, true); break;
-			default: return ES_NOT_HANDLED;
+			default: return EventState::NotHandled;
 		}
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -699,10 +699,10 @@ EventState PickerWindow::OnHotkey(int hotkey)
 				this->SetFocusedWidget(WID_PW_CLASS_FILTER);
 			}
 			SetFocusedWindow(this);
-			return ES_HANDLED;
+			return EventState::Handled;
 
 		default:
-			return ES_NOT_HANDLED;
+			return EventState::NotHandled;
 	}
 }
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -834,8 +834,8 @@ struct BuildRailToolbarWindow : Window {
 	EventState OnCTRLStateChange() override
 	{
 		/* do not toggle Remove button by Ctrl when placing station */
-		if (!this->IsWidgetLowered(WID_RAT_BUILD_STATION) && !this->IsWidgetLowered(WID_RAT_BUILD_WAYPOINT) && RailToolbar_CtrlChanged(this)) return ES_HANDLED;
-		return ES_NOT_HANDLED;
+		if (!this->IsWidgetLowered(WID_RAT_BUILD_STATION) && !this->IsWidgetLowered(WID_RAT_BUILD_WAYPOINT) && RailToolbar_CtrlChanged(this)) return EventState::Handled;
+		return EventState::NotHandled;
 	}
 
 	void OnRealtimeTick([[maybe_unused]] uint delta_ms) override
@@ -846,7 +846,7 @@ struct BuildRailToolbarWindow : Window {
 	/**
 	 * Selects new RailType based on SpecialHotkeys and order defined in _sorted_railtypes.
 	 * @param hotkey Defines what action to perform.
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	EventState ChangeRailTypeOnHotkey(int hotkey)
 	{
@@ -863,19 +863,19 @@ struct BuildRailToolbarWindow : Window {
 		if (_thd.GetCallbackWnd() == this) SetCursor(this->GetCursorForWidget(this->last_user_action), PAL_NONE);
 		for (WindowClass cls : {WindowClass::BuildStation, WindowClass::BuildSignal, WindowClass::BuildWaypoint, WindowClass::BuildDepot}) SetWindowDirty(cls, TRANSPORT_RAIL);
 
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	/**
 	 * Handler for global hotkeys of the BuildRailToolbarWindow.
 	 * @param hotkey Hotkey
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState RailToolbarGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return EventState::NotHandled;
 		Window *w = ShowBuildRailToolbar(_last_built_railtype);
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 
@@ -1414,13 +1414,13 @@ public:
 	/**
 	 * Handler for global hotkeys of the BuildRailStationWindow.
 	 * @param hotkey Hotkey
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState BuildRailStationGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode == GameMode::Menu) return ES_NOT_HANDLED;
+		if (_game_mode == GameMode::Menu) return EventState::NotHandled;
 		Window *w = ShowStationBuilder(FindWindowById(WindowClass::BuildToolbar, TRANSPORT_RAIL));
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -615,7 +615,7 @@ struct BuildRoadToolbarWindow : Window {
 	/**
 	* Selects new RoadType based on SpecialHotkeys and order defined in _sorted_roadtypes.
 	* @param hotkey Defines what action to perform.
-	* @return ES_HANDLED if hotkey was accepted.
+	* @return EventState::Handled if hotkey was accepted.
 	*/
 	EventState ChangeRoadTypeOnHotkey(int hotkey)
 	{
@@ -636,7 +636,7 @@ struct BuildRoadToolbarWindow : Window {
 		if (_thd.GetCallbackWnd() == this) SetCursor(this->GetCursorForWidget(this->last_started_action), PAL_NONE);
 		for (WindowClass cls : {WindowClass::BuildBusStation, WindowClass::BuildTruckStation, WindowClass::BuildWaypoint, WindowClass::BuildDepot}) SetWindowDirty(cls, TRANSPORT_ROAD);
 
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	EventState OnHotkey(int hotkey) override
@@ -868,8 +868,8 @@ struct BuildRoadToolbarWindow : Window {
 
 	EventState OnCTRLStateChange() override
 	{
-		if (RoadToolbar_CtrlChanged(this)) return ES_HANDLED;
-		return ES_NOT_HANDLED;
+		if (RoadToolbar_CtrlChanged(this)) return EventState::Handled;
+		return EventState::NotHandled;
 	}
 
 	void OnRealtimeTick([[maybe_unused]] uint delta_ms) override
@@ -882,7 +882,7 @@ struct BuildRoadToolbarWindow : Window {
 	 * @param hotkey Hotkey
 	 * @param last_build Last build road type
 	 * @param rtt The road/tram type.
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState RoadTramToolbarGlobalHotkeys(int hotkey, RoadType last_build, RoadTramType rtt)
 	{
@@ -893,7 +893,7 @@ struct BuildRoadToolbarWindow : Window {
 				break;
 
 			case GameMode::Editor:
-				if (!GetRoadTypes(true).Any(GetMaskForRoadTramType(rtt))) return ES_NOT_HANDLED;
+				if (!GetRoadTypes(true).Any(GetMaskForRoadTramType(rtt))) return EventState::NotHandled;
 				w = ShowBuildRoadScenToolbar(last_build);
 				break;
 
@@ -901,7 +901,7 @@ struct BuildRoadToolbarWindow : Window {
 				break;
 		}
 
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -1160,13 +1160,13 @@ struct ScriptDebugWindow : public Window {
 	/**
 	 * Handler for global hotkeys of the ScriptDebugWindow.
 	 * @param hotkey Hotkey
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState ScriptDebugGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return EventState::NotHandled;
 		Window *w = ShowScriptDebugWindow(CompanyID::Invalid());
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -318,13 +318,13 @@ struct SignListWindow : Window, SignList {
 	/**
 	 * Handler for global hotkeys of the SignListWindow.
 	 * @param hotkey Hotkey
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState SignListGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode == GameMode::Menu) return ES_NOT_HANDLED;
+		if (_game_mode == GameMode::Menu) return EventState::NotHandled;
 		Window *w = ShowSignList();
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -313,13 +313,13 @@ struct TerraformToolbarWindow : Window {
 	/**
 	 * Handler for global hotkeys of the TerraformToolbarWindow.
 	 * @param hotkey Hotkey
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState TerraformToolbarGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GameMode::Normal) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Normal) return EventState::NotHandled;
 		Window *w = ShowTerraformToolbar(nullptr);
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 
@@ -731,11 +731,11 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 			case WID_ETT_PLACE_DESERT:
 				if (this->IsWidgetLowered(this->last_user_action)) {
 					SetSelectionRed(_ctrl_pressed);
-					return ES_HANDLED;
+					return EventState::Handled;
 				}
 				break;
 		}
-		return ES_NOT_HANDLED;
+		return EventState::NotHandled;
 	}
 
 	void OnPlaceObjectAbort() override
@@ -747,13 +747,13 @@ struct ScenarioEditorLandscapeGenerationWindow : Window {
 	/**
 	 * Handler for global hotkeys of the ScenarioEditorLandscapeGenerationWindow.
 	 * @param hotkey Hotkey
-	 * @return ES_HANDLED if hotkey was accepted.
+	 * @return EventState::Handled if hotkey was accepted.
 	 */
 	static EventState TerraformToolbarEditorGlobalHotkeys(int hotkey)
 	{
-		if (_game_mode != GameMode::Editor) return ES_NOT_HANDLED;
+		if (_game_mode != GameMode::Editor) return EventState::NotHandled;
 		Window *w = ShowEditorTerraformToolbar();
-		if (w == nullptr) return ES_NOT_HANDLED;
+		if (w == nullptr) return EventState::NotHandled;
 		return w->OnHotkey(hotkey);
 	}
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2090,10 +2090,10 @@ struct MainToolbarWindow : Window {
 			case MTHK_CLIENT_LIST: if (_networking) ShowClientList(); break;
 			case MTHK_SIGN_LIST: ShowSignList(); break;
 			case MTHK_LANDINFO: cbf = PlaceLandBlockInfo(); break;
-			default: return ES_NOT_HANDLED;
+			default: return EventState::NotHandled;
 		}
 		if (cbf != CallBackFunction::None) _last_started_action = cbf;
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override
@@ -2457,13 +2457,13 @@ struct ScenarioEditorToolbarWindow : Window {
 				case MainToolbarEditorHotkeys::GenerateTown: ShowFoundTownWindow(); break;
 				case MainToolbarEditorHotkeys::BuildRoad: ShowBuildRoadScenToolbar(_last_built_roadtype); break;
 				case MainToolbarEditorHotkeys::BuildTram: ShowBuildRoadScenToolbar(_last_built_tramtype); break;
-				default: return ES_NOT_HANDLED;
+				default: return EventState::NotHandled;
 			}
 			if (cbf != CallBackFunction::None) _last_started_action = cbf;
 		} else {
 			this->OnClick({}, hotkey, 0);
 		}
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	void OnPlaceObject([[maybe_unused]] Point pt, TileIndex tile) override

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -3474,31 +3474,31 @@ calc_heightdiff_single_direction:;
  */
 EventState VpHandlePlaceSizingDrag()
 {
-	if (_special_mouse_mode != WSM_SIZING && _special_mouse_mode != WSM_DRAGGING) return ES_NOT_HANDLED;
+	if (_special_mouse_mode != WSM_SIZING && _special_mouse_mode != WSM_DRAGGING) return EventState::NotHandled;
 
 	/* stop drag mode if the window has been closed */
 	Window *w = _thd.GetCallbackWnd();
 	if (w == nullptr) {
 		ResetObjectToPlace();
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	/* while dragging execute the drag procedure of the corresponding window (mostly VpSelectTilesWithMethod() ) */
 	if (_left_button_down) {
 		if (_special_mouse_mode == WSM_DRAGGING) {
 			/* Only register a drag event when the mouse moved. */
-			if (_thd.new_pos.x == _thd.selstart.x && _thd.new_pos.y == _thd.selstart.y) return ES_HANDLED;
+			if (_thd.new_pos.x == _thd.selstart.x && _thd.new_pos.y == _thd.selstart.y) return EventState::Handled;
 			_thd.selstart.x = _thd.new_pos.x;
 			_thd.selstart.y = _thd.new_pos.y;
 		}
 
 		w->OnPlaceDrag(_thd.select_method, _thd.select_proc, GetTileBelowCursor());
-		return ES_HANDLED;
+		return EventState::Handled;
 	}
 
 	/* Mouse button released. */
 	_special_mouse_mode = WSM_NONE;
-	if (_special_mouse_mode == WSM_DRAGGING) return ES_HANDLED;
+	if (_special_mouse_mode == WSM_DRAGGING) return EventState::Handled;
 
 	/* Keep the selected tool, but reset it to the original mode. */
 	HighLightStyle others = _thd.place_mode & ~(HT_DRAG_MASK | HT_DIR_MASK);
@@ -3516,7 +3516,7 @@ EventState VpHandlePlaceSizingDrag()
 	HideMeasurementTooltips();
 	w->OnPlaceMouseUp(_thd.select_method, _thd.select_proc, _thd.selend, TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y));
 
-	return ES_HANDLED;
+	return EventState::Handled;
 }
 
 /**

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2465,14 +2465,14 @@ Scrollbar::size_type Scrollbar::GetScrolledRowFromWidget(int clickpos, const Win
  * This does not update the actual position of this scroll bar, that is left to the caller. It does,
  * however use the capacity and count of the scroll bar for the bounds and amount to scroll.
  *
- * When the count is 0 or the return is ES_NOT_HANDLED, then the position is not updated.
+ * When the count is 0 or the return is EventState::NotHandled, then the position is not updated.
  * With WKC_UP and WKC_DOWN the position goes one up or down respectively.
  * With WKC_PAGEUP and WKC_PAGEDOWN the position goes one capacity up or down respectively.
  * With WKC_HOME the first position is selected and with WKC_END the last position is selected.
  * This function ensures that pos is in the range [0..count).
  * @param list_position The current position in the list.
  * @param keycode The pressed key code.
- * @return ES_NOT_HANDLED when another key than the 6 specific keys was pressed, otherwise ES_HANDLED.
+ * @return EventState::NotHandled when another key than the 6 specific keys was pressed, otherwise EventState::Handled.
  */
 EventState Scrollbar::UpdateListPositionOnKeyPress(int &list_position, uint16_t keycode) const
 {
@@ -2509,14 +2509,14 @@ EventState Scrollbar::UpdateListPositionOnKeyPress(int &list_position, uint16_t 
 			break;
 
 		default:
-			return ES_NOT_HANDLED;
+			return EventState::NotHandled;
 	}
 
 	/* If there are no elements, there is nothing to scroll/update. */
 	if (this->GetCount() != 0) {
 		list_position = Clamp(new_pos, 0, this->GetCount() - 1);
 	}
-	return ES_HANDLED;
+	return EventState::Handled;
 }
 
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -571,17 +571,17 @@ void Window::SetWidgetDirty(WidgetID widget_index) const
 /**
  * A hotkey has been pressed.
  * @param hotkey  Hotkey index, by default a widget index of a button or editbox.
- * @return #ES_HANDLED if the key press has been handled, and the hotkey is not unavailable for some reason.
+ * @return #EventState::Handled if the key press has been handled, and the hotkey is not unavailable for some reason.
  */
 EventState Window::OnHotkey(int hotkey)
 {
-	if (hotkey < 0) return ES_NOT_HANDLED;
+	if (hotkey < 0) return EventState::NotHandled;
 
 	NWidgetCore *nw = this->GetWidget<NWidgetCore>(hotkey);
-	if (nw == nullptr || nw->IsDisabled()) return ES_NOT_HANDLED;
+	if (nw == nullptr || nw->IsDisabled()) return EventState::NotHandled;
 
 	if (nw->type == WWT_EDITBOX) {
-		if (this->IsShaded()) return ES_NOT_HANDLED;
+		if (this->IsShaded()) return EventState::NotHandled;
 
 		/* Focus editbox */
 		this->SetFocusedWidget(hotkey);
@@ -590,7 +590,7 @@ EventState Window::OnHotkey(int hotkey)
 		/* Click button */
 		this->OnClick(Point(), hotkey, 1);
 	}
-	return ES_HANDLED;
+	return EventState::Handled;
 }
 
 /**
@@ -1964,9 +1964,9 @@ static void HandlePlacePresize()
  */
 static EventState HandleMouseDragDrop()
 {
-	if (_special_mouse_mode != WSM_DRAGDROP) return ES_NOT_HANDLED;
+	if (_special_mouse_mode != WSM_DRAGDROP) return EventState::NotHandled;
 
-	if (_left_button_down && _cursor.delta.x == 0 && _cursor.delta.y == 0) return ES_HANDLED; // Dragging, but the mouse did not move.
+	if (_left_button_down && _cursor.delta.x == 0 && _cursor.delta.y == 0) return EventState::Handled; // Dragging, but the mouse did not move.
 
 	Window *w = _thd.GetCallbackWnd();
 	if (w != nullptr) {
@@ -1982,7 +1982,7 @@ static EventState HandleMouseDragDrop()
 	}
 
 	if (!_left_button_down) ResetObjectToPlace(); // Button released, finished dragging.
-	return ES_HANDLED;
+	return EventState::Handled;
 }
 
 /** Report position of the mouse to the underlying window. */
@@ -2168,10 +2168,10 @@ static bool _dragging_window; ///< A window is being dragged or resized.
 static EventState HandleWindowDragging()
 {
 	/* Get out immediately if no window is being dragged at all. */
-	if (!_dragging_window) return ES_NOT_HANDLED;
+	if (!_dragging_window) return EventState::NotHandled;
 
 	/* If button still down, but cursor hasn't moved, there is nothing to do. */
-	if (_left_button_down && _cursor.delta.x == 0 && _cursor.delta.y == 0) return ES_HANDLED;
+	if (_left_button_down && _cursor.delta.x == 0 && _cursor.delta.y == 0) return EventState::Handled;
 
 	/* Otherwise find the window... */
 	for (Window *w : Window::Iterate()) {
@@ -2266,7 +2266,7 @@ static EventState HandleWindowDragging()
 			EnsureVisibleCaption(w, nx, ny);
 
 			w->SetDirty();
-			return ES_HANDLED;
+			return EventState::Handled;
 		} else if (w->flags.Test(WindowFlag::SizingLeft) || w->flags.Test(WindowFlag::SizingRight)) {
 			/* Stop the sizing if the left mouse button was released */
 			if (!_left_button_down) {
@@ -2310,7 +2310,7 @@ static EventState HandleWindowDragging()
 			}
 
 			/* Window already on size */
-			if (x == 0 && y == 0) return ES_HANDLED;
+			if (x == 0 && y == 0) return EventState::Handled;
 
 			/* Now find the new cursor pos.. this is NOT _cursor, because we move in steps. */
 			_drag_delta.y += y;
@@ -2325,12 +2325,12 @@ static EventState HandleWindowDragging()
 
 			/* ResizeWindow sets both pre- and after-size to dirty for redrawing */
 			ResizeWindow(w, x, y);
-			return ES_HANDLED;
+			return EventState::Handled;
 		}
 	}
 
 	_dragging_window = false;
-	return ES_HANDLED;
+	return EventState::Handled;
 }
 
 /**
@@ -2418,7 +2418,7 @@ static EventState HandleActiveWidget()
 			if (!_left_button_down) {
 				w->SetWidgetDirty(w->mouse_capture_widget);
 				w->mouse_capture_widget = INVALID_WIDGET;
-				return ES_HANDLED;
+				return EventState::Handled;
 			}
 
 			/* Handle scrollbar internally, or dispatch click event */
@@ -2427,16 +2427,16 @@ static EventState HandleActiveWidget()
 				HandleScrollbarScrolling(w);
 			} else {
 				/* If cursor hasn't moved, there is nothing to do. */
-				if (_cursor.delta.x == 0 && _cursor.delta.y == 0) return ES_HANDLED;
+				if (_cursor.delta.x == 0 && _cursor.delta.y == 0) return EventState::Handled;
 
 				Point pt = { _cursor.pos.x - w->left, _cursor.pos.y - w->top };
 				w->OnClick(pt, w->mouse_capture_widget, 0);
 			}
-			return ES_HANDLED;
+			return EventState::Handled;
 		}
 	}
 
-	return ES_NOT_HANDLED;
+	return EventState::NotHandled;
 }
 
 /**
@@ -2447,7 +2447,7 @@ static EventState HandleViewportScroll()
 {
 	bool scrollwheel_scrolling = _settings_client.gui.scrollwheel_scrolling == ScrollWheelScrolling::ScrollMap && _cursor.wheel_moved;
 
-	if (!_scrolling_viewport) return ES_NOT_HANDLED;
+	if (!_scrolling_viewport) return EventState::NotHandled;
 
 	/* When we don't have a last scroll window we are starting to scroll.
 	 * When the last scroll window and this are not the same we went
@@ -2458,14 +2458,14 @@ static EventState HandleViewportScroll()
 		_cursor.fix_at = false;
 		_scrolling_viewport = false;
 		_last_scroll_window = nullptr;
-		return ES_NOT_HANDLED;
+		return EventState::NotHandled;
 	}
 
 	if (_last_scroll_window == GetMainWindow() && _last_scroll_window->viewport->follow_vehicle != VehicleID::Invalid()) {
 		/* If the main window is following a vehicle, then first let go of it! */
 		const Vehicle *veh = Vehicle::Get(_last_scroll_window->viewport->follow_vehicle)->GetMovingFront();
 		ScrollMainWindowTo(veh->x_pos, veh->y_pos, veh->z_pos, true); // This also resets follow_vehicle
-		return ES_NOT_HANDLED;
+		return EventState::NotHandled;
 	}
 
 	Point delta;
@@ -2494,7 +2494,7 @@ static EventState HandleViewportScroll()
 	_cursor.delta.x = 0;
 	_cursor.delta.y = 0;
 	_cursor.wheel_moved = false;
-	return ES_HANDLED;
+	return EventState::Handled;
 }
 
 /**
@@ -2564,13 +2564,13 @@ static bool MaybeBringWindowToFront(Window *w)
  * @param wid Editbox widget.
  * @param key     the Unicode value of the key.
  * @param keycode the untranslated key code including shift state.
- * @return #ES_HANDLED if the key press has been handled and no other
+ * @return #EventState::Handled if the key press has been handled and no other
  *         window should receive the event.
  */
 EventState Window::HandleEditBoxKey(WidgetID wid, char32_t key, uint16_t keycode)
 {
 	QueryString *query = this->GetQueryString(wid);
-	if (query == nullptr) return ES_NOT_HANDLED;
+	if (query == nullptr) return EventState::NotHandled;
 
 	int action = QueryString::ACTION_NOTHING;
 
@@ -2607,7 +2607,7 @@ EventState Window::HandleEditBoxKey(WidgetID wid, char32_t key, uint16_t keycode
 			break;
 
 		case HKPR_NOT_HANDLED:
-			return ES_NOT_HANDLED;
+			return EventState::NotHandled;
 
 		default: break;
 	}
@@ -2632,7 +2632,7 @@ EventState Window::HandleEditBoxKey(WidgetID wid, char32_t key, uint16_t keycode
 			break;
 	}
 
-	return ES_HANDLED;
+	return EventState::Handled;
 }
 
 /**
@@ -2646,7 +2646,7 @@ void HandleToolbarHotkey(int hotkey)
 	Window *w = FindWindowById(WindowClass::MainToolbar, 0);
 	if (w != nullptr) {
 		if (w->window_desc.hotkeys != nullptr) {
-			if (hotkey >= 0 && w->OnHotkey(hotkey) == ES_HANDLED) return;
+			if (hotkey >= 0 && w->OnHotkey(hotkey) == EventState::Handled) return;
 		}
 	}
 }
@@ -2680,9 +2680,9 @@ void HandleKeypress(uint keycode, char32_t key)
 	if (EditBoxInGlobalFocus()) {
 		/* All input will in this case go to the focused editbox */
 		if (_focused_window->window_class == WindowClass::Console) {
-			if (_focused_window->OnKeyPress(key, keycode) == ES_HANDLED) return;
+			if (_focused_window->OnKeyPress(key, keycode) == EventState::Handled) return;
 		} else {
-			if (_focused_window->HandleEditBoxKey(_focused_window->nested_focus->GetIndex(), key, keycode) == ES_HANDLED) return;
+			if (_focused_window->HandleEditBoxKey(_focused_window->nested_focus->GetIndex(), key, keycode) == EventState::Handled) return;
 		}
 	}
 
@@ -2691,9 +2691,9 @@ void HandleKeypress(uint keycode, char32_t key)
 		if (w->window_class == WindowClass::MainToolbar) continue;
 		if (w->window_desc.hotkeys != nullptr) {
 			int hotkey = w->window_desc.hotkeys->CheckMatch(keycode);
-			if (hotkey >= 0 && w->OnHotkey(hotkey) == ES_HANDLED) return;
+			if (hotkey >= 0 && w->OnHotkey(hotkey) == EventState::Handled) return;
 		}
-		if (w->OnKeyPress(key, keycode) == ES_HANDLED) return;
+		if (w->OnKeyPress(key, keycode) == EventState::Handled) return;
 	}
 
 	Window *w = FindWindowById(WindowClass::MainToolbar, 0);
@@ -2701,9 +2701,9 @@ void HandleKeypress(uint keycode, char32_t key)
 	if (w != nullptr) {
 		if (w->window_desc.hotkeys != nullptr) {
 			int hotkey = w->window_desc.hotkeys->CheckMatch(keycode);
-			if (hotkey >= 0 && w->OnHotkey(hotkey) == ES_HANDLED) return;
+			if (hotkey >= 0 && w->OnHotkey(hotkey) == EventState::Handled) return;
 		}
-		if (w->OnKeyPress(key, keycode) == ES_HANDLED) return;
+		if (w->OnKeyPress(key, keycode) == EventState::Handled) return;
 	}
 
 	HandleGlobalHotkeys(key, keycode);
@@ -2716,7 +2716,7 @@ void HandleCtrlChanged()
 {
 	/* Call the event, start with the uppermost window. */
 	for (Window *w : Window::IterateFromFront()) {
-		if (w->OnCTRLStateChange() == ES_HANDLED) return;
+		if (w->OnCTRLStateChange() == EventState::Handled) return;
 	}
 }
 
@@ -2877,11 +2877,11 @@ static void MouseLoop(MouseClick click, int mousewheel)
 	HandlePlacePresize();
 	UpdateTileSelection();
 
-	if (VpHandlePlaceSizingDrag()  == ES_HANDLED) return;
-	if (HandleMouseDragDrop()      == ES_HANDLED) return;
-	if (HandleWindowDragging()     == ES_HANDLED) return;
-	if (HandleActiveWidget()       == ES_HANDLED) return;
-	if (HandleViewportScroll()     == ES_HANDLED) return;
+	if (VpHandlePlaceSizingDrag()  == EventState::Handled) return;
+	if (HandleMouseDragDrop()      == EventState::Handled) return;
+	if (HandleWindowDragging()     == EventState::Handled) return;
+	if (HandleActiveWidget()       == EventState::Handled) return;
+	if (HandleViewportScroll()     == EventState::Handled) return;
 
 	HandleMouseOver();
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -647,19 +647,19 @@ public:
 	 * A key has been pressed.
 	 * @param key     the Unicode value of the key.
 	 * @param keycode the untranslated key code including shift state.
-	 * @return #ES_HANDLED if the key press has been handled and no other
+	 * @return #EventState::Handled if the key press has been handled and no other
 	 *         window should receive the event.
 	 */
-	virtual EventState OnKeyPress([[maybe_unused]] char32_t key, [[maybe_unused]] uint16_t keycode) { return ES_NOT_HANDLED; }
+	virtual EventState OnKeyPress([[maybe_unused]] char32_t key, [[maybe_unused]] uint16_t keycode) { return EventState::NotHandled; }
 
 	virtual EventState OnHotkey(int hotkey);
 
 	/**
 	 * The state of the control key has changed
-	 * @return #ES_HANDLED if the change has been handled and no other
+	 * @return #EventState::Handled if the change has been handled and no other
 	 *         window should receive the event.
 	 */
-	virtual EventState OnCTRLStateChange() { return ES_NOT_HANDLED; }
+	virtual EventState OnCTRLStateChange() { return EventState::NotHandled; }
 
 
 	/**

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -813,9 +813,9 @@ public:
 };
 
 /** State of handling an event. */
-enum EventState : uint8_t {
-	ES_HANDLED,     ///< The passed event is handled.
-	ES_NOT_HANDLED, ///< The passed event is not handled.
+enum class EventState : uint8_t {
+	Handled, ///< The passed event is handled.
+	NotHandled, ///< The passed event is not handled.
 };
 
 #endif /* WINDOW_TYPE_H */


### PR DESCRIPTION
## Motivation / Problem

More type safety.


## Description

Make `EventState` a scoped enum.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
