### PR TITLE
Codechange: VarTypes/SLE_ enumeration cleanup

### DIFF
--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -709,13 +709,9 @@ enum VarTypes : uint16_t {
 	SLE_INT64        = SLE_FILE_I64 | SLE_VAR_I64,
 	SLE_UINT64       = SLE_FILE_U64 | SLE_VAR_U64,
 	SLE_STRINGID     = SLE_FILE_STRINGID | SLE_VAR_U32,
-	SLE_STRING       = SLE_FILE_STRING   | SLE_VAR_STR,
-	SLE_STRINGQUOTE  = SLE_FILE_STRING   | SLE_VAR_STRQ,
+	SLE_STR          = SLE_FILE_STRING   | SLE_VAR_STR,
+	SLE_STRQ         = SLE_FILE_STRING   | SLE_VAR_STRQ,
 	SLE_NAME         = SLE_FILE_STRINGID | SLE_VAR_NAME,
-
-	/* Shortcut values */
-	SLE_STR   = SLE_STRING,
-	SLE_STRQ  = SLE_STRINGQUOTE,
 
 	/* 8 bits allocated for a maximum of 8 flags
 	 * Flags directing saving/loading of a variable */

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -696,9 +696,6 @@ enum VarTypes : uint16_t {
 	SLE_VAR_NAME  = 14 << 4, ///< old custom name to be converted to a string pointer
 	/* 1 more possible memory-primitives */
 
-	/* Shortcut values */
-	SLE_VAR_CHAR = SLE_VAR_I8,
-
 	/* Default combinations of variables. As savegames change, so can variables
 	 * and thus it is possible that the saved value and internal size do not
 	 * match and you need to specify custom combo. The defaults are listed here */
@@ -711,7 +708,6 @@ enum VarTypes : uint16_t {
 	SLE_UINT32       = SLE_FILE_U32 | SLE_VAR_U32,
 	SLE_INT64        = SLE_FILE_I64 | SLE_VAR_I64,
 	SLE_UINT64       = SLE_FILE_U64 | SLE_VAR_U64,
-	SLE_CHAR         = SLE_FILE_I8  | SLE_VAR_CHAR,
 	SLE_STRINGID     = SLE_FILE_STRINGID | SLE_VAR_U32,
 	SLE_STRING       = SLE_FILE_STRING   | SLE_VAR_STR,
 	SLE_STRINGQUOTE  = SLE_FILE_STRING   | SLE_VAR_STRQ,

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -718,7 +718,6 @@ enum VarTypes : uint16_t {
 	SLE_NAME         = SLE_FILE_STRINGID | SLE_VAR_NAME,
 
 	/* Shortcut values */
-	SLE_INT   = SLE_INT32,
 	SLE_STR   = SLE_STRING,
 	SLE_STRQ  = SLE_STRINGQUOTE,
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -718,7 +718,6 @@ enum VarTypes : uint16_t {
 	SLE_NAME         = SLE_FILE_STRINGID | SLE_VAR_NAME,
 
 	/* Shortcut values */
-	SLE_UINT  = SLE_UINT32,
 	SLE_INT   = SLE_INT32,
 	SLE_STR   = SLE_STRING,
 	SLE_STRQ  = SLE_STRINGQUOTE,

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -386,7 +386,7 @@ public:
 		 SLE_CONDVAR(GoodsEntry, amount_fract, SLE_UINT8, SaveLoadVersion::FractionalCargoDelivery, SaveLoadVersion::MaxVersion),
 		SLEG_CONDREFLIST("packets", _packets, REF_CARGO_PACKET, SaveLoadVersion::CargoPackets, SaveLoadVersion::Cargodist),
 		SLEG_CONDVAR("old_num_dests", _old_num_dests, SLE_UINT32, SaveLoadVersion::Cargodist, SaveLoadVersion::SaveloadListLength),
-		SLEG_CONDVAR("cargo.reserved_count", SlStationGoods::cargo_reserved_count, SLE_UINT, SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
+		SLEG_CONDVAR("cargo.reserved_count", SlStationGoods::cargo_reserved_count, SLE_UINT32, SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
 		 SLE_CONDVAR(GoodsEntry, link_graph, SLE_UINT16, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
 		 SLE_CONDVAR(GoodsEntry, node, SLE_UINT16, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
 		SLEG_CONDVAR("old_num_flows", _old_num_flows, SLE_UINT32, SaveLoadVersion::Cargodist, SaveLoadVersion::SaveloadListLength),

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -698,7 +698,7 @@ public:
 		SLE_CONDVAR(Vehicle, refit_cap, SLE_UINT16, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
 		SLEG_CONDVAR("cargo_count", _cargo_count, SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::CargoPackets),
 		SLE_CONDREFLIST(Vehicle, cargo.packets, REF_CARGO_PACKET, SaveLoadVersion::CargoPackets, SaveLoadVersion::MaxVersion),
-		SLE_CONDARR(Vehicle, cargo.action_counts, SLE_UINT, to_underlying(VehicleCargoList::MoveToAction::End), SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
+		SLE_CONDARR(Vehicle, cargo.action_counts, SLE_UINT32, to_underlying(VehicleCargoList::MoveToAction::End), SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, cargo_age_counter, SLE_UINT16, SaveLoadVersion::NewGRFCustomCargoAging, SaveLoadVersion::MaxVersion),
 
 		    SLE_VAR(Vehicle, day_counter,           SLE_UINT8),

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -405,7 +405,7 @@ static const SaveLoad _script_byte[] = {
 			if (!test) {
 				_script_sl_byte = (uint8_t)len;
 				SlObject(nullptr, _script_byte);
-				SlCopy(const_cast<char *>(view.data()), len, SLE_CHAR);
+				SlCopy(const_cast<char *>(view.data()), len, SLE_INT8);
 			}
 			return true;
 		}
@@ -612,7 +612,7 @@ bool ScriptInstance::IsPaused()
 		case SQSL_STRING: {
 			SlObject(nullptr, _script_byte);
 			static char buf[std::numeric_limits<decltype(_script_sl_byte)>::max()];
-			SlCopy(buf, _script_sl_byte, SLE_CHAR);
+			SlCopy(buf, _script_sl_byte, SLE_INT8);
 			if (data != nullptr) data->push_back(StrMakeValid(std::string_view(buf, _script_sl_byte)));
 			return true;
 		}

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -69,7 +69,7 @@ val_cb   = SettingsValueAbsolute
 
 [SDT_VAR]
 var      = engine_renew_money
-type     = SLE_UINT
+type     = SLE_UINT32
 flags    = SettingFlag::PerCompany, SettingFlag::GuiCurrency
 def      = 100000
 min      = 0

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -158,7 +158,7 @@ cat      = SC_BASIC
 ; workaround for implicit lengthof() in SDTG_LIST
 [SDTG_LIST]
 name     = ""resolution""
-type     = SLE_UINT
+type     = SLE_UINT32
 length   = 2
 var      = _cur_resolution
 def      = ""0,0""
@@ -214,7 +214,7 @@ def      = """"
 [SDTG_VAR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""small_size""
-type     = SLE_UINT
+type     = SLE_UINT32
 var      = _fcsettings.small.size
 def      = 0
 min      = 0
@@ -223,7 +223,7 @@ max      = 72
 [SDTG_VAR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""medium_size""
-type     = SLE_UINT
+type     = SLE_UINT32
 var      = _fcsettings.medium.size
 def      = 0
 min      = 0
@@ -232,7 +232,7 @@ max      = 72
 [SDTG_VAR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""large_size""
-type     = SLE_UINT
+type     = SLE_UINT32
 var      = _fcsettings.large.size
 def      = 0
 min      = 0
@@ -241,7 +241,7 @@ max      = 72
 [SDTG_VAR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""mono_size""
-type     = SLE_UINT
+type     = SLE_UINT32
 var      = _fcsettings.mono.size
 def      = 0
 min      = 0
@@ -261,7 +261,7 @@ def      = false
 
 [SDTG_VAR]
 name     = ""sprite_cache_size_px""
-type     = SLE_UINT
+type     = SLE_UINT32
 var      = _sprite_cache_size
 def      = 128
 min      = 1
@@ -277,7 +277,7 @@ cat      = SC_BASIC
 
 [SDTG_VAR]
 name     = ""transparency_options""
-type     = SLE_UINT
+type     = SLE_UINT32
 var      = _transparency_opt
 def      = 0
 min      = 0
@@ -286,7 +286,7 @@ cat      = SC_BASIC
 
 [SDTG_VAR]
 name     = ""transparency_locks""
-type     = SLE_UINT
+type     = SLE_UINT32
 var      = _transparency_lock
 def      = 0
 min      = 0
@@ -295,7 +295,7 @@ cat      = SC_BASIC
 
 [SDTG_VAR]
 name     = ""invisibility_options""
-type     = SLE_UINT
+type     = SLE_UINT32
 var      = _invisibility_opt
 def      = 0
 min      = 0

--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -214,7 +214,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_look_ahead_signal_p0
-type     = SLE_INT
+type     = SLE_INT32
 from     = SaveLoadVersion::Yapf
 def      = 500
 min      = -1000000
@@ -223,7 +223,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_look_ahead_signal_p1
-type     = SLE_INT
+type     = SLE_INT32
 from     = SaveLoadVersion::Yapf
 def      = -100
 min      = -1000000
@@ -232,7 +232,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_look_ahead_signal_p2
-type     = SLE_INT
+type     = SLE_INT32
 from     = SaveLoadVersion::Yapf
 def      = 5
 min      = -1000000

--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -100,7 +100,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.max_search_nodes
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 10000
 min      = 500
@@ -115,7 +115,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_firstred_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 10 * YAPF_TILE_LENGTH
 min      = 0
@@ -124,7 +124,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_firstred_exit_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 100 * YAPF_TILE_LENGTH
 min      = 0
@@ -133,7 +133,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_lastred_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 10 * YAPF_TILE_LENGTH
 min      = 0
@@ -142,7 +142,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_lastred_exit_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 100 * YAPF_TILE_LENGTH
 min      = 0
@@ -151,7 +151,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_station_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 10 * YAPF_TILE_LENGTH
 min      = 0
@@ -160,7 +160,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_slope_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 2 * YAPF_TILE_LENGTH
 min      = 0
@@ -169,7 +169,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_curve45_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 1 * YAPF_TILE_LENGTH
 min      = 0
@@ -178,7 +178,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_curve90_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 6 * YAPF_TILE_LENGTH
 min      = 0
@@ -187,7 +187,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_depot_reverse_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 50 * YAPF_TILE_LENGTH
 min      = 0
@@ -196,7 +196,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_crossing_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 3 * YAPF_TILE_LENGTH
 min      = 0
@@ -205,7 +205,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_look_ahead_max_signals
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapf
 def      = 10
 min      = 1
@@ -241,7 +241,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_pbs_cross_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapp
 def      = 3 * YAPF_TILE_LENGTH
 min      = 0
@@ -250,7 +250,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_pbs_station_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapp
 def      = 8 * YAPF_TILE_LENGTH
 min      = 0
@@ -259,7 +259,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_pbs_signal_back_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapp
 def      = 15 * YAPF_TILE_LENGTH
 min      = 0
@@ -268,7 +268,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_doubleslip_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::Yapp
 def      = 1 * YAPF_TILE_LENGTH
 min      = 0
@@ -277,7 +277,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_longer_platform_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 8 * YAPF_TILE_LENGTH
 min      = 0
@@ -286,7 +286,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_longer_platform_per_tile_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 0 * YAPF_TILE_LENGTH
 min      = 0
@@ -295,7 +295,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_shorter_platform_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 40 * YAPF_TILE_LENGTH
 min      = 0
@@ -304,7 +304,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_shorter_platform_per_tile_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 0 * YAPF_TILE_LENGTH
 min      = 0
@@ -313,7 +313,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_slope_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 2 * YAPF_TILE_LENGTH
 min      = 0
@@ -322,7 +322,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_curve_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 1 * YAPF_TILE_LENGTH
 min      = 0
@@ -331,7 +331,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_crossing_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 3 * YAPF_TILE_LENGTH
 min      = 0
@@ -340,7 +340,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_stop_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::DriveThroughRoadStops
 def      = 8 * YAPF_TILE_LENGTH
 min      = 0
@@ -349,7 +349,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_stop_occupied_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::RoadStopOccupancyPenalty
 def      = 8 * YAPF_TILE_LENGTH
 min      = 0
@@ -358,7 +358,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_stop_bay_occupied_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::RoadStopOccupancyPenalty
 def      = 15 * YAPF_TILE_LENGTH
 min      = 0
@@ -367,7 +367,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.maximum_go_to_depot_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::MaximumDepotPenalty
 def      = 20 * YAPF_TILE_LENGTH
 min      = 0
@@ -376,7 +376,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.ship_curve45_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::ShipCurvePenalty
 def      = 1 * YAPF_TILE_LENGTH
 min      = 0
@@ -385,7 +385,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.ship_curve90_penalty
-type     = SLE_UINT
+type     = SLE_UINT32
 from     = SaveLoadVersion::ShipCurvePenalty
 def      = 6 * YAPF_TILE_LENGTH
 min      = 0


### PR DESCRIPTION
## Motivation / Problem

The VarTypes enumeration, i.e. the one with `SLE_...` has a number of elements that are more a hassle than really useful.

For example `SLE_UINT` as alias for `SLE_UINT32`, of `SLE_STR` as alias for the unused `SLE_STRING`.


## Description

* Prefer SLE_INT32 over SLE_INT
* Prefer SLE_UINT32 over SLE_UINT
* Use SLE_INT8 instead of SLE_CHAR; there is field that's actually using it.
* Remove essentially pointless 'shortcut values'


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
