### PR TITLE
Codechange: make SavegameType scoped

### DIFF
--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -194,23 +194,23 @@ void Gamelog::Print(std::function<void(const std::string &)> proc)
 	fmt::format_to(output_iterator, "Conversion from ");
 	switch (this->type) {
 		default: NOT_REACHED();
-		case SGT_OTTD:
+		case SavegameType::OTTD:
 			fmt::format_to(output_iterator, "OTTD savegame without gamelog: version {}, {}",
 				GB(this->version, 8, 16), GB(this->version, 0, 8));
 			break;
 
-		case SGT_TTO:
+		case SavegameType::TTO:
 			fmt::format_to(output_iterator, "TTO savegame");
 			break;
 
-		case SGT_TTD:
+		case SavegameType::TTD:
 			fmt::format_to(output_iterator, "TTD savegame");
 			break;
 
-		case SGT_TTDP1:
-		case SGT_TTDP2:
+		case SavegameType::TTDP1:
+		case SavegameType::TTDP2:
 			fmt::format_to(output_iterator, "TTDP savegame, {} format",
-				this->type == SGT_TTDP1 ? "old" : "new");
+				this->type == SavegameType::TTDP1 ? "old" : "new");
 			if (this->version != 0) {
 				fmt::format_to(output_iterator, ", TTDP version {}.{}.{}.{}",
 					GB(this->version, 24, 8), GB(this->version, 20, 4),
@@ -401,7 +401,7 @@ void Gamelog::Oldver()
 	assert(this->action_type == GamelogActionType::Load);
 
 	this->Change(std::make_unique<LoggedChangeOldVersion>(_savegame_type,
-		(_savegame_type == SGT_OTTD ? ((uint32_t)_sl_version << 8 | _sl_minor_version) : _ttdp_version)));
+		(_savegame_type == SavegameType::OTTD ? (static_cast<uint32_t>(_sl_version) << 8 | _sl_minor_version) : _ttdp_version)));
 }
 
 /**

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -122,8 +122,8 @@ uint8_t ReadByte(LoadgameState &ls)
 bool LoadChunk(LoadgameState &ls, void *base, const OldChunks *chunks)
 {
 	for (const OldChunks *chunk = chunks; chunk->type != OC_END; chunk++) {
-		if (((chunk->type & OC_TTD) && _savegame_type == SGT_TTO) ||
-				((chunk->type & OC_TTO) && _savegame_type != SGT_TTO)) {
+		if (((chunk->type & OC_TTD) && _savegame_type == SavegameType::TTO) ||
+				((chunk->type & OC_TTO) && _savegame_type != SavegameType::TTO)) {
 			/* TTD(P)-only chunk, but TTO savegame || TTO-only chunk, but TTD/TTDP savegame */
 			continue;
 		}
@@ -217,18 +217,18 @@ static std::tuple<SavegameType, std::string> DetermineOldSavegameTypeAndName(Fil
 	long pos = ftell(f);
 	char buffer[std::max(TTO_HEADER_SIZE, TTD_HEADER_SIZE)];
 	if (pos < 0 || fread(buffer, 1, lengthof(buffer), f) != lengthof(buffer)) {
-		return { SGT_INVALID, "(broken) Unable to read file" };
+		return { SavegameType::Invalid, "(broken) Unable to read file" };
 	}
 
 	if (VerifyOldNameChecksum(buffer, TTO_HEADER_SIZE) && fseek(f, pos + TTO_HEADER_SIZE, SEEK_SET) == 0) {
-		return { SGT_TTO, "(TTO) " + StrMakeValid(std::string_view{buffer, TTO_HEADER_SIZE - HEADER_CHECKSUM_SIZE}) };
+		return { SavegameType::TTO, "(TTO) " + StrMakeValid(std::string_view{buffer, TTO_HEADER_SIZE - HEADER_CHECKSUM_SIZE}) };
 	}
 
 	if (VerifyOldNameChecksum(buffer, TTD_HEADER_SIZE) && fseek(f, pos + TTD_HEADER_SIZE, SEEK_SET) == 0) {
-		return { SGT_TTD, "(TTD) " + StrMakeValid(std::string_view{buffer, TTD_HEADER_SIZE - HEADER_CHECKSUM_SIZE}) };
+		return { SavegameType::TTD, "(TTD) " + StrMakeValid(std::string_view{buffer, TTD_HEADER_SIZE - HEADER_CHECKSUM_SIZE}) };
 	}
 
-	return { SGT_INVALID, "(broken) Unknown" };
+	return { SavegameType::Invalid, "(broken) Unknown" };
 }
 
 typedef bool LoadOldMainProc(LoadgameState &ls);
