### PR TITLE
Add: Ability to flip (control-click) articulated vehicles in the depot

### DIFF
--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -598,6 +598,15 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 				for (const Vehicle *u = v; u->IsArticulatedPart(); u = u->Previous()) artic_before++;
 				uint8_t artic_after = 0;
 				for (const Vehicle *u = v; u->HasArticulatedPart(); u = u->Next()) artic_after++;
+
+				/* articulated trains can be flipped and those need special treatment */
+				if (v->type == VehicleType::Train) {
+					const Train *t = Train::From(v);
+					if (t->flags.Test(VehicleRailFlag::Flipped)) {
+						std::swap(artic_after, artic_before);
+					}
+				}
+
 				v->grf_cache.position_in_vehicle = artic_before | artic_after << 8;
 				SetBit(v->grf_cache.cache_valid, NCVV_POSITION_IN_VEHICLE);
 			}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -43,6 +43,8 @@
 
 #include "safeguards.h"
 
+extern void ChangeVehicleViewWindow(VehicleID from_index, VehicleID to_index);
+
 static Track ChooseTrainTrack(Train *v, TileIndex tile, DiagDirection enterdir, TrackBits tracks, bool force_res, bool *got_reservation, bool mark_stuck);
 static bool TrainCheckIfLineEnds(Train *v, bool reverse = true);
 bool TrainController(Train *v, Vehicle *nomove, bool reverse = true); // Also used in vehicle_sl.cpp.
@@ -2113,6 +2115,86 @@ static void ReverseTrainDirection(Train *consist)
 }
 
 /**
+ * Flip an articulated vehicle around within its consist.
+ * @param v %Train to flip.
+ * @return Front of the train after the flip operation
+ */
+static Train *ReverseArticulatedTrainDirection(Train *v)
+{
+	Train *const start = v->GetFirstEnginePart();
+	Train *const end = v->GetLastEnginePart();
+
+	if (start == end || start == nullptr) {
+		return v->First();
+	}
+
+	assert(end);
+
+	Train *after_end = end->Next();
+	Train *before_start = start->Previous();
+
+	if (before_start) {
+		before_start->SetNext(nullptr);
+	}
+
+	TrainList segment;
+	Train *current = start;
+	while (current != after_end && current != nullptr) {
+		segment.push_back(current);
+
+		/* invert the flip flag because this is the only place we look at every single vehicle */
+		current->flags.Flip(VehicleRailFlag::Flipped);
+		current->InvalidateNewGRFCache();
+
+		/* break up the segment here because when we go to stitch it back together later we don't want to make a looped train */
+		Train *next = current->Next();
+		current->SetNext(nullptr);
+		current = next;
+	}
+
+	/* turn every part around */
+	for (size_t i = segment.size() - 1; i > 0; --i) {
+		segment[i]->SetNext(segment[i - 1]);
+	}
+
+	/* swap crucial flags between the front and rear vehicles */
+	std::swap(start->type, end->type);
+	std::swap(start->flags, end->flags);
+	std::swap(start->vehstatus, end->vehstatus);
+	std::swap(start->vehicle_flags, end->vehicle_flags);
+	std::swap(start->gv_flags, end->gv_flags);
+	std::swap(start->subtype, end->subtype);
+	std::swap(start->unitnumber, end->unitnumber);
+
+	std::swap(start->vcache, end->vcache);
+	std::swap(start->gcache, end->gcache);
+
+	std::swap(start->age, end->age);
+	std::swap(start->max_age, end->max_age);
+	std::swap(start->reliability, end->reliability);
+	std::swap(start->reliability_spd_dec, end->reliability_spd_dec);
+
+	/* stitch our newly reversed section back into the train */
+	if (before_start != nullptr) {
+		before_start->SetNext(end);
+	}
+	segment.front()->SetNext(after_end);
+
+	/* Update caches */
+	Train *new_first = end;
+	while (new_first->Previous() != nullptr) new_first = new_first->Previous();
+
+	Train *new_end = start;
+	while (new_end->Next() != nullptr) new_end = new_end->Next();
+
+	for (Train *it = new_first; it != nullptr; it = it->Next()) {
+		it->SetNext(it->Next());
+	}
+
+	return new_first;
+}
+
+/**
  * Reverse train.
  * @param flags type of operation
  * @param veh_id train to reverse
@@ -2130,7 +2212,7 @@ CommandCost CmdReverseTrainDirection(DoCommandFlags flags, VehicleID veh_id, boo
 	if (reverse_single_veh) {
 		/* turn a single unit around */
 
