### PR TITLE
Codechange: split VarTypes into separate enumerations and recombine as struct

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -192,7 +192,7 @@ typedef int32_t CheckButtonClick(int32_t new_value, int32_t change_direction);
 
 /** Information of a cheat. */
 struct CheatEntry {
-	VarType type;          ///< type of selector
+	VarMemType type; ///< type of selector
 	StringID str;          ///< string with descriptive text
 	void *variable;        ///< pointer to the variable
 	bool *been_used;       ///< has this cheat been used before?
@@ -204,15 +204,15 @@ struct CheatEntry {
  * Order matches with the values of #CheatNumbers
  */
 static const CheatEntry _cheats_ui[] = {
-	{SLE_INT32, STR_CHEAT_MONEY,           &_money_cheat_amount,                          &_cheats.money.been_used,            &ClickMoneyCheat         },
-	{SLE_UINT8, STR_CHEAT_CHANGE_COMPANY,  &_local_company,                               &_cheats.switch_company.been_used,   &ClickChangeCompanyCheat },
-	{SLE_BOOL,  STR_CHEAT_EXTRA_DYNAMITE,  &_cheats.magic_bulldozer.value,                &_cheats.magic_bulldozer.been_used,  nullptr                  },
-	{SLE_BOOL,  STR_CHEAT_CROSSINGTUNNELS, &_cheats.crossing_tunnels.value,               &_cheats.crossing_tunnels.been_used, nullptr                  },
-	{SLE_BOOL,  STR_CHEAT_NO_JETCRASH,     &_cheats.no_jetcrash.value,                    &_cheats.no_jetcrash.been_used,      nullptr                  },
-	{SLE_BOOL,  STR_CHEAT_SETUP_PROD,      &_cheats.setup_prod.value,                     &_cheats.setup_prod.been_used,       &ClickSetProdCheat       },
-	{SLE_BOOL,  STR_CHEAT_STATION_RATING,  &_cheats.station_rating.value,                 &_cheats.station_rating.been_used,   nullptr                  },
-	{SLE_UINT8, STR_CHEAT_EDIT_MAX_HL,     &_settings_game.construction.map_height_limit, &_cheats.edit_max_hl.been_used,      &ClickChangeMaxHlCheat   },
-	{SLE_INT32, STR_CHEAT_CHANGE_DATE,     &TimerGameCalendar::year,                      &_cheats.change_date.been_used,      &ClickChangeDateCheat    },
+	{SLE_VAR_I32, STR_CHEAT_MONEY, &_money_cheat_amount, &_cheats.money.been_used, &ClickMoneyCheat },
+	{SLE_VAR_U8, STR_CHEAT_CHANGE_COMPANY, &_local_company, &_cheats.switch_company.been_used, &ClickChangeCompanyCheat },
+	{SLE_VAR_BL, STR_CHEAT_EXTRA_DYNAMITE, &_cheats.magic_bulldozer.value, &_cheats.magic_bulldozer.been_used, nullptr },
+	{SLE_VAR_BL, STR_CHEAT_CROSSINGTUNNELS, &_cheats.crossing_tunnels.value, &_cheats.crossing_tunnels.been_used, nullptr },
+	{SLE_VAR_BL, STR_CHEAT_NO_JETCRASH, &_cheats.no_jetcrash.value, &_cheats.no_jetcrash.been_used, nullptr },
+	{SLE_VAR_BL, STR_CHEAT_SETUP_PROD, &_cheats.setup_prod.value, &_cheats.setup_prod.been_used, &ClickSetProdCheat },
+	{SLE_VAR_BL, STR_CHEAT_STATION_RATING, &_cheats.station_rating.value, &_cheats.station_rating.been_used, nullptr },
+	{SLE_VAR_U8, STR_CHEAT_EDIT_MAX_HL, &_settings_game.construction.map_height_limit, &_cheats.edit_max_hl.been_used, &ClickChangeMaxHlCheat },
+	{SLE_VAR_I32, STR_CHEAT_CHANGE_DATE, &TimerGameCalendar::year, &_cheats.change_date.been_used, &ClickChangeDateCheat },
 };
 
 static_assert(CHT_NUM_CHEATS == lengthof(_cheats_ui));
@@ -282,7 +282,7 @@ struct CheatWindow : Window {
 			const CheatEntry *ce = &_cheats_ui[i];
 
 			std::string str;
-			switch (GetVarMemType(ce->type)) {
+			switch (ce->type) {
 				case SLE_VAR_BL: {
 					bool on = (*(bool*)ce->variable);
 
@@ -379,7 +379,7 @@ struct CheatWindow : Window {
 	{
 		uint width = 0;
 		for (const auto &ce : _cheats_ui) {
-			switch (GetVarMemType(ce.type)) {
+			switch (ce.type) {
 				case SLE_VAR_BL:
 					width = std::max(width, GetStringBoundingBox(GetString(ce.str, STR_CONFIG_SETTING_ON)).width);
 					width = std::max(width, GetStringBoundingBox(GetString(ce.str, STR_CONFIG_SETTING_OFF)).width);
@@ -465,7 +465,7 @@ struct CheatWindow : Window {
 		this->clicked_setting = nullptr;
 		*ce->been_used = true;
 
-		switch (GetVarMemType(ce->type)) {
+		switch (ce->type) {
 			case SLE_VAR_BL:
 				value ^= 1;
 				if (ce->proc != nullptr) ce->proc(value, 0);

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -282,8 +282,8 @@ struct CheatWindow : Window {
 			const CheatEntry *ce = &_cheats_ui[i];
 
 			std::string str;
-			switch (ce->type) {
-				case SLE_BOOL: {
+			switch (GetVarMemType(ce->type)) {
+				case SLE_VAR_BL: {
 					bool on = (*(bool*)ce->variable);
 
 					DrawBoolButton(button_left, y + button_y_offset, Colours::Yellow, Colours::Grey, on, true);
@@ -379,8 +379,8 @@ struct CheatWindow : Window {
 	{
 		uint width = 0;
 		for (const auto &ce : _cheats_ui) {
-			switch (ce.type) {
-				case SLE_BOOL:
+			switch (GetVarMemType(ce.type)) {
+				case SLE_VAR_BL:
 					width = std::max(width, GetStringBoundingBox(GetString(ce.str, STR_CONFIG_SETTING_ON)).width);
 					width = std::max(width, GetStringBoundingBox(GetString(ce.str, STR_CONFIG_SETTING_OFF)).width);
 					break;
@@ -465,8 +465,8 @@ struct CheatWindow : Window {
 		this->clicked_setting = nullptr;
 		*ce->been_used = true;
 
-		switch (ce->type) {
-			case SLE_BOOL:
+		switch (GetVarMemType(ce->type)) {
+			case SLE_VAR_BL:
 				value ^= 1;
 				if (ce->proc != nullptr) ce->proc(value, 0);
 				break;

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -506,10 +506,10 @@ static const SaveLoad _company_desc[] = {
 	SLE_CONDSSTRNAME(CompanyProperties, face.style_label, "face_style", SLE_STR, SaveLoadVersion::FaceStyles, SaveLoadVersion::MaxVersion),
 
 	/* money was changed to a 64 bit field in savegame version 1. */
-	SLE_CONDVAR(CompanyProperties, money, SLE_VAR_I64 | SLE_FILE_I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigCurrency),
+	SLE_CONDVAR(CompanyProperties, money, SLE_FILE_I32 | SLE_VAR_I64, SaveLoadVersion::MinVersion, SaveLoadVersion::BigCurrency),
 	SLE_CONDVAR(CompanyProperties, money, SLE_INT64, SaveLoadVersion::BigCurrency, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(CompanyProperties, current_loan, SLE_VAR_I64 | SLE_FILE_I32, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
+	SLE_CONDVAR(CompanyProperties, current_loan, SLE_FILE_I32 | SLE_VAR_I64, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
 	SLE_CONDVAR(CompanyProperties, current_loan, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(CompanyProperties, max_loan, SLE_INT64, SaveLoadVersion::MaxLoanForCompany, SaveLoadVersion::MaxVersion),
 
@@ -531,7 +531,7 @@ static const SaveLoad _company_desc[] = {
 	SLE_CONDVAR(CompanyProperties, bankrupt_asked, SLE_FILE_U8 | SLE_VAR_U16, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCompanies),
 	SLE_CONDVAR(CompanyProperties, bankrupt_asked, SLE_UINT16, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
 	    SLE_VAR(CompanyProperties, bankrupt_timeout,      SLE_INT16),
-	SLE_CONDVAR(CompanyProperties, bankrupt_value, SLE_VAR_I64 | SLE_FILE_I32, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
+	SLE_CONDVAR(CompanyProperties, bankrupt_value, SLE_FILE_I32 | SLE_VAR_I64, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
 	SLE_CONDVAR(CompanyProperties, bankrupt_value, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
 
 	/* yearly expenses was changed to 64-bit in savegame version 2. */

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -24,7 +24,7 @@ struct PRICChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		/* Old games store 49 base prices, very old games store them as int32_t */
-		int vt = IsSavegameVersionBefore(SaveLoadVersion::UnifyCurrency) ? SLE_FILE_I32 : SLE_FILE_I64;
+		VarFileType vt = IsSavegameVersionBefore(SaveLoadVersion::UnifyCurrency) ? SLE_FILE_I32 : SLE_FILE_I64;
 		SlCopy(nullptr, 49, vt | SLE_VAR_NULL);
 		SlCopy(nullptr, 49, SLE_FILE_U16 | SLE_VAR_NULL);
 	}
@@ -37,7 +37,7 @@ struct CAPRChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		uint num_cargo = IsSavegameVersionBefore(SaveLoadVersion::NewGRFCargo) ? 12 : IsSavegameVersionBefore(SaveLoadVersion::ExtendCargotypes) ? 32 : NUM_CARGO;
-		int vt = IsSavegameVersionBefore(SaveLoadVersion::UnifyCurrency) ? SLE_FILE_I32 : SLE_FILE_I64;
+		VarFileType vt = IsSavegameVersionBefore(SaveLoadVersion::UnifyCurrency) ? SLE_FILE_I32 : SLE_FILE_I64;
 		SlCopy(nullptr, num_cargo, vt | SLE_VAR_NULL);
 		SlCopy(nullptr, num_cargo, SLE_FILE_U16 | SLE_VAR_NULL);
 	}

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -584,10 +584,10 @@ struct SavegameFileType {
 	 * @param file_type The file type.
 	 * @param has_field_length Does this field have a length?
 	 */
-	SavegameFileType(VarType file_type, bool has_field_length = false) : storage(file_type)
+	SavegameFileType(VarFileType file_type, bool has_field_length = false) : storage(to_underlying(file_type))
 	{
 		/* 0 is not allowed as it's the end-of-table marker, larger is not allowed due to the field length bit. */
-		assert(IsInsideMM(file_type, 1, 1 << HAS_FIELD_LENGTH_BIT));
+		assert(IsInsideMM(to_underlying(file_type), 1, 1 << HAS_FIELD_LENGTH_BIT));
 		AssignBit(this->storage, HAS_FIELD_LENGTH_BIT, has_field_length);
 	}
 
@@ -611,10 +611,10 @@ struct SavegameFileType {
 	 * Get the \c VarType for this field.
 	 * @return The \c VarType.
 	 */
-	constexpr VarType Type() const
+	constexpr VarFileType Type() const
 	{
 		assert(!this->IsEnd());
-		return GB(storage, 0, HAS_FIELD_LENGTH_BIT);
+		return static_cast<VarFileType>(GB(storage, 0, HAS_FIELD_LENGTH_BIT));
 	}
 };
 
@@ -1153,15 +1153,15 @@ static void SlStdString(void *ptr, VarType conv)
 			SlReadString(*str, len);
 
 			StringValidationSettings settings = StringValidationSetting::ReplaceWithQuestionMark;
-			if ((conv & SLF_ALLOW_CONTROL) != 0) {
+			if (conv.flags.Test(SLF_ALLOW_CONTROL)) {
 				settings.Set(StringValidationSetting::AllowControlCode);
 				if (IsSavegameVersionBefore(SaveLoadVersion::EncodedStringFormat)) FixSCCEncoded(*str, IsSavegameVersionBefore(SaveLoadVersion::MoveSccEncoded));
 				if (IsSavegameVersionBefore(SaveLoadVersion::FixSccEncodedNegative)) FixSCCEncodedNegative(*str);
 			}
-			if ((conv & SLF_ALLOW_NEWLINE) != 0) {
+			if (conv.flags.Test(SLF_ALLOW_NEWLINE)) {
 				settings.Set(StringValidationSetting::AllowNewline);
 			}
-			if ((conv & SLF_REPLACE_TABCRLF) != 0) {
+			if (conv.flags.Test(SLF_REPLACE_TABCRLF)) {
 				settings.Set(StringValidationSetting::ReplaceTabCrNlWithSpace);
 			}
 			StrMakeValidInPlace(*str, settings);
@@ -1413,14 +1413,14 @@ void SlSaveLoadRef(void *ptr, VarType conv)
 {
 	switch (_sl.action) {
 		case SaveLoadAction::Save:
-			SlWriteUint32(ReferenceToInt(*static_cast<void **>(ptr), static_cast<SLRefType>(conv)));
+			SlWriteUint32(ReferenceToInt(*static_cast<void **>(ptr), conv.ref));
 			break;
 		case SaveLoadAction::LoadCheck:
 		case SaveLoadAction::Load:
 			*static_cast<size_t *>(ptr) = IsSavegameVersionBefore(SaveLoadVersion::MoreCargoPackets) ? SlReadUint16() : SlReadUint32();
 			break;
 		case SaveLoadAction::Ptrs:
-			*static_cast<void **>(ptr) = IntToReference(*static_cast<size_t *>(ptr), static_cast<SLRefType>(conv));
+			*static_cast<void **>(ptr) = IntToReference(*static_cast<size_t *>(ptr), conv.ref);
 			break;
 		case SaveLoadAction::Null:
 			*static_cast<void **>(ptr) = nullptr;
@@ -1450,7 +1450,7 @@ public:
 		const SlStorageT *list = static_cast<const SlStorageT *>(storage);
 
 		int type_size = SlGetArrayLength(list->size());
-		int item_size = SlCalcConvFileLen(cmd == SaveLoadType::Variable ? conv : static_cast<VarType>(SLE_FILE_U32));
+		int item_size = SlCalcConvFileLen(cmd == SaveLoadType::Variable ? conv : VarType{SLE_FILE_U32, {}});
 		return list->size() * item_size + type_size;
 	}
 
@@ -1744,7 +1744,6 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 {
 	if (!SlIsObjectValidInSavegame(sld)) return false;
 
-	VarType conv = GB(sld.conv, 0, 8);
 	switch (sld.cmd) {
 		case SaveLoadType::Variable:
 		case SaveLoadType::Reference:
@@ -1756,12 +1755,12 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 			void *ptr = GetVariableAddress(object, sld);
 
 			switch (sld.cmd) {
-				case SaveLoadType::Variable: SlSaveLoadConv(ptr, conv); break;
-				case SaveLoadType::Reference: SlSaveLoadRef(ptr, conv); break;
-				case SaveLoadType::Array: SlArray(ptr, sld.length, conv); break;
-				case SaveLoadType::ReferenceList: SlRefList(ptr, conv); break;
-				case SaveLoadType::ReferenceVector: SlRefVector(ptr, conv); break;
-				case SaveLoadType::Vector: SlVector(ptr, conv); break;
+				case SaveLoadType::Variable: SlSaveLoadConv(ptr, sld.conv); break;
+				case SaveLoadType::Reference: SlSaveLoadRef(ptr, sld.conv); break;
+				case SaveLoadType::Array: SlArray(ptr, sld.length, sld.conv); break;
+				case SaveLoadType::ReferenceList: SlRefList(ptr, sld.conv); break;
+				case SaveLoadType::ReferenceVector: SlRefVector(ptr, sld.conv); break;
+				case SaveLoadType::Vector: SlVector(ptr, sld.conv); break;
 				case SaveLoadType::String: SlStdString(ptr, sld.conv); break;
 				default: NOT_REACHED();
 			}

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -627,12 +627,12 @@ static SavegameFileType GetSavegameFileType(const SaveLoad &sld)
 {
 	switch (sld.cmd) {
 		case SaveLoadType::Variable:
-			return GetVarFileType(sld.conv); break;
+			return sld.conv.file;
 
 		case SaveLoadType::String:
 		case SaveLoadType::Array:
 		case SaveLoadType::Vector:
-			return { GetVarFileType(sld.conv), true }; break;
+			return { sld.conv.file, true };
 
 		case SaveLoadType::Reference:
 			return IsSavegameVersionBefore(SaveLoadVersion::MoreCargoPackets) ? SLE_FILE_U16 : SLE_FILE_U32;
@@ -690,7 +690,7 @@ static inline uint SlCalcConvMemLen(VarMemType conv)
  */
 static inline uint8_t SlCalcConvFileLen(VarType conv)
 {
-	switch (GetVarFileType(conv)) {
+	switch (conv.file) {
 		case SLE_FILE_I8: return sizeof(int8_t);
 		case SLE_FILE_U8: return sizeof(uint8_t);
 		case SLE_FILE_I16: return sizeof(int16_t);
@@ -926,7 +926,7 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 			int64_t x = ReadValue(ptr, conv.mem);
 
 			/* Write the value to the file and check if its value is in the desired range */
-			switch (GetVarFileType(conv)) {
+			switch (conv.file) {
 				case SLE_FILE_I8:
 					assert(x >= -128 && x <= 127);
 					SlWriteByte(x);
@@ -966,7 +966,7 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 		case SaveLoadAction::Load: {
 			int64_t x;
 			/* Read a value from the file */
-			switch (GetVarFileType(conv)) {
+			switch (conv.file) {
 				case SLE_FILE_I8: x = static_cast<int8_t>(SlReadByte()); break;
 				case SLE_FILE_U8: x = static_cast<uint8_t>(SlReadByte()); break;
 				case SLE_FILE_I16: x = static_cast<int16_t>(SlReadUint16()); break;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -569,11 +569,61 @@ static inline uint SlGetArrayLength(size_t length)
 }
 
 /**
+ * Container/wrapper for the file type that is used in tables in the save game.
+ * This is essentially \c VarFileType, but with a bit denoting that the type has a field length and a value denoting end-of-table.
+ */
+struct SavegameFileType {
+	static constexpr uint8_t HAS_FIELD_LENGTH_BIT = 4; ///< Set this bit to denote the type has a field length.
+	uint8_t storage{}; ///< Actual storage of the file type.
+
+	/** Create an end-of-table marker. */
+	SavegameFileType() {}
+
+	/**
+	 * Create the type.
+	 * @param file_type The file type.
+	 * @param has_field_length Does this field have a length?
+	 */
+	SavegameFileType(VarType file_type, bool has_field_length = false) : storage(file_type)
+	{
+		/* 0 is not allowed as it's the end-of-table marker, larger is not allowed due to the field length bit. */
+		assert(IsInsideMM(file_type, 1, 1 << HAS_FIELD_LENGTH_BIT));
+		AssignBit(this->storage, HAS_FIELD_LENGTH_BIT, has_field_length);
+	}
+
+	/**
+	 * Is this the end-of-table marker?
+	 * @return \c true iff this is an end-of-table marker.
+	 */
+	constexpr bool IsEnd() const { return storage == 0; }
+
+	/**
+	 * Does this field have a length?
+	 * @return \c true iff this field has a length.
+	 */
+	constexpr bool HasFieldLength() const
+	{
+		assert(!this->IsEnd());
+		return HasBit(storage, HAS_FIELD_LENGTH_BIT);
+	}
+
+	/**
+	 * Get the \c VarType for this field.
+	 * @return The \c VarType.
+	 */
+	constexpr VarType Type() const
+	{
+		assert(!this->IsEnd());
+		return GB(storage, 0, HAS_FIELD_LENGTH_BIT);
+	}
+};
+
+/**
  * Return the type as saved/loaded inside the savegame.
  * @param sld The save-load configuration for a single variable.
  * @return The type description part for the way the data is stored in the file.
  */
-static uint8_t GetSavegameFileType(const SaveLoad &sld)
+static SavegameFileType GetSavegameFileType(const SaveLoad &sld)
 {
 	switch (sld.cmd) {
 		case SaveLoadType::Variable:
@@ -582,21 +632,21 @@ static uint8_t GetSavegameFileType(const SaveLoad &sld)
 		case SaveLoadType::String:
 		case SaveLoadType::Array:
 		case SaveLoadType::Vector:
-			return GetVarFileType(sld.conv) | SLE_FILE_HAS_LENGTH_FIELD; break;
+			return { GetVarFileType(sld.conv), true }; break;
 
 		case SaveLoadType::Reference:
 			return IsSavegameVersionBefore(SaveLoadVersion::MoreCargoPackets) ? SLE_FILE_U16 : SLE_FILE_U32;
 
 		case SaveLoadType::ReferenceList:
 		case SaveLoadType::ReferenceVector:
-			return (IsSavegameVersionBefore(SaveLoadVersion::MoreCargoPackets) ? SLE_FILE_U16 : SLE_FILE_U32) | SLE_FILE_HAS_LENGTH_FIELD;
+			return { IsSavegameVersionBefore(SaveLoadVersion::MoreCargoPackets) ? SLE_FILE_U16 : SLE_FILE_U32, true };
 
 		case SaveLoadType::SaveByte:
 			return SLE_FILE_U8;
 
 		case SaveLoadType::Struct:
 		case SaveLoadType::StructList:
-			return SLE_FILE_STRUCT | SLE_FILE_HAS_LENGTH_FIELD;
+			return { SLE_FILE_STRUCT, true };
 
 		default: NOT_REACHED();
 	}
@@ -641,7 +691,6 @@ static inline uint SlCalcConvMemLen(VarType conv)
 static inline uint8_t SlCalcConvFileLen(VarType conv)
 {
 	switch (GetVarFileType(conv)) {
-		case SLE_FILE_END: return 0;
 		case SLE_FILE_I8: return sizeof(int8_t);
 		case SLE_FILE_U8: return sizeof(uint8_t);
 		case SLE_FILE_I16: return sizeof(int16_t);
@@ -1899,9 +1948,9 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 			}
 
 			while (true) {
-				uint8_t type = 0;
-				SlSaveLoadConv(&type, SLE_UINT8);
-				if (type == SLE_FILE_END) break;
+				SavegameFileType type{};
+				SlSaveLoadConv(&type.storage, SLE_UINT8);
+				if (type.IsEnd()) break;
 
 				std::string key;
 				SlStdString(&key, SLE_STR);
@@ -1909,29 +1958,27 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 				auto sld_it = key_lookup.find(key);
 				if (sld_it == key_lookup.end()) {
 					/* SLA_LOADCHECK triggers this debug statement a lot and is perfectly normal. */
-					Debug(sl, _sl.action == SaveLoadAction::Load ? 2 : 6, "Field '{}' of type 0x{:02x} not found, skipping", key, type);
+					Debug(sl, _sl.action == SaveLoadAction::Load ? 2 : 6, "Field '{}' of type 0x{:02x} not found, skipping", key, type.storage);
 
 					std::shared_ptr<SaveLoadHandler> handler = nullptr;
 					SaveLoadType saveload_type;
-					switch (type & SLE_FILE_TYPE_MASK) {
+					switch (type.Type()) {
 						case SLE_FILE_STRING:
-							/* Strings are always marked with SLE_FILE_HAS_LENGTH_FIELD, as they are a list of chars. */
 							saveload_type = SaveLoadType::String;
 							break;
 
 						case SLE_FILE_STRUCT:
-							/* Structs are always marked with SLE_FILE_HAS_LENGTH_FIELD as SaveLoadType::Struct is seen as a list of 0/1 in length. */
 							saveload_type = SaveLoadType::StructList;
 							handler = std::make_shared<SlSkipHandler>();
 							break;
 
 						default:
-							saveload_type = (type & SLE_FILE_HAS_LENGTH_FIELD) ? SaveLoadType::Array : SaveLoadType::Variable;
+							saveload_type = type.HasFieldLength() ? SaveLoadType::Array : SaveLoadType::Variable;
 							break;
 					}
 
 					/* We don't know this field, so read to nothing. */
-					saveloads.emplace_back(std::move(key), saveload_type, (static_cast<VarType>(type) & SLE_FILE_TYPE_MASK) | SLE_VAR_NULL, 1, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion, nullptr, 0, std::move(handler));
+					saveloads.emplace_back(std::move(key), saveload_type, type.Type() | SLE_VAR_NULL, 1, SaveLoadVersion::MinVersion, SaveLoadVersion::MaxVersion, nullptr, 0, std::move(handler));
 					continue;
 				}
 
@@ -1940,9 +1987,9 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 				 * conversion. If this error triggers, that clearly didn't
 				 * happen and this is a friendly poke to the developer to bump
 				 * the savegame version and add conversion code. */
-				uint8_t correct_type = GetSavegameFileType(*sld_it->second);
-				if (correct_type != type) {
-					Debug(sl, 1, "Field type for '{}' was expected to be 0x{:02x} but 0x{:02x} was found", key, correct_type, type);
+				SavegameFileType correct_type = GetSavegameFileType(*sld_it->second);
+				if (correct_type.storage != type.storage) {
+					Debug(sl, 1, "Field type for '{}' was expected to be 0x{:02x} but 0x{:02x} was found", key, correct_type.storage, type.storage);
 					SlErrorCorrupt("Field type is different than expected");
 				}
 				saveloads.emplace_back(*sld_it->second);
@@ -1969,16 +2016,16 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 				/* Make sure we are not storing empty keys. */
 				assert(!sld.name.empty());
 
-				uint8_t type = GetSavegameFileType(sld);
-				assert(type != SLE_FILE_END);
+				SavegameFileType type = GetSavegameFileType(sld);
+				assert(!type.IsEnd());
 
-				SlSaveLoadConv(&type, SLE_UINT8);
+				SlSaveLoadConv(&type.storage, SLE_UINT8);
 				SlStdString(const_cast<std::string *>(&sld.name), SLE_STR);
 			}
 
 			/* Add an end-of-header marker. */
-			uint8_t type = SLE_FILE_END;
-			SlSaveLoadConv(&type, SLE_UINT8);
+			SavegameFileType type{};
+			SlSaveLoadConv(&type.storage, SLE_UINT8);
 
 			/* After the table, write down any sub-tables we might have. */
 			for (auto &sld : slt) {

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -869,9 +869,9 @@ size_t SlGetFieldLength()
  * type, eg one with other flags because it is parsed
  * @return returns the value of the pointer-setting
  */
-int64_t ReadValue(const void *ptr, VarType conv)
+int64_t ReadValue(const void *ptr, VarMemType conv)
 {
-	switch (GetVarMemType(conv)) {
+	switch (conv) {
 		case SLE_VAR_BL: return (*static_cast<const bool *>(ptr) != 0);
 		case SLE_VAR_I8: return *static_cast<const int8_t *>(ptr);
 		case SLE_VAR_U8: return *static_cast<const uint8_t *>(ptr);
@@ -893,9 +893,9 @@ int64_t ReadValue(const void *ptr, VarType conv)
  *             with other flags. It is parsed upon read
  * @param val the new value being given to the variable
  */
-void WriteValue(void *ptr, VarType conv, int64_t val)
+void WriteValue(void *ptr, VarMemType conv, int64_t val)
 {
-	switch (GetVarMemType(conv)) {
+	switch (conv) {
 		case SLE_VAR_BL: *static_cast<bool *>(ptr) = (val != 0); break;
 		case SLE_VAR_I8: *static_cast<int8_t *>(ptr) = val; break;
 		case SLE_VAR_U8: *static_cast<uint8_t *>(ptr) = val; break;
@@ -923,7 +923,7 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 {
 	switch (_sl.action) {
 		case SaveLoadAction::Save: {
-			int64_t x = ReadValue(ptr, conv);
+			int64_t x = ReadValue(ptr, conv.mem);
 
 			/* Write the value to the file and check if its value is in the desired range */
 			switch (GetVarFileType(conv)) {
@@ -980,7 +980,7 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 			}
 
 			/* Write The value to the struct. These ARE endian safe. */
-			WriteValue(ptr, conv, x);
+			WriteValue(ptr, conv.mem, x);
 			break;
 		}
 		case SaveLoadAction::Ptrs: break;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -658,9 +658,9 @@ static SavegameFileType GetSavegameFileType(const SaveLoad &sld)
  * @param conv VarType type of variable that is used for calculating the size
  * @return Return the size of this type in bytes
  */
-static inline uint SlCalcConvMemLen(VarType conv)
+static inline uint SlCalcConvMemLen(VarMemType conv)
 {
-	switch (GetVarMemType(conv)) {
+	switch (conv) {
 		case SLE_VAR_BL: return sizeof(bool);
 		case SLE_VAR_I8: return sizeof(int8_t);
 		case SLE_VAR_U8: return sizeof(uint8_t);
@@ -1145,7 +1145,7 @@ static void SlStdString(void *ptr, VarType conv)
 		case SaveLoadAction::LoadCheck:
 		case SaveLoadAction::Load: {
 			size_t len = SlReadArrayLength();
-			if (GetVarMemType(conv) == SLE_VAR_NULL) {
+			if (conv.mem == SLE_VAR_NULL) {
 				SlSkipBytes(len);
 				return;
 			}
@@ -1183,7 +1183,7 @@ static void SlStdString(void *ptr, VarType conv)
  */
 static void SlCopyInternal(void *object, size_t length, VarType conv)
 {
-	if (GetVarMemType(conv) == SLE_VAR_NULL) {
+	if (conv.mem == SLE_VAR_NULL) {
 		assert(_sl.action != SaveLoadAction::Save); // Use SaveLoadType::Null if you want to write null-bytes
 		SlSkipBytes(length * SlCalcConvFileLen(conv));
 		return;
@@ -1213,7 +1213,7 @@ static void SlCopyInternal(void *object, size_t length, VarType conv)
 		SlCopyBytes(object, length);
 	} else {
 		uint8_t *a = static_cast<uint8_t *>(object);
-		uint8_t mem_size = SlCalcConvMemLen(conv);
+		uint8_t mem_size = SlCalcConvMemLen(conv.mem);
 
 		for (; length != 0; length --) {
 			SlSaveLoadConv(a, conv);
@@ -1273,7 +1273,7 @@ static void SlArray(void *array, size_t length, VarType conv)
 		case SaveLoadAction::Load: {
 			if (!IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength)) {
 				size_t sv_length = SlReadArrayLength();
-				if (GetVarMemType(conv) == SLE_VAR_NULL) {
+				if (conv.mem == SLE_VAR_NULL) {
 					/* We don't know this field, so we assume the length in the savegame is correct. */
 					length = sv_length;
 				} else if (sv_length != length) {
@@ -1588,7 +1588,7 @@ static void SlRefVector(void *vector, VarType conv)
  */
 static inline size_t SlCalcVectorLen(const void *vector, VarType conv)
 {
-	switch (GetVarMemType(conv)) {
+	switch (conv.mem) {
 		case SLE_VAR_BL: NOT_REACHED(); // Not supported
 		case SLE_VAR_I8: return SlStorageHelper<std::vector, int8_t>::SlCalcLen(vector, conv);
 		case SLE_VAR_U8: return SlStorageHelper<std::vector, uint8_t>::SlCalcLen(vector, conv);
@@ -1615,7 +1615,7 @@ static inline size_t SlCalcVectorLen(const void *vector, VarType conv)
  */
 static void SlVector(void *vector, VarType conv)
 {
-	switch (GetVarMemType(conv)) {
+	switch (conv.mem) {
 		case SLE_VAR_BL: NOT_REACHED(); // Not supported
 		case SLE_VAR_I8: SlStorageHelper<std::vector, int8_t>::SlSaveLoad(vector, conv); break;
 		case SLE_VAR_U8: SlStorageHelper<std::vector, uint8_t>::SlSaveLoad(vector, conv); break;
@@ -1785,7 +1785,7 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 		}
 
 		case SaveLoadType::Null: {
-			assert(GetVarMemType(sld.conv) == SLE_VAR_NULL);
+			assert(sld.conv.mem == SLE_VAR_NULL);
 
 			switch (_sl.action) {
 				case SaveLoadAction::LoadCheck:

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -652,72 +652,120 @@ enum SLRefType : uint8_t {
 	REF_LINK_GRAPH_JOB = 11, ///< Load/save a reference to a link graph job.
 };
 
-/**
- * VarTypes is the general bitmasked magic type that tells us
- * certain characteristics about the variable it refers to. For example
- * SLE_FILE_* gives the size(type) as it would be in the savegame and
- * SLE_VAR_* the size(type) as it is in memory during runtime. These are
- * the first 8 bits (0-3 SLE_FILE, 4-7 SLE_VAR).
- * Bits 8-15 are reserved for various flags as explained below
- */
-enum VarTypes : uint16_t {
+/** The types/structures of data that can be stored in the file. */
+enum VarFileType : uint8_t {
 	/* 4 bits allocated a maximum of 16 types for NumberType.
 	 * NOTE: the SLE_FILE_NNN values are stored in the savegame! */
 	/* Value 0 is used to mark end-of-header in tables. Do not use here! */
-	SLE_FILE_I8       =  1,
-	SLE_FILE_U8       =  2,
-	SLE_FILE_I16      =  3,
-	SLE_FILE_U16      =  4,
-	SLE_FILE_I32      =  5,
-	SLE_FILE_U32      =  6,
-	SLE_FILE_I64      =  7,
-	SLE_FILE_U64      =  8,
-	SLE_FILE_STRINGID =  9, ///< StringID offset into strings-array
-	SLE_FILE_STRING   = 10,
-	SLE_FILE_STRUCT   = 11,
+	SLE_FILE_I8 = 1, ///< A 8 bit signed int.
+	SLE_FILE_U8 = 2, ///< A 8 bit unsigned int.
+	SLE_FILE_I16 = 3, ///< A 16 bit signed int.
+	SLE_FILE_U16 = 4, ///< A 16 bit unsigned int.
+	SLE_FILE_I32 = 5, ///< A 32 bit signed int.
+	SLE_FILE_U32 = 6, ///< A 32 bit unsigned int.
+	SLE_FILE_I64 = 7, ///< A 64 bit signed int.
+	SLE_FILE_U64 = 8, ///< A 64 bit unsigned int.
+	SLE_FILE_STRINGID = 9, ///< StringID offset into strings-array.
+	SLE_FILE_STRING = 10, ///< A string.
+	SLE_FILE_STRUCT = 11, ///< An arbitrary structure.
 	/* 4 more possible file-primitives */
-
-	/* 4 bits allocated a maximum of 16 types for NumberType */
-	SLE_VAR_BL    =  0 << 4,
-	SLE_VAR_I8    =  1 << 4,
-	SLE_VAR_U8    =  2 << 4,
-	SLE_VAR_I16   =  3 << 4,
-	SLE_VAR_U16   =  4 << 4,
-	SLE_VAR_I32   =  5 << 4,
-	SLE_VAR_U32   =  6 << 4,
-	SLE_VAR_I64   =  7 << 4,
-	SLE_VAR_U64   =  8 << 4,
-	SLE_VAR_NULL  =  9 << 4, ///< useful to write zeros in savegame.
-	SLE_VAR_STR   = 12 << 4, ///< string pointer
-	SLE_VAR_STRQ  = 13 << 4, ///< string pointer enclosed in quotes
-	SLE_VAR_NAME  = 14 << 4, ///< old custom name to be converted to a string pointer
-	/* 1 more possible memory-primitives */
-
-	/* Default combinations of variables. As savegames change, so can variables
-	 * and thus it is possible that the saved value and internal size do not
-	 * match and you need to specify custom combo. The defaults are listed here */
-	SLE_BOOL         = SLE_FILE_I8  | SLE_VAR_BL,
-	SLE_INT8         = SLE_FILE_I8  | SLE_VAR_I8,
-	SLE_UINT8        = SLE_FILE_U8  | SLE_VAR_U8,
-	SLE_INT16        = SLE_FILE_I16 | SLE_VAR_I16,
-	SLE_UINT16       = SLE_FILE_U16 | SLE_VAR_U16,
-	SLE_INT32        = SLE_FILE_I32 | SLE_VAR_I32,
-	SLE_UINT32       = SLE_FILE_U32 | SLE_VAR_U32,
-	SLE_INT64        = SLE_FILE_I64 | SLE_VAR_I64,
-	SLE_UINT64       = SLE_FILE_U64 | SLE_VAR_U64,
-	SLE_STRINGID     = SLE_FILE_STRINGID | SLE_VAR_U32,
-	SLE_STR          = SLE_FILE_STRING   | SLE_VAR_STR,
-	SLE_STRQ         = SLE_FILE_STRING   | SLE_VAR_STRQ,
-	SLE_NAME         = SLE_FILE_STRINGID | SLE_VAR_NAME,
-
-	/* 8 bits allocated for a maximum of 8 flags
-	 * Flags directing saving/loading of a variable */
-	SLF_ALLOW_CONTROL   = 1 << 8, ///< Allow control codes in the strings.
-	SLF_ALLOW_NEWLINE   = 1 << 9, ///< Allow new lines in the strings.
-	SLF_REPLACE_TABCRLF = 1 << 10, ///< Replace tabs, cr and lf in the string with spaces.
 };
 
-typedef uint32_t VarType;
+/** The types/structures of data we have in memory. */
+enum VarMemType : uint8_t {
+	/* 4 bits allocated a maximum of 16 types for NumberType */
+	SLE_VAR_BL = 0, ///< A boolean value.
+	SLE_VAR_I8 = 1, ///< A 8 bit signed int.
+	SLE_VAR_U8 = 2, ///< A 8 bit unsigned int.
+	SLE_VAR_I16 = 3, ///< A 16 bit signed int.
+	SLE_VAR_U16 = 4, ///< A 16 bit unsigned int.
+	SLE_VAR_I32 = 5, ///< A 32 bit signed int.
+	SLE_VAR_U32 = 6, ///< A 32 bit unsigned int.
+	SLE_VAR_I64 = 7, ///< A 64 bit signed int.
+	SLE_VAR_U64 = 8, ///< A 64 bit unsigned int.
+	SLE_VAR_NULL = 9, ///< useful to write zeros in savegame.
+	SLE_VAR_STR = 12, ///< string pointer
+	SLE_VAR_STRQ = 13, ///< string pointer enclosed in quotes
+	SLE_VAR_NAME = 14, ///< old custom name to be converted to a string pointer
+	/* 1 more possible memory-primitives */
+};
+
+/** Flags directing saving/loading of a variable. */
+enum SaveLoadFlag : uint8_t {
+	SLF_ALLOW_CONTROL = 0, ///< Allow control codes in the strings.
+	SLF_ALLOW_NEWLINE = 1, ///< Allow new lines in the strings.
+	SLF_REPLACE_TABCRLF = 2, ///< Replace tabs, cr and lf in the string with spaces.
+};
+/** Bitset of \c SaveLoadFlag elements. */
+using SaveLoadFlags = EnumBitSet<SaveLoadFlag, uint8_t>;
+
+/** Container of a variable's characteristics about a variable's storage. */
+struct VarType {
+	VarFileType file{}; ///< The way of storing data in the file.
+	VarMemType mem{}; ///< The way of storing data in memory.
+	SaveLoadFlags flags{}; ///< Any flags related to the type.
+	SLRefType ref{}; ///< The reference type.
+
+	/** Create an empty \c VarType. */
+	constexpr VarType() {}
+
+	/**
+	 * Create a \c VarType with the given file and memory configurations.
+	 * @param file The file storage configuration.
+	 * @param mem The memory storage configuration.
+	 */
+	constexpr VarType(VarFileType file, VarMemType mem) : file(file), mem(mem) {}
+
+	/**
+	 * Create a `VarType` linking to a reference.
+	 * @param ref The reference.
+	 */
+	constexpr VarType(SLRefType ref) : ref(ref) {}
+
+	/**
+	 * Equality operator.
+	 * @param other The element to compare to.
+	 * @return \c true iff all elements of this and other are the same.
+	 */
+	constexpr bool operator==(const VarType &other) const = default;
+
+	/**
+	 * Transitional helper function to add a \c SaveLoadFlag to this type.
+	 * @param flag The flag to set.
+	 * @return A copy of this with the flag set.
+	 */
+	constexpr VarType operator|(SaveLoadFlag flag) const
+	{
+		VarType copy = *this;
+		copy.flags.Set(flag);
+		return copy;
+	}
+};
+
+/**
+ * Transitional helper function to combine a file and memory storage configuration.
+ * @param file The file configuration.
+ * @param mem The memory configuration.
+ * @return The created \c VarType.
+ */
+constexpr VarType operator|(VarFileType file, VarMemType mem)
+{
+	return {file, mem};
+}
+
+constexpr VarType SLE_BOOL{ SLE_FILE_I8, SLE_VAR_BL }; ///< Store a boolean (as int8).
+constexpr VarType SLE_INT8{ SLE_FILE_I8, SLE_VAR_I8 }; ///< Store a 8 bits signed int.
+constexpr VarType SLE_UINT8{ SLE_FILE_U8, SLE_VAR_U8 }; ///< Store a 8 bits unsigned int.
+constexpr VarType SLE_INT16{ SLE_FILE_I16, SLE_VAR_I16 }; ///< Store a 16 bits signed int.
+constexpr VarType SLE_UINT16{ SLE_FILE_U16, SLE_VAR_U16 }; ///< Store a 16 bits unsigned int.
+constexpr VarType SLE_INT32{ SLE_FILE_I32, SLE_VAR_I32 }; ///< Store a 32 bits signed int.
+constexpr VarType SLE_UINT32{ SLE_FILE_U32, SLE_VAR_U32 }; ///< Store a 32 bits unsigned int.
+constexpr VarType SLE_INT64{ SLE_FILE_I64, SLE_VAR_I64 }; ///< Store a 64 bits signed int.
+constexpr VarType SLE_UINT64{ SLE_FILE_U64, SLE_VAR_U64 }; ///< Store a 64 bits unsigned int.
+constexpr VarType SLE_STRINGID{ SLE_FILE_STRINGID, SLE_VAR_U32 }; ///< Store a StringID.
+constexpr VarType SLE_STR{ SLE_FILE_STRING, SLE_VAR_STR }; ///< Store string.
+constexpr VarType SLE_STRQ{ SLE_FILE_STRING, SLE_VAR_STRQ }; ///< Store a string with quotes.
+constexpr VarType SLE_NAME{ SLE_FILE_STRINGID, SLE_VAR_NAME }; ///< A string stored in the custom string array.
 
 /** Type of data saved. */
 enum class SaveLoadType : uint8_t {
@@ -774,9 +822,9 @@ struct SaveLoadCompat {
  * @param type VarType holding information about the variable-type
  * @return the SLE_VAR_* part of a variable-type description
  */
-inline constexpr VarType GetVarMemType(VarType type)
+inline constexpr VarMemType GetVarMemType(VarType type)
 {
-	return GB(type, 4, 4) << 4;
+	return type.mem;
 }
 
 /**
@@ -785,9 +833,9 @@ inline constexpr VarType GetVarMemType(VarType type)
  * @param type VarType holding information about the file-type
  * @return the SLE_FILE_* part of a variable-type description
  */
-inline constexpr VarType GetVarFileType(VarType type)
+inline constexpr VarFileType GetVarFileType(VarType type)
 {
-	return GB(type, 0, 4);
+	return type.file;
 }
 
 /**

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -817,17 +817,6 @@ struct SaveLoadCompat {
 };
 
 /**
- * Get the NumberType of a setting. This describes the integer type
- * as it is represented in memory
- * @param type VarType holding information about the variable-type
- * @return the SLE_VAR_* part of a variable-type description
- */
-inline constexpr VarMemType GetVarMemType(VarType type)
-{
-	return type.mem;
-}
-
-/**
  * Get the FileType of a setting. This describes the integer type
  * as it is represented in a savegame/file
  * @param type VarType holding information about the file-type
@@ -836,16 +825,6 @@ inline constexpr VarMemType GetVarMemType(VarType type)
 inline constexpr VarFileType GetVarFileType(VarType type)
 {
 	return type.file;
-}
-
-/**
- * Check if the given saveload type is a numeric type.
- * @param conv the type to check
- * @return True if it's a numeric type.
- */
-inline constexpr bool IsNumericType(VarType conv)
-{
-	return GetVarMemType(conv) <= SLE_VAR_U64;
 }
 
 /**
@@ -1356,7 +1335,7 @@ inline bool SlIsObjectCurrentlyValid(SaveLoadVersion version_from, SaveLoadVersi
 inline void *GetVariableAddress(const void *object, const SaveLoad &sld)
 {
 	/* Entry is a null-variable, mostly used to read old savegames etc. */
-	if (GetVarMemType(sld.conv) == SLE_VAR_NULL) {
+	if (sld.conv.mem == SLE_VAR_NULL) {
 		assert(sld.address_proc == nullptr);
 		return nullptr;
 	}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -853,9 +853,9 @@ inline constexpr bool IsNumericType(VarType conv)
  * @param type VarType to get size of.
  * @return size of type in bytes.
  */
-inline constexpr size_t SlVarSize(VarType type)
+inline constexpr size_t SlVarSize(VarMemType type)
 {
-	switch (GetVarMemType(type)) {
+	switch (type) {
 		case SLE_VAR_BL: return sizeof(bool);
 		case SLE_VAR_I8: return sizeof(int8_t);
 		case SLE_VAR_U8: return sizeof(uint8_t);
@@ -884,10 +884,10 @@ inline constexpr size_t SlVarSize(VarType type)
 inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t length, size_t size)
 {
 	switch (cmd) {
-		case SaveLoadType::Variable: return SlVarSize(type) == size;
+		case SaveLoadType::Variable: return SlVarSize(type.mem) == size;
 		case SaveLoadType::Reference: return sizeof(void *) == size;
-		case SaveLoadType::String: return SlVarSize(type) == size;
-		case SaveLoadType::Array: return SlVarSize(type) * length <= size; // Partial load of array is permitted.
+		case SaveLoadType::String: return SlVarSize(type.mem) == size;
+		case SaveLoadType::Array: return SlVarSize(type.mem) * length <= size; // Partial load of array is permitted.
 		case SaveLoadType::Vector: return sizeof(std::vector<void *>) == size;
 		case SaveLoadType::ReferenceList: return sizeof(std::list<void *>) == size;
 		case SaveLoadType::ReferenceVector: return sizeof(std::vector<void *>) == size;
@@ -1366,8 +1366,8 @@ inline void *GetVariableAddress(const void *object, const SaveLoad &sld)
 	return sld.address_proc(const_cast<void *>(object), sld.extra_data);
 }
 
-int64_t ReadValue(const void *ptr, VarType conv);
-void WriteValue(void *ptr, VarType conv, int64_t val);
+int64_t ReadValue(const void *ptr, VarMemType conv);
+void WriteValue(void *ptr, VarMemType conv, int64_t val);
 
 void SlSetArrayIndex(uint index);
 static void SlSetArrayIndex(const ConvertibleThroughBase auto &index) { SlSetArrayIndex(index.base()); }

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -817,17 +817,6 @@ struct SaveLoadCompat {
 };
 
 /**
- * Get the FileType of a setting. This describes the integer type
- * as it is represented in a savegame/file
- * @param type VarType holding information about the file-type
- * @return the SLE_FILE_* part of a variable-type description
- */
-inline constexpr VarFileType GetVarFileType(VarType type)
-{
-	return type.file;
-}
-
-/**
  * Return expect size in bytes of a VarType
  * @param type VarType to get size of.
  * @return size of type in bytes.

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -663,7 +663,7 @@ enum SLRefType : uint8_t {
 enum VarTypes : uint16_t {
 	/* 4 bits allocated a maximum of 16 types for NumberType.
 	 * NOTE: the SLE_FILE_NNN values are stored in the savegame! */
-	SLE_FILE_END      =  0, ///< Used to mark end-of-header in tables.
+	/* Value 0 is used to mark end-of-header in tables. Do not use here! */
 	SLE_FILE_I8       =  1,
 	SLE_FILE_U8       =  2,
 	SLE_FILE_I16      =  3,
@@ -676,9 +676,6 @@ enum VarTypes : uint16_t {
 	SLE_FILE_STRING   = 10,
 	SLE_FILE_STRUCT   = 11,
 	/* 4 more possible file-primitives */
-
-	SLE_FILE_TYPE_MASK = 0xf, ///< Mask to get the file-type (and not any flags).
-	SLE_FILE_HAS_LENGTH_FIELD = 1 << 4, ///< Bit stored in savegame to indicate field has a length field for each entry.
 
 	/* 4 bits allocated a maximum of 16 types for NumberType */
 	SLE_VAR_BL    =  0 << 4,

--- a/src/saveload/settings_sl.cpp
+++ b/src/saveload/settings_sl.cpp
@@ -85,7 +85,7 @@ static std::vector<SaveLoad> GetSettingsDesc(const SettingTable &settings, bool 
 		if (is_loading && sd->flags.Test(SettingFlag::NoNetworkSync) && _networking && !_network_server) {
 			if (IsSavegameVersionBefore(SaveLoadVersion::TableChunks)) {
 				/* We don't want to read this setting, so we do need to skip over it. */
-				saveloads.emplace_back(sd->GetName(), sd->save.cmd, GetVarFileType(sd->save.conv) | SLE_VAR_NULL, sd->save.length, sd->save.version_from, sd->save.version_to, nullptr, 0, nullptr);
+				saveloads.emplace_back(sd->GetName(), sd->save.cmd, sd->save.conv.file | SLE_VAR_NULL, sd->save.length, sd->save.version_from, sd->save.version_to, nullptr, 0, nullptr);
 			}
 			continue;
 		}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -507,8 +507,8 @@ static const SaveLoad _old_station_desc[] = {
 	    SLE_VAR(Station, owner,                      SLE_UINT8),
 	    SLE_VAR(Station, facilities,                 SLE_UINT8),
 	    SLE_VAR(Station, airport.type,               SLE_UINT8),
-	SLE_CONDVARNAME(Station, airport.blocks, "airport.flags", SLE_VAR_U64 | SLE_FILE_U16, SaveLoadVersion::MinVersion, SaveLoadVersion::BiggerStationVariables),
-	SLE_CONDVARNAME(Station, airport.blocks, "airport.flags", SLE_VAR_U64 | SLE_FILE_U32, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::MoreAirportBlocks),
+	SLE_CONDVARNAME(Station, airport.blocks, "airport.flags", SLE_FILE_U16 | SLE_VAR_U64, SaveLoadVersion::MinVersion, SaveLoadVersion::BiggerStationVariables),
+	SLE_CONDVARNAME(Station, airport.blocks, "airport.flags", SLE_FILE_U32 | SLE_VAR_U64, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::MoreAirportBlocks),
 	SLE_CONDVARNAME(Station, airport.blocks, "airport.flags", SLE_UINT64, SaveLoadVersion::MoreAirportBlocks, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDVAR(Station, last_vehicle_type, SLE_UINT8, SaveLoadVersion::LastVehicleType, SaveLoadVersion::MaxVersion),

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -133,8 +133,10 @@ static bool IsSignedVarMemType(VarType vt)
 		case SLE_VAR_I32:
 		case SLE_VAR_I64:
 			return true;
+
+		default:
+			return false;
 	}
-	return false;
 }
 
 /**
@@ -704,13 +706,13 @@ void ListSettingDesc::ParseValue(const IniItem *item, void *object) const
 		str = this->def;
 	}
 	void *ptr = GetVariableAddress(object, this->save);
-	if (!LoadIntList(str, ptr, this->save.length, GetVarMemType(this->save.conv))) {
+	if (!LoadIntList(str, ptr, this->save.length, this->save.conv)) {
 		_settings_error_list.emplace_back(
 			GetEncodedString(STR_CONFIG_ERROR),
 			GetEncodedString(STR_CONFIG_ERROR_ARRAY, this->GetName()));
 
 		/* Use default */
-		LoadIntList(this->def, ptr, this->save.length, GetVarMemType(this->save.conv));
+		LoadIntList(this->def, ptr, this->save.length, this->save.conv);
 	}
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -307,7 +307,7 @@ static std::optional<std::vector<uint32_t>> ParseIntList(std::string_view str)
  * @param type the type of elements the array holds (eg INT8, UINT16, etc.)
  * @return return true on success and false on error
  */
-static bool LoadIntList(std::optional<std::string_view> str, void *array, int nelems, VarType type)
+static bool LoadIntList(std::optional<std::string_view> str, void *array, int nelems, VarMemType type)
 {
 	size_t elem_size = SlVarSize(type);
 	std::byte *p = static_cast<std::byte *>(array);
@@ -582,7 +582,7 @@ void IntSettingDesc::MakeValueValid(int32_t &val) const
 void IntSettingDesc::Write(const void *object, int32_t val) const
 {
 	void *ptr = GetVariableAddress(object, this->save);
-	WriteValue(ptr, this->save.conv, (int64_t)val);
+	WriteValue(ptr, this->save.conv.mem, (int64_t)val);
 }
 
 /**
@@ -593,7 +593,7 @@ void IntSettingDesc::Write(const void *object, int32_t val) const
 int32_t IntSettingDesc::Read(const void *object) const
 {
 	void *ptr = GetVariableAddress(object, this->save);
-	return (int32_t)ReadValue(ptr, this->save.conv);
+	return (int32_t)ReadValue(ptr, this->save.conv.mem);
 }
 
 /**
@@ -706,13 +706,13 @@ void ListSettingDesc::ParseValue(const IniItem *item, void *object) const
 		str = this->def;
 	}
 	void *ptr = GetVariableAddress(object, this->save);
-	if (!LoadIntList(str, ptr, this->save.length, this->save.conv)) {
+	if (!LoadIntList(str, ptr, this->save.length, this->save.conv.mem)) {
 		_settings_error_list.emplace_back(
 			GetEncodedString(STR_CONFIG_ERROR),
 			GetEncodedString(STR_CONFIG_ERROR_ARRAY, this->GetName()));
 
 		/* Use default */
-		LoadIntList(this->def, ptr, this->save.length, this->save.conv);
+		LoadIntList(this->def, ptr, this->save.length, this->save.conv.mem);
 	}
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -127,7 +127,7 @@ using SettingDescProcList = void(IniFile &ini, std::string_view grpname, StringL
 
 static bool IsSignedVarMemType(VarType vt)
 {
-	switch (GetVarMemType(vt)) {
+	switch (vt.mem) {
 		case SLE_VAR_I8:
 		case SLE_VAR_I16:
 		case SLE_VAR_I32:
@@ -339,7 +339,7 @@ std::string ListSettingDesc::FormatValue(const void *object) const
 	std::string result;
 	for (size_t i = 0; i != this->save.length; i++) {
 		int64_t v;
-		switch (GetVarMemType(this->save.conv)) {
+		switch (this->save.conv.mem) {
 			case SLE_VAR_BL:
 			case SLE_VAR_I8:  v = *(const   int8_t *)p; p += 1; break;
 			case SLE_VAR_U8:  v = *(const  uint8_t *)p; p += 1; break;
@@ -533,7 +533,7 @@ void IntSettingDesc::MakeValueValid(int32_t &val) const
 	 * supported. Unsigned 8 and 16-bit variables are safe since they fit into a signed
 	 * 32-bit variable
 	 * TODO: Support 64-bit settings/variables; requires 64 bit over command protocol! */
-	switch (GetVarMemType(this->save.conv)) {
+	switch (this->save.conv.mem) {
 		case SLE_VAR_NULL: return;
 		case SLE_VAR_BL:
 		case SLE_VAR_I8:
@@ -582,7 +582,7 @@ void IntSettingDesc::MakeValueValid(int32_t &val) const
 void IntSettingDesc::Write(const void *object, int32_t val) const
 {
 	void *ptr = GetVariableAddress(object, this->save);
-	WriteValue(ptr, this->save.conv.mem, (int64_t)val);
+	WriteValue(ptr, this->save.conv.mem, static_cast<int64_t>(val));
 }
 
 /**
@@ -593,7 +593,7 @@ void IntSettingDesc::Write(const void *object, int32_t val) const
 int32_t IntSettingDesc::Read(const void *object) const
 {
 	void *ptr = GetVariableAddress(object, this->save);
-	return (int32_t)ReadValue(ptr, this->save.conv.mem);
+	return static_cast<int32_t>(ReadValue(ptr, this->save.conv.mem));
 }
 
 /**
@@ -797,7 +797,7 @@ void IntSettingDesc::ResetToDefault(void *object) const
 std::string StringSettingDesc::FormatValue(const void *object) const
 {
 	const std::string &str = this->Read(object);
-	switch (GetVarMemType(this->save.conv)) {
+	switch (this->save.conv.mem) {
 		case SLE_VAR_STR: return str;
 
 		case SLE_VAR_STRQ:
@@ -814,7 +814,7 @@ bool StringSettingDesc::IsSameValue(const IniItem *item, void *object) const
 {
 	/* The ini parsing removes the quotes, which are needed to retain the spaces in STRQs,
 	 * so those values are always different in the parsed ini item than they should be. */
-	if (GetVarMemType(this->save.conv) == SLE_VAR_STRQ) return false;
+	if (this->save.conv.mem == SLE_VAR_STRQ) return false;
 
 	const std::string &str = this->Read(object);
 	return item->value->compare(str) == 0;
@@ -1932,7 +1932,7 @@ bool SetSettingValue(const StringSettingDesc *sd, std::string_view value, bool f
 {
 	assert(sd->flags.Test(SettingFlag::NoNetworkSync));
 
-	if (GetVarMemType(sd->save.conv) == SLE_VAR_STRQ && value == "(null)") {
+	if (sd->save.conv.mem == SLE_VAR_STRQ && value == "(null)") {
 		value = {};
 	}
 

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -30,7 +30,7 @@ static StringID SettingHelpWallclock(const IntSettingDesc &sd);
 template <typename T>
 constexpr bool DoesMaxFitVariable(T max, VarType type)
 {
-	switch (GetVarMemType(type)) {
+	switch (type.mem) {
 		case SLE_VAR_BL: return max <= 1;
 		case SLE_VAR_I8: return max <= INT8_MAX;
 		case SLE_VAR_U8: return std::make_unsigned_t<T>(max) <= UINT8_MAX;


### PR DESCRIPTION
## Motivation / Problem

`VarTypes` are the configuration of how variables are to be read/written (type in save game and memory). This is currently done by bit-stuffing two enumerations and some flags into an enum. That can't be made into nice/proper enumerations, so something needs to be done.


## Description

* Unify the order of the configuration of how data is stored in the file and in memory (use file, memory order)
* Split the `VarType` enumeration into `VarFileType`, `VarMemType`, `SaveLoadFlag`(s) and a couple of global consts for `VarType`s that were a combination of `VarFileType` and `VarMemType`.
* Introduce a `VarType` struct that contains the `VarFileType`, `VarMemType`, `SaveLoadFlags` and `SLRefType`, which was `static_cast` into the `VarType` and later extracted.
* Make some places use `VarMemType` where that's more applicable.
* Replace `GetVarMemType` and `GetVarFileType` with the appropriate direct access of the `VarType` member.


## Limitations

* Built upon 15802.
* Do we need to reconsider naming conventions here? Maybe prefix everything with `Sl` or `SL`?
* Making enumerations scoped are for a future PR.
* `SaveLoadFlags` are basically `StringValidationSettings` in disguise. I'll leave that change for a future PR.
* Leaving some transitional helpers. These will go away in a future PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
