### PR TITLE
Codechange: replace symbol_pos magic numbers with scoped enum and EnumBitSet

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -28,52 +28,52 @@
 	 *   |   |    |                              |              |                 |     |  | */
 /** The original currency specifications. */
 static const std::array<CurrencySpec, CURRENCY_END> origin_currency_specs = {{
-	{    1, "", CF_NOEURO,                     "\u00a3",   "",             "GBP", 0, STR_GAME_OPTIONS_CURRENCY_GBP    }, ///< british pound
-	{    2, "", CF_NOEURO,                     "$",        "",             "USD", 0, STR_GAME_OPTIONS_CURRENCY_USD    }, ///< american dollar
-	{    2, "", CF_ISEURO,                     "\u20ac",   "",             "EUR", 0, STR_GAME_OPTIONS_CURRENCY_EUR    }, ///< euro
-	{  220, "", CF_NOEURO,                     "\u00a5",   "",             "JPY", 0, STR_GAME_OPTIONS_CURRENCY_JPY    }, ///< japanese yen
-	{   27, "", TimerGameCalendar::Year{2002}, "",         NBSP "S.",      "ATS", 1, STR_GAME_OPTIONS_CURRENCY_ATS    }, ///< austrian schilling
-	{   81, "", TimerGameCalendar::Year{2002}, "BEF" NBSP, "",             "BEF", 0, STR_GAME_OPTIONS_CURRENCY_BEF    }, ///< belgian franc
-	{    2, "", CF_NOEURO,                     "CHF" NBSP, "",             "CHF", 0, STR_GAME_OPTIONS_CURRENCY_CHF    }, ///< swiss franc
-	{   41, "", CF_NOEURO,                     "",         NBSP "K\u010d", "CZK", 1, STR_GAME_OPTIONS_CURRENCY_CZK    }, ///< czech koruna
-	{    4, "", TimerGameCalendar::Year{2002}, "DM" NBSP,  "",             "DEM", 0, STR_GAME_OPTIONS_CURRENCY_DEM    }, ///< deutsche mark
-	{   11, "", CF_NOEURO,                     "",         NBSP "kr",      "DKK", 1, STR_GAME_OPTIONS_CURRENCY_DKK    }, ///< danish krone
-	{  333, "", TimerGameCalendar::Year{2002}, "Pts" NBSP, "",             "ESP", 0, STR_GAME_OPTIONS_CURRENCY_ESP    }, ///< spanish peseta
-	{   12, "", TimerGameCalendar::Year{2002}, "",         NBSP "mk",      "FIM", 1, STR_GAME_OPTIONS_CURRENCY_FIM    }, ///< finnish markka
-	{   13, "", TimerGameCalendar::Year{2002}, "FF" NBSP,  "",             "FRF", 0, STR_GAME_OPTIONS_CURRENCY_FRF    }, ///< french franc
-	{  681, "", TimerGameCalendar::Year{2002}, "",         "Dr.",          "GRD", 1, STR_GAME_OPTIONS_CURRENCY_GRD    }, ///< greek drachma
-	{  378, "", CF_NOEURO,                     "",         NBSP "Ft",      "HUF", 1, STR_GAME_OPTIONS_CURRENCY_HUF    }, ///< hungarian forint
-	{  130, "", CF_NOEURO,                     "",         NBSP "Kr",      "ISK", 1, STR_GAME_OPTIONS_CURRENCY_ISK    }, ///< icelandic krona
-	{ 3873, "", TimerGameCalendar::Year{2002}, "",         NBSP "L.",      "ITL", 1, STR_GAME_OPTIONS_CURRENCY_ITL    }, ///< italian lira
-	{    4, "", TimerGameCalendar::Year{2002}, "NLG" NBSP, "",             "NLG", 0, STR_GAME_OPTIONS_CURRENCY_NLG    }, ///< dutch gulden
-	{   12, "", CF_NOEURO,                     "",         NBSP "Kr",      "NOK", 1, STR_GAME_OPTIONS_CURRENCY_NOK    }, ///< norwegian krone
-	{    6, "", CF_NOEURO,                     "",         NBSP "z\u0142", "PLN", 1, STR_GAME_OPTIONS_CURRENCY_PLN    }, ///< polish zloty
-	{    5, "", CF_NOEURO,                     "",         NBSP "Lei",     "RON", 1, STR_GAME_OPTIONS_CURRENCY_RON    }, ///< romanian leu
-	{   50, "", CF_NOEURO,                     "",         NBSP "p",       "RUR", 1, STR_GAME_OPTIONS_CURRENCY_RUR    }, ///< russian rouble
-	{  479, "", TimerGameCalendar::Year{2007}, "",         NBSP "SIT",     "SIT", 1, STR_GAME_OPTIONS_CURRENCY_SIT    }, ///< slovenian tolar
-	{   13, "", CF_NOEURO,                     "",         NBSP "Kr",      "SEK", 1, STR_GAME_OPTIONS_CURRENCY_SEK    }, ///< swedish krona
-	{    3, "", CF_NOEURO,                     "",         NBSP "TL",      "TRY", 1, STR_GAME_OPTIONS_CURRENCY_TRY    }, ///< turkish lira
-	{   60, "", TimerGameCalendar::Year{2009}, "",         NBSP "Sk",      "SKK", 1, STR_GAME_OPTIONS_CURRENCY_SKK    }, ///< slovak koruna
-	{    4, "", CF_NOEURO,                     "R$" NBSP,  "",             "BRL", 0, STR_GAME_OPTIONS_CURRENCY_BRL    }, ///< brazil real
-	{   31, "", TimerGameCalendar::Year{2011}, "",         NBSP "EEK",     "EEK", 1, STR_GAME_OPTIONS_CURRENCY_EEK    }, ///< estonian krooni
-	{    4, "", TimerGameCalendar::Year{2015}, "",         NBSP "Lt",      "LTL", 1, STR_GAME_OPTIONS_CURRENCY_LTL    }, ///< lithuanian litas
-	{ 1850, "", CF_NOEURO,                     "\u20a9",   "",             "KRW", 0, STR_GAME_OPTIONS_CURRENCY_KRW    }, ///< south korean won
-	{   13, "", CF_NOEURO,                     "R" NBSP,   "",             "ZAR", 0, STR_GAME_OPTIONS_CURRENCY_ZAR    }, ///< south african rand
-	{    1, "", CF_NOEURO,                     "",         "",             "",    2, STR_GAME_OPTIONS_CURRENCY_CUSTOM }, ///< custom currency {add further languages below}
-	{    3, "", CF_NOEURO,                     "",         NBSP "GEL",     "GEL", 1, STR_GAME_OPTIONS_CURRENCY_GEL    }, ///< Georgian Lari
-	{ 4901, "", CF_NOEURO,                     "",         NBSP "Rls",     "IRR", 1, STR_GAME_OPTIONS_CURRENCY_IRR    }, ///< Iranian Rial
-	{   80, "", CF_NOEURO,                     "",         NBSP "rub",     "RUB", 1, STR_GAME_OPTIONS_CURRENCY_RUB    }, ///< New Russian Ruble
-	{   24, "", CF_NOEURO,                     "$",        "",             "MXN", 0, STR_GAME_OPTIONS_CURRENCY_MXN    }, ///< Mexican peso
-	{   40, "", CF_NOEURO,                     "NTD" NBSP, "",             "NTD", 0, STR_GAME_OPTIONS_CURRENCY_NTD    }, ///< new taiwan dollar
-	{    8, "", CF_NOEURO,                     "\u00a5",   "",             "CNY", 0, STR_GAME_OPTIONS_CURRENCY_CNY    }, ///< chinese renminbi
-	{   10, "", CF_NOEURO,                     "HKD" NBSP, "",             "HKD", 0, STR_GAME_OPTIONS_CURRENCY_HKD    }, ///< hong kong dollar
-	{   90, "", CF_NOEURO,                     "\u20b9",   "",             "INR", 0, STR_GAME_OPTIONS_CURRENCY_INR    }, ///< Indian Rupee
-	{   19, "", CF_NOEURO,                     "Rp",       "",             "IDR", 0, STR_GAME_OPTIONS_CURRENCY_IDR    }, ///< Indonesian Rupiah
-	{    5, "", CF_NOEURO,                     "RM",       "",             "MYR", 0, STR_GAME_OPTIONS_CURRENCY_MYR    }, ///< Malaysian Ringgit
-	{    1, "", TimerGameCalendar::Year{2014}, "",         NBSP "Ls",      "LVL", 1, STR_GAME_OPTIONS_CURRENCY_LVL    }, ///< latvian lats
-	{  400, "", TimerGameCalendar::Year{2002}, "",         "$00",          "PTE", 1, STR_GAME_OPTIONS_CURRENCY_PTE    }, ///< portuguese escudo
-	{   50, "", CF_NOEURO,                     "",         NBSP "\u20B4",  "UAH", 1, STR_GAME_OPTIONS_CURRENCY_UAH    }, ///< ukrainian hryvnia
-	{35000, "", CF_NOEURO,                     "",         NBSP "\u20AB",  "VND", 1, STR_GAME_OPTIONS_CURRENCY_VND    }, ///< Vietnamese Dong
+	{    1, "", CF_NOEURO,                     "\u00a3",   "",             "GBP", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_GBP }, ///< british pound
+	{    2, "", CF_NOEURO,                     "$",        "",             "USD", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_USD }, ///< american dollar
+	{    2, "", CF_ISEURO,                     "\u20ac",   "",             "EUR", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_EUR }, ///< euro
+	{  220, "", CF_NOEURO,                     "\u00a5",   "",             "JPY", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_JPY }, ///< japanese yen
+	{   27, "", TimerGameCalendar::Year{2002}, "",         NBSP "S.",      "ATS", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_ATS }, ///< austrian schilling
+	{   81, "", TimerGameCalendar::Year{2002}, "BEF" NBSP, "",             "BEF", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_BEF }, ///< belgian franc
+	{    2, "", CF_NOEURO,                     "CHF" NBSP, "",             "CHF", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_CHF }, ///< swiss franc
+	{   41, "", CF_NOEURO,                     "",         NBSP "K\u010d", "CZK", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_CZK }, ///< czech koruna
+	{    4, "", TimerGameCalendar::Year{2002}, "DM" NBSP,  "",             "DEM", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_DEM }, ///< deutsche mark
+	{   11, "", CF_NOEURO,                     "",         NBSP "kr",      "DKK", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_DKK }, ///< danish krone
+	{  333, "", TimerGameCalendar::Year{2002}, "Pts" NBSP, "",             "ESP", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_ESP }, ///< spanish peseta
+	{   12, "", TimerGameCalendar::Year{2002}, "",         NBSP "mk",      "FIM", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_FIM }, ///< finnish markka
+	{   13, "", TimerGameCalendar::Year{2002}, "FF" NBSP,  "",             "FRF", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_FRF }, ///< french franc
+	{  681, "", TimerGameCalendar::Year{2002}, "",         "Dr.",          "GRD", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_GRD }, ///< greek drachma
+	{  378, "", CF_NOEURO,                     "",         NBSP "Ft",      "HUF", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_HUF }, ///< hungarian forint
+	{  130, "", CF_NOEURO,                     "",         NBSP "Kr",      "ISK", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_ISK }, ///< icelandic krona
+	{ 3873, "", TimerGameCalendar::Year{2002}, "",         NBSP "L.",      "ITL", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_ITL }, ///< italian lira
+	{    4, "", TimerGameCalendar::Year{2002}, "NLG" NBSP, "",             "NLG", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_NLG }, ///< dutch gulden
+	{   12, "", CF_NOEURO,                     "",         NBSP "Kr",      "NOK", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_NOK }, ///< norwegian krone
+	{    6, "", CF_NOEURO,                     "",         NBSP "z\u0142", "PLN", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_PLN }, ///< polish zloty
+	{    5, "", CF_NOEURO,                     "",         NBSP "Lei",     "RON", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_RON }, ///< romanian leu
+	{   50, "", CF_NOEURO,                     "",         NBSP "p",       "RUR", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_RUR }, ///< russian rouble
+	{  479, "", TimerGameCalendar::Year{2007}, "",         NBSP "SIT",     "SIT", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_SIT }, ///< slovenian tolar
+	{   13, "", CF_NOEURO,                     "",         NBSP "Kr",      "SEK", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_SEK }, ///< swedish krona
+	{    3, "", CF_NOEURO,                     "",         NBSP "TL",      "TRY", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_TRY }, ///< turkish lira
+	{   60, "", TimerGameCalendar::Year{2009}, "",         NBSP "Sk",      "SKK", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_SKK }, ///< slovak koruna
+	{    4, "", CF_NOEURO,                     "R$" NBSP,  "",             "BRL", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_BRL }, ///< brazil real
+	{   31, "", TimerGameCalendar::Year{2011}, "",         NBSP "EEK",     "EEK", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_EEK }, ///< estonian krooni
+	{    4, "", TimerGameCalendar::Year{2015}, "",         NBSP "Lt",      "LTL", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_LTL }, ///< lithuanian litas
+	{ 1850, "", CF_NOEURO,                     "\u20a9",   "",             "KRW", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_KRW }, ///< south korean won
+	{   13, "", CF_NOEURO,                     "R" NBSP,   "",             "ZAR", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_ZAR }, ///< south african rand
+	{    1, "", CF_NOEURO,                     "",         "",             "",    {CurrencySymbolPosition::Prefix, CurrencySymbolPosition::Suffix}, STR_GAME_OPTIONS_CURRENCY_CUSTOM }, ///< custom currency {add further languages below}
+	{    3, "", CF_NOEURO,                     "",         NBSP "GEL",     "GEL", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_GEL }, ///< Georgian Lari
+	{ 4901, "", CF_NOEURO,                     "",         NBSP "Rls",     "IRR", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_IRR }, ///< Iranian Rial
+	{   80, "", CF_NOEURO,                     "",         NBSP "rub",     "RUB", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_RUB }, ///< New Russian Ruble
+	{   24, "", CF_NOEURO,                     "$",        "",             "MXN", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_MXN }, ///< Mexican peso
+	{   40, "", CF_NOEURO,                     "NTD" NBSP, "",             "NTD", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_NTD }, ///< new taiwan dollar
+	{    8, "", CF_NOEURO,                     "\u00a5",   "",             "CNY", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_CNY }, ///< chinese renminbi
+	{   10, "", CF_NOEURO,                     "HKD" NBSP, "",             "HKD", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_HKD }, ///< hong kong dollar
+	{   90, "", CF_NOEURO,                     "\u20b9",   "",             "INR", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_INR }, ///< Indian Rupee
+	{   19, "", CF_NOEURO,                     "Rp",       "",             "IDR", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_IDR }, ///< Indonesian Rupiah
+	{    5, "", CF_NOEURO,                     "RM",       "",             "MYR", CurrencySymbolPosition::Prefix, STR_GAME_OPTIONS_CURRENCY_MYR }, ///< Malaysian Ringgit
+	{    1, "", TimerGameCalendar::Year{2014}, "",         NBSP "Ls",      "LVL", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_LVL }, ///< latvian lats
+	{  400, "", TimerGameCalendar::Year{2002}, "",         "$00",          "PTE", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_PTE }, ///< portuguese escudo
+	{   50, "", CF_NOEURO,                     "",         NBSP "\u20B4",  "UAH", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_UAH }, ///< ukrainian hryvnia
+	{35000, "", CF_NOEURO,                     "",         NBSP "\u20AB",  "VND", CurrencySymbolPosition::Suffix, STR_GAME_OPTIONS_CURRENCY_VND }, ///< Vietnamese Dong
 }};
 
 /** Array of currencies used by the system */

