### PR TITLE
Codechange: split currency.h to _type.h and _func.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,7 +133,8 @@ add_files(
     crashlog.cpp
     crashlog.h
     currency.cpp
-    currency.h
+    currency_func.h
+    currency_type.h
     date_gui.cpp
     date_gui.h
     debug.cpp

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -12,7 +12,7 @@
 #include "cheat_type.h"
 #include "company_base.h"
 #include "company_func.h"
-#include "currency.h"
+#include "currency_func.h"
 #include "saveload/saveload.h"
 #include "vehicle_base.h"
 #include "textbuf_gui.h"

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -8,7 +8,7 @@
 /** @file company_gui.cpp %Company related GUIs. */
 
 #include "stdafx.h"
-#include "currency.h"
+#include "currency_func.h"
 #include "error.h"
 #include "gui.h"
 #include "settings_gui.h"

--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -10,7 +10,7 @@
 #include "stdafx.h"
 #include "core/bitmath_func.hpp"
 
-#include "currency.h"
+#include "currency_func.h"
 #include "news_func.h"
 #include "settings_type.h"
 #include "string_type.h"

--- a/src/currency_func.h
+++ b/src/currency_func.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file currency_func.h Functions to handle different currencies. */
+
+#ifndef CURRENCY_FUNC_H
+#define CURRENCY_FUNC_H
+
+#include "currency_type.h"
+#include "settings_type.h"
+
+extern std::array<CurrencySpec, CURRENCY_END> _currency_specs;
+
+/**
+ * Get the custom currency.
+ * @return Reference to custom currency.
+ */
+inline CurrencySpec &GetCustomCurrency()
+{
+	return _currency_specs[CURRENCY_CUSTOM];
+}
+
+/**
+ * Get the currently selected currency.
+ * @return Read-only reference to the current currency.
+ */
+inline const CurrencySpec &GetCurrency()
+{
+	return _currency_specs[GetGameSettings().locale.currency];
+}
+
+uint64_t GetMaskOfAllowedCurrencies();
+void ResetCurrencies(bool preserve_custom = true);
+uint8_t GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id);
+
+#endif /* CURRENCY_FUNC_H */

--- a/src/currency_type.h
+++ b/src/currency_type.h
@@ -5,13 +5,12 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
  */
 
-/** @file currency.h Functions to handle different currencies. */
+/** @file currency_type.h Types related to currencies. */
 
-#ifndef CURRENCY_H
-#define CURRENCY_H
+#ifndef CURRENCY_TYPE_H
+#define CURRENCY_TYPE_H
 
 #include "timer/timer_game_calendar.h"
-#include "settings_type.h"
 #include "strings_type.h"
 
 static constexpr TimerGameCalendar::Year CF_NOEURO{0}; ///< Currency never switches to the Euro (as far as known).
