### PR TITLE
Codechange: make PerformanceElement scoped

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -81,7 +81,7 @@
 
 	for (const Company *c : Company::Iterate()) {
 		if (c->is_ai) {
-			PerformanceMeasurer framerate((PerformanceElement)(PFE_AI0 + c->index));
+			PerformanceMeasurer framerate(static_cast<PerformanceElement>(PerformanceElement::AI0 + c->index));
 			AutoRestoreBackup cur_company(_current_company, c->index);
 			c->ai_instance->GameLoop();
 			/* Occasionally collect garbage; every 255 ticks do one company.
@@ -90,7 +90,7 @@
 				c->ai_instance->CollectGarbage();
 			}
 		} else {
-			PerformanceMeasurer::SetInactive((PerformanceElement)(PFE_AI0 + c->index));
+			PerformanceMeasurer::SetInactive(static_cast<PerformanceElement>(PerformanceElement::AI0 + c->index));
 		}
 	}
 }
@@ -103,7 +103,7 @@
 /* static */ void AI::Stop(CompanyID company)
 {
 	if (_networking && !_network_server) return;
-	PerformanceMeasurer::SetInactive((PerformanceElement)(PFE_AI0 + company));
+	PerformanceMeasurer::SetInactive(static_cast<PerformanceElement>(PerformanceElement::AI0 + company));
 
 	AutoRestoreBackup cur_company(_current_company, company);
 	Company *c = Company::Get(company);

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -69,6 +69,16 @@
 	return;
 }
 
+/**
+ * Get the \c PerformanceElement for the AI of the given company.
+ * @param company The company to get the PerformanceElement for.
+ * @return The \c PerformanceElement.
+ */
+static constexpr PerformanceElement GetAIPerformanceElement(CompanyID company)
+{
+	return static_cast<PerformanceElement>(PerformanceElement::AI0 + company);
+}
+
 /* static */ void AI::GameLoop()
 {
 	/* If we are in networking, only servers run this function, and that only if it is allowed */
@@ -81,7 +91,7 @@
 
 	for (const Company *c : Company::Iterate()) {
 		if (c->is_ai) {
-			PerformanceMeasurer framerate(static_cast<PerformanceElement>(PerformanceElement::AI0 + c->index));
+			PerformanceMeasurer framerate(GetAIPerformanceElement(c->index));
 			AutoRestoreBackup cur_company(_current_company, c->index);
 			c->ai_instance->GameLoop();
 			/* Occasionally collect garbage; every 255 ticks do one company.
@@ -90,7 +100,7 @@
 				c->ai_instance->CollectGarbage();
 			}
 		} else {
-			PerformanceMeasurer::SetInactive(static_cast<PerformanceElement>(PerformanceElement::AI0 + c->index));
+			PerformanceMeasurer::SetInactive(GetAIPerformanceElement(c->index));
 		}
 	}
 }
@@ -103,7 +113,7 @@
 /* static */ void AI::Stop(CompanyID company)
 {
 	if (_networking && !_network_server) return;
-	PerformanceMeasurer::SetInactive(static_cast<PerformanceElement>(PerformanceElement::AI0 + company));
+	PerformanceMeasurer::SetInactive(GetAIPerformanceElement(company));
 
 	AutoRestoreBackup cur_company(_current_company, company);
 	Company *c = Company::Get(company);

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -2141,7 +2141,7 @@ bool Aircraft::Tick()
 {
 	if (!this->IsNormalAircraft()) return true;
 
-	PerformanceAccumulator framerate(PFE_GL_AIRCRAFT);
+	PerformanceAccumulator framerate(PerformanceElement::GameLoopAircraft);
 
 	this->tick_counter++;
 

--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -74,7 +74,7 @@ void AddAnimatedTile(TileIndex tile, bool mark_dirty)
  */
 void AnimateAnimatedTiles()
 {
-	PerformanceAccumulator landscape_framerate(PFE_GL_LANDSCAPE);
+	PerformanceAccumulator landscape_framerate(PerformanceElement::GameLoopLandscape);
 
 	for (auto it = std::begin(_animated_tiles); it != std::end(_animated_tiles); /* nothing */) {
 		TileIndex &tile = *it;

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -214,22 +214,22 @@ namespace {
 	 * Elements are initialized with the expected rate in recorded values per second.
 	 * @hideinitializer
 	 */
-	PerformanceData _pf_data[PFE_MAX] = {
-		PerformanceData(GL_RATE),               // PFE_GAMELOOP
-		PerformanceData(1),                     // PFE_ACC_GL_ECONOMY
-		PerformanceData(1),                     // PFE_ACC_GL_TRAINS
-		PerformanceData(1),                     // PFE_ACC_GL_ROADVEHS
-		PerformanceData(1),                     // PFE_ACC_GL_SHIPS
-		PerformanceData(1),                     // PFE_ACC_GL_AIRCRAFT
-		PerformanceData(1),                     // PFE_GL_LANDSCAPE
-		PerformanceData(1),                     // PFE_GL_LINKGRAPH
-		PerformanceData(1000.0 / 30),           // PFE_DRAWING
-		PerformanceData(1),                     // PFE_ACC_DRAWWORLD
-		PerformanceData(60.0),                  // PFE_VIDEO
-		PerformanceData(1000.0 * 8192 / 44100), // PFE_SOUND
-		PerformanceData(1),                     // PFE_ALLSCRIPTS
-		PerformanceData(1),                     // PFE_GAMESCRIPT
-		PerformanceData(1),                     // PFE_AI0 ...
+	static EnumIndexArray<PerformanceData, PerformanceElement, PerformanceElement::End> _pf_data = {
+		PerformanceData(GL_RATE), // PerformanceElement::GameLoop
+		PerformanceData(1), // PerformanceElement::GameLoopEconomy
+		PerformanceData(1), // PerformanceElement::GameLoopTrains
+		PerformanceData(1), // PerformanceElement::GameLoopRoadVehicles
+		PerformanceData(1), // PerformanceElement::GameLoopShips
+		PerformanceData(1), // PerformanceElement::GameLoopAircraft
+		PerformanceData(1), // PerformanceElement::GameLoopLandscape
+		PerformanceData(1), // PerformanceElement::GameLoopLinkGraph
+		PerformanceData(1000.0 / 30), // PerformanceElement::Drawing
+		PerformanceData(1), // PerformanceElement::ViewportDrawing
+		PerformanceData(60.0), // PerformanceElement::Video
+		PerformanceData(1000.0 * 8192 / 44100), // PerformanceElement::Sound
+		PerformanceData(1), // PerformanceElement::AllScripts
+		PerformanceData(1), // PerformanceElement::GameScript
+		PerformanceData(1), // PerformanceElement::AI0 ...
 		PerformanceData(1),
 		PerformanceData(1),
 		PerformanceData(1),
@@ -243,7 +243,7 @@ namespace {
 		PerformanceData(1),
 		PerformanceData(1),
 		PerformanceData(1),
-		PerformanceData(1),                     // PFE_AI14
+		PerformanceData(1), // PerformanceElement::AI14
 	};
 
 }
@@ -268,7 +268,7 @@ static TimingMeasurement GetPerformanceTimer()
  */
 PerformanceMeasurer::PerformanceMeasurer(PerformanceElement elem)
 {
-	assert(elem < PFE_MAX);
+	assert(elem < PerformanceElement::End);
 
 	this->elem = elem;
 	this->start_time = GetPerformanceTimer();
@@ -277,17 +277,17 @@ PerformanceMeasurer::PerformanceMeasurer(PerformanceElement elem)
 /** Finish a cycle of a measured element and store the measurement taken. */
 PerformanceMeasurer::~PerformanceMeasurer()
 {
-	if (this->elem == PFE_ALLSCRIPTS) {
+	if (this->elem == PerformanceElement::AllScripts) {
 		/* Hack to not record scripts total when no scripts are active */
-		bool any_active = _pf_data[PFE_GAMESCRIPT].num_valid > 0;
-		for (PerformanceElement e : EnumRange(PFE_AI0, PFE_MAX)) any_active |= _pf_data[e].num_valid > 0;
+		bool any_active = _pf_data[PerformanceElement::GameScript].num_valid > 0;
+		for (PerformanceElement e : EnumRange(PerformanceElement::AI0, PerformanceElement::End)) any_active |= _pf_data[e].num_valid > 0;
 		if (!any_active) {
-			PerformanceMeasurer::SetInactive(PFE_ALLSCRIPTS);
+			PerformanceMeasurer::SetInactive(PerformanceElement::AllScripts);
 			return;
 		}
 	}
-	if (this->elem == PFE_SOUND) {
-		/* PFE_SOUND measurements are made from the mixer thread.
+	if (this->elem == PerformanceElement::Sound) {
+		/* PerformanceElement::Sound measurements are made from the mixer thread.
 		 * _pf_data cannot be concurrently accessed from the mixer thread
 		 * and the main thread, so store the measurement results in a
 		 * mutex-protected queue which is drained by the main thread.
@@ -340,7 +340,7 @@ void PerformanceMeasurer::SetExpectedRate(double rate)
  */
 PerformanceAccumulator::PerformanceAccumulator(PerformanceElement elem)
 {
-	assert(elem < PFE_MAX);
+	assert(elem < PerformanceElement::End);
 
 	this->elem = elem;
 	this->start_time = GetPerformanceTimer();
@@ -366,36 +366,37 @@ void PerformanceAccumulator::Reset(PerformanceElement elem)
 void ShowFrametimeGraphWindow(PerformanceElement elem);
 
 
-static const PerformanceElement DISPLAY_ORDER_PFE[PFE_MAX] = {
-	PFE_GAMELOOP,
-	PFE_GL_ECONOMY,
-	PFE_GL_TRAINS,
-	PFE_GL_ROADVEHS,
-	PFE_GL_SHIPS,
-	PFE_GL_AIRCRAFT,
-	PFE_GL_LANDSCAPE,
-	PFE_ALLSCRIPTS,
-	PFE_GAMESCRIPT,
-	PFE_AI0,
-	PFE_AI1,
-	PFE_AI2,
-	PFE_AI3,
-	PFE_AI4,
-	PFE_AI5,
-	PFE_AI6,
-	PFE_AI7,
-	PFE_AI8,
-	PFE_AI9,
-	PFE_AI10,
-	PFE_AI11,
-	PFE_AI12,
-	PFE_AI13,
-	PFE_AI14,
-	PFE_GL_LINKGRAPH,
-	PFE_DRAWING,
-	PFE_DRAWWORLD,
-	PFE_VIDEO,
-	PFE_SOUND,
+/** Order of the performance elements in the user interface. */
+static constexpr EnumIndexArray<PerformanceElement, PerformanceElement, PerformanceElement::End> DISPLAY_ORDER_PFE = {
+	PerformanceElement::GameLoop,
+	PerformanceElement::GameLoopEconomy,
+	PerformanceElement::GameLoopTrains,
+	PerformanceElement::GameLoopRoadVehicles,
+	PerformanceElement::GameLoopShips,
+	PerformanceElement::GameLoopAircraft,
+	PerformanceElement::GameLoopLandscape,
+	PerformanceElement::AllScripts,
+	PerformanceElement::GameScript,
+	PerformanceElement::AI0,
+	PerformanceElement::AI1,
+	PerformanceElement::AI2,
+	PerformanceElement::AI3,
+	PerformanceElement::AI4,
+	PerformanceElement::AI5,
+	PerformanceElement::AI6,
+	PerformanceElement::AI7,
+	PerformanceElement::AI8,
+	PerformanceElement::AI9,
+	PerformanceElement::AI10,
+	PerformanceElement::AI11,
+	PerformanceElement::AI12,
+	PerformanceElement::AI13,
+	PerformanceElement::AI14,
+	PerformanceElement::GameLoopLinkGraph,
+	PerformanceElement::Drawing,
+	PerformanceElement::ViewportDrawing,
+	PerformanceElement::Video,
+	PerformanceElement::Sound,
 };
 
 static std::string_view GetAIName(int ai_index)
@@ -469,8 +470,9 @@ struct FramerateWindow : Window {
 	CachedDecimal rate_gameloop{}; ///< cached game loop tick rate
 	CachedDecimal rate_drawing{}; ///< cached drawing frame rate
 	CachedDecimal speed_gameloop{}; ///< cached game loop speed factor
-	std::array<CachedDecimal, PFE_MAX> times_shortterm{}; ///< cached short term average times
-	std::array<CachedDecimal, PFE_MAX> times_longterm{}; ///< cached long term average times
+	using CachedDecimalArray = EnumIndexArray<CachedDecimal, PerformanceElement, PerformanceElement::End>; ///< Array of cached decimals
+	CachedDecimalArray times_shortterm{}; ///< cached short term average times
+	CachedDecimalArray times_longterm{}; ///< cached long term average times
 
 	static constexpr int MIN_ELEMENTS = 5; ///< smallest number of elements to display
 
@@ -492,15 +494,15 @@ struct FramerateWindow : Window {
 
 	void UpdateData()
 	{
-		double gl_rate = _pf_data[PFE_GAMELOOP].GetRate();
-		this->rate_gameloop.SetRate(gl_rate, _pf_data[PFE_GAMELOOP].expected_rate);
-		this->speed_gameloop.SetRate(gl_rate / _pf_data[PFE_GAMELOOP].expected_rate, 1.0);
+		double gl_rate = _pf_data[PerformanceElement::GameLoop].GetRate();
+		this->rate_gameloop.SetRate(gl_rate, _pf_data[PerformanceElement::GameLoop].expected_rate);
+		this->speed_gameloop.SetRate(gl_rate / _pf_data[PerformanceElement::GameLoop].expected_rate, 1.0);
 		if (this->IsShaded()) return; // in small mode, this is everything needed
 
-		this->rate_drawing.SetRate(_pf_data[PFE_DRAWING].GetRate(), _settings_client.gui.refresh_rate);
+		this->rate_drawing.SetRate(_pf_data[PerformanceElement::Drawing].GetRate(), _settings_client.gui.refresh_rate);
 
 		int new_active = 0;
-		for (PerformanceElement e : EnumRange(PFE_MAX)) {
+		for (PerformanceElement e : EnumRange(PerformanceElement::End)) {
 			this->times_shortterm[e].SetTime(_pf_data[e].GetAverageDurationMilliseconds(8), MILLISECONDS_PER_TICK);
 			this->times_longterm[e].SetTime(_pf_data[e].GetAverageDurationMilliseconds(NUM_FRAMERATE_POINTS), MILLISECONDS_PER_TICK);
 			if (_pf_data[e].num_valid > 0) {
@@ -563,10 +565,10 @@ struct FramerateWindow : Window {
 				for (PerformanceElement e : DISPLAY_ORDER_PFE) {
 					if (_pf_data[e].num_valid == 0) continue;
 					Dimension line_size;
-					if (e < PFE_AI0) {
-						line_size = GetStringBoundingBox(STR_FRAMERATE_GAMELOOP + e);
+					if (e < PerformanceElement::AI0) {
+						line_size = GetStringBoundingBox(STR_FRAMERATE_GAMELOOP + to_underlying(e));
 					} else {
-						line_size = GetStringBoundingBox(GetString(STR_FRAMERATE_AI, e - PFE_AI0 + 1, GetAIName(e - PFE_AI0)));
+						line_size = GetStringBoundingBox(GetString(STR_FRAMERATE_AI, e - PerformanceElement::AI0 + 1, GetAIName(e - PerformanceElement::AI0)));
 					}
 					size.width = std::max(size.width, line_size.width);
 				}
@@ -593,7 +595,7 @@ struct FramerateWindow : Window {
 	 * @param heading_str The header of the column.
 	 * @param values The values to draw.
 	 */
-	void DrawElementTimesColumn(const Rect &r, StringID heading_str, std::span<const CachedDecimal> values) const
+	void DrawElementTimesColumn(const Rect &r, StringID heading_str, const CachedDecimalArray &values) const
 	{
 		const Scrollbar *sb = this->GetScrollbar(WID_FRW_SCROLLBAR);
 		int32_t skip = sb->GetPosition();
@@ -626,13 +628,13 @@ struct FramerateWindow : Window {
 			if (_pf_data[e].num_valid == 0) continue;
 			if (skip > 0) {
 				skip--;
-			} else if (e == PFE_GAMESCRIPT || e >= PFE_AI0) {
-				uint64_t value = e == PFE_GAMESCRIPT ? Game::GetInstance()->GetAllocatedMemory() : Company::Get(e - PFE_AI0)->ai_instance->GetAllocatedMemory();
+			} else if (e == PerformanceElement::GameScript || e >= PerformanceElement::AI0) {
+				uint64_t value = e == PerformanceElement::GameScript ? Game::GetInstance()->GetAllocatedMemory() : Company::Get(e - PerformanceElement::AI0)->ai_instance->GetAllocatedMemory();
 				DrawString(r.left, r.right, y, GetString(STR_FRAMERATE_BYTES_GOOD, value), TextColour::FromString, SA_RIGHT | SA_FORCE);
 				y += GetCharacterHeight(FontSize::Normal);
 				drawable--;
 				if (drawable == 0) break;
-			} else if (e == PFE_SOUND) {
+			} else if (e == PerformanceElement::Sound) {
 				DrawString(r.left, r.right, y, GetString(STR_FRAMERATE_BYTES_GOOD, GetSoundPoolAllocatedMemory()), TextColour::FromString, SA_RIGHT | SA_FORCE);
 				y += GetCharacterHeight(FontSize::Normal);
 				drawable--;
@@ -660,10 +662,10 @@ struct FramerateWindow : Window {
 					if (skip > 0) {
 						skip--;
 					} else {
-						if (e < PFE_AI0) {
-							DrawString(r.left, r.right, y, STR_FRAMERATE_GAMELOOP + e, TextColour::FromString, SA_LEFT);
+						if (e < PerformanceElement::AI0) {
+							DrawString(r.left, r.right, y, STR_FRAMERATE_GAMELOOP + to_underlying(e), TextColour::FromString, SA_LEFT);
 						} else {
-							DrawString(r.left, r.right, y, GetString(STR_FRAMERATE_AI, e - PFE_AI0 + 1, GetAIName(e - PFE_AI0)), TextColour::FromString, SA_LEFT);
+							DrawString(r.left, r.right, y, GetString(STR_FRAMERATE_AI, e - PerformanceElement::AI0 + 1, GetAIName(e - PerformanceElement::AI0)), TextColour::FromString, SA_LEFT);
 						}
 						y += GetCharacterHeight(FontSize::Normal);
 						drawable--;
@@ -759,10 +761,10 @@ struct FrametimeGraphWindow : Window {
 	{
 		switch (widget) {
 			case WID_FGW_CAPTION:
-				if (this->element < PFE_AI0) {
-					return GetString(STR_FRAMETIME_CAPTION_GAMELOOP + this->element);
+				if (this->element < PerformanceElement::AI0) {
+					return GetString(STR_FRAMETIME_CAPTION_GAMELOOP + to_underlying(this->element));
 				}
-				return GetString(STR_FRAMETIME_CAPTION_AI, this->element - PFE_AI0 + 1, GetAIName(this->element - PFE_AI0));
+				return GetString(STR_FRAMETIME_CAPTION_AI, this->element - PerformanceElement::AI0 + 1, GetAIName(this->element - PerformanceElement::AI0));
 
 			default:
 				return this->Window::GetWidgetString(widget, stringid);
@@ -792,7 +794,7 @@ struct FrametimeGraphWindow : Window {
 		 * this lands exactly on the scale = 2 vs scale = 4 boundary.
 		 * To avoid excessive switching of the horizontal scale, bias these performance
 		 * categories away from this scale boundary. */
-		if (this->element == PFE_DRAWING || this->element == PFE_DRAWWORLD) range += (range / 2);
+		if (this->element == PerformanceElement::Drawing || this->element == PerformanceElement::ViewportDrawing) range += (range / 2);
 
 		/* Determine horizontal scale based on period covered by 60 points
 		 * (slightly less than 2 seconds at full game speed) */
@@ -1037,7 +1039,7 @@ void ShowFramerateWindow()
  */
 void ShowFrametimeGraphWindow(PerformanceElement elem)
 {
-	if (elem < PFE_FIRST || elem >= PFE_MAX) return; // maybe warn?
+	if (elem >= PerformanceElement::End) return; // maybe warn?
 	AllocateWindowDescFront<FrametimeGraphWindow>(_frametime_graph_window_desc, elem);
 }
 
@@ -1050,7 +1052,7 @@ void ConPrintFramerate()
 
 	IConsolePrint(TextColour::Silver, "Based on num. data points: {} {} {}", count1, count2, count3);
 
-	static const std::array<std::string_view, PFE_MAX> MEASUREMENT_NAMES = {
+	static const EnumIndexArray<std::string_view, PerformanceElement, PerformanceElement::End> MEASUREMENT_NAMES = {
 		"Game loop",
 		"  GL station ticks",
 		"  GL train ticks",
@@ -1070,7 +1072,7 @@ void ConPrintFramerate()
 
 	bool printed_anything = false;
 
-	for (const auto &e : { PFE_GAMELOOP, PFE_DRAWING, PFE_VIDEO }) {
+	for (const auto &e : { PerformanceElement::GameLoop, PerformanceElement::Drawing, PerformanceElement::Video }) {
 		auto &pf = _pf_data[e];
 		if (pf.num_valid == 0) continue;
 		IConsolePrint(TextColour::Green, "{} rate: {:.2f}fps  (expected: {:.2f}fps)",
@@ -1080,14 +1082,14 @@ void ConPrintFramerate()
 		printed_anything = true;
 	}
 
-	for (PerformanceElement e : EnumRange(PFE_MAX)) {
+	for (PerformanceElement e : EnumRange(PerformanceElement::End)) {
 		auto &pf = _pf_data[e];
 		if (pf.num_valid == 0) continue;
 		std::string_view name;
-		if (e < PFE_AI0) {
+		if (e < PerformanceElement::AI0) {
 			name = MEASUREMENT_NAMES[e];
 		} else {
-			ai_name_buf = fmt::format("AI {} {}", e - PFE_AI0 + 1, GetAIName(e - PFE_AI0));
+			ai_name_buf = fmt::format("AI {} {}", e - PerformanceElement::AI0 + 1, GetAIName(e - PerformanceElement::AI0));
 			name = ai_name_buf;
 		}
 		IConsolePrint(TextColour::LightBlue, "{} times: {:.2f}ms  {:.2f}ms  {:.2f}ms",
@@ -1104,8 +1106,8 @@ void ConPrintFramerate()
 }
 
 /**
- * This drains the PFE_SOUND measurement data queue into _pf_data.
- * PFE_SOUND measurements are made by the mixer thread and so cannot be stored
+ * This drains the PerformanceElement::Sound measurement data queue into _pf_data.
+ * PerformanceElement::Sound measurements are made by the mixer thread and so cannot be stored
  * into _pf_data directly, because this would not be thread safe and would violate
  * the invariants of the FPS and frame graph windows.
  * @see PerformanceMeasurement::~PerformanceMeasurement()
@@ -1115,7 +1117,7 @@ void ProcessPendingPerformanceMeasurements()
 	if (_sound_perf_pending.load(std::memory_order_acquire)) {
 		std::lock_guard lk(_sound_perf_lock);
 		for (size_t i = 0; i < _sound_perf_measurements.size(); i += 2) {
-			_pf_data[PFE_SOUND].Add(_sound_perf_measurements[i], _sound_perf_measurements[i + 1]);
+			_pf_data[PerformanceElement::Sound].Add(_sound_perf_measurements[i], _sound_perf_measurements[i + 1]);
 		}
 		_sound_perf_measurements.clear();
 		_sound_perf_pending.store(false, std::memory_order_relaxed);

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -399,10 +399,26 @@ static constexpr EnumIndexArray<PerformanceElement, PerformanceElement, Performa
 	PerformanceElement::Sound,
 };
 
-static std::string_view GetAIName(int ai_index)
+/**
+ * Get the \c CompanyID associated with the AI of the given \c PerformanceElement.
+ * @param e The element to convert.
+ * @return The \c CompanyID.
+ */
+static constexpr CompanyID GetAIIndex(PerformanceElement e)
 {
-	if (!Company::IsValidAiID(ai_index)) return {};
-	return Company::Get(ai_index)->ai_info->GetName();
+	return CompanyID(e - PerformanceElement::AI0);
+}
+
+/**
+ * Get the name of the AI of the given \c PerformanceElement.
+ * @param e The element to get the name for.
+ * @return The name of an empty string.
+ */
+static std::string_view GetAIName(PerformanceElement e)
+{
+	CompanyID c = GetAIIndex(e);
+	if (!Company::IsValidAiID(c)) return {};
+	return Company::Get(c)->ai_info->GetName();
 }
 
 /** @hideinitializer */
@@ -568,7 +584,7 @@ struct FramerateWindow : Window {
 					if (e < PerformanceElement::AI0) {
 						line_size = GetStringBoundingBox(STR_FRAMERATE_GAMELOOP + to_underlying(e));
 					} else {
-						line_size = GetStringBoundingBox(GetString(STR_FRAMERATE_AI, e - PerformanceElement::AI0 + 1, GetAIName(e - PerformanceElement::AI0)));
+						line_size = GetStringBoundingBox(GetString(STR_FRAMERATE_AI, GetAIIndex(e) + 1, GetAIName(e)));
 					}
 					size.width = std::max(size.width, line_size.width);
 				}
@@ -629,7 +645,7 @@ struct FramerateWindow : Window {
 			if (skip > 0) {
 				skip--;
 			} else if (e == PerformanceElement::GameScript || e >= PerformanceElement::AI0) {
-				uint64_t value = e == PerformanceElement::GameScript ? Game::GetInstance()->GetAllocatedMemory() : Company::Get(e - PerformanceElement::AI0)->ai_instance->GetAllocatedMemory();
+				uint64_t value = e == PerformanceElement::GameScript ? Game::GetInstance()->GetAllocatedMemory() : Company::Get(GetAIIndex(e))->ai_instance->GetAllocatedMemory();
 				DrawString(r.left, r.right, y, GetString(STR_FRAMERATE_BYTES_GOOD, value), TextColour::FromString, SA_RIGHT | SA_FORCE);
 				y += GetCharacterHeight(FontSize::Normal);
 				drawable--;
@@ -665,7 +681,7 @@ struct FramerateWindow : Window {
 						if (e < PerformanceElement::AI0) {
 							DrawString(r.left, r.right, y, STR_FRAMERATE_GAMELOOP + to_underlying(e), TextColour::FromString, SA_LEFT);
 						} else {
-							DrawString(r.left, r.right, y, GetString(STR_FRAMERATE_AI, e - PerformanceElement::AI0 + 1, GetAIName(e - PerformanceElement::AI0)), TextColour::FromString, SA_LEFT);
+							DrawString(r.left, r.right, y, GetString(STR_FRAMERATE_AI, GetAIIndex(e) + 1, GetAIName(e)), TextColour::FromString, SA_LEFT);
 						}
 						y += GetCharacterHeight(FontSize::Normal);
 						drawable--;
@@ -764,7 +780,7 @@ struct FrametimeGraphWindow : Window {
 				if (this->element < PerformanceElement::AI0) {
 					return GetString(STR_FRAMETIME_CAPTION_GAMELOOP + to_underlying(this->element));
 				}
-				return GetString(STR_FRAMETIME_CAPTION_AI, this->element - PerformanceElement::AI0 + 1, GetAIName(this->element - PerformanceElement::AI0));
+				return GetString(STR_FRAMETIME_CAPTION_AI, GetAIIndex(this->element) + 1, GetAIName(this->element));
 
 			default:
 				return this->Window::GetWidgetString(widget, stringid);
@@ -1089,7 +1105,7 @@ void ConPrintFramerate()
 		if (e < PerformanceElement::AI0) {
 			name = MEASUREMENT_NAMES[e];
 		} else {
-			ai_name_buf = fmt::format("AI {} {}", e - PerformanceElement::AI0 + 1, GetAIName(e - PerformanceElement::AI0));
+			ai_name_buf = fmt::format("AI {} {}", GetAIIndex(e) + 1, GetAIName(e));
 			name = ai_name_buf;
 		}
 		IConsolePrint(TextColour::LightBlue, "{} times: {:.2f}ms  {:.2f}ms  {:.2f}ms",

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -11,7 +11,7 @@
  * @par Adding new measurements
  * Adding a new measurement requires multiple steps, which are outlined here.
  * The first thing to do is add a new member of the #PerformanceElement enum.
- * It must be added before \c PFE_MAX and should be added in a logical place.
+ * It must be added before \c PerformanceElement::End and should be added in a logical place.
  * For example, an element of the game loop would be added next to the other game loop elements, and a rendering element next to the other rendering elements.
  *
  * @par
@@ -43,39 +43,39 @@
  * @note When adding new elements here, make sure to also update all other locations depending on the length and order of this enum.
  * See <em>Adding new measurements</em> above.
  */
-enum PerformanceElement : uint8_t {
-	PFE_FIRST = 0,
-	PFE_GAMELOOP = 0,  ///< Speed of gameloop processing.
-	PFE_GL_ECONOMY,    ///< Time spent processing cargo movement
-	PFE_GL_TRAINS,     ///< Time spent processing trains
-	PFE_GL_ROADVEHS,   ///< Time spend processing road vehicles
-	PFE_GL_SHIPS,      ///< Time spent processing ships
-	PFE_GL_AIRCRAFT,   ///< Time spent processing aircraft
-	PFE_GL_LANDSCAPE,  ///< Time spent processing other world features
-	PFE_GL_LINKGRAPH,  ///< Time spent waiting for link graph background jobs
-	PFE_DRAWING,       ///< Speed of drawing world and GUI.
-	PFE_DRAWWORLD,     ///< Time spent drawing world viewports in GUI
-	PFE_VIDEO,         ///< Speed of painting drawn video buffer.
-	PFE_SOUND,         ///< Speed of mixing audio samples
-	PFE_ALLSCRIPTS,    ///< Sum of all GS/AI scripts
-	PFE_GAMESCRIPT,    ///< Game script execution
-	PFE_AI0,           ///< AI execution for player slot 1
-	PFE_AI1,           ///< AI execution for player slot 2
-	PFE_AI2,           ///< AI execution for player slot 3
-	PFE_AI3,           ///< AI execution for player slot 4
-	PFE_AI4,           ///< AI execution for player slot 5
-	PFE_AI5,           ///< AI execution for player slot 6
-	PFE_AI6,           ///< AI execution for player slot 7
-	PFE_AI7,           ///< AI execution for player slot 8
-	PFE_AI8,           ///< AI execution for player slot 9
-	PFE_AI9,           ///< AI execution for player slot 10
-	PFE_AI10,          ///< AI execution for player slot 11
-	PFE_AI11,          ///< AI execution for player slot 12
-	PFE_AI12,          ///< AI execution for player slot 13
-	PFE_AI13,          ///< AI execution for player slot 14
-	PFE_AI14,          ///< AI execution for player slot 15
-	PFE_MAX,           ///< End of enum, must be last.
+enum class PerformanceElement : uint8_t {
+	GameLoop, ///< Speed of gameloop processing.
+	GameLoopEconomy, ///< Time spent processing cargo movement
+	GameLoopTrains, ///< Time spent processing trains
+	GameLoopRoadVehicles, ///< Time spend processing road vehicles
+	GameLoopShips, ///< Time spent processing ships
+	GameLoopAircraft, ///< Time spent processing aircraft
+	GameLoopLandscape, ///< Time spent processing other world features
+	GameLoopLinkGraph, ///< Time spent waiting for link graph background jobs
+	Drawing, ///< Speed of drawing world and GUI.
+	ViewportDrawing, ///< Time spent drawing world viewports in GUI
+	Video, ///< Speed of painting drawn video buffer.
+	Sound, ///< Speed of mixing audio samples
+	AllScripts, ///< Sum of all GS/AI scripts
+	GameScript, ///< Game script execution
+	AI0, ///< AI execution for player slot 1
+	AI1, ///< AI execution for player slot 2
+	AI2, ///< AI execution for player slot 3
+	AI3, ///< AI execution for player slot 4
+	AI4, ///< AI execution for player slot 5
+	AI5, ///< AI execution for player slot 6
+	AI6, ///< AI execution for player slot 7
+	AI7, ///< AI execution for player slot 8
+	AI8, ///< AI execution for player slot 9
+	AI9, ///< AI execution for player slot 10
+	AI10, ///< AI execution for player slot 11
+	AI11, ///< AI execution for player slot 12
+	AI12, ///< AI execution for player slot 13
+	AI13, ///< AI execution for player slot 14
+	AI14, ///< AI execution for player slot 15
+	End, ///< End of enum, must be last.
 };
+DECLARE_ENUM_AS_SEQUENTIAL(PerformanceElement)
 
 /** Type used to hold a performance timing measurement */
 typedef uint64_t TimingMeasurement;

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -31,15 +31,15 @@
 /* static */ void Game::GameLoop()
 {
 	if (_networking && !_network_server) {
-		PerformanceMeasurer::SetInactive(PFE_GAMESCRIPT);
+		PerformanceMeasurer::SetInactive(PerformanceElement::GameScript);
 		return;
 	}
 	if (Game::instance == nullptr) {
-		PerformanceMeasurer::SetInactive(PFE_GAMESCRIPT);
+		PerformanceMeasurer::SetInactive(PerformanceElement::GameScript);
 		return;
 	}
 
-	PerformanceMeasurer framerate(PFE_GAMESCRIPT);
+	PerformanceMeasurer framerate(PerformanceElement::GameScript);
 
 	Game::frame_counter++;
 

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -803,7 +803,7 @@ TileIndex _cur_tileloop_tile;
  */
 void RunTileLoop()
 {
-	PerformanceAccumulator framerate(PFE_GL_LANDSCAPE);
+	PerformanceAccumulator framerate(PerformanceElement::GameLoopLandscape);
 
 	/* The pseudorandom sequence of tiles is generated using a Galois linear feedback
 	 * shift register (LFSR). This allows a deterministic pseudorandom ordering, but
@@ -1727,7 +1727,7 @@ void OnTick_LinkGraph();
 void CallLandscapeTick()
 {
 	{
-		PerformanceAccumulator framerate(PFE_GL_LANDSCAPE);
+		PerformanceAccumulator framerate(PerformanceElement::GameLoopLandscape);
 
 		OnTick_Town();
 		OnTick_Trees();

--- a/src/linkgraph/linkgraphschedule.cpp
+++ b/src/linkgraph/linkgraphschedule.cpp
@@ -207,10 +207,10 @@ void OnTick_LinkGraph()
 		LinkGraphSchedule::instance.SpawnNext();
 	} else if (offset == (_settings_game.linkgraph.recalc_interval / EconomyTime::SECONDS_PER_DAY) / 2) {
 		if (!_networking || _network_server) {
-			PerformanceMeasurer::SetInactive(PFE_GL_LINKGRAPH);
+			PerformanceMeasurer::SetInactive(PerformanceElement::GameLoopLinkGraph);
 			LinkGraphSchedule::instance.JoinNext();
 		} else {
-			PerformanceMeasurer framerate(PFE_GL_LINKGRAPH);
+			PerformanceMeasurer framerate(PerformanceElement::GameLoopLinkGraph);
 			LinkGraphSchedule::instance.JoinNext();
 		}
 	}

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -125,7 +125,7 @@ void MxCloseAllChannels()
 
 void MxMixSamples(void *buffer, uint samples)
 {
-	PerformanceMeasurer framerate(PFE_SOUND);
+	PerformanceMeasurer framerate(PerformanceElement::Sound);
 	static uint last_samples = 0;
 	if (samples != last_samples) {
 		framerate.SetExpectedRate((double)_play_rate / samples);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1212,13 +1212,13 @@ void StateGameLoop()
 
 	/* Don't execute the state loop during pause or when modal windows are open. */
 	if (_pause_mode.Any() || HasModalProgress()) {
-		PerformanceMeasurer::Paused(PFE_GAMELOOP);
-		PerformanceMeasurer::Paused(PFE_GL_ECONOMY);
-		PerformanceMeasurer::Paused(PFE_GL_TRAINS);
-		PerformanceMeasurer::Paused(PFE_GL_ROADVEHS);
-		PerformanceMeasurer::Paused(PFE_GL_SHIPS);
-		PerformanceMeasurer::Paused(PFE_GL_AIRCRAFT);
-		PerformanceMeasurer::Paused(PFE_GL_LANDSCAPE);
+		PerformanceMeasurer::Paused(PerformanceElement::GameLoop);
+		PerformanceMeasurer::Paused(PerformanceElement::GameLoopEconomy);
+		PerformanceMeasurer::Paused(PerformanceElement::GameLoopTrains);
+		PerformanceMeasurer::Paused(PerformanceElement::GameLoopRoadVehicles);
+		PerformanceMeasurer::Paused(PerformanceElement::GameLoopShips);
+		PerformanceMeasurer::Paused(PerformanceElement::GameLoopAircraft);
+		PerformanceMeasurer::Paused(PerformanceElement::GameLoopLandscape);
 
 		if (!HasModalProgress()) UpdateLandscapingLimits();
 #ifndef DEBUG_DUMP_COMMANDS
@@ -1227,8 +1227,8 @@ void StateGameLoop()
 		return;
 	}
 
-	PerformanceMeasurer framerate(PFE_GAMELOOP);
-	PerformanceAccumulator::Reset(PFE_GL_LANDSCAPE);
+	PerformanceMeasurer framerate(PerformanceElement::GameLoop);
+	PerformanceAccumulator::Reset(PerformanceElement::GameLoopLandscape);
 
 	if (_game_mode == GameMode::Editor) {
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
@@ -1267,7 +1267,7 @@ void StateGameLoop()
 
 #ifndef DEBUG_DUMP_COMMANDS
 		{
-			PerformanceMeasurer script_framerate(PFE_ALLSCRIPTS);
+			PerformanceMeasurer script_framerate(PerformanceElement::AllScripts);
 			AI::GameLoop();
 			Game::GameLoop();
 		}

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1649,7 +1649,7 @@ Money RoadVehicle::GetRunningCost() const
 
 bool RoadVehicle::Tick()
 {
-	PerformanceAccumulator framerate(PFE_GL_ROADVEHS);
+	PerformanceAccumulator framerate(PerformanceElement::GameLoopRoadVehicles);
 
 	this->tick_counter++;
 

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -787,7 +787,7 @@ static void ShipController(Ship *v)
 
 bool Ship::Tick()
 {
-	PerformanceAccumulator framerate(PFE_GL_SHIPS);
+	PerformanceAccumulator framerate(PerformanceElement::GameLoopShips);
 
 	if (!this->vehstatus.Test(VehState::Stopped)) this->running_ticks++;
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -4177,7 +4177,7 @@ bool Train::Tick()
 	this->tick_counter++;
 
 	if (this->IsFrontEngine()) {
-		PerformanceAccumulator framerate(PFE_GL_TRAINS);
+		PerformanceAccumulator framerate(PerformanceElement::GameLoopTrains);
 
 		if (!this->vehstatus.Test(VehState::Stopped) || this->cur_speed > 0) this->running_ticks++;
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -988,13 +988,13 @@ void CallVehicleTicks()
 	RunEconomyVehicleDayProc();
 
 	{
-		PerformanceMeasurer framerate(PFE_GL_ECONOMY);
+		PerformanceMeasurer framerate(PerformanceElement::GameLoopEconomy);
 		for (Station *st : Station::Iterate()) LoadUnloadStation(st);
 	}
-	PerformanceAccumulator::Reset(PFE_GL_TRAINS);
-	PerformanceAccumulator::Reset(PFE_GL_ROADVEHS);
-	PerformanceAccumulator::Reset(PFE_GL_SHIPS);
-	PerformanceAccumulator::Reset(PFE_GL_AIRCRAFT);
+	PerformanceAccumulator::Reset(PerformanceElement::GameLoopTrains);
+	PerformanceAccumulator::Reset(PerformanceElement::GameLoopRoadVehicles);
+	PerformanceAccumulator::Reset(PerformanceElement::GameLoopShips);
+	PerformanceAccumulator::Reset(PerformanceElement::GameLoopAircraft);
 
 	for (Vehicle *v : Vehicle::Iterate()) {
 		[[maybe_unused]] VehicleID vehicle_index = v->index;

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -57,7 +57,7 @@ void VideoDriver_Allegro::MakeDirty(int left, int top, int width, int height)
 
 void VideoDriver_Allegro::Paint()
 {
-	PerformanceMeasurer framerate(PFE_VIDEO);
+	PerformanceMeasurer framerate(PerformanceElement::Video);
 
 	size_t n = _num_dirty_rects;
 	if (n == 0) return;

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -310,7 +310,7 @@ void VideoDriver_CocoaOpenGL::ReleaseVideoPointer()
 
 void VideoDriver_CocoaOpenGL::Paint()
 {
-	PerformanceMeasurer framerate(PFE_VIDEO);
+	PerformanceMeasurer framerate(PerformanceElement::Video);
 
 	if (CopyPalette(_local_palette)) {
 		Blitter *blitter = BlitterFactory::GetCurrentBlitter();

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -746,7 +746,7 @@ void VideoDriver_CocoaQuartz::CheckPaletteAnim()
 /** Draw window */
 void VideoDriver_CocoaQuartz::Paint()
 {
-	PerformanceMeasurer framerate(PFE_VIDEO);
+	PerformanceMeasurer framerate(PerformanceElement::Video);
 
 	/* Check if we need to do anything */
 	if (IsEmptyRect(this->dirty_rect) || [ this->window isMiniaturized ]) return;

--- a/src/video/sdl2_default_v.cpp
+++ b/src/video/sdl2_default_v.cpp
@@ -96,7 +96,7 @@ void VideoDriver_SDL_Default::MakePalette()
 
 void VideoDriver_SDL_Default::Paint()
 {
-	PerformanceMeasurer framerate(PFE_VIDEO);
+	PerformanceMeasurer framerate(PerformanceElement::Video);
 
 	if (IsEmptyRect(this->dirty_rect) && this->local_palette.count_dirty == 0) return;
 

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -180,7 +180,7 @@ void VideoDriver_SDL_OpenGL::ReleaseVideoPointer()
 
 void VideoDriver_SDL_OpenGL::Paint()
 {
-	PerformanceMeasurer framerate(PFE_VIDEO);
+	PerformanceMeasurer framerate(PerformanceElement::Video);
 
 	if (this->local_palette.count_dirty != 0) {
 		Blitter *blitter = BlitterFactory::GetCurrentBlitter();

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1259,7 +1259,7 @@ void VideoDriver_Win32GDI::PaletteChanged(HWND hWnd)
 
 void VideoDriver_Win32GDI::Paint()
 {
-	PerformanceMeasurer framerate(PFE_VIDEO);
+	PerformanceMeasurer framerate(PerformanceElement::Video);
 
 	if (IsEmptyRect(this->dirty_rect)) return;
 
@@ -1609,7 +1609,7 @@ void VideoDriver_Win32OpenGL::ReleaseVideoPointer()
 
 void VideoDriver_Win32OpenGL::Paint()
 {
-	PerformanceMeasurer framerate(PFE_VIDEO);
+	PerformanceMeasurer framerate(PerformanceElement::Video);
 
 	if (_local_palette.count_dirty != 0) {
 		Blitter *blitter = BlitterFactory::GetCurrentBlitter();

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1906,7 +1906,7 @@ static inline void ViewportDraw(const Viewport &vp, int left, int top, int right
  */
 void Window::DrawViewport() const
 {
-	PerformanceAccumulator framerate(PFE_DRAWWORLD);
+	PerformanceAccumulator framerate(PerformanceElement::ViewportDrawing);
 
 	DrawPixelInfo *dpi = _cur_dpi;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3148,8 +3148,8 @@ void UpdateWindows()
 
 	last_time = now;
 
-	PerformanceMeasurer framerate(PFE_DRAWING);
-	PerformanceAccumulator::Reset(PFE_DRAWWORLD);
+	PerformanceMeasurer framerate(PerformanceElement::Drawing);
+	PerformanceAccumulator::Reset(PerformanceElement::ViewportDrawing);
 
 	ProcessPendingPerformanceMeasurements();
 


### PR DESCRIPTION
## Motivation / Problem

Unifying the way enumerations are done.


## Description

* Make `PerformanceElement` scoped.
* Introduce `CachedDecimalArray` as 'typedef' of `EnumIndexArray` and use that, including a replacement of `std::span` to prevent a lot of `to_underlying`.
* Make `PerformanceElement` sequential, i.e. allow adding/subtracting numbers and determining the difference between two elements to prevent lots of `to_underlying`.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