--- a/src/currency_type.h
+++ b/src/currency_type.h
@@ -75,6 +75,15 @@ enum Currency : uint8_t {
 /** Bitmask of \c Currency. */
 using Currencies = EnumBitSet<Currency, uint64_t, CURRENCY_END>;
 
+/** The currency symbol positions that we can show. */
+enum class CurrencySymbolPosition : uint8_t {
+	Prefix, ///< Show the prefix value.
+	Suffix, ///< Show the suffix value.
+};
+
+/** Bitmask of \c CurrencySymbolPosition. */
+using CurrencySymbolPositions = EnumBitSet<CurrencySymbolPosition, uint8_t>;
+
 /** Specification of a currency. */
 struct CurrencySpec {
 	uint16_t rate; ///< The conversion rate compared to the base currency.
@@ -83,16 +92,7 @@ struct CurrencySpec {
 	std::string prefix; ///< Prefix to apply when formatting money in this currency.
 	std::string suffix; ///< Suffix to apply when formatting money in this currency.
 	std::string code; ///< 3 letter untranslated code to identify the currency.
-	/**
-	 * The currency symbol is represented by two possible values, prefix and suffix
-	 * Usage of one or the other is determined by #symbol_pos.
-	 * 0 = prefix
-	 * 1 = suffix
-	 * 2 = both : Special case only for custom currency.
-	 *            It is not a spec from Newgrf,
-	 *            rather a way to let users do what they want with custom currency
-	 */
-	uint8_t symbol_pos;
+	CurrencySymbolPositions symbol_pos; ///< Which currency symbols should we show?
 	StringID name; ///< Translated name of this currency.
 };
 

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -183,7 +183,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					StrMakeValidInPlace(_currency_specs[curidx].separator);
 					/* By specifying only one bit, we prevent errors,
 					 * since newgrf specs said that only 0 and 1 can be set for symbol_pos */
-					_currency_specs[curidx].symbol_pos = GB(options, 8, 1);
+					_currency_specs[curidx].symbol_pos = HasBit(options, 8) ? CurrencySymbolPosition::Suffix : CurrencySymbolPosition::Prefix;
 				} else {
 					GrfMsg(1, "GlobalVarChangeInfo: Currency option {} out of range, ignoring", curidx);
 				}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -603,10 +603,8 @@ static void FormatGenericCurrency(StringBuilder &builder, const CurrencySpec *sp
 		number = -number;
 	}
 
-	/* Add prefix part, following symbol_pos specification.
-	 * Here, it can can be either 0 (prefix) or 2 (both prefix and suffix).
-	 * The only remaining value is 1 (suffix), so everything that is not 1 */
-	if (spec->symbol_pos != 1) builder += spec->prefix;
+	/* Add prefix part, following symbol_pos specification. */
+	if (spec->symbol_pos.Test(CurrencySymbolPosition::Prefix)) builder += spec->prefix;
 
 	StringID number_str = STR_NULL;
 
@@ -637,10 +635,8 @@ static void FormatGenericCurrency(StringBuilder &builder, const CurrencySpec *sp
 		FormatString(builder, GetStringPtr(number_str), {});
 	}
 
-	/* Add suffix part, following symbol_pos specification.
-	 * Here, it can can be either 1 (suffix) or 2 (both prefix and suffix).
-	 * The only remaining value is 1 (prefix), so everything that is not 0 */
-	if (spec->symbol_pos != 0) builder += spec->suffix;
+	/* Add suffix part, following symbol_pos specification. */
+	if (spec->symbol_pos.Test(CurrencySymbolPosition::Suffix)) builder += spec->suffix;
 
 	if (negative) {
 		builder.PutUtf8(SCC_POP_COLOUR);


### PR DESCRIPTION
## Motivation / Problem

Magic numbers are not clear; a named enumeration, or even `EnumBitSet` make it much clearer.

`symbol_pos` is weird, it contains two values from a NewGRF specification and then introduces a third. Finally, when using it, it is checking whether it's not one of the two NewGRF values.


## Description

Introduce `CurrencySymbolPosition` with `Prefix` and `Suffix`, and `CurrencySymbolPositions` as bit set.
When using the symbol position, check it against the set bit instead.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
