### PR TITLE
Codechange: use Currency over uint8_t

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -85,8 +85,7 @@ std::array<CurrencySpec, CURRENCY_END> _currency_specs;
  * When a grf sends currencies, they are based on the order defined by TTDPatch.
  * So, we must reindex them to our own order.
  */
-const uint8_t TTDPatch_To_OTTDIndex[] =
-{
+const Currency _ttdpatch_to_ottd_currency[] = {
 	CURRENCY_GBP,
 	CURRENCY_USD,
 	CURRENCY_FRF,
@@ -114,11 +113,12 @@ const uint8_t TTDPatch_To_OTTDIndex[] =
  * it is a grf written for ottd, thus returning the same id.
  * Only called from newgrf.cpp
  * @param grfcurr_id currency id coming from newgrf
- * @return the corrected index
+ * @return The corrected index, or \c CURRENCY_END when invalid.
  */
-uint8_t GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id)
+Currency GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id)
 {
-	return (grfcurr_id >= lengthof(TTDPatch_To_OTTDIndex)) ? grfcurr_id : TTDPatch_To_OTTDIndex[grfcurr_id];
+	if (grfcurr_id >= std::size(_ttdpatch_to_ottd_currency)) return CURRENCY_END;
+	return _ttdpatch_to_ottd_currency[grfcurr_id];
 }
 
 /**

--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -148,7 +148,7 @@ static const IntervalTimer<TimerGameCalendar> _check_switch_to_euro({TimerGameCa
 	if (_currency_specs[_settings_game.locale.currency].to_euro != CF_NOEURO &&
 			_currency_specs[_settings_game.locale.currency].to_euro != CF_ISEURO &&
 			TimerGameCalendar::year >= _currency_specs[_settings_game.locale.currency].to_euro) {
-		_settings_game.locale.currency = 2; // this is the index of euro above.
+		_settings_game.locale.currency = CURRENCY_EUR;
 		AddNewsItem(GetEncodedString(STR_NEWS_EURO_INTRODUCTION), NewsType::Economy, NewsStyle::Normal, {});
 	}
 });

--- a/src/currency_func.h
+++ b/src/currency_func.h
@@ -35,6 +35,6 @@ inline const CurrencySpec &GetCurrency()
 
 Currencies GetMaskOfAllowedCurrencies();
 void ResetCurrencies(bool preserve_custom = true);
-uint8_t GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id);
+Currency GetNewgrfCurrencyIdConverted(uint8_t grfcurr_id);
 
 #endif /* CURRENCY_FUNC_H */

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -146,7 +146,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 			}
 
 			case 0x0A: { // Currency display names
-				uint curidx = GetNewgrfCurrencyIdConverted(id);
+				Currency curidx = GetNewgrfCurrencyIdConverted(id);
 				if (curidx < CURRENCY_END) {
 					AddStringForMapping(GRFStringID{buf.ReadWord()}, [curidx](StringID str) {
 						_currency_specs[curidx].name = str;
@@ -159,7 +159,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 			}
 
 			case 0x0B: { // Currency multipliers
-				uint curidx = GetNewgrfCurrencyIdConverted(id);
+				Currency curidx = GetNewgrfCurrencyIdConverted(id);
 				uint32_t rate = buf.ReadDWord();
 
 				if (curidx < CURRENCY_END) {
@@ -168,13 +168,13 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					 * to be compatible */
 					_currency_specs[curidx].rate = rate / 1000;
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Currency multipliers {} out of range, ignoring", curidx);
+					GrfMsg(1, "GlobalVarChangeInfo: Currency multipliers {} out of range, ignoring", id);
 				}
 				break;
 			}
 
 			case 0x0C: { // Currency options
-				uint curidx = GetNewgrfCurrencyIdConverted(id);
+				Currency curidx = GetNewgrfCurrencyIdConverted(id);
 				uint16_t options = buf.ReadWord();
 
 				if (curidx < CURRENCY_END) {
@@ -185,43 +185,43 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					 * since newgrf specs said that only 0 and 1 can be set for symbol_pos */
 					_currency_specs[curidx].symbol_pos = HasBit(options, 8) ? CurrencySymbolPosition::Suffix : CurrencySymbolPosition::Prefix;
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Currency option {} out of range, ignoring", curidx);
+					GrfMsg(1, "GlobalVarChangeInfo: Currency option {} out of range, ignoring", id);
 				}
 				break;
 			}
 
 			case 0x0D: { // Currency prefix symbol
-				uint curidx = GetNewgrfCurrencyIdConverted(id);
+				Currency curidx = GetNewgrfCurrencyIdConverted(id);
 				std::string prefix = ReadDWordAsString(buf);
 
 				if (curidx < CURRENCY_END) {
 					_currency_specs[curidx].prefix = std::move(prefix);
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", curidx);
+					GrfMsg(1, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", id);
 				}
 				break;
 			}
 
 			case 0x0E: { // Currency suffix symbol
-				uint curidx = GetNewgrfCurrencyIdConverted(id);
+				Currency curidx = GetNewgrfCurrencyIdConverted(id);
 				std::string suffix = ReadDWordAsString(buf);
 
 				if (curidx < CURRENCY_END) {
 					_currency_specs[curidx].suffix = std::move(suffix);
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", curidx);
+					GrfMsg(1, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", id);
 				}
 				break;
 			}
 
 			case 0x0F: { //  Euro introduction dates
-				uint curidx = GetNewgrfCurrencyIdConverted(id);
+				Currency curidx = GetNewgrfCurrencyIdConverted(id);
 				TimerGameCalendar::Year year_euro{buf.ReadWord()};
 
 				if (curidx < CURRENCY_END) {
 					_currency_specs[curidx].to_euro = year_euro;
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Euro intro date {} out of range, ignoring", curidx);
+					GrfMsg(1, "GlobalVarChangeInfo: Euro intro date {} out of range, ignoring", id);
 				}
 				break;
 			}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -186,17 +186,17 @@ static void UpdateExclusiveRights()
 	}
 }
 
-static const uint8_t convert_currency[] = {
-	 0,  1, 12,  8,  3,
-	10, 14, 19,  4,  5,
-	 9, 11, 13,  6, 17,
-	16, 22, 21,  7, 15,
-	18,  2, 20,
-};
-
 /** Since savegame version 4.2 the currencies are arranged differently. */
 static void UpdateCurrencies()
 {
+	constexpr Currency convert_currency[] = {
+		CURRENCY_GBP, CURRENCY_USD, CURRENCY_FRF, CURRENCY_DEM, CURRENCY_JPY,
+		CURRENCY_ESP, CURRENCY_HUF, CURRENCY_PLN, CURRENCY_ATS, CURRENCY_BEF,
+		CURRENCY_DKK, CURRENCY_FIM, CURRENCY_GRD, CURRENCY_CHF, CURRENCY_NLG,
+		CURRENCY_ITL, CURRENCY_SIT, CURRENCY_RUR, CURRENCY_CZK, CURRENCY_ISK,
+		CURRENCY_NOK, CURRENCY_EUR, CURRENCY_RON,
+	};
+
 	_settings_game.locale.currency = convert_currency[_settings_game.locale.currency];
 }
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1425,7 +1425,7 @@ struct GameOptionsWindow : Window {
 		switch (widget) {
 			case WID_GO_CURRENCY_DROPDOWN: // Currency
 				if (index == CURRENCY_CUSTOM) ShowCustCurrency();
-				this->opt->locale.currency = index;
+				this->opt->locale.currency = static_cast<Currency>(index);
 				ReInitAllWindows(false);
 				break;
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -18,6 +18,7 @@
 #include "network/network_type.h"
 #include "company_type.h"
 #include "cargotype.h"
+#include "currency_type.h"
 #include "linkgraph/linkgraph_type.h"
 #include "zoom_type.h"
 #include "openttd.h"
@@ -357,7 +358,7 @@ struct MusicSettings {
 
 /** Settings related to currency/unit systems. */
 struct LocaleSettings {
-	uint8_t currency; ///< currency we currently use
+	Currency currency; ///< Currency we currently use
 	uint8_t units_velocity; ///< unit system for velocity of trains and road vehicles
 	uint8_t units_velocity_nautical; ///< unit system for velocity of ships and aircraft
 	uint8_t units_power; ///< unit system for power


### PR DESCRIPTION
## Motivation / Problem

Preparation to make `Currency` a scoped enumeration.


## Description

* Make the currency field of settings a `Currency` instead of `uint8_t`.
* Make the return type of `GetNewgrfCurrencyIdConverted` a `Currency` instead of `uint8_t`.


## Limitations

Excludes actually making `Currency` a scoped enumeration.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
