### PR TITLE
Codechange: simplify/shrink SaveLoadCompat

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2025,7 +2025,7 @@ std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLo
 	std::vector<SaveLoad> saveloads;
 
 	/* Build a key lookup mapping based on the available fields. */
-	std::map<std::string, std::vector<const SaveLoad *>> key_lookup;
+	std::map<std::string_view, std::vector<const SaveLoad *>> key_lookup;
 	for (auto &sld : slt) {
 		/* All entries should have a name; otherwise the entry should just be removed. */
 		assert(!sld.name.empty());
@@ -2038,7 +2038,7 @@ std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLo
 			/* In old savegames there can be data we no longer care for. We
 			 * skip this by simply reading the amount of bytes indicated and
 			 * send those to /dev/null. */
-			saveloads.emplace_back("", SaveLoadType::Null, GetVarFileType(slc.null_type) | SLE_VAR_NULL, slc.null_length, slc.version_from, slc.version_to, nullptr, 0, nullptr);
+			saveloads.emplace_back("", SaveLoadType::Null, SLE_FILE_U8 | SLE_VAR_NULL, slc.null_length, slc.version_from, slc.version_to, nullptr, 0, nullptr);
 		} else {
 			auto sld_it = key_lookup.find(slc.name);
 			/* If this branch triggers, it means that an entry in the

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -769,14 +769,13 @@ struct SaveLoad {
 /**
  * SaveLoad information for backwards compatibility.
  *
- * At SLV_SETTINGS_NAME a new method of keeping track of fields in a savegame
+ * At SaveLoadVersion::TableChunks a new method of keeping track of fields in a savegame
  * was added, where the order of fields is no longer important. For older
  * savegames we still need to know the correct order. This struct is the glue
  * to make that happen.
  */
 struct SaveLoadCompat {
-	std::string name; ///< Name of the field.
-	VarTypes null_type; ///< The type associated with the NULL field; defaults to SLE_FILE_U8 to just count bytes.
+	std::string_view name; ///< Name of the field.
 	uint16_t null_length; ///< Length of the NULL field.
 	SaveLoadVersion version_from; ///< Save/load the variable starting from this savegame version.
 	SaveLoadVersion version_to; ///< Save/load the variable before this savegame version.
@@ -1262,7 +1261,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * Field name where the real SaveLoad can be located.
  * @param name The name of the field.
  */
-#define SLC_VAR(name) {name, SLE_FILE_U8, 0, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion}
+#define SLC_VAR(name) {name, 0, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion}
 
 /**
  * Empty space in every savegame version.
@@ -1270,7 +1269,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from   First savegame version that has the empty space.
  * @param to     Last savegame version that has the empty space.
  */
-#define SLC_NULL(length, from, to) {{}, SLE_FILE_U8, length, from, to}
+#define SLC_NULL(length, from, to) {{}, length, from, to}
 
 /**
  * Checks whether the savegame is below \a major.\a minor.


### PR DESCRIPTION
## Motivation / Problem

There is one field that actually uses `VarTypes` as type, instead of a container of constants. However, it's also always containing the same value.

The names of elements are stored as `std::string`, when `std::string_view` would suffice as well.


## Description

* Remove `null_type` and replace it's only use with the constant value it's always set to.
* Change `name` from `std::string` to `std::string_view`.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
