### PR TITLE
Codechange: make SaveLoadType scoped

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -576,26 +576,26 @@ static inline uint SlGetArrayLength(size_t length)
 static uint8_t GetSavegameFileType(const SaveLoad &sld)
 {
 	switch (sld.cmd) {
-		case SL_VAR:
+		case SaveLoadType::Variable:
 			return GetVarFileType(sld.conv); break;
 
-		case SL_STDSTR:
-		case SL_ARR:
-		case SL_VECTOR:
+		case SaveLoadType::String:
+		case SaveLoadType::Array:
+		case SaveLoadType::Vector:
 			return GetVarFileType(sld.conv) | SLE_FILE_HAS_LENGTH_FIELD; break;
 
-		case SL_REF:
+		case SaveLoadType::Reference:
 			return IsSavegameVersionBefore(SaveLoadVersion::MoreCargoPackets) ? SLE_FILE_U16 : SLE_FILE_U32;
 
-		case SL_REFLIST:
-		case SL_REFVECTOR:
+		case SaveLoadType::ReferenceList:
+		case SaveLoadType::ReferenceVector:
 			return (IsSavegameVersionBefore(SaveLoadVersion::MoreCargoPackets) ? SLE_FILE_U16 : SLE_FILE_U32) | SLE_FILE_HAS_LENGTH_FIELD;
 
-		case SL_SAVEBYTE:
+		case SaveLoadType::SaveByte:
 			return SLE_FILE_U8;
 
-		case SL_STRUCT:
-		case SL_STRUCTLIST:
+		case SaveLoadType::Struct:
+		case SaveLoadType::StructList:
 			return SLE_FILE_STRUCT | SLE_FILE_HAS_LENGTH_FIELD;
 
 		default: NOT_REACHED();
@@ -1125,7 +1125,7 @@ static void SlStdString(void *ptr, VarType conv)
 }
 
 /**
- * Internal function to save/Load a list of SL_VARs.
+ * Internal function to save/Load a list of SaveLoadType::Variables.
  * SlCopy() and SlArray() are very similar, with the exception of the header.
  * This function represents the common part.
  * @param object The object being manipulated.
@@ -1135,7 +1135,7 @@ static void SlStdString(void *ptr, VarType conv)
 static void SlCopyInternal(void *object, size_t length, VarType conv)
 {
 	if (GetVarMemType(conv) == SLE_VAR_NULL) {
-		assert(_sl.action != SLA_SAVE); // Use SL_NULL if you want to write null-bytes
+		assert(_sl.action != SLA_SAVE); // Use SaveLoadType::Null if you want to write null-bytes
 		SlSkipBytes(length * SlCalcConvFileLen(conv));
 		return;
 	}
@@ -1174,7 +1174,7 @@ static void SlCopyInternal(void *object, size_t length, VarType conv)
 }
 
 /**
- * Copy a list of SL_VARs to/from a savegame.
+ * Copy a list of SaveLoadType::Variables to/from a savegame.
  * These entries are copied as-is, and you as caller have to make sure things
  * like length-fields are calculated correctly.
  * @param object The object being manipulated.
@@ -1207,7 +1207,7 @@ static inline size_t SlCalcArrayLen(size_t length, VarType conv)
 }
 
 /**
- * Save/Load the length of the array followed by the array of SL_VAR elements.
+ * Save/Load the length of the array followed by the array of SaveLoadType::Variable elements.
  * @param array The array being manipulated
  * @param length The length of the array in elements
  * @param conv VarType type of the atomic array (int, uint8_t, uint64_t, etc.)
@@ -1394,23 +1394,23 @@ public:
 	 * @param cmd The SaveLoadType ware are saving/loading.
 	 * @return The size of this type in bytes.
 	 */
-	static size_t SlCalcLen(const void *storage, VarType conv, SaveLoadType cmd = SL_VAR)
+	static size_t SlCalcLen(const void *storage, VarType conv, SaveLoadType cmd = SaveLoadType::Variable)
 	{
-		assert(cmd == SL_VAR || cmd == SL_REF);
+		assert(cmd == SaveLoadType::Variable || cmd == SaveLoadType::Reference);
 
 		const SlStorageT *list = static_cast<const SlStorageT *>(storage);
 
 		int type_size = SlGetArrayLength(list->size());
-		int item_size = SlCalcConvFileLen(cmd == SL_VAR ? conv : static_cast<VarType>(SLE_FILE_U32));
+		int item_size = SlCalcConvFileLen(cmd == SaveLoadType::Variable ? conv : static_cast<VarType>(SLE_FILE_U32));
 		return list->size() * item_size + type_size;
 	}
 
 	static void SlSaveLoadMember(SaveLoadType cmd, Tvar *item, VarType conv)
 	{
 		switch (cmd) {
-			case SL_VAR: SlSaveLoadConv(item, conv); break;
-			case SL_REF: SlSaveLoadRef(item, conv); break;
-			case SL_STDSTR: SlStdString(item, conv); break;
+			case SaveLoadType::Variable: SlSaveLoadConv(item, conv); break;
+			case SaveLoadType::Reference: SlSaveLoadRef(item, conv); break;
+			case SaveLoadType::String: SlStdString(item, conv); break;
 			default:
 				NOT_REACHED();
 		}
@@ -1422,9 +1422,9 @@ public:
 	 * @param conv VarType type of variable that is used for calculating the size.
 	 * @param cmd The SaveLoadType ware are saving/loading.
 	 */
-	static void SlSaveLoad(void *storage, VarType conv, SaveLoadType cmd = SL_VAR)
+	static void SlSaveLoad(void *storage, VarType conv, SaveLoadType cmd = SaveLoadType::Variable)
 	{
-		assert(cmd == SL_VAR || cmd == SL_REF || cmd == SL_STDSTR);
+		assert(cmd == SaveLoadType::Variable || cmd == SaveLoadType::Reference || cmd == SaveLoadType::String);
 
 		SlStorageT *list = static_cast<SlStorageT *>(storage);
 
@@ -1441,9 +1441,9 @@ public:
 			case SLA_LOAD: {
 				size_t length;
 				switch (cmd) {
-					case SL_VAR: length = IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength) ? SlReadUint32() : SlReadArrayLength(); break;
-					case SL_REF: length = IsSavegameVersionBefore(SaveLoadVersion::MoreCargoPackets) ? SlReadUint16() : IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength) ? SlReadUint32() : SlReadArrayLength(); break;
-					case SL_STDSTR: length = SlReadArrayLength(); break;
+					case SaveLoadType::Variable: length = IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength) ? SlReadUint32() : SlReadArrayLength(); break;
+					case SaveLoadType::Reference: length = IsSavegameVersionBefore(SaveLoadVersion::MoreCargoPackets) ? SlReadUint16() : IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength) ? SlReadUint32() : SlReadArrayLength(); break;
+					case SaveLoadType::String: length = SlReadArrayLength(); break;
 					default: NOT_REACHED();
 				}
 
