### PR TITLE
Codechange: make ClientID a scoped enumeration

### DIFF
--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -357,7 +357,7 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 
 	/* Build the new vehicle */
 	VehicleID new_veh_id;
-	std::tie(cost, new_veh_id, std::ignore, std::ignore, std::ignore) = Command<Commands::BuildVehicle>::Do({DoCommandFlag::Execute, DoCommandFlag::AutoReplace}, old_veh->tile, e, true, INVALID_CARGO, INVALID_CLIENT_ID);
+	std::tie(cost, new_veh_id, std::ignore, std::ignore, std::ignore) = Command<Commands::BuildVehicle>::Do({DoCommandFlag::Execute, DoCommandFlag::AutoReplace}, old_veh->tile, e, true, INVALID_CARGO, ClientID::Invalid);
 	if (cost.Failed()) return cost;
 
 	Vehicle *new_veh = Vehicle::Get(new_veh_id);
@@ -489,11 +489,11 @@ static CommandCost ReplaceFreeUnit(Vehicle **single_unit, DoCommandFlags flags, 
 		}
 
 		/* Sell the old vehicle */
-		cost.AddCost(Command<Commands::SellVehicle>::Do(flags, old_v->index, false, false, INVALID_CLIENT_ID));
+		cost.AddCost(Command<Commands::SellVehicle>::Do(flags, old_v->index, false, false, ClientID::Invalid));
 
 		/* If we are not in DoCommandFlag::Execute undo everything */
 		if (!flags.Test(DoCommandFlag::Execute)) {
-			Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, new_v->index, false, false, INVALID_CLIENT_ID);
+			Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, new_v->index, false, false, ClientID::Invalid);
 		}
 	}
 
@@ -633,7 +633,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlags flags, bool wago
 					assert(RailVehInfo(wagon->engine_type)->railveh_type == RailVehicleType::Wagon);
 
 					/* Sell wagon */
-					[[maybe_unused]] CommandCost ret = Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, wagon->index, false, false, INVALID_CLIENT_ID);
+					[[maybe_unused]] CommandCost ret = Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, wagon->index, false, false, ClientID::Invalid);
 					assert(ret.Succeeded());
 					it->new_veh = nullptr;
 
@@ -665,7 +665,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlags flags, bool wago
 					/* Sell the vehicle.
 					 * Note: This might temporarily construct new trains, so use DoCommandFlag::AutoReplace to prevent
 					 *       it from failing due to engine limits. */
-					cost.AddCost(Command<Commands::SellVehicle>::Do(DoCommandFlags{flags}.Set(DoCommandFlag::AutoReplace), w->index, false, false, INVALID_CLIENT_ID));
+					cost.AddCost(Command<Commands::SellVehicle>::Do(DoCommandFlags{flags}.Set(DoCommandFlag::AutoReplace), w->index, false, false, ClientID::Invalid));
 					if (flags.Test(DoCommandFlag::Execute)) {
 						it->old_veh = nullptr;
 						if (it == std::begin(replacements)) old_head = nullptr;
@@ -696,7 +696,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlags flags, bool wago
 		if (!flags.Test(DoCommandFlag::Execute)) {
 			for (auto it = std::rbegin(replacements); it != std::rend(replacements); ++it) {
 				if (it->new_veh != nullptr) {
-					Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, it->new_veh->index, false, false, INVALID_CLIENT_ID);
+					Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, it->new_veh->index, false, false, ClientID::Invalid);
 					it->new_veh = nullptr;
 				}
 			}
@@ -723,12 +723,12 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlags flags, bool wago
 				}
 
 				/* Sell the old vehicle */
-				cost.AddCost(Command<Commands::SellVehicle>::Do(flags, old_head->index, false, false, INVALID_CLIENT_ID));
+				cost.AddCost(Command<Commands::SellVehicle>::Do(flags, old_head->index, false, false, ClientID::Invalid));
 			}
 
 			/* If we are not in DoCommandFlag::Execute undo everything */
 			if (!flags.Test(DoCommandFlag::Execute)) {
-				Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, new_head->index, false, false, INVALID_CLIENT_ID);
+				Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, new_head->index, false, false, ClientID::Invalid);
 			}
 		}
 	}

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1375,7 +1375,7 @@ struct BuildVehicleWindow : Window {
 
 		if (!this->listview_mode) {
 			/* Query for cost and refitted capacity */
-			auto [ret, veh_id, refit_capacity, refit_mail, cargo_capacities] = Command<Commands::BuildVehicle>::Do(DoCommandFlag::QueryCost, TileIndex(this->window_number), this->sel_engine, true, cargo, INVALID_CLIENT_ID);
+			auto [ret, veh_id, refit_capacity, refit_mail, cargo_capacities] = Command<Commands::BuildVehicle>::Do(DoCommandFlag::QueryCost, TileIndex(this->window_number), this->sel_engine, true, cargo, ClientID::Invalid);
 			if (ret.Succeeded()) {
 				this->te.cost          = ret.GetCost() - e->GetCost();
 				this->te.capacity      = refit_capacity;
@@ -1697,9 +1697,9 @@ struct BuildVehicleWindow : Window {
 		CargoType cargo = this->cargo_filter_criteria;
 		if (cargo == CargoFilterCriteria::CF_ANY || cargo == CargoFilterCriteria::CF_ENGINES || cargo == CargoFilterCriteria::CF_NONE) cargo = INVALID_CARGO;
 		if (this->vehicle_type == VehicleType::Train && RailVehInfo(sel_eng)->railveh_type == RailVehicleType::Wagon) {
-			Command<Commands::BuildVehicle>::Post(GetCmdBuildVehMsg(this->vehicle_type), CcBuildWagon, TileIndex(this->window_number), sel_eng, true, cargo, INVALID_CLIENT_ID);
+			Command<Commands::BuildVehicle>::Post(GetCmdBuildVehMsg(this->vehicle_type), CcBuildWagon, TileIndex(this->window_number), sel_eng, true, cargo, ClientID::Invalid);
 		} else {
-			Command<Commands::BuildVehicle>::Post(GetCmdBuildVehMsg(this->vehicle_type), CcBuildPrimaryVehicle, TileIndex(this->window_number), sel_eng, true, cargo, INVALID_CLIENT_ID);
+			Command<Commands::BuildVehicle>::Post(GetCmdBuildVehMsg(this->vehicle_type), CcBuildPrimaryVehicle, TileIndex(this->window_number), sel_eng, true, cargo, ClientID::Invalid);
 		}
 
 		/* Update last used variant in hierarchy and refresh if necessary. */

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -285,7 +285,7 @@ protected:
 	static inline void SetClientIdHelper([[maybe_unused]] T &data)
 	{
 		if constexpr (std::is_same_v<ClientID, T>) {
-			if (data == INVALID_CLIENT_ID) data = CLIENT_ID_SERVER;
+			if (data == ClientID::Invalid) data = ClientID::Server;
 		}
 	}
 
@@ -372,7 +372,7 @@ protected:
 	static inline bool ClientIdIsSet([[maybe_unused]] T &data)
 	{
 		if constexpr (std::is_same_v<ClientID, T>) {
-			return data != INVALID_CLIENT_ID;
+			return data != ClientID::Invalid;
 		} else {
 			return true;
 		}

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -671,7 +671,7 @@ TimeoutTimer<TimerGameTick> _new_competitor_timeout({ TimerGameTick::Priority::C
 
 	/* Send a command to all clients to start up a new AI.
 	 * Works fine for Multiplayer and Singleplayer */
-	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, CompanyID::Invalid(), CompanyRemoveReason::None, INVALID_CLIENT_ID);
+	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, CompanyID::Invalid(), CompanyRemoveReason::None, ClientID::Invalid);
 });
 
 /** Start of a new game. */
@@ -792,7 +792,7 @@ void OnTick_Companies()
 			for (auto i = 0; i < _settings_game.difficulty.max_no_competitors; i++) {
 				if (_networking && num_companies++ >= _settings_client.network.max_companies) break;
 				if (num_ais++ >= _settings_game.difficulty.max_no_competitors) break;
-				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, CompanyID::Invalid(), {}, INVALID_CLIENT_ID);
+				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, CompanyID::Invalid(), {}, ClientID::Invalid);
 			}
 			timeout = 10 * 60 * Ticks::TICKS_PER_SECOND;
 		}

