### PR TITLE
Feature: Create new folders from the save dialog

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -126,6 +126,38 @@ std::string FiosGetCurrentPath()
 }
 
 /**
+ * Create a new subdirectory inside the current FIOS path.
+ * The caller must validate the name against path traversal. This function only reports the OS-level result.
+ * @param name Name of the directory to create (a single path segment, not a path).
+ * @return The outcome of the creation attempt.
+ */
+DirectoryCreateResult FiosCreateDirectory(std::string_view name)
+{
+	assert(_fios_path != nullptr);
+
+	/* Remove trailing path separator, if present. */
+	std::string_view base = *_fios_path;
+	if (!base.empty() && base.back() == PATHSEPCHAR) base.remove_suffix(1);
+	/* Join with a single separator, converting via OTTD2FS so non-ASCII names work on Windows. */
+	std::filesystem::path target = OTTD2FS(fmt::format("{}{}{}", base, PATHSEP, name));
+
+	std::error_code error_code;
+	if (std::filesystem::create_directory(target, error_code)) {
+		return DirectoryCreateResult::Success;
+	}
+
+	/* A false return with no error means the target already exists. Confirm it is a directory to tell it apart from a stray file or other entry. */
+	if (!error_code) {
+		return std::filesystem::is_directory(target, error_code) ? DirectoryCreateResult::AlreadyExists : DirectoryCreateResult::OtherError;
+	}
+
+	/* An existing non-directory file shows up here as file_exists. */
+	if (error_code == std::errc::file_exists) return DirectoryCreateResult::AlreadyExists;
+	if (error_code == std::errc::permission_denied || error_code == std::errc::read_only_file_system) return DirectoryCreateResult::PermissionDenied;
+	return DirectoryCreateResult::OtherError;
+}
+
+/**
  * Browse to a new path based on the passed \a item, starting at #_fios_path.
  * @param *item Item telling us what to do.
  * @return \c true when the path got changed.

--- a/src/fios.h
+++ b/src/fios.h
@@ -25,6 +25,14 @@ enum SaveLoadInvalidateWindowData : uint8_t {
 	SLIWD_FILTER_CHANGES,        ///< The filename filter has changed (via the editbox)
 };
 
+/** Outcome of a directory creation attempt. */
+enum class DirectoryCreateResult : uint8_t {
+	Success,            ///< Directory was created.
+	AlreadyExists,      ///< A file or directory with that name already exists.
+	PermissionDenied,   ///< The OS rejected the operation for permission reasons.
+	OtherError,         ///< Any other filesystem error.
+};
+
 using CompanyPropertiesMap = std::map<uint, std::unique_ptr<CompanyProperties>>;
 
 /**
@@ -105,6 +113,7 @@ std::string FiosGetCurrentPath();
 std::optional<uint64_t> FiosGetDiskFreeSpace(const std::string &path);
 std::string FiosMakeHeightmapName(std::string_view name);
 std::string FiosMakeSavegameName(std::string_view name);
+DirectoryCreateResult FiosCreateDirectory(std::string_view name);
 
 std::tuple<FiosType, std::string> FiosGetSavegameListCallback(SaveLoadOperation fop, std::string_view file, std::string_view ext);
 std::tuple<FiosType, std::string> FiosGetScenarioListCallback(SaveLoadOperation fop, std::string_view file, std::string_view ext);

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -16,6 +16,7 @@
 #include "network/network.h"
 #include "network/network_content.h"
 #include "strings_func.h"
+#include "string_func.h"
 #include "fileio_func.h"
 #include "fios.h"
 #include "window_func.h"
@@ -282,8 +283,9 @@ static constexpr std::initializer_list<NWidgetPart> _nested_save_dialog_widgets 
 				NWidget(WWT_EDITBOX, Colours::Grey, WID_SL_SAVE_OSK_TITLE), SetPadding(2, 2, 2, 2), SetFill(1, 0), SetResize(1, 0),
 						SetStringTip(STR_SAVELOAD_OSKTITLE, STR_SAVELOAD_EDITBOX_TOOLTIP),
 			EndContainer(),
-			/* Save/delete buttons */
-			NWidget(NWID_HORIZONTAL),
+			/* New directory/delete/save buttons */
+			NWidget(NWID_HORIZONTAL, NWidContainerFlag::EqualSize),
+				NWidget(WWT_PUSHTXTBTN, Colours::Grey, WID_SL_NEW_DIRECTORY), SetStringTip(STR_SAVELOAD_NEW_DIRECTORY_BUTTON, STR_SAVELOAD_NEW_DIRECTORY_TOOLTIP), SetFill(1, 0), SetResize(1, 0),
 				NWidget(WWT_PUSHTXTBTN, Colours::Grey, WID_SL_DELETE_SELECTION), SetStringTip(STR_SAVELOAD_DELETE_BUTTON, STR_SAVELOAD_DELETE_TOOLTIP), SetFill(1, 0), SetResize(1, 0),
 				NWidget(WWT_PUSHTXTBTN, Colours::Grey, WID_SL_SAVE_GAME),        SetStringTip(STR_SAVELOAD_SAVE_BUTTON, STR_SAVELOAD_SAVE_TOOLTIP),     SetFill(1, 0), SetResize(1, 0),
 			EndContainer(),