@@ -1483,7 +1483,7 @@ public:
  */
 static inline size_t SlCalcRefListLen(const void *list, VarType conv)
 {
-	return SlStorageHelper<std::list, void *>::SlCalcLen(list, conv, SL_REF);
+	return SlStorageHelper<std::list, void *>::SlCalcLen(list, conv, SaveLoadType::Reference);
 }
 
 /**
@@ -1500,7 +1500,7 @@ static void SlRefList(void *list, VarType conv)
 		if (_sl.need_length == NL_CALCLENGTH) return;
 	}
 
-	SlStorageHelper<std::list, void *>::SlSaveLoad(list, conv, SL_REF);
+	SlStorageHelper<std::list, void *>::SlSaveLoad(list, conv, SaveLoadType::Reference);
 }
 
 /**
@@ -1511,7 +1511,7 @@ static void SlRefList(void *list, VarType conv)
  */
 static size_t SlCalcRefVectorLen(const void *vector, VarType conv)
 {
-	return SlStorageHelper<std::vector, void *>::SlCalcLen(vector, conv, SL_REF);
+	return SlStorageHelper<std::vector, void *>::SlCalcLen(vector, conv, SaveLoadType::Reference);
 }
 
 /**
@@ -1528,7 +1528,7 @@ static void SlRefVector(void *vector, VarType conv)
 		if (_sl.need_length == NL_CALCLENGTH) return;
 	}
 
-	SlStorageHelper<std::vector, void *>::SlSaveLoad(vector, conv, SL_REF);
+	SlStorageHelper<std::vector, void *>::SlSaveLoad(vector, conv, SaveLoadType::Reference);
 }
 
 /**
@@ -1583,7 +1583,7 @@ static void SlVector(void *vector, VarType conv)
 			 * This is permitted for load-related actions, because invalid fields of this type are present
 			 * from SaveLoadVersion::CompanyAllowList up to SaveLoadVersion::CompanyAllowListV2. */
 			assert(_sl.action != SLA_SAVE);
-			SlStorageHelper<std::vector, std::string>::SlSaveLoad(vector, conv, SL_STDSTR);
+			SlStorageHelper<std::vector, std::string>::SlSaveLoad(vector, conv, SaveLoadType::String);
 			break;
 
 		default: NOT_REACHED();
