### PR TITLE
Codechange: make OpenGLSprite::Texture scoped

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1342,7 +1342,7 @@ void OpenGLBackend::RenderOglSprite(const OpenGLSprite *gl_sprite, PaletteID pal
 }
 
 
-/* static */ std::array<GLuint, OpenGLSprite::NUM_TEX> OpenGLSprite::dummy_tex{};
+/* static */ EnumIndexArray<GLuint, OpenGLSprite::Texture, OpenGLSprite::Texture::End> OpenGLSprite::dummy_tex{};
 /* static */ GLuint OpenGLSprite::pal_identity = 0;
 /* static */ GLuint OpenGLSprite::pal_tex = 0;
 /* static */ GLuint OpenGLSprite::pal_pbo = 0;
@@ -1353,9 +1353,9 @@ void OpenGLBackend::RenderOglSprite(const OpenGLSprite *gl_sprite, PaletteID pal
  */
 /* static */ bool OpenGLSprite::Create()
 {
-	_glGenTextures(NUM_TEX, OpenGLSprite::dummy_tex.data());
+	_glGenTextures(static_cast<GLsizei>(OpenGLSprite::dummy_tex.size()), OpenGLSprite::dummy_tex.data());
 
-	for (int t = TEX_RGBA; t < NUM_TEX; t++) {
+	for (Texture t : EnumRange<Texture>(Texture::End)) {
 		_glBindTexture(GL_TEXTURE_2D, OpenGLSprite::dummy_tex[t]);
 
 		_glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
@@ -1370,12 +1370,12 @@ void OpenGLBackend::RenderOglSprite(const OpenGLSprite *gl_sprite, PaletteID pal
 
 	/* Load dummy RGBA texture. */
 	const Colour rgb_pixel(0, 0, 0);
-	_glBindTexture(GL_TEXTURE_2D, OpenGLSprite::dummy_tex[TEX_RGBA]);
+	_glBindTexture(GL_TEXTURE_2D, OpenGLSprite::dummy_tex[Texture::RGBA]);
 	_glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 1, 1, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, &rgb_pixel);
 
 	/* Load dummy remap texture. */
 	const uint pal = 0;
-	_glBindTexture(GL_TEXTURE_2D, OpenGLSprite::dummy_tex[TEX_REMAP]);
+	_glBindTexture(GL_TEXTURE_2D, OpenGLSprite::dummy_tex[Texture::Remap]);
 	_glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, 1, 1, 0, GL_RED, GL_UNSIGNED_BYTE, &pal);
 
 	/* Create palette remap textures. */
@@ -1414,7 +1414,7 @@ void OpenGLBackend::RenderOglSprite(const OpenGLSprite *gl_sprite, PaletteID pal
 /** Free all common resources for sprite rendering. */
 /* static */ void OpenGLSprite::Destroy()
 {
-	_glDeleteTextures(NUM_TEX, OpenGLSprite::dummy_tex.data());
+	_glDeleteTextures(static_cast<GLsizei>(OpenGLSprite::dummy_tex.size()), OpenGLSprite::dummy_tex.data());
 	_glDeleteTextures(1, &OpenGLSprite::pal_identity);
 	_glDeleteTextures(1, &OpenGLSprite::pal_tex);
 	if (_glDeleteBuffers != nullptr) _glDeleteBuffers(1, &OpenGLSprite::pal_pbo);
@@ -1441,10 +1441,10 @@ OpenGLSprite::OpenGLSprite(SpriteType sprite_type, const SpriteLoader::SpriteCol
 	_glActiveTexture(GL_TEXTURE0);
 	_glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
-	for (int t = TEX_RGBA; t < NUM_TEX; t++) {
+	for (Texture t : EnumRange<Texture>(Texture::End)) {
 		/* Sprite component present? */
-		if (t == TEX_RGBA && root_sprite.colours == SpriteComponent::Palette) continue;
-		if (t == TEX_REMAP && !root_sprite.colours.Test(SpriteComponent::Palette)) continue;
+		if (t == Texture::RGBA && root_sprite.colours == SpriteComponent::Palette) continue;
+		if (t == Texture::Remap && !root_sprite.colours.Test(SpriteComponent::Palette)) continue;
 
 		/* Allocate texture. */
 		_glGenTextures(1, &this->tex[t]);
@@ -1459,7 +1459,7 @@ OpenGLSprite::OpenGLSprite(SpriteType sprite_type, const SpriteLoader::SpriteCol
 		/* Set size. */
 		for (int i = 0, w = this->dim.width, h = this->dim.height; i < levels; i++, w /= 2, h /= 2) {
 			assert(w * h != 0);
-			if (t == TEX_REMAP) {
+			if (t == Texture::Remap) {
 				_glTexImage2D(GL_TEXTURE_2D, i, GL_R8, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, nullptr);
 			} else {
 				_glTexImage2D(GL_TEXTURE_2D, i, GL_RGBA8, w, h, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, nullptr);
@@ -1479,7 +1479,7 @@ OpenGLSprite::OpenGLSprite(SpriteType sprite_type, const SpriteLoader::SpriteCol
 /** Delete the textures we allocated. */
 OpenGLSprite::~OpenGLSprite()
 {
-	_glDeleteTextures(NUM_TEX, this->tex.data());
+	_glDeleteTextures(static_cast<GLsizei>(this->tex.size()), this->tex.data());
 }
 
 /**
@@ -1498,7 +1498,7 @@ void OpenGLSprite::Update(uint width, uint height, uint level, const SpriteLoade
 	_glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 	_glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 
-	if (this->tex[TEX_RGBA] != 0) {
+	if (this->tex[Texture::RGBA] != 0) {
 		/* Unpack pixel data */
 		size_t size = static_cast<size_t>(width) * height;
 		Colour *rgba = buf_rgba.Allocate(size);
@@ -1509,11 +1509,11 @@ void OpenGLSprite::Update(uint width, uint height, uint level, const SpriteLoade
 			rgba[i].a = data[i].a;
 		}
 
-		_glBindTexture(GL_TEXTURE_2D, this->tex[TEX_RGBA]);
+		_glBindTexture(GL_TEXTURE_2D, this->tex[Texture::RGBA]);
 		_glTexSubImage2D(GL_TEXTURE_2D, level, 0, 0, width, height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, rgba);
 	}
 
-	if (this->tex[TEX_REMAP] != 0) {
+	if (this->tex[Texture::Remap] != 0) {
 		/* Unpack and align pixel data. */
 		size_t pitch = Align(width, 4);
 
@@ -1525,7 +1525,7 @@ void OpenGLSprite::Update(uint width, uint height, uint level, const SpriteLoade
 			}
 		}
 
-		_glBindTexture(GL_TEXTURE_2D, this->tex[TEX_REMAP]);
+		_glBindTexture(GL_TEXTURE_2D, this->tex[Texture::Remap]);
 		_glTexSubImage2D(GL_TEXTURE_2D, level, 0, 0, width, height, GL_RED, GL_UNSIGNED_BYTE, buf_pal.GetBuffer());
 	}
 
@@ -1550,9 +1550,9 @@ inline Dimension OpenGLSprite::GetSize(ZoomLevel level) const
 bool OpenGLSprite::BindTextures() const
 {
 	_glActiveTexture(GL_TEXTURE0);
-	_glBindTexture(GL_TEXTURE_2D, this->tex[TEX_RGBA] != 0 ? this->tex[TEX_RGBA] : OpenGLSprite::dummy_tex[TEX_RGBA]);
+	_glBindTexture(GL_TEXTURE_2D, this->tex[Texture::RGBA] != 0 ? this->tex[Texture::RGBA] : OpenGLSprite::dummy_tex[Texture::RGBA]);
 	_glActiveTexture(GL_TEXTURE0 + 2);
-	_glBindTexture(GL_TEXTURE_2D, this->tex[TEX_REMAP] != 0 ? this->tex[TEX_REMAP] : OpenGLSprite::dummy_tex[TEX_REMAP]);
+	_glBindTexture(GL_TEXTURE_2D, this->tex[Texture::Remap] != 0 ? this->tex[Texture::Remap] : OpenGLSprite::dummy_tex[Texture::Remap]);
 
-	return this->tex[TEX_RGBA] != 0;
+	return this->tex[Texture::RGBA] != 0;
 }

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -120,18 +120,18 @@ public:
 class OpenGLSprite {
 private:
 	/** Enum of all used OpenGL texture objects. */
-	enum Texture : uint8_t {
-		TEX_RGBA,    ///< RGBA texture part.
-		TEX_REMAP,   ///< Remap texture part.
-		NUM_TEX
+	enum class Texture : uint8_t {
+		RGBA, ///< RGBA texture part.
+		Remap, ///< Remap texture part.
+		End, ///< End marker.
 	};
 
 	Dimension dim{};
-	std::array<GLuint, NUM_TEX> tex{}; ///< The texture objects.
+	EnumIndexArray<GLuint, Texture, Texture::End> tex{}; ///< The texture objects.
 	int16_t x_offs = 0;  ///< Number of pixels to shift the sprite to the right.
 	int16_t y_offs = 0;  ///< Number of pixels to shift the sprite downwards.
 
-	static std::array<GLuint, NUM_TEX> dummy_tex; ///< 1x1 dummy textures to substitute for unused sprite components.
+	static EnumIndexArray<GLuint, Texture, Texture::End> dummy_tex; ///< 1x1 dummy textures to substitute for unused sprite components.
 
 	static GLuint pal_identity; ///< Identity texture mapping.
 	static GLuint pal_tex;      ///< Texture for palette remap.


### PR DESCRIPTION
## Motivation / Problem

Type safety/strictness.


## Description

* Make `OpenGLSprite`'s `Texture` a scoped enum.
* Use `std::array`'s `size()` when passing its `data()` (over using an enum).
* Use `EnumRange` instead of manual `for`-loop logic.


## Limitations

None?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