--- a/src/company_cmd.h
+++ b/src/company_cmd.h
@@ -14,7 +14,7 @@
 #include "company_type.h"
 #include "livery.h"
 
-enum ClientID : uint32_t;
+enum class ClientID : uint32_t;
 enum class Colours : uint8_t;
 
 CommandCost CmdCompanyCtrl(DoCommandFlags flags, CompanyCtrlAction cca, CompanyID company_id, CompanyRemoveReason reason, ClientID client_id);

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -2244,7 +2244,7 @@ struct CompanyWindow : Window
 				this->query_widget = WID_C_COMPANY_JOIN;
 				CompanyID company = this->window_number;
 				if (_network_server) {
-					NetworkServerDoMove(CLIENT_ID_SERVER, company);
+					NetworkServerDoMove(ClientID::Server, company);
 					MarkWholeScreenDirty();
 				} else {
 					/* just send the join command */

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -40,7 +40,7 @@ std::optional<FileHandle> _iconsole_output_file;
 void IConsoleInit()
 {
 	_iconsole_output_file = std::nullopt;
-	_redirect_console_to_client = INVALID_CLIENT_ID;
+	_redirect_console_to_client = ClientID::Invalid;
 	_redirect_console_to_admin  = AdminID::Invalid();
 
 	IConsoleGUIInit();
@@ -91,7 +91,7 @@ void IConsolePrint(ExtendedTextColour colour_code, const std::string &string)
 {
 	assert(IsValidConsoleColour(colour_code));
 
-	if (_redirect_console_to_client != INVALID_CLIENT_ID) {
+	if (_redirect_console_to_client != ClientID::Invalid) {
 		/* Redirect the string to the client */
 		NetworkServerSendRcon(_redirect_console_to_client, colour_code, string);
 		return;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -698,7 +698,7 @@ static bool ConKickOrBan(std::string_view arg, bool ban, std::string_view reason
 		 * kicking frees closes and subsequently free the connection related instances, which we
 		 * would be reading from and writing to after returning. So we would read or write data
 		 * from freed memory up till the segfault triggers. */
-		if (*client_id == CLIENT_ID_SERVER || *client_id == _redirect_console_to_client) {
+		if (*client_id == ClientID::Server || *client_id == _redirect_console_to_client) {
 			IConsolePrint(CC_ERROR, "You can not {} yourself!", ban ? "ban" : "kick");
 			return true;
 		}
@@ -945,7 +945,7 @@ static bool ConClientNickChange(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (*client_id == CLIENT_ID_SERVER) {
+	if (*client_id == ClientID::Server) {
 		IConsolePrint(CC_ERROR, "Please use the command 'name' to change your own name!");
 		return true;
 	}
@@ -1024,7 +1024,7 @@ static bool ConJoinCompany(std::span<std::string_view> argv)
 
 	/* non-dedicated server may just do the move! */
 	if (_network_server) {
-		NetworkServerDoMove(CLIENT_ID_SERVER, *company_id);
+		NetworkServerDoMove(ClientID::Server, *company_id);
 	} else {
 		NetworkClientRequestMove(*company_id);
 	}
@@ -1070,7 +1070,7 @@ static bool ConMoveClient(std::span<std::string_view> argv)
 		return true;
 	}
 
-	if (ci->client_id == CLIENT_ID_SERVER && _network_dedicated) {
+	if (ci->client_id == ClientID::Server && _network_dedicated) {
 		IConsolePrint(CC_ERROR, "You cannot move the server!");
 		return true;
 	}
@@ -1118,7 +1118,7 @@ static bool ConResetCompany(std::span<std::string_view> argv)
 		IConsolePrint(CC_ERROR, "Cannot remove company: a client is connected to that company.");
 		return false;
 	}
-	const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
+	const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(ClientID::Server);
 	assert(ci != nullptr);
 	if (ci->client_playas == *index) {
 		IConsolePrint(CC_ERROR, "Cannot remove company: the server is connected to that company.");
@@ -1126,7 +1126,7 @@ static bool ConResetCompany(std::span<std::string_view> argv)
 	}
 
 	/* It is safe to remove this company */
-	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, *index, CompanyRemoveReason::Manual, INVALID_CLIENT_ID);
+	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, *index, CompanyRemoveReason::Manual, ClientID::Invalid);
 	IConsolePrint(CC_DEFAULT, "Company deleted.");
 
 	return true;
@@ -1563,7 +1563,7 @@ static bool ConStartAI(std::span<std::string_view> argv)
 	}
 
 	/* Start a new AI company */
-	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, CompanyID::Invalid(), CompanyRemoveReason::None, INVALID_CLIENT_ID);
+	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, CompanyID::Invalid(), CompanyRemoveReason::None, ClientID::Invalid);
 
 	return true;
 }
@@ -1605,8 +1605,8 @@ static bool ConReloadAI(std::span<std::string_view> argv)
 	}
 
 	/* First kill the company of the AI, then start a new one. This should start the current AI again */
-	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, *company_id, CompanyRemoveReason::Manual, INVALID_CLIENT_ID);
-	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, *company_id, CompanyRemoveReason::None, INVALID_CLIENT_ID);
+	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, *company_id, CompanyRemoveReason::Manual, ClientID::Invalid);
+	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, *company_id, CompanyRemoveReason::None, ClientID::Invalid);
 	IConsolePrint(CC_DEFAULT, "AI reloaded.");
 
 	return true;
