### PR TITLE
Codechange: extract function to look up fontsize by name

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2403,6 +2403,19 @@ static bool ConContent(std::span<std::string_view> argv)
 }
 #endif /* defined(WITH_ZLIB) */
 
+/**
+ * Get FontSize by name
+ * @param name The name to look up.
+ * @return The FontSize matching the given name,
+ */
+static FontSize GetFontSizeByName(std::string_view name)
+{
+	for (FontSize fs : EnumRange(FontSize::End)) {
+		if (StrEqualsIgnoreCase(name, FontSizeToName(fs))) return fs;
+	}
+	return FontSize::End;
+}
+
 /** Managing the font configuration. @copydoc IConsoleCmdProc */
 static bool ConFont(std::span<std::string_view> argv)
 {
@@ -2421,15 +2434,11 @@ static bool ConFont(std::span<std::string_view> argv)
 		return true;
 	}
 
-	FontSize argfs;
-	for (argfs = FontSize::Begin; argfs < FontSize::End; argfs++) {
-		if (argv.size() > 1 && StrEqualsIgnoreCase(argv[1], FontSizeToName(argfs))) break;
-	}
-
-	/* First argument must be a FontSize. */
-	if (argv.size() > 1 && argfs == FontSize::End) return false;
-
 	if (argv.size() > 2) {
+		/* First argument must be a FontSize. */
+		FontSize argfs = GetFontSizeByName(argv[1]);
+		if (argfs == FontSize::End) return false;
+
 		FontCacheSubSetting *setting = GetFontCacheSubSetting(argfs);
 		std::string font = setting->font;
 		uint size = setting->size;

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -254,7 +254,6 @@ enum class FontSize : uint8_t {
 	End, ///< Marker for the end of the enumerations.
 	Begin = FontSize::Normal, ///< Marker for the first font in the enumeration.
 };
-DECLARE_INCREMENT_DECREMENT_OPERATORS(FontSize)
 
 /** Bitset of \c FontSize elements. */
 using FontSizes = EnumBitSet<FontSize, uint8_t>;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

In the `font` console command, looking up the font size by name is curious as a loop is followed even if no argument is provided, or the argument will not be used.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Create a small function to look up font size by name with a simpler loop, and call it only when the `font` command will use the font size parameter.

`DECLARE_INCREMENT_DECREMENT_OPERATORS` is no longer needed for `FontSize`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