@@ -257,8 +257,8 @@ bool LoadOldSaveGame(std::string_view file)
 	LoadOldMainProc *proc = nullptr;
 
 	switch (type) {
-		case SGT_TTO: proc = &LoadTTOMain; break;
-		case SGT_TTD: proc = &LoadTTDMain; break;
+		case SavegameType::TTO: proc = &LoadTTOMain; break;
+		case SavegameType::TTD: proc = &LoadTTDMain; break;
 		default:
 			Debug(oldloader, 0, "Unknown savegame type; cannot be loaded");
 			break;

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -471,12 +471,12 @@ static inline Colours RemapTTOColour(Colours tto)
 
 static inline uint RemapTownIndex(uint x)
 {
-	return _savegame_type == SGT_TTO ? (x - 0x264) / 78 : (x - 0x264) / 94;
+	return _savegame_type == SavegameType::TTO ? (x - 0x264) / 78 : (x - 0x264) / 94;
 }
 
 static inline uint RemapOrderIndex(uint x)
 {
-	return _savegame_type == SGT_TTO ? (x - 0x1AC4) / 2 : (x - 0x1C18) / 2;
+	return _savegame_type == SavegameType::TTO ? (x - 0x1AC4) / 2 : (x - 0x1C18) / 2;
 }
 
 extern std::vector<TileIndex> _animated_tiles;
@@ -519,7 +519,7 @@ static void ReadTTDPatchFlags(LoadgameState &ls)
 	_old_extra_chunk_nums = 0;
 	_bump_assert_value = 0;
 
-	if (_savegame_type == SGT_TTO) {
+	if (_savegame_type == SavegameType::TTO) {
 		ls.vehicle_names.resize(800);
 		return;
 	}
@@ -542,7 +542,7 @@ static void ReadTTDPatchFlags(LoadgameState &ls)
 	/* The first 17 bytes are used by TTDP1, which translates to the first 9 m3s and first 8 m4s. */
 	for (TileIndex i{}; i <= 8; i++) { // check tile 0, too
 		Tile tile(i);
-		if (tile.m3() != 0 || (i != 8 && tile.m4() != 0)) _savegame_type = SGT_TTDP1;
+		if (tile.m3() != 0 || (i != 8 && tile.m4() != 0)) _savegame_type = SavegameType::TTDP1;
 	}
 
 	/* Check if we have a modern TTDPatch savegame (has extra data all around) */
@@ -550,17 +550,17 @@ static void ReadTTDPatchFlags(LoadgameState &ls)
 	Tile ttdp2_header_second(Map::Size() - 2);
 	if (ttdp2_header_first.m3() == 'T' && ttdp2_header_first.m4() == 'T' &&
 		ttdp2_header_second.m3() == 'D' && ttdp2_header_second.m4() == 'p') {
-		_savegame_type = SGT_TTDP2;
+		_savegame_type = SavegameType::TTDP2;
 	}
 
-	Tile extra_chunk_tile = Tile(_savegame_type == SGT_TTDP2 ? Map::Size() - 1 : 1);
+	Tile extra_chunk_tile = Tile(_savegame_type == SavegameType::TTDP2 ? Map::Size() - 1 : 1);
 	_old_extra_chunk_nums = extra_chunk_tile.m3() | extra_chunk_tile.m4() << 8;
 
 	/* Clean the misused places */
 	for (TileIndex i{}; i < 9; i++) ClearOldMap3(i);
 	for (TileIndex i = TileXY(0, Map::MaxY()); i < Map::Size(); i++) ClearOldMap3(i);
 
-	if (_savegame_type == SGT_TTDP2) Debug(oldloader, 2, "Found TTDPatch game");
+	if (_savegame_type == SavegameType::TTDP2) Debug(oldloader, 2, "Found TTDPatch game");
 
 	Debug(oldloader, 3, "Vehicle-multiplier is set to {} ({} vehicles)", ls.vehicle_multiplier, ls.vehicle_multiplier * 850);
 }
@@ -626,7 +626,7 @@ static bool LoadOldTown(LoadgameState &ls, int num)
 	if (!LoadChunk(ls, t, town_chunk)) return false;
 
 	if (t->xy != 0) {
-		if (_savegame_type == SGT_TTO) {
+		if (_savegame_type == SavegameType::TTO) {
 			/* 0x10B6 is auto-generated name, others are custom names */
 			t->townnametype = t->townnametype == 0x10B6 ? 0x20C1 : t->townnametype + 0x2A00;
 		}
@@ -726,7 +726,7 @@ static const OldChunks goods_chunk[] = {
 static bool LoadOldGood(LoadgameState &ls, int num)
 {
 	/* for TTO games, 12th (num == 11) goods entry is created in the Station constructor */
-	if (_savegame_type == SGT_TTO && num == 11) return true;
+	if (_savegame_type == SavegameType::TTO && num == 11) return true;
 
 	Station *st = Station::Get(_current_station_id);
 	GoodsEntry *ge = &st->goods[num];
@@ -790,7 +790,7 @@ static bool LoadOldStation(LoadgameState &ls, int num)
 	if (st->xy != 0) {
 		st->town = RemapTown(st->xy);
 
-		if (_savegame_type == SGT_TTO) {
+		if (_savegame_type == SavegameType::TTO) {
 			if (IsInsideBS(_old_string_id, 0x180F, 32)) {
 				st->string_id = STR_SV_STNAME + (_old_string_id - 0x180F); // automatic name
 			} else {
@@ -874,7 +874,7 @@ static bool LoadOldIndustry(LoadgameState &ls, int num)
 
 		i->town = RemapTown(i->location.tile);
 
-		if (_savegame_type == SGT_TTO) {
+		if (_savegame_type == SavegameType::TTO) {
 			if (i->type > 0x06) i->type++; // Printing Works were added
 			if (i->type == 0x0A) i->type = 0x12; // Iron Ore Mine has different ID
 
@@ -905,7 +905,7 @@ static bool LoadOldCompanyYearly(LoadgameState &ls, int num)
 	Company *c = Company::Get(_current_company_id);
 
 	for (ExpensesType i : EnumRange(ExpensesType::End)) {
-		if (_savegame_type == SGT_TTO && i == ExpensesType::Property) {
+		if (_savegame_type == SavegameType::TTO && i == ExpensesType::Property) {
 			_old_yearly = 0; // property maintenance
 		} else {
 			if (!LoadChunk(ls, nullptr, _company_yearly_chunk)) return false;
@@ -1001,7 +1001,7 @@ static bool LoadOldCompany(LoadgameState &ls, int num)
 		return true;
 	}
 
-	if (_savegame_type == SGT_TTO) {
+	if (_savegame_type == SavegameType::TTO) {
 		/* adjust manager's face */
 		if (HasBit(c->face.bits, 27) && GB(c->face.bits, 26, 1) == GB(c->face.bits, 19, 1)) {
 			/* if face would be black in TTD, adjust tie colour and thereby face colour */
@@ -1266,7 +1266,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 
 		Vehicle *v;
 
-		if (_savegame_type == SGT_TTO) {
+		if (_savegame_type == SavegameType::TTO) {
 			uint type = ReadByte(ls);
 			switch (type) {
 				default: return false;
@@ -1369,7 +1369,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 		}
 
 		if (_old_order_ptr != 0 && _old_order_ptr != 0xFFFFFFFF) {
-			uint max = _savegame_type == SGT_TTO ? 3000 : 5000;
+			uint max = _savegame_type == SavegameType::TTO ? 3000 : 5000;
 			uint old_id = RemapOrderIndex(_old_order_ptr);
 			if (old_id < max) v->old_orders = old_id + 1;
 		}
@@ -1404,7 +1404,7 @@ bool LoadOldCustomString(LoadgameState &ls, int index)
 	 * Validation and conversion to UTF-8 are happening at a later stage.
 	 */
 	std::string &str = _old_name_array[index];
-	str.resize(_savegame_type == SGT_TTO ? 24 : 32);
+	str.resize(_savegame_type == SavegameType::TTO ? 24 : 32);
 	for (auto &c : str) c = ReadByte(ls);
 
 	return true;
@@ -1427,7 +1427,7 @@ static bool LoadOldSign(LoadgameState &ls, int num)
 	if (!LoadChunk(ls, si, sign_chunk)) return false;
 
 	if (_old_string_id != 0) {
-		if (_savegame_type == SGT_TTO) {
+		if (_savegame_type == SavegameType::TTO) {
 			if (_old_string_id != 0x140A) si->name = CopyFromOldName(_old_string_id + 0x2A00);
 		} else {
 			si->name = CopyFromOldName(RemapOldStringID(_old_string_id));
@@ -1465,7 +1465,7 @@ static const OldChunks engine_chunk[] = {
 
 static bool LoadOldEngine(LoadgameState &ls, int num)
 {
-	Engine *e = _savegame_type == SGT_TTO ? &_old_engines[num] : GetTempDataEngine(static_cast<EngineID>(num));
+	Engine *e = _savegame_type == SavegameType::TTO ? &_old_engines[num] : GetTempDataEngine(static_cast<EngineID>(num));
 	return LoadChunk(ls, e, engine_chunk);
 }
 
@@ -1524,7 +1524,7 @@ static bool LoadOldGameDifficulty(LoadgameState &ls, int)
 
 static bool LoadOldMapPart1(LoadgameState &ls, int)
 {
-	if (_savegame_type == SGT_TTO) {
+	if (_savegame_type == SavegameType::TTO) {
 		Map::Allocate(OLD_MAP_SIZE, OLD_MAP_SIZE);
 	}
 
@@ -1535,7 +1535,7 @@ static bool LoadOldMapPart1(LoadgameState &ls, int)
 		t.m2() = ReadByte(ls);
 	}
 
-	if (_savegame_type != SGT_TTO) {
+	if (_savegame_type != SavegameType::TTO) {
 		/* old map3 is split into to m3 and m4 */
 		for (auto t : Map::Iterate()) {
 			t.m3() = ReadByte(ls);

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -29,7 +29,7 @@ void Order::ConvertFromOldSavegame()
 	this->flags = 0;
 
 	/* First handle non-stop - use value from savegame if possible, else use value from config file */
-	if (_settings_client.gui.sg_new_nonstop || (IsSavegameVersionBefore(SaveLoadVersion::SavePatches) && _savegame_type != SGT_TTO && _savegame_type != SGT_TTD && _settings_client.gui.new_nonstop)) {
+	if (_settings_client.gui.sg_new_nonstop || (IsSavegameVersionBefore(SaveLoadVersion::SavePatches) && _savegame_type != SavegameType::TTO && _savegame_type != SavegameType::TTD && _settings_client.gui.new_nonstop)) {
 		/* OFB_NON_STOP */
 		this->SetNonStopType((old_flags & 8) ? OrderNonStopFlags{OrderNonStopFlag::NonStop, OrderNonStopFlag::GoVia} : OrderNonStopFlag::NonStop);
 	} else {

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -3201,7 +3201,7 @@ static SaveLoadResult DoLoad(std::shared_ptr<LoadFilter> reader, bool load_check
 
 	ClearSaveLoadState();
 
-	_savegame_type = SGT_OTTD;
+	_savegame_type = SavegameType::OTTD;
 
 	if (load_check) {
 		/* The only part from AfterLoadGame() we need */

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -440,12 +440,12 @@ struct FileToSaveLoad {
 
 /** Types of save games. */
 enum SavegameType : uint8_t {
-	SGT_TTD,    ///< TTD  savegame (can be detected incorrectly)
-	SGT_TTDP1,  ///< TTDP savegame ( -//- ) (data at NW border)
-	SGT_TTDP2,  ///< TTDP savegame in new format (data at SE border)
-	SGT_OTTD,   ///< OTTD savegame
-	SGT_TTO,    ///< TTO savegame
-	SGT_INVALID = 0xFF, ///< broken savegame (used internally)
+	TTD, ///< TTD savegame (can be detected incorrectly)
+	TTDP1, ///< TTDP savegame ( -//- ) (data at NW border)
+	TTDP2, ///< TTDP savegame in new format (data at SE border)
+	OTTD, ///< OTTD savegame
+	TTO, ///< TTO savegame
+	Invalid = 0xFF, ///< broken savegame (used internally)
 };
 
 extern FileToSaveLoad _file_to_saveload;


### PR DESCRIPTION
## Motivation / Problem

Our endeavour to make enumerations scoped.


## Description

Make `SavegameType` scoped.


## Limitations

Most enumeration values are still fully capitalised, but `Ttd` or `Ottd` looks really weird.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