@@ -1649,7 +1649,7 @@ static bool ConStopAI(std::span<std::string_view> argv)
 	}
 
 	/* Now kill the company of the AI. */
-	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, *company_id, CompanyRemoveReason::Manual, INVALID_CLIENT_ID);
+	Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, *company_id, CompanyRemoveReason::Manual, ClientID::Invalid);
 	IConsolePrint(CC_DEFAULT, "AI stopped, company deleted.");
 
 	return true;
@@ -2050,7 +2050,7 @@ static bool ConSay(std::span<std::string_view> argv)
 		NetworkClientSendChat(NetworkAction::ChatBroadcast, NetworkChatDestinationType::Broadcast, 0 /* param does not matter */, argv[1]);
 	} else {
 		bool from_admin = (_redirect_console_to_admin < AdminID::Invalid());
-		NetworkServerSendChat(NetworkAction::ChatBroadcast, NetworkChatDestinationType::Broadcast, 0, argv[1], CLIENT_ID_SERVER, from_admin);
+		NetworkServerSendChat(NetworkAction::ChatBroadcast, NetworkChatDestinationType::Broadcast, 0, argv[1], ClientID::Server, from_admin);
 	}
 
 	return true;
@@ -2082,7 +2082,7 @@ static bool ConSayCompany(std::span<std::string_view> argv)
 		NetworkClientSendChat(NetworkAction::ChatTeam, NetworkChatDestinationType::Team, company_id->base(), argv[2]);
 	} else {
 		bool from_admin = (_redirect_console_to_admin < AdminID::Invalid());
-		NetworkServerSendChat(NetworkAction::ChatTeam, NetworkChatDestinationType::Team, company_id->base(), argv[2], CLIENT_ID_SERVER, from_admin);
+		NetworkServerSendChat(NetworkAction::ChatTeam, NetworkChatDestinationType::Team, company_id->base(), argv[2], ClientID::Server, from_admin);
 	}
 
 	return true;
@@ -2106,10 +2106,10 @@ static bool ConSayClient(std::span<std::string_view> argv)
 	}
 
 	if (!_network_server) {
-		NetworkClientSendChat(NetworkAction::ChatClient, NetworkChatDestinationType::Client, *client_id, argv[2]);
+		NetworkClientSendChat(NetworkAction::ChatClient, NetworkChatDestinationType::Client, to_underlying(*client_id), argv[2]);
 	} else {
 		bool from_admin = (_redirect_console_to_admin < AdminID::Invalid());
-		NetworkServerSendChat(NetworkAction::ChatClient, NetworkChatDestinationType::Client, *client_id, argv[2], CLIENT_ID_SERVER, from_admin);
+		NetworkServerSendChat(NetworkAction::ChatClient, NetworkChatDestinationType::Client, to_underlying(*client_id), argv[2], ClientID::Server, from_admin);
 	}
 
 	return true;

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -1107,7 +1107,7 @@ struct DepotWindow : Window {
 				this->SetDirty();
 
 				bool sell_cmd = (v->type == VehicleType::Train && (widget == WID_D_SELL_CHAIN || _ctrl_pressed));
-				Command<Commands::SellVehicle>::Post(GetCmdSellVehMsg(v->type), v->tile, v->index, sell_cmd, true, INVALID_CLIENT_ID);
+				Command<Commands::SellVehicle>::Post(GetCmdSellVehMsg(v->type), v->tile, v->index, sell_cmd, true, ClientID::Invalid);
 				break;
 			}
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -620,7 +620,7 @@ static void CompanyCheckBankrupt(Company *c)
 			 * player we are sure (the above check) that we are not the local
 			 * company and thus we won't be moved. */
 			if (!_networking || _network_server) {
-				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, c->index, CompanyRemoveReason::Bankrupt, INVALID_CLIENT_ID);
+				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, c->index, CompanyRemoveReason::Bankrupt, ClientID::Invalid);
 				return;
 			}
 			break;

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -410,7 +410,7 @@ struct MainWindow : Window
 
 			case GHK_CHAT_SERVER: // send text to the server
 				if (_networking && !_network_server) {
-					ShowNetworkChatQueryWindow(NetworkChatDestinationType::Client, CLIENT_ID_SERVER);
+					ShowNetworkChatQueryWindow(NetworkChatDestinationType::Client, to_underlying(ClientID::Server));
 				}
 				break;
 

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -524,7 +524,7 @@ protected:
 
 	NetworkGameSocketHandler(SOCKET s);
 public:
