### PR TITLE
Change: upgrade emscripten from 3.1.57 to 6.0.1

### DIFF
--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -14,7 +14,7 @@ jobs:
     container:
       # If you change this version, change the numbers in the cache step,
       # .github/workflows/preview-build.yml (2x) and os/emscripten/Dockerfile too.
-      image: emscripten/emsdk:3.1.57
+      image: emscripten/emsdk:5.0.7
 
     steps:
     - name: Checkout
@@ -24,20 +24,13 @@ jobs:
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
-    - name: Update to modern GCC
-      run: |
-        apt-get update
-        apt-get install -y gcc-12 g++-12
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
-        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
-
     - name: Setup cache
       uses: actions/cache@v5
       with:
         # If you change this version, change the numbers in the image configuration step,
         # .github/workflows/preview-build.yml (2x) and os/emscripten/Dockerfile too.
         path: /emsdk/upstream/emscripten/cache
-        key: 3.1.57-${{ runner.os }}
+        key: 5.0.7-${{ runner.os }}
 
     - name: Add liblzma support
       run: |

--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -14,7 +14,7 @@ jobs:
     container:
       # If you change this version, change the numbers in the cache step,
       # .github/workflows/preview-build.yml (2x) and os/emscripten/Dockerfile too.
-      image: emscripten/emsdk:5.0.7
+      image: emscripten/emsdk:6.0.1
 
     steps:
     - name: Checkout
@@ -30,7 +30,7 @@ jobs:
         # If you change this version, change the numbers in the image configuration step,
         # .github/workflows/preview-build.yml (2x) and os/emscripten/Dockerfile too.
         path: /emsdk/upstream/emscripten/cache
-        key: 5.0.7-${{ runner.os }}
+        key: 6.0.1-${{ runner.os }}
 
     - name: Add liblzma support
       run: |

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       # If you change this version, change the numbers in the cache step,
       # .github/workflows/ci-emscripten.yml (2x) and os/emscripten/Dockerfile too.
-      image: emscripten/emsdk:5.0.7
+      image: emscripten/emsdk:6.0.1
 
     steps:
     - name: Checkout
@@ -30,7 +30,7 @@ jobs:
         path: /emsdk/upstream/emscripten/cache
         # If you change this version, change the numbers in the image configuration step,
         # .github/workflows/ci-emscripten.yml (2x) and os/emscripten/Dockerfile too.
-        key: 5.0.7-${{ runner.os }}
+        key: 6.0.1-${{ runner.os }}
 
     - name: Add liblzma support
       run: |

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       # If you change this version, change the numbers in the cache step,
       # .github/workflows/ci-emscripten.yml (2x) and os/emscripten/Dockerfile too.
-      image: emscripten/emsdk:3.1.57
+      image: emscripten/emsdk:5.0.7
 
     steps:
     - name: Checkout
@@ -24,20 +24,13 @@ jobs:
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
         git checkout -b pr${{ github.event.pull_request.number }}
 
-    - name: Update to modern GCC
-      run: |
-        apt-get update
-        apt-get install -y gcc-12 g++-12
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
-        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
-
     - name: Setup cache
       uses: actions/cache@v5
       with:
         path: /emsdk/upstream/emscripten/cache
         # If you change this version, change the numbers in the image configuration step,
         # .github/workflows/ci-emscripten.yml (2x) and os/emscripten/Dockerfile too.
-        key: 3.1.57-${{ runner.os }}
+        key: 5.0.7-${{ runner.os }}
 
     - name: Add liblzma support
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,7 @@ if(EMSCRIPTEN)
     add_definitions(-s DISABLE_EXCEPTION_CATCHING=0)
 
     # Export functions to Javascript.
-    target_link_libraries(WASM::WASM INTERFACE "-s EXPORTED_FUNCTIONS='[\"_main\", \"_em_openttd_add_server\"]' -s EXPORTED_RUNTIME_METHODS='[\"cwrap\"]'")
+    target_link_libraries(WASM::WASM INTERFACE "-s EXPORTED_FUNCTIONS='[\"_main\", \"_em_openttd_add_server\"]' -s EXPORTED_RUNTIME_METHODS='[\"cwrap\", \"HEAPU8\"]'")
 
     # Preload all the files we generate during build.
     # As we do not compile with FreeType / FontConfig, we also have no way to

--- a/os/emscripten/Dockerfile
+++ b/os/emscripten/Dockerfile
@@ -1,11 +1,8 @@
 # If you change this version, change the numbers in .github/workflows/ci-emscripten.yml (2x)
 # and .github/workflows/preview-build.yml (2x) too.
-FROM emscripten/emsdk:3.1.57
+FROM emscripten/emsdk:5.0.7
 
 RUN apt-get update \
-    && apt-get install -y gcc-12 g++-12 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/os/emscripten/Dockerfile
+++ b/os/emscripten/Dockerfile
@@ -1,6 +1,6 @@
 # If you change this version, change the numbers in .github/workflows/ci-emscripten.yml (2x)
 # and .github/workflows/preview-build.yml (2x) too.
-FROM emscripten/emsdk:5.0.7
+FROM emscripten/emsdk:6.0.1
 
 RUN apt-get update \
     && apt-get clean \


### PR DESCRIPTION
## Motivation / Problem

We're using a 2+ year old version of emscripten, and manually installing a gcc version.

Next to this, the current version does not support SDL3.


## Description

* Update the emscripten version.
* Remove the gcc update code, as the new version comes with gcc 13.3.0.
* Explicitly export `HEAPU8` as that's not exported automagically any more, but used.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
