### PR TITLE
Codechange: make ChunkType scoped

### DIFF
--- a/docs/savegame_format.md
+++ b/docs/savegame_format.md
@@ -69,19 +69,19 @@ An example of a valid tag is `PLYR` when looking at it via ASCII, which contains
 `[4..4]` - Next follows a byte where the lower 4 bits contain the type.
 The possible valid types are:
 
-- `0` - `CH_RIFF` - This chunk is a binary blob.
-- `1` - `CH_ARRAY` - This chunk is a list of items.
-- `2` - `CH_SPARSE_ARRAY` - This chunk is a list of items.
-- `3` - `CH_TABLE` - This chunk is self-describing list of items.
-- `4` - `CH_SPARSE_TABLE` - This chunk is self-describing list of items.
+- `0` - `ChunkType::Riff` - This chunk is a binary blob.
+- `1` - `ChunkType::Array` - This chunk is a list of items.
+- `2` - `ChunkType::SparseArray` - This chunk is a list of items.
+- `3` - `ChunkType::Table` - This chunk is self-describing list of items.
+- `4` - `ChunkType::SparseTable` - This chunk is self-describing list of items.
 
 Now per type the format is (slightly) different.
 
-### CH_RIFF
+### ChunkType::Riff
 
 (since savegame version 295, this chunk type is only used for MAP-chunks, containing bit-information about each tile on the map)
 
-A `CH_RIFF` starts with an `uint24` which together with the upper-bits of the type defines the length of the chunk.
+A `ChunkType::Riff` starts with an `uint24` which together with the upper-bits of the type defines the length of the chunk.
 In pseudo-code:
 
 ```
@@ -94,11 +94,11 @@ if type == 0
 The next `length` bytes are part of the chunk.
 What those bytes mean depends on the tag of the chunk; further details per chunk can be found in the source-code.
 
-### CH_ARRAY / CH_SPARSE_ARRAY
+### ChunkType::Array / ChunkType::SparseArray
 
 (this chunk type is deprecated since savegame version 295 and is no longer in use)
 
-`[0..G1]` - A `CH_ARRAY` / `CH_SPARSE_ARRAY` starts with a `gamma`, indicating the size of the next item plus one.
+`[0..G1]` - A `ChunkType::Array` / `ChunkType::SparseArray` starts with a `gamma`, indicating the size of the next item plus one.
 If this size value is zero, it indicates the end of the list.
 This indicates the full length of the next item minus one.
 In psuedo-code:
@@ -111,21 +111,21 @@ loop
     read <size> bytes
 ```
 
-`[]` - For `CH_ARRAY` there is an implicit index.
+`[]` - For `ChunkType::Array` there is an implicit index.
 The loop starts at zero, and every iteration adds one to the index.
 For entries in the game that were not allocated, the `size` will be zero.
 
-`[G1+1..G2]` - For `CH_SPARSE_ARRAY` there is an explicit index.
+`[G1+1..G2]` - For `ChunkType::SparseArray` there is an explicit index.
 The `gamma` following the size indicates the index.
 
-The content of the item is a binary blob, and similar to `CH_RIFF`, it depends on the tag of the chunk what it means.
+The content of the item is a binary blob, and similar to `ChunkType::Riff`, it depends on the tag of the chunk what it means.
 Please check the source-code for further details.
 
-### CH_TABLE / CH_SPARSE_TABLE
+### ChunkType::Table / ChunkType::SparseTable
 
 (this chunk type only exists since savegame version 295)
 
-Both `CH_TABLE` and `CH_SPARSE_TABLE` are very similar to `CH_ARRAY` / `CH_SPARSE_ARRAY` respectively.
+Both `ChunkType::Table` and `ChunkType::SparseTable` are very similar to `ChunkType::Array` / `ChunkType::SparseArray` respectively.
 The only change is that the chunk starts with a header.
 This header describes the chunk in details; with the header you know the meaning of each byte in the binary blob that follows.
 
@@ -168,7 +168,7 @@ struct | substruct3
 The headers will be, in order: `table`, `substruct1`, `substruct3`, `substruct2`, each ending with a `type` is zero field.
 
 After reading all the fields of all the headers, there is a list of records.
-To read this, see `CH_ARRAY` / `CH_SPARSE_ARRAY` for details.
+To read this, see `ChunkType::Array` / `ChunkType::SparseArray` for details.
 
 As each `type` has a well defined length, you can read the records even without knowing anything about the chunk-tag yourself.
 
@@ -187,7 +187,7 @@ The prefix is strongly advised to avoid conflicts with future-settings in an unp
 
 ## Scripts custom data format
 