-	ClientID client_id = INVALID_CLIENT_ID; ///< Client identifier
+	ClientID client_id = ClientID::Invalid; ///< Client identifier
 	uint32_t last_frame = 0; ///< Last frame we have executed
 	uint32_t last_frame_server = 0; ///< Last frame the server has executed
 	CommandQueue incoming_queue; ///< The command-queue awaiting handling

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -865,7 +865,7 @@ static void NetworkInitServerClientInfo()
 {
 	/* There should be always space for the server. */
 	assert(NetworkClientInfo::CanAllocateItem());
-	NetworkClientInfo *ci = NetworkClientInfo::Create(CLIENT_ID_SERVER);
+	NetworkClientInfo *ci = NetworkClientInfo::Create(ClientID::Server);
 	ci->client_playas = COMPANY_SPECTATOR;
 
 	ci->client_name = _settings_client.network.client_name;
@@ -953,7 +953,7 @@ bool NetworkServerStart()
 	_frame_counter_server = 0;
 	_frame_counter_max = 0;
 	_last_sync_frame = 0;
-	_network_own_client_id = CLIENT_ID_SERVER;
+	_network_own_client_id = ClientID::Server;
 
 	_network_clients_connected = 0;
 
@@ -987,7 +987,7 @@ void NetworkOnGameStart()
 
 	if (!_network_dedicated) {
 		Company *c = Company::GetIfValid(GetFirstPlayableCompanyID());
-		NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
+		NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(ClientID::Server);
 		if (c != nullptr && ci != nullptr) {
 			ci->client_playas = c->index;
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -240,7 +240,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientJoin(ClientID clien
 {
 	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientJoin);
 
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 	this->SendPacket(std::move(p));
 
 	return NetworkRecvStatus::Okay;
@@ -259,7 +259,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientInfo(const NetworkC
 
 	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientInfo);
 
-	p->Send_uint32(ci->client_id);
+	p->Send_uint32(to_underlying(ci->client_id));
 	p->Send_string(cs == nullptr ? "" : const_cast<NetworkAddress &>(cs->client_address).GetHostname());
 	p->Send_string(ci->client_name);
 	p->Send_uint8 (0); // Used to be language
@@ -281,7 +281,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientUpdate(const Networ
 {
 	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientUpdate);
 
-	p->Send_uint32(ci->client_id);
+	p->Send_uint32(to_underlying(ci->client_id));
 	p->Send_string(ci->client_name);
 	p->Send_uint8 (ci->client_playas);
 
@@ -299,7 +299,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientQuit(ClientID clien
 {
 	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientQuit);
 
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 	this->SendPacket(std::move(p));
 
 	return NetworkRecvStatus::Okay;
@@ -315,7 +315,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendClientError(ClientID clie
 {
 	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerClientError);
 
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 	p->Send_uint8(to_underlying(error));
 	this->SendPacket(std::move(p));
 
@@ -473,7 +473,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendChat(NetworkAction action
 
 	p->Send_uint8(to_underlying(action));
 	p->Send_uint8(to_underlying(desttype));
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 	p->Send_string(msg);
 	p->Send_uint64(data);
 
@@ -646,7 +646,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdLogging(ClientID clien
 {
 	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerCommandLogging);
 
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 	p->Send_uint8 (cp.company);
 	p->Send_uint16(to_underlying(cp.cmd));
 	p->Send_buffer(cp.data);
@@ -732,15 +732,16 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminPoll(Packet &p)
 		case AdminUpdateType::ClientInfo:
 			/* The admin is requesting client info. */
 			if (d1 == UINT32_MAX) {
-				this->SendClientInfo(nullptr, NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER));
+				this->SendClientInfo(nullptr, NetworkClientInfo::GetByClientID(ClientID::Server));
 				for (const NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {
 					this->SendClientInfo(cs, cs->GetInfo());
 				}
 			} else {
-				if (d1 == CLIENT_ID_SERVER) {
-					this->SendClientInfo(nullptr, NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER));
+				ClientID client{d1};
+				if (client == ClientID::Server) {
+					this->SendClientInfo(nullptr, NetworkClientInfo::GetByClientID(ClientID::Server));
 				} else {
-					const NetworkClientSocket *cs = NetworkClientSocket::GetByClientID((ClientID)d1);
+					const NetworkClientSocket *cs = NetworkClientSocket::GetByClientID(client);
 					if (cs != nullptr) this->SendClientInfo(cs, cs->GetInfo());
 				}
 			}

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -22,7 +22,7 @@ extern NetworkClientInfoPool _networkclientinfo_pool;
 
 /** Container for all information known about a client. */
 struct NetworkClientInfo : NetworkClientInfoPool::PoolItem<&_networkclientinfo_pool> {
-	ClientID client_id = INVALID_CLIENT_ID; ///< Client identifier (same as ClientState->client_id)
+	ClientID client_id = ClientID::Invalid; ///< Client identifier (same as ClientState->client_id)
 	std::string client_name{}; ///< Name of the client
 	std::string public_key{}; ///< The public key of the client.
 	CompanyID client_playas = CompanyID::Invalid(); ///< As which company is this client playing (CompanyID)
@@ -33,7 +33,7 @@ struct NetworkClientInfo : NetworkClientInfoPool::PoolItem<&_networkclientinfo_p
 	 * @param index The index into the client info pool.
 	 * @param client_id The unique identifier of the client.
 	 */
-	NetworkClientInfo(ClientPoolID index, ClientID client_id = INVALID_CLIENT_ID) : NetworkClientInfoPool::PoolItem<&_networkclientinfo_pool>(index), client_id(client_id) {}
+	NetworkClientInfo(ClientPoolID index, ClientID client_id = ClientID::Invalid) : NetworkClientInfoPool::PoolItem<&_networkclientinfo_pool>(index), client_id(client_id) {}
 	~NetworkClientInfo();
 
 	static NetworkClientInfo *GetByClientID(ClientID client_id);

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -261,7 +261,7 @@ static void SendChat(std::string_view buf, NetworkChatDestinationType type, int 
 	if (!_network_server) {
 		MyClient::SendChat(action, type, dest, buf, 0);
 	} else {
-		NetworkServerSendChat(action, type, dest, buf, CLIENT_ID_SERVER);
+		NetworkServerSendChat(action, type, dest, buf, ClientID::Server);
 	}
 }
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1131,7 +1131,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerNewGame(Packet &)
 		/* To throttle the reconnects a bit, every clients waits its
 		 * Client ID modulo 16 + 1 (value 0 means no reconnect).
 		 * This way reconnects should be spread out a bit. */
-		_network_reconnect = _network_own_client_id % 16 + 1;
+		_network_reconnect = to_underlying(_network_own_client_id) % 16 + 1;
 		ShowErrorMessage(GetEncodedString(STR_NETWORK_MESSAGE_SERVER_REBOOT), {}, WarningLevel::Critical);
 	}
 
@@ -1161,12 +1161,12 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMove(Packet &p)
 	if (this->status < ServerStatus::Authorized) return NetworkRecvStatus::MalformedPacket;
 
 	/* Nothing more in this packet... */
-	ClientID client_id   = (ClientID)p.Recv_uint32();
-	CompanyID company_id = (CompanyID)p.Recv_uint8();
+	ClientID client_id{p.Recv_uint32()};
+	CompanyID company_id{p.Recv_uint8()};
 
 	Debug(net, 9, "Client::ReceiveServerMove(): client_id={}, company_id={}", client_id, company_id);
 
-	if (client_id == 0) {
+	if (client_id == ClientID::Invalid) {
 		/* definitely an invalid client id, debug message and do nothing. */
 		Debug(net, 1, "Received invalid client index = 0");
 		return NetworkRecvStatus::MalformedPacket;
@@ -1351,7 +1351,7 @@ void NetworkUpdateClientName(const std::string &client_name)
 		if (NetworkMakeClientNameUnique(temporary_name)) {
 			NetworkTextMessage(NetworkAction::ClientNameChange, CC_DEFAULT, false, ci->client_name, temporary_name);
 			ci->client_name = std::move(temporary_name);
-			NetworkUpdateClientInfo(CLIENT_ID_SERVER);
+			NetworkUpdateClientInfo(ClientID::Server);
 			InvalidateWindowData(WindowClass::NetworkClientList, 0);
 		}
 	}

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -56,7 +56,7 @@
 
 static void ShowNetworkStartServerWindow();
 
-static ClientID _admin_client_id = INVALID_CLIENT_ID; ///< For what client a confirmation window is open.
+static ClientID _admin_client_id = ClientID::Invalid; ///< For what client a confirmation window is open.
 static CompanyID _admin_company_id = CompanyID::Invalid(); ///< For what company a confirmation window is open.
 
 /**
@@ -1338,7 +1338,7 @@ static void AdminCompanyResetCallback(Window *, bool confirmed)
 {
 	if (confirmed) {
 		if (NetworkCompanyHasClients(_admin_company_id)) return;
-		Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, _admin_company_id, CompanyRemoveReason::Manual, INVALID_CLIENT_ID);
+		Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, _admin_company_id, CompanyRemoveReason::Manual, ClientID::Invalid);
 	}
 }
 
@@ -1558,7 +1558,7 @@ public:
 		SpriteID player_icon = 0;
 		if (ci->client_id == _network_own_client_id) {
 			player_icon = SPR_PLAYER_SELF;
-		} else if (ci->client_id == CLIENT_ID_SERVER) {
+		} else if (ci->client_id == ClientID::Server) {
 			player_icon = SPR_PLAYER_HOST;
 		}
 
@@ -1581,7 +1581,7 @@ public:
 			if (ci != nullptr) {
 				if (ci->client_id == _network_own_client_id) {
 					return GetEncodedString(STR_NETWORK_CLIENT_LIST_PLAYER_ICON_SELF_TOOLTIP);
-				} else if (ci->client_id == CLIENT_ID_SERVER) {
+				} else if (ci->client_id == ClientID::Server) {
 					return GetEncodedString(STR_NETWORK_CLIENT_LIST_PLAYER_ICON_HOST_TOOLTIP);
 				}
 			}
@@ -1638,7 +1638,7 @@ private:
 	static void OnClickCompanyJoin(NetworkClientListWindow *, Point, CompanyID company_id)
 	{
 		if (_network_server) {
-			NetworkServerDoMove(CLIENT_ID_SERVER, company_id);
+			NetworkServerDoMove(ClientID::Server, company_id);
 			MarkWholeScreenDirty();
 		} else {
 			NetworkClientRequestMove(company_id);
@@ -1706,7 +1706,7 @@ private:
 	 */
 	static void OnClickClientChat(NetworkClientListWindow *, Point, ClientID client_id)
 	{
-		ShowNetworkChatQueryWindow(NetworkChatDestinationType::Client, client_id);
+		ShowNetworkChatQueryWindow(NetworkChatDestinationType::Client, to_underlying(client_id));
 	}
 
 	/**

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -46,7 +46,7 @@
 
 DECLARE_INCREMENT_DECREMENT_OPERATORS(ClientID)
 /** The identifier counter for new clients (is never decreased) */
-static ClientID _network_client_id = CLIENT_ID_FIRST;
+static ClientID _network_client_id = ClientID::First;
 
 /** Make very sure the preconditions given in network_type.h are actually followed */
 static_assert(NetworkClientSocketPool::MAX_SIZE > MAX_CLIENTS);
@@ -210,7 +210,7 @@ ServerNetworkGameSocketHandler::~ServerNetworkGameSocketHandler()
 {
 	delete this->GetInfo();
 
-	if (_redirect_console_to_client == this->client_id) _redirect_console_to_client = INVALID_CLIENT_ID;
+	if (_redirect_console_to_client == this->client_id) _redirect_console_to_client = ClientID::Invalid;
 	OrderBackup::ResetUser(this->client_id);
 
 	if (this->savegame != nullptr) {
@@ -329,9 +329,9 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendClientInfo(NetworkClientIn
 {
 	Debug(net, 9, "client[{}] SendClientInfo(): client_id={}", this->client_id, ci->client_id);
 
-	if (ci->client_id != INVALID_CLIENT_ID) {
+	if (ci->client_id != ClientID::Invalid) {
 		auto p = std::make_unique<Packet>(this, PacketGameType::ServerClientInfo);
-		p->Send_uint32(ci->client_id);
+		p->Send_uint32(to_underlying(ci->client_id));
 		p->Send_uint8 (ci->client_playas);
 		p->Send_string(ci->client_name);
 		p->Send_string(ci->public_key);
@@ -504,7 +504,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendWelcome()
 	_network_game_info.clients_on++;
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerWelcome);
-	p->Send_uint32(this->client_id);
+	p->Send_uint32(to_underlying(this->client_id));
 	this->SendPacket(std::move(p));
 
 	/* Transmit info about all the active clients */
@@ -514,7 +514,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendWelcome()
 		}
 	}
 	/* Also send the info of the server */
-	return this->SendClientInfo(NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER));
+	return this->SendClientInfo(NetworkClientInfo::GetByClientID(ClientID::Server));
 }
 
 /**
@@ -636,7 +636,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendJoin(ClientID client_id)
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerClientJoined);
 
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 
 	this->SendPacket(std::move(p));
 	return NetworkRecvStatus::Okay;
@@ -724,7 +724,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendChat(NetworkAction action,
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerChat);
 
 	p->Send_uint8(to_underlying(action));
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 	p->Send_bool  (self_send);
 	p->Send_string(msg);
 	p->Send_uint64(data);
@@ -770,7 +770,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendErrorQuit(ClientID client_
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerErrorQuit);
 
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 	p->Send_uint8(to_underlying(errorno));
 
 	this->SendPacket(std::move(p));
@@ -788,7 +788,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendQuit(ClientID client_id)
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerQuit);
 
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 
 	this->SendPacket(std::move(p));
 	return NetworkRecvStatus::Okay;
@@ -850,7 +850,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMove(ClientID client_id, C
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerMove);
 
-	p->Send_uint32(client_id);
+	p->Send_uint32(to_underlying(client_id));
 	p->Send_uint8(company_id);
 	this->SendPacket(std::move(p));
 	return NetworkRecvStatus::Okay;
@@ -1131,12 +1131,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientCommand(Packet &p
 		return this->SendError(NetworkErrorCode::NotExpected);
 	}
 
-	if (GetCommandFlags(cp.cmd).Test(CommandFlag::Server) && ci->client_id != CLIENT_ID_SERVER) {
+	if (GetCommandFlags(cp.cmd).Test(CommandFlag::Server) && ci->client_id != ClientID::Server) {
 		IConsolePrint(CC_WARNING, "Kicking client #{} (IP: {}) due to calling a server only command {}.", ci->client_id, this->GetClientIP(), cp.cmd);
 		return this->SendError(NetworkErrorCode::Kicked);
 	}
 
-	if (!GetCommandFlags(cp.cmd).Test(CommandFlag::Spectator) && !Company::IsValidID(cp.company) && ci->client_id != CLIENT_ID_SERVER) {
+	if (!GetCommandFlags(cp.cmd).Test(CommandFlag::Spectator) && !Company::IsValidID(cp.company) && ci->client_id != ClientID::Server) {
 		IConsolePrint(CC_WARNING, "Kicking client #{} (IP: {}) due to calling a non-spectator command {}.", ci->client_id, this->GetClientIP(), cp.cmd);
 		return this->SendError(NetworkErrorCode::Kicked);
 	}
@@ -1160,14 +1160,14 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientCommand(Packet &p
 
 		/* Check if we are full - else it's possible for spectators to send a Commands::CompanyControl and the company is created regardless of max_companies! */
 		if (Company::GetNumItems() >= _settings_client.network.max_companies) {
-			NetworkServerSendChat(NetworkAction::ServerMessage, NetworkChatDestinationType::Client, ci->client_id, "cannot create new company, server full", CLIENT_ID_SERVER);
+			NetworkServerSendChat(NetworkAction::ServerMessage, NetworkChatDestinationType::Client, to_underlying(ci->client_id), "cannot create new company, server full", ClientID::Server);
 			return NetworkRecvStatus::Okay;
 		}
 	}
 
 	if (cp.cmd == Commands::CompanyAllowListControl) {
 		/* Maybe the client just got moved before allowing? */
-		if (ci->client_id != CLIENT_ID_SERVER && ci->client_playas != cp.company) return NetworkRecvStatus::Okay;
+		if (ci->client_id != ClientID::Server && ci->client_playas != cp.company) return NetworkRecvStatus::Okay;
 
 		/* Only allow clients to add/remove currently joined clients. The server owner does not go via this method, so is allowed to do more. */
 		std::string public_key = std::get<1>(EndianBufferReader::ToValue<CommandTraits<Commands::CompanyAllowListControl>::Args>(cp.data));
@@ -1312,7 +1312,7 @@ void NetworkServerSendChat(NetworkAction action, NetworkChatDestinationType dest
 	switch (desttype) {
 		case NetworkChatDestinationType::Client:
 			/* Are we sending to the server? */
-			if ((ClientID)dest == CLIENT_ID_SERVER) {
+			if ((ClientID)dest == ClientID::Server) {
 				ci = NetworkClientInfo::GetByClientID(from_id);
 				/* Display the text locally, and that is it */
 				if (ci != nullptr) {
@@ -1334,7 +1334,7 @@ void NetworkServerSendChat(NetworkAction action, NetworkChatDestinationType dest
 
 			/* Display the message locally (so you know you have sent it) */
 			if (from_id != (ClientID)dest) {
-				if (from_id == CLIENT_ID_SERVER) {
+				if (from_id == ClientID::Server) {
 					ci = NetworkClientInfo::GetByClientID(from_id);
 					ci_to = NetworkClientInfo::GetByClientID((ClientID)dest);
 					if (ci != nullptr && ci_to != nullptr) {
@@ -1370,10 +1370,10 @@ void NetworkServerSendChat(NetworkAction action, NetworkChatDestinationType dest
 			}
 
 			ci = NetworkClientInfo::GetByClientID(from_id);
-			ci_own = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
+			ci_own = NetworkClientInfo::GetByClientID(ClientID::Server);
 			if (ci != nullptr && ci_own != nullptr && ci_own->client_playas == dest) {
 				NetworkTextMessage(action, GetDrawStringCompanyColour(ci->client_playas), false, ci->client_name, msg, data);
-				if (from_id == CLIENT_ID_SERVER) show_local = false;
+				if (from_id == ClientID::Server) show_local = false;
 				ci_to = ci_own;
 			}
 
@@ -1382,7 +1382,7 @@ void NetworkServerSendChat(NetworkAction action, NetworkChatDestinationType dest
 
 			/* Display the message locally (so you know you have sent it) */
 			if (ci != nullptr && show_local) {
-				if (from_id == CLIENT_ID_SERVER) {
+				if (from_id == ClientID::Server) {
 					StringID str = Company::IsValidID(ci_to->client_playas) ? STR_COMPANY_NAME : STR_NETWORK_SPECTATORS;
 					std::string name = GetString(str, ci_to->client_playas);
 					NetworkTextMessage(action, GetDrawStringCompanyColour(ci_own->client_playas), true, name, msg, data);
@@ -1517,7 +1517,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientRemoteConsoleComm
 
 	_redirect_console_to_client = this->client_id;
 	IConsoleCmdExec(command);
-	_redirect_console_to_client = INVALID_CLIENT_ID;
+	_redirect_console_to_client = ClientID::Invalid;
 	return NetworkRecvStatus::Okay;
 }
 
@@ -1622,7 +1622,7 @@ static void NetworkAutoCleanCompanies()
 	}
 
 	if (!_network_dedicated) {
-		const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
+		const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(ClientID::Server);
 		assert(ci != nullptr);
 		if (Company::IsValidID(ci->client_playas)) has_clients.Set(ci->client_playas);
 	}
@@ -1645,13 +1645,13 @@ static void NetworkAutoCleanCompanies()
 			/* Is the company empty for autoclean_protected-months? */
 			if (_settings_client.network.autoclean_protected != 0 && c->months_empty > _settings_client.network.autoclean_protected) {
 				/* Shut the company down */
-				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, c->index, CompanyRemoveReason::Autoclean, INVALID_CLIENT_ID);
+				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, c->index, CompanyRemoveReason::Autoclean, ClientID::Invalid);
 				IConsolePrint(CC_INFO, "Auto-cleaned company #{}.", c->index + 1);
 			}
 			/* Is the company empty for autoclean_novehicles-months, and has no vehicles? */
 			if (_settings_client.network.autoclean_novehicles != 0 && c->months_empty > _settings_client.network.autoclean_novehicles && !has_vehicles.Test(c->index)) {
 				/* Shut the company down */
-				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, c->index, CompanyRemoveReason::Autoclean, INVALID_CLIENT_ID);
+				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, c->index, CompanyRemoveReason::Autoclean, ClientID::Invalid);
 				IConsolePrint(CC_INFO, "Auto-cleaned company #{} with no vehicles.", c->index + 1);
 			}
 		} else {
@@ -1681,7 +1681,7 @@ bool NetworkMakeClientNameUnique(std::string &name)
 			}
 		}
 		/* Check if it is the same as the server-name */
-		const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
+		const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(ClientID::Server);
 		if (ci != nullptr) {
 			if (ci->client_name == name) is_name_unique = false; // name already in use
 		}
@@ -2035,7 +2035,7 @@ void NetworkServerUpdateGameInfo()
 void NetworkServerDoMove(ClientID client_id, CompanyID company_id)
 {
 	/* Only allow non-dedicated servers and normal clients to be moved */
-	if (client_id == CLIENT_ID_SERVER && _network_dedicated) return;
+	if (client_id == ClientID::Server && _network_dedicated) return;
 
 	NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
 	assert(ci != nullptr);
@@ -2045,7 +2045,7 @@ void NetworkServerDoMove(ClientID client_id, CompanyID company_id)
 
 	ci->client_playas = company_id;
 
-	if (client_id == CLIENT_ID_SERVER) {
+	if (client_id == ClientID::Server) {
 		SetLocalCompany(company_id);
 	} else {
 		NetworkClientSocket *cs = NetworkClientSocket::GetByClientID(client_id);
@@ -2087,7 +2087,7 @@ void NetworkServerSendRcon(ClientID client_id, ExtendedTextColour colour_code, s
  */
 void NetworkServerKickClient(ClientID client_id, std::string_view reason)
 {
-	if (client_id == CLIENT_ID_SERVER) return;
+	if (client_id == ClientID::Server) return;
 	NetworkClientSocket::GetByClientID(client_id)->SendError(NetworkErrorCode::Kicked, reason);
 }
 
@@ -2132,7 +2132,7 @@ uint NetworkServerKickOrBanIP(std::string_view ip, bool ban, std::string_view re
 	 * and writing to after returning. So we would read or write data from freed memory up till
 	 * the segfault triggers. */
 	for (NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {
-		if (cs->client_id == CLIENT_ID_SERVER) continue;
+		if (cs->client_id == ClientID::Server) continue;
 		if (cs->client_id == _redirect_console_to_client) continue;
 		if (cs->client_address.IsInNetmask(ip)) {
 			NetworkServerKickClient(cs->client_id, reason);
@@ -2180,7 +2180,7 @@ void NetworkPrintClients()
 					ci->client_id,
 					ci->client_name,
 					ci->client_playas + (Company::IsValidID(ci->client_playas) ? 1 : 0),
-					ci->client_id == CLIENT_ID_SERVER ? "server" : NetworkClientSocket::GetByClientID(ci->client_id)->GetClientIP());
+					ci->client_id == ClientID::Server ? "server" : NetworkClientSocket::GetByClientID(ci->client_id)->GetClientIP());
 		} else {
 			IConsolePrint(CC_INFO, "Client #{}  name: '{}'  company: {}",
 					ci->client_id,

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -40,10 +40,10 @@ enum class ServerGameType : uint8_t {
 };
 
 /** 'Unique' identifier to be given to clients */
-enum ClientID : uint32_t {
-	INVALID_CLIENT_ID = 0, ///< Client is not part of anything
-	CLIENT_ID_SERVER  = 1, ///< Servers always have this ID
-	CLIENT_ID_FIRST   = 2, ///< The first client ID
+enum class ClientID : uint32_t {
+	Invalid = 0, ///< Client is not part of anything
+	Server = 1, ///< Servers always have this ID
+	First = 2, ///< The first client ID
 };
 
 /** Indices into the client related pools */

--- a/src/order_backup.cpp
+++ b/src/order_backup.cpp
@@ -175,11 +175,11 @@ CommandCost CmdClearOrderBackup(DoCommandFlags flags, TileIndex tile, ClientID u
  */
 /* static */ void OrderBackup::Reset(TileIndex t, bool from_gui)
 {
-	/* The user has CLIENT_ID_SERVER as default when network play is not active,
+	/* The user has ClientID::Server as default when network play is not active,
 	 * but compiled it. A network client has its own variable for the unique
 	 * client/user identifier. Finally if networking isn't compiled in the
 	 * default is just plain and simple: 0. */
-	ClientID user = _networking && !_network_server ? _network_own_client_id : CLIENT_ID_SERVER;
+	ClientID user = _networking && !_network_server ? _network_own_client_id : ClientID::Server;
 
 	for (OrderBackup *ob : OrderBackup::Iterate()) {
 		/* If this is a GUI action, and it's not a backup of us, ignore it. */

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -20,7 +20,7 @@
 /** Unique identifier for an order backup. */
 using OrderBackupID = PoolID<uint8_t, struct OrderBackupIDTag, 255, 0xFF>;
 struct OrderBackup;
-enum ClientID : uint32_t;
+enum class ClientID : uint32_t;
 
 /** The pool type for order backups. */
 using OrderBackupPool = Pool<OrderBackup, OrderBackupID, 1>;

--- a/src/script/api/script_clientlist.cpp
+++ b/src/script/api/script_clientlist.cpp
@@ -19,7 +19,7 @@ ScriptClientList::ScriptClientList()
 {
 	if (!_networking) return;
 	for (const NetworkClientInfo *ci : NetworkClientInfo::Iterate()) {
-		this->AddItem(ci->client_id);
+		this->AddItem(to_underlying(ci->client_id));
 	}
 }
 
@@ -36,6 +36,6 @@ ScriptClientList_Company::ScriptClientList_Company(ScriptCompany::CompanyID comp
 	}
 
 	for (const NetworkClientInfo *ci : NetworkClientInfo::Iterate()) {
-		if (ci->client_playas == c) this->AddItem(ci->client_id);
+		if (ci->client_playas == c) this->AddItem(to_underlying(ci->client_id));
 	}
 }

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -388,7 +388,7 @@ namespace ScriptObjectInternal {
 	static inline void SetClientIdHelper(T &data)
 	{
 		if constexpr (std::is_same_v<ClientID, T>) {
-			if (data == INVALID_CLIENT_ID) data = (ClientID)UINT32_MAX;
+			if (data == ClientID::Invalid) data = static_cast<ClientID>(UINT32_MAX);
 		}
 	}
 

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -82,7 +82,7 @@
 
 	EnforcePreconditionCustomError(VEHICLE_INVALID, !ScriptGameSettings::IsDisabledVehicleType((ScriptVehicle::VehicleType)type), ScriptVehicle::ERR_VEHICLE_BUILD_DISABLED);
 
-	if (!ScriptObject::Command<Commands::BuildVehicle>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, engine_id, true, cargo, INVALID_CLIENT_ID)) return VEHICLE_INVALID;
+	if (!ScriptObject::Command<Commands::BuildVehicle>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, engine_id, true, cargo, ClientID::Invalid)) return VEHICLE_INVALID;
 
 	/* In case of test-mode, we return VehicleID 0 */
 	return VehicleID::Begin();
@@ -104,7 +104,7 @@
 	if (!ScriptEngine::IsBuildable(engine_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
 
-	auto [res, veh_id, refit_capacity, refit_mail, cargo_capacities] = ::Command<Commands::BuildVehicle>::Do(DoCommandFlag::QueryCost, depot, engine_id, true, cargo, INVALID_CLIENT_ID);
+	auto [res, veh_id, refit_capacity, refit_mail, cargo_capacities] = ::Command<Commands::BuildVehicle>::Do(DoCommandFlag::QueryCost, depot, engine_id, true, cargo, ClientID::Invalid);
 	return res.Succeeded() ? refit_capacity : -1;
 }
 
@@ -172,7 +172,7 @@
 	EnforcePrecondition(false, IsValidVehicle(vehicle_id));
 
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
-	return ScriptObject::Command<Commands::SellVehicle>::Do(vehicle_id, v->type == ::VehicleType::Train, false, INVALID_CLIENT_ID);
+	return ScriptObject::Command<Commands::SellVehicle>::Do(vehicle_id, v->type == ::VehicleType::Train, false, ClientID::Invalid);
 }
 
 /* static */ bool ScriptVehicle::_SellWagonInternal(VehicleID vehicle_id, SQInteger wagon, bool sell_attached_wagons)
@@ -184,7 +184,7 @@
 	const Train *v = ::Train::Get(vehicle_id);
 	while (wagon-- > 0) v = v->GetNextUnit();
 
-	return ScriptObject::Command<Commands::SellVehicle>::Do(v->index, sell_attached_wagons, false, INVALID_CLIENT_ID);
+	return ScriptObject::Command<Commands::SellVehicle>::Do(v->index, sell_attached_wagons, false, ClientID::Invalid);
 }
 
 /* static */ bool ScriptVehicle::SellWagon(VehicleID vehicle_id, SQInteger wagon)

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -1017,8 +1017,8 @@ struct ScriptDebugWindow : public Window {
 			case WID_SCRD_RELOAD_TOGGLE:
 				if (this->filter.script_debug_company == OWNER_DEITY) break;
 				/* First kill the company of the AI, then start a new one. This should start the current AI again */
-				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, this->filter.script_debug_company, CompanyRemoveReason::Manual, INVALID_CLIENT_ID);
-				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, this->filter.script_debug_company, CompanyRemoveReason::None, INVALID_CLIENT_ID);
+				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::Delete, this->filter.script_debug_company, CompanyRemoveReason::Manual, ClientID::Invalid);
+				Command<Commands::CompanyControl>::Post(CompanyCtrlAction::NewAI, this->filter.script_debug_company, CompanyRemoveReason::None, ClientID::Invalid);
 				break;
 
 			case WID_SCRD_SETTINGS:

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -604,7 +604,7 @@ static CallBackFunction MenuClickCompany(int index)
 
 			case CTMN_SPECTATE:
 				if (_network_server) {
-					NetworkServerDoMove(CLIENT_ID_SERVER, COMPANY_SPECTATOR);
+					NetworkServerDoMove(ClientID::Server, COMPANY_SPECTATOR);
 					MarkWholeScreenDirty();
 				} else {
 					NetworkClientRequestMove(COMPANY_SPECTATOR);

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -225,7 +225,7 @@ std::tuple<CommandCost, VehicleID, uint, uint16_t, CargoArray> CmdBuildVehicle(D
 
 		/* If we are not in DoCommandFlag::Execute undo everything */
 		if (flags != subflags) {
-			Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, v->index, false, false, INVALID_CLIENT_ID);
+			Command<Commands::SellVehicle>::Do(DoCommandFlag::Execute, v->index, false, false, ClientID::Invalid);
 		}
 	}
 
@@ -719,7 +719,7 @@ CommandCost CmdDepotSellAllVehicles(DoCommandFlags flags, TileIndex tile, Vehicl
 	CommandCost last_error = CMD_ERROR;
 	bool had_success = false;
 	for (const Vehicle *v : list) {
-		CommandCost ret = Command<Commands::SellVehicle>::Do(flags, v->index, true, false, INVALID_CLIENT_ID);
+		CommandCost ret = Command<Commands::SellVehicle>::Do(flags, v->index, true, false, ClientID::Invalid);
 		if (ret.Succeeded()) {
 			cost.AddCost(ret.GetCost());
 			had_success = true;
@@ -890,11 +890,11 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlags flags, TileInd
 		if (flags.Test(DoCommandFlag::Execute) && !v->IsPrimaryVehicle()) build_flags.Set(DoCommandFlag::AutoReplace);
 
 		CommandCost cost;
-		std::tie(cost, new_veh_id, std::ignore, std::ignore, std::ignore) = Command<Commands::BuildVehicle>::Do(build_flags, tile, v->engine_type, false, INVALID_CARGO, INVALID_CLIENT_ID);
+		std::tie(cost, new_veh_id, std::ignore, std::ignore, std::ignore) = Command<Commands::BuildVehicle>::Do(build_flags, tile, v->engine_type, false, INVALID_CARGO, ClientID::Invalid);
 
 		if (cost.Failed()) {
 			/* Can't build a part, then sell the stuff we already made; clear up the mess */
-			if (w_front != nullptr) Command<Commands::SellVehicle>::Do(flags, w_front->index, true, false, INVALID_CLIENT_ID);
+			if (w_front != nullptr) Command<Commands::SellVehicle>::Do(flags, w_front->index, true, false, ClientID::Invalid);
 			return { cost, VehicleID::Invalid() };
 		}
 
@@ -918,8 +918,8 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlags flags, TileInd
 				if (result.Failed()) {
 					/* The train can't be joined to make the same consist as the original.
 					 * Sell what we already made (clean up) and return an error.           */
-					Command<Commands::SellVehicle>::Do(flags, w_front->index, true, false, INVALID_CLIENT_ID);
-					Command<Commands::SellVehicle>::Do(flags, w->index,       true, false, INVALID_CLIENT_ID);
+					Command<Commands::SellVehicle>::Do(flags, w_front->index, true, false, ClientID::Invalid);
+					Command<Commands::SellVehicle>::Do(flags, w->index, true, false, ClientID::Invalid);
 					return { result, VehicleID::Invalid() }; // return error and the message returned from Commands::MoveRailVehicle
 				}
 			} else {
@@ -1000,7 +1000,7 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlags flags, TileInd
 		CommandCost result = Command<Commands::CloneOrder>::Do(flags, (share_orders ? CO_SHARE : CO_COPY), w_front->index, v_front->index);
 		if (result.Failed()) {
 			/* The vehicle has already been bought, so now it must be sold again. */
-			Command<Commands::SellVehicle>::Do(flags, w_front->index, true, false, INVALID_CLIENT_ID);
+			Command<Commands::SellVehicle>::Do(flags, w_front->index, true, false, ClientID::Invalid);
 			return { result, VehicleID::Invalid() };
 		}
 
@@ -1011,7 +1011,7 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlags flags, TileInd
 		 * check whether the company has enough money manually. */
 		if (!CheckCompanyHasMoney(total_cost)) {
 			/* The vehicle has already been bought, so now it must be sold again. */
-			Command<Commands::SellVehicle>::Do(flags, w_front->index, true, false, INVALID_CLIENT_ID);
+			Command<Commands::SellVehicle>::Do(flags, w_front->index, true, false, ClientID::Invalid);
 			return { total_cost, VehicleID::Invalid() };
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

Proving someone's assumptions ;)


## Description

Make `ClientID` a scoped enum.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
