### PR TITLE
Codechange: make TextEffectMode scoped

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -517,7 +517,7 @@ void ShowCostOrIncomeAnimation(int x, int y, int z, Money cost)
 		cost = -cost;
 		msg = STR_INCOME_FLOAT_INCOME;
 	}
-	AddTextEffect(GetEncodedString(msg, cost), pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
+	AddTextEffect(GetEncodedString(msg, cost), pt.x, pt.y, Ticks::DAY_TICKS, TextEffectMode::Rising);
 }
 
 /**
@@ -533,14 +533,14 @@ void ShowFeederIncomeAnimation(int x, int y, int z, Money transfer, Money income
 	Point pt = RemapCoords(x, y, z);
 
 	if (income == 0) {
-		AddTextEffect(GetEncodedString(STR_FEEDER, transfer), pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
+		AddTextEffect(GetEncodedString(STR_FEEDER, transfer), pt.x, pt.y, Ticks::DAY_TICKS, TextEffectMode::Rising);
 	} else {
 		StringID msg = STR_FEEDER_COST;
 		if (income < 0) {
 			income = -income;
 			msg = STR_FEEDER_INCOME;
 		}
-		AddTextEffect(GetEncodedString(msg, transfer, income), pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
+		AddTextEffect(GetEncodedString(msg, transfer, income), pt.x, pt.y, Ticks::DAY_TICKS, TextEffectMode::Rising);
 	}
 }
 
@@ -559,7 +559,7 @@ TextEffectID ShowFillingPercent(int x, int y, int z, uint8_t percent, StringID s
 
 	assert(string != STR_NULL);
 
-	return AddTextEffect(GetEncodedString(string, percent), pt.x, pt.y, 0, TE_STATIC);
+	return AddTextEffect(GetEncodedString(string, percent), pt.x, pt.y, 0, TextEffectMode::Static);
 }
 
 /**

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -22,7 +22,7 @@
 /** Container for all information about a text effect */
 struct TextEffect : public ViewportSign {
 	TextEffectMode mode; ///< Type of text effect.
-	uint8_t duration; ///< How long the text effect should stay, in ticks (applies only when mode == TE_RISING)
+	uint8_t duration; ///< How long the text effect should stay, in ticks (applies only when mode == TextEffectMode::Rising)
 	EncodedString msg; ///< Encoded message for text effect.
 
 	/** Reset the text effect */
@@ -30,10 +30,10 @@ struct TextEffect : public ViewportSign {
 	{
 		this->MarkDirty();
 		this->width_normal = 0;
-		this->mode = TE_INVALID;
+		this->mode = TextEffectMode::Invalid;
 	}
 
-	inline bool IsValid() const { return this->mode != TE_INVALID; }
+	inline bool IsValid() const { return this->mode != TextEffectMode::Invalid; }
 };
 
 static std::vector<TextEffect> _text_effects; ///< Text effects are stored there
@@ -94,7 +94,7 @@ const IntervalTimer<TimerWindow> move_all_text_effects_interval = {std::chrono::
 
 	for (TextEffect &te : _text_effects) {
 		if (!te.IsValid()) continue;
-		if (te.mode != TE_RISING) continue;
+		if (te.mode != TextEffectMode::Rising) continue;
 
 		if (te.duration < count) {
 			te.Reset();
@@ -126,7 +126,7 @@ void DrawTextEffects(DrawPixelInfo *dpi)
 	for (const TextEffect &te : _text_effects) {
 		if (!te.IsValid()) continue;
 
-		if (te.mode == TE_RISING || _settings_client.gui.loading_indicators) {
+		if (te.mode == TextEffectMode::Rising || _settings_client.gui.loading_indicators) {
 			std::string *str = ViewportAddString(dpi, &te, flags, Colours::Invalid);
 			if (str == nullptr) continue;
 

--- a/src/texteff.hpp
+++ b/src/texteff.hpp
@@ -17,10 +17,10 @@
 /**
  * Text effect modes.
  */
-enum TextEffectMode : uint8_t {
-	TE_INVALID, ///< Text effect is invalid.
-	TE_RISING, ///< Make the text effect slowly go upwards
-	TE_STATIC, ///< Keep the text effect static
+enum class TextEffectMode : uint8_t {
+	Invalid, ///< Text effect is invalid.
+	Rising, ///< Make the text effect slowly go upwards
+	Static, ///< Keep the text effect static
 };
 
 using TextEffectID = uint16_t;

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2973,7 +2973,7 @@ void CcStartStopVehicle(Commands, const CommandCost &result, VehicleID veh_id, b
 	StringID msg = v->vehstatus.Test(VehState::Stopped) ? STR_VEHICLE_COMMAND_STOPPED : STR_VEHICLE_COMMAND_STARTED;
 	const Vehicle *moving_front = v->GetMovingFront();
 	Point pt = RemapCoords(moving_front->x_pos, moving_front->y_pos, moving_front->z_pos);
-	AddTextEffect(GetEncodedString(msg), pt.x, pt.y, Ticks::DAY_TICKS, TE_RISING);
+	AddTextEffect(GetEncodedString(msg), pt.x, pt.y, Ticks::DAY_TICKS, TextEffectMode::Rising);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Our endeavour to use scoped enums.


## Description

Make `TextEffectMode` scoped.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
