### PR TITLE
Change: prevent oversized purchase list windows

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -962,7 +962,7 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 	const int offset = (rtl ? -circle_width : circle_width) / 2;
 	const int level_width = rtl ? -WidgetDimensions::scaled.hsep_indent : WidgetDimensions::scaled.hsep_indent;
 
-	for (auto it = first; it != last; ++it) {
+	for (auto it = first; it != last; ++it, ir = ir.Translate(0, step_size)) {
 		const auto &item = *it;
 		const Engine *e = Engine::Get(item.engine_id);
 
@@ -970,6 +970,13 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 		bool has_variants = item.flags.Test(EngineDisplayFlag::HasVariants);
 		bool is_folded    = item.flags.Test(EngineDisplayFlag::IsFolded);
 		bool shaded       = item.flags.Test(EngineDisplayFlag::Shaded);
+
+		/* Set up clipping area for the row, keeping coordinates relative to the window. */
+		DrawPixelInfo tmp_dpi;
+		if (!FillDrawPixelInfo(&tmp_dpi, ir)) continue;
+		tmp_dpi.left += ir.left;
+		tmp_dpi.top += ir.top;
+		AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 
 		Rect textr = ir.Shrink(WidgetDimensions::scaled.matrix);
 		Rect tr = ir.Indent(indent, rtl);
@@ -1146,8 +1153,6 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 
 		/* The left/right bounds are adjusted to not overlap with the sort detail that is on the left/right depending on the RTL setting. */
 		DrawString(tr.left + (rtl ? sort_detail_width : 0), tr.right - (rtl ? 0 : sort_detail_width), textr.top + normal_text_y_offset, name, tc);
-
-		ir = ir.Translate(0, step_size);
 	}
 }
 

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -176,7 +176,7 @@ static void InitBlocksizeForVehicles(VehicleType type, EngineImageType image_typ
 {
 	int max_extend_left  = 0;
 	int max_extend_right = 0;
-	uint max_height = 0;
+	uint height = 0;
 
 	for (const Engine *e : Engine::IterateType(type)) {
 		if (!e->IsEnabled()) continue;
@@ -192,7 +192,7 @@ static void InitBlocksizeForVehicles(VehicleType type, EngineImageType image_typ
 			case VehicleType::Ship: GetShipSpriteSize(eid, x, y, x_offs, y_offs, image_type); break;
 			case VehicleType::Aircraft: GetAircraftSpriteSize(eid, x, y, x_offs, y_offs, image_type); break;
 		}
-		if (y > max_height) max_height = y;
+		if (y > height) height = y;
 		if (-x_offs > max_extend_left) max_extend_left = -x_offs;
 		if ((int)x + x_offs > max_extend_right) max_extend_right = x + x_offs;
 	}
@@ -200,15 +200,19 @@ static void InitBlocksizeForVehicles(VehicleType type, EngineImageType image_typ
 	int min_extend = ScaleSpriteTrad(16);
 	int max_extend = ScaleSpriteTrad(98);
 
+	/* Limit sprite height to limits based on original design height to prevent window size running away. */
+	int min_height = ScaleSpriteTrad(GetVehicleHeight(type));
+	int max_height = min_height + min_height / 2;
+
 	switch (image_type) {
 		case EngineImageType::InDepot:
-			_base_block_sizes_depot[type].height       = std::max<uint>(ScaleSpriteTrad(GetVehicleHeight(type)), max_height);
-			_base_block_sizes_depot[type].extend_left  = Clamp(max_extend_left, min_extend, max_extend);
+			_base_block_sizes_depot[type].height = Clamp(height, min_height, max_height);
+			_base_block_sizes_depot[type].extend_left = Clamp(max_extend_left, min_extend, max_extend);
 			_base_block_sizes_depot[type].extend_right = Clamp(max_extend_right, min_extend, max_extend);
 			break;
 		case EngineImageType::Purchase:
-			_base_block_sizes_purchase[type].height       = std::max<uint>(ScaleSpriteTrad(GetVehicleHeight(type)), max_height);
-			_base_block_sizes_purchase[type].extend_left  = Clamp(max_extend_left, min_extend, max_extend);
+			_base_block_sizes_purchase[type].height = Clamp(height, min_height, max_height);
+			_base_block_sizes_purchase[type].extend_left = Clamp(max_extend_left, min_extend, max_extend);
 			_base_block_sizes_purchase[type].extend_right = Clamp(max_extend_right, min_extend, max_extend);
 			break;
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Warning: this is an opinionated PR.

r24839 (245e32a10efb0dc924289a8cdec089cd13f3b47d) introduced support for oversized purchase list sprites, but didn't put any limits on height. This means that authors can, deliberately or accidentally, cause purchase lists to grow to awkward sizes.

An example from a post on Reddit.

<img width="1080" height="570" alt="image" src="https://github.com/user-attachments/assets/022e3ee0-97c3-4bc6-a1ca-b0bd1be779b1" />

These sprite sizes are much larger than the original design size of the window, not helped by the graphics author using double-scale sprites in the purchase list.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of allowing free rein on sprite heights with no limit, apply a limit of 1x and 1.5x of the original design height to purchase list sprites. These limits are 14 or 24 scaled pixels depending on vehicle type, so the upper limit becomes a conservative 21 or 36 scaled pixels.

Sprite widths are already limited, and although the limit is overly generous, this PR does not touch that as many authors have used (rightly or wrongly) the extra space to represent longer articulated vehicles.

Because the height can now be limited below the sprite height, drawing for each row is now clipped to the row.

<img width="561" height="771" alt="image" src="https://github.com/user-attachments/assets/3d91652f-eb51-4087-a14d-d7069303c893" />

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Some authors used 2x sprites at 1x zoom level for GUI lists. These will no longer fit, but this should not really have been supported as interface scaling (even the early versions) is preferable as it should be a user's choice, not an author's choice.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
