### PR TITLE
Codefix 21bee91: Doxygen copied documentation wrongly

### DIFF
--- a/src/town.h
+++ b/src/town.h
@@ -68,9 +68,9 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	/** @name Town name.
 	 * @{ */
-	uint32_t townnamegrfid = 0;
-	uint16_t townnametype = 0;
-	uint32_t townnameparts = 0;
+	uint32_t townnamegrfid = 0; ///< NewGRF id that contains the name. O is not used.
+	uint16_t townnametype = 0; ///< The style of the name.
+	uint32_t townnameparts = 0; ///< Random number that give unique town name when passed to generator.
 	std::string name{}; ///< Custom town name. If empty, the town was not renamed and uses the generated name.
 	mutable std::string cached_name{}; ///< NOSAVE: Cache of the resolved name of the town, if not using a custom town name
 	/** @} */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Doxygen DISTRIBUTE_GROUP_DOC is greedy.
When first member in group does not provide documentation then doxygen copies documentation of next documented member in that group to it. That results in such invalid documentation:
<img width="747" height="303" alt="Zrzut ekranu z 2026-06-17 15-55-47" src="https://github.com/user-attachments/assets/5720d72f-a9e6-4c15-84e0-b02572f89b17" />

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Document these three members of Town class, fixing the issue.
<img width="695" height="286" alt="Zrzut ekranu z 2026-06-17 16-17-29" src="https://github.com/user-attachments/assets/c279b92a-3141-4e07-840e-6ee20b3820fc" />

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
