### PR TITLE
Codechange: replace SaveLoadFlags with StringValidationSettings

### DIFF
--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -492,11 +492,11 @@ public:
 static const SaveLoad _company_desc[] = {
 	    SLE_VAR(CompanyProperties, name_2,          SLE_UINT32),
 	    SLE_VAR(CompanyProperties, name_1,          SLE_STRINGID),
-	SLE_CONDSSTR(CompanyProperties, name, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(CompanyProperties, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 
 	    SLE_VAR(CompanyProperties, president_name_1, SLE_STRINGID),
 	    SLE_VAR(CompanyProperties, president_name_2, SLE_UINT32),
-	SLE_CONDSSTR(CompanyProperties, president_name, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(CompanyProperties, president_name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDVECTOR(CompanyProperties, allow_list, SLE_STR, SaveLoadVersion::CompanyAllowList, SaveLoadVersion::CompanyAllowListV2),
 	SLEG_CONDSTRUCTLIST("allow_list", SlAllowListData, SaveLoadVersion::CompanyAllowListV2, SaveLoadVersion::MaxVersion),

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -121,7 +121,7 @@ static uint32_t _game_saveload_strings;
 class SlGameLanguageString : public DefaultSaveLoadHandler<SlGameLanguageString, LanguageStrings> {
 public:
 	static inline const SaveLoad description[] = {
-		SLEG_SSTR("string", _game_saveload_string, SLE_STR | SLF_ALLOW_CONTROL | SLF_REPLACE_TABCRLF),
+		SLEG_SSTR("string", _game_saveload_string, SLE_STR | StringValidationSetting::AllowControlCode | StringValidationSetting::ReplaceTabCrNlWithSpace),
 	};
 	static inline const SaveLoadCompatTable compat_description = _game_language_string_sl_compat;
 

--- a/src/saveload/goal_sl.cpp
+++ b/src/saveload/goal_sl.cpp
@@ -20,8 +20,8 @@ static const SaveLoad _goals_desc[] = {
 	     SLE_VAR(Goal, company,   SLE_FILE_U16 | SLE_VAR_U8),
 	     SLE_VAR(Goal, type,      SLE_FILE_U16 | SLE_VAR_U8),
 	     SLE_VAR(Goal, dst,       SLE_UINT32),
-	    SLE_SSTR(Goal, text,      SLE_STR | SLF_ALLOW_CONTROL),
-	SLE_CONDSSTR(Goal, progress, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
+	    SLE_SSTR(Goal, text,      SLE_STR | StringValidationSetting::AllowControlCode),
+	SLE_CONDSSTR(Goal, progress, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
 	 SLE_CONDVAR(Goal, completed, SLE_BOOL, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
 };
 

--- a/src/saveload/group_sl.cpp
+++ b/src/saveload/group_sl.cpp
@@ -18,7 +18,7 @@
 
 static const SaveLoad _group_desc[] = {
 	 SLE_CONDVAR(Group, name, SLE_NAME, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
-	SLE_CONDSSTR(Group, name, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Group, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 	     SLE_VAR(Group, owner,              SLE_UINT8),
 	     SLE_VAR(Group, vehicle_type,       SLE_UINT8),
 	     SLE_VAR(Group, flags,              SLE_UINT8),

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -202,7 +202,7 @@ static const SaveLoad _industry_desc[] = {
 	SLE_CONDREF(Industry, psa, REF_STORAGE, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDVAR(Industry, random, SLE_UINT16, SaveLoadVersion::NewGRFIndustryRandomTriggers, SaveLoadVersion::MaxVersion),
-	SLE_CONDSSTR(Industry, text, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::IndustryText, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Industry, text, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::IndustryText, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDVAR(Industry, valid_history, SLE_UINT64, SaveLoadVersion::IndustryNumValidHistory, SaveLoadVersion::MaxVersion),
 

--- a/src/saveload/league_sl.cpp
+++ b/src/saveload/league_sl.cpp
@@ -20,8 +20,8 @@ static const SaveLoad _league_table_elements_desc[] = {
 	SLE_CONDVAR(LeagueTableElement, rating, SLE_FILE_U64 | SLE_VAR_I64, SaveLoadVersion::MinVersion, SaveLoadVersion::LinkgraphEdges),
 	SLE_CONDVAR(LeagueTableElement, rating, SLE_INT64, SaveLoadVersion::LinkgraphEdges, SaveLoadVersion::MaxVersion),
 	    SLE_VAR(LeagueTableElement, company,     SLE_UINT8),
-	   SLE_SSTR(LeagueTableElement, text,        SLE_STR | SLF_ALLOW_CONTROL),
-	   SLE_SSTR(LeagueTableElement, score,       SLE_STR | SLF_ALLOW_CONTROL),
+	   SLE_SSTR(LeagueTableElement, text,        SLE_STR | StringValidationSetting::AllowControlCode),
+	   SLE_SSTR(LeagueTableElement, score,       SLE_STR | StringValidationSetting::AllowControlCode),
 	    SLE_VAR(LeagueTableElement, link.type,   SLE_UINT8),
 	    SLE_VAR(LeagueTableElement, link.target, SLE_UINT32),
 };
@@ -52,9 +52,9 @@ struct LEAEChunkHandler : ChunkHandler {
 };
 
 static const SaveLoad _league_tables_desc[] = {
-	SLE_SSTR(LeagueTable, title, SLE_STR | SLF_ALLOW_CONTROL),
-	SLE_SSTR(LeagueTable, header, SLE_STR | SLF_ALLOW_CONTROL),
-	SLE_SSTR(LeagueTable, footer, SLE_STR | SLF_ALLOW_CONTROL),
+	SLE_SSTR(LeagueTable, title, SLE_STR | StringValidationSetting::AllowControlCode),
+	SLE_SSTR(LeagueTable, header, SLE_STR | StringValidationSetting::AllowControlCode),
+	SLE_SSTR(LeagueTable, footer, SLE_STR | StringValidationSetting::AllowControlCode),
 };
 
 struct LEATChunkHandler : ChunkHandler {

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1152,17 +1152,11 @@ static void SlStdString(void *ptr, VarType conv)
 
 			SlReadString(*str, len);
 
-			StringValidationSettings settings = StringValidationSetting::ReplaceWithQuestionMark;
-			if (conv.flags.Test(SLF_ALLOW_CONTROL)) {
-				settings.Set(StringValidationSetting::AllowControlCode);
+			StringValidationSettings settings = conv.string_validation_settings;
+			settings.Set(StringValidationSetting::ReplaceWithQuestionMark);
+			if (settings.Test(StringValidationSetting::AllowControlCode)) {
 				if (IsSavegameVersionBefore(SaveLoadVersion::EncodedStringFormat)) FixSCCEncoded(*str, IsSavegameVersionBefore(SaveLoadVersion::MoveSccEncoded));
 				if (IsSavegameVersionBefore(SaveLoadVersion::FixSccEncodedNegative)) FixSCCEncodedNegative(*str);
-			}
-			if (conv.flags.Test(SLF_ALLOW_NEWLINE)) {
-				settings.Set(StringValidationSetting::AllowNewline);
-			}
-			if (conv.flags.Test(SLF_REPLACE_TABCRLF)) {
-				settings.Set(StringValidationSetting::ReplaceTabCrNlWithSpace);
 			}
 			StrMakeValidInPlace(*str, settings);
 		}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -690,20 +690,11 @@ enum VarMemType : uint8_t {
 	/* 1 more possible memory-primitives */
 };
 
-/** Flags directing saving/loading of a variable. */
-enum SaveLoadFlag : uint8_t {
-	SLF_ALLOW_CONTROL = 0, ///< Allow control codes in the strings.
-	SLF_ALLOW_NEWLINE = 1, ///< Allow new lines in the strings.
-	SLF_REPLACE_TABCRLF = 2, ///< Replace tabs, cr and lf in the string with spaces.
-};
-/** Bitset of \c SaveLoadFlag elements. */
-using SaveLoadFlags = EnumBitSet<SaveLoadFlag, uint8_t>;
-
 /** Container of a variable's characteristics about a variable's storage. */
 struct VarType {
 	VarFileType file{}; ///< The way of storing data in the file.
 	VarMemType mem{}; ///< The way of storing data in memory.
-	SaveLoadFlags flags{}; ///< Any flags related to the type.
+	StringValidationSettings string_validation_settings{}; ///< Any settings related to validation of the strings.
 	SLRefType ref{}; ///< The reference type.
 
 	/** Create an empty \c VarType. */
@@ -731,13 +722,13 @@ struct VarType {
 
 	/**
 	 * Transitional helper function to add a \c SaveLoadFlag to this type.
-	 * @param flag The flag to set.
-	 * @return A copy of this with the flag set.
+	 * @param string_validation_setting The string_validation_setting to set.
+	 * @return A copy of this with the string_validation_setting set.
 	 */
-	constexpr VarType operator|(SaveLoadFlag flag) const
+	constexpr VarType operator|(StringValidationSetting string_validation_setting) const
 	{
 		VarType copy = *this;
-		copy.flags.Set(flag);
+		copy.string_validation_settings.Set(string_validation_setting);
 		return copy;
 	}
 };

--- a/src/saveload/signs_sl.cpp
+++ b/src/saveload/signs_sl.cpp
@@ -20,7 +20,7 @@
 /** Description of a sign within the savegame. */
 static const SaveLoad _sign_desc[] = {
 	SLE_CONDVAR(Sign, name, SLE_NAME, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
-	SLE_CONDSSTR(Sign, name, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Sign, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Sign, x, SLE_FILE_I16 | SLE_VAR_I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
 	SLE_CONDVAR(Sign, y, SLE_FILE_I16 | SLE_VAR_I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
 	SLE_CONDVAR(Sign, x, SLE_INT32, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -496,7 +496,7 @@ static const SaveLoad _old_station_desc[] = {
 	SLE_CONDVAR(Station, train_station.h, SLE_FILE_U8 | SLE_VAR_U16, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
 	    SLE_VAR(Station, string_id,                  SLE_STRINGID),
-	SLE_CONDSSTR(Station, name, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Station, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Station, indtype, SLE_UINT8, SaveLoadVersion::NewGRFSuppliedStationName, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Station, had_vehicle_of_type, SLE_FILE_U16 | SLE_VAR_U8, SaveLoadVersion::MinVersion, SaveLoadVersion::WaypointMoreLikeStation),
 	SLE_CONDVAR(Station, had_vehicle_of_type, SLE_UINT8, SaveLoadVersion::WaypointMoreLikeStation, SaveLoadVersion::MaxVersion),
@@ -585,7 +585,7 @@ public:
 		    SLE_VAR(BaseStation, xy,                     SLE_UINT32),
 		    SLE_REF(BaseStation, town,                   REF_TOWN),
 		    SLE_VAR(BaseStation, string_id,              SLE_STRINGID),
-		   SLE_SSTR(BaseStation, name,                   SLE_STR | SLF_ALLOW_CONTROL),
+		   SLE_SSTR(BaseStation, name,                   SLE_STR | StringValidationSetting::AllowControlCode),
 		    SLE_VAR(BaseStation, delete_ctr,             SLE_UINT8),
 		    SLE_VAR(BaseStation, owner,                  SLE_UINT8),
 		    SLE_VAR(BaseStation, facilities,             SLE_UINT8),

--- a/src/saveload/story_sl.cpp
+++ b/src/saveload/story_sl.cpp
@@ -35,7 +35,7 @@ static const SaveLoad _story_page_elements_desc[] = {
 	SLE_CONDVAR(StoryPageElement, type, SLE_FILE_U16 | SLE_VAR_U8, SaveLoadVersion::MinVersion, SaveLoadVersion::Storybooks),
 	SLE_CONDVAR(StoryPageElement, type, SLE_UINT8, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
 	    SLE_VAR(StoryPageElement, referenced_id, SLE_UINT32),
-	   SLE_SSTR(StoryPageElement, text,          SLE_STR | SLF_ALLOW_CONTROL),
+	   SLE_SSTR(StoryPageElement, text,          SLE_STR | StringValidationSetting::AllowControlCode),
 };
 
 struct STPEChunkHandler : ChunkHandler {
@@ -77,7 +77,7 @@ static const SaveLoad _story_pages_desc[] = {
 	    SLE_VAR(StoryPage, date,       SLE_UINT32),
 	SLE_CONDVAR(StoryPage, company, SLE_FILE_U16 | SLE_VAR_U8, SaveLoadVersion::MinVersion, SaveLoadVersion::Storybooks),
 	SLE_CONDVAR(StoryPage, company, SLE_UINT8, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
-	   SLE_SSTR(StoryPage, title,      SLE_STR | SLF_ALLOW_CONTROL),
+	   SLE_SSTR(StoryPage, title,      SLE_STR | StringValidationSetting::AllowControlCode),
 };
 
 struct STPAChunkHandler : ChunkHandler {

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -302,7 +302,7 @@ static const SaveLoad _town_desc[] = {
 	SLE_CONDVAR(Town, townnamegrfid, SLE_UINT32, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
 	    SLE_VAR(Town, townnametype,          SLE_UINT16),
 	    SLE_VAR(Town, townnameparts,         SLE_UINT32),
-	SLE_CONDSSTR(Town, name, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Town, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 
 	    SLE_VAR(Town, flags,                 SLE_UINT8),
 	SLE_CONDVAR(Town, statues, SLE_FILE_U8 | SLE_VAR_U16, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCompanies),
@@ -340,7 +340,7 @@ static const SaveLoad _town_desc[] = {
 
 	SLE_CONDARR(Town, goal, SLE_UINT32, to_underlying(TownAcceptanceEffect::End), SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDSSTR(Town, text, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::ScriptTownText, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Town, text, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ScriptTownText, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDVAR(Town, time_until_rebuild, SLE_FILE_U8 | SLE_VAR_U16, SaveLoadVersion::MinVersion, SaveLoadVersion::TownGrowthControl),
 	SLE_CONDVAR(Town, time_until_rebuild, SLE_UINT16, SaveLoadVersion::TownGrowthControl, SaveLoadVersion::MaxVersion),

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -658,7 +658,7 @@ public:
 
 		    SLE_REF(Vehicle, next,                  REF_VEHICLE_OLD),
 		SLE_CONDVAR(Vehicle, name, SLE_NAME, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
-		SLE_CONDSSTR(Vehicle, name, SLE_STR | SLF_ALLOW_CONTROL, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+		SLE_CONDSSTR(Vehicle, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, unitnumber, SLE_FILE_U8 | SLE_VAR_U16, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerUnitNumber),
 		SLE_CONDVAR(Vehicle, unitnumber, SLE_UINT16, SaveLoadVersion::LargerUnitNumber, SaveLoadVersion::MaxVersion),
 		    SLE_VAR(Vehicle, owner,                 SLE_UINT8),


### PR DESCRIPTION
## Motivation / Problem

The `SaveLoadFlags` are essentially `StringValidationSettings` but with slightly different values.


## Description

Replace `SaveLoadFlags` with `StringValidationSettings`.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