-Script chunks (`AIPL` and `GSDT`) use `CH_TABLE` chunk type.
+Script chunks (`AIPL` and `GSDT`) use `ChunkType::Table` chunk type.
 
 At the end of each record there's an `uint8` to indicate if there's custom data (1) or not (0).
 

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -73,7 +73,7 @@ static void SaveReal_AIPL(int arg)
 }
 
 struct AIPLChunkHandler : ChunkHandler {
-	AIPLChunkHandler() : ChunkHandler('AIPL', CH_TABLE) {}
+	AIPLChunkHandler() : ChunkHandler('AIPL', ChunkType::Table) {}
 
 	void Load() const override
 	{

--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -23,7 +23,7 @@ static const SaveLoad _animated_tile_desc[] = {
 };
 
 struct ANITChunkHandler : ChunkHandler {
-	ANITChunkHandler() : ChunkHandler('ANIT', CH_TABLE) {}
+	ANITChunkHandler() : ChunkHandler('ANIT', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/autoreplace_sl.cpp
+++ b/src/saveload/autoreplace_sl.cpp
@@ -26,7 +26,7 @@ static const SaveLoad _engine_renew_desc[] = {
 };
 
 struct ERNWChunkHandler : ChunkHandler {
-	ERNWChunkHandler() : ChunkHandler('ERNW', CH_TABLE) {}
+	ERNWChunkHandler() : ChunkHandler('ERNW', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/cargomonitor_sl.cpp
+++ b/src/saveload/cargomonitor_sl.cpp
@@ -45,7 +45,7 @@ static CargoMonitorID FixupCargoMonitor(CargoMonitorID number)
 
 /** #_cargo_deliveries monitoring map. */
 struct CMDLChunkHandler : ChunkHandler {
-	CMDLChunkHandler() : ChunkHandler('CMDL', CH_TABLE) {}
+	CMDLChunkHandler() : ChunkHandler('CMDL', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -88,7 +88,7 @@ struct CMDLChunkHandler : ChunkHandler {
 
 /** #_cargo_pickups monitoring map. */
 struct CMPUChunkHandler : ChunkHandler {
-	CMPUChunkHandler() : ChunkHandler('CMPU', CH_TABLE) {}
+	CMPUChunkHandler() : ChunkHandler('CMPU', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -143,7 +143,7 @@ SaveLoadTable GetCargoPacketDesc()
 }
 
 struct CAPAChunkHandler : ChunkHandler {
-	CAPAChunkHandler() : ChunkHandler('CAPA', CH_TABLE) {}
+	CAPAChunkHandler() : ChunkHandler('CAPA', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/cheat_sl.cpp
+++ b/src/saveload/cheat_sl.cpp
@@ -39,7 +39,7 @@ static const SaveLoad _cheats_desc[] = {
 
 
 struct CHTSChunkHandler : ChunkHandler {
-	CHTSChunkHandler() : ChunkHandler('CHTS', CH_TABLE) {}
+	CHTSChunkHandler() : ChunkHandler('CHTS', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -551,7 +551,7 @@ static const SaveLoad _company_desc[] = {
 };
 
 struct PLYRChunkHandler : ChunkHandler {
-	PLYRChunkHandler() : ChunkHandler('PLYR', CH_TABLE) {}
+	PLYRChunkHandler() : ChunkHandler('PLYR', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/depot_sl.cpp
+++ b/src/saveload/depot_sl.cpp
@@ -30,7 +30,7 @@ static const SaveLoad _depot_desc[] = {
 };
 
 struct DEPTChunkHandler : ChunkHandler {
-	DEPTChunkHandler() : ChunkHandler('DEPT', CH_TABLE) {}
+	DEPTChunkHandler() : ChunkHandler('DEPT', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -19,7 +19,7 @@
 
 /** Prices in pre 126 savegames */
 struct PRICChunkHandler : ChunkHandler {
-	PRICChunkHandler() : ChunkHandler('PRIC', CH_READONLY) {}
+	PRICChunkHandler() : ChunkHandler('PRIC', ChunkType::ReadOnly) {}
 
 	void Load() const override
 	{
@@ -32,7 +32,7 @@ struct PRICChunkHandler : ChunkHandler {
 
 /** Cargo payment rates in pre 126 savegames */
 struct CAPRChunkHandler : ChunkHandler {
-	CAPRChunkHandler() : ChunkHandler('CAPR', CH_READONLY) {}
+	CAPRChunkHandler() : ChunkHandler('CAPR', ChunkType::ReadOnly) {}
 
 	void Load() const override
 	{
@@ -58,7 +58,7 @@ static const SaveLoad _economy_desc[] = {
 
 /** Economy variables */
 struct ECMYChunkHandler : ChunkHandler {
-	ECMYChunkHandler() : ChunkHandler('ECMY', CH_TABLE) {}
+	ECMYChunkHandler() : ChunkHandler('ECMY', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -89,7 +89,7 @@ static const SaveLoad _cargopayment_desc[] = {
 };
 
 struct CAPYChunkHandler : ChunkHandler {
-	CAPYChunkHandler() : ChunkHandler('CAPY', CH_TABLE) {}
+	CAPYChunkHandler() : ChunkHandler('CAPY', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -62,7 +62,7 @@ Engine *GetTempDataEngine(EngineID index, VehicleType type, uint16_t local_id)
 }
 
 struct ENGNChunkHandler : ChunkHandler {
-	ENGNChunkHandler() : ChunkHandler('ENGN', CH_TABLE) {}
+	ENGNChunkHandler() : ChunkHandler('ENGN', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -135,7 +135,7 @@ void ResetTempEngineData()
 }
 
 struct ENGSChunkHandler : ChunkHandler {
-	ENGSChunkHandler() : ChunkHandler('ENGS', CH_READONLY) {}
+	ENGSChunkHandler() : ChunkHandler('ENGS', ChunkType::ReadOnly) {}
 
 	void Load() const override
 	{
@@ -162,7 +162,7 @@ static const SaveLoad _engine_id_mapping_desc[] = {
 };
 
 struct EIDSChunkHandler : ChunkHandler {
-	EIDSChunkHandler() : ChunkHandler('EIDS', CH_TABLE) {}
+	EIDSChunkHandler() : ChunkHandler('EIDS', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -52,7 +52,7 @@ static void SaveReal_GSDT(int)
 }
 
 struct GSDTChunkHandler : ChunkHandler {
-	GSDTChunkHandler() : ChunkHandler('GSDT', CH_TABLE) {}
+	GSDTChunkHandler() : ChunkHandler('GSDT', ChunkType::Table) {}
 
 	void Load() const override
 	{
@@ -153,7 +153,7 @@ static const SaveLoad _game_language_desc[] = {
 };
 
 struct GSTRChunkHandler : ChunkHandler {
-	GSTRChunkHandler() : ChunkHandler('GSTR', CH_TABLE) {}
+	GSTRChunkHandler() : ChunkHandler('GSTR', ChunkType::Table) {}
 
 	void Load() const override
 	{

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -375,7 +375,7 @@ static const SaveLoad _gamelog_desc[] = {
 };
 
 struct GLOGChunkHandler : ChunkHandler {
-	GLOGChunkHandler() : ChunkHandler('GLOG', CH_TABLE) {}
+	GLOGChunkHandler() : ChunkHandler('GLOG', ChunkType::Table) {}
 
 	void LoadCommon(Gamelog &gamelog) const
 	{

--- a/src/saveload/goal_sl.cpp
+++ b/src/saveload/goal_sl.cpp
@@ -26,7 +26,7 @@ static const SaveLoad _goals_desc[] = {
 };
 
 struct GOALChunkHandler : ChunkHandler {
-	GOALChunkHandler() : ChunkHandler('GOAL', CH_TABLE) {}
+	GOALChunkHandler() : ChunkHandler('GOAL', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/group_sl.cpp
+++ b/src/saveload/group_sl.cpp
@@ -30,7 +30,7 @@ static const SaveLoad _group_desc[] = {
 };
 
 struct GRPSChunkHandler : ChunkHandler {
-	GRPSChunkHandler() : ChunkHandler('GRPS', CH_TABLE) {}
+	GRPSChunkHandler() : ChunkHandler('GRPS', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -211,7 +211,7 @@ static const SaveLoad _industry_desc[] = {
 };
 
 struct INDYChunkHandler : ChunkHandler {
-	INDYChunkHandler() : ChunkHandler('INDY', CH_TABLE) {}
+	INDYChunkHandler() : ChunkHandler('INDY', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -317,7 +317,7 @@ static const SaveLoad _industry_builder_desc[] = {
 
 /** Industry builder. */
 struct IBLDChunkHandler : ChunkHandler {
-	IBLDChunkHandler() : ChunkHandler('IBLD', CH_TABLE) {}
+	IBLDChunkHandler() : ChunkHandler('IBLD', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -348,7 +348,7 @@ static const SaveLoad _industrytype_builder_desc[] = {
 
 /** Industry-type build data. */
 struct ITBLChunkHandler : ChunkHandler {
-	ITBLChunkHandler() : ChunkHandler('ITBL', CH_TABLE) {}
+	ITBLChunkHandler() : ChunkHandler('ITBL', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -34,7 +34,7 @@ void AfterLoadLabelMaps()
 }
 
 struct RAILChunkHandler : ChunkHandler {
-	RAILChunkHandler() : ChunkHandler('RAIL', CH_TABLE) {}
+	RAILChunkHandler() : ChunkHandler('RAIL', ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
 		SLE_VAR(LabelObject<RailTypeLabel>, label, SLE_UINT32),
@@ -69,7 +69,7 @@ struct RAILChunkHandler : ChunkHandler {
 };
 
 struct ROTTChunkHandler : ChunkHandler {
-	ROTTChunkHandler() : ChunkHandler('ROTT', CH_TABLE) {}
+	ROTTChunkHandler() : ChunkHandler('ROTT', ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
 		SLE_VAR(LabelObject<RoadTypeLabel>, label, SLE_UINT32),

--- a/src/saveload/league_sl.cpp
+++ b/src/saveload/league_sl.cpp
@@ -27,7 +27,7 @@ static const SaveLoad _league_table_elements_desc[] = {
 };
 
 struct LEAEChunkHandler : ChunkHandler {
-	LEAEChunkHandler() : ChunkHandler('LEAE', CH_TABLE) {}
+	LEAEChunkHandler() : ChunkHandler('LEAE', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -58,7 +58,7 @@ static const SaveLoad _league_tables_desc[] = {
 };
 
 struct LEATChunkHandler : ChunkHandler {
-	LEATChunkHandler() : ChunkHandler('LEAT', CH_TABLE) {}
+	LEATChunkHandler() : ChunkHandler('LEAT', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -259,7 +259,7 @@ void AfterLoadLinkGraphs()
  * All link graphs.
  */
 struct LGRPChunkHandler : ChunkHandler {
-	LGRPChunkHandler() : ChunkHandler('LGRP', CH_TABLE) {}
+	LGRPChunkHandler() : ChunkHandler('LGRP', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -287,7 +287,7 @@ struct LGRPChunkHandler : ChunkHandler {
  * All link graph jobs.
  */
 struct LGRJChunkHandler : ChunkHandler {
-	LGRJChunkHandler() : ChunkHandler('LGRJ', CH_TABLE) {}
+	LGRJChunkHandler() : ChunkHandler('LGRJ', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -315,7 +315,7 @@ struct LGRJChunkHandler : ChunkHandler {
  * Link graph schedule.
  */
 struct LGRSChunkHandler : ChunkHandler {
-	LGRSChunkHandler() : ChunkHandler('LGRS', CH_TABLE) {}
+	LGRSChunkHandler() : ChunkHandler('LGRS', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -27,7 +27,7 @@ static const SaveLoad _map_desc[] = {
 };
 
 struct MAPSChunkHandler : ChunkHandler {
-	MAPSChunkHandler() : ChunkHandler('MAPS', CH_TABLE) {}
+	MAPSChunkHandler() : ChunkHandler('MAPS', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -67,7 +67,7 @@ struct MAPSChunkHandler : ChunkHandler {
 static const uint MAP_SL_BUF_SIZE = 4096;
 
 struct MAPTChunkHandler : ChunkHandler {
-	MAPTChunkHandler() : ChunkHandler('MAPT', CH_RIFF) {}
+	MAPTChunkHandler() : ChunkHandler('MAPT', ChunkType::Riff) {}
 
 	void Load() const override
 	{
@@ -94,7 +94,7 @@ struct MAPTChunkHandler : ChunkHandler {
 };
 
 struct MAPHChunkHandler : ChunkHandler {
-	MAPHChunkHandler() : ChunkHandler('MAPH', CH_RIFF) {}
+	MAPHChunkHandler() : ChunkHandler('MAPH', ChunkType::Riff) {}
 
 	void Load() const override
 	{
@@ -121,7 +121,7 @@ struct MAPHChunkHandler : ChunkHandler {
 };
 
 struct MAPOChunkHandler : ChunkHandler {
-	MAPOChunkHandler() : ChunkHandler('MAPO', CH_RIFF) {}
+	MAPOChunkHandler() : ChunkHandler('MAPO', ChunkType::Riff) {}
 
 	void Load() const override
 	{
@@ -148,7 +148,7 @@ struct MAPOChunkHandler : ChunkHandler {
 };
 
 struct MAP2ChunkHandler : ChunkHandler {
-	MAP2ChunkHandler() : ChunkHandler('MAP2', CH_RIFF) {}
+	MAP2ChunkHandler() : ChunkHandler('MAP2', ChunkType::Riff) {}
 
 	void Load() const override
 	{
@@ -178,7 +178,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 };
 
 struct M3LOChunkHandler : ChunkHandler {
-	M3LOChunkHandler() : ChunkHandler('M3LO', CH_RIFF) {}
+	M3LOChunkHandler() : ChunkHandler('M3LO', ChunkType::Riff) {}
 
 	void Load() const override
 	{
@@ -205,7 +205,7 @@ struct M3LOChunkHandler : ChunkHandler {
 };
 
 struct M3HIChunkHandler : ChunkHandler {
-	M3HIChunkHandler() : ChunkHandler('M3HI', CH_RIFF) {}
+	M3HIChunkHandler() : ChunkHandler('M3HI', ChunkType::Riff) {}
 
 	void Load() const override
 	{
@@ -232,7 +232,7 @@ struct M3HIChunkHandler : ChunkHandler {
 };
 
 struct MAP5ChunkHandler : ChunkHandler {
-	MAP5ChunkHandler() : ChunkHandler('MAP5', CH_RIFF) {}
+	MAP5ChunkHandler() : ChunkHandler('MAP5', ChunkType::Riff) {}
 
 	void Load() const override
 	{
@@ -259,7 +259,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 };
 
 struct MAPEChunkHandler : ChunkHandler {
-	MAPEChunkHandler() : ChunkHandler('MAPE', CH_RIFF) {}
+	MAPEChunkHandler() : ChunkHandler('MAPE', ChunkType::Riff) {}
 
 	void Load() const override
 	{
@@ -299,7 +299,7 @@ struct MAPEChunkHandler : ChunkHandler {
 };
 
 struct MAP7ChunkHandler : ChunkHandler {
-	MAP7ChunkHandler() : ChunkHandler('MAP7', CH_RIFF) {}
+	MAP7ChunkHandler() : ChunkHandler('MAP7', ChunkType::Riff) {}
 
 	void Load() const override
 	{
@@ -326,7 +326,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 };
 
 struct MAP8ChunkHandler : ChunkHandler {
-	MAP8ChunkHandler() : ChunkHandler('MAP8', CH_RIFF) {}
+	MAP8ChunkHandler() : ChunkHandler('MAP8', ChunkType::Riff) {}
 
 	void Load() const override
 	{

--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -121,7 +121,7 @@ static const SaveLoad _date_check_desc[] = {
  * @note currently some unrelated stuff is just put here.
  */
 struct DATEChunkHandler : ChunkHandler {
-	DATEChunkHandler() : ChunkHandler('DATE', CH_TABLE) {}
+	DATEChunkHandler() : ChunkHandler('DATE', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -165,7 +165,7 @@ static const SaveLoad _view_desc[] = {
 };
 
 struct VIEWChunkHandler : ChunkHandler {
-	VIEWChunkHandler() : ChunkHandler('VIEW', CH_TABLE) {}
+	VIEWChunkHandler() : ChunkHandler('VIEW', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -62,7 +62,7 @@ void NewGRFMappingChunkHandler::Load() const
 }
 
 struct NGRFChunkHandler : ChunkHandler {
-	NGRFChunkHandler() : ChunkHandler('NGRF', CH_TABLE) {}
+	NGRFChunkHandler() : ChunkHandler('NGRF', ChunkType::Table) {}
 
 	static inline std::array<uint32_t, GRFConfig::MAX_NUM_PARAMS> param;
 	static inline uint8_t num_params;

--- a/src/saveload/newgrf_sl.h
+++ b/src/saveload/newgrf_sl.h
@@ -16,7 +16,7 @@
 struct NewGRFMappingChunkHandler : ChunkHandler {
 	OverrideManagerBase &mapping;
 
-	NewGRFMappingChunkHandler(uint32_t id, OverrideManagerBase &mapping) : ChunkHandler(id, CH_TABLE), mapping(mapping) {}
+	NewGRFMappingChunkHandler(uint32_t id, OverrideManagerBase &mapping) : ChunkHandler(id, ChunkType::Table), mapping(mapping) {}
 	void Save() const override;
 	void Load() const override;
 };

--- a/src/saveload/object_sl.cpp
+++ b/src/saveload/object_sl.cpp
@@ -30,7 +30,7 @@ static const SaveLoad _object_desc[] = {
 };
 
 struct OBJSChunkHandler : ChunkHandler {
-	OBJSChunkHandler() : ChunkHandler('OBJS', CH_TABLE) {}
+	OBJSChunkHandler() : ChunkHandler('OBJS', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -159,7 +159,7 @@ SaveLoadTable GetOrderDescription()
 }
 
 struct ORDRChunkHandler : ChunkHandler {
-	ORDRChunkHandler() : ChunkHandler('ORDR', CH_READONLY) {}
+	ORDRChunkHandler() : ChunkHandler('ORDR', ChunkType::ReadOnly) {}
 
 	void Load() const override
 	{
@@ -249,7 +249,7 @@ SaveLoadTable GetOrderListDescription()
 }
 
 struct ORDLChunkHandler : ChunkHandler {
-	ORDLChunkHandler() : ChunkHandler('ORDL', CH_TABLE) {}
+	ORDLChunkHandler() : ChunkHandler('ORDL', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -320,7 +320,7 @@ SaveLoadTable GetOrderBackupDescription()
 }
 
 struct BKORChunkHandler : ChunkHandler {
-	BKORChunkHandler() : ChunkHandler('BKOR', CH_TABLE) {}
+	BKORChunkHandler() : ChunkHandler('BKOR', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/randomizer_sl.cpp
+++ b/src/saveload/randomizer_sl.cpp
@@ -19,7 +19,7 @@ static const SaveLoad _randomizer_desc[] = {
 };
 
 struct SRNDChunkHandler : ChunkHandler {
-	SRNDChunkHandler() : ChunkHandler('SRND', CH_TABLE)
+	SRNDChunkHandler() : ChunkHandler('SRND', ChunkType::Table)
 	{}
 
 	void Save() const override

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -196,7 +196,7 @@ struct MemoryDumper {
 struct SaveLoadParams {
 	SaveLoadAction action;               ///< are we doing a save or a load atm.
 	NeedLength need_length;              ///< working in NeedLength (Autolength) mode?
-	uint8_t block_mode;                     ///< ???
+	ChunkType chunk_type; ///< The type of chunk we are reading or writing.
 	bool error;                          ///< did an error occur or not
 
 	size_t obj_len;                      ///< the length of the current object we are busy with
@@ -707,11 +707,11 @@ int SlIterateArray()
 		}
 
 		int index;
-		switch (_sl.block_mode) {
-			case CH_SPARSE_TABLE:
-			case CH_SPARSE_ARRAY: index = static_cast<int>(SlReadSparseIndex()); break;
-			case CH_TABLE:
-			case CH_ARRAY:        index = _sl.array_index++; break;
+		switch (_sl.chunk_type) {
+			case ChunkType::SparseTable:
+			case ChunkType::SparseArray: index = static_cast<int>(SlReadSparseIndex()); break;
+			case ChunkType::Table:
+			case ChunkType::Array: index = _sl.array_index++; break;
 			default:
 				Debug(sl, 0, "SlIterateArray error");
 				return -1; // error
@@ -743,30 +743,30 @@ void SlSetLength(size_t length)
 	switch (_sl.need_length) {
 		case NL_WANTLENGTH:
 			_sl.need_length = NL_NONE;
-			if ((_sl.block_mode == CH_TABLE || _sl.block_mode == CH_SPARSE_TABLE) && _sl.expect_table_header) {
+			if ((_sl.chunk_type == ChunkType::Table || _sl.chunk_type == ChunkType::SparseTable) && _sl.expect_table_header) {
 				_sl.expect_table_header = false;
 				SlWriteArrayLength(length + 1);
 				break;
 			}
 
-			switch (_sl.block_mode) {
-				case CH_RIFF:
+			switch (_sl.chunk_type) {
+				case ChunkType::Riff:
 					/* Ugly encoding of >16M RIFF chunks
 					 * The lower 24 bits are normal
 					 * The uppermost 4 bits are bits 24:27 */
 					assert(length < (1 << 28));
 					SlWriteUint32((uint32_t)((length & 0xFFFFFF) | ((length >> 24) << 28)));
 					break;
-				case CH_TABLE:
-				case CH_ARRAY:
+				case ChunkType::Table:
+				case ChunkType::Array:
 					assert(_sl.last_array_index <= _sl.array_index);
 					while (++_sl.last_array_index <= _sl.array_index) {
 						SlWriteArrayLength(1);
 					}
 					SlWriteArrayLength(length + 1);
 					break;
-				case CH_SPARSE_TABLE:
-				case CH_SPARSE_ARRAY:
+				case ChunkType::SparseTable:
+				case ChunkType::SparseArray:
 					SlWriteArrayLength(length + 1 + SlGetArrayLength(_sl.array_index)); // Also include length of sparse index.
 					SlWriteSparseIndex(_sl.array_index);
 					break;
@@ -1880,8 +1880,8 @@ class SlSkipHandler : public SaveLoadHandler {
  */
 std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 {
-	/* You can only use SlTableHeader if you are a CH_TABLE. */
-	assert(_sl.block_mode == CH_TABLE || _sl.block_mode == CH_SPARSE_TABLE);
+	/* You can only use SlTableHeader if you are a ChunkType::Table or ChunkType::SparseTable. */
+	assert(_sl.chunk_type == ChunkType::Table || _sl.chunk_type == ChunkType::SparseTable);
 
 	switch (_sl.action) {
 		case SLA_LOAD_CHECK:
@@ -2019,8 +2019,8 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLoadCompatTable &slct)
 {
 	assert(_sl.action == SLA_LOAD || _sl.action == SLA_LOAD_CHECK);
-	/* CH_TABLE / CH_SPARSE_TABLE always have a header. */
-	if (_sl.block_mode == CH_TABLE || _sl.block_mode == CH_SPARSE_TABLE) return SlTableHeader(slt);
+	/* ChunkType::Table / ChunkType::SparseTable always have a header. */
+	if (_sl.chunk_type == ChunkType::Table || _sl.chunk_type == ChunkType::SparseTable) return SlTableHeader(slt);
 
 	std::vector<SaveLoad> saveloads;
 
@@ -2106,16 +2106,16 @@ void SlAutolength(AutolengthProc *proc, int arg)
 
 void ChunkHandler::LoadCheck(size_t len) const
 {
-	switch (_sl.block_mode) {
-		case CH_TABLE:
-		case CH_SPARSE_TABLE:
+	switch (_sl.chunk_type) {
+		case ChunkType::Table:
+		case ChunkType::SparseTable:
 			SlTableHeader({});
 			[[fallthrough]];
-		case CH_ARRAY:
-		case CH_SPARSE_ARRAY:
+		case ChunkType::Array:
+		case ChunkType::SparseArray:
 			SlSkipArray();
 			break;
-		case CH_RIFF:
+		case ChunkType::Riff:
 			SlSkipBytes(len);
 			break;
 		default:
@@ -2131,9 +2131,9 @@ static void SlLoadChunk(const ChunkHandler &ch)
 {
 	uint8_t m = SlReadByte();
 
-	_sl.block_mode = m & CH_TYPE_MASK;
+	_sl.chunk_type = static_cast<ChunkType>(m & to_underlying(ChunkType::FileTypeMask));
 	_sl.obj_len = 0;
-	_sl.expect_table_header = (_sl.block_mode == CH_TABLE || _sl.block_mode == CH_SPARSE_TABLE);
+	_sl.expect_table_header = (_sl.chunk_type == ChunkType::Table || _sl.chunk_type == ChunkType::SparseTable);
 
 	/* The header should always be at the start. Read the length; the
 	 * Load() should as first action process the header. */
@@ -2141,19 +2141,19 @@ static void SlLoadChunk(const ChunkHandler &ch)
 		if (SlIterateArray() != INT32_MAX) SlErrorCorrupt("Table chunk without header");
 	}
 
-	switch (_sl.block_mode) {
-		case CH_TABLE:
-		case CH_ARRAY:
+	switch (_sl.chunk_type) {
+		case ChunkType::Table:
+		case ChunkType::Array:
 			_sl.array_index = 0;
 			ch.Load();
 			if (_next_offs != 0) SlErrorCorrupt("Invalid array length");
 			break;
-		case CH_SPARSE_TABLE:
-		case CH_SPARSE_ARRAY:
+		case ChunkType::SparseTable:
+		case ChunkType::SparseArray:
 			ch.Load();
 			if (_next_offs != 0) SlErrorCorrupt("Invalid array length");
 			break;
-		case CH_RIFF: {
+		case ChunkType::Riff: {
 			/* Read length */
 			size_t len = (SlReadByte() << 16) | ((m >> 4) << 24);
 			len += SlReadUint16();
@@ -2184,9 +2184,9 @@ static void SlLoadCheckChunk(const ChunkHandler &ch)
 {
 	uint8_t m = SlReadByte();
 
-	_sl.block_mode = m & CH_TYPE_MASK;
+	_sl.chunk_type = static_cast<ChunkType>(m & to_underlying(ChunkType::FileTypeMask));
 	_sl.obj_len = 0;
-	_sl.expect_table_header = (_sl.block_mode == CH_TABLE || _sl.block_mode == CH_SPARSE_TABLE);
+	_sl.expect_table_header = (_sl.chunk_type == ChunkType::Table || _sl.chunk_type == ChunkType::SparseTable);
 
 	/* The header should always be at the start. Read the length; the
 	 * LoadCheck() should as first action process the header. */
@@ -2194,17 +2194,17 @@ static void SlLoadCheckChunk(const ChunkHandler &ch)
 		if (SlIterateArray() != INT32_MAX) SlErrorCorrupt("Table chunk without header");
 	}
 
-	switch (_sl.block_mode) {
-		case CH_TABLE:
-		case CH_ARRAY:
+	switch (_sl.chunk_type) {
+		case ChunkType::Table:
+		case ChunkType::Array:
 			_sl.array_index = 0;
 			ch.LoadCheck();
 			break;
-		case CH_SPARSE_TABLE:
-		case CH_SPARSE_ARRAY:
+		case ChunkType::SparseTable:
+		case ChunkType::SparseArray:
 			ch.LoadCheck();
 			break;
-		case CH_RIFF: {
+		case ChunkType::Riff: {
 			/* Read length */
 			size_t len = (SlReadByte() << 16) | ((m >> 4) << 24);
 			len += SlReadUint16();
@@ -2233,30 +2233,30 @@ static void SlLoadCheckChunk(const ChunkHandler &ch)
  */
 static void SlSaveChunk(const ChunkHandler &ch)
 {
-	if (ch.type == CH_READONLY) return;
+	if (ch.type == ChunkType::ReadOnly) return;
 
 	SlWriteUint32(ch.id);
 	Debug(sl, 2, "Saving chunk {}", ch.GetName());
 
-	_sl.block_mode = ch.type;
-	_sl.expect_table_header = (_sl.block_mode == CH_TABLE || _sl.block_mode == CH_SPARSE_TABLE);
+	_sl.chunk_type = ch.type;
+	_sl.expect_table_header = (_sl.chunk_type == ChunkType::Table || _sl.chunk_type == ChunkType::SparseTable);
 
-	_sl.need_length = (_sl.expect_table_header || _sl.block_mode == CH_RIFF) ? NL_WANTLENGTH : NL_NONE;
+	_sl.need_length = (_sl.expect_table_header || _sl.chunk_type == ChunkType::Riff) ? NL_WANTLENGTH : NL_NONE;
 
-	switch (_sl.block_mode) {
-		case CH_RIFF:
+	switch (_sl.chunk_type) {
+		case ChunkType::Riff:
 			ch.Save();
 			break;
-		case CH_TABLE:
-		case CH_ARRAY:
+		case ChunkType::Table:
+		case ChunkType::Array:
 			_sl.last_array_index = 0;
-			SlWriteByte(_sl.block_mode);
+			SlWriteByte(to_underlying(_sl.chunk_type));
 			ch.Save();
 			SlWriteArrayLength(0); // Terminate arrays
 			break;
-		case CH_SPARSE_TABLE:
-		case CH_SPARSE_ARRAY:
-			SlWriteByte(_sl.block_mode);
+		case ChunkType::SparseTable:
+		case ChunkType::SparseArray:
+			SlWriteByte(to_underlying(_sl.chunk_type));
 			ch.Save();
 			SlWriteArrayLength(0); // Terminate arrays
 			break;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -329,9 +329,9 @@ enum class SaveLoadVersion : uint16_t {
 	GroupReplaceWagonRemoval, ///< Saveload version: 291, GitHub pull request: 7441\n Per-group wagon removal flag.
 	CustomSubsidyDuration, ///< Saveload version: 292, GitHub pull request: 9081\n Configurable subsidy duration.
 	SaveloadListLength, ///< Saveload version: 293, GitHub pull request: 9374\n Consistency in list length with SaveLoadType::Struct / SaveLoadType::StructList / SaveLoadType::ReferenceList.
-	RiffToArray, ///< Saveload version: 294, GitHub pull request: 9375\n Changed many CH_RIFF chunks to CH_ARRAY chunks.
+	RiffToArray, ///< Saveload version: 294, GitHub pull request: 9375\n Changed many ChunkType::Riff chunks to ChunkType::Array chunks.
 
-	TableChunks, ///< Saveload version: 295, GitHub pull request: 9322\n Introduction of CH_TABLE and CH_SPARSE_TABLE.
+	TableChunks, ///< Saveload version: 295, GitHub pull request: 9322\n Introduction of ChunkType::Table and ChunkType::SparseTable.
 	ScriptInt64, ///< Saveload version: 296, GitHub pull request: 9415\n SQInteger is 64bit but was saved as 32bit.
 	LinkgraphTravelTime, ///< Saveload version: 297, GitHub pull request: 9457, release: 12.0-RC1\n Store travel time in the linkgraph.
 	DockDockingtiles, ///< Saveload version: 298, GitHub pull request: 9578\n All tiles around docks may be docking tiles.
@@ -467,15 +467,15 @@ SaveLoadResult LoadWithFilter(std::shared_ptr<struct LoadFilter> reader);
 typedef void AutolengthProc(int);
 
 /** Type of a chunk. */
-enum ChunkType : uint8_t {
-	CH_RIFF = 0,
-	CH_ARRAY = 1,
-	CH_SPARSE_ARRAY = 2,
-	CH_TABLE = 3,
-	CH_SPARSE_TABLE = 4,
+enum class ChunkType : uint8_t {
+	Riff = 0, ///< 4 bits store the chunk type, 28 bits the number of bytes.
+	Array = 1, ///< Contiguous array of elements starting at index 0.
+	SparseArray = 2, ///< Array of elements with index for each element.
+	Table = 3, ///< An \c Array with a header describing the elements.
+	SparseTable = 4, ///< A \c SparseArray with a header describing the elements.
 
-	CH_TYPE_MASK = 0xf, ///< All ChunkType values have to be within this mask.
-	CH_READONLY, ///< Chunk is never saved.
+	FileTypeMask = 0xf, ///< All ChunkType values that are saved in the file have to be within this mask.
+	ReadOnly, ///< Chunk is never saved.
 };
 
 /** Handlers and description of chunk. */
@@ -490,7 +490,7 @@ struct ChunkHandler {
 
 	/**
 	 * Save the chunk.
-	 * Must be overridden, unless Chunk type is CH_READONLY.
+	 * Must be overridden, unless Chunk type is ChunkType::ReadOnly.
 	 */
 	virtual void Save() const { NOT_REACHED(); }
 

--- a/src/saveload/settings_sl.cpp
+++ b/src/saveload/settings_sl.cpp
@@ -142,7 +142,7 @@ static void SaveSettings(const SettingTable &settings, void *object)
 }
 
 struct OPTSChunkHandler : ChunkHandler {
-	OPTSChunkHandler() : ChunkHandler('OPTS', CH_READONLY) {}
+	OPTSChunkHandler() : ChunkHandler('OPTS', ChunkType::ReadOnly) {}
 
 	void Load() const override
 	{
@@ -156,7 +156,7 @@ struct OPTSChunkHandler : ChunkHandler {
 };
 
 struct PATSChunkHandler : ChunkHandler {
-	PATSChunkHandler() : ChunkHandler('PATS', CH_TABLE) {}
+	PATSChunkHandler() : ChunkHandler('PATS', ChunkType::Table) {}
 
 	void Load() const override
 	{

--- a/src/saveload/signs_sl.cpp
+++ b/src/saveload/signs_sl.cpp
@@ -32,7 +32,7 @@ static const SaveLoad _sign_desc[] = {
 };
 
 struct SIGNChunkHandler : ChunkHandler {
-	SIGNChunkHandler() : ChunkHandler('SIGN', CH_TABLE) {}
+	SIGNChunkHandler() : ChunkHandler('SIGN', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -531,7 +531,7 @@ static const SaveLoad _old_station_desc[] = {
 };
 
 struct STNSChunkHandler : ChunkHandler {
-	STNSChunkHandler() : ChunkHandler('STNS', CH_READONLY) {}
+	STNSChunkHandler() : ChunkHandler('STNS', ChunkType::ReadOnly) {}
 
 	void Load() const override
 	{
@@ -722,7 +722,7 @@ static const SaveLoad _station_desc[] = {
 };
 
 struct STNNChunkHandler : ChunkHandler {
-	STNNChunkHandler() : ChunkHandler('STNN', CH_TABLE) {}
+	STNNChunkHandler() : ChunkHandler('STNN', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -765,7 +765,7 @@ struct STNNChunkHandler : ChunkHandler {
 };
 
 struct ROADChunkHandler : ChunkHandler {
-	ROADChunkHandler() : ChunkHandler('ROAD', CH_TABLE) {}
+	ROADChunkHandler() : ChunkHandler('ROAD', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -25,7 +25,7 @@ static const SaveLoad _storage_desc[] = {
 
 /** Persistent storage data. */
 struct PSACChunkHandler : ChunkHandler {
-	PSACChunkHandler() : ChunkHandler('PSAC', CH_TABLE) {}
+	PSACChunkHandler() : ChunkHandler('PSAC', ChunkType::Table) {}
 
 	void Load() const override
 	{

--- a/src/saveload/story_sl.cpp
+++ b/src/saveload/story_sl.cpp
@@ -39,7 +39,7 @@ static const SaveLoad _story_page_elements_desc[] = {
 };
 
 struct STPEChunkHandler : ChunkHandler {
-	STPEChunkHandler() : ChunkHandler('STPE', CH_TABLE) {}
+	STPEChunkHandler() : ChunkHandler('STPE', ChunkType::Table) {}
 
 	void Save() const override
 	{
@@ -81,7 +81,7 @@ static const SaveLoad _story_pages_desc[] = {
 };
 
 struct STPAChunkHandler : ChunkHandler {
-	STPAChunkHandler() : ChunkHandler('STPA', CH_TABLE) {}
+	STPAChunkHandler() : ChunkHandler('STPA', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -111,7 +111,7 @@ void InitializeOldNames()
 }
 
 struct NAMEChunkHandler : ChunkHandler {
-	NAMEChunkHandler() : ChunkHandler('NAME', CH_READONLY) {}
+	NAMEChunkHandler() : ChunkHandler('NAME', ChunkType::ReadOnly) {}
 
 	void Load() const override
 	{

--- a/src/saveload/subsidy_sl.cpp
+++ b/src/saveload/subsidy_sl.cpp
@@ -30,7 +30,7 @@ static const SaveLoad _subsidies_desc[] = {
 };
 
 struct SUBSChunkHandler : ChunkHandler {
-	SUBSChunkHandler() : ChunkHandler('SUBS', CH_TABLE) {}
+	SUBSChunkHandler() : ChunkHandler('SUBS', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -374,7 +374,7 @@ struct HIDSChunkHandler : NewGRFMappingChunkHandler {
 };
 
 struct CITYChunkHandler : ChunkHandler {
-	CITYChunkHandler() : ChunkHandler('CITY', CH_TABLE) {}
+	CITYChunkHandler() : ChunkHandler('CITY', ChunkType::Table) {}
 
 	void Save() const override
 	{

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -1114,7 +1114,7 @@ static const SaveLoad _vehicle_desc[] = {
 };
 
 struct VEHSChunkHandler : ChunkHandler {
-	VEHSChunkHandler() : ChunkHandler('VEHS', CH_SPARSE_TABLE) {}
+	VEHSChunkHandler() : ChunkHandler('VEHS', ChunkType::SparseTable) {}
 
 	void Save() const override
 	{

--- a/src/saveload/water_regions_sl.cpp
+++ b/src/saveload/water_regions_sl.cpp
@@ -17,7 +17,7 @@ extern void SlSkipArray();
 
 /** Water Region savegame data is no longer used, but still needed for old savegames to load without errors. */
 struct WaterRegionChunkHandler : ChunkHandler {
-	WaterRegionChunkHandler() : ChunkHandler('WRGN', CH_READONLY)
+	WaterRegionChunkHandler() : ChunkHandler('WRGN', ChunkType::ReadOnly)
 	{}
 
 	void Load() const override

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -186,7 +186,7 @@ static const SaveLoad _old_waypoint_desc[] = {
 };
 
 struct CHKPChunkHandler : ChunkHandler {
-	CHKPChunkHandler() : ChunkHandler('CHKP', CH_READONLY) {}
+	CHKPChunkHandler() : ChunkHandler('CHKP', ChunkType::ReadOnly) {}
 
 	void Load() const override
 	{


### PR DESCRIPTION
## Motivation / Problem

Type safety.


## Description

* Make `ChunkType` scoped.
* Rename `block_mode` to `chunk_type`, and change its type from `uint8_t` to `ChunkType`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