@@ -1620,7 +1620,7 @@ static size_t SlCalcTableHeader(const SaveLoadTable &slt)
 
 	for (auto &sld : slt) {
 		if (!SlIsObjectValidInSavegame(sld)) continue;
-		if (sld.cmd == SL_STRUCTLIST || sld.cmd == SL_STRUCT) {
+		if (sld.cmd == SaveLoadType::StructList || sld.cmd == SaveLoadType::Struct) {
 			length += SlCalcTableHeader(sld.handler->GetDescription());
 		}
 	}
@@ -1652,18 +1652,18 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld)
 	if (!SlIsObjectValidInSavegame(sld)) return 0;
 
 	switch (sld.cmd) {
-		case SL_VAR: return SlCalcConvFileLen(sld.conv);
-		case SL_REF: return SlCalcRefLen();
-		case SL_ARR: return SlCalcArrayLen(sld.length, sld.conv);
-		case SL_REFLIST: return SlCalcRefListLen(GetVariableAddress(object, sld), sld.conv);
-		case SL_REFVECTOR: return SlCalcRefVectorLen(GetVariableAddress(object, sld), sld.conv);
-		case SL_VECTOR: return SlCalcVectorLen(GetVariableAddress(object, sld), sld.conv);
-		case SL_STDSTR: return SlCalcStdStringLen(GetVariableAddress(object, sld));
-		case SL_SAVEBYTE: return 1; // a byte is logically of size 1
-		case SL_NULL: return SlCalcConvFileLen(sld.conv) * sld.length;
+		case SaveLoadType::Variable: return SlCalcConvFileLen(sld.conv);
+		case SaveLoadType::Reference: return SlCalcRefLen();
+		case SaveLoadType::Array: return SlCalcArrayLen(sld.length, sld.conv);
+		case SaveLoadType::ReferenceList: return SlCalcRefListLen(GetVariableAddress(object, sld), sld.conv);
+		case SaveLoadType::ReferenceVector: return SlCalcRefVectorLen(GetVariableAddress(object, sld), sld.conv);
+		case SaveLoadType::Vector: return SlCalcVectorLen(GetVariableAddress(object, sld), sld.conv);
+		case SaveLoadType::String: return SlCalcStdStringLen(GetVariableAddress(object, sld));
+		case SaveLoadType::SaveByte: return 1; // a byte is logically of size 1
+		case SaveLoadType::Null: return SlCalcConvFileLen(sld.conv) * sld.length;
 
-		case SL_STRUCT:
-		case SL_STRUCTLIST: {
+		case SaveLoadType::Struct:
+		case SaveLoadType::StructList: {
 			NeedLength old_need_length = _sl.need_length;
 			size_t old_obj_len = _sl.obj_len;
 
@@ -1679,7 +1679,7 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld)
 			_sl.obj_len = old_obj_len;
 			_sl.need_length = old_need_length;
 
-			if (sld.cmd == SL_STRUCT) {
+			if (sld.cmd == SaveLoadType::Struct) {
 				length += SlGetArrayLength(1);
 			}
 
@@ -1697,32 +1697,32 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 
 	VarType conv = GB(sld.conv, 0, 8);
 	switch (sld.cmd) {
-		case SL_VAR:
-		case SL_REF:
-		case SL_ARR:
-		case SL_REFLIST:
-		case SL_REFVECTOR:
-		case SL_VECTOR:
-		case SL_STDSTR: {
+		case SaveLoadType::Variable:
+		case SaveLoadType::Reference:
+		case SaveLoadType::Array:
+		case SaveLoadType::ReferenceList:
+		case SaveLoadType::ReferenceVector:
+		case SaveLoadType::Vector:
+		case SaveLoadType::String: {
 			void *ptr = GetVariableAddress(object, sld);
 
 			switch (sld.cmd) {
-				case SL_VAR: SlSaveLoadConv(ptr, conv); break;
-				case SL_REF: SlSaveLoadRef(ptr, conv); break;
-				case SL_ARR: SlArray(ptr, sld.length, conv); break;
-				case SL_REFLIST: SlRefList(ptr, conv); break;
-				case SL_REFVECTOR: SlRefVector(ptr, conv); break;
-				case SL_VECTOR: SlVector(ptr, conv); break;
-				case SL_STDSTR: SlStdString(ptr, sld.conv); break;
+				case SaveLoadType::Variable: SlSaveLoadConv(ptr, conv); break;
+				case SaveLoadType::Reference: SlSaveLoadRef(ptr, conv); break;
+				case SaveLoadType::Array: SlArray(ptr, sld.length, conv); break;
+				case SaveLoadType::ReferenceList: SlRefList(ptr, conv); break;
+				case SaveLoadType::ReferenceVector: SlRefVector(ptr, conv); break;
+				case SaveLoadType::Vector: SlVector(ptr, conv); break;
+				case SaveLoadType::String: SlStdString(ptr, sld.conv); break;
 				default: NOT_REACHED();
 			}
 			break;
 		}
 
-		/* SL_SAVEBYTE writes a value to the savegame to identify the type of an object.
+		/* SaveLoadType::SaveByte writes a value to the savegame to identify the type of an object.
 		 * When loading, the value is read explicitly with SlReadByte() to determine which
 		 * object description to use. */
-		case SL_SAVEBYTE: {
+		case SaveLoadType::SaveByte: {
 			void *ptr = GetVariableAddress(object, sld);
 
 			switch (_sl.action) {
@@ -1736,7 +1736,7 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 			break;
 		}
 
-		case SL_NULL: {
+		case SaveLoadType::Null: {
 			assert(GetVarMemType(sld.conv) == SLE_VAR_NULL);
 
 			switch (_sl.action) {
@@ -1750,11 +1750,11 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 			break;
 		}
 
-		case SL_STRUCT:
-		case SL_STRUCTLIST:
+		case SaveLoadType::Struct:
+		case SaveLoadType::StructList:
 			switch (_sl.action) {
 				case SLA_SAVE: {
-					if (sld.cmd == SL_STRUCT) {
+					if (sld.cmd == SaveLoadType::Struct) {
 						/* Store in the savegame if this struct was written or not. */
 						SlSetStructListLength(SlCalcObjMemberLength(object, sld) > SlGetArrayLength(1) ? 1 : 0);
 					}
@@ -1763,7 +1763,7 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 				}
 
 				case SLA_LOAD_CHECK: {
-					if (sld.cmd == SL_STRUCT && !IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength)) {
+					if (sld.cmd == SaveLoadType::Struct && !IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength)) {
 						SlGetStructListLength(1);
 					}
 					sld.handler->LoadCheck(object);
@@ -1771,7 +1771,7 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 				}
 
 				case SLA_LOAD: {
-					if (sld.cmd == SL_STRUCT && !IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength)) {
+					if (sld.cmd == SaveLoadType::Struct && !IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength)) {
 						SlGetStructListLength(1);
 					}
 					sld.handler->Load(object);
@@ -1916,17 +1916,17 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 					switch (type & SLE_FILE_TYPE_MASK) {
 						case SLE_FILE_STRING:
 							/* Strings are always marked with SLE_FILE_HAS_LENGTH_FIELD, as they are a list of chars. */
-							saveload_type = SL_STDSTR;
+							saveload_type = SaveLoadType::String;
 							break;
 
 						case SLE_FILE_STRUCT:
-							/* Structs are always marked with SLE_FILE_HAS_LENGTH_FIELD as SL_STRUCT is seen as a list of 0/1 in length. */
-							saveload_type = SL_STRUCTLIST;
+							/* Structs are always marked with SLE_FILE_HAS_LENGTH_FIELD as SaveLoadType::Struct is seen as a list of 0/1 in length. */
+							saveload_type = SaveLoadType::StructList;
 							handler = std::make_shared<SlSkipHandler>();
 							break;
 
 						default:
-							saveload_type = (type & SLE_FILE_HAS_LENGTH_FIELD) ? SL_ARR : SL_VAR;
+							saveload_type = (type & SLE_FILE_HAS_LENGTH_FIELD) ? SaveLoadType::Array : SaveLoadType::Variable;
 							break;
 					}
 
@@ -1949,7 +1949,7 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 			}
 
 			for (auto &sld : saveloads) {
-				if (sld.cmd == SL_STRUCTLIST || sld.cmd == SL_STRUCT) {
+				if (sld.cmd == SaveLoadType::StructList || sld.cmd == SaveLoadType::Struct) {
 					sld.handler->load_description = SlTableHeader(sld.handler->GetDescription());
 				}
 			}
@@ -1983,7 +1983,7 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 			/* After the table, write down any sub-tables we might have. */
 			for (auto &sld : slt) {
 				if (!SlIsObjectValidInSavegame(sld)) continue;
-				if (sld.cmd == SL_STRUCTLIST || sld.cmd == SL_STRUCT) {
+				if (sld.cmd == SaveLoadType::StructList || sld.cmd == SaveLoadType::Struct) {
 					/* SlCalcTableHeader already looks in sub-lists, so avoid the length being added twice. */
 					NeedLength old_need_length = _sl.need_length;
 					_sl.need_length = NL_NONE;
@@ -2038,7 +2038,7 @@ std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLo
 			/* In old savegames there can be data we no longer care for. We
 			 * skip this by simply reading the amount of bytes indicated and
 			 * send those to /dev/null. */
-			saveloads.emplace_back("", SL_NULL, GetVarFileType(slc.null_type) | SLE_VAR_NULL, slc.null_length, slc.version_from, slc.version_to, nullptr, 0, nullptr);
+			saveloads.emplace_back("", SaveLoadType::Null, GetVarFileType(slc.null_type) | SLE_VAR_NULL, slc.null_length, slc.version_from, slc.version_to, nullptr, 0, nullptr);
 		} else {
 			auto sld_it = key_lookup.find(slc.name);
 			/* If this branch triggers, it means that an entry in the
@@ -2058,7 +2058,7 @@ std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLo
 
 	for (auto &sld : saveloads) {
 		if (!SlIsObjectValidInSavegame(sld)) continue;
-		if (sld.cmd == SL_STRUCTLIST || sld.cmd == SL_STRUCT) {
+		if (sld.cmd == SaveLoadType::StructList || sld.cmd == SaveLoadType::Struct) {
 			sld.handler->load_description = SlCompatTableHeader(sld.handler->GetDescription(), sld.handler->GetCompatDescription());
 		}
 	}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -328,7 +328,7 @@ enum class SaveLoadVersion : uint16_t {
 	MapgenSettingsRevamp, ///< Saveload version: 290, GitHub pull request: 8891, release: 1.11\n Revamp of some mapgen settings (snow coverage, desert coverage, heightmap height, custom terrain type).
 	GroupReplaceWagonRemoval, ///< Saveload version: 291, GitHub pull request: 7441\n Per-group wagon removal flag.
 	CustomSubsidyDuration, ///< Saveload version: 292, GitHub pull request: 9081\n Configurable subsidy duration.
-	SaveloadListLength, ///< Saveload version: 293, GitHub pull request: 9374\n Consistency in list length with SL_STRUCT / SL_STRUCTLIST / SL_DEQUE / SL_REFLIST.
+	SaveloadListLength, ///< Saveload version: 293, GitHub pull request: 9374\n Consistency in list length with SaveLoadType::Struct / SaveLoadType::StructList / SaveLoadType::ReferenceList.
 	RiffToArray, ///< Saveload version: 294, GitHub pull request: 9375\n Changed many CH_RIFF chunks to CH_ARRAY chunks.
 
 	TableChunks, ///< Saveload version: 295, GitHub pull request: 9322\n Introduction of CH_TABLE and CH_SPARSE_TABLE.
@@ -564,7 +564,7 @@ public:
 	virtual void LoadCheck([[maybe_unused]] void *object) const {}
 
 	/**
-	 * A post-load callback to fix #SL_REF integers into pointers.
+	 * A post-load callback to fix #SaveLoadType::Reference integers into pointers.
 	 * @param object The object to fix.
 	 */
 	virtual void FixPointers([[maybe_unused]] void *object) const {}
@@ -630,7 +630,7 @@ public:
 	void LoadCheck(void *object) const override { this->LoadCheck(static_cast<TObject *>(object)); }
 
 	/**
-	 * A post-load callback to fix #SL_REF integers into pointers.
+	 * A post-load callback to fix #SaveLoadType::Reference integers into pointers.
 	 * @param object The object to fix.
 	 */
 	virtual void FixPointers([[maybe_unused]] TObject *object) const {}
@@ -733,22 +733,22 @@ enum VarTypes : uint16_t {
 typedef uint32_t VarType;
 
 /** Type of data saved. */
-enum SaveLoadType : uint8_t {
-	SL_VAR         =  0, ///< Save/load a variable.
-	SL_REF         =  1, ///< Save/load a reference.
-	SL_STRUCT      =  2, ///< Save/load a struct.
+enum class SaveLoadType : uint8_t {
+	Variable = 0, ///< Save/load a variable.
+	Reference = 1, ///< Save/load a reference.
+	Struct = 2, ///< Save/load a struct.
 
-	SL_STDSTR      =  4, ///< Save/load a \c std::string.
+	String = 4, ///< Save/load a \c std::string.
 
-	SL_ARR         =  5, ///< Save/load a fixed-size array of #SL_VAR elements.
-	SL_VECTOR      =  7, ///< Save/load a vector of #SL_VAR elements.
-	SL_REFLIST     =  8, ///< Save/load a list of #SL_REF elements.
-	SL_STRUCTLIST  =  9, ///< Save/load a list of structs.
+	Array = 5, ///< Save/load a fixed-size array of #SaveLoadType::Variable elements.
+	Vector = 7, ///< Save/load a vector of #SaveLoadType::Variable elements.
+	ReferenceList = 8, ///< Save/load a list of #SaveLoadType::Reference elements.
+	StructList = 9, ///< Save/load a list of structs.
 
-	SL_SAVEBYTE    = 10, ///< Save (but not load) a byte.
-	SL_NULL        = 11, ///< Save null-bytes and load to nowhere.
+	SaveByte = 10, ///< Save (but not load) a byte.
+	Null = 11, ///< Save null-bytes and load to nowhere.
 
-	SL_REFVECTOR   = 12, ///< Save/load a vector of #SL_REF elements.
+	ReferenceVector = 12, ///< Save/load a vector of #SaveLoadType::Reference elements.
 };
 
 typedef void *SaveLoadAddrProc(void *base, size_t extra);
@@ -850,14 +850,14 @@ inline constexpr size_t SlVarSize(VarType type)
 inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t length, size_t size)
 {
 	switch (cmd) {
-		case SL_VAR: return SlVarSize(type) == size;
-		case SL_REF: return sizeof(void *) == size;
-		case SL_STDSTR: return SlVarSize(type) == size;
-		case SL_ARR: return SlVarSize(type) * length <= size; // Partial load of array is permitted.
-		case SL_VECTOR: return sizeof(std::vector<void *>) == size;
-		case SL_REFLIST: return sizeof(std::list<void *>) == size;
-		case SL_REFVECTOR: return sizeof(std::vector<void *>) == size;
-		case SL_SAVEBYTE: return true;
+		case SaveLoadType::Variable: return SlVarSize(type) == size;
+		case SaveLoadType::Reference: return sizeof(void *) == size;
+		case SaveLoadType::String: return SlVarSize(type) == size;
+		case SaveLoadType::Array: return SlVarSize(type) * length <= size; // Partial load of array is permitted.
+		case SaveLoadType::Vector: return sizeof(std::vector<void *>) == size;
+		case SaveLoadType::ReferenceList: return sizeof(std::list<void *>) == size;
+		case SaveLoadType::ReferenceVector: return sizeof(std::vector<void *>) == size;
+		case SaveLoadType::SaveByte: return true;
 		default: NOT_REACHED();
 	}
 }
@@ -904,7 +904,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the field.
  * @param to       Last savegame version that has the field.
  */
-#define SLE_CONDVAR(base, variable, type, from, to) SLE_GENERAL(SL_VAR, base, variable, type, 0, from, to, 0)
+#define SLE_CONDVAR(base, variable, type, from, to) SLE_GENERAL(SaveLoadType::Variable, base, variable, type, 0, from, to, 0)
 
 /**
  * Storage of a variable in some savegame versions.
@@ -915,7 +915,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the field.
  * @param to       Last savegame version that has the field.
  */
-#define SLE_CONDVARNAME(base, variable, name, type, from, to) SLE_GENERAL_NAME(SL_VAR, name, base, variable, type, 0, from, to, 0)
+#define SLE_CONDVARNAME(base, variable, name, type, from, to) SLE_GENERAL_NAME(SaveLoadType::Variable, name, base, variable, type, 0, from, to, 0)
 
 /**
  * Storage of a reference in some savegame versions.
@@ -925,10 +925,10 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the field.
  * @param to       Last savegame version that has the field.
  */
-#define SLE_CONDREF(base, variable, type, from, to) SLE_GENERAL(SL_REF, base, variable, type, 0, from, to, 0)
+#define SLE_CONDREF(base, variable, type, from, to) SLE_GENERAL(SaveLoadType::Reference, base, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a fixed-size array of #SL_VAR elements in some savegame versions.
+ * Storage of a fixed-size array of #SaveLoadType::Variable elements in some savegame versions.
  * @param base     Name of the class or struct containing the array.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
@@ -936,10 +936,10 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the array.
  * @param to       Last savegame version that has the array.
  */
-#define SLE_CONDARR(base, variable, type, length, from, to) SLE_GENERAL(SL_ARR, base, variable, type, length, from, to, 0)
+#define SLE_CONDARR(base, variable, type, length, from, to) SLE_GENERAL(SaveLoadType::Array, base, variable, type, length, from, to, 0)
 
 /**
- * Storage of a fixed-size array of #SL_VAR elements in some savegame versions.
+ * Storage of a fixed-size array of #SaveLoadType::Variable elements in some savegame versions.
  * @param base     Name of the class or struct containing the array.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param name     Field name for table chunks.
@@ -948,18 +948,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the array.
  * @param to       Last savegame version that has the array.
  */
-#define SLE_CONDARRNAME(base, variable, name, type, length, from, to) SLE_GENERAL_NAME(SL_ARR, name, base, variable, type, length, from, to, 0)
-
-/**
- * Storage of a string in some savegame versions.
- * @param base     Name of the class or struct containing the string.
- * @param variable Name of the variable in the class or struct referenced by \a base.
- * @param type     Storage of the data in memory and in the savegame.
- * @param length   Number of elements in the string (only used for fixed size buffers).
- * @param from     First savegame version that has the string.
- * @param to       Last savegame version that has the string.
- */
-#define SLE_CONDSTR(base, variable, type, length, from, to) SLE_GENERAL(SL_STR, base, variable, type, length, from, to, 0)
+#define SLE_CONDARRNAME(base, variable, name, type, length, from, to) SLE_GENERAL_NAME(SaveLoadType::Array, name, base, variable, type, length, from, to, 0)
 
 /**
  * Storage of a \c std::string in some savegame versions.
@@ -969,7 +958,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the string.
  * @param to       Last savegame version that has the string.
  */
-#define SLE_CONDSSTR(base, variable, type, from, to) SLE_GENERAL(SL_STDSTR, base, variable, type, 0, from, to, 0)
+#define SLE_CONDSSTR(base, variable, type, from, to) SLE_GENERAL(SaveLoadType::String, base, variable, type, 0, from, to, 0)
 
 /**
  * Storage of a \c std::string in some savegame versions.
@@ -980,47 +969,47 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the string.
  * @param to       Last savegame version that has the string.
  */
-#define SLE_CONDSSTRNAME(base, variable, name, type, from, to) SLE_GENERAL_NAME(SL_STDSTR, name, base, variable, type, 0, from, to, 0)
+#define SLE_CONDSSTRNAME(base, variable, name, type, from, to) SLE_GENERAL_NAME(SaveLoadType::String, name, base, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a list of #SL_REF elements in some savegame versions.
+ * Storage of a list of #SaveLoadType::Reference elements in some savegame versions.
  * @param base     Name of the class or struct containing the list.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
  * @param from     First savegame version that has the list.
  * @param to       Last savegame version that has the list.
  */
-#define SLE_CONDREFLIST(base, variable, type, from, to) SLE_GENERAL(SL_REFLIST, base, variable, type, 0, from, to, 0)
+#define SLE_CONDREFLIST(base, variable, type, from, to) SLE_GENERAL(SaveLoadType::ReferenceList, base, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a vector of #SL_REF elements in some savegame versions.
+ * Storage of a vector of #SaveLoadType::Reference elements in some savegame versions.
  * @param base     Name of the class or struct containing the vector.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
  * @param from     First savegame version that has the vector.
  * @param to       Last savegame version that has the vector.
  */
-#define SLE_CONDREFVECTOR(base, variable, type, from, to) SLE_GENERAL(SL_REFVECTOR, base, variable, type, 0, from, to, 0)
+#define SLE_CONDREFVECTOR(base, variable, type, from, to) SLE_GENERAL(SaveLoadType::ReferenceVector, base, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a vector of #SL_VAR elements in some savegame versions.
+ * Storage of a vector of #SaveLoadType::Variable elements in some savegame versions.
  * @param base     Name of the class or struct containing the list.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
  * @param from     First savegame version that has the list.
  * @param to       Last savegame version that has the list.
  */
-#define SLE_CONDVECTOR(base, variable, type, from, to) SLE_GENERAL(SL_VECTOR, base, variable, type, 0, from, to, 0)
+#define SLE_CONDVECTOR(base, variable, type, from, to) SLE_GENERAL(SaveLoadType::Vector, base, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a vector of #SL_VAR elements in some savegame versions.
+ * Storage of a vector of #SaveLoadType::Variable elements in some savegame versions.
  * @param base     Name of the class or struct containing the list.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
  * @param from     First savegame version that has the list.
  * @param to       Last savegame version that has the list.
  */
-#define SLE_CONDVECTOR(base, variable, type, from, to) SLE_GENERAL(SL_VECTOR, base, variable, type, 0, from, to, 0)
+#define SLE_CONDVECTOR(base, variable, type, from, to) SLE_GENERAL(SaveLoadType::Vector, base, variable, type, 0, from, to, 0)
 
 /**
  * Storage of a variable in every version of a savegame.
@@ -1048,7 +1037,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_REF(base, variable, type) SLE_CONDREF(base, variable, type, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion)
 
 /**
- * Storage of fixed-size array of #SL_VAR elements in every version of a savegame.
+ * Storage of fixed-size array of #SaveLoadType::Variable elements in every version of a savegame.
  * @param base     Name of the class or struct containing the array.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
@@ -1057,7 +1046,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_ARR(base, variable, type, length) SLE_CONDARR(base, variable, type, length, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion)
 
 /**
- * Storage of fixed-size array of #SL_VAR elements in every version of a savegame.
+ * Storage of fixed-size array of #SaveLoadType::Variable elements in every version of a savegame.
  * @param base     Name of the class or struct containing the array.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param name     Field name for table chunks.
@@ -1084,7 +1073,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_SSTRNAME(base, variable, name, type) SLE_CONDSSTRNAME(base, variable, name, type, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion)
 
 /**
- * Storage of a list of #SL_REF elements in every savegame version.
+ * Storage of a list of #SaveLoadType::Reference elements in every savegame version.
  * @param base     Name of the class or struct containing the list.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
@@ -1092,7 +1081,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_REFLIST(base, variable, type) SLE_CONDREFLIST(base, variable, type, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion)
 
 /**
- * Storage of a vector of #SL_REF elements in every savegame version.
+ * Storage of a vector of #SaveLoadType::Reference elements in every savegame version.
  * @param base     Name of the class or struct containing the vector.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
@@ -1109,7 +1098,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param base     Name of the class or struct containing the variable.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  */
-#define SLE_SAVEBYTE(base, variable) SLE_GENERAL(SL_SAVEBYTE, base, variable, 0, 0, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion, 0)
+#define SLE_SAVEBYTE(base, variable) SLE_GENERAL(SaveLoadType::SaveByte, base, variable, {}, 0, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion, 0)
 
 /**
  * Storage of global simple variables, references (pointers), and arrays.
@@ -1135,7 +1124,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the field.
  * @param to       Last savegame version that has the field.
  */
-#define SLEG_CONDVAR(name, variable, type, from, to) SLEG_GENERAL(name, SL_VAR, variable, type, 0, from, to, 0)
+#define SLEG_CONDVAR(name, variable, type, from, to) SLEG_GENERAL(name, SaveLoadType::Variable, variable, type, 0, from, to, 0)
 
 /**
  * Storage of a global reference in some savegame versions.
@@ -1145,10 +1134,10 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the field.
  * @param to       Last savegame version that has the field.
  */
-#define SLEG_CONDREF(name, variable, type, from, to) SLEG_GENERAL(name, SL_REF, variable, type, 0, from, to, 0)
+#define SLEG_CONDREF(name, variable, type, from, to) SLEG_GENERAL(name, SaveLoadType::Reference, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a global fixed-size array of #SL_VAR elements in some savegame versions.
+ * Storage of a global fixed-size array of #SaveLoadType::Variable elements in some savegame versions.
  * @param name     The name of the field.
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.
@@ -1156,7 +1145,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the array.
  * @param to       Last savegame version that has the array.
  */
-#define SLEG_CONDARR(name, variable, type, length, from, to) SLEG_GENERAL(name, SL_ARR, variable, type, length, from, to, 0)
+#define SLEG_CONDARR(name, variable, type, length, from, to) SLEG_GENERAL(name, SaveLoadType::Array, variable, type, length, from, to, 0)
 
 /**
  * Storage of a global \c std::string in some savegame versions.
@@ -1166,7 +1155,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the string.
  * @param to       Last savegame version that has the string.
  */
-#define SLEG_CONDSSTR(name, variable, type, from, to) SLEG_GENERAL(name, SL_STDSTR, variable, type, 0, from, to, 0)
+#define SLEG_CONDSSTR(name, variable, type, from, to) SLEG_GENERAL(name, SaveLoadType::String, variable, type, 0, from, to, 0)
 
 /**
  * Storage of a structs in some savegame versions.
@@ -1175,7 +1164,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the struct.
  * @param to       Last savegame version that has the struct.
  */
-#define SLEG_CONDSTRUCT(name, handler, from, to) SaveLoad {name, SL_STRUCT, 0, 0, from, to, nullptr, 0, std::make_shared<handler>()}
+#define SLEG_CONDSTRUCT(name, handler, from, to) SaveLoad {name, SaveLoadType::Struct, {}, 0, from, to, nullptr, 0, std::make_shared<handler>()}
 
 /**
  * Storage of a global reference list in some savegame versions.
@@ -1185,17 +1174,17 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the list.
  * @param to       Last savegame version that has the list.
  */
-#define SLEG_CONDREFLIST(name, variable, type, from, to) SLEG_GENERAL(name, SL_REFLIST, variable, type, 0, from, to, 0)
+#define SLEG_CONDREFLIST(name, variable, type, from, to) SLEG_GENERAL(name, SaveLoadType::ReferenceList, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a global vector of #SL_VAR elements in some savegame versions.
+ * Storage of a global vector of #SaveLoadType::Variable elements in some savegame versions.
  * @param name     The name of the field.
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.
  * @param from     First savegame version that has the list.
  * @param to       Last savegame version that has the list.
  */
-#define SLEG_CONDVECTOR(name, variable, type, from, to) SLEG_GENERAL(name, SL_VECTOR, variable, type, 0, from, to, 0)
+#define SLEG_CONDVECTOR(name, variable, type, from, to) SLEG_GENERAL(name, SaveLoadType::Vector, variable, type, 0, from, to, 0)
 
 /**
  * Storage of a list of structs in some savegame versions.
@@ -1204,7 +1193,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @param from     First savegame version that has the list.
  * @param to       Last savegame version that has the list.
  */
-#define SLEG_CONDSTRUCTLIST(name, handler, from, to) SaveLoad {name, SL_STRUCTLIST, 0, 0, from, to, nullptr, 0, std::make_shared<handler>()}
+#define SLEG_CONDSTRUCTLIST(name, handler, from, to) SaveLoad {name, SaveLoadType::StructList, {}, 0, from, to, nullptr, 0, std::make_shared<handler>()}
 
 /**
  * Storage of a global variable in every savegame version.
@@ -1223,7 +1212,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLEG_REF(name, variable, type) SLEG_CONDREF(name, variable, type, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion)
 
 /**
- * Storage of a global fixed-size array of #SL_VAR elements in every savegame version.
+ * Storage of a global fixed-size array of #SaveLoadType::Variable elements in every savegame version.
  * @param name     The name of the field.
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.
@@ -1255,7 +1244,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLEG_REFLIST(name, variable, type) SLEG_CONDREFLIST(name, variable, type, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion)
 
 /**
- * Storage of a global vector of #SL_VAR elements in every savegame version.
+ * Storage of a global vector of #SaveLoadType::Variable elements in every savegame version.
  * @param name     The name of the field.
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -79,45 +79,45 @@ template <typename T> constexpr T ConvertEnumClass(T value) { return value; }
 /* Macros for various objects to go in the configuration file.
  * This section is for global variables */
 #define SDTG_VAR(name, type, flags, var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook, from, to, cat, extra, startup)\
-	NSD(Int, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook)
+	NSD(Int, SLEG_GENERAL(name, SaveLoadType::Variable, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook)
 
 #define SDTG_BOOL(name, flags, var, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
-	NSD(Bool, SLEG_GENERAL(name, SL_VAR, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
+	NSD(Bool, SLEG_GENERAL(name, SaveLoadType::Variable, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
 #define SDTG_LIST(name, type, flags, var, def, length, from, to, cat, extra, startup)\
-	NSD(List, SLEG_GENERAL(name, SL_ARR, var, type, length, from, to, extra),flags, startup, def)
+	NSD(List, SLEG_GENERAL(name, SaveLoadType::Array, var, type, length, from, to, extra),flags, startup, def)
 
 #define SDTG_SSTR(name, type, flags, var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(String, SLEG_GENERAL(name, SL_STDSTR, var, type, sizeof(var), from, to, extra), flags, startup, def, max_length, pre_check, post_callback)
+	NSD(String, SLEG_GENERAL(name, SaveLoadType::String, var, type, sizeof(var), from, to, extra), flags, startup, def, max_length, pre_check, post_callback)
 
 #define SDTG_OMANY(name, type, flags, var, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
-	NSD(OneOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
+	NSD(OneOfMany, SLEG_GENERAL(name, SaveLoadType::Variable, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
 
 #define SDTG_MMANY(name, type, flags, var, def, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLEG_GENERAL(name, SL_VAR, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
+	NSD(ManyOfMany, SLEG_GENERAL(name, SaveLoadType::Variable, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
 
 /* Macros for various objects to go in the configuration file.
  * This section is for structures where their various members are saved */
 #define SDT_VAR(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook, from, to, cat, extra, startup)\
-	NSD(Int, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook)
+	NSD(Int, SLE_GENERAL(SaveLoadType::Variable, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook)
 
 #define SDT_VAR_NAME(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup, name)\
-	NSD(Int, SLE_GENERAL_NAME(SL_VAR, name, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
+	NSD(Int, SLE_GENERAL_NAME(SaveLoadType::Variable, name, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
 #define SDT_BOOL(base, var, flags, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
-	NSD(Bool, SLE_GENERAL(SL_VAR, base, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
+	NSD(Bool, SLE_GENERAL(SaveLoadType::Variable, base, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
 #define SDT_LIST(base, var, type, flags, def, from, to, cat, extra, startup)\
-	NSD(List, SLE_GENERAL(SL_ARR, base, var, type, lengthof(((base*)8)->var), from, to, extra), flags, startup, def)
+	NSD(List, SLE_GENERAL(SaveLoadType::Array, base, var, type, lengthof(((base*)8)->var), from, to, extra), flags, startup, def)
 
 #define SDT_SSTR(base, var, type, flags, def, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(String, SLE_GENERAL(SL_STDSTR, base, var, type, sizeof(((base*)8)->var), from, to, extra), flags, startup, def, 0, pre_check, post_callback)
+	NSD(String, SLE_GENERAL(SaveLoadType::String, base, var, type, sizeof(((base*)8)->var), from, to, extra), flags, startup, def, 0, pre_check, post_callback)
 
 #define SDT_OMANY(base, var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, load, cat, extra, startup)\
-	NSD(OneOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, load)
+	NSD(OneOfMany, SLE_GENERAL(SaveLoadType::Variable, base, var, type, 1, from, to, extra), flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, load)
 
 #define SDT_MMANY(base, var, type, flags, def, full, str, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, strhelp, strval, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
+	NSD(ManyOfMany, SLE_GENERAL(SaveLoadType::Variable, base, var, type, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, full, nullptr)
 
 
 #define SDTC_VAR(var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook, from, to, cat, extra, startup)\

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -70,7 +70,7 @@ startup  = false
 [SDTG_LIST]
 name     = ""diff_custom""
 sdt_cmd  = SDT_INTLIST
-sle_cmd  = SL_ARR
+sle_cmd  = SaveLoadType::Array
 type     = SLE_FILE_I16 | SLE_VAR_U16
 flags    = SettingFlag::NotInConfig
 var      = _old_diff_custom
@@ -81,7 +81,7 @@ to       = SaveLoadVersion::TownTolerancePauseMode
 [SDTG_LIST]
 name     = ""diff_custom""
 sdt_cmd  = SDT_INTLIST
-sle_cmd  = SL_ARR
+sle_cmd  = SaveLoadType::Array
 type     = SLE_UINT16
 flags    = SettingFlag::NotInConfig
 var      = _old_diff_custom


### PR DESCRIPTION
## Motivation / Problem

Our ongoing segment of `make xyz scoped`.


## Description

*  Make `SaveLoadType` scoped.
* Remove unused `SLE_CONDSTR`.
* Replace instantiating type in the SLE macro's with `{}` instead of `0` to make future changes to the type easier, if we're touching the line anyway.


## Limitations

Probably conflicts with one or more of my other open PRs in the real of the save load code.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