@@ -343,6 +345,7 @@ static void SortSaveGameList(FileList &file_list)
 struct SaveLoadWindow : public Window {
 private:
 	static const uint EDITBOX_MAX_SIZE   =  50;
+	static const uint MAX_DIRECTORY_NAME_CHARS = 64; ///< Maximum length of a new directory name in characters.
 
 	QueryString filename_editbox; ///< Filename editbox.
 	AbstractFileType abstract_filetype{}; ///< Type of file to select.
@@ -383,6 +386,77 @@ private:
 				/* Reset file name to current date on successful delete */
 				if (save_load_window->abstract_filetype == AbstractFileType::Savegame) save_load_window->GenerateFileName();
 			}
+		}
+	}
+
+	/**
+	 * Check a user-entered name for use as a single directory component. Any other name the OS
+	 * dislikes is caught by FiosCreateDirectory and reported as an error.
+	 * @param name The candidate name. The caller must have stripped whitespace and rejected empty names.
+	 * @return The error to show if the name is unusable, or std::nullopt if it is valid.
+	 */
+	static std::optional<StringID> GetDirectoryNameError(const std::string &name)
+	{
+		assert(!name.empty());
+
+		/* Reject path and drive separators, which would turn the name into a path. */
+		if (name.find_first_of("/\\:") != std::string::npos) return STR_ERROR_DIRECTORY_ILLEGAL_NAME;
+		/* Reject a leading dot. This covers the current and parent directory entries and hidden names the list would never show. */
+		if (name.front() == '.') return STR_ERROR_DIRECTORY_LEADING_DOT;
+
+		return std::nullopt;
+	}
+
+	/**
+	 * Open the query used to enter a new directory name.
+	 * @param initial_name Name to pre-fill, used to let the user correct a rejected name.
+	 */
+	void ShowNewDirectoryQuery(std::string_view initial_name = {})
+	{
+		/* An unchanged name would otherwise be treated as cancel, so the AcceptUnchanged flag lets the pre-filled name be resubmitted to try again. */
+		ShowQueryString(
+				initial_name,
+				STR_SAVELOAD_NEW_DIRECTORY_QUERY_CAPTION,
+				MAX_DIRECTORY_NAME_CHARS,
+				this,
+				CS_ALPHANUMERAL,
+				{QueryStringFlag::LengthIsInChars, QueryStringFlag::AcceptUnchanged});
+	}
+
+	/**
+	 * Validate a user-entered directory name and, if valid, create the directory in the current FIOS path.
+	 * A name the user can still fix (invalid, or already in use) re-opens the query pre-filled so
+	 * they can try again. Other failures just show an error. On success, refreshes the file list.
+	 * @param query_text The raw text returned from the query dialog.
+	 */
+	void HandleNewDirectoryRequest(const std::string &query_text)
+	{
+		/* CS_ALPHANUMERAL allows spaces, so trim them before validating. */
+		const std::string name{StrTrimView(query_text, " ")};
+
+		/* An empty name is treated as a cancel, the same as other query dialogs. */
+		if (name.empty()) return;
+
+		if (auto error = GetDirectoryNameError(name); error.has_value()) {
+			this->ShowNewDirectoryQuery(name);
+			ShowErrorMessage(GetEncodedString(STR_ERROR_CANNOT_CREATE_DIRECTORY), GetEncodedString(*error), WarningLevel::Error);
+			return;
+		}
+
+		switch (FiosCreateDirectory(name)) {
+			case DirectoryCreateResult::Success:
+				this->InvalidateData(SLIWD_RESCAN_FILES);
+				break;
+			case DirectoryCreateResult::AlreadyExists:
+				this->ShowNewDirectoryQuery(name);
+				ShowErrorMessage(GetEncodedString(STR_ERROR_CANNOT_CREATE_DIRECTORY), GetEncodedString(STR_ERROR_DIRECTORY_NAME_IN_USE), WarningLevel::Error);
+				break;
+			case DirectoryCreateResult::PermissionDenied:
+				ShowErrorMessage(GetEncodedString(STR_ERROR_CANNOT_CREATE_DIRECTORY), GetEncodedString(STR_ERROR_DIRECTORY_PERMISSION_DENIED), WarningLevel::Error);
+				break;
+			case DirectoryCreateResult::OtherError:
+				ShowErrorMessage(GetEncodedString(STR_ERROR_CANNOT_CREATE_DIRECTORY), {}, WarningLevel::Error);
+				break;
 		}
 	}
 
