### PR TITLE
Codechange: use ClientID for the 'user' of OrderBackup

### DIFF
--- a/src/order_backup.cpp
+++ b/src/order_backup.cpp
@@ -44,7 +44,7 @@ OrderBackup::OrderBackup(OrderBackupID index) :
  * @param v    The vehicle to make a backup of.
  * @param user The user that is requesting the backup.
  */
-OrderBackup::OrderBackup(OrderBackupID index, const Vehicle *v, uint32_t user) :
+OrderBackup::OrderBackup(OrderBackupID index, const Vehicle *v, ClientID user) :
 	OrderBackupPool::PoolItem<&_order_backup_pool>(index), user(user), tile(v->tile), group(v->group_id)
 {
 	this->CopyConsistPropertiesFrom(v);
@@ -92,7 +92,7 @@ void OrderBackup::DoRestore(Vehicle *v)
  * @param user The user that is requesting the backup.
  * @note Will automatically remove any previous backups of this user.
  */
-/* static */ void OrderBackup::Backup(const Vehicle *v, uint32_t user)
+/* static */ void OrderBackup::Backup(const Vehicle *v, ClientID user)
 {
 	/* Don't use reset as that broadcasts over the network to reset the variable,
 	 * which is what we are doing at the moment. */
@@ -110,7 +110,7 @@ void OrderBackup::DoRestore(Vehicle *v)
  * @param user The user that built the vehicle, thus wants to restore.
  * @note After restoration the backup will automatically be removed.
  */
-/* static */ void OrderBackup::Restore(Vehicle *v, uint32_t user)
+/* static */ void OrderBackup::Restore(Vehicle *v, ClientID user)
 {
 	for (OrderBackup *ob : OrderBackup::Iterate()) {
 		if (v->tile != ob->tile || ob->user != user) continue;
@@ -126,7 +126,7 @@ void OrderBackup::DoRestore(Vehicle *v)
  * @param user The user associated with the OrderBackup.
  * @note Must not be used from the GUI!
  */
-/* static */ void OrderBackup::ResetOfUser(TileIndex tile, uint32_t user)
+/* static */ void OrderBackup::ResetOfUser(TileIndex tile, ClientID user)
 {
 	for (OrderBackup *ob : OrderBackup::Iterate()) {
 		if (ob->user == user && (ob->tile == tile || tile == INVALID_TILE)) delete ob;
@@ -154,7 +154,7 @@ CommandCost CmdClearOrderBackup(DoCommandFlags flags, TileIndex tile, ClientID u
  * @pre _network_server.
  * @note Must not be used from a command.
  */
-/* static */ void OrderBackup::ResetUser(uint32_t user)
+/* static */ void OrderBackup::ResetUser(ClientID user)
 {
 	assert(_network_server);
 
@@ -179,7 +179,7 @@ CommandCost CmdClearOrderBackup(DoCommandFlags flags, TileIndex tile, ClientID u
 	 * but compiled it. A network client has its own variable for the unique
 	 * client/user identifier. Finally if networking isn't compiled in the
 	 * default is just plain and simple: 0. */
-	uint32_t user = _networking && !_network_server ? _network_own_client_id : CLIENT_ID_SERVER;
+	ClientID user = _networking && !_network_server ? _network_own_client_id : CLIENT_ID_SERVER;
 
 	for (OrderBackup *ob : OrderBackup::Iterate()) {
 		/* If this is a GUI action, and it's not a backup of us, ignore it. */

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -20,6 +20,7 @@
 /** Unique identifier for an order backup. */
 using OrderBackupID = PoolID<uint8_t, struct OrderBackupIDTag, 255, 0xFF>;
 struct OrderBackup;
+enum ClientID : uint32_t;
 
 /** The pool type for order backups. */
 using OrderBackupPool = Pool<OrderBackup, OrderBackupID, 1>;
@@ -39,7 +40,7 @@ private:
 	template <typename T>
 	friend class SlOrders;
 
-	uint32_t user = 0; ///< The user that requested the backup.
+	ClientID user{}; ///< The user that requested the backup.
 	TileIndex tile = INVALID_TILE; ///< Tile of the depot where the order was changed.
 	GroupID group = GroupID::Invalid(); ///< The group the vehicle was part of.
 
@@ -51,16 +52,16 @@ private:
 
 	friend OrderBackupPoolItem; ///< Loading of order backups.
 	OrderBackup(OrderBackupID index);
-	OrderBackup(OrderBackupID index, const Vehicle *v, uint32_t user);
+	OrderBackup(OrderBackupID index, const Vehicle *v, ClientID user);
 
 public:
 	~OrderBackup();
 
-	static void Backup(const Vehicle *v, uint32_t user);
-	static void Restore(Vehicle *v, uint32_t user);
+	static void Backup(const Vehicle *v, ClientID user);
+	static void Restore(Vehicle *v, ClientID user);
 
-	static void ResetOfUser(TileIndex tile, uint32_t user);
-	static void ResetUser(uint32_t user);
+	static void ResetOfUser(TileIndex tile, ClientID user);
+	static void ResetUser(ClientID user);
 	static void Reset(TileIndex tile = INVALID_TILE, bool from_gui = true);
 
 	static void ClearGroup(GroupID group);


### PR DESCRIPTION
## Motivation / Problem

We are always passing `ClientID` to these functions, so they better accept them `ClientID` becomes a scoped enum.


## Description

* Change `uint32_t` with `ClientID`.
* Forward declare `ClientID`, so we don't need to include the whole network stack.


## Limitations

Function and variable names still refer to user, and that probably ought to be renamed.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