-		if (v->IsMultiheaded() || EngInfo(v->engine_type)->callback_mask.Test(VehicleCallbackMask::ArticEngine)) {
+		if (v->IsMultiheaded()) {
 			return CommandCost(STR_ERROR_CAN_T_REVERSE_DIRECTION_RAIL_VEHICLE_MULTIPLE_UNITS);
 		}
 
@@ -2141,13 +2223,32 @@ CommandCost CmdReverseTrainDirection(DoCommandFlags flags, VehicleID veh_id, boo
 		}
 
 		if (flags.Test(DoCommandFlag::Execute)) {
-			v->flags.Flip(VehicleRailFlag::Flipped);
+			if (EngInfo(v->engine_type)->callback_mask.Test(VehicleCallbackMask::ArticEngine)) {
+				Train *old_front = front;
+				front = ReverseArticulatedTrainDirection(v);
 
-			front->ConsistChanged(CCF_ARRANGE);
-			SetWindowDirty(WindowClass::VehicleDepot, front->tile);
-			SetWindowDirty(WindowClass::VehicleDetails, front->index);
-			InvalidateWindowData(WindowClass::VehicleView, front->index);
-			SetWindowClassesDirty(WindowClass::TrainList);
+				if (old_front != front) {
+					NormaliseTrainHead(front);
+					ChangeVehicleViewWindow(old_front->index, front->index);
+				} else {
+					InvalidateWindowData(WindowClass::VehicleRefit, front->index);
+					InvalidateWindowData(WindowClass::VehicleOrders, front->index);
+					InvalidateNewGRFInspectWindow(GrfSpecFeature::Trains, front->index);
+
+					InvalidateWindowData(WindowClass::VehicleView, front->index);
+				}
+
+				InvalidateWindowData(WindowClass::VehicleDepot, v->tile);
+				InvalidateWindowClassesData(WindowClass::TrainList, 0);
+			} else {
+				v->flags.Flip(VehicleRailFlag::Flipped);
+
+				front->ConsistChanged(CCF_ARRANGE);
+				SetWindowDirty(WindowClass::VehicleDepot, front->tile);
+				SetWindowDirty(WindowClass::VehicleDetails, front->index);
+				InvalidateWindowData(WindowClass::VehicleView, front->index);
+				SetWindowClassesDirty(WindowClass::TrainList);
+			}
 		}
 	} else {
 		/* turn the whole train around */


### PR DESCRIPTION
## Motivation / Problem

The inability to flip articulated rail vehicles (really "newgrf multiple units/steam locomotives") is basically arbitrary, it'd be nice to be able to do that.


## Description

Stop excluding vehicles from being flipped based on their articulated flag, instead special-case flip behaviour to call a new function that
* Splits the vehicle out of the consist
* Inverts the train linked-list for the selected vehicle.
* Dirties caches as needed for that linked list
* Sets the flip flag on all the vehicles
* Swap relevant "front vehicle only" data from the old front vehicle to the new front vehicle.
* Stitches the vehicles back into the existing consist.

I acknowledge that I am kind of using this pull request to seek feedback on how to do this better. This is the first approach that came to mind but it does work.


## Limitations

I think this code is pretty ugly and it's certainly not accounting for all the edge cases. To be complete it needs:

* A list of all the variables that are conventionally "only valid for the front part of an articulated vehicle"
* More thorough manual testing. (multiplayer?)
* Some sort of reminder in the train code that new vars need to be accounted for inside ReverseArticulatedTrainDirection
* Some features may want extending in the future (nml's reverse_build_probability is obvious) to actually build the articulated vehicle "backwards" from the start. In that case this code should move to articulated_vehicles.cpp?
* I wrote this on my own and nobody wanted to give feedback on it before it was a pull request so it's very possible nobody except me cares about the feature!
 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