@@ -806,6 +880,10 @@ public:
 				/* Note, this is also called via the OSK; and we need to lower the button. */
 				this->HandleButtonClick(WID_SL_SAVE_GAME);
 				break;
+
+			case WID_SL_NEW_DIRECTORY: // Create directory
+				this->ShowNewDirectoryQuery();
+				break;
 		}
 	}
 
@@ -977,6 +1055,11 @@ public:
 			this->selected = nullptr;
 			this->InvalidateData(SLIWD_SELECTION_CHANGES);
 		}
+	}
+
+	void OnQueryTextFinished(std::optional<std::string> str) override
+	{
+		if (str.has_value()) this->HandleNewDirectoryRequest(*str);
 	}
 };
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3399,6 +3399,9 @@ STR_SAVELOAD_LOAD_BUTTON                                        :{BLACK}Load
 STR_SAVELOAD_LOAD_TOOLTIP                                       :{BLACK}Load the selected game
 STR_SAVELOAD_LOAD_HEIGHTMAP_TOOLTIP                             :{BLACK}Load the selected heightmap
 STR_SAVELOAD_LOAD_TOWN_DATA_TOOLTIP                             :{BLACK}Load the selected town data
+STR_SAVELOAD_NEW_DIRECTORY_BUTTON                               :{BLACK}New Folder
+STR_SAVELOAD_NEW_DIRECTORY_TOOLTIP                              :{BLACK}Create a new folder in the current location
+STR_SAVELOAD_NEW_DIRECTORY_QUERY_CAPTION                        :{WHITE}Enter a name for the new folder
 STR_SAVELOAD_DETAIL_CAPTION                                     :{BLACK}Game Details
 STR_SAVELOAD_DETAIL_NOT_AVAILABLE                               :{BLACK}No information available
 STR_SAVELOAD_DETAIL_COMPANY_INDEX                               :{SILVER}{COMMA}: {WHITE}{STRING1}
@@ -5065,6 +5068,11 @@ STR_ERROR_AUTOSAVE_FAILED                                       :Autosave failed
 STR_ERROR_UNABLE_TO_READ_DRIVE                                  :{BLACK}Unable to read drive
 STR_ERROR_GAME_SAVE_FAILED                                      :Game save failed...
 STR_ERROR_UNABLE_TO_DELETE_FILE                                 :Unable to delete file
+STR_ERROR_CANNOT_CREATE_DIRECTORY                               :Cannot create folder...
+STR_ERROR_DIRECTORY_NAME_IN_USE                                 :A file or folder with that name already exists
+STR_ERROR_DIRECTORY_ILLEGAL_NAME                                :Folder name cannot contain special characters
+STR_ERROR_DIRECTORY_LEADING_DOT                                 :Folder name cannot start with a dot
+STR_ERROR_DIRECTORY_PERMISSION_DENIED                           :You do not have permission to create a folder here
 STR_ERROR_GAME_LOAD_FAILED                                      :Game load failed...
 STR_GAME_SAVELOAD_ERROR_BROKEN_INTERNAL_ERROR                   :Internal error: {RAW_STRING}
 STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME                         :Broken savegame - {RAW_STRING}

--- a/src/widgets/fios_widget.h
+++ b/src/widgets/fios_widget.h
@@ -25,6 +25,7 @@ enum SaveLoadWidgets : WidgetID {
 	WID_SL_SAVE_OSK_TITLE,          ///< Title textbox, only available for save operations.
 	WID_SL_DELETE_SELECTION,        ///< Delete button, only available for save operations.
 	WID_SL_SAVE_GAME,               ///< Save button, only available for save operations.
+	WID_SL_NEW_DIRECTORY,           ///< Button to create a new directory in the current path.
 	WID_SL_CONTENT_DOWNLOAD_SEL,    ///< Selection 'stack' to 'hide' the content download.
 	WID_SL_DETAILS,                 ///< Panel with game details.
 	WID_SL_NEWGRF_INFO,             ///< Button to open NewGgrf configuration.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
When saving a game, the only way to organise saves into folders is to create the folder outside OpenTTD first, then come back. There's no way to make a new folder from the save dialog itself, so tidying up saved games means leaving the game, or having all of your saves in one long list.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Adds a "New Folder" button to the save dialog. Clicking it prompts for a name and creates that folder in the current directory and refreshes the file list.

<img width="847" height="513" alt="image" src="https://github.com/user-attachments/assets/02a95809-6cc4-47da-905e-a7665904903b" />

<img width="398" height="275" alt="image" src="https://github.com/user-attachments/assets/900794c5-42f1-4a4e-8662-ceb0281ce94e" />



Names with path separators or `.` / `..` are rejected, so the input stays a single folder. Anything else is left to the OS, the same as saving a game does. If the folder can't be created the player gets a message, with a specific one for the folder already existing or permission being denied.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
The folder name length is capped at 64 characters, matching the save-filename editbox.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
