### PR TITLE
Codechange: rename Currencies to Currency and introduce Currencies as EnumBitSet

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -129,7 +129,7 @@ uint64_t GetMaskOfAllowedCurrencies()
 {
 	uint64_t mask = 0LL;
 
-	for (Currencies i : EnumRange(CURRENCY_END)) {
+	for (Currency i : EnumRange(CURRENCY_END)) {
 		TimerGameCalendar::Year to_euro = _currency_specs[i].to_euro;
 
 		if (to_euro != CF_NOEURO && to_euro != CF_ISEURO && TimerGameCalendar::year >= to_euro) continue;
@@ -161,7 +161,7 @@ static const IntervalTimer<TimerGameCalendar> _check_switch_to_euro({TimerGameCa
  */
 void ResetCurrencies(bool preserve_custom)
 {
-	for (Currencies i : EnumRange(CURRENCY_END)) {
+	for (Currency i : EnumRange(CURRENCY_END)) {
 		if (preserve_custom && i == CURRENCY_CUSTOM) continue;
 		_currency_specs[i] = origin_currency_specs[i];
 	}

--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -125,18 +125,18 @@ uint8_t GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id)
  * get a mask of the allowed currencies depending on the year
  * @return mask of currencies
  */
-uint64_t GetMaskOfAllowedCurrencies()
+Currencies GetMaskOfAllowedCurrencies()
 {
-	uint64_t mask = 0LL;
+	Currencies mask{};
 
 	for (Currency i : EnumRange(CURRENCY_END)) {
 		TimerGameCalendar::Year to_euro = _currency_specs[i].to_euro;
 
 		if (to_euro != CF_NOEURO && to_euro != CF_ISEURO && TimerGameCalendar::year >= to_euro) continue;
 		if (to_euro == CF_ISEURO && TimerGameCalendar::year < 2000) continue;
-		SetBit(mask, i);
+		mask.Set(i);
 	}
-	SetBit(mask, CURRENCY_CUSTOM); // always allow custom currency
+	mask.Set(CURRENCY_CUSTOM); // always allow custom currency
 	return mask;
 }
 

--- a/src/currency_func.h
+++ b/src/currency_func.h
@@ -33,7 +33,7 @@ inline const CurrencySpec &GetCurrency()
 	return _currency_specs[GetGameSettings().locale.currency];
 }
 
-uint64_t GetMaskOfAllowedCurrencies();
+Currencies GetMaskOfAllowedCurrencies();
 void ResetCurrencies(bool preserve_custom = true);
 uint8_t GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id);
 

--- a/src/currency_type.h
+++ b/src/currency_type.h
@@ -22,7 +22,7 @@ static constexpr TimerGameCalendar::Year MIN_EURO_YEAR{2000}; ///< The earliest 
  * savegame compatibility and in order to refer to them quickly, especially
  * for referencing the custom one.
  */
-enum Currencies : uint8_t {
+enum Currency : uint8_t {
 	CURRENCY_GBP,       ///< British Pound
 	CURRENCY_USD,       ///< US Dollar
 	CURRENCY_EUR,       ///< Euro

--- a/src/currency_type.h
+++ b/src/currency_type.h
@@ -72,6 +72,9 @@ enum Currency : uint8_t {
 	CURRENCY_END,       ///< always the last item
 };
 
+/** Bitmask of \c Currency. */
+using Currencies = EnumBitSet<Currency, uint64_t, CURRENCY_END>;
+
 /** Specification of a currency. */
 struct CurrencySpec {
 	uint16_t rate; ///< The conversion rate compared to the base currency.

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -477,23 +477,23 @@ struct GameOptionsWindow : Window {
 		switch (widget) {
 			case WID_GO_CURRENCY_DROPDOWN: { // Setup currencies dropdown
 				*selected_index = this->opt->locale.currency;
-				uint64_t disabled = _game_mode == GameMode::Menu ? 0LL : ~GetMaskOfAllowedCurrencies();
+				Currencies disabled = _game_mode == GameMode::Menu ? Currencies{} : GetMaskOfAllowedCurrencies().Flip();
 
 				/* Add non-custom currencies; sorted naturally */
-				for (const CurrencySpec &currency : _currency_specs) {
-					int i = &currency - _currency_specs.data();
+				for (Currency i : EnumRange(CURRENCY_END)) {
 					if (i == CURRENCY_CUSTOM) continue;
+					const CurrencySpec &currency = _currency_specs[i];
 					if (currency.code.empty()) {
-						list.push_back(MakeDropDownListStringItem(currency.name, i, HasBit(disabled, i)));
+						list.push_back(MakeDropDownListStringItem(currency.name, i, disabled.Test(i)));
 					} else {
-						list.push_back(MakeDropDownListStringItem(GetString(STR_GAME_OPTIONS_CURRENCY_CODE, currency.name, currency.code), i, HasBit(disabled, i)));
+						list.push_back(MakeDropDownListStringItem(GetString(STR_GAME_OPTIONS_CURRENCY_CODE, currency.name, currency.code), i, disabled.Test(i)));
 					}
 				}
 				std::sort(list.begin(), list.end(), DropDownListStringItem::NatSortFunc);
 
 				/* Append custom currency at the end */
 				list.push_back(MakeDropDownListDividerItem()); // separator line
-				list.push_back(MakeDropDownListStringItem(STR_GAME_OPTIONS_CURRENCY_CUSTOM, CURRENCY_CUSTOM, HasBit(disabled, CURRENCY_CUSTOM)));
+				list.push_back(MakeDropDownListStringItem(STR_GAME_OPTIONS_CURRENCY_CUSTOM, CURRENCY_CUSTOM, disabled.Test(CURRENCY_CUSTOM)));
 				break;
 			}
 


### PR DESCRIPTION
## Motivation / Problem

Enumerations should have a singular name, e.g. Currency over Currencies. Similarly, a bit set of an enumeration should use `EnumBitSet` instead of a base type.


## Description

* Rename `Currencies` to `Currency`.
* Introduce and use `Currencies` as `EnumBitSet`.


## Limitations

`Currency` should become a scoped enum, and `Currency` should be used in more places as type. However, these are beyond the scope of this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
