### PR TITLE
Fix: Road YAPF Calculate cost of first tile of first segment for a path

### DIFF
--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -113,12 +113,20 @@ public:
 	/** @copydoc CYapfBaseT::PfCalcCostFunc */
 	inline bool PfCalcCost(Node &n, [[maybe_unused]] const TrackFollower *follower)
 	{
+		int parent_cost = 0;
 		int segment_cost = 0;
 		uint tiles = 0;
+
 		/* start at n.key.tile / n.key.td and walk to the end of segment */
 		TileIndex tile = n.key.tile;
 		Trackdir trackdir = n.key.td;
-		int parent_cost = (n.parent != nullptr) ? n.parent->cost : 0;
+
+		if (n.parent != nullptr) parent_cost += n.parent->cost;
+
+		/* calculate cost for the junction tile the vehicle is entering only for the first segment */
+		if (n.parent != nullptr && parent_cost == 0) {
+			segment_cost += Yapf().OneTileCost(n.parent->GetTile(), n.parent->GetTrackdir());
+		}
 
 		for (;;) {
 			/* base tile cost depending on distance between edges */

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -300,7 +300,13 @@ public:
 			return true;
 		}
 
-		n.estimate = n.cost + OctileDistanceCost(n.segment_last_tile, n.segment_last_td, this->dest_tile);
+		if(n.cost == 0 && n.parent->cost == 0){
+			/* calculate estimate from StartupNode for the first segment */
+			n.estimate = n.cost + OctileDistanceCost(n.parent->GetTile(), n.parent->GetTrackdir(), this->dest_tile);
+		} else {
+			n.estimate = n.cost + OctileDistanceCost(n.segment_last_tile, n.segment_last_td, this->dest_tile);
+		}
+
 		assert(n.estimate >= n.parent->estimate);
 		return true;
 	}

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -113,15 +113,12 @@ public:
 	/** @copydoc CYapfBaseT::PfCalcCostFunc */
 	inline bool PfCalcCost(Node &n, [[maybe_unused]] const TrackFollower *follower)
 	{
-		int parent_cost = 0;
 		int segment_cost = 0;
 		uint tiles = 0;
-
 		/* start at n.key.tile / n.key.td and walk to the end of segment */
 		TileIndex tile = n.key.tile;
 		Trackdir trackdir = n.key.td;
-
-		if (n.parent != nullptr) parent_cost += n.parent->cost;
+		int parent_cost = (n.parent != nullptr) ? n.parent->cost : 0;
 
 		/* calculate cost for the junction tile the vehicle is entering only for the first segment */
 		if (n.parent != nullptr && parent_cost == 0) {


### PR DESCRIPTION
## Motivation / Problem
Issue https://github.com/OpenTTD/OpenTTD/issues/15701

I have been trying to improve road traffic problems for vehicles. One discussion I was involved in was [here](https://github.com/OpenTTD/OpenTTD/discussions/12384) led me to experiment with checking each tile for stopped vehicles which worked but was far too CPU intensive. 

Recently I have come back to try to solve this by distributing vehicles across road paths that have equal cost (for example where 2x2 or 3x3 grids are used). Although I considered this wouldn't be satisfactory for release, I still wanted to experiment with this by randomly selecting the trackdir for each new segment the pathfinder traverses. This was unsuccessful (for other reasons), but while debugging it I found that segments that I had manually calculated to be equal were different in the yapf result, which appeared to be a miscalculation by the yapf.

Eventually I worked out that the rules for selecting the best node were superceding my random trackdir code, so I also abandoned that experiment. 

But I was still left with the path cost miscalculation bug and the fix I had written for it. I have decided to submit it for posterity.


## Description 
The very first tile (the StartupNode) of a path is not being costed. 
This tile can have a differing cost depending upon whether the vehicle turns or goes straight through it.

Routes that started with the option of straight ahead and 90deg turn on the StartupNode have had the 90g turn segment under-costed by 71 because the `YAPF_TILE_CORNER_LENGTH` was not applied.

This code change calls the existing `OneTileCost` function one extra time for the StartupNode (parent of the first node in a segment), only when it is the first segment.

The CostEstimate is also modified to measure from the same tile as the StartupNode by referencing the parent of the first node in the segment.

## Limitations
I am not aware of any bugs or edge cases.

## LLM Disclosure
LLMs and LLM coding agents were **not** used in this PR description or for any code in this PR.
LLM Chat was used for explaining C++ concepts to this webdev chump, and used as a rubber ducky.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
