### PR TITLE
Codechange: make GraphicsFileType scoped

### DIFF
--- a/src/base_media_graphics.h
+++ b/src/base_media_graphics.h
@@ -13,14 +13,14 @@
 #include "base_media_base.h"
 
 /** Types of graphics in the base graphics set */
-enum GraphicsFileType : uint8_t {
-	GFT_BASE,     ///< Base sprites for all climates
-	GFT_LOGOS,    ///< Logos, landscape icons and original terrain generator sprites
-	GFT_ARCTIC,   ///< Landscape replacement sprites for arctic
-	GFT_TROPICAL, ///< Landscape replacement sprites for tropical
-	GFT_TOYLAND,  ///< Landscape replacement sprites for toyland
-	GFT_EXTRA,    ///< Extra sprites that were not part of the original sprites
-	MAX_GFT,      ///< We are looking for this amount of GRFs
+enum class GraphicsFileType : uint8_t {
+	Base, ///< Base sprites for all climates
+	Logos, ///< Logos, landscape icons and original terrain generator sprites
+	Arctic, ///< Landscape replacement sprites for arctic
+	Tropical, ///< Landscape replacement sprites for tropical
+	Toyland, ///< Landscape replacement sprites for toyland
+	Extra, ///< Extra sprites that were not part of the original sprites
+	End, ///< We are looking for this amount of GRFs
 };
 
 /** Blitter type for base graphics sets. */
@@ -33,7 +33,7 @@ struct GRFConfig;
 
 /** Instantiation of BaseSetTraits for a GraphicSet. */
 template <> struct BaseSetTraits<struct GraphicsSet> {
-	static constexpr size_t num_files = MAX_GFT; ///< Number of files in a graphics set.
+	static constexpr size_t num_files = to_underlying(GraphicsFileType::End); ///< Number of files in a graphics set.
 	static constexpr bool search_in_tars = true; ///< Graphics can be in a tar file.
 	static constexpr std::string_view set_type = "graphics"; ///< The type of set.
 };

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -172,7 +172,7 @@ static void LoadSpriteTables()
 {
 	const GraphicsSet *used_set = BaseGraphics::GetUsedSet();
 
-	LoadGrfFile(used_set->files[GFT_BASE].filename, 0, PaletteType::DOS != used_set->palette);
+	LoadGrfFile(used_set->files[to_underlying(GraphicsFileType::Base)].filename, 0, PaletteType::DOS != used_set->palette);
 
 	/*
 	 * The second basic file always starts at the given location and does
@@ -180,7 +180,7 @@ static void LoadSpriteTables()
 	 * has a few sprites less. However, we do not care about those missing
 	 * sprites as they are not shown anyway (logos in intro game).
 	 */
-	LoadGrfFile(used_set->files[GFT_LOGOS].filename, 4793, PaletteType::DOS != used_set->palette);
+	LoadGrfFile(used_set->files[to_underlying(GraphicsFileType::Logos)].filename, 4793, PaletteType::DOS != used_set->palette);
 
 	/*
 	 * Load additional sprites for climates other than temperate.
@@ -189,7 +189,7 @@ static void LoadSpriteTables()
 	 */
 	if (_settings_game.game_creation.landscape != LandscapeType::Temperate) {
 		LoadGrfFileIndexed(
-			used_set->files[GFT_ARCTIC + to_underlying(_settings_game.game_creation.landscape) - 1].filename,
+			used_set->files[to_underlying(GraphicsFileType::Arctic) + to_underlying(_settings_game.game_creation.landscape) - 1].filename,
 			_landscape_spriteindexes[to_underlying(_settings_game.game_creation.landscape) - 1],
 			PaletteType::DOS != used_set->palette
 		);
@@ -377,7 +377,7 @@ bool GraphicsSet::FillSetDetails(const IniFile &ini, const std::string &path, co
 GRFConfig &GraphicsSet::GetOrCreateExtraConfig() const
 {
 	if (!this->extra_cfg) {
-		this->extra_cfg = std::make_unique<GRFConfig>(this->files[GFT_EXTRA].filename);
+		this->extra_cfg = std::make_unique<GRFConfig>(this->files[to_underlying(GraphicsFileType::Extra)].filename);
 
 		/* We know the palette of the base set, so if the base NewGRF is not
 		 * setting one, use the palette of the base set and not the global


### PR DESCRIPTION
## Motivation / Problem

Cleaning up global scope.


## Description

Make `GraphicsFileType` scoped.


## Limitations

Basically all uses now have `to_underlying` because it's used to index a generic array. Making that array `EnumIndexed` isn't helping as there are generic functions like `FillSetDetails` that iterate over the elements by index, which would require distinguishing between  `EnumRange` and integer ranges. That'd be a lot of boiler plate for basically nothing.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