@@ -75,11 +74,11 @@ enum Currencies : uint8_t {
 
 /** Specification of a currency. */
 struct CurrencySpec {
-	uint16_t rate;           ///< The conversion rate compared to the base currency.
+	uint16_t rate; ///< The conversion rate compared to the base currency.
 	std::string separator; ///< The thousands separator for this currency.
 	TimerGameCalendar::Year to_euro; ///< Year of switching to the Euro. May also be #CF_NOEURO or #CF_ISEURO.
-	std::string prefix;    ///< Prefix to apply when formatting money in this currency.
-	std::string suffix;    ///< Suffix to apply when formatting money in this currency.
+	std::string prefix; ///< Prefix to apply when formatting money in this currency.
+	std::string suffix; ///< Suffix to apply when formatting money in this currency.
 	std::string code; ///< 3 letter untranslated code to identify the currency.
 	/**
 	 * The currency symbol is represented by two possible values, prefix and suffix
@@ -91,38 +90,7 @@ struct CurrencySpec {
 	 *            rather a way to let users do what they want with custom currency
 	 */
 	uint8_t symbol_pos;
-	StringID name;
-
-	CurrencySpec() = default;
-
-	CurrencySpec(uint16_t rate, std::string_view separator, TimerGameCalendar::Year to_euro, std::string_view prefix, std::string_view suffix, std::string_view code, uint8_t symbol_pos, StringID name) :
-		rate(rate), separator(separator), to_euro(to_euro), prefix(prefix), suffix(suffix), code(code), symbol_pos(symbol_pos), name(name)
-	{
-	}
+	StringID name; ///< Translated name of this currency.
 };
 
-extern std::array<CurrencySpec, CURRENCY_END> _currency_specs;
-
-/**
- * Get the custom currency.
- * @return Reference to custom currency.
- */
-inline CurrencySpec &GetCustomCurrency()
-{
-	return _currency_specs[CURRENCY_CUSTOM];
-}
-
-/**
- * Get the currently selected currency.
- * @return Read-only reference to the current currency.
- */
-inline const CurrencySpec &GetCurrency()
-{
-	return _currency_specs[GetGameSettings().locale.currency];
-}
-
-uint64_t GetMaskOfAllowedCurrencies();
-void ResetCurrencies(bool preserve_custom = true);
-uint8_t GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id);
-
-#endif /* CURRENCY_H */
+#endif /* CURRENCY_TYPE_H */

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -21,7 +21,7 @@
 #include "sound_func.h"
 #include "gfx_func.h"
 #include "core/geometry_func.hpp"
-#include "currency.h"
+#include "currency_func.h"
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 #include "timer/timer_game_tick.h"

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -8,7 +8,7 @@
 /** @file main_gui.cpp Handling of the main viewport. */
 
 #include "stdafx.h"
-#include "currency.h"
+#include "currency_type.h"
 #include "spritecache.h"
 #include "window_gui.h"
 #include "window_func.h"

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -20,7 +20,7 @@
 #include "newgrf_engine.h"
 #include "newgrf_text.h"
 #include "spritecache.h"
-#include "currency.h"
+#include "currency_func.h"
 #include "landscape.h"
 #include "newgrf_badge.h"
 #include "newgrf_badge_config.h"

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -9,7 +9,7 @@
 
 #include "../stdafx.h"
 #include "../debug.h"
-#include "../currency.h"
+#include "../currency_func.h"
 #include "../landscape.h"
 #include "../language.h"
 #include "../rev.h"

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -26,7 +26,7 @@
 #include "core/string_consumer.hpp"
 #include "settings_table.h"
 #include "debug.h"
-#include "currency.h"
+#include "currency_func.h"
 #include "network/network.h"
 #include "network/network_func.h"
 #include "network/core/config.h"

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -8,7 +8,7 @@
 /** @file settings_gui.cpp GUI for settings. */
 
 #include "stdafx.h"
-#include "currency.h"
+#include "currency_func.h"
 #include "error.h"
 #include "settings_gui.h"
 #include "textbuf_gui.h"

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -9,7 +9,7 @@
 
 #include "stdafx.h"
 #include "settings_table.h"
-#include "currency.h"
+#include "currency_type.h"
 #include "screenshot.h"
 #include "network/network.h"
 #include "network/network_func.h"

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -8,7 +8,7 @@
 /** @file strings.cpp Handling of translated strings. */
 
 #include "stdafx.h"
-#include "currency.h"
+#include "currency_func.h"
 #include "station_base.h"
 #include "town.h"
 #include "waypoint_base.h"

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -20,7 +20,7 @@
 #include "timer/timer_game_economy.h"
 #include "3rdparty/fmt/ranges.h"
 
-#include "currency.h"
+#include "currency_func.h"
 #include "fontcache.h"
 #include "language.h"
 


### PR DESCRIPTION
## Motivation / Problem

To make the type for currencies scoped, the setting field for the currency needs to become of type Currency. However, currency.h needs to include settings_type.h, and settings_type.h would need to include currency.h... which isn't possible.


## Description

Split currency.h into currency_type.h and currency_func.h.


## Limitations

Not necessarily useful on its own, but adding the currency typing to this PR makes it harder to review.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
