### PR TITLE
Codechange: move VarType constants into 'VarTypes'

### DIFF
--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -29,16 +29,16 @@ static std::string _ai_saveload_settings;
 static bool        _ai_saveload_is_random;
 
 static const SaveLoad _ai_company_desc[] = {
-	   SLEG_SSTR("name",      _ai_saveload_name,         SLE_STR),
-	   SLEG_SSTR("settings",  _ai_saveload_settings,     SLE_STR),
-	SLEG_CONDVAR("version", _ai_saveload_version, SLE_UINT32, SaveLoadVersion::StoreAIVersion, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("is_random", _ai_saveload_is_random, SLE_BOOL, SaveLoadVersion::SplitLoadWaitCounters, SaveLoadVersion::AILocalConfig),
+	   SLEG_SSTR("name",      _ai_saveload_name,         VarTypes::STR),
+	   SLEG_SSTR("settings",  _ai_saveload_settings,     VarTypes::STR),
+	SLEG_CONDVAR("version", _ai_saveload_version, VarTypes::U32, SaveLoadVersion::StoreAIVersion, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("is_random", _ai_saveload_is_random, VarTypes::BOOL, SaveLoadVersion::SplitLoadWaitCounters, SaveLoadVersion::AILocalConfig),
 };
 
 static const SaveLoad _ai_running_desc[] = {
-	SLEG_CONDSSTR("running_name", _ai_saveload_name, SLE_STR, SaveLoadVersion::AILocalConfig, SaveLoadVersion::MaxVersion),
-	SLEG_CONDSSTR("running_settings", _ai_saveload_settings, SLE_STR, SaveLoadVersion::AILocalConfig, SaveLoadVersion::MaxVersion),
-	 SLEG_CONDVAR("running_version", _ai_saveload_version, SLE_UINT32, SaveLoadVersion::AILocalConfig, SaveLoadVersion::MaxVersion),
+	SLEG_CONDSSTR("running_name", _ai_saveload_name, VarTypes::STR, SaveLoadVersion::AILocalConfig, SaveLoadVersion::MaxVersion),
+	SLEG_CONDSSTR("running_settings", _ai_saveload_settings, VarTypes::STR, SaveLoadVersion::AILocalConfig, SaveLoadVersion::MaxVersion),
+	 SLEG_CONDVAR("running_version", _ai_saveload_version, VarTypes::U32, SaveLoadVersion::AILocalConfig, SaveLoadVersion::MaxVersion),
 };
 
 static void SaveReal_AIPL(int arg)

--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -19,7 +19,7 @@
 extern std::vector<TileIndex> _animated_tiles;
 
 static const SaveLoad _animated_tile_desc[] = {
-	 SLEG_VECTOR("tiles", _animated_tiles, SLE_UINT32),
+	 SLEG_VECTOR("tiles", _animated_tiles, VarTypes::U32),
 };
 
 struct ANITChunkHandler : ChunkHandler {
@@ -39,7 +39,7 @@ struct ANITChunkHandler : ChunkHandler {
 		if (IsSavegameVersionBefore(SaveLoadVersion::NewGRFMoreAnimation)) {
 			/* In pre version 6, we has 16bit per tile, now we have 32bit per tile, convert it ;) */
 			TileIndex anim_list[256];
-			SlCopy(anim_list, 256, IsSavegameVersionBefore(SaveLoadVersion::MultipleRoadStops) ? (VarFileType::U16 | VarMemType::U32) : SLE_UINT32);
+			SlCopy(anim_list, 256, IsSavegameVersionBefore(SaveLoadVersion::MultipleRoadStops) ? (VarFileType::U16 | VarMemType::U32) : VarTypes::U32);
 
 			for (int i = 0; i < 256; i++) {
 				if (anim_list[i] == 0) break;
@@ -52,7 +52,7 @@ struct ANITChunkHandler : ChunkHandler {
 			size_t count = SlGetFieldLength() / sizeof(_animated_tiles.front());
 			_animated_tiles.clear();
 			_animated_tiles.resize(_animated_tiles.size() + count);
-			SlCopy(_animated_tiles.data(), count, SLE_UINT32);
+			SlCopy(_animated_tiles.data(), count, VarTypes::U32);
 			return;
 		}
 

--- a/src/saveload/autoreplace_sl.cpp
+++ b/src/saveload/autoreplace_sl.cpp
@@ -17,12 +17,12 @@
 #include "../safeguards.h"
 
 static const SaveLoad _engine_renew_desc[] = {
-	    SLE_VAR(EngineRenew, from,     SLE_UINT16),
-	    SLE_VAR(EngineRenew, to,       SLE_UINT16),
+	    SLE_VAR(EngineRenew, from,     VarTypes::U16),
+	    SLE_VAR(EngineRenew, to,       VarTypes::U16),
 
 	    SLE_REF(EngineRenew, next,     SLRefType::EngineRenew),
-	SLE_CONDVAR(EngineRenew, group_id, SLE_UINT16, SaveLoadVersion::VehicleGroups, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(EngineRenew, replace_when_old, SLE_BOOL, SaveLoadVersion::AutoreplaceWhenOldTreeLimit, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(EngineRenew, group_id, VarTypes::U16, SaveLoadVersion::VehicleGroups, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(EngineRenew, replace_when_old, VarTypes::BOOL, SaveLoadVersion::AutoreplaceWhenOldTreeLimit, SaveLoadVersion::MaxVersion),
 };
 
 struct ERNWChunkHandler : ChunkHandler {

--- a/src/saveload/cargomonitor_sl.cpp
+++ b/src/saveload/cargomonitor_sl.cpp
@@ -24,8 +24,8 @@ struct TempStorage {
 
 /** Description of the #TempStorage structure for the purpose of load and save. */
 static const SaveLoad _cargomonitor_pair_desc[] = {
-	SLE_VAR(TempStorage, number, SLE_UINT32),
-	SLE_VAR(TempStorage, amount, SLE_UINT32),
+	SLE_VAR(TempStorage, number, VarTypes::U32),
+	SLE_VAR(TempStorage, amount, VarTypes::U32),
 };
 
 static CargoMonitorID FixupCargoMonitor(CargoMonitorID number)

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -125,19 +125,19 @@
 SaveLoadTable GetCargoPacketDesc()
 {
 	static const SaveLoad _cargopacket_desc[] = {
-		SLE_VARNAME(CargoPacket, first_station, "source", SLE_UINT16),
-		SLE_VAR(CargoPacket, source_xy,       SLE_UINT32),
+		SLE_VARNAME(CargoPacket, first_station, "source", VarTypes::U16),
+		SLE_VAR(CargoPacket, source_xy,       VarTypes::U32),
 		SLE_CONDVARNAME(CargoPacket, next_hop, "loaded_at_xy", VarFileType::U32 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::RemoveLoadedAtXY),
-		SLE_CONDVARNAME(CargoPacket, next_hop, "loaded_at_xy", SLE_UINT16, SaveLoadVersion::RemoveLoadedAtXY, SaveLoadVersion::MaxVersion),
-		SLE_VAR(CargoPacket, count,           SLE_UINT16),
+		SLE_CONDVARNAME(CargoPacket, next_hop, "loaded_at_xy", VarTypes::U16, SaveLoadVersion::RemoveLoadedAtXY, SaveLoadVersion::MaxVersion),
+		SLE_VAR(CargoPacket, count,           VarTypes::U16),
 		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCargoAge),
-		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", SLE_UINT16, SaveLoadVersion::MoreCargoAge, SaveLoadVersion::PeriodsInTransitRename),
-		SLE_CONDVAR(CargoPacket, periods_in_transit, SLE_UINT16, SaveLoadVersion::PeriodsInTransitRename, SaveLoadVersion::MaxVersion),
-		SLE_VAR(CargoPacket, feeder_share,    SLE_INT64),
-		SLE_CONDVARNAME(CargoPacket, source.type, "source_type", SLE_UINT8, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
-		SLE_CONDVARNAME(CargoPacket, source.id, "source_id", SLE_UINT16, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CargoPacket, travelled.x, SLE_INT16, SaveLoadVersion::CargoTravelled, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CargoPacket, travelled.y, SLE_INT16, SaveLoadVersion::CargoTravelled, SaveLoadVersion::MaxVersion),
+		SLE_CONDVARNAME(CargoPacket, periods_in_transit, "days_in_transit", VarTypes::U16, SaveLoadVersion::MoreCargoAge, SaveLoadVersion::PeriodsInTransitRename),
+		SLE_CONDVAR(CargoPacket, periods_in_transit, VarTypes::U16, SaveLoadVersion::PeriodsInTransitRename, SaveLoadVersion::MaxVersion),
+		SLE_VAR(CargoPacket, feeder_share,    VarTypes::I64),
+		SLE_CONDVARNAME(CargoPacket, source.type, "source_type", VarTypes::U8, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
+		SLE_CONDVARNAME(CargoPacket, source.id, "source_id", VarTypes::U16, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CargoPacket, travelled.x, VarTypes::I16, SaveLoadVersion::CargoTravelled, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CargoPacket, travelled.y, VarTypes::I16, SaveLoadVersion::CargoTravelled, SaveLoadVersion::MaxVersion),
 	};
 	return _cargopacket_desc;
 }

--- a/src/saveload/cheat_sl.cpp
+++ b/src/saveload/cheat_sl.cpp
@@ -17,24 +17,24 @@
 #include "../safeguards.h"
 
 static const SaveLoad _cheats_desc[] = {
-	SLE_VAR(Cheats, magic_bulldozer.been_used, SLE_BOOL),
-	SLE_VAR(Cheats, magic_bulldozer.value, SLE_BOOL),
-	SLE_VAR(Cheats, switch_company.been_used, SLE_BOOL),
-	SLE_VAR(Cheats, switch_company.value, SLE_BOOL),
-	SLE_VAR(Cheats, money.been_used, SLE_BOOL),
-	SLE_VAR(Cheats, money.value, SLE_BOOL),
-	SLE_VAR(Cheats, crossing_tunnels.been_used, SLE_BOOL),
-	SLE_VAR(Cheats, crossing_tunnels.value, SLE_BOOL),
-	SLE_VAR(Cheats, no_jetcrash.been_used, SLE_BOOL),
-	SLE_VAR(Cheats, no_jetcrash.value, SLE_BOOL),
-	SLE_VAR(Cheats, change_date.been_used, SLE_BOOL),
-	SLE_VAR(Cheats, change_date.value, SLE_BOOL),
-	SLE_VAR(Cheats, setup_prod.been_used, SLE_BOOL),
-	SLE_VAR(Cheats, setup_prod.value, SLE_BOOL),
-	SLE_VAR(Cheats, edit_max_hl.been_used, SLE_BOOL),
-	SLE_VAR(Cheats, edit_max_hl.value, SLE_BOOL),
-	SLE_CONDVAR(Cheats, station_rating.been_used, SLE_BOOL, SaveLoadVersion::StationRatingCheat, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Cheats, station_rating.value, SLE_BOOL, SaveLoadVersion::StationRatingCheat, SaveLoadVersion::MaxVersion),
+	SLE_VAR(Cheats, magic_bulldozer.been_used, VarTypes::BOOL),
+	SLE_VAR(Cheats, magic_bulldozer.value, VarTypes::BOOL),
+	SLE_VAR(Cheats, switch_company.been_used, VarTypes::BOOL),
+	SLE_VAR(Cheats, switch_company.value, VarTypes::BOOL),
+	SLE_VAR(Cheats, money.been_used, VarTypes::BOOL),
+	SLE_VAR(Cheats, money.value, VarTypes::BOOL),
+	SLE_VAR(Cheats, crossing_tunnels.been_used, VarTypes::BOOL),
+	SLE_VAR(Cheats, crossing_tunnels.value, VarTypes::BOOL),
+	SLE_VAR(Cheats, no_jetcrash.been_used, VarTypes::BOOL),
+	SLE_VAR(Cheats, no_jetcrash.value, VarTypes::BOOL),
+	SLE_VAR(Cheats, change_date.been_used, VarTypes::BOOL),
+	SLE_VAR(Cheats, change_date.value, VarTypes::BOOL),
+	SLE_VAR(Cheats, setup_prod.been_used, VarTypes::BOOL),
+	SLE_VAR(Cheats, setup_prod.value, VarTypes::BOOL),
+	SLE_VAR(Cheats, edit_max_hl.been_used, VarTypes::BOOL),
+	SLE_VAR(Cheats, edit_max_hl.value, VarTypes::BOOL),
+	SLE_CONDVAR(Cheats, station_rating.been_used, VarTypes::BOOL, SaveLoadVersion::StationRatingCheat, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Cheats, station_rating.value, VarTypes::BOOL, SaveLoadVersion::StationRatingCheat, SaveLoadVersion::MaxVersion),
 };
 
 
@@ -58,8 +58,8 @@ struct CHTSChunkHandler : ChunkHandler {
 			std::vector<SaveLoad> oslt;
 
 			/* Cheats were added over the years without a savegame bump. They are
-			 * stored as 2 SLE_BOOLs per entry. "count" indicates how many SLE_BOOLs
-			 * are stored for this savegame. So read only "count" SLE_BOOLs (and in
+			 * stored as 2 VarTypes::BOOLs per entry. "count" indicates how many VarTypes::BOOLs
+			 * are stored for this savegame. So read only "count" VarTypes::BOOLs (and in
 			 * result "count / 2" cheats). */
 			for (auto &sld : slt) {
 				count--;

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -294,7 +294,7 @@ public:
 class SlCompanyOldAI : public DefaultSaveLoadHandler<SlCompanyOldAI, CompanyProperties> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(CompanyOldAI, num_build_rec, SLE_UINT8, SaveLoadVersion::MinVersion, SaveLoadVersion::NoAI),
+		SLE_CONDVAR(CompanyOldAI, num_build_rec, VarTypes::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::NoAI),
 		SLEG_STRUCTLIST("buildrec", SlCompanyOldAIBuildRec),
 	};
 	static inline const SaveLoadCompatTable compat_description = _company_old_ai_compat;
@@ -315,17 +315,17 @@ public:
 	static inline const SaveLoad description[] = {
 		/* Engine renewal settings */
 		SLE_CONDREF(CompanyProperties, engine_renew_list, SLRefType::EngineRenew, SaveLoadVersion::EngineRenewPool, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CompanyProperties, settings.engine_renew, SLE_BOOL, SaveLoadVersion::EngineRenew, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CompanyProperties, settings.engine_renew_months, SLE_INT16, SaveLoadVersion::EngineRenew, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CompanyProperties, settings.engine_renew_money, SLE_UINT32, SaveLoadVersion::EngineRenew, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CompanyProperties, settings.renew_keep_length, SLE_BOOL, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyProperties, settings.engine_renew, VarTypes::BOOL, SaveLoadVersion::EngineRenew, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyProperties, settings.engine_renew_months, VarTypes::I16, SaveLoadVersion::EngineRenew, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyProperties, settings.engine_renew_money, VarTypes::U32, SaveLoadVersion::EngineRenew, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyProperties, settings.renew_keep_length, VarTypes::BOOL, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
 		/* Default vehicle settings */
-		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_ispercent, SLE_BOOL, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_trains, SLE_UINT16, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_roadveh, SLE_UINT16, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_aircraft, SLE_UINT16, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_ships, SLE_UINT16, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_ispercent, VarTypes::BOOL, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_trains, VarTypes::U16, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_roadveh, VarTypes::U16, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_aircraft, VarTypes::U16, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_ships, VarTypes::U16, SaveLoadVersion::CompanyServiceIntervals, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _company_settings_compat;
 
@@ -351,16 +351,16 @@ class SlCompanyEconomy : public DefaultSaveLoadHandler<SlCompanyEconomy, Company
 public:
 	static inline const SaveLoad description[] = {
 		SLE_CONDVAR(CompanyEconomyEntry, income, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::VehicleCurrencyStationChanges),
-		SLE_CONDVAR(CompanyEconomyEntry, income, SLE_INT64, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyEconomyEntry, income, VarTypes::I64, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(CompanyEconomyEntry, expenses, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::VehicleCurrencyStationChanges),
-		SLE_CONDVAR(CompanyEconomyEntry, expenses, SLE_INT64, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyEconomyEntry, expenses, VarTypes::I64, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(CompanyEconomyEntry, company_value, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::VehicleCurrencyStationChanges),
-		SLE_CONDVAR(CompanyEconomyEntry, company_value, SLE_INT64, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(CompanyEconomyEntry, company_value, VarTypes::I64, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
-		SLE_CONDVAR(CompanyEconomyEntry, delivered_cargo[NUM_CARGO - 1], SLE_INT32, SaveLoadVersion::MinVersion, SaveLoadVersion::CountIndividualCargoes),
-		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo, SLE_UINT32, 32, SaveLoadVersion::CountIndividualCargoes, SaveLoadVersion::ExtendCargotypes),
-		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo, SLE_UINT32, NUM_CARGO, SaveLoadVersion::ExtendCargotypes, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(CompanyEconomyEntry, performance_history, SLE_INT32),
+		SLE_CONDVAR(CompanyEconomyEntry, delivered_cargo[NUM_CARGO - 1], VarTypes::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::CountIndividualCargoes),
+		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo, VarTypes::U32, 32, SaveLoadVersion::CountIndividualCargoes, SaveLoadVersion::ExtendCargotypes),
+		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo, VarTypes::U32, NUM_CARGO, SaveLoadVersion::ExtendCargotypes, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(CompanyEconomyEntry, performance_history, VarTypes::I32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _company_economy_compat;
 
@@ -410,9 +410,9 @@ public:
 class SlCompanyLiveries : public DefaultSaveLoadHandler<SlCompanyLiveries, CompanyProperties> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(Livery, in_use, SLE_UINT8, SaveLoadVersion::Liveries, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Livery, colour1, SLE_UINT8, SaveLoadVersion::Liveries, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Livery, colour2, SLE_UINT8, SaveLoadVersion::Liveries, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Livery, in_use, VarTypes::U8, SaveLoadVersion::Liveries, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Livery, colour1, VarTypes::U8, SaveLoadVersion::Liveries, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Livery, colour2, VarTypes::U8, SaveLoadVersion::Liveries, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _company_liveries_compat;
 
@@ -479,7 +479,7 @@ public:
 	};
 
 	static inline const SaveLoad description[] = {
-		SLE_SSTR(KeyWrapper, key, SLE_STR),
+		SLE_SSTR(KeyWrapper, key, VarTypes::STR),
 	};
 	static inline const SaveLoadCompatTable compat_description = {};
 
@@ -490,59 +490,59 @@ public:
 
 /** Save/load of companies. */
 static const SaveLoad _company_desc[] = {
-	    SLE_VAR(CompanyProperties, name_2,          SLE_UINT32),
-	    SLE_VAR(CompanyProperties, name_1,          SLE_STRINGID),
-	SLE_CONDSSTR(CompanyProperties, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(CompanyProperties, name_2,          VarTypes::U32),
+	    SLE_VAR(CompanyProperties, name_1,          VarTypes::STRINGID),
+	SLE_CONDSSTR(CompanyProperties, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 
-	    SLE_VAR(CompanyProperties, president_name_1, SLE_STRINGID),
-	    SLE_VAR(CompanyProperties, president_name_2, SLE_UINT32),
-	SLE_CONDSSTR(CompanyProperties, president_name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(CompanyProperties, president_name_1, VarTypes::STRINGID),
+	    SLE_VAR(CompanyProperties, president_name_2, VarTypes::U32),
+	SLE_CONDSSTR(CompanyProperties, president_name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVECTOR(CompanyProperties, allow_list, SLE_STR, SaveLoadVersion::CompanyAllowList, SaveLoadVersion::CompanyAllowListV2),
+	SLE_CONDVECTOR(CompanyProperties, allow_list, VarTypes::STR, SaveLoadVersion::CompanyAllowList, SaveLoadVersion::CompanyAllowListV2),
 	SLEG_CONDSTRUCTLIST("allow_list", SlAllowListData, SaveLoadVersion::CompanyAllowListV2, SaveLoadVersion::MaxVersion),
-	SLE_VAR(CompanyProperties, allow_any, SLE_BOOL),
+	SLE_VAR(CompanyProperties, allow_any, VarTypes::BOOL),
 
-	SLE_VARNAME(CompanyProperties, face.bits, "face", SLE_UINT32),
-	SLE_CONDSSTRNAME(CompanyProperties, face.style_label, "face_style", SLE_STR, SaveLoadVersion::FaceStyles, SaveLoadVersion::MaxVersion),
+	SLE_VARNAME(CompanyProperties, face.bits, "face", VarTypes::U32),
+	SLE_CONDSSTRNAME(CompanyProperties, face.style_label, "face_style", VarTypes::STR, SaveLoadVersion::FaceStyles, SaveLoadVersion::MaxVersion),
 
 	/* money was changed to a 64 bit field in savegame version 1. */
 	SLE_CONDVAR(CompanyProperties, money, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::BigCurrency),
-	SLE_CONDVAR(CompanyProperties, money, SLE_INT64, SaveLoadVersion::BigCurrency, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, money, VarTypes::I64, SaveLoadVersion::BigCurrency, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDVAR(CompanyProperties, current_loan, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
-	SLE_CONDVAR(CompanyProperties, current_loan, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(CompanyProperties, max_loan, SLE_INT64, SaveLoadVersion::MaxLoanForCompany, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, current_loan, VarTypes::I64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, max_loan, VarTypes::I64, SaveLoadVersion::MaxLoanForCompany, SaveLoadVersion::MaxVersion),
 
-	    SLE_VAR(CompanyProperties, colour,                SLE_UINT8),
-	    SLE_VAR(CompanyProperties, money_fraction,        SLE_UINT8),
-	    SLE_VAR(CompanyProperties, block_preview,         SLE_UINT8),
+	    SLE_VAR(CompanyProperties, colour,                VarTypes::U8),
+	    SLE_VAR(CompanyProperties, money_fraction,        VarTypes::U8),
+	    SLE_VAR(CompanyProperties, block_preview,         VarTypes::U8),
 
 	SLE_CONDVAR(CompanyProperties, location_of_HQ, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(CompanyProperties, location_of_HQ, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, location_of_HQ, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(CompanyProperties, last_build_coordinate, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(CompanyProperties, last_build_coordinate, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, last_build_coordinate, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(CompanyProperties, inaugurated_year, VarFileType::U8 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-	SLE_CONDVAR(CompanyProperties, inaugurated_year, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(CompanyProperties, inaugurated_year_calendar, SLE_INT32, SaveLoadVersion::CompanyInauguratedPeriodV2, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, inaugurated_year, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, inaugurated_year_calendar, VarTypes::I32, SaveLoadVersion::CompanyInauguratedPeriodV2, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(CompanyProperties, num_valid_stat_ent, SLE_UINT8, SaveLoadVersion::MinVersion, SaveLoadVersion::SaveloadListLength),
+	SLE_CONDVAR(CompanyProperties, num_valid_stat_ent, VarTypes::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::SaveloadListLength),
 
-	    SLE_VAR(CompanyProperties, months_of_bankruptcy,  SLE_UINT8),
+	    SLE_VAR(CompanyProperties, months_of_bankruptcy,  VarTypes::U8),
 	SLE_CONDVAR(CompanyProperties, bankrupt_asked, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCompanies),
-	SLE_CONDVAR(CompanyProperties, bankrupt_asked, SLE_UINT16, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
-	    SLE_VAR(CompanyProperties, bankrupt_timeout,      SLE_INT16),
+	SLE_CONDVAR(CompanyProperties, bankrupt_asked, VarTypes::U16, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(CompanyProperties, bankrupt_timeout,      VarTypes::I16),
 	SLE_CONDVAR(CompanyProperties, bankrupt_value, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
-	SLE_CONDVAR(CompanyProperties, bankrupt_value, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, bankrupt_value, VarTypes::I64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
 
 	/* yearly expenses was changed to 64-bit in savegame version 2. */
 	SLE_CONDARR(CompanyProperties, yearly_expenses, VarFileType::I32 | VarMemType::I64, 3 * 13, SaveLoadVersion::MinVersion, SaveLoadVersion::VehicleCurrencyStationChanges),
-	SLE_CONDARR(CompanyProperties, yearly_expenses, SLE_INT64, 3 * 13, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+	SLE_CONDARR(CompanyProperties, yearly_expenses, VarTypes::I64, 3 * 13, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(CompanyProperties, is_ai, SLE_BOOL, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, is_ai, VarTypes::BOOL, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(CompanyProperties, terraform_limit, SLE_UINT32, SaveLoadVersion::TerraformLimits, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(CompanyProperties, clear_limit, SLE_UINT32, SaveLoadVersion::TerraformLimits, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(CompanyProperties, tree_limit, SLE_UINT32, SaveLoadVersion::AutoreplaceWhenOldTreeLimit, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, terraform_limit, VarTypes::U32, SaveLoadVersion::TerraformLimits, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, clear_limit, VarTypes::U32, SaveLoadVersion::TerraformLimits, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(CompanyProperties, tree_limit, VarTypes::U32, SaveLoadVersion::AutoreplaceWhenOldTreeLimit, SaveLoadVersion::MaxVersion),
 	SLEG_STRUCT("settings", SlCompanySettings),
 	SLEG_CONDSTRUCT("old_ai", SlCompanyOldAI, SaveLoadVersion::MinVersion, SaveLoadVersion::NoAI),
 	SLEG_STRUCT("cur_economy", SlCompanyEconomy),

--- a/src/saveload/depot_sl.cpp
+++ b/src/saveload/depot_sl.cpp
@@ -21,12 +21,12 @@ static TownID _town_index;
 
 static const SaveLoad _depot_desc[] = {
 	 SLE_CONDVAR(Depot, xy, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	 SLE_CONDVAR(Depot, xy, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("town_index", _town_index, SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::UniqueDepotNames),
+	 SLE_CONDVAR(Depot, xy, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("town_index", _town_index, VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::UniqueDepotNames),
 	 SLE_CONDREF(Depot, town, SLRefType::Town, SaveLoadVersion::UniqueDepotNames, SaveLoadVersion::MaxVersion),
-	 SLE_CONDVAR(Depot, town_cn, SLE_UINT16, SaveLoadVersion::UniqueDepotNames, SaveLoadVersion::MaxVersion),
-	SLE_CONDSSTR(Depot, name, SLE_STR, SaveLoadVersion::UniqueDepotNames, SaveLoadVersion::MaxVersion),
-	 SLE_CONDVAR(Depot, build_date, SLE_INT32, SaveLoadVersion::NewGRFDepotBuildDate, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Depot, town_cn, VarTypes::U16, SaveLoadVersion::UniqueDepotNames, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Depot, name, VarTypes::STR, SaveLoadVersion::UniqueDepotNames, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Depot, build_date, VarTypes::I32, SaveLoadVersion::NewGRFDepotBuildDate, SaveLoadVersion::MaxVersion),
 };
 
 struct DEPTChunkHandler : ChunkHandler {

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -45,15 +45,15 @@ struct CAPRChunkHandler : ChunkHandler {
 
 static const SaveLoad _economy_desc[] = {
 	SLE_CONDVAR(Economy, old_max_loan_unround, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
-	SLE_CONDVAR(Economy, old_max_loan_unround, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::CumulatedInflation),
-	SLE_CONDVAR(Economy, old_max_loan_unround_fract, SLE_UINT16, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::CumulatedInflation),
-	SLE_CONDVAR(Economy, inflation_prices, SLE_UINT64, SaveLoadVersion::CumulatedInflation, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Economy, inflation_payment, SLE_UINT64, SaveLoadVersion::CumulatedInflation, SaveLoadVersion::MaxVersion),
-	    SLE_VAR(Economy, fluct,                         SLE_INT16),
-	    SLE_VAR(Economy, interest_rate,                 SLE_UINT8),
-	    SLE_VAR(Economy, infl_amount,                   SLE_UINT8),
-	    SLE_VAR(Economy, infl_amount_pr,                SLE_UINT8),
-	SLE_CONDVAR(Economy, industry_daily_change_counter, SLE_UINT32, SaveLoadVersion::SpreadIndustryProductionChanges, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Economy, old_max_loan_unround, VarTypes::I64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::CumulatedInflation),
+	SLE_CONDVAR(Economy, old_max_loan_unround_fract, VarTypes::U16, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::CumulatedInflation),
+	SLE_CONDVAR(Economy, inflation_prices, VarTypes::U64, SaveLoadVersion::CumulatedInflation, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Economy, inflation_payment, VarTypes::U64, SaveLoadVersion::CumulatedInflation, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(Economy, fluct,                         VarTypes::I16),
+	    SLE_VAR(Economy, interest_rate,                 VarTypes::U8),
+	    SLE_VAR(Economy, infl_amount,                   VarTypes::U8),
+	    SLE_VAR(Economy, infl_amount_pr,                VarTypes::U8),
+	SLE_CONDVAR(Economy, industry_daily_change_counter, VarTypes::U32, SaveLoadVersion::SpreadIndustryProductionChanges, SaveLoadVersion::MaxVersion),
 };
 
 /** Economy variables */
@@ -83,9 +83,9 @@ struct ECMYChunkHandler : ChunkHandler {
 
 static const SaveLoad _cargopayment_desc[] = {
 	    SLE_REF(CargoPayment, front,           SLRefType::Vehicle),
-	    SLE_VAR(CargoPayment, route_profit,    SLE_INT64),
-	    SLE_VAR(CargoPayment, visual_profit,   SLE_INT64),
-	SLE_CONDVAR(CargoPayment, visual_transfer, SLE_INT64, SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(CargoPayment, route_profit,    VarTypes::I64),
+	    SLE_VAR(CargoPayment, visual_profit,   VarTypes::I64),
+	SLE_CONDVAR(CargoPayment, visual_transfer, VarTypes::I64, SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
 };
 
 struct CAPYChunkHandler : ChunkHandler {

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -20,25 +20,25 @@
 
 static const SaveLoad _engine_desc[] = {
 	 SLE_CONDVAR(Engine, intro_date, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-	 SLE_CONDVAR(Engine, intro_date, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Engine, intro_date, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
 	 SLE_CONDVAR(Engine, age, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-	 SLE_CONDVAR(Engine, age, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
-	     SLE_VAR(Engine, reliability,         SLE_UINT16),
-	     SLE_VAR(Engine, reliability_spd_dec, SLE_UINT16),
-	     SLE_VAR(Engine, reliability_start,   SLE_UINT16),
-	     SLE_VAR(Engine, reliability_max,     SLE_UINT16),
-	     SLE_VAR(Engine, reliability_final,   SLE_UINT16),
-	     SLE_VAR(Engine, duration_phase_1,    SLE_UINT16),
-	     SLE_VAR(Engine, duration_phase_2,    SLE_UINT16),
-	     SLE_VAR(Engine, duration_phase_3,    SLE_UINT16),
-	     SLE_VAR(Engine, flags,               SLE_UINT8),
-	 SLE_CONDVAR(Engine, preview_asked, SLE_UINT16, SaveLoadVersion::RobustEnginePreview, SaveLoadVersion::MaxVersion),
-	 SLE_CONDVAR(Engine, preview_company, SLE_UINT8, SaveLoadVersion::RobustEnginePreview, SaveLoadVersion::MaxVersion),
-	     SLE_VAR(Engine, preview_wait,        SLE_UINT8),
+	 SLE_CONDVAR(Engine, age, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+	     SLE_VAR(Engine, reliability,         VarTypes::U16),
+	     SLE_VAR(Engine, reliability_spd_dec, VarTypes::U16),
+	     SLE_VAR(Engine, reliability_start,   VarTypes::U16),
+	     SLE_VAR(Engine, reliability_max,     VarTypes::U16),
+	     SLE_VAR(Engine, reliability_final,   VarTypes::U16),
+	     SLE_VAR(Engine, duration_phase_1,    VarTypes::U16),
+	     SLE_VAR(Engine, duration_phase_2,    VarTypes::U16),
+	     SLE_VAR(Engine, duration_phase_3,    VarTypes::U16),
+	     SLE_VAR(Engine, flags,               VarTypes::U8),
+	 SLE_CONDVAR(Engine, preview_asked, VarTypes::U16, SaveLoadVersion::RobustEnginePreview, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Engine, preview_company, VarTypes::U8, SaveLoadVersion::RobustEnginePreview, SaveLoadVersion::MaxVersion),
+	     SLE_VAR(Engine, preview_wait,        VarTypes::U8),
 	 SLE_CONDVAR(Engine, company_avail, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCompanies),
-	 SLE_CONDVAR(Engine, company_avail, SLE_UINT16, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
-	 SLE_CONDVAR(Engine, company_hidden, SLE_UINT16, SaveLoadVersion::HideEnginesForCompany, SaveLoadVersion::MaxVersion),
-	SLE_CONDSSTR(Engine, name, SLE_STR, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Engine, company_avail, VarTypes::U16, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Engine, company_hidden, VarTypes::U16, SaveLoadVersion::HideEnginesForCompany, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Engine, name, VarTypes::STR, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 };
 
 static TypedIndexContainer<std::vector<Engine>, EngineID> _temp_engine;
@@ -143,7 +143,7 @@ struct ENGSChunkHandler : ChunkHandler {
 		 * was always 256 entries. */
 		TypedIndexContainer<std::array<StringID, 256>, EngineID> names{};
 
-		SlCopy(names.data(), std::size(names), SLE_STRINGID);
+		SlCopy(names.data(), std::size(names), VarTypes::STRINGID);
 
 		/* Copy each string into the temporary engine array. */
 		for (EngineID engine = EngineID::Begin(); engine < std::size(names); ++engine) {
@@ -155,10 +155,10 @@ struct ENGSChunkHandler : ChunkHandler {
 
 /** Save and load the mapping between the engine id in the pool, and the grf file it came from. */
 static const SaveLoad _engine_id_mapping_desc[] = {
-	SLE_VAR(EngineIDMapping, grfid,         SLE_UINT32),
-	SLE_VAR(EngineIDMapping, internal_id,   SLE_UINT16),
-	SLE_VAR(EngineIDMapping, type,          SLE_UINT8),
-	SLE_VAR(EngineIDMapping, substitute_id, SLE_UINT8),
+	SLE_VAR(EngineIDMapping, grfid,         VarTypes::U32),
+	SLE_VAR(EngineIDMapping, internal_id,   VarTypes::U16),
+	SLE_VAR(EngineIDMapping, type,          VarTypes::U8),
+	SLE_VAR(EngineIDMapping, substitute_id, VarTypes::U8),
 };
 
 struct EIDSChunkHandler : ChunkHandler {

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -27,9 +27,9 @@ static int         _game_saveload_version;
 static std::string _game_saveload_settings;
 
 static const SaveLoad _game_script_desc[] = {
-	   SLEG_SSTR("name",      _game_saveload_name,         SLE_STR),
-	   SLEG_SSTR("settings",  _game_saveload_settings,     SLE_STR),
-	    SLEG_VAR("version",   _game_saveload_version,   SLE_UINT32),
+	   SLEG_SSTR("name",      _game_saveload_name,         VarTypes::STR),
+	   SLEG_SSTR("settings",  _game_saveload_settings,     VarTypes::STR),
+	    SLEG_VAR("version",   _game_saveload_version,   VarTypes::U32),
 };
 
 static void SaveReal_GSDT(int)
@@ -121,7 +121,7 @@ static uint32_t _game_saveload_strings;
 class SlGameLanguageString : public DefaultSaveLoadHandler<SlGameLanguageString, LanguageStrings> {
 public:
 	static inline const SaveLoad description[] = {
-		SLEG_SSTR("string", _game_saveload_string, SLE_STR | StringValidationSetting::AllowControlCode | StringValidationSetting::ReplaceTabCrNlWithSpace),
+		SLEG_SSTR("string", _game_saveload_string, VarTypes::STR | StringValidationSetting::AllowControlCode | StringValidationSetting::ReplaceTabCrNlWithSpace),
 	};
 	static inline const SaveLoadCompatTable compat_description = _game_language_string_sl_compat;
 
@@ -147,8 +147,8 @@ public:
 };
 
 static const SaveLoad _game_language_desc[] = {
-	SLE_SSTR(LanguageStrings, language, SLE_STR),
-	SLEG_CONDVAR("count", _game_saveload_strings, SLE_UINT32, SaveLoadVersion::MinVersion, SaveLoadVersion::SaveloadListLength),
+	SLE_SSTR(LanguageStrings, language, VarTypes::STR),
+	SLEG_CONDVAR("count", _game_saveload_strings, VarTypes::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::SaveloadListLength),
 	SLEG_STRUCTLIST("strings", SlGameLanguageString),
 };
 

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -22,8 +22,8 @@
 class SlGamelogMode : public DefaultSaveLoadHandler<SlGamelogMode, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeMode, mode,      "mode.mode",      SLE_UINT8),
-		SLE_VARNAME(LoggedChangeMode, landscape, "mode.landscape", SLE_UINT8),
+		SLE_VARNAME(LoggedChangeMode, mode,      "mode.mode",      VarTypes::U8),
+		SLE_VARNAME(LoggedChangeMode, landscape, "mode.landscape", VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_mode_sl_compat;
 
@@ -48,11 +48,11 @@ public:
 	static char revision_text[GAMELOG_REVISION_LENGTH];
 
 	static inline const SaveLoad description[] = {
-		 SLEG_CONDARR("revision.text", SlGamelogRevision::revision_text, SLE_UINT8, GAMELOG_REVISION_LENGTH, SaveLoadVersion::MinVersion, SaveLoadVersion::StringGamelog),
-		SLE_CONDSSTRNAME(LoggedChangeRevision, text, "revision.text", SLE_STR, SaveLoadVersion::StringGamelog, SaveLoadVersion::MaxVersion),
-		     SLE_VARNAME(LoggedChangeRevision, newgrf,   "revision.newgrf",   SLE_UINT32),
-		     SLE_VARNAME(LoggedChangeRevision, slver,    "revision.slver",    SLE_UINT16),
-		     SLE_VARNAME(LoggedChangeRevision, modified, "revision.modified", SLE_UINT8),
+		 SLEG_CONDARR("revision.text", SlGamelogRevision::revision_text, VarTypes::U8, GAMELOG_REVISION_LENGTH, SaveLoadVersion::MinVersion, SaveLoadVersion::StringGamelog),
+		SLE_CONDSSTRNAME(LoggedChangeRevision, text, "revision.text", VarTypes::STR, SaveLoadVersion::StringGamelog, SaveLoadVersion::MaxVersion),
+		     SLE_VARNAME(LoggedChangeRevision, newgrf,   "revision.newgrf",   VarTypes::U32),
+		     SLE_VARNAME(LoggedChangeRevision, slver,    "revision.slver",    VarTypes::U16),
+		     SLE_VARNAME(LoggedChangeRevision, modified, "revision.modified", VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_revision_sl_compat;
 
@@ -80,8 +80,8 @@ public:
 class SlGamelogOldver : public DefaultSaveLoadHandler<SlGamelogOldver, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeOldVersion, type,    "oldver.type",    SLE_UINT32),
-		SLE_VARNAME(LoggedChangeOldVersion, version, "oldver.version", SLE_UINT32),
+		SLE_VARNAME(LoggedChangeOldVersion, type,    "oldver.type",    VarTypes::U32),
+		SLE_VARNAME(LoggedChangeOldVersion, version, "oldver.version", VarTypes::U32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_oldver_sl_compat;
 
@@ -103,9 +103,9 @@ public:
 class SlGamelogSetting : public DefaultSaveLoadHandler<SlGamelogSetting, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_SSTRNAME(LoggedChangeSettingChanged, name,   "setting.name",   SLE_STR),
-		 SLE_VARNAME(LoggedChangeSettingChanged, oldval, "setting.oldval", SLE_INT32),
-		 SLE_VARNAME(LoggedChangeSettingChanged, newval, "setting.newval", SLE_INT32),
+		SLE_SSTRNAME(LoggedChangeSettingChanged, name,   "setting.name",   VarTypes::STR),
+		 SLE_VARNAME(LoggedChangeSettingChanged, oldval, "setting.oldval", VarTypes::I32),
+		 SLE_VARNAME(LoggedChangeSettingChanged, newval, "setting.newval", VarTypes::I32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_setting_sl_compat;
 
@@ -127,8 +127,8 @@ public:
 class SlGamelogGrfadd : public DefaultSaveLoadHandler<SlGamelogGrfadd, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFAdd, grfid,  "grfadd.grfid",  SLE_UINT32    ),
-		SLE_ARRNAME(LoggedChangeGRFAdd, md5sum, "grfadd.md5sum", SLE_UINT8,  16),
+		SLE_VARNAME(LoggedChangeGRFAdd, grfid,  "grfadd.grfid",  VarTypes::U32    ),
+		SLE_ARRNAME(LoggedChangeGRFAdd, md5sum, "grfadd.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfadd_sl_compat;
 
@@ -150,7 +150,7 @@ public:
 class SlGamelogGrfrem : public DefaultSaveLoadHandler<SlGamelogGrfrem, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", SLE_UINT32),
+		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", VarTypes::U32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfrem_sl_compat;
 
@@ -172,8 +172,8 @@ public:
 class SlGamelogGrfcompat : public DefaultSaveLoadHandler<SlGamelogGrfcompat, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFChanged, grfid,  "grfcompat.grfid",  SLE_UINT32    ),
-		SLE_ARRNAME(LoggedChangeGRFChanged, md5sum, "grfcompat.md5sum", SLE_UINT8,  16),
+		SLE_VARNAME(LoggedChangeGRFChanged, grfid,  "grfcompat.grfid",  VarTypes::U32    ),
+		SLE_ARRNAME(LoggedChangeGRFChanged, md5sum, "grfcompat.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfcompat_sl_compat;
 
@@ -195,7 +195,7 @@ public:
 class SlGamelogGrfparam : public DefaultSaveLoadHandler<SlGamelogGrfparam, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", SLE_UINT32),
+		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", VarTypes::U32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfparam_sl_compat;
 
@@ -217,8 +217,8 @@ public:
 class SlGamelogGrfmove : public DefaultSaveLoadHandler<SlGamelogGrfmove, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFMoved, grfid,  "grfmove.grfid",  SLE_UINT32),
-		SLE_VARNAME(LoggedChangeGRFMoved, offset, "grfmove.offset", SLE_INT32),
+		SLE_VARNAME(LoggedChangeGRFMoved, grfid,  "grfmove.grfid",  VarTypes::U32),
+		SLE_VARNAME(LoggedChangeGRFMoved, offset, "grfmove.offset", VarTypes::I32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfmove_sl_compat;
 
@@ -240,9 +240,9 @@ public:
 class SlGamelogGrfbug : public DefaultSaveLoadHandler<SlGamelogGrfbug, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFBug, data,  "grfbug.data",  SLE_UINT64),
-		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", SLE_UINT32),
-		SLE_VARNAME(LoggedChangeGRFBug, bug,   "grfbug.bug",   SLE_UINT8),
+		SLE_VARNAME(LoggedChangeGRFBug, data,  "grfbug.data",  VarTypes::U64),
+		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", VarTypes::U32),
+		SLE_VARNAME(LoggedChangeGRFBug, bug,   "grfbug.bug",   VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfbug_sl_compat;
 
@@ -267,7 +267,7 @@ class SlGamelogEmergency : public DefaultSaveLoadHandler<SlGamelogEmergency, Log
 public:
 	/** We need to store something, so store a "true" value. */
 	static inline const SaveLoad description[] = {
-		SLEG_CONDVAR("is_emergency_save", _is_emergency_save, SLE_BOOL, SaveLoadVersion::RiffToArray, SaveLoadVersion::MaxVersion),
+		SLEG_CONDVAR("is_emergency_save", _is_emergency_save, VarTypes::BOOL, SaveLoadVersion::RiffToArray, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_emergency_sl_compat;
 
@@ -368,9 +368,9 @@ public:
 };
 
 static const SaveLoad _gamelog_desc[] = {
-	SLE_CONDVAR(LoggedAction, at, SLE_UINT8, SaveLoadVersion::RiffToArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(LoggedAction, at, VarTypes::U8, SaveLoadVersion::RiffToArray, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(LoggedAction, tick, VarFileType::U16 | VarMemType::U64, SaveLoadVersion::MinVersion, SaveLoadVersion::U64TickCounter),
-	SLE_CONDVAR(LoggedAction, tick, SLE_UINT64, SaveLoadVersion::U64TickCounter, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(LoggedAction, tick, VarTypes::U64, SaveLoadVersion::U64TickCounter, SaveLoadVersion::MaxVersion),
 	SLEG_STRUCTLIST("action", SlGamelogAction),
 };
 

--- a/src/saveload/goal_sl.cpp
+++ b/src/saveload/goal_sl.cpp
@@ -19,10 +19,10 @@
 static const SaveLoad _goals_desc[] = {
 	     SLE_VAR(Goal, company,   VarFileType::U16 | VarMemType::U8),
 	     SLE_VAR(Goal, type,      VarFileType::U16 | VarMemType::U8),
-	     SLE_VAR(Goal, dst,       SLE_UINT32),
-	    SLE_SSTR(Goal, text,      SLE_STR | StringValidationSetting::AllowControlCode),
-	SLE_CONDSSTR(Goal, progress, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
-	 SLE_CONDVAR(Goal, completed, SLE_BOOL, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
+	     SLE_VAR(Goal, dst,       VarTypes::U32),
+	    SLE_SSTR(Goal, text,      VarTypes::STR | StringValidationSetting::AllowControlCode),
+	SLE_CONDSSTR(Goal, progress, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Goal, completed, VarTypes::BOOL, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
 };
 
 struct GOALChunkHandler : ChunkHandler {

--- a/src/saveload/group_sl.cpp
+++ b/src/saveload/group_sl.cpp
@@ -17,16 +17,16 @@
 #include "../safeguards.h"
 
 static const SaveLoad _group_desc[] = {
-	 SLE_CONDVAR(Group, name, SLE_NAME, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
-	SLE_CONDSSTR(Group, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
-	     SLE_VAR(Group, owner,              SLE_UINT8),
-	     SLE_VAR(Group, vehicle_type,       SLE_UINT8),
-	     SLE_VAR(Group, flags,              SLE_UINT8),
-	 SLE_CONDVAR(Group, livery.in_use, SLE_UINT8, SaveLoadVersion::GroupLiveries, SaveLoadVersion::MaxVersion),
-	 SLE_CONDVAR(Group, livery.colour1, SLE_UINT8, SaveLoadVersion::GroupLiveries, SaveLoadVersion::MaxVersion),
-	 SLE_CONDVAR(Group, livery.colour2, SLE_UINT8, SaveLoadVersion::GroupLiveries, SaveLoadVersion::MaxVersion),
-	 SLE_CONDVAR(Group, parent, SLE_UINT16, SaveLoadVersion::GroupHierarchy, SaveLoadVersion::MaxVersion),
-	 SLE_CONDVAR(Group, number, SLE_UINT16, SaveLoadVersion::GroupNumbers, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Group, name, VarTypes::NAME, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
+	SLE_CONDSSTR(Group, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	     SLE_VAR(Group, owner,              VarTypes::U8),
+	     SLE_VAR(Group, vehicle_type,       VarTypes::U8),
+	     SLE_VAR(Group, flags,              VarTypes::U8),
+	 SLE_CONDVAR(Group, livery.in_use, VarTypes::U8, SaveLoadVersion::GroupLiveries, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Group, livery.colour1, VarTypes::U8, SaveLoadVersion::GroupLiveries, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Group, livery.colour2, VarTypes::U8, SaveLoadVersion::GroupLiveries, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Group, parent, VarTypes::U16, SaveLoadVersion::GroupHierarchy, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(Group, number, VarTypes::U16, SaveLoadVersion::GroupNumbers, SaveLoadVersion::MaxVersion),
 };
 
 struct GRPSChunkHandler : ChunkHandler {

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -22,8 +22,8 @@ static OldPersistentStorage _old_ind_persistent_storage;
 class SlIndustryAcceptedHistory : public DefaultSaveLoadHandler<SlIndustryAcceptedHistory, Industry::AcceptedCargo> {
 public:
 	static inline const SaveLoad description[] = {
-		 SLE_VAR(Industry::AcceptedHistory, accepted, SLE_UINT16),
-		 SLE_VAR(Industry::AcceptedHistory, waiting, SLE_UINT16),
+		 SLE_VAR(Industry::AcceptedHistory, accepted, VarTypes::U16),
+		 SLE_VAR(Industry::AcceptedHistory, waiting, VarTypes::U16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _industry_produced_history_sl_compat;
 
@@ -58,10 +58,10 @@ public:
 class SlIndustryAccepted : public VectorSaveLoadHandler<SlIndustryAccepted, Industry, Industry::AcceptedCargo, INDUSTRY_NUM_INPUTS> {
 public:
 	static inline const SaveLoad description[] = {
-		 SLE_VAR(Industry::AcceptedCargo, cargo, SLE_UINT8),
-		 SLE_VAR(Industry::AcceptedCargo, waiting, SLE_UINT16),
-		 SLE_VAR(Industry::AcceptedCargo, last_accepted, SLE_INT32),
-		SLE_CONDVAR(Industry::AcceptedCargo, accumulated_waiting, SLE_UINT32, SaveLoadVersion::IndustryAcceptedHistory, SaveLoadVersion::MaxVersion),
+		 SLE_VAR(Industry::AcceptedCargo, cargo, VarTypes::U8),
+		 SLE_VAR(Industry::AcceptedCargo, waiting, VarTypes::U16),
+		 SLE_VAR(Industry::AcceptedCargo, last_accepted, VarTypes::I32),
+		SLE_CONDVAR(Industry::AcceptedCargo, accumulated_waiting, VarTypes::U32, SaveLoadVersion::IndustryAcceptedHistory, SaveLoadVersion::MaxVersion),
 		SLEG_CONDSTRUCTLIST("history", SlIndustryAcceptedHistory, SaveLoadVersion::IndustryAcceptedHistory, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _industry_accepts_sl_compat;
@@ -86,8 +86,8 @@ public:
 class SlIndustryProducedHistory : public DefaultSaveLoadHandler<SlIndustryProducedHistory, Industry::ProducedCargo> {
 public:
 	static inline const SaveLoad description[] = {
-		 SLE_VAR(Industry::ProducedHistory, production, SLE_UINT16),
-		 SLE_VAR(Industry::ProducedHistory, transported, SLE_UINT16),
+		 SLE_VAR(Industry::ProducedHistory, production, VarTypes::U16),
+		 SLE_VAR(Industry::ProducedHistory, transported, VarTypes::U16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _industry_produced_history_sl_compat;
 
@@ -120,9 +120,9 @@ public:
 class SlIndustryProduced : public VectorSaveLoadHandler<SlIndustryProduced, Industry, Industry::ProducedCargo, INDUSTRY_NUM_OUTPUTS> {
 public:
 	static inline const SaveLoad description[] = {
-		 SLE_VAR(Industry::ProducedCargo, cargo, SLE_UINT8),
-		 SLE_VAR(Industry::ProducedCargo, waiting, SLE_UINT16),
-		 SLE_VAR(Industry::ProducedCargo, rate, SLE_UINT8),
+		 SLE_VAR(Industry::ProducedCargo, cargo, VarTypes::U8),
+		 SLE_VAR(Industry::ProducedCargo, waiting, VarTypes::U16),
+		 SLE_VAR(Industry::ProducedCargo, rate, VarTypes::U8),
 		SLEG_STRUCTLIST("history", SlIndustryProducedHistory),
 	};
 	static inline const SaveLoadCompatTable compat_description = _industry_produced_sl_compat;
@@ -154,57 +154,57 @@ public:
 
 static const SaveLoad _industry_desc[] = {
 	SLE_CONDVAR(Industry, location.tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(Industry, location.tile, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Industry, location.tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	    SLE_VAR(Industry, location.w,                 VarFileType::U8 | VarMemType::U16),
 	    SLE_VAR(Industry, location.h,                 VarFileType::U8 | VarMemType::U16),
 	    SLE_REF(Industry, town,                       SLRefType::Town),
 	SLE_CONDREF(Industry, neutral_station, SLRefType::Station, SaveLoadVersion::ServeNeutralIndustries, SaveLoadVersion::MaxVersion),
-	SLEG_CONDARR("produced_cargo", SlIndustryProduced::old_cargo, SLE_UINT8, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::StoreIndustryCargo, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("produced_cargo", SlIndustryProduced::old_cargo, SLE_UINT8, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
-	SLEG_CONDARR("incoming_cargo_waiting", SlIndustryAccepted::old_waiting, SLE_UINT16, INDUSTRY_ORIGINAL_NUM_INPUTS, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("incoming_cargo_waiting", SlIndustryAccepted::old_waiting, SLE_UINT16, INDUSTRY_NUM_INPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
-	SLEG_CONDARR("produced_cargo_waiting", SlIndustryProduced::old_waiting, SLE_UINT16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("produced_cargo_waiting", SlIndustryProduced::old_waiting, SLE_UINT16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
-	SLEG_CONDARR("production_rate", SlIndustryProduced::old_rate, SLE_UINT8, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("production_rate", SlIndustryProduced::old_rate, SLE_UINT8, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
-	SLEG_CONDARR("accepts_cargo", SlIndustryAccepted::old_cargo, SLE_UINT8, INDUSTRY_ORIGINAL_NUM_INPUTS, SaveLoadVersion::StoreIndustryCargo, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("accepts_cargo", SlIndustryAccepted::old_cargo, SLE_UINT8, INDUSTRY_NUM_INPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
-	    SLE_VAR(Industry, prod_level,                 SLE_UINT8),
-	SLEG_CONDARR("this_month_production", SlIndustryProduced::old_this_month_production, SLE_UINT16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("this_month_production", SlIndustryProduced::old_this_month_production, SLE_UINT16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
-	SLEG_CONDARR("this_month_transported", SlIndustryProduced::old_this_month_transported, SLE_UINT16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("this_month_transported", SlIndustryProduced::old_this_month_transported, SLE_UINT16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
-	SLEG_CONDARR("last_month_production", SlIndustryProduced::old_last_month_production, SLE_UINT16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("last_month_production", SlIndustryProduced::old_last_month_production, SLE_UINT16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
-	SLEG_CONDARR("last_month_transported", SlIndustryProduced::old_last_month_transported, SLE_UINT16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("last_month_transported", SlIndustryProduced::old_last_month_transported, SLE_UINT16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	SLEG_CONDARR("produced_cargo", SlIndustryProduced::old_cargo, VarTypes::U8, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::StoreIndustryCargo, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("produced_cargo", SlIndustryProduced::old_cargo, VarTypes::U8, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	SLEG_CONDARR("incoming_cargo_waiting", SlIndustryAccepted::old_waiting, VarTypes::U16, INDUSTRY_ORIGINAL_NUM_INPUTS, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("incoming_cargo_waiting", SlIndustryAccepted::old_waiting, VarTypes::U16, INDUSTRY_NUM_INPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	SLEG_CONDARR("produced_cargo_waiting", SlIndustryProduced::old_waiting, VarTypes::U16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("produced_cargo_waiting", SlIndustryProduced::old_waiting, VarTypes::U16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	SLEG_CONDARR("production_rate", SlIndustryProduced::old_rate, VarTypes::U8, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("production_rate", SlIndustryProduced::old_rate, VarTypes::U8, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	SLEG_CONDARR("accepts_cargo", SlIndustryAccepted::old_cargo, VarTypes::U8, INDUSTRY_ORIGINAL_NUM_INPUTS, SaveLoadVersion::StoreIndustryCargo, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("accepts_cargo", SlIndustryAccepted::old_cargo, VarTypes::U8, INDUSTRY_NUM_INPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	    SLE_VAR(Industry, prod_level,                 VarTypes::U8),
+	SLEG_CONDARR("this_month_production", SlIndustryProduced::old_this_month_production, VarTypes::U16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("this_month_production", SlIndustryProduced::old_this_month_production, VarTypes::U16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	SLEG_CONDARR("this_month_transported", SlIndustryProduced::old_this_month_transported, VarTypes::U16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("this_month_transported", SlIndustryProduced::old_this_month_transported, VarTypes::U16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	SLEG_CONDARR("last_month_production", SlIndustryProduced::old_last_month_production, VarTypes::U16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("last_month_production", SlIndustryProduced::old_last_month_production, VarTypes::U16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	SLEG_CONDARR("last_month_transported", SlIndustryProduced::old_last_month_transported, VarTypes::U16, INDUSTRY_ORIGINAL_NUM_OUTPUTS, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("last_month_transported", SlIndustryProduced::old_last_month_transported, VarTypes::U16, INDUSTRY_NUM_OUTPUTS, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
 
-	    SLE_VAR(Industry, counter,                    SLE_UINT16),
+	    SLE_VAR(Industry, counter,                    VarTypes::U16),
 
-	    SLE_VAR(Industry, type,                       SLE_UINT8),
-	    SLE_VAR(Industry, owner,                      SLE_UINT8),
-	    SLE_VAR(Industry, random_colour,              SLE_UINT8),
+	    SLE_VAR(Industry, type,                       VarTypes::U8),
+	    SLE_VAR(Industry, owner,                      VarTypes::U8),
+	    SLE_VAR(Industry, random_colour,              VarTypes::U8),
 	SLE_CONDVAR(Industry, last_prod_year, VarFileType::U8 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-	SLE_CONDVAR(Industry, last_prod_year, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
-	    SLE_VAR(Industry, was_cargo_delivered,        SLE_UINT8),
-	SLE_CONDVAR(Industry, ctlflags, SLE_UINT8, SaveLoadVersion::GSIndustryControl, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Industry, last_prod_year, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(Industry, was_cargo_delivered,        VarTypes::U8),
+	SLE_CONDVAR(Industry, ctlflags, VarTypes::U8, SaveLoadVersion::GSIndustryControl, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Industry, founder, SLE_UINT8, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Industry, construction_date, SLE_INT32, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Industry, construction_type, SLE_UINT8, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("last_cargo_accepted_at[0]", SlIndustryAccepted::old_last_accepted[0], SLE_INT32, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::ExtendIndustryCargoSlots),
-	SLEG_CONDARR("last_cargo_accepted_at", SlIndustryAccepted::old_last_accepted, SLE_INT32, 16, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
-	SLE_CONDVAR(Industry, selected_layout, SLE_UINT8, SaveLoadVersion::NewGRFIndustryLayout, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Industry, exclusive_supplier, SLE_UINT8, SaveLoadVersion::GSIndustryControl, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Industry, exclusive_consumer, SLE_UINT8, SaveLoadVersion::GSIndustryControl, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Industry, founder, VarTypes::U8, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Industry, construction_date, VarTypes::I32, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Industry, construction_type, VarTypes::U8, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("last_cargo_accepted_at[0]", SlIndustryAccepted::old_last_accepted[0], VarTypes::I32, SaveLoadVersion::CargoPaymentOverflow, SaveLoadVersion::ExtendIndustryCargoSlots),
+	SLEG_CONDARR("last_cargo_accepted_at", SlIndustryAccepted::old_last_accepted, VarTypes::I32, 16, SaveLoadVersion::ExtendIndustryCargoSlots, SaveLoadVersion::IndustryCargoReorganise),
+	SLE_CONDVAR(Industry, selected_layout, VarTypes::U8, SaveLoadVersion::NewGRFIndustryLayout, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Industry, exclusive_supplier, VarTypes::U8, SaveLoadVersion::GSIndustryControl, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Industry, exclusive_consumer, VarTypes::U8, SaveLoadVersion::GSIndustryControl, SaveLoadVersion::MaxVersion),
 
-	SLEG_CONDARR("storage", _old_ind_persistent_storage.storage, SLE_UINT32, 16, SaveLoadVersion::NewGRFPersistentStorage, SaveLoadVersion::PersistentStoragePool),
+	SLEG_CONDARR("storage", _old_ind_persistent_storage.storage, VarTypes::U32, 16, SaveLoadVersion::NewGRFPersistentStorage, SaveLoadVersion::PersistentStoragePool),
 	SLE_CONDREF(Industry, psa, SLRefType::Storage, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Industry, random, SLE_UINT16, SaveLoadVersion::NewGRFIndustryRandomTriggers, SaveLoadVersion::MaxVersion),
-	SLE_CONDSSTR(Industry, text, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::IndustryText, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Industry, random, VarTypes::U16, SaveLoadVersion::NewGRFIndustryRandomTriggers, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Industry, text, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::IndustryText, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Industry, valid_history, SLE_UINT64, SaveLoadVersion::IndustryNumValidHistory, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Industry, valid_history, VarTypes::U64, SaveLoadVersion::IndustryNumValidHistory, SaveLoadVersion::MaxVersion),
 
 	SLEG_CONDSTRUCTLIST("accepted", SlIndustryAccepted, SaveLoadVersion::IndustryCargoReorganise, SaveLoadVersion::MaxVersion),
 	SLEG_CONDSTRUCTLIST("produced", SlIndustryProduced, SaveLoadVersion::IndustryCargoReorganise, SaveLoadVersion::MaxVersion),
@@ -312,7 +312,7 @@ struct TIDSChunkHandler : NewGRFMappingChunkHandler {
 
 /** Description of the data to save and load in #IndustryBuildData. */
 static const SaveLoad _industry_builder_desc[] = {
-	SLEG_VAR("wanted_inds", _industry_builder.wanted_inds, SLE_UINT32),
+	SLEG_VAR("wanted_inds", _industry_builder.wanted_inds, VarTypes::U32),
 };
 
 /** Industry builder. */
@@ -339,11 +339,11 @@ struct IBLDChunkHandler : ChunkHandler {
 
 /** Description of the data to save and load in #IndustryTypeBuildData. */
 static const SaveLoad _industrytype_builder_desc[] = {
-	SLE_VAR(IndustryTypeBuildData, probability,  SLE_UINT32),
-	SLE_VAR(IndustryTypeBuildData, min_number,   SLE_UINT8),
-	SLE_VAR(IndustryTypeBuildData, target_count, SLE_UINT16),
-	SLE_VAR(IndustryTypeBuildData, max_wait,     SLE_UINT16),
-	SLE_VAR(IndustryTypeBuildData, wait_count,   SLE_UINT16),
+	SLE_VAR(IndustryTypeBuildData, probability,  VarTypes::U32),
+	SLE_VAR(IndustryTypeBuildData, min_number,   VarTypes::U8),
+	SLE_VAR(IndustryTypeBuildData, target_count, VarTypes::U16),
+	SLE_VAR(IndustryTypeBuildData, max_wait,     VarTypes::U16),
+	SLE_VAR(IndustryTypeBuildData, wait_count,   VarTypes::U16),
 };
 
 /** Industry-type build data. */

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -37,7 +37,7 @@ struct RAILChunkHandler : ChunkHandler {
 	RAILChunkHandler() : ChunkHandler('RAIL', ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RailTypeLabel>, label, SLE_UINT32),
+		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::U32),
 	};
 
 	void Save() const override
@@ -72,8 +72,8 @@ struct ROTTChunkHandler : ChunkHandler {
 	ROTTChunkHandler() : ChunkHandler('ROTT', ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RoadTypeLabel>, label, SLE_UINT32),
-		SLE_VAR(LabelObject<RoadTypeLabel>, subtype, SLE_UINT8),
+		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::U32),
+		SLE_VAR(LabelObject<RoadTypeLabel>, subtype, VarTypes::U8),
 	};
 
 	void Save() const override

--- a/src/saveload/league_sl.cpp
+++ b/src/saveload/league_sl.cpp
@@ -16,14 +16,14 @@
 #include "../safeguards.h"
 
 static const SaveLoad _league_table_elements_desc[] = {
-	    SLE_VAR(LeagueTableElement, table,       SLE_UINT8),
+	    SLE_VAR(LeagueTableElement, table,       VarTypes::U8),
 	SLE_CONDVAR(LeagueTableElement, rating, VarFileType::U64 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::LinkgraphEdges),
-	SLE_CONDVAR(LeagueTableElement, rating, SLE_INT64, SaveLoadVersion::LinkgraphEdges, SaveLoadVersion::MaxVersion),
-	    SLE_VAR(LeagueTableElement, company,     SLE_UINT8),
-	   SLE_SSTR(LeagueTableElement, text,        SLE_STR | StringValidationSetting::AllowControlCode),
-	   SLE_SSTR(LeagueTableElement, score,       SLE_STR | StringValidationSetting::AllowControlCode),
-	    SLE_VAR(LeagueTableElement, link.type,   SLE_UINT8),
-	    SLE_VAR(LeagueTableElement, link.target, SLE_UINT32),
+	SLE_CONDVAR(LeagueTableElement, rating, VarTypes::I64, SaveLoadVersion::LinkgraphEdges, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(LeagueTableElement, company,     VarTypes::U8),
+	   SLE_SSTR(LeagueTableElement, text,        VarTypes::STR | StringValidationSetting::AllowControlCode),
+	   SLE_SSTR(LeagueTableElement, score,       VarTypes::STR | StringValidationSetting::AllowControlCode),
+	    SLE_VAR(LeagueTableElement, link.type,   VarTypes::U8),
+	    SLE_VAR(LeagueTableElement, link.target, VarTypes::U32),
 };
 
 struct LEAEChunkHandler : ChunkHandler {
@@ -52,9 +52,9 @@ struct LEAEChunkHandler : ChunkHandler {
 };
 
 static const SaveLoad _league_tables_desc[] = {
-	SLE_SSTR(LeagueTable, title, SLE_STR | StringValidationSetting::AllowControlCode),
-	SLE_SSTR(LeagueTable, header, SLE_STR | StringValidationSetting::AllowControlCode),
-	SLE_SSTR(LeagueTable, footer, SLE_STR | StringValidationSetting::AllowControlCode),
+	SLE_SSTR(LeagueTable, title, VarTypes::STR | StringValidationSetting::AllowControlCode),
+	SLE_SSTR(LeagueTable, header, VarTypes::STR | StringValidationSetting::AllowControlCode),
+	SLE_SSTR(LeagueTable, footer, VarTypes::STR | StringValidationSetting::AllowControlCode),
 };
 
 struct LEATChunkHandler : ChunkHandler {

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -31,13 +31,13 @@ static NodeID _linkgraph_from; ///< Contains the current "from" node being saved
 class SlLinkgraphEdge : public DefaultSaveLoadHandler<SlLinkgraphEdge, Node> {
 public:
 	static inline const SaveLoad description[] = {
-		    SLE_VAR(Edge, capacity,                 SLE_UINT32),
-		    SLE_VAR(Edge, usage,                    SLE_UINT32),
-		SLE_CONDVAR(Edge, travel_time_sum, SLE_UINT64, SaveLoadVersion::LinkgraphTravelTime, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Edge, last_unrestricted_update, SLE_INT32),
-		SLE_CONDVAR(Edge, last_restricted_update, SLE_INT32, SaveLoadVersion::LinkgraphRestrictedFlow, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Edge, dest_node,                SLE_UINT16),
-		SLE_CONDVARNAME(Edge, dest_node, "next_edge", SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::LinkgraphEdges),
+		    SLE_VAR(Edge, capacity,                 VarTypes::U32),
+		    SLE_VAR(Edge, usage,                    VarTypes::U32),
+		SLE_CONDVAR(Edge, travel_time_sum, VarTypes::U64, SaveLoadVersion::LinkgraphTravelTime, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Edge, last_unrestricted_update, VarTypes::I32),
+		SLE_CONDVAR(Edge, last_restricted_update, VarTypes::I32, SaveLoadVersion::LinkgraphRestrictedFlow, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Edge, dest_node,                VarTypes::U16),
+		SLE_CONDVARNAME(Edge, dest_node, "next_edge", VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::LinkgraphEdges),
 	};
 	static inline const SaveLoadCompatTable compat_description = _linkgraph_edge_sl_compat;
 
@@ -96,11 +96,11 @@ public:
 class SlLinkgraphNode : public DefaultSaveLoadHandler<SlLinkgraphNode, LinkGraph> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(Node, xy, SLE_UINT32, SaveLoadVersion::LinkgraphLocationDisasterStore, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Node, supply,      SLE_UINT32),
-		    SLE_VAR(Node, demand,      SLE_UINT32),
-		    SLE_VAR(Node, station,     SLE_UINT16),
-		    SLE_VAR(Node, last_update, SLE_INT32),
+		SLE_CONDVAR(Node, xy, VarTypes::U32, SaveLoadVersion::LinkgraphLocationDisasterStore, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Node, supply,      VarTypes::U32),
+		    SLE_VAR(Node, demand,      VarTypes::U32),
+		    SLE_VAR(Node, station,     VarTypes::U16),
+		    SLE_VAR(Node, last_update, VarTypes::I32),
 		SLEG_STRUCTLIST("edges", SlLinkgraphEdge),
 	};
 	static inline const SaveLoadCompatTable compat_description = _linkgraph_node_sl_compat;
@@ -136,9 +136,9 @@ public:
 SaveLoadTable GetLinkGraphDesc()
 {
 	static const SaveLoad link_graph_desc[] = {
-		 SLE_VAR(LinkGraph, last_compression, SLE_INT32),
-		SLEG_CONDVAR("num_nodes", _num_nodes, SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::SaveloadListLength),
-		 SLE_VAR(LinkGraph, cargo,            SLE_UINT8),
+		 SLE_VAR(LinkGraph, last_compression, VarTypes::I32),
+		SLEG_CONDVAR("num_nodes", _num_nodes, VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::SaveloadListLength),
+		 SLE_VAR(LinkGraph, cargo,            VarTypes::U8),
 		SLEG_STRUCTLIST("nodes", SlLinkgraphNode),
 	};
 	return link_graph_desc;
@@ -182,8 +182,8 @@ SaveLoadTable GetLinkGraphJobDesc()
 	static std::vector<SaveLoad> saveloads;
 
 	static const SaveLoad job_desc[] = {
-		SLE_VAR(LinkGraphJob, join_date,        SLE_INT32),
-		SLE_VAR(LinkGraphJob, link_graph.index, SLE_UINT16),
+		SLE_VAR(LinkGraphJob, join_date,        VarTypes::I32),
+		SLE_VAR(LinkGraphJob, link_graph.index, VarTypes::U16),
 		SLEG_STRUCT("linkgraph", SlLinkgraphJobProxy),
 	};
 

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -22,8 +22,8 @@ static uint32_t _map_dim_x;
 static uint32_t _map_dim_y;
 
 static const SaveLoad _map_desc[] = {
-	SLEG_CONDVAR("dim_x", _map_dim_x, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("dim_y", _map_dim_y, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("dim_x", _map_dim_x, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("dim_y", _map_dim_y, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 };
 
 struct MAPSChunkHandler : ChunkHandler {
@@ -75,7 +75,7 @@ struct MAPTChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).type() = buf[j];
 		}
 	}
@@ -88,7 +88,7 @@ struct MAPTChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).type();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 		}
 	}
 };
@@ -102,7 +102,7 @@ struct MAPHChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).height() = buf[j];
 		}
 	}
@@ -115,7 +115,7 @@ struct MAPHChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).height();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 		}
 	}
 };
@@ -129,7 +129,7 @@ struct MAPOChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m1() = buf[j];
 		}
 	}
@@ -142,7 +142,7 @@ struct MAPOChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m1();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 		}
 	}
 };
@@ -158,7 +158,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 		for (TileIndex i{}; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE,
 				/* In those versions the m2 was 8 bits */
-				IsSavegameVersionBefore(SaveLoadVersion::BigMap) ? VarFileType::U8 | VarMemType::U16 : SLE_UINT16
+				IsSavegameVersionBefore(SaveLoadVersion::BigMap) ? VarFileType::U8 | VarMemType::U16 : VarTypes::U16
 			);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m2() = buf[j];
 		}
@@ -172,7 +172,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 		SlSetLength(static_cast<uint32_t>(size) * sizeof(uint16_t));
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m2();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U16);
 		}
 	}
 };
@@ -186,7 +186,7 @@ struct M3LOChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m3() = buf[j];
 		}
 	}
@@ -199,7 +199,7 @@ struct M3LOChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m3();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 		}
 	}
 };
@@ -213,7 +213,7 @@ struct M3HIChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m4() = buf[j];
 		}
 	}
@@ -226,7 +226,7 @@ struct M3HIChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m4();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 		}
 	}
 };
@@ -240,7 +240,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m5() = buf[j];
 		}
 	}
@@ -253,7 +253,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m5();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 		}
 	}
 };
@@ -269,7 +269,7 @@ struct MAPEChunkHandler : ChunkHandler {
 		if (IsSavegameVersionBefore(SaveLoadVersion::BridgeWormhole)) {
 			for (TileIndex i{}; i != size;) {
 				/* 1024, otherwise we overflow on 64x64 maps! */
-				SlCopy(buf.data(), 1024, SLE_UINT8);
+				SlCopy(buf.data(), 1024, VarTypes::U8);
 				for (uint j = 0; j != 1024; j++) {
 					Tile(i++).m6() = GB(buf[j], 0, 2);
 					Tile(i++).m6() = GB(buf[j], 2, 2);
@@ -279,7 +279,7 @@ struct MAPEChunkHandler : ChunkHandler {
 			}
 		} else {
 			for (TileIndex i{}; i != size;) {
-				SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+				SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 				for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m6() = buf[j];
 			}
 		}
@@ -293,7 +293,7 @@ struct MAPEChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m6();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 		}
 	}
 };
@@ -307,7 +307,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m7() = buf[j];
 		}
 	}
@@ -320,7 +320,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m7();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
 		}
 	}
 };
@@ -334,7 +334,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U16);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m8() = buf[j];
 		}
 	}
@@ -347,7 +347,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 		SlSetLength(static_cast<uint32_t>(size) * sizeof(uint16_t));
 		for (TileIndex i{}; i != size;) {
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m8();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U16);
 		}
 	}
 };

--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -85,35 +85,35 @@ extern TimeoutTimer<TimerGameTick> _new_competitor_timeout;
 
 static const SaveLoad _date_desc[] = {
 	SLEG_CONDVAR("date", TimerGameCalendar::date, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-	SLEG_CONDVAR("date", TimerGameCalendar::date, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
-	    SLEG_VAR("date_fract",             TimerGameCalendar::date_fract,             SLE_UINT16),
+	SLEG_CONDVAR("date", TimerGameCalendar::date, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+	    SLEG_VAR("date_fract",             TimerGameCalendar::date_fract,             VarTypes::U16),
 	SLEG_CONDVAR("tick_counter", TimerGameTick::counter, VarFileType::U16 | VarMemType::U64, SaveLoadVersion::MinVersion, SaveLoadVersion::U64TickCounter),
-	SLEG_CONDVAR("tick_counter", TimerGameTick::counter, SLE_UINT64, SaveLoadVersion::U64TickCounter, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("economy_date", TimerGameEconomy::date, SLE_INT32, SaveLoadVersion::EconomyDate, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("economy_date_fract", TimerGameEconomy::date_fract, SLE_UINT16, SaveLoadVersion::EconomyDate, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("days_since_last_month", TimerGameEconomy::days_since_last_month, SLE_UINT32, SaveLoadVersion::IndustryAcceptedHistory, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("calendar_sub_date_fract", TimerGameCalendar::sub_date_fract, SLE_UINT16, SaveLoadVersion::CalendarSubDateFract, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("age_cargo_skip_counter", _age_cargo_skip_counter, SLE_UINT8, SaveLoadVersion::MinVersion, SaveLoadVersion::NewGRFCustomCargoAging),
+	SLEG_CONDVAR("tick_counter", TimerGameTick::counter, VarTypes::U64, SaveLoadVersion::U64TickCounter, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("economy_date", TimerGameEconomy::date, VarTypes::I32, SaveLoadVersion::EconomyDate, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("economy_date_fract", TimerGameEconomy::date_fract, VarTypes::U16, SaveLoadVersion::EconomyDate, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("days_since_last_month", TimerGameEconomy::days_since_last_month, VarTypes::U32, SaveLoadVersion::IndustryAcceptedHistory, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("calendar_sub_date_fract", TimerGameCalendar::sub_date_fract, VarTypes::U16, SaveLoadVersion::CalendarSubDateFract, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("age_cargo_skip_counter", _age_cargo_skip_counter, VarTypes::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::NewGRFCustomCargoAging),
 	SLEG_CONDVAR("cur_tileloop_tile", _cur_tileloop_tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLEG_CONDVAR("cur_tileloop_tile", _cur_tileloop_tile, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
-	    SLEG_VAR("next_disaster_start",         _disaster_delay,         SLE_UINT16),
-	    SLEG_VAR("random_state[0]",        _random.state[0],        SLE_UINT32),
-	    SLEG_VAR("random_state[1]",        _random.state[1],        SLE_UINT32),
+	SLEG_CONDVAR("cur_tileloop_tile", _cur_tileloop_tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	    SLEG_VAR("next_disaster_start",         _disaster_delay,         VarTypes::U16),
+	    SLEG_VAR("random_state[0]",        _random.state[0],        VarTypes::U32),
+	    SLEG_VAR("random_state[1]",        _random.state[1],        VarTypes::U32),
 	    SLEG_VAR("company_tick_counter", _cur_company_tick_index, VarFileType::U8  | VarMemType::U32),
-	    SLEG_VAR("trees_tick_counter",     _trees_tick_ctr,         SLE_UINT8),
-	SLEG_CONDVAR("pause_mode", _pause_mode, SLE_UINT8, SaveLoadVersion::TownTolerancePauseMode, SaveLoadVersion::MaxVersion),
-	SLEG_CONDSSTR("id", _game_session_stats.savegame_id, SLE_STR, SaveLoadVersion::SavegameId, SaveLoadVersion::MaxVersion),
+	    SLEG_VAR("trees_tick_counter",     _trees_tick_ctr,         VarTypes::U8),
+	SLEG_CONDVAR("pause_mode", _pause_mode, VarTypes::U8, SaveLoadVersion::TownTolerancePauseMode, SaveLoadVersion::MaxVersion),
+	SLEG_CONDSSTR("id", _game_session_stats.savegame_id, VarTypes::STR, SaveLoadVersion::SavegameId, SaveLoadVersion::MaxVersion),
 	/* For older savegames, we load the current value as the "period"; afterload will set the "fired" and "elapsed". */
 	SLEG_CONDVAR("next_competitor_start", _new_competitor_timeout.period.value, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::NextCompetitorStartOverflow),
-	SLEG_CONDVAR("next_competitor_start", _new_competitor_timeout.period.value, SLE_UINT32, SaveLoadVersion::NextCompetitorStartOverflow, SaveLoadVersion::AIStartDate),
-	SLEG_CONDVAR("competitors_interval", _new_competitor_timeout.period.value, SLE_UINT32, SaveLoadVersion::AIStartDate, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("competitors_interval_elapsed", _new_competitor_timeout.storage.elapsed, SLE_UINT32, SaveLoadVersion::AIStartDate, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("competitors_interval_fired", _new_competitor_timeout.fired, SLE_BOOL, SaveLoadVersion::AIStartDate, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("next_competitor_start", _new_competitor_timeout.period.value, VarTypes::U32, SaveLoadVersion::NextCompetitorStartOverflow, SaveLoadVersion::AIStartDate),
+	SLEG_CONDVAR("competitors_interval", _new_competitor_timeout.period.value, VarTypes::U32, SaveLoadVersion::AIStartDate, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("competitors_interval_elapsed", _new_competitor_timeout.storage.elapsed, VarTypes::U32, SaveLoadVersion::AIStartDate, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("competitors_interval_fired", _new_competitor_timeout.fired, VarTypes::BOOL, SaveLoadVersion::AIStartDate, SaveLoadVersion::MaxVersion),
 };
 
 static const SaveLoad _date_check_desc[] = {
 	SLEG_CONDVAR("date", _load_check_data.current_date, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-	SLEG_CONDVAR("date", _load_check_data.current_date, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("date", _load_check_data.current_date, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
 };
 
 /**
@@ -158,10 +158,10 @@ struct DATEChunkHandler : ChunkHandler {
 
 static const SaveLoad _view_desc[] = {
 	SLEG_CONDVAR("x", _saved_scrollpos_x, VarFileType::I16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLEG_CONDVAR("x", _saved_scrollpos_x, SLE_INT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("x", _saved_scrollpos_x, VarTypes::I32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	SLEG_CONDVAR("y", _saved_scrollpos_y, VarFileType::I16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLEG_CONDVAR("y", _saved_scrollpos_y, SLE_INT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
-	    SLEG_VAR("zoom", _saved_scrollpos_zoom, SLE_UINT8),
+	SLEG_CONDVAR("y", _saved_scrollpos_y, VarTypes::I32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	    SLEG_VAR("zoom", _saved_scrollpos_zoom, VarTypes::U8),
 };
 
 struct VIEWChunkHandler : ChunkHandler {

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -19,11 +19,11 @@
 
 /** Save and load the mapping between a spec and the NewGRF it came from. */
 static const SaveLoad _newgrf_mapping_desc[] = {
-	SLE_VAR(EntityIDMapping, grfid,         SLE_UINT32),
+	SLE_VAR(EntityIDMapping, grfid,         VarTypes::U32),
 	SLE_CONDVAR(EntityIDMapping, entity_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
-	SLE_CONDVAR(EntityIDMapping, entity_id, SLE_UINT16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(EntityIDMapping, entity_id, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(EntityIDMapping, substitute_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
-	SLE_CONDVAR(EntityIDMapping, substitute_id, SLE_UINT16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(EntityIDMapping, substitute_id, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 };
 
 /**
@@ -68,13 +68,13 @@ struct NGRFChunkHandler : ChunkHandler {
 	static inline uint8_t num_params;
 
 	static inline const SaveLoad description[] = {
-		   SLE_SSTR(GRFConfig, filename,         SLE_STR),
-		    SLE_VAR(GRFConfig, ident.grfid,      SLE_UINT32),
-		    SLE_ARR(GRFConfig, ident.md5sum,     SLE_UINT8,  16),
-		SLE_CONDVAR(GRFConfig, version, SLE_UINT32, SaveLoadVersion::StoreNewGRFVersion, SaveLoadVersion::MaxVersion),
-		   SLEG_ARR("param", param,              SLE_UINT32, std::size(param)),
-		   SLEG_VAR("num_params", num_params,    SLE_UINT8),
-		SLE_CONDVAR(GRFConfig, palette, SLE_UINT8, SaveLoadVersion::NewGRFPalette, SaveLoadVersion::MaxVersion),
+		   SLE_SSTR(GRFConfig, filename,         VarTypes::STR),
+		    SLE_VAR(GRFConfig, ident.grfid,      VarTypes::U32),
+		    SLE_ARR(GRFConfig, ident.md5sum,     VarTypes::U8,  16),
+		SLE_CONDVAR(GRFConfig, version, VarTypes::U32, SaveLoadVersion::StoreNewGRFVersion, SaveLoadVersion::MaxVersion),
+		   SLEG_ARR("param", param,              VarTypes::U32, std::size(param)),
+		   SLEG_VAR("num_params", num_params,    VarTypes::U8),
+		SLE_CONDVAR(GRFConfig, palette, VarTypes::U8, SaveLoadVersion::NewGRFPalette, SaveLoadVersion::MaxVersion),
 	};
 
 	void SaveParameters(const GRFConfig &config) const

--- a/src/saveload/object_sl.cpp
+++ b/src/saveload/object_sl.cpp
@@ -19,14 +19,14 @@
 #include "../safeguards.h"
 
 static const SaveLoad _object_desc[] = {
-	    SLE_VAR(Object, location.tile,              SLE_UINT32),
+	    SLE_VAR(Object, location.tile,              VarTypes::U32),
 	    SLE_VAR(Object, location.w,                 VarFileType::U8 | VarMemType::U16),
 	    SLE_VAR(Object, location.h,                 VarFileType::U8 | VarMemType::U16),
 	    SLE_REF(Object, town,                       SLRefType::Town),
-	    SLE_VAR(Object, build_date,                 SLE_UINT32),
-	SLE_CONDVARNAME(Object, recolour_offset, "colour", SLE_UINT8, SaveLoadVersion::IndustryPlatform, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Object, view, SLE_UINT8, SaveLoadVersion::NewGRFObjectView, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Object, type, SLE_UINT16, SaveLoadVersion::ObjectTypeToPool, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(Object, build_date,                 VarTypes::U32),
+	SLE_CONDVARNAME(Object, recolour_offset, "colour", VarTypes::U8, SaveLoadVersion::IndustryPlatform, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Object, view, VarTypes::U8, SaveLoadVersion::NewGRFObjectView, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Object, type, VarTypes::U16, SaveLoadVersion::ObjectTypeToPool, SaveLoadVersion::MaxVersion),
 };
 
 struct OBJSChunkHandler : ChunkHandler {

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -144,15 +144,15 @@ OldOrderSaveLoadItem &AllocateOldOrder(size_t pool_index)
 SaveLoadTable GetOrderDescription()
 {
 	static const SaveLoad _order_desc[] = {
-		     SLE_VARNAME(OldOrderSaveLoadItem, order.type,  "type",  SLE_UINT8),
-		     SLE_VARNAME(OldOrderSaveLoadItem, order.flags, "flags", SLE_UINT8),
-		     SLE_VARNAME(OldOrderSaveLoadItem, order.dest,  "dest",  SLE_UINT16),
+		     SLE_VARNAME(OldOrderSaveLoadItem, order.type,  "type",  VarTypes::U8),
+		     SLE_VARNAME(OldOrderSaveLoadItem, order.flags, "flags", VarTypes::U8),
+		     SLE_VARNAME(OldOrderSaveLoadItem, order.dest,  "dest",  VarTypes::U16),
 		 SLE_CONDVARNAME(OldOrderSaveLoadItem, next, "next", VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCargoPackets),
-		 SLE_CONDVARNAME(OldOrderSaveLoadItem, next, "next", SLE_UINT32, SaveLoadVersion::MoreCargoPackets, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVARNAME(OldOrderSaveLoadItem, order.refit_cargo, "refit_cargo", SLE_UINT8, SaveLoadVersion::RefitOrders, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVARNAME(OldOrderSaveLoadItem, order.wait_time, "wait_time", SLE_UINT16, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVARNAME(OldOrderSaveLoadItem, order.travel_time, "travel_time", SLE_UINT16, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVARNAME(OldOrderSaveLoadItem, order.max_speed, "max_speed", SLE_UINT16, SaveLoadVersion::OrderMaxSpeed, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVARNAME(OldOrderSaveLoadItem, next, "next", VarTypes::U32, SaveLoadVersion::MoreCargoPackets, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVARNAME(OldOrderSaveLoadItem, order.refit_cargo, "refit_cargo", VarTypes::U8, SaveLoadVersion::RefitOrders, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVARNAME(OldOrderSaveLoadItem, order.wait_time, "wait_time", VarTypes::U16, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVARNAME(OldOrderSaveLoadItem, order.travel_time, "travel_time", VarTypes::U16, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVARNAME(OldOrderSaveLoadItem, order.max_speed, "max_speed", VarTypes::U16, SaveLoadVersion::OrderMaxSpeed, SaveLoadVersion::MaxVersion),
 	};
 
 	return _order_desc;
@@ -174,7 +174,7 @@ struct ORDRChunkHandler : ChunkHandler {
 				len /= sizeof(uint16_t);
 				std::vector<uint16_t> orders(len);
 
-				SlCopy(&orders[0], len, SLE_UINT16);
+				SlCopy(&orders[0], len, VarTypes::U16);
 
 				for (size_t i = 0; i < len; ++i) {
 					auto &item = AllocateOldOrder(i);
@@ -184,7 +184,7 @@ struct ORDRChunkHandler : ChunkHandler {
 				len /= sizeof(uint32_t);
 				std::vector<uint32_t> orders(len);
 
-				SlCopy(&orders[0], len, SLE_UINT32);
+				SlCopy(&orders[0], len, VarTypes::U32);
 
 				for (size_t i = 0; i < len; ++i) {
 					auto &item = AllocateOldOrder(i);
@@ -218,13 +218,13 @@ template <typename T>
 class SlOrders : public VectorSaveLoadHandler<SlOrders<T>, T, Order> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VAR(Order, type,        SLE_UINT8),
-		SLE_VAR(Order, flags,       SLE_UINT8),
-		SLE_VAR(Order, dest,        SLE_UINT16),
-		SLE_VAR(Order, refit_cargo, SLE_UINT8),
-		SLE_VAR(Order, wait_time,   SLE_UINT16),
-		SLE_VAR(Order, travel_time, SLE_UINT16),
-		SLE_VAR(Order, max_speed,   SLE_UINT16),
+		SLE_VAR(Order, type,        VarTypes::U8),
+		SLE_VAR(Order, flags,       VarTypes::U8),
+		SLE_VAR(Order, dest,        VarTypes::U16),
+		SLE_VAR(Order, refit_cargo, VarTypes::U8),
+		SLE_VAR(Order, wait_time,   VarTypes::U16),
+		SLE_VAR(Order, travel_time, VarTypes::U16),
+		SLE_VAR(Order, max_speed,   VarTypes::U16),
 	};
 	static inline const SaveLoadCompatTable compat_description = {};
 
@@ -241,7 +241,7 @@ SaveLoadTable GetOrderListDescription()
 {
 	static const SaveLoad _orderlist_desc[] = {
 		SLE_CONDVARNAME(OrderList, old_order_index, "first", VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCargoPackets),
-		SLE_CONDVARNAME(OrderList, old_order_index, "first", SLE_UINT32, SaveLoadVersion::MoreCargoPackets, SaveLoadVersion::OrdersOwnedByOrderlist),
+		SLE_CONDVARNAME(OrderList, old_order_index, "first", VarTypes::U32, SaveLoadVersion::MoreCargoPackets, SaveLoadVersion::OrdersOwnedByOrderlist),
 		SLEG_CONDSTRUCTLIST("orders", SlOrders<OrderList>, SaveLoadVersion::OrdersOwnedByOrderlist, SaveLoadVersion::MaxVersion),
 	};
 
@@ -296,23 +296,23 @@ struct ORDLChunkHandler : ChunkHandler {
 SaveLoadTable GetOrderBackupDescription()
 {
 	static const SaveLoad _order_backup_desc[] = {
-		     SLE_VAR(OrderBackup, user,                     SLE_UINT32),
-		     SLE_VAR(OrderBackup, tile,                     SLE_UINT32),
-		     SLE_VAR(OrderBackup, group,                    SLE_UINT16),
+		     SLE_VAR(OrderBackup, user,                     VarTypes::U32),
+		     SLE_VAR(OrderBackup, tile,                     VarTypes::U32),
+		     SLE_VAR(OrderBackup, group,                    VarTypes::U16),
 		 SLE_CONDVAR(OrderBackup, service_interval, VarFileType::U32 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::FixOrderBackup),
-		 SLE_CONDVAR(OrderBackup, service_interval, SLE_UINT16, SaveLoadVersion::FixOrderBackup, SaveLoadVersion::MaxVersion),
-		    SLE_SSTR(OrderBackup, name,                     SLE_STR),
+		 SLE_CONDVAR(OrderBackup, service_interval, VarTypes::U16, SaveLoadVersion::FixOrderBackup, SaveLoadVersion::MaxVersion),
+		    SLE_SSTR(OrderBackup, name,                     VarTypes::STR),
 		 SLE_CONDREF(OrderBackup, clone, SLRefType::Vehicle, SaveLoadVersion::FixOrderBackup, SaveLoadVersion::MaxVersion),
-		     SLE_VAR(OrderBackup, cur_real_order_index,     SLE_UINT8),
-		 SLE_CONDVAR(OrderBackup, cur_implicit_order_index, SLE_UINT8, SaveLoadVersion::BackupOrderState, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(OrderBackup, current_order_time, SLE_UINT32, SaveLoadVersion::BackupOrderState, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(OrderBackup, lateness_counter, SLE_INT32, SaveLoadVersion::BackupOrderState, SaveLoadVersion::MaxVersion),
+		     SLE_VAR(OrderBackup, cur_real_order_index,     VarTypes::U8),
+		 SLE_CONDVAR(OrderBackup, cur_implicit_order_index, VarTypes::U8, SaveLoadVersion::BackupOrderState, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(OrderBackup, current_order_time, VarTypes::U32, SaveLoadVersion::BackupOrderState, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(OrderBackup, lateness_counter, VarTypes::I32, SaveLoadVersion::BackupOrderState, SaveLoadVersion::MaxVersion),
 		 SLE_CONDVAR(OrderBackup, timetable_start, VarFileType::I32 | VarMemType::U64, SaveLoadVersion::BackupOrderState, SaveLoadVersion::TimetableStartTicksFix),
-		 SLE_CONDVAR(OrderBackup, timetable_start, SLE_UINT64, SaveLoadVersion::TimetableStartTicksFix, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(OrderBackup, timetable_start, VarTypes::U64, SaveLoadVersion::TimetableStartTicksFix, SaveLoadVersion::MaxVersion),
 		 SLE_CONDVAR(OrderBackup, vehicle_flags, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::BackupOrderState, SaveLoadVersion::ServiceIntervalPercent),
-		 SLE_CONDVAR(OrderBackup, vehicle_flags, SLE_UINT16, SaveLoadVersion::ServiceIntervalPercent, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(OrderBackup, vehicle_flags, VarTypes::U16, SaveLoadVersion::ServiceIntervalPercent, SaveLoadVersion::MaxVersion),
 		SLE_CONDVARNAME(OrderBackup, old_order_index, "orders", VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCargoPackets),
-		SLE_CONDVARNAME(OrderBackup, old_order_index, "orders", SLE_UINT32, SaveLoadVersion::MoreCargoPackets, SaveLoadVersion::OrdersOwnedByOrderlist),
+		SLE_CONDVARNAME(OrderBackup, old_order_index, "orders", VarTypes::U32, SaveLoadVersion::MoreCargoPackets, SaveLoadVersion::OrdersOwnedByOrderlist),
 		SLEG_CONDSTRUCTLIST("orders", SlOrders<OrderBackup>, SaveLoadVersion::OrdersOwnedByOrderlist, SaveLoadVersion::MaxVersion),
 	};
 

--- a/src/saveload/randomizer_sl.cpp
+++ b/src/saveload/randomizer_sl.cpp
@@ -14,8 +14,8 @@
 #include "../safeguards.h"
 
 static const SaveLoad _randomizer_desc[] = {
-	SLE_VAR(Randomizer, state[0], SLE_UINT32),
-	SLE_VAR(Randomizer, state[1], SLE_UINT32),
+	SLE_VAR(Randomizer, state[0], VarTypes::U32),
+	SLE_VAR(Randomizer, state[1], VarTypes::U32),
 };
 
 struct SRNDChunkHandler : ChunkHandler {

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1187,8 +1187,8 @@ static void SlCopyInternal(void *object, size_t length, VarType conv)
 	 * as a byte-type. So detect this, and adjust object size accordingly */
 	if (_sl.action != SaveLoadAction::Save && _sl_version == SaveLoadVersion::MinVersion) {
 		/* all objects except difficulty settings */
-		if (conv == SLE_INT16 || conv == SLE_UINT16 || conv == SLE_STRINGID ||
-				conv == SLE_INT32 || conv == SLE_UINT32) {
+		if (conv == VarTypes::I16 || conv == VarTypes::U16 || conv == VarTypes::STRINGID ||
+				conv == VarTypes::I32 || conv == VarTypes::U32) {
 			SlCopyBytes(object, length * SlCalcConvFileLen(conv));
 			return;
 		}
@@ -1203,7 +1203,7 @@ static void SlCopyInternal(void *object, size_t length, VarType conv)
 
 	/* If the size of elements is 1 byte both in file and memory, no special
 	 * conversion is needed, use specialized copy-copy function to speed up things */
-	if (conv == SLE_INT8 || conv == SLE_UINT8) {
+	if (conv == VarTypes::I8 || conv == VarTypes::U8) {
 		SlCopyBytes(object, length);
 	} else {
 		uint8_t *a = static_cast<uint8_t *>(object);
@@ -1655,11 +1655,11 @@ static size_t SlCalcTableHeader(const SaveLoadTable &slt)
 	for (auto &sld : slt) {
 		if (!SlIsObjectValidInSavegame(sld)) continue;
 
-		length += SlCalcConvFileLen(SLE_UINT8);
+		length += SlCalcConvFileLen(VarTypes::U8);
 		length += SlCalcStdStringLen(&sld.name);
 	}
 
-	length += SlCalcConvFileLen(SLE_UINT8); // End-of-list entry.
+	length += SlCalcConvFileLen(VarTypes::U8); // End-of-list entry.
 
 	for (auto &sld : slt) {
 		if (!SlIsObjectValidInSavegame(sld)) continue;
@@ -1942,11 +1942,11 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 
 			while (true) {
 				SavegameFileType type{};
-				SlSaveLoadConv(&type.storage, SLE_UINT8);
+				SlSaveLoadConv(&type.storage, VarTypes::U8);
 				if (type.IsEnd()) break;
 
 				std::string key;
-				SlStdString(&key, SLE_STR);
+				SlStdString(&key, VarTypes::STR);
 
 				auto sld_it = key_lookup.find(key);
 				if (sld_it == key_lookup.end()) {
@@ -2012,13 +2012,13 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 				SavegameFileType type = GetSavegameFileType(sld);
 				assert(!type.IsEnd());
 
-				SlSaveLoadConv(&type.storage, SLE_UINT8);
-				SlStdString(const_cast<std::string *>(&sld.name), SLE_STR);
+				SlSaveLoadConv(&type.storage, VarTypes::U8);
+				SlStdString(const_cast<std::string *>(&sld.name), VarTypes::STR);
 			}
 
 			/* Add an end-of-header marker. */
 			SavegameFileType type{};
-			SlSaveLoadConv(&type.storage, SLE_UINT8);
+			SlSaveLoadConv(&type.storage, VarTypes::U8);
 
 			/* After the table, write down any sub-tables we might have. */
 			for (auto &sld : slt) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -744,19 +744,22 @@ constexpr VarType operator|(VarFileType file, VarMemType mem)
 	return {file, mem};
 }
 
-constexpr VarType SLE_BOOL{ VarFileType::I8, VarMemType::Bool }; ///< Store a boolean (as int8).
-constexpr VarType SLE_INT8{ VarFileType::I8, VarMemType::I8 }; ///< Store a 8 bits signed int.
-constexpr VarType SLE_UINT8{ VarFileType::U8, VarMemType::U8 }; ///< Store a 8 bits unsigned int.
-constexpr VarType SLE_INT16{ VarFileType::I16, VarMemType::I16 }; ///< Store a 16 bits signed int.
-constexpr VarType SLE_UINT16{ VarFileType::U16, VarMemType::U16 }; ///< Store a 16 bits unsigned int.
-constexpr VarType SLE_INT32{ VarFileType::I32, VarMemType::I32 }; ///< Store a 32 bits signed int.
-constexpr VarType SLE_UINT32{ VarFileType::U32, VarMemType::U32 }; ///< Store a 32 bits unsigned int.
-constexpr VarType SLE_INT64{ VarFileType::I64, VarMemType::I64 }; ///< Store a 64 bits signed int.
-constexpr VarType SLE_UINT64{ VarFileType::U64, VarMemType::U64 }; ///< Store a 64 bits unsigned int.
-constexpr VarType SLE_STRINGID{ VarFileType::StringID, VarMemType::U32 }; ///< Store a StringID.
-constexpr VarType SLE_STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
-constexpr VarType SLE_STRQ{ VarFileType::String, VarMemType::StrQ }; ///< Store a string with quotes.
-constexpr VarType SLE_NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
+/** Container for holding some default \c VarType instances. */
+struct VarTypes {
+	static constexpr VarType BOOL{ VarFileType::I8, VarMemType::Bool }; ///< Store a boolean (as int8).
+	static constexpr VarType I8{ VarFileType::I8, VarMemType::I8 }; ///< Store a 8 bits signed int.
+	static constexpr VarType U8{ VarFileType::U8, VarMemType::U8 }; ///< Store a 8 bits unsigned int.
+	static constexpr VarType I16{ VarFileType::I16, VarMemType::I16 }; ///< Store a 16 bits signed int.
+	static constexpr VarType U16{ VarFileType::U16, VarMemType::U16 }; ///< Store a 16 bits unsigned int.
+	static constexpr VarType I32{ VarFileType::I32, VarMemType::I32 }; ///< Store a 32 bits signed int.
+	static constexpr VarType U32{ VarFileType::U32, VarMemType::U32 }; ///< Store a 32 bits unsigned int.
+	static constexpr VarType I64{ VarFileType::I64, VarMemType::I64 }; ///< Store a 64 bits signed int.
+	static constexpr VarType U64{ VarFileType::U64, VarMemType::U64 }; ///< Store a 64 bits unsigned int.
+	static constexpr VarType STRINGID{ VarFileType::StringID, VarMemType::U32 }; ///< Store a StringID.
+	static constexpr VarType STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
+	static constexpr VarType STRQ{ VarFileType::String, VarMemType::StrQ }; ///< Store a string with quotes.
+	static constexpr VarType NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
+};
 
 /** Type of data saved. */
 enum class SaveLoadType : uint8_t {

--- a/src/saveload/signs_sl.cpp
+++ b/src/saveload/signs_sl.cpp
@@ -19,16 +19,16 @@
 
 /** Description of a sign within the savegame. */
 static const SaveLoad _sign_desc[] = {
-	SLE_CONDVAR(Sign, name, SLE_NAME, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
-	SLE_CONDSSTR(Sign, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Sign, name, VarTypes::NAME, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
+	SLE_CONDSSTR(Sign, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Sign, x, VarFileType::I16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
 	SLE_CONDVAR(Sign, y, VarFileType::I16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
-	SLE_CONDVAR(Sign, x, SLE_INT32, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Sign, y, SLE_INT32, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Sign, owner, SLE_UINT8, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Sign, x, VarTypes::I32, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Sign, y, VarTypes::I32, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Sign, owner, VarTypes::U8, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Sign, z, VarFileType::U8 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::VehicleCentreAndZPos),
-	SLE_CONDVAR(Sign, z, SLE_INT32, SaveLoadVersion::VehicleCentreAndZPos, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Sign, text_colour, SLE_UINT8, SaveLoadVersion::SignTextColours, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Sign, z, VarTypes::I32, SaveLoadVersion::VehicleCentreAndZPos, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Sign, text_colour, VarTypes::U8, SaveLoadVersion::SignTextColours, SaveLoadVersion::MaxVersion),
 };
 
 struct SIGNChunkHandler : ChunkHandler {

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -157,8 +157,8 @@ void AfterLoadRoadStops()
 }
 
 static const SaveLoad _roadstop_desc[] = {
-	SLE_VAR(RoadStop, xy,           SLE_UINT32),
-	SLE_VAR(RoadStop, status,       SLE_UINT8),
+	SLE_VAR(RoadStop, xy,           VarTypes::U32),
+	SLE_VAR(RoadStop, status,       VarTypes::U8),
 	SLE_REF(RoadStop, next,         SLRefType::RoadStop),
 };
 
@@ -209,9 +209,9 @@ template <typename T>
 class SlStationSpecList : public VectorSaveLoadHandler<SlStationSpecList<T>, BaseStation, SpecMapping<T>> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(SpecMapping<T>, grfid, SLE_UINT32, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(SpecMapping<T>, grfid, VarTypes::U32, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(SpecMapping<T>, localidx, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::NewGRFStations, SaveLoadVersion::ExtendEntityMapping),
-		SLE_CONDVAR(SpecMapping<T>, localidx, SLE_UINT16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(SpecMapping<T>, localidx, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _station_spec_list_sl_compat;
 
@@ -234,8 +234,8 @@ public:
 	using StationWaitingTriggersPair = std::pair<const TileIndex, StationRandomTriggers>;
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(StationWaitingTriggersPair, first, SLE_UINT32),
-		SLE_VAR(StationWaitingTriggersPair, second, SLE_UINT8),
+		SLE_VAR(StationWaitingTriggersPair, first, VarTypes::U32),
+		SLE_VAR(StationWaitingTriggersPair, second, VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = _station_cargo_sl_compat;
 
@@ -263,7 +263,7 @@ public:
 class SlStationCargo : public DefaultSaveLoadHandler<SlStationCargo, GoodsEntry> {
 public:
 	static inline const SaveLoad description[] = {
-		    SLE_VAR(StationCargoPair, first,  SLE_UINT16),
+		    SLE_VAR(StationCargoPair, first,  VarTypes::U16),
 		SLE_REFLIST(StationCargoPair, second, SLRefType::CargoPacket),
 	};
 	static inline const SaveLoadCompatTable compat_description = _station_cargo_sl_compat;
@@ -309,10 +309,10 @@ public:
 class SlStationFlow : public DefaultSaveLoadHandler<SlStationFlow, GoodsEntry> {
 public:
 	static inline const SaveLoad description[] = {
-		    SLE_VAR(FlowSaveLoad, source,     SLE_UINT16),
-		    SLE_VAR(FlowSaveLoad, via,        SLE_UINT16),
-		    SLE_VAR(FlowSaveLoad, share,      SLE_UINT32),
-		SLE_CONDVAR(FlowSaveLoad, restricted, SLE_BOOL, SaveLoadVersion::LinkgraphRestrictedFlow, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(FlowSaveLoad, source,     VarTypes::U16),
+		    SLE_VAR(FlowSaveLoad, via,        VarTypes::U16),
+		    SLE_VAR(FlowSaveLoad, share,      VarTypes::U32),
+		SLE_CONDVAR(FlowSaveLoad, restricted, VarTypes::BOOL, SaveLoadVersion::LinkgraphRestrictedFlow, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _station_flow_sl_compat;
 
@@ -371,26 +371,26 @@ public:
 	static inline uint cargo_reserved_count;
 
 	static inline const SaveLoad description[] = {
-		SLEG_CONDVAR("waiting_acceptance", _waiting_acceptance, SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::CargoPackets),
-		 SLE_CONDVAR(GoodsEntry, status, SLE_UINT8, SaveLoadVersion::CargoPackets, SaveLoadVersion::MaxVersion),
-		     SLE_VAR(GoodsEntry, time_since_pickup,    SLE_UINT8),
-		     SLE_VAR(GoodsEntry, rating,               SLE_UINT8),
+		SLEG_CONDVAR("waiting_acceptance", _waiting_acceptance, VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::CargoPackets),
+		 SLE_CONDVAR(GoodsEntry, status, VarTypes::U8, SaveLoadVersion::CargoPackets, SaveLoadVersion::MaxVersion),
+		     SLE_VAR(GoodsEntry, time_since_pickup,    VarTypes::U8),
+		     SLE_VAR(GoodsEntry, rating,               VarTypes::U8),
 		SLEG_CONDVAR("cargo_source", _cargo_source, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerCargoSource),
-		SLEG_CONDVAR("cargo_source", _cargo_source, SLE_UINT16, SaveLoadVersion::LargerCargoSource, SaveLoadVersion::CargoPackets),
-		SLEG_CONDVAR("cargo_source_xy", _cargo_source_xy, SLE_UINT32, SaveLoadVersion::CargoSourceTile, SaveLoadVersion::CargoPackets),
-		SLEG_CONDVAR("cargo_days", _cargo_periods, SLE_UINT8, SaveLoadVersion::MinVersion, SaveLoadVersion::CargoPackets),
-		     SLE_VAR(GoodsEntry, last_speed,           SLE_UINT8),
-		     SLE_VAR(GoodsEntry, last_age,             SLE_UINT8),
+		SLEG_CONDVAR("cargo_source", _cargo_source, VarTypes::U16, SaveLoadVersion::LargerCargoSource, SaveLoadVersion::CargoPackets),
+		SLEG_CONDVAR("cargo_source_xy", _cargo_source_xy, VarTypes::U32, SaveLoadVersion::CargoSourceTile, SaveLoadVersion::CargoPackets),
+		SLEG_CONDVAR("cargo_days", _cargo_periods, VarTypes::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::CargoPackets),
+		     SLE_VAR(GoodsEntry, last_speed,           VarTypes::U8),
+		     SLE_VAR(GoodsEntry, last_age,             VarTypes::U8),
 		SLEG_CONDVAR("cargo_feeder_share", _cargo_feeder_share, VarFileType::U32 | VarMemType::I64, SaveLoadVersion::TransferOrder, SaveLoadVersion::UnifyCurrency),
-		SLEG_CONDVAR("cargo_feeder_share", _cargo_feeder_share, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::CargoPackets),
-		 SLE_CONDVAR(GoodsEntry, amount_fract, SLE_UINT8, SaveLoadVersion::FractionalCargoDelivery, SaveLoadVersion::MaxVersion),
+		SLEG_CONDVAR("cargo_feeder_share", _cargo_feeder_share, VarTypes::I64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::CargoPackets),
+		 SLE_CONDVAR(GoodsEntry, amount_fract, VarTypes::U8, SaveLoadVersion::FractionalCargoDelivery, SaveLoadVersion::MaxVersion),
 		SLEG_CONDREFLIST("packets", _packets, SLRefType::CargoPacket, SaveLoadVersion::CargoPackets, SaveLoadVersion::Cargodist),
-		SLEG_CONDVAR("old_num_dests", _old_num_dests, SLE_UINT32, SaveLoadVersion::Cargodist, SaveLoadVersion::SaveloadListLength),
-		SLEG_CONDVAR("cargo.reserved_count", SlStationGoods::cargo_reserved_count, SLE_UINT32, SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(GoodsEntry, link_graph, SLE_UINT16, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(GoodsEntry, node, SLE_UINT16, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
-		SLEG_CONDVAR("old_num_flows", _old_num_flows, SLE_UINT32, SaveLoadVersion::Cargodist, SaveLoadVersion::SaveloadListLength),
-		 SLE_CONDVAR(GoodsEntry, max_waiting_cargo, SLE_UINT32, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
+		SLEG_CONDVAR("old_num_dests", _old_num_dests, VarTypes::U32, SaveLoadVersion::Cargodist, SaveLoadVersion::SaveloadListLength),
+		SLEG_CONDVAR("cargo.reserved_count", SlStationGoods::cargo_reserved_count, VarTypes::U32, SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(GoodsEntry, link_graph, VarTypes::U16, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(GoodsEntry, node, VarTypes::U16, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
+		SLEG_CONDVAR("old_num_flows", _old_num_flows, VarTypes::U32, SaveLoadVersion::Cargodist, SaveLoadVersion::SaveloadListLength),
+		 SLE_CONDVAR(GoodsEntry, max_waiting_cargo, VarTypes::U32, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
 		SLEG_CONDSTRUCTLIST("flow", SlStationFlow, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
 		SLEG_CONDSTRUCTLIST("cargo", SlStationCargo, SaveLoadVersion::Cargodist, SaveLoadVersion::MaxVersion),
 	};
@@ -486,43 +486,43 @@ public:
 
 static const SaveLoad _old_station_desc[] = {
 	SLE_CONDVAR(Station, xy, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(Station, xy, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Station, xy, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Station, train_station.tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(Station, train_station.tile, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Station, train_station.tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Station, airport.tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(Station, airport.tile, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Station, airport.tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	    SLE_REF(Station, town,                       SLRefType::Town),
 	    SLE_VAR(Station, train_station.w,            VarFileType::U8 | VarMemType::U16),
 	SLE_CONDVAR(Station, train_station.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
-	    SLE_VAR(Station, string_id,                  SLE_STRINGID),
-	SLE_CONDSSTR(Station, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Station, indtype, SLE_UINT8, SaveLoadVersion::NewGRFSuppliedStationName, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(Station, string_id,                  VarTypes::STRINGID),
+	SLE_CONDSSTR(Station, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Station, indtype, VarTypes::U8, SaveLoadVersion::NewGRFSuppliedStationName, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Station, had_vehicle_of_type, VarFileType::U16 | VarMemType::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::WaypointMoreLikeStation),
-	SLE_CONDVAR(Station, had_vehicle_of_type, SLE_UINT8, SaveLoadVersion::WaypointMoreLikeStation, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Station, had_vehicle_of_type, VarTypes::U8, SaveLoadVersion::WaypointMoreLikeStation, SaveLoadVersion::MaxVersion),
 
-	    SLE_VAR(Station, time_since_load,            SLE_UINT8),
-	    SLE_VAR(Station, time_since_unload,          SLE_UINT8),
-	    SLE_VAR(Station, delete_ctr,                 SLE_UINT8),
-	    SLE_VAR(Station, owner,                      SLE_UINT8),
-	    SLE_VAR(Station, facilities,                 SLE_UINT8),
-	    SLE_VAR(Station, airport.type,               SLE_UINT8),
+	    SLE_VAR(Station, time_since_load,            VarTypes::U8),
+	    SLE_VAR(Station, time_since_unload,          VarTypes::U8),
+	    SLE_VAR(Station, delete_ctr,                 VarTypes::U8),
+	    SLE_VAR(Station, owner,                      VarTypes::U8),
+	    SLE_VAR(Station, facilities,                 VarTypes::U8),
+	    SLE_VAR(Station, airport.type,               VarTypes::U8),
 	SLE_CONDVARNAME(Station, airport.blocks, "airport.flags", VarFileType::U16 | VarMemType::U64, SaveLoadVersion::MinVersion, SaveLoadVersion::BiggerStationVariables),
 	SLE_CONDVARNAME(Station, airport.blocks, "airport.flags", VarFileType::U32 | VarMemType::U64, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::MoreAirportBlocks),
-	SLE_CONDVARNAME(Station, airport.blocks, "airport.flags", SLE_UINT64, SaveLoadVersion::MoreAirportBlocks, SaveLoadVersion::MaxVersion),
+	SLE_CONDVARNAME(Station, airport.blocks, "airport.flags", VarTypes::U64, SaveLoadVersion::MoreAirportBlocks, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Station, last_vehicle_type, SLE_UINT8, SaveLoadVersion::LastVehicleType, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Station, last_vehicle_type, VarTypes::U8, SaveLoadVersion::LastVehicleType, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDVAR(Station, build_date, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::BigDates),
-	SLE_CONDVAR(Station, build_date, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Station, build_date, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDREF(Station, bus_stops, SLRefType::RoadStop, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	SLE_CONDREF(Station, truck_stops, SLRefType::RoadStop, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 
 	/* Used by newstations for graphic variations */
-	SLE_CONDVAR(Station, random_bits, SLE_UINT16, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
-	SLE_CONDVARNAME(Station, waiting_random_triggers, "waiting_triggers", SLE_UINT8, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
-	SLEG_CONDVAR("num_specs", SlStationSpecList<StationSpec>::last_num_specs, SLE_UINT8, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Station, random_bits, VarTypes::U16, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
+	SLE_CONDVARNAME(Station, waiting_random_triggers, "waiting_triggers", VarTypes::U8, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
+	SLEG_CONDVAR("num_specs", SlStationSpecList<StationSpec>::last_num_specs, VarTypes::U8, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDREFLIST(Station, loading_vehicles, SLRefType::Vehicle, SaveLoadVersion::FifoLoading, SaveLoadVersion::MaxVersion),
 
@@ -566,9 +566,9 @@ struct STNSChunkHandler : ChunkHandler {
 class SlRoadStopTileData : public VectorSaveLoadHandler<SlRoadStopTileData, BaseStation, RoadStopTileData> {
 public:
 	static inline const SaveLoad description[] = {
-	    SLE_VAR(RoadStopTileData, tile,            SLE_UINT32),
-	    SLE_VAR(RoadStopTileData, random_bits,     SLE_UINT8),
-	    SLE_VAR(RoadStopTileData, animation_frame, SLE_UINT8),
+	    SLE_VAR(RoadStopTileData, tile,            VarTypes::U32),
+	    SLE_VAR(RoadStopTileData, random_bits,     VarTypes::U8),
+	    SLE_VAR(RoadStopTileData, animation_frame, VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = {};
 
@@ -582,20 +582,20 @@ public:
 class SlStationBase : public DefaultSaveLoadHandler<SlStationBase, BaseStation> {
 public:
 	static inline const SaveLoad description[] = {
-		    SLE_VAR(BaseStation, xy,                     SLE_UINT32),
+		    SLE_VAR(BaseStation, xy,                     VarTypes::U32),
 		    SLE_REF(BaseStation, town,                   SLRefType::Town),
-		    SLE_VAR(BaseStation, string_id,              SLE_STRINGID),
-		   SLE_SSTR(BaseStation, name,                   SLE_STR | StringValidationSetting::AllowControlCode),
-		    SLE_VAR(BaseStation, delete_ctr,             SLE_UINT8),
-		    SLE_VAR(BaseStation, owner,                  SLE_UINT8),
-		    SLE_VAR(BaseStation, facilities,             SLE_UINT8),
-		    SLE_VAR(BaseStation, build_date,             SLE_INT32),
+		    SLE_VAR(BaseStation, string_id,              VarTypes::STRINGID),
+		   SLE_SSTR(BaseStation, name,                   VarTypes::STR | StringValidationSetting::AllowControlCode),
+		    SLE_VAR(BaseStation, delete_ctr,             VarTypes::U8),
+		    SLE_VAR(BaseStation, owner,                  VarTypes::U8),
+		    SLE_VAR(BaseStation, facilities,             VarTypes::U8),
+		    SLE_VAR(BaseStation, build_date,             VarTypes::I32),
 
 		/* Used by newstations for graphic variations */
-		    SLE_VAR(BaseStation, random_bits,            SLE_UINT16),
-		    SLE_VARNAME(BaseStation, waiting_random_triggers, "waiting_triggers", SLE_UINT8),
+		    SLE_VAR(BaseStation, random_bits,            VarTypes::U16),
+		    SLE_VARNAME(BaseStation, waiting_random_triggers, "waiting_triggers", VarTypes::U8),
 	   SLEG_STRUCTLIST("tile_waiting_triggers", SlStationWaitingTriggers),
-	 SLEG_CONDVAR("num_specs", SlStationSpecList<StationSpec>::last_num_specs, SLE_UINT8, SaveLoadVersion::MinVersion, SaveLoadVersion::SaveloadListLength),
+	 SLEG_CONDVAR("num_specs", SlStationSpecList<StationSpec>::last_num_specs, VarTypes::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::SaveloadListLength),
 	};
 	static inline const SaveLoadCompatTable compat_description = _station_base_sl_compat;
 
@@ -622,37 +622,37 @@ class SlStationNormal : public DefaultSaveLoadHandler<SlStationNormal, BaseStati
 public:
 	static inline const SaveLoad description[] = {
 		SLEG_STRUCT("base", SlStationBase),
-		    SLE_VAR(Station, train_station.tile,         SLE_UINT32),
+		    SLE_VAR(Station, train_station.tile,         VarTypes::U32),
 		    SLE_VAR(Station, train_station.w,            VarFileType::U8 | VarMemType::U16),
 		    SLE_VAR(Station, train_station.h,            VarFileType::U8 | VarMemType::U16),
 
 		    SLE_REF(Station, bus_stops,                  SLRefType::RoadStop),
 		    SLE_REF(Station, truck_stops,                SLRefType::RoadStop),
-		SLE_CONDVAR(Station, ship_station.tile, SLE_UINT32, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Station, ship_station.tile, VarTypes::U32, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Station, ship_station.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Station, ship_station.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Station, docking_station.tile, SLE_UINT32, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Station, docking_station.tile, VarTypes::U32, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Station, docking_station.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Station, docking_station.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Station, airport.tile,               SLE_UINT32),
+		    SLE_VAR(Station, airport.tile,               VarTypes::U32),
 		SLE_CONDVAR(Station, airport.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::StoreAirportSize, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Station, airport.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::StoreAirportSize, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Station, airport.type,               SLE_UINT8),
-		SLE_CONDVAR(Station, airport.layout, SLE_UINT8, SaveLoadVersion::NewGRFAirportSmoke, SaveLoadVersion::MaxVersion),
-		SLE_VARNAME(Station, airport.blocks, "airport.flags", SLE_UINT64),
-		SLE_CONDVAR(Station, airport.rotation, SLE_UINT8, SaveLoadVersion::NewGRFAirportSmoke, SaveLoadVersion::MaxVersion),
-		SLEG_CONDARR("storage", _old_st_persistent_storage.storage, SLE_UINT32, 16, SaveLoadVersion::NewGRFAirportSmoke, SaveLoadVersion::PersistentStoragePool),
+		    SLE_VAR(Station, airport.type,               VarTypes::U8),
+		SLE_CONDVAR(Station, airport.layout, VarTypes::U8, SaveLoadVersion::NewGRFAirportSmoke, SaveLoadVersion::MaxVersion),
+		SLE_VARNAME(Station, airport.blocks, "airport.flags", VarTypes::U64),
+		SLE_CONDVAR(Station, airport.rotation, VarTypes::U8, SaveLoadVersion::NewGRFAirportSmoke, SaveLoadVersion::MaxVersion),
+		SLEG_CONDARR("storage", _old_st_persistent_storage.storage, VarTypes::U32, 16, SaveLoadVersion::NewGRFAirportSmoke, SaveLoadVersion::PersistentStoragePool),
 		SLE_CONDREF(Station, airport.psa, SLRefType::Storage, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::MaxVersion),
 
-		    SLE_VAR(Station, indtype,                    SLE_UINT8),
+		    SLE_VAR(Station, indtype,                    VarTypes::U8),
 
-		    SLE_VAR(Station, time_since_load,            SLE_UINT8),
-		    SLE_VAR(Station, time_since_unload,          SLE_UINT8),
-		    SLE_VAR(Station, last_vehicle_type,          SLE_UINT8),
-		    SLE_VAR(Station, had_vehicle_of_type,        SLE_UINT8),
+		    SLE_VAR(Station, time_since_load,            VarTypes::U8),
+		    SLE_VAR(Station, time_since_unload,          VarTypes::U8),
+		    SLE_VAR(Station, last_vehicle_type,          VarTypes::U8),
+		    SLE_VAR(Station, had_vehicle_of_type,        VarTypes::U8),
 		SLE_REFLIST(Station, loading_vehicles,           SLRefType::Vehicle),
 		SLE_CONDVAR(Station, always_accepted, VarFileType::U32 | VarMemType::U64, SaveLoadVersion::TownAcceptance, SaveLoadVersion::ExtendCargotypes),
-		SLE_CONDVAR(Station, always_accepted, SLE_UINT64, SaveLoadVersion::ExtendCargotypes, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Station, always_accepted, VarTypes::U64, SaveLoadVersion::ExtendCargotypes, SaveLoadVersion::MaxVersion),
 		SLEG_CONDSTRUCTLIST("speclist", SlRoadStopTileData, SaveLoadVersion::NewGRFRoadStops, SaveLoadVersion::RoadStopTileData),
 		SLEG_STRUCTLIST("goods", SlStationGoods),
 	};
@@ -681,13 +681,13 @@ class SlStationWaypoint : public DefaultSaveLoadHandler<SlStationWaypoint, BaseS
 public:
 	static inline const SaveLoad description[] = {
 		SLEG_STRUCT("base", SlStationBase),
-		    SLE_VAR(Waypoint, town_cn,                   SLE_UINT16),
+		    SLE_VAR(Waypoint, town_cn,                   VarTypes::U16),
 
-		SLE_CONDVAR(Waypoint, train_station.tile, SLE_UINT32, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Waypoint, train_station.tile, VarTypes::U32, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Waypoint, train_station.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Waypoint, train_station.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Waypoint, waypoint_flags, SLE_UINT16, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Waypoint, road_waypoint_area.tile, SLE_UINT32, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Waypoint, waypoint_flags, VarTypes::U16, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Waypoint, road_waypoint_area.tile, VarTypes::U32, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Waypoint, road_waypoint_area.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Waypoint, road_waypoint_area.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
 	};

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -18,9 +18,9 @@
 
 /** Description of the data to save and load in #PersistentStorage. */
 static const SaveLoad _storage_desc[] = {
-	 SLE_CONDVAR(PersistentStorage, grfid, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
-	 SLE_CONDARR(PersistentStorage, storage, SLE_UINT32, 16, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::ExtendPersistentStorage),
-	 SLE_CONDARR(PersistentStorage, storage, SLE_UINT32, 256, SaveLoadVersion::ExtendPersistentStorage, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(PersistentStorage, grfid, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	 SLE_CONDARR(PersistentStorage, storage, VarTypes::U32, 16, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::ExtendPersistentStorage),
+	 SLE_CONDARR(PersistentStorage, storage, VarTypes::U32, 256, SaveLoadVersion::ExtendPersistentStorage, SaveLoadVersion::MaxVersion),
 };
 
 /** Persistent storage data. */

--- a/src/saveload/story_sl.cpp
+++ b/src/saveload/story_sl.cpp
@@ -30,12 +30,12 @@ void AfterLoadStoryBook()
 
 static const SaveLoad _story_page_elements_desc[] = {
 	SLE_CONDVAR(StoryPageElement, sort_value, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::Storybooks),
-	SLE_CONDVAR(StoryPageElement, sort_value, SLE_UINT32, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
-	    SLE_VAR(StoryPageElement, page,          SLE_UINT16),
+	SLE_CONDVAR(StoryPageElement, sort_value, VarTypes::U32, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(StoryPageElement, page,          VarTypes::U16),
 	SLE_CONDVAR(StoryPageElement, type, VarFileType::U16 | VarMemType::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::Storybooks),
-	SLE_CONDVAR(StoryPageElement, type, SLE_UINT8, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
-	    SLE_VAR(StoryPageElement, referenced_id, SLE_UINT32),
-	   SLE_SSTR(StoryPageElement, text,          SLE_STR | StringValidationSetting::AllowControlCode),
+	SLE_CONDVAR(StoryPageElement, type, VarTypes::U8, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(StoryPageElement, referenced_id, VarTypes::U32),
+	   SLE_SSTR(StoryPageElement, text,          VarTypes::STR | StringValidationSetting::AllowControlCode),
 };
 
 struct STPEChunkHandler : ChunkHandler {
@@ -73,11 +73,11 @@ struct STPEChunkHandler : ChunkHandler {
 
 static const SaveLoad _story_pages_desc[] = {
 	SLE_CONDVAR(StoryPage, sort_value, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::Storybooks),
-	SLE_CONDVAR(StoryPage, sort_value, SLE_UINT32, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
-	    SLE_VAR(StoryPage, date,       SLE_UINT32),
+	SLE_CONDVAR(StoryPage, sort_value, VarTypes::U32, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(StoryPage, date,       VarTypes::U32),
 	SLE_CONDVAR(StoryPage, company, VarFileType::U16 | VarMemType::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::Storybooks),
-	SLE_CONDVAR(StoryPage, company, SLE_UINT8, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
-	   SLE_SSTR(StoryPage, title,      SLE_STR | StringValidationSetting::AllowControlCode),
+	SLE_CONDVAR(StoryPage, company, VarTypes::U8, SaveLoadVersion::Storybooks, SaveLoadVersion::MaxVersion),
+	   SLE_SSTR(StoryPage, title,      VarTypes::STR | StringValidationSetting::AllowControlCode),
 };
 
 struct STPAChunkHandler : ChunkHandler {

--- a/src/saveload/subsidy_sl.cpp
+++ b/src/saveload/subsidy_sl.cpp
@@ -17,16 +17,16 @@
 #include "../safeguards.h"
 
 static const SaveLoad _subsidies_desc[] = {
-	    SLE_VAR(Subsidy, cargo_type, SLE_UINT8),
+	    SLE_VAR(Subsidy, cargo_type, VarTypes::U8),
 	SLE_CONDVAR(Subsidy, remaining, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::CustomSubsidyDuration),
-	SLE_CONDVAR(Subsidy, remaining, SLE_UINT16, SaveLoadVersion::CustomSubsidyDuration, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Subsidy, awarded, SLE_UINT8, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
-	SLE_CONDVARNAME(Subsidy, src.type, "src_type", SLE_UINT8, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
-	SLE_CONDVARNAME(Subsidy, dst.type, "dst_type", SLE_UINT8, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Subsidy, remaining, VarTypes::U16, SaveLoadVersion::CustomSubsidyDuration, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Subsidy, awarded, VarTypes::U8, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
+	SLE_CONDVARNAME(Subsidy, src.type, "src_type", VarTypes::U8, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
+	SLE_CONDVARNAME(Subsidy, dst.type, "dst_type", VarTypes::U8, SaveLoadVersion::RemoveSubsidyStationBinding, SaveLoadVersion::MaxVersion),
 	SLE_CONDVARNAME(Subsidy, src.id, "src", VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
-	SLE_CONDVARNAME(Subsidy, src.id, "src", SLE_UINT16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
+	SLE_CONDVARNAME(Subsidy, src.id, "src", VarTypes::U16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
 	SLE_CONDVARNAME(Subsidy, dst.id, "dst", VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
-	SLE_CONDVARNAME(Subsidy, dst.id, "dst", SLE_UINT16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
+	SLE_CONDVARNAME(Subsidy, dst.id, "dst", VarTypes::U16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
 };
 
 struct SUBSChunkHandler : ChunkHandler {

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -117,10 +117,10 @@ void UpdateHousesAndTowns()
 class SlTownOldSupplied : public DefaultSaveLoadHandler<SlTownOldSupplied, Town> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(TransportedCargoStat<uint32_t>, old_max, SLE_UINT32, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(TransportedCargoStat<uint32_t>, new_max, SLE_UINT32, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(TransportedCargoStat<uint32_t>, old_act, SLE_UINT32, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(TransportedCargoStat<uint32_t>, new_act, SLE_UINT32, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(TransportedCargoStat<uint32_t>, old_max, VarTypes::U32, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(TransportedCargoStat<uint32_t>, new_max, VarTypes::U32, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(TransportedCargoStat<uint32_t>, old_act, VarTypes::U32, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(TransportedCargoStat<uint32_t>, new_act, VarTypes::U32, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _town_supplied_sl_compat;
 
@@ -158,8 +158,8 @@ public:
 class SlTownSuppliedHistory : public DefaultSaveLoadHandler<SlTownSuppliedHistory, Town::SuppliedCargo> {
 public:
 	static inline const SaveLoad description[] = {
-		 SLE_VAR(Town::SuppliedHistory, production, SLE_UINT32),
-		 SLE_VAR(Town::SuppliedHistory, transported, SLE_UINT32),
+		 SLE_VAR(Town::SuppliedHistory, production, VarTypes::U32),
+		 SLE_VAR(Town::SuppliedHistory, transported, VarTypes::U32),
 	};
 	static inline const SaveLoadCompatTable compat_description = {};
 
@@ -186,7 +186,7 @@ public:
 class SlTownSupplied : public VectorSaveLoadHandler<SlTownSupplied, Town, Town::SuppliedCargo> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(Town::SuppliedCargo, cargo, SLE_UINT8),
+		SLE_VAR(Town::SuppliedCargo, cargo, VarTypes::U8),
 		SLEG_STRUCTLIST("history", SlTownSuppliedHistory),
 	};
 	inline const static SaveLoadCompatTable compat_description = {};
@@ -199,7 +199,7 @@ class SlTownAcceptedHistory : public DefaultSaveLoadHandler<SlTownAcceptedHistor
 public:
 	/** Saveload description for handler. */
 	static inline const SaveLoad description[] = {
-		 SLE_VAR(Town::AcceptedHistory, accepted, SLE_UINT32),
+		 SLE_VAR(Town::AcceptedHistory, accepted, VarTypes::U32),
 	};
 	/** Compatibility saveload description for handler. */
 	static inline const SaveLoadCompatTable compat_description = {};
@@ -229,7 +229,7 @@ class SlTownAccepted : public VectorSaveLoadHandler<SlTownAccepted, Town, Town::
 public:
 	/** Saveload description for handler. */
 	inline static const SaveLoad description[] = {
-		SLE_VAR(Town::AcceptedCargo, cargo, SLE_UINT8),
+		SLE_VAR(Town::AcceptedCargo, cargo, VarTypes::U8),
 		SLEG_STRUCTLIST("history", SlTownAcceptedHistory),
 	};
 	/** Compatibility saveload description for handler. */
@@ -241,10 +241,10 @@ public:
 class SlTownReceived : public DefaultSaveLoadHandler<SlTownReceived, Town> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(TransportedCargoStat<uint16_t>, old_max, SLE_UINT16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(TransportedCargoStat<uint16_t>, new_max, SLE_UINT16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(TransportedCargoStat<uint16_t>, old_act, SLE_UINT16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(TransportedCargoStat<uint16_t>, new_act, SLE_UINT16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(TransportedCargoStat<uint16_t>, old_max, VarTypes::U16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(TransportedCargoStat<uint16_t>, new_max, VarTypes::U16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(TransportedCargoStat<uint16_t>, old_act, VarTypes::U16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(TransportedCargoStat<uint16_t>, new_act, VarTypes::U16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _town_received_sl_compat;
 
@@ -274,9 +274,9 @@ private:
 	};
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VAR(AcceptanceMatrix, area.tile, SLE_UINT32),
-		SLE_VAR(AcceptanceMatrix, area.w,    SLE_UINT16),
-		SLE_VAR(AcceptanceMatrix, area.h,    SLE_UINT16),
+		SLE_VAR(AcceptanceMatrix, area.tile, VarTypes::U32),
+		SLE_VAR(AcceptanceMatrix, area.w,    VarTypes::U16),
+		SLE_VAR(AcceptanceMatrix, area.h,    VarTypes::U16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _town_acceptance_matrix_sl_compat;
 
@@ -297,68 +297,68 @@ static std::array<Town::SuppliedHistory, 2> _old_mail_supplied{};
 
 static const SaveLoad _town_desc[] = {
 	SLE_CONDVAR(Town, xy, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(Town, xy, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, xy, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Town, townnamegrfid, SLE_UINT32, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
-	    SLE_VAR(Town, townnametype,          SLE_UINT16),
-	    SLE_VAR(Town, townnameparts,         SLE_UINT32),
-	SLE_CONDSSTR(Town, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, townnamegrfid, VarTypes::U32, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(Town, townnametype,          VarTypes::U16),
+	    SLE_VAR(Town, townnameparts,         VarTypes::U32),
+	SLE_CONDSSTR(Town, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 
-	    SLE_VAR(Town, flags,                 SLE_UINT8),
+	    SLE_VAR(Town, flags,                 VarTypes::U8),
 	SLE_CONDVAR(Town, statues, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCompanies),
-	SLE_CONDVAR(Town, statues, SLE_UINT16, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, statues, VarTypes::U16, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDVAR(Town, have_ratings, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCompanies),
-	SLE_CONDVAR(Town, have_ratings, SLE_UINT16, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
-	SLE_CONDARR(Town, ratings, SLE_INT16, 8, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCompanies),
-	SLE_CONDARR(Town, ratings, SLE_INT16, MAX_COMPANIES, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
-	SLE_CONDARR(Town, unwanted, SLE_INT8, 8, SaveLoadVersion::TownTolerancePauseMode, SaveLoadVersion::MoreCompanies),
-	SLE_CONDARR(Town, unwanted, SLE_INT8, MAX_COMPANIES, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, have_ratings, VarTypes::U16, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
+	SLE_CONDARR(Town, ratings, VarTypes::I16, 8, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCompanies),
+	SLE_CONDARR(Town, ratings, VarTypes::I16, MAX_COMPANIES, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
+	SLE_CONDARR(Town, unwanted, VarTypes::I8, 8, SaveLoadVersion::TownTolerancePauseMode, SaveLoadVersion::MoreCompanies),
+	SLE_CONDARR(Town, unwanted, VarTypes::I8, MAX_COMPANIES, SaveLoadVersion::MoreCompanies, SaveLoadVersion::MaxVersion),
 
 	/* Slots 0 and 2 are passengers and mail respectively for old saves. */
 	SLEG_CONDVAR("supplied[CT_PASSENGERS].old_max", _old_pass_supplied[LAST_MONTH].production, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerTownCargoStatistics),
-	SLEG_CONDVAR("supplied[CT_PASSENGERS].old_max", _old_pass_supplied[LAST_MONTH].production, SLE_UINT32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
+	SLEG_CONDVAR("supplied[CT_PASSENGERS].old_max", _old_pass_supplied[LAST_MONTH].production, VarTypes::U32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
 	SLEG_CONDVAR( "supplied[CT_MAIL].old_max", _old_mail_supplied[LAST_MONTH].production, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerTownCargoStatistics),
-	SLEG_CONDVAR( "supplied[CT_MAIL].old_max", _old_mail_supplied[LAST_MONTH].production, SLE_UINT32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
+	SLEG_CONDVAR( "supplied[CT_MAIL].old_max", _old_mail_supplied[LAST_MONTH].production, VarTypes::U32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
 	SLEG_CONDVAR("supplied[CT_PASSENGERS].new_max", _old_pass_supplied[THIS_MONTH].production, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerTownCargoStatistics),
-	SLEG_CONDVAR("supplied[CT_PASSENGERS].new_max", _old_pass_supplied[THIS_MONTH].production, SLE_UINT32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
+	SLEG_CONDVAR("supplied[CT_PASSENGERS].new_max", _old_pass_supplied[THIS_MONTH].production, VarTypes::U32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
 	SLEG_CONDVAR( "supplied[CT_MAIL].new_max", _old_mail_supplied[THIS_MONTH].production, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerTownCargoStatistics),
-	SLEG_CONDVAR( "supplied[CT_MAIL].new_max", _old_mail_supplied[THIS_MONTH].production, SLE_UINT32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
+	SLEG_CONDVAR( "supplied[CT_MAIL].new_max", _old_mail_supplied[THIS_MONTH].production, VarTypes::U32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
 	SLEG_CONDVAR("supplied[CT_PASSENGERS].old_act", _old_pass_supplied[LAST_MONTH].transported, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerTownCargoStatistics),
-	SLEG_CONDVAR("supplied[CT_PASSENGERS].old_act", _old_pass_supplied[LAST_MONTH].transported, SLE_UINT32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
+	SLEG_CONDVAR("supplied[CT_PASSENGERS].old_act", _old_pass_supplied[LAST_MONTH].transported, VarTypes::U32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
 	SLEG_CONDVAR( "supplied[CT_MAIL].old_act", _old_mail_supplied[LAST_MONTH].transported, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerTownCargoStatistics),
-	SLEG_CONDVAR( "supplied[CT_MAIL].old_act", _old_mail_supplied[LAST_MONTH].transported, SLE_UINT32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
+	SLEG_CONDVAR( "supplied[CT_MAIL].old_act", _old_mail_supplied[LAST_MONTH].transported, VarTypes::U32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
 	SLEG_CONDVAR("supplied[CT_PASSENGERS].new_act", _old_pass_supplied[THIS_MONTH].transported, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerTownCargoStatistics),
-	SLEG_CONDVAR("supplied[CT_PASSENGERS].new_act", _old_pass_supplied[THIS_MONTH].transported, SLE_UINT32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
+	SLEG_CONDVAR("supplied[CT_PASSENGERS].new_act", _old_pass_supplied[THIS_MONTH].transported, VarTypes::U32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
 	SLEG_CONDVAR( "supplied[CT_MAIL].new_act", _old_mail_supplied[THIS_MONTH].transported, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerTownCargoStatistics),
-	SLEG_CONDVAR( "supplied[CT_MAIL].new_act", _old_mail_supplied[THIS_MONTH].transported, SLE_UINT32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
+	SLEG_CONDVAR( "supplied[CT_MAIL].new_act", _old_mail_supplied[THIS_MONTH].transported, VarTypes::U32, SaveLoadVersion::LargerTownCargoStatistics, SaveLoadVersion::ScriptTownGrowth),
 
-	SLE_CONDVARNAME(Town, received[TownAcceptanceEffect::Food].old_act, "received[TE_FOOD].old_act", SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::ScriptTownGrowth),
-	SLE_CONDVARNAME(Town, received[TownAcceptanceEffect::Water].old_act, "received[TE_WATER].old_act", SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::ScriptTownGrowth),
-	SLE_CONDVARNAME(Town, received[TownAcceptanceEffect::Food].new_act, "received[TE_FOOD].new_act", SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::ScriptTownGrowth),
-	SLE_CONDVARNAME(Town, received[TownAcceptanceEffect::Water].new_act, "received[TE_WATER].new_act", SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::ScriptTownGrowth),
+	SLE_CONDVARNAME(Town, received[TownAcceptanceEffect::Food].old_act, "received[TE_FOOD].old_act", VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ScriptTownGrowth),
+	SLE_CONDVARNAME(Town, received[TownAcceptanceEffect::Water].old_act, "received[TE_WATER].old_act", VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ScriptTownGrowth),
+	SLE_CONDVARNAME(Town, received[TownAcceptanceEffect::Food].new_act, "received[TE_FOOD].new_act", VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ScriptTownGrowth),
+	SLE_CONDVARNAME(Town, received[TownAcceptanceEffect::Water].new_act, "received[TE_WATER].new_act", VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ScriptTownGrowth),
 
-	SLE_CONDARR(Town, goal, SLE_UINT32, to_underlying(TownAcceptanceEffect::End), SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+	SLE_CONDARR(Town, goal, VarTypes::U32, to_underlying(TownAcceptanceEffect::End), SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDSSTR(Town, text, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ScriptTownText, SaveLoadVersion::MaxVersion),
+	SLE_CONDSSTR(Town, text, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ScriptTownText, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDVAR(Town, time_until_rebuild, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::TownGrowthControl),
-	SLE_CONDVAR(Town, time_until_rebuild, SLE_UINT16, SaveLoadVersion::TownGrowthControl, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, time_until_rebuild, VarTypes::U16, SaveLoadVersion::TownGrowthControl, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Town, grow_counter, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::TownGrowthControl),
-	SLE_CONDVAR(Town, grow_counter, SLE_UINT16, SaveLoadVersion::TownGrowthControl, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, grow_counter, VarTypes::U16, SaveLoadVersion::TownGrowthControl, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(Town, growth_rate, VarFileType::U8 | VarMemType::I16, SaveLoadVersion::MinVersion, SaveLoadVersion::TownGrowthControl),
 	SLE_CONDVAR(Town, growth_rate, VarFileType::I16 | VarMemType::U16, SaveLoadVersion::TownGrowthControl, SaveLoadVersion::ScriptTownGrowth),
-	SLE_CONDVAR(Town, growth_rate, SLE_UINT16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, growth_rate, VarTypes::U16, SaveLoadVersion::ScriptTownGrowth, SaveLoadVersion::MaxVersion),
 
-	    SLE_VAR(Town, fund_buildings_months, SLE_UINT8),
-	    SLE_VAR(Town, road_build_months,     SLE_UINT8),
+	    SLE_VAR(Town, fund_buildings_months, VarTypes::U8),
+	    SLE_VAR(Town, road_build_months,     VarTypes::U8),
 
-	SLE_CONDVAR(Town, exclusivity, SLE_UINT8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Town, exclusive_counter, SLE_UINT8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, exclusivity, VarTypes::U8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, exclusive_counter, VarTypes::U8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Town, larger_town, SLE_BOOL, SaveLoadVersion::Cities, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Town, layout, SLE_UINT8, SaveLoadVersion::RoadLayoutPerTown, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Town, valid_history, SLE_UINT64, SaveLoadVersion::TownSupplyHistory, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, larger_town, VarTypes::BOOL, SaveLoadVersion::Cities, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, layout, VarTypes::U8, SaveLoadVersion::RoadLayoutPerTown, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, valid_history, VarTypes::U64, SaveLoadVersion::TownSupplyHistory, SaveLoadVersion::MaxVersion),
 
 	SLE_CONDREFVECTOR(Town, psa_list, SLRefType::Storage, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::MaxVersion),
 

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -654,134 +654,134 @@ static Money  _cargo_feeder_share;
 class SlVehicleCommon : public DefaultSaveLoadHandler<SlVehicleCommon, Vehicle> {
 public:
 	static inline const SaveLoad description[] = {
-		    SLE_VAR(Vehicle, subtype,               SLE_UINT8),
+		    SLE_VAR(Vehicle, subtype,               VarTypes::U8),
 
 		    SLE_REF(Vehicle, next,                  SLRefType::OldVehicle),
-		SLE_CONDVAR(Vehicle, name, SLE_NAME, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
-		SLE_CONDSSTR(Vehicle, name, SLE_STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, name, VarTypes::NAME, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
+		SLE_CONDSSTR(Vehicle, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, unitnumber, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerUnitNumber),
-		SLE_CONDVAR(Vehicle, unitnumber, SLE_UINT16, SaveLoadVersion::LargerUnitNumber, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Vehicle, owner,                 SLE_UINT8),
+		SLE_CONDVAR(Vehicle, unitnumber, VarTypes::U16, SaveLoadVersion::LargerUnitNumber, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Vehicle, owner,                 VarTypes::U8),
 		SLE_CONDVAR(Vehicle, tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		SLE_CONDVAR(Vehicle, tile, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, dest_tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		SLE_CONDVAR(Vehicle, dest_tile, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, dest_tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 
 		SLE_CONDVAR(Vehicle, x_pos, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		SLE_CONDVAR(Vehicle, x_pos, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, x_pos, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, y_pos, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		SLE_CONDVAR(Vehicle, y_pos, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, y_pos, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, z_pos, VarFileType::U8 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::VehicleCentreAndZPos),
-		SLE_CONDVAR(Vehicle, z_pos, SLE_INT32, SaveLoadVersion::VehicleCentreAndZPos, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Vehicle, direction,             SLE_UINT8),
+		SLE_CONDVAR(Vehicle, z_pos, VarTypes::I32, SaveLoadVersion::VehicleCentreAndZPos, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Vehicle, direction,             VarTypes::U8),
 
-		    SLE_VAR(Vehicle, spritenum,             SLE_UINT8),
-		    SLE_VAR(Vehicle, engine_type,           SLE_UINT16),
-		    SLE_VAR(Vehicle, cur_speed,             SLE_UINT16),
-		    SLE_VAR(Vehicle, subspeed,              SLE_UINT8),
-		    SLE_VAR(Vehicle, acceleration,          SLE_UINT8),
-		SLE_CONDVAR(Vehicle, motion_counter, SLE_UINT32, SaveLoadVersion::VehMotionCounter, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Vehicle, progress,              SLE_UINT8),
+		    SLE_VAR(Vehicle, spritenum,             VarTypes::U8),
+		    SLE_VAR(Vehicle, engine_type,           VarTypes::U16),
+		    SLE_VAR(Vehicle, cur_speed,             VarTypes::U16),
+		    SLE_VAR(Vehicle, subspeed,              VarTypes::U8),
+		    SLE_VAR(Vehicle, acceleration,          VarTypes::U8),
+		SLE_CONDVAR(Vehicle, motion_counter, VarTypes::U32, SaveLoadVersion::VehMotionCounter, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Vehicle, progress,              VarTypes::U8),
 
-		    SLE_VAR(Vehicle, vehstatus,             SLE_UINT8),
+		    SLE_VAR(Vehicle, vehstatus,             VarTypes::U8),
 		SLE_CONDVAR(Vehicle, last_station_visited, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
-		SLE_CONDVAR(Vehicle, last_station_visited, SLE_UINT16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, last_loading_station, SLE_UINT16, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, last_station_visited, VarTypes::U16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, last_loading_station, VarTypes::U16, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
 
-		    SLE_VAR(Vehicle, cargo_type,            SLE_UINT8),
-		SLE_CONDVAR(Vehicle, cargo_subtype, SLE_UINT8, SaveLoadVersion::LiveryRefit, SaveLoadVersion::MaxVersion),
-		SLEG_CONDVAR("cargo_days", _cargo_periods, SLE_UINT8, SaveLoadVersion::MinVersion, SaveLoadVersion::CargoPackets),
+		    SLE_VAR(Vehicle, cargo_type,            VarTypes::U8),
+		SLE_CONDVAR(Vehicle, cargo_subtype, VarTypes::U8, SaveLoadVersion::LiveryRefit, SaveLoadVersion::MaxVersion),
+		SLEG_CONDVAR("cargo_days", _cargo_periods, VarTypes::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::CargoPackets),
 		SLEG_CONDVAR("cargo_source", _cargo_source, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::LargerCargoSource),
-		SLEG_CONDVAR("cargo_source", _cargo_source, SLE_UINT16, SaveLoadVersion::LargerCargoSource, SaveLoadVersion::CargoPackets),
-		SLEG_CONDVAR("cargo_source_xy", _cargo_source_xy, SLE_UINT32, SaveLoadVersion::CargoSourceTile, SaveLoadVersion::CargoPackets),
-		    SLE_VAR(Vehicle, cargo_cap,             SLE_UINT16),
-		SLE_CONDVAR(Vehicle, refit_cap, SLE_UINT16, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
-		SLEG_CONDVAR("cargo_count", _cargo_count, SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::CargoPackets),
+		SLEG_CONDVAR("cargo_source", _cargo_source, VarTypes::U16, SaveLoadVersion::LargerCargoSource, SaveLoadVersion::CargoPackets),
+		SLEG_CONDVAR("cargo_source_xy", _cargo_source_xy, VarTypes::U32, SaveLoadVersion::CargoSourceTile, SaveLoadVersion::CargoPackets),
+		    SLE_VAR(Vehicle, cargo_cap,             VarTypes::U16),
+		SLE_CONDVAR(Vehicle, refit_cap, VarTypes::U16, SaveLoadVersion::GoalProgressPlaneAcceleration, SaveLoadVersion::MaxVersion),
+		SLEG_CONDVAR("cargo_count", _cargo_count, VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::CargoPackets),
 		SLE_CONDREFLIST(Vehicle, cargo.packets, SLRefType::CargoPacket, SaveLoadVersion::CargoPackets, SaveLoadVersion::MaxVersion),
-		SLE_CONDARR(Vehicle, cargo.action_counts, SLE_UINT32, to_underlying(VehicleCargoList::MoveToAction::End), SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, cargo_age_counter, SLE_UINT16, SaveLoadVersion::NewGRFCustomCargoAging, SaveLoadVersion::MaxVersion),
+		SLE_CONDARR(Vehicle, cargo.action_counts, VarTypes::U32, to_underlying(VehicleCargoList::MoveToAction::End), SaveLoadVersion::CargoReservation, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, cargo_age_counter, VarTypes::U16, SaveLoadVersion::NewGRFCustomCargoAging, SaveLoadVersion::MaxVersion),
 
-		    SLE_VAR(Vehicle, day_counter,           SLE_UINT8),
-		    SLE_VAR(Vehicle, tick_counter,          SLE_UINT8),
-		SLE_CONDVAR(Vehicle, running_ticks, SLE_UINT8, SaveLoadVersion::FractionProfitRunningTicks, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Vehicle, day_counter,           VarTypes::U8),
+		    SLE_VAR(Vehicle, tick_counter,          VarTypes::U8),
+		SLE_CONDVAR(Vehicle, running_ticks, VarTypes::U8, SaveLoadVersion::FractionProfitRunningTicks, SaveLoadVersion::MaxVersion),
 
-		    SLE_VAR(Vehicle, cur_implicit_order_index,  SLE_UINT8),
-		SLE_CONDVAR(Vehicle, cur_real_order_index, SLE_UINT8, SaveLoadVersion::TrackRealAndAutoOrders, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Vehicle, cur_implicit_order_index,  VarTypes::U8),
+		SLE_CONDVAR(Vehicle, cur_real_order_index, VarTypes::U8, SaveLoadVersion::TrackRealAndAutoOrders, SaveLoadVersion::MaxVersion),
 
 		/* This next line is for version 4 and prior compatibility.. it temporarily reads
 		type and flags (which were both 4 bits) into type. Later on this is
 		converted correctly */
-		SLE_CONDVAR(Vehicle, current_order.type, SLE_UINT8, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
+		SLE_CONDVAR(Vehicle, current_order.type, VarTypes::U8, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
 		SLE_CONDVAR(Vehicle, current_order.dest, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
 
 		/* Orders for version 5 and on */
-		SLE_CONDVAR(Vehicle, current_order.type, SLE_UINT8, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, current_order.flags, SLE_UINT8, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, current_order.dest, SLE_UINT16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, current_order.type, VarTypes::U8, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, current_order.flags, VarTypes::U8, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, current_order.dest, VarTypes::U16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
 
 		/* Refit in current order */
-		SLE_CONDVAR(Vehicle, current_order.refit_cargo, SLE_UINT8, SaveLoadVersion::RefitOrders, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, current_order.refit_cargo, VarTypes::U8, SaveLoadVersion::RefitOrders, SaveLoadVersion::MaxVersion),
 
 		/* Timetable in current order */
-		SLE_CONDVAR(Vehicle, current_order.wait_time, SLE_UINT16, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, current_order.travel_time, SLE_UINT16, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, current_order.max_speed, SLE_UINT16, SaveLoadVersion::CurrentOrderMaxSpeed, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, current_order.wait_time, VarTypes::U16, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, current_order.travel_time, VarTypes::U16, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, current_order.max_speed, VarTypes::U16, SaveLoadVersion::CurrentOrderMaxSpeed, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, timetable_start, VarFileType::I32 | VarMemType::U64, SaveLoadVersion::TimetableStart, SaveLoadVersion::TimetableStartTicks),
-		SLE_CONDVAR(Vehicle, timetable_start, SLE_UINT64, SaveLoadVersion::TimetableStartTicks, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, timetable_start, VarTypes::U64, SaveLoadVersion::TimetableStartTicks, SaveLoadVersion::MaxVersion),
 
 		SLE_CONDVARNAME(Vehicle, old_orders, "orders", VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MoreCargoPackets),
-		SLE_CONDVARNAME(Vehicle, old_orders, "orders", SLE_UINT32, SaveLoadVersion::MoreCargoPackets, SaveLoadVersion::OrderList),
+		SLE_CONDVARNAME(Vehicle, old_orders, "orders", VarTypes::U32, SaveLoadVersion::MoreCargoPackets, SaveLoadVersion::OrderList),
 		SLE_CONDREF(Vehicle, orders, SLRefType::OrderList, SaveLoadVersion::OrderList, SaveLoadVersion::MaxVersion),
 
 		SLE_CONDVAR(Vehicle, age, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-		SLE_CONDVAR(Vehicle, age, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, economy_age, SLE_INT32, SaveLoadVersion::VehicleEconomyAge, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, age, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, economy_age, VarTypes::I32, SaveLoadVersion::VehicleEconomyAge, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, max_age, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-		SLE_CONDVAR(Vehicle, max_age, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, max_age, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, date_of_last_service, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-		SLE_CONDVAR(Vehicle, date_of_last_service, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, date_of_last_service_newgrf, SLE_INT32, SaveLoadVersion::NewGRFLastService, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, service_interval, SLE_UINT16, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
+		SLE_CONDVAR(Vehicle, date_of_last_service, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, date_of_last_service_newgrf, VarTypes::I32, SaveLoadVersion::NewGRFLastService, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, service_interval, VarTypes::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
 		SLE_CONDVAR(Vehicle, service_interval, VarFileType::U32 | VarMemType::U16, SaveLoadVersion::BigDates, SaveLoadVersion::ServiceIntervalPercent),
-		SLE_CONDVAR(Vehicle, service_interval, SLE_UINT16, SaveLoadVersion::ServiceIntervalPercent, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Vehicle, reliability,           SLE_UINT16),
-		    SLE_VAR(Vehicle, reliability_spd_dec,   SLE_UINT16),
-		    SLE_VAR(Vehicle, breakdown_ctr,         SLE_UINT8),
-		    SLE_VAR(Vehicle, breakdown_delay,       SLE_UINT8),
-		    SLE_VAR(Vehicle, breakdowns_since_last_service, SLE_UINT8),
-		    SLE_VAR(Vehicle, breakdown_chance,      SLE_UINT8),
+		SLE_CONDVAR(Vehicle, service_interval, VarTypes::U16, SaveLoadVersion::ServiceIntervalPercent, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Vehicle, reliability,           VarTypes::U16),
+		    SLE_VAR(Vehicle, reliability_spd_dec,   VarTypes::U16),
+		    SLE_VAR(Vehicle, breakdown_ctr,         VarTypes::U8),
+		    SLE_VAR(Vehicle, breakdown_delay,       VarTypes::U8),
+		    SLE_VAR(Vehicle, breakdowns_since_last_service, VarTypes::U8),
+		    SLE_VAR(Vehicle, breakdown_chance,      VarTypes::U8),
 		SLE_CONDVAR(Vehicle, build_year, VarFileType::U8 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-		SLE_CONDVAR(Vehicle, build_year, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, build_year, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
 
-		    SLE_VAR(Vehicle, load_unload_ticks,     SLE_UINT16),
-		SLEG_CONDVAR("cargo_paid_for", _cargo_paid_for, SLE_UINT16, SaveLoadVersion::CountPaidForCargo, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Vehicle, load_unload_ticks,     VarTypes::U16),
+		SLEG_CONDVAR("cargo_paid_for", _cargo_paid_for, VarTypes::U16, SaveLoadVersion::CountPaidForCargo, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, vehicle_flags, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::GradualLoading, SaveLoadVersion::ServiceIntervalPercent),
-		SLE_CONDVAR(Vehicle, vehicle_flags, SLE_UINT16, SaveLoadVersion::ServiceIntervalPercent, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, vehicle_flags, VarTypes::U16, SaveLoadVersion::ServiceIntervalPercent, SaveLoadVersion::MaxVersion),
 
 		SLE_CONDVAR(Vehicle, profit_this_year, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
-		SLE_CONDVAR(Vehicle, profit_this_year, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, profit_this_year, VarTypes::I64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, profit_last_year, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
-		SLE_CONDVAR(Vehicle, profit_last_year, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, profit_last_year, VarTypes::I64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
 		SLEG_CONDVAR("cargo_feeder_share", _cargo_feeder_share, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::FeederShare, SaveLoadVersion::UnifyCurrency),
-		SLEG_CONDVAR("cargo_feeder_share", _cargo_feeder_share, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::CargoPackets),
+		SLEG_CONDVAR("cargo_feeder_share", _cargo_feeder_share, VarTypes::I64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::CargoPackets),
 		SLE_CONDVAR(Vehicle, value, VarFileType::I32 | VarMemType::I64, SaveLoadVersion::MinVersion, SaveLoadVersion::UnifyCurrency),
-		SLE_CONDVAR(Vehicle, value, SLE_INT64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, value, VarTypes::I64, SaveLoadVersion::UnifyCurrency, SaveLoadVersion::MaxVersion),
 
 		SLE_CONDVAR(Vehicle, random_bits, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::ExtendVehicleRandom),
-		SLE_CONDVAR(Vehicle, random_bits, SLE_UINT16, SaveLoadVersion::ExtendVehicleRandom, SaveLoadVersion::MaxVersion),
-		SLE_CONDVARNAME(Vehicle, waiting_random_triggers, "waiting_triggers", SLE_UINT8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, random_bits, VarTypes::U16, SaveLoadVersion::ExtendVehicleRandom, SaveLoadVersion::MaxVersion),
+		SLE_CONDVARNAME(Vehicle, waiting_random_triggers, "waiting_triggers", VarTypes::U8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
 		SLE_CONDREF(Vehicle, next_shared, SLRefType::Vehicle, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, group_id, SLE_UINT16, SaveLoadVersion::VehicleGroups, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, group_id, VarTypes::U16, SaveLoadVersion::VehicleGroups, SaveLoadVersion::MaxVersion),
 
 		SLE_CONDVAR(Vehicle, current_order_time, VarFileType::U32 | VarMemType::I32, SaveLoadVersion::Timetables, SaveLoadVersion::TimetableTicksType),
-		SLE_CONDVAR(Vehicle, current_order_time, SLE_INT32, SaveLoadVersion::TimetableTicksType, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, last_loading_tick, SLE_UINT64, SaveLoadVersion::LastLoadingTick, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, lateness_counter, SLE_INT32, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, current_order_time, VarTypes::I32, SaveLoadVersion::TimetableTicksType, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, last_loading_tick, VarTypes::U64, SaveLoadVersion::LastLoadingTick, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, lateness_counter, VarTypes::I32, SaveLoadVersion::Timetables, SaveLoadVersion::MaxVersion),
 
-		SLE_CONDVAR(Vehicle, depot_unbunching_last_departure, SLE_UINT64, SaveLoadVersion::DepotUnbunching, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, depot_unbunching_next_departure, SLE_UINT64, SaveLoadVersion::DepotUnbunching, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Vehicle, round_trip_time, SLE_INT32, SaveLoadVersion::DepotUnbunching, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, depot_unbunching_last_departure, VarTypes::U64, SaveLoadVersion::DepotUnbunching, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, depot_unbunching_next_departure, VarTypes::U64, SaveLoadVersion::DepotUnbunching, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, round_trip_time, VarTypes::I32, SaveLoadVersion::DepotUnbunching, SaveLoadVersion::MaxVersion),
 	};
 
 	static inline const SaveLoadCompatTable compat_description = _vehicle_common_sl_compat;
@@ -806,14 +806,14 @@ class SlVehicleTrain : public DefaultSaveLoadHandler<SlVehicleTrain, Vehicle> {
 public:
 	static inline const SaveLoad description[] = {
 		 SLEG_STRUCT("common", SlVehicleCommon),
-		     SLE_VAR(Train, crash_anim_pos,      SLE_UINT16),
-		     SLE_VAR(Train, force_proceed,       SLE_UINT8),
-		     SLE_VAR(Train, track,               SLE_UINT8),
+		     SLE_VAR(Train, crash_anim_pos,      VarTypes::U16),
+		     SLE_VAR(Train, force_proceed,       VarTypes::U8),
+		     SLE_VAR(Train, track,               VarTypes::U8),
 
 		 SLE_CONDVAR(Train, flags, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::Yapp),
-		 SLE_CONDVAR(Train, flags, SLE_UINT16, SaveLoadVersion::Yapp, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(Train, wait_counter, SLE_UINT16, SaveLoadVersion::SplitLoadWaitCounters, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(Train, gv_flags, SLE_UINT16, SaveLoadVersion::RvRealisticAcceleration, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Train, flags, VarTypes::U16, SaveLoadVersion::Yapp, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Train, wait_counter, VarTypes::U16, SaveLoadVersion::SplitLoadWaitCounters, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Train, gv_flags, VarTypes::U16, SaveLoadVersion::RvRealisticAcceleration, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _vehicle_train_sl_compat;
 
@@ -839,8 +839,8 @@ public:
 class SlVehicleRoadVehPath : public VectorSaveLoadHandler<SlVehicleRoadVehPath, RoadVehicle, RoadVehPathElement> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VAR(RoadVehPathElement, trackdir, SLE_UINT8),
-		SLE_VAR(RoadVehPathElement, tile, SLE_UINT32),
+		SLE_VAR(RoadVehPathElement, trackdir, VarTypes::U8),
+		SLE_VAR(RoadVehPathElement, tile, VarTypes::U32),
 	};
 	static inline const SaveLoadCompatTable compat_description = {};
 
@@ -857,17 +857,17 @@ public:
 
 	static inline const SaveLoad description[] = {
 		  SLEG_STRUCT("common", SlVehicleCommon),
-		      SLE_VAR(RoadVehicle, state,                SLE_UINT8),
-		      SLE_VAR(RoadVehicle, frame,                SLE_UINT8),
-		      SLE_VAR(RoadVehicle, blocked_ctr,          SLE_UINT16),
-		      SLE_VAR(RoadVehicle, overtaking,           SLE_UINT8),
-		      SLE_VAR(RoadVehicle, overtaking_ctr,       SLE_UINT8),
-		      SLE_VAR(RoadVehicle, crashed_ctr,          SLE_UINT16),
-		      SLE_VAR(RoadVehicle, reverse_ctr,          SLE_UINT8),
-		SLEG_CONDVECTOR("path.td", rv_path_td, SLE_UINT8, SaveLoadVersion::RoadvehPathCache, SaveLoadVersion::PathCacheFormat),
-		SLEG_CONDVECTOR("path.tile", rv_path_tile, SLE_UINT32, SaveLoadVersion::RoadvehPathCache, SaveLoadVersion::PathCacheFormat),
+		      SLE_VAR(RoadVehicle, state,                VarTypes::U8),
+		      SLE_VAR(RoadVehicle, frame,                VarTypes::U8),
+		      SLE_VAR(RoadVehicle, blocked_ctr,          VarTypes::U16),
+		      SLE_VAR(RoadVehicle, overtaking,           VarTypes::U8),
+		      SLE_VAR(RoadVehicle, overtaking_ctr,       VarTypes::U8),
+		      SLE_VAR(RoadVehicle, crashed_ctr,          VarTypes::U16),
+		      SLE_VAR(RoadVehicle, reverse_ctr,          VarTypes::U8),
+		SLEG_CONDVECTOR("path.td", rv_path_td, VarTypes::U8, SaveLoadVersion::RoadvehPathCache, SaveLoadVersion::PathCacheFormat),
+		SLEG_CONDVECTOR("path.tile", rv_path_tile, VarTypes::U32, SaveLoadVersion::RoadvehPathCache, SaveLoadVersion::PathCacheFormat),
 		SLEG_CONDSTRUCTLIST("path", SlVehicleRoadVehPath, SaveLoadVersion::PathCacheFormat, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(RoadVehicle, gv_flags, SLE_UINT16, SaveLoadVersion::RvRealisticAcceleration, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(RoadVehicle, gv_flags, VarTypes::U16, SaveLoadVersion::RvRealisticAcceleration, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _vehicle_roadveh_sl_compat;
 
@@ -915,7 +915,7 @@ public:
 class SlVehicleShipPath : public VectorSaveLoadHandler<SlVehicleShipPath, Ship, ShipPathElement> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VAR(ShipPathElement, trackdir, SLE_UINT8),
+		SLE_VAR(ShipPathElement, trackdir, VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = {};
 
@@ -928,10 +928,10 @@ public:
 
 	static inline const SaveLoad description[] = {
 		  SLEG_STRUCT("common", SlVehicleCommon),
-		      SLE_VAR(Ship, state,                     SLE_UINT8),
-		SLEG_CONDVECTOR("path", ship_path_td, SLE_UINT8, SaveLoadVersion::ShipPathCache, SaveLoadVersion::PathCacheFormat),
+		      SLE_VAR(Ship, state,                     VarTypes::U8),
+		SLEG_CONDVECTOR("path", ship_path_td, VarTypes::U8, SaveLoadVersion::ShipPathCache, SaveLoadVersion::PathCacheFormat),
 		SLEG_CONDSTRUCTLIST("path", SlVehicleShipPath, SaveLoadVersion::PathCacheFormat, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(Ship, rotation, SLE_UINT8, SaveLoadVersion::ShipRotation, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Ship, rotation, VarTypes::U8, SaveLoadVersion::ShipRotation, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _vehicle_ship_sl_compat;
 
@@ -964,20 +964,20 @@ class SlVehicleAircraft : public DefaultSaveLoadHandler<SlVehicleAircraft, Vehic
 public:
 	static inline const SaveLoad description[] = {
 		 SLEG_STRUCT("common", SlVehicleCommon),
-		     SLE_VAR(Aircraft, crashed_counter,       SLE_UINT16),
-		     SLE_VAR(Aircraft, pos,                   SLE_UINT8),
+		     SLE_VAR(Aircraft, crashed_counter,       VarTypes::U16),
+		     SLE_VAR(Aircraft, pos,                   VarTypes::U8),
 
 		 SLE_CONDVAR(Aircraft, targetairport, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
-		 SLE_CONDVAR(Aircraft, targetairport, SLE_UINT16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Aircraft, targetairport, VarTypes::U16, SaveLoadVersion::BigMap, SaveLoadVersion::MaxVersion),
 
-		     SLE_VAR(Aircraft, state,                 SLE_UINT8),
+		     SLE_VAR(Aircraft, state,                 VarTypes::U8),
 
-		 SLE_CONDVAR(Aircraft, previous_pos, SLE_UINT8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(Aircraft, last_direction, SLE_UINT8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(Aircraft, number_consecutive_turns, SLE_UINT8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Aircraft, previous_pos, VarTypes::U8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Aircraft, last_direction, VarTypes::U8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Aircraft, number_consecutive_turns, VarTypes::U8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
-		 SLE_CONDVAR(Aircraft, turn_counter, SLE_UINT8, SaveLoadVersion::SplitLoadWaitCounters, SaveLoadVersion::MaxVersion),
-		 SLE_CONDVAR(Aircraft, flags, SLE_UINT8, SaveLoadVersion::NewGRFAircraftRange, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Aircraft, turn_counter, VarTypes::U8, SaveLoadVersion::SplitLoadWaitCounters, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Aircraft, flags, VarTypes::U8, SaveLoadVersion::NewGRFAircraftRange, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _vehicle_aircraft_sl_compat;
 
@@ -1003,26 +1003,26 @@ public:
 class SlVehicleEffect : public DefaultSaveLoadHandler<SlVehicleEffect, Vehicle> {
 public:
 	static inline const SaveLoad description[] = {
-		     SLE_VAR(Vehicle, subtype,               SLE_UINT8),
+		     SLE_VAR(Vehicle, subtype,               VarTypes::U8),
 
 		 SLE_CONDVAR(Vehicle, tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		 SLE_CONDVAR(Vehicle, tile, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Vehicle, tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 
 		 SLE_CONDVAR(Vehicle, x_pos, VarFileType::I16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		 SLE_CONDVAR(Vehicle, x_pos, SLE_INT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Vehicle, x_pos, VarTypes::I32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 		 SLE_CONDVAR(Vehicle, y_pos, VarFileType::I16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		 SLE_CONDVAR(Vehicle, y_pos, SLE_INT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Vehicle, y_pos, VarTypes::I32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 		 SLE_CONDVAR(Vehicle, z_pos, VarFileType::U8 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::VehicleCentreAndZPos),
-		 SLE_CONDVAR(Vehicle, z_pos, SLE_INT32, SaveLoadVersion::VehicleCentreAndZPos, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Vehicle, z_pos, VarTypes::I32, SaveLoadVersion::VehicleCentreAndZPos, SaveLoadVersion::MaxVersion),
 
 		     SLE_VAR(Vehicle, sprite_cache.sprite_seq.seq[0].sprite, VarFileType::U16 | VarMemType::U32),
-		     SLE_VAR(Vehicle, progress,              SLE_UINT8),
-		     SLE_VAR(Vehicle, vehstatus,             SLE_UINT8),
+		     SLE_VAR(Vehicle, progress,              VarTypes::U8),
+		     SLE_VAR(Vehicle, vehstatus,             VarTypes::U8),
 
-		     SLE_VAR(EffectVehicle, animation_state,    SLE_UINT16),
-		     SLE_VAR(EffectVehicle, animation_substate, SLE_UINT8),
+		     SLE_VAR(EffectVehicle, animation_state,    VarTypes::U16),
+		     SLE_VAR(EffectVehicle, animation_substate, VarTypes::U8),
 
-		 SLE_CONDVAR(Vehicle, spritenum, SLE_UINT8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
+		 SLE_CONDVAR(Vehicle, spritenum, VarTypes::U8, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _vehicle_effect_sl_compat;
 
@@ -1050,36 +1050,36 @@ public:
 	static inline const SaveLoad description[] = {
 		    SLE_REF(Vehicle, next,                  SLRefType::OldVehicle),
 
-		    SLE_VAR(Vehicle, subtype,               SLE_UINT8),
+		    SLE_VAR(Vehicle, subtype,               VarTypes::U8),
 		SLE_CONDVAR(Vehicle, tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		SLE_CONDVAR(Vehicle, tile, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, dest_tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		SLE_CONDVAR(Vehicle, dest_tile, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, dest_tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 
 		SLE_CONDVAR(Vehicle, x_pos, VarFileType::I16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		SLE_CONDVAR(Vehicle, x_pos, SLE_INT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, x_pos, VarTypes::I32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, y_pos, VarFileType::I16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-		SLE_CONDVAR(Vehicle, y_pos, SLE_INT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(Vehicle, y_pos, VarTypes::I32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Vehicle, z_pos, VarFileType::U8 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::VehicleCentreAndZPos),
-		SLE_CONDVAR(Vehicle, z_pos, SLE_INT32, SaveLoadVersion::VehicleCentreAndZPos, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Vehicle, direction,             SLE_UINT8),
+		SLE_CONDVAR(Vehicle, z_pos, VarTypes::I32, SaveLoadVersion::VehicleCentreAndZPos, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Vehicle, direction,             VarTypes::U8),
 
-		    SLE_VAR(Vehicle, owner,                 SLE_UINT8),
-		    SLE_VAR(Vehicle, vehstatus,             SLE_UINT8),
+		    SLE_VAR(Vehicle, owner,                 VarTypes::U8),
+		    SLE_VAR(Vehicle, vehstatus,             VarTypes::U8),
 		SLE_CONDVARNAME(DisasterVehicle, state, "current_order.dest", VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::BigMap),
-		SLE_CONDVARNAME(DisasterVehicle, state, "current_order.dest", SLE_UINT16, SaveLoadVersion::BigMap, SaveLoadVersion::DisasterVehState),
-		SLE_CONDVAR(DisasterVehicle, state, SLE_UINT16, SaveLoadVersion::DisasterVehState, SaveLoadVersion::MaxVersion),
+		SLE_CONDVARNAME(DisasterVehicle, state, "current_order.dest", VarTypes::U16, SaveLoadVersion::BigMap, SaveLoadVersion::DisasterVehState),
+		SLE_CONDVAR(DisasterVehicle, state, VarTypes::U16, SaveLoadVersion::DisasterVehState, SaveLoadVersion::MaxVersion),
 
 		    SLE_VAR(Vehicle, sprite_cache.sprite_seq.seq[0].sprite, VarFileType::U16 | VarMemType::U32),
 		SLE_CONDVAR(Vehicle, age, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::MinVersion, SaveLoadVersion::BigDates),
-		SLE_CONDVAR(Vehicle, age, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Vehicle, tick_counter,          SLE_UINT8),
+		SLE_CONDVAR(Vehicle, age, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+		    SLE_VAR(Vehicle, tick_counter,          VarTypes::U8),
 
 		SLE_CONDVAR(DisasterVehicle, image_override, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LinkgraphLocationDisasterStore),
-		SLE_CONDVAR(DisasterVehicle, image_override, SLE_UINT32, SaveLoadVersion::LinkgraphLocationDisasterStore, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(DisasterVehicle, image_override, VarTypes::U32, SaveLoadVersion::LinkgraphLocationDisasterStore, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(DisasterVehicle, big_ufo_destroyer_target, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::LinkgraphLocationDisasterStore),
-		SLE_CONDVAR(DisasterVehicle, big_ufo_destroyer_target, SLE_UINT32, SaveLoadVersion::LinkgraphLocationDisasterStore, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(DisasterVehicle, flags, SLE_UINT8, SaveLoadVersion::MaxBridgeMapHeight, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(DisasterVehicle, big_ufo_destroyer_target, VarTypes::U32, SaveLoadVersion::LinkgraphLocationDisasterStore, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(DisasterVehicle, flags, VarTypes::U8, SaveLoadVersion::MaxBridgeMapHeight, SaveLoadVersion::MaxVersion),
 	};
 
 	static inline const SaveLoadCompatTable compat_description = _vehicle_disaster_sl_compat;

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -169,20 +169,20 @@ void ResetOldWaypoints()
 
 static const SaveLoad _old_waypoint_desc[] = {
 	SLE_CONDVAR(OldWaypoint, xy, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(OldWaypoint, xy, SLE_UINT32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(OldWaypoint, town_index, SLE_UINT16, SaveLoadVersion::LinkWaypointToTown, SaveLoadVersion::WaypointMoreLikeStation),
+	SLE_CONDVAR(OldWaypoint, xy, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, town_index, VarTypes::U16, SaveLoadVersion::LinkWaypointToTown, SaveLoadVersion::WaypointMoreLikeStation),
 	SLE_CONDREF(OldWaypoint, town, SLRefType::Town, SaveLoadVersion::WaypointMoreLikeStation, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(OldWaypoint, town_cn, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::LinkWaypointToTown, SaveLoadVersion::MoreWaypointsPerTown),
-	SLE_CONDVAR(OldWaypoint, town_cn, SLE_UINT16, SaveLoadVersion::MoreWaypointsPerTown, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(OldWaypoint, string_id, SLE_STRINGID, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
-	SLE_CONDSSTR(OldWaypoint, name, SLE_STR, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
-	    SLE_VAR(OldWaypoint, delete_ctr, SLE_UINT8),
+	SLE_CONDVAR(OldWaypoint, town_cn, VarTypes::U16, SaveLoadVersion::MoreWaypointsPerTown, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, string_id, VarTypes::STRINGID, SaveLoadVersion::MinVersion, SaveLoadVersion::ReplaceCustomNameArray),
+	SLE_CONDSSTR(OldWaypoint, name, VarTypes::STR, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
+	    SLE_VAR(OldWaypoint, delete_ctr, VarTypes::U8),
 
 	SLE_CONDVAR(OldWaypoint, build_date, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::BigDates),
-	SLE_CONDVAR(OldWaypoint, build_date, SLE_INT32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(OldWaypoint, localidx, SLE_UINT8, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(OldWaypoint, grfid, SLE_UINT32, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(OldWaypoint, owner, SLE_UINT8, SaveLoadVersion::NewGRFPalette, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, build_date, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, localidx, VarTypes::U8, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, grfid, VarTypes::U32, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, owner, VarTypes::U8, SaveLoadVersion::NewGRFPalette, SaveLoadVersion::MaxVersion),
 };
 
 struct CHKPChunkHandler : ChunkHandler {

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -365,7 +365,7 @@ static uint8_t _script_sl_byte; ///< Used as source/target by the script saveloa
 
 /** SaveLoad array that saves/loads exactly one byte. */
 static const SaveLoad _script_byte[] = {
-	SLEG_VAR("type", _script_sl_byte, SLE_UINT8),
+	SLEG_VAR("type", _script_sl_byte, VarTypes::U8),
 };
 
 /* static */ bool ScriptInstance::SaveObject(HSQUIRRELVM vm, SQInteger index, int max_depth, bool test)
@@ -385,7 +385,7 @@ static const SaveLoad _script_byte[] = {
 			sq_getinteger(vm, index, &res);
 			if (!test) {
 				int64_t value = (int64_t)res;
-				SlCopy(&value, 1, SLE_INT64);
+				SlCopy(&value, 1, VarTypes::I64);
 			}
 			return true;
 		}
@@ -405,7 +405,7 @@ static const SaveLoad _script_byte[] = {
 			if (!test) {
 				_script_sl_byte = (uint8_t)len;
 				SlObject(nullptr, _script_byte);
-				SlCopy(const_cast<char *>(view.data()), len, SLE_INT8);
+				SlCopy(const_cast<char *>(view.data()), len, VarTypes::I8);
 			}
 			return true;
 		}
@@ -604,7 +604,7 @@ bool ScriptInstance::IsPaused()
 	switch (_script_sl_byte) {
 		case SQSL_INT: {
 			int64_t value;
-			SlCopy(&value, 1, IsSavegameVersionBefore(SaveLoadVersion::ScriptInt64) ? VarFileType::I32 | VarMemType::I64 : SLE_INT64);
+			SlCopy(&value, 1, IsSavegameVersionBefore(SaveLoadVersion::ScriptInt64) ? VarFileType::I32 | VarMemType::I64 : VarTypes::I64);
 			if (data != nullptr) data->push_back(static_cast<SQInteger>(value));
 			return true;
 		}
@@ -612,7 +612,7 @@ bool ScriptInstance::IsPaused()
 		case SQSL_STRING: {
 			SlObject(nullptr, _script_byte);
 			static char buf[std::numeric_limits<decltype(_script_sl_byte)>::max()];
-			SlCopy(buf, _script_sl_byte, SLE_INT8);
+			SlCopy(buf, _script_sl_byte, VarTypes::I8);
 			if (data != nullptr) data->push_back(StrMakeValid(std::string_view(buf, _script_sl_byte)));
 			return true;
 		}

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -94,7 +94,7 @@ constexpr bool DoesMaxFitVariable(T max, VarType type) { return DoesMaxFitVariab
 	NSD(Int, SLEG_GENERAL(name, SaveLoadType::Variable, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, get_range_hook)
 
 #define SDTG_BOOL(name, flags, var, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
-	NSD(Bool, SLEG_GENERAL(name, SaveLoadType::Variable, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
+	NSD(Bool, SLEG_GENERAL(name, SaveLoadType::Variable, var, VarTypes::BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
 #define SDTG_LIST(name, type, flags, var, def, length, from, to, cat, extra, startup)\
 	NSD(List, SLEG_GENERAL(name, SaveLoadType::Array, var, type, length, from, to, extra),flags, startup, def)
@@ -117,7 +117,7 @@ constexpr bool DoesMaxFitVariable(T max, VarType type) { return DoesMaxFitVariab
 	NSD(Int, SLE_GENERAL_NAME(SaveLoadType::Variable, name, base, var, type, 1, from, to, extra), flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
 #define SDT_BOOL(base, var, flags, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)\
-	NSD(Bool, SLE_GENERAL(SaveLoadType::Variable, base, var, SLE_BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
+	NSD(Bool, SLE_GENERAL(SaveLoadType::Variable, base, var, VarTypes::BOOL, 1, from, to, extra), flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook)
 
 #define SDT_LIST(base, var, type, flags, def, from, to, cat, extra, startup)\
 	NSD(List, SLE_GENERAL(SaveLoadType::Array, base, var, type, lengthof(((base*)8)->var), from, to, extra), flags, startup, def)

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -57,7 +57,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = engine_renew_months
-type     = SLE_INT16
+type     = VarTypes::I16
 flags    = SettingFlag::PerCompany
 def      = 6
 min      = -12
@@ -69,7 +69,7 @@ val_cb   = SettingsValueAbsolute
 
 [SDT_VAR]
 var      = engine_renew_money
-type     = SLE_UINT32
+type     = VarTypes::U32
 flags    = SettingFlag::PerCompany, SettingFlag::GuiCurrency
 def      = 100000
 min      = 0
@@ -91,7 +91,7 @@ post_cb  = UpdateAllServiceInterval
 
 [SDT_VAR]
 var      = vehicle.servint_trains
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::PerCompany, SettingFlag::GuiZeroIsSpecial
 def      = DEF_SERVINT_DAYS_TRAINS
 min      = MIN_SERVINT_MINUTES
@@ -108,7 +108,7 @@ range_cb = GetServiceIntervalRange
 
 [SDT_VAR]
 var      = vehicle.servint_roadveh
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::PerCompany, SettingFlag::GuiZeroIsSpecial
 def      = DEF_SERVINT_DAYS_ROADVEH
 min      = MIN_SERVINT_MINUTES
@@ -125,7 +125,7 @@ range_cb = GetServiceIntervalRange
 
 [SDT_VAR]
 var      = vehicle.servint_ships
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::PerCompany, SettingFlag::GuiZeroIsSpecial
 def      = DEF_SERVINT_DAYS_SHIPS
 min      = MIN_SERVINT_MINUTES
@@ -142,7 +142,7 @@ range_cb = GetServiceIntervalRange
 
 [SDT_VAR]
 var      = vehicle.servint_aircraft
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::PerCompany, SettingFlag::GuiZeroIsSpecial
 def      = DEF_SERVINT_DAYS_AIRCRAFT
 min      = MIN_SERVINT_MINUTES

--- a/src/table/settings/currency_settings.ini
+++ b/src/table/settings/currency_settings.ini
@@ -40,30 +40,30 @@ startup  = false
 
 [SDT_VAR]
 var      = rate
-type     = SLE_UINT16
+type     = VarTypes::U16
 def      = 1
 min      = 0
 max      = UINT16_MAX
 
 [SDT_SSTR]
 var      = separator
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 def      = "".""
 cat      = SC_BASIC
 
 [SDT_VAR]
 var      = to_euro
-type     = SLE_INT32
+type     = VarTypes::I32
 def      = 0
 min      = CalendarTime::MIN_YEAR
 max      = CalendarTime::MAX_YEAR
 
 [SDT_SSTR]
 var      = prefix
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 def      = """"
 
 [SDT_SSTR]
 var      = suffix
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 def      = "" credits""

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -56,7 +56,7 @@ startup  = false
 ; The next 18 entries are important for savegame compatibility. Do NOT remove those. See HandleOldDiffCustom() for more details.
 [SDT_VAR]
 var      = difficulty.max_no_competitors
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 def      = 0
 min      = 0
@@ -67,7 +67,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.competitors_interval
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::AIStartDate
 def      = 10
 min      = MIN_COMPETITORS_INTERVAL
@@ -76,7 +76,7 @@ interval = 1
 
 [SDT_VAR]
 var      = difficulty.competitor_start_time
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 to       = SaveLoadVersion::RemoveOldAISettings
 def      = 2
@@ -85,7 +85,7 @@ max      = 3
 
 [SDT_VAR]
 var      = difficulty.number_towns
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::NewgameOnly
 def      = 2
@@ -97,7 +97,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.industry_density
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::GuiDropdown
 def      = IndustryDensity::Normal
@@ -110,7 +110,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.max_loan
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::NewgameOnly, SettingFlag::SceneditToo, SettingFlag::GuiCurrency, SettingFlag::GuiZeroIsSpecial
 def      = 300000
@@ -125,7 +125,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.initial_interest
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::NewgameOnly, SettingFlag::SceneditToo
 def      = 2
@@ -138,7 +138,7 @@ strval   = STR_CONFIG_SETTING_PERCENTAGE
 
 [SDT_VAR]
 var      = difficulty.vehicle_costs
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::NewgameOnly, SettingFlag::SceneditToo, SettingFlag::GuiDropdown
 def      = 0
@@ -152,7 +152,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.competitor_speed
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::GuiDropdown
 def      = 2
@@ -166,7 +166,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.competitor_intelligence
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 to       = SaveLoadVersion::RemoveOldAISettings
 def      = 0
@@ -175,7 +175,7 @@ max      = 2
 
 [SDT_VAR]
 var      = difficulty.vehicle_breakdowns
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::GuiDropdown
 def      = VehicleBreakdowns::Reduced
@@ -188,7 +188,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.subsidy_multiplier
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::GuiDropdown
 def      = 2
@@ -201,7 +201,7 @@ strval   = STR_SUBSIDY_X1_5
 
 [SDT_VAR]
 var      = difficulty.subsidy_duration
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::CustomSubsidyDuration
 flags    = SettingFlag::GuiZeroIsSpecial
 def      = 1
@@ -215,7 +215,7 @@ strval   = STR_CONFIG_SETTING_SUBSIDY_DURATION_VALUE
 
 [SDT_VAR]
 var      = difficulty.construction_cost
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::NewgameOnly, SettingFlag::SceneditToo, SettingFlag::GuiDropdown
 def      = 0
@@ -229,7 +229,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.terrain_type
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly
 def      = GenworldMaxHeight::Flat
@@ -242,7 +242,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.quantity_sea_lakes
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::NewgameOnly
 def      = 0
@@ -267,7 +267,7 @@ def      = false
 
 [SDT_OMANY]
 var      = difficulty.train_flip_reverse_allowed
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::DriveBackwards
 flags    = SettingFlag::GuiDropdown
 def      = TrainFlipReversingAllowed::All
@@ -288,7 +288,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = difficulty.town_council_tolerance
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::GuiDropdown
 def      = 0
@@ -303,7 +303,7 @@ post_cb  = DifficultyNoiseChange
 [SDTG_VAR]
 name     = ""diff_level""
 var      = _old_diff_level
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInConfig
 from     = SaveLoadVersion::MergeOptsPats
 to       = SaveLoadVersion::ScriptSettingsProfile

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -48,7 +48,7 @@ startup  = false
 
 [SDT_VAR]
 var      = economy.town_layout
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::TownLayout
 flags    = SettingFlag::GuiDropdown
 def      = TownLayout::Original
@@ -70,7 +70,7 @@ strhelp  = STR_CONFIG_SETTING_ALLOW_TOWN_ROADS_HELPTEXT
 
 [SDT_VAR]
 var      = economy.found_town
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::FoundTown
 flags    = SettingFlag::GuiDropdown
 def      = TownFounding::Forbidden
@@ -85,7 +85,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = economy.place_houses
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::GuiDropdown
 def      = PlaceHouses::Forbidden
 min      = PlaceHouses::Forbidden
@@ -106,7 +106,7 @@ strhelp  = STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS_HELPTEXT
 
 [SDT_VAR]
 var      = economy.town_cargogen_mode
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::TownCargogen
 flags    = SettingFlag::GuiDropdown
 def      = TownCargoGenMode::Bitcount
@@ -188,7 +188,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = economy.type
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::GuiDropdown
 def      = EconomyType::Smooth
 min      = EconomyType::Begin
@@ -202,7 +202,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = economy.feeder_payment_share
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::VirtualFeederSharePayment
 def      = 75
 min      = 0
@@ -214,7 +214,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = economy.town_growth_rate
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::TownGrowthControl
 flags    = SettingFlag::GuiDropdown
 def      = 2
@@ -226,7 +226,7 @@ strval   = STR_CONFIG_SETTING_TOWN_GROWTH_NONE
 
 [SDT_VAR]
 var      = economy.larger_towns
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::TownGrowthControl
 flags    = SettingFlag::GuiZeroIsSpecial
 def      = 4
@@ -239,7 +239,7 @@ strval   = STR_CONFIG_SETTING_LARGER_TOWNS_VALUE
 
 [SDT_VAR]
 var      = economy.initial_city_size
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Cities
 def      = 2
 min      = 1
@@ -251,7 +251,7 @@ strval   = STR_JUST_COMMA
 
 [SDT_VAR]
 var      = economy.town_min_distance
-type     = SLE_UINT16
+type     = VarTypes::U16
 def      = 20
 min      = 10
 max      = 500
@@ -268,7 +268,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = economy.dist_local_authority
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = 20
 min      = 5
 max      = 60
@@ -276,7 +276,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = economy.town_noise_population[0]
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::AirportNoise
 def      = 800
 min      = 200
@@ -285,7 +285,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = economy.town_noise_population[1]
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::AirportNoise
 def      = 2000
 min      = 400
@@ -294,7 +294,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = economy.town_noise_population[2]
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::AirportNoise
 def      = 4000
 min      = 800
@@ -303,7 +303,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = economy.town_noise_population[3]
-type     = SLE_UINT16
+type     = VarTypes::U16
 def      = 400
 min      = 100
 max      = 65535
@@ -320,7 +320,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = economy.timekeeping_units
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly, SettingFlag::SceneditToo
 def      = TimekeepingUnits::Calendar
 min      = TimekeepingUnits::Calendar
@@ -333,7 +333,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = economy.minutes_per_calendar_year
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::GuiZeroIsSpecial, SettingFlag::NoNetwork
 def      = CalendarTime::DEF_MINUTES_PER_YEAR
 min      = CalendarTime::FROZEN_MINUTES_PER_YEAR
@@ -349,7 +349,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = economy.town_cargo_scale
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NoNetwork
 def      = DEF_CARGO_SCALE
 min      = MIN_CARGO_SCALE
@@ -362,7 +362,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = economy.industry_cargo_scale
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NoNetwork
 def      = DEF_CARGO_SCALE
 min      = MIN_CARGO_SCALE
@@ -375,7 +375,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = economy.cargo_aging_rate
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::GuiZeroIsSpecial, SettingFlag::NoNetwork
 def      = 100
 min      = 0

--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -107,7 +107,7 @@ strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_AIRPORTS_HELPTEXT
 
 [SDT_VAR]
 var      = station.station_spread
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = 12
 min      = 4
 max      = 64
@@ -143,7 +143,7 @@ post_cb  = [](auto) { CloseWindowById(WindowClass::JoinStation, 0); }
 
 [SDT_OMANY]
 var      = vehicle.road_side
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::GuiDropdown, SettingFlag::NoNetwork
 def      = 1
@@ -157,7 +157,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = vehicle.train_acceleration_model
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::GuiDropdown
 def      = AccelerationModel::Realistic
 min      = AccelerationModel::Original
@@ -170,7 +170,7 @@ post_cb  = TrainAccelerationModelChanged
 
 [SDT_VAR]
 var      = vehicle.roadveh_acceleration_model
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::RvRealisticAcceleration
 flags    = SettingFlag::GuiDropdown
 def      = AccelerationModel::Realistic
@@ -184,7 +184,7 @@ post_cb  = RoadVehAccelerationModelChanged
 
 [SDT_VAR]
 var      = vehicle.train_slope_steepness
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::TrainSlopeSteepness
 def      = 3
 min      = 0
@@ -198,7 +198,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = vehicle.roadveh_slope_steepness
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::RvRealisticAcceleration
 def      = 7
 min      = 0
@@ -212,7 +212,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = vehicle.max_train_length
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MaxLengthAndReverseSignals
 def      = 7
 min      = 1
@@ -225,7 +225,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = vehicle.smoke_amount
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::NewGRFAirportSmoke
 flags    = SettingFlag::GuiDropdown
 def      = 2
@@ -244,7 +244,7 @@ strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT
 
 [SDT_VAR]
 var      = vehicle.max_trains
-type     = SLE_UINT16
+type     = VarTypes::U16
 def      = 500
 min      = 0
 max      = 5000
@@ -256,7 +256,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = vehicle.max_roadveh
-type     = SLE_UINT16
+type     = VarTypes::U16
 def      = 500
 min      = 0
 max      = 5000
@@ -268,7 +268,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = vehicle.max_aircraft
-type     = SLE_UINT16
+type     = VarTypes::U16
 def      = 200
 min      = 0
 max      = 5000
@@ -280,7 +280,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = vehicle.max_ships
-type     = SLE_UINT16
+type     = VarTypes::U16
 def      = 300
 min      = 0
 max      = 5000
@@ -310,7 +310,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = vehicle.freight_trains
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::FreightWeight
 flags    = SettingFlag::NoNetwork
 def      = 1
@@ -324,7 +324,7 @@ post_cb  = UpdateConsists
 
 [SDT_VAR]
 var      = vehicle.plane_speed
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::PlaneSpeedFactor
 flags    = SettingFlag::NoNetwork
 def      = 4
@@ -344,7 +344,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = vehicle.plane_crashes
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::ReducePlaneCrashes
 flags    = SettingFlag::GuiDropdown
 def      = 2
@@ -367,7 +367,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = vehicle.extend_vehicle_life
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = 0
 min      = 0
 max      = 100
@@ -384,7 +384,7 @@ to       = SaveLoadVersion::CompanyServiceIntervals
 
 [SDTG_VAR]
 name     = ""vehicle.servint_trains""
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::GuiZeroIsSpecial
 var      = _old_vds.servint_trains
 def      = 150
@@ -394,7 +394,7 @@ to       = SaveLoadVersion::CompanyServiceIntervals
 
 [SDTG_VAR]
 name     = ""vehicle.servint_roadveh""
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::GuiZeroIsSpecial
 var      = _old_vds.servint_roadveh
 def      = 150
@@ -404,7 +404,7 @@ to       = SaveLoadVersion::CompanyServiceIntervals
 
 [SDTG_VAR]
 name     = ""vehicle.servint_ships""
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::GuiZeroIsSpecial
 var      = _old_vds.servint_ships
 def      = 360
@@ -414,7 +414,7 @@ to       = SaveLoadVersion::CompanyServiceIntervals
 
 [SDTG_VAR]
 name     = ""vehicle.servint_aircraft""
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::GuiZeroIsSpecial
 var      = _old_vds.servint_aircraft
 def      = 150

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -58,7 +58,7 @@ startup  = false
 
 [SDTC_VAR]
 var      = gui.autosave_interval
-type     = SLE_UINT32
+type     = VarTypes::U32
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 10
 min      = 0
@@ -72,7 +72,7 @@ cat      = SC_EXPERT
 
 [SDTC_OMANY]
 var      = gui.date_format_in_default_names
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2
@@ -93,7 +93,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.auto_scrolling
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = ViewportAutoscrolling::Disabled
 min      = ViewportAutoscrolling::Disabled
@@ -106,7 +106,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 ifdef    = UNIX
 var      = gui.scroll_mode
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = ViewportScrollMode::MapRMB
 min      = ViewportScrollMode::ViewportRMBFixed
@@ -119,7 +119,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 ifndef    = UNIX
 var      = gui.scroll_mode
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = ViewportScrollMode::ViewportRMBFixed
 min      = ViewportScrollMode::ViewportRMBFixed
@@ -138,7 +138,7 @@ strhelp  = STR_CONFIG_SETTING_SMOOTH_SCROLLING_HELPTEXT
 
 [SDTC_OMANY]
 var      = gui.right_click_wnd_close
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = RightClickClose::No
 min      = RightClickClose::No
@@ -161,7 +161,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 ifdef    = __APPLE__
 var      = gui.right_mouse_btn_emulation
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 0
 min      = 0
@@ -181,7 +181,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.errmsg_duration
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 5
 min      = 0
@@ -192,7 +192,7 @@ strval   = STR_CONFIG_SETTING_SECONDS_VALUE
 
 [SDTC_VAR]
 var      = gui.hover_delay_ms
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiZeroIsSpecial
 def      = 250
 min      = 50
@@ -204,7 +204,7 @@ strval   = STR_CONFIG_SETTING_HOVER_DELAY_VALUE
 
 [SDTC_OMANY]
 var      = gui.osk_activation
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 str      = STR_CONFIG_SETTING_OSK_ACTIVATION
 strhelp  = STR_CONFIG_SETTING_OSK_ACTIVATION_HELPTEXT
@@ -217,7 +217,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.toolbar_pos
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 min      = 0
@@ -230,7 +230,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.statusbar_pos
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 min      = 0
@@ -243,7 +243,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.window_snap_radius
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiZeroIsSpecial
 def      = 10
 min      = 1
@@ -255,7 +255,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.window_soft_limit
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiZeroIsSpecial
 def      = 20
 min      = 5
@@ -268,7 +268,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.zoom_min
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = ZoomLevel::Min
 min      = ZoomLevel::Min
@@ -281,7 +281,7 @@ startup  = true
 
 [SDTC_VAR]
 var      = gui.zoom_max
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = ZoomLevel::Max
 min      = ZoomLevel::Out2x
@@ -294,7 +294,7 @@ startup  = true
 
 [SDTC_VAR]
 var      = gui.sprite_zoom_min
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = ZoomLevel::Min
 min      = ZoomLevel::Min
@@ -321,7 +321,7 @@ strhelp  = STR_CONFIG_SETTING_LINK_TERRAFORM_TOOLBAR_HELPTEXT
 
 [SDTC_VAR]
 var      = gui.smallmap_land_colour
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 0
 min      = 0
@@ -333,7 +333,7 @@ post_cb  = RedrawSmallmap
 
 [SDTC_VAR]
 var      = gui.linkgraph_colours
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 0
 min      = 0
@@ -346,7 +346,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.liveries
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = LIT_ALL
 min      = LIT_NONE
@@ -358,7 +358,7 @@ post_cb  = InvalidateCompanyLiveryWindow
 
 [SDTC_VAR]
 var      = gui.starting_colour
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = Colours::End
 min      = 0
@@ -369,7 +369,7 @@ strval   = STR_COLOUR_DARK_BLUE
 
 [SDTC_VAR]
 var      = gui.starting_colour_secondary
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = Colours::End
 min      = 0
@@ -396,7 +396,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.scrollwheel_scrolling
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = ScrollWheelScrolling::ZoomMap
 min      = ScrollWheelScrolling::ZoomMap
@@ -408,7 +408,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.scrollwheel_multiplier
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 5
 min      = 1
@@ -429,7 +429,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.advanced_vehicle_list
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 min      = 0
@@ -440,7 +440,7 @@ strval   = STR_CONFIG_SETTING_COMPANIES_OFF
 
 [SDTC_VAR]
 var      = gui.timetable_mode
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 0
 min      = 0
@@ -470,7 +470,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.loading_indicators
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 min      = 0
@@ -483,7 +483,7 @@ cat      = SC_BASIC
 
 [SDTC_OMANY]
 var      = gui.default_rail_road_type
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = DefaultRailRoadType::FirstAvailable
 min      = DefaultRailRoadType::FirstAvailable
@@ -496,7 +496,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.signal_gui_mode
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 0
 min      = 0
@@ -509,7 +509,7 @@ cat      = SC_ADVANCED
 
 [SDTC_VAR]
 var      = gui.default_signal_type
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 5
 min      = 0
@@ -517,7 +517,7 @@ max      = 5
 
 [SDTC_VAR]
 var      = gui.coloured_news_year
-type     = SLE_INT32
+type     = VarTypes::I32
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 2000
 min      = CalendarTime::MIN_YEAR
@@ -530,7 +530,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.cycle_signal_types
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = SIGNAL_CYCLE_GROUP
 min      = SIGNAL_CYCLE_GROUP
@@ -543,7 +543,7 @@ cat      = SC_ADVANCED
 
 [SDTC_VAR]
 var      = gui.drag_signals_density
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 4
 min      = 1
@@ -564,7 +564,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.semaphore_build_before
-type     = SLE_INT32
+type     = VarTypes::I32
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 1950
 min      = CalendarTime::MIN_YEAR
@@ -586,7 +586,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.order_review_system
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = OrderReviewSystem::ExcludeStopped
 min      = OrderReviewSystem::Off
@@ -621,7 +621,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.stop_location
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 min      = 0
@@ -652,7 +652,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.max_num_autosaves
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 16
 min      = 0
@@ -665,7 +665,7 @@ def      = true
 
 [SDTC_VAR]
 var      = gui.news_message_timeout
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 2
 min      = 1
@@ -682,7 +682,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.station_numtracks
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 1
 min      = 1
@@ -690,7 +690,7 @@ max      = 7
 
 [SDTC_VAR]
 var      = gui.station_platlength
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 5
 min      = 1
@@ -719,7 +719,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.station_gui_group_order
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 3
 min      = 0
@@ -728,7 +728,7 @@ interval = 1
 
 [SDTC_VAR]
 var      = gui.station_gui_sort_by
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 0
 min      = 0
@@ -737,7 +737,7 @@ interval = 1
 
 [SDTC_VAR]
 var      = gui.station_gui_sort_order
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 0
 min      = 0
@@ -746,7 +746,7 @@ interval = 1
 
 [SDTC_VAR]
 var      = gui.missing_strings_threshold
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 25
 min      = 1
@@ -755,7 +755,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.graph_line_thickness
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 3
 min      = 1
@@ -798,7 +798,7 @@ def      = false
 
 [SDTC_VAR]
 var      = gui.settings_restriction_mode
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 0
 min      = 0
@@ -806,7 +806,7 @@ max      = 2
 
 [SDTC_VAR]
 var      = gui.developer
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 1
 min      = 0
@@ -842,7 +842,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.newgrf_default_palette
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 min      = 0
@@ -852,7 +852,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.console_backlog_timeout
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 100
 min      = 10
@@ -860,7 +860,7 @@ max      = 65500
 
 [SDTC_VAR]
 var      = gui.console_backlog_length
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 100
 min      = 10
@@ -868,7 +868,7 @@ max      = 65500
 
 [SDTC_VAR]
 var      = gui.refresh_rate
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 60
 min      = 10
@@ -878,7 +878,7 @@ startup  = true
 
 [SDTC_VAR]
 var      = gui.fast_forward_speed_limit
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiZeroIsSpecial, SettingFlag::NoNetwork
 def      = 2500
 min      = 0
@@ -891,7 +891,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.network_chat_box_width_pct
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 40
 min      = 10
@@ -900,7 +900,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.network_chat_box_height
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 25
 min      = 5
@@ -909,7 +909,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.network_chat_timeout
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 20
 min      = 1

--- a/src/table/settings/linkgraph_settings.ini
+++ b/src/table/settings/linkgraph_settings.ini
@@ -40,7 +40,7 @@ startup  = false
 
 [SDT_VAR]
 var      = linkgraph.recalc_interval
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::Cargodist
 def      = 8
 min      = 4
@@ -53,7 +53,7 @@ extra    = offsetof(LinkGraphSettings, recalc_interval)
 
 [SDT_VAR]
 var      = linkgraph.recalc_time
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::Cargodist
 def      = 32
 min      = 1
@@ -66,7 +66,7 @@ extra    = offsetof(LinkGraphSettings, recalc_time)
 
 [SDT_VAR]
 var      = linkgraph.distribution_pax
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Cargodist
 flags    = SettingFlag::GuiDropdown
 def      = DistributionType::Manual
@@ -80,7 +80,7 @@ extra    = offsetof(LinkGraphSettings, distribution_pax)
 
 [SDT_VAR]
 var      = linkgraph.distribution_mail
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Cargodist
 flags    = SettingFlag::GuiDropdown
 def      = DistributionType::Manual
@@ -94,7 +94,7 @@ extra    = offsetof(LinkGraphSettings, distribution_mail)
 
 [SDT_VAR]
 var      = linkgraph.distribution_armoured
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Cargodist
 flags    = SettingFlag::GuiDropdown
 def      = DistributionType::Manual
@@ -108,7 +108,7 @@ extra    = offsetof(LinkGraphSettings, distribution_armoured)
 
 [SDT_VAR]
 var      = linkgraph.distribution_default
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Cargodist
 flags    = SettingFlag::GuiDropdown
 def      = DistributionType::Manual
@@ -122,7 +122,7 @@ extra    = offsetof(LinkGraphSettings, distribution_default)
 
 [SDT_VAR]
 var      = linkgraph.accuracy
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Cargodist
 def      = 16
 min      = 2
@@ -135,7 +135,7 @@ extra    = offsetof(LinkGraphSettings, accuracy)
 
 [SDT_VAR]
 var      = linkgraph.demand_distance
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Cargodist
 def      = 100
 min      = 0
@@ -148,7 +148,7 @@ extra    = offsetof(LinkGraphSettings, demand_distance)
 
 [SDT_VAR]
 var      = linkgraph.demand_size
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Cargodist
 def      = 100
 min      = 0
@@ -161,7 +161,7 @@ extra    = offsetof(LinkGraphSettings, demand_size)
 
 [SDT_VAR]
 var      = linkgraph.short_path_saturation
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Cargodist
 def      = 80
 min      = 0

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -51,7 +51,7 @@ startup  = false
 
 [SDT_OMANY]
 var      = locale.currency
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::NoNetworkSync
 def      = Currency::GBP
@@ -63,7 +63,7 @@ cat      = SC_BASIC
 [SDTG_OMANY]
 name     = ""units""
 var      = _old_units
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 to       = SaveLoadVersion::SeparateLocaleUnits
 flags    = SettingFlag::NotInConfig
@@ -75,7 +75,7 @@ cat      = SC_BASIC
 
 [SDT_OMANY]
 var      = locale.units_velocity
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::SeparateLocaleUnits
 flags    = SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
@@ -89,7 +89,7 @@ val_cb   = SettingsValueVelocityUnit
 
 [SDT_OMANY]
 var      = locale.units_velocity_nautical
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::VelocityNautical
 flags    = SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
@@ -103,7 +103,7 @@ val_cb   = SettingsValueVelocityUnit
 
 [SDT_OMANY]
 var      = locale.units_power
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::SeparateLocaleUnits
 flags    = SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
@@ -117,7 +117,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_IMPERIAL
 
 [SDT_OMANY]
 var      = locale.units_weight
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::SeparateLocaleUnits
 flags    = SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
@@ -131,7 +131,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_IMPERIAL
 
 [SDT_OMANY]
 var      = locale.units_volume
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::SeparateLocaleUnits
 flags    = SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
@@ -145,7 +145,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_IMPERIAL
 
 [SDT_OMANY]
 var      = locale.units_force
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::SeparateLocaleUnits
 flags    = SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
@@ -159,7 +159,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_IMPERIAL
 
 [SDT_OMANY]
 var      = locale.units_height
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::SeparateLocaleUnits
 flags    = SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
@@ -173,7 +173,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_IMPERIAL
 
 [SDT_SSTR]
 var      = locale.digit_group_separator
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 from     = SaveLoadVersion::DigitGroupSeparator
 flags    = SettingFlag::NoNetworkSync
 def      = """"
@@ -182,7 +182,7 @@ cat      = SC_BASIC
 
 [SDT_SSTR]
 var      = locale.digit_group_separator_currency
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 from     = SaveLoadVersion::DigitGroupSeparator
 flags    = SettingFlag::NoNetworkSync
 def      = """"
@@ -191,7 +191,7 @@ cat      = SC_BASIC
 
 [SDT_SSTR]
 var      = locale.digit_decimal_separator
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 from     = SaveLoadVersion::CumulatedInflation
 flags    = SettingFlag::NoNetworkSync
 def      = """"

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -60,14 +60,14 @@ startup  = true
 
 [SDTG_MMANY]
 name     = ""display_opt""
-type     = SLE_UINT8
+type     = VarTypes::U8
 var      = _display_opt
 def      = DisplayOptions({DisplayOption::ShowTownNames, DisplayOption::ShowStationNames, DisplayOption::ShowSigns, DisplayOption::FullAnimation, DisplayOption::FullDetail, DisplayOption::ShowWaypointNames, DisplayOption::ShowCompetitorSigns})
 full     = _display_opt_modes
 
 [SDTG_MMANY]
 name     = ""facility_display_opt""
-type     = SLE_UINT8
+type     = VarTypes::U8
 var      = _facility_display_opt
 def      = StationFacilities({StationFacility::Train, StationFacility::TruckStop, StationFacility::BusStop, StationFacility::Airport, StationFacility::Dock, STATION_FACILITY_GHOST})
 full     = _facility_display_opt_modes
@@ -100,7 +100,7 @@ cat      = SC_BASIC
 
 [SDTG_OMANY]
 name     = ""support8bpp""
-type     = SLE_UINT8
+type     = VarTypes::U8
 var      = _support8bpp
 def      = 0
 max      = 2
@@ -109,48 +109,48 @@ cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""soundsset""
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 var      = BaseSounds::ini_set
 def      = """"
 cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""musicset""
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 var      = BaseMusic::ini_set
 def      = """"
 cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""videodriver""
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 var      = _ini_videodriver
 def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""musicdriver""
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 var      = _ini_musicdriver
 def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""sounddriver""
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 var      = _ini_sounddriver
 def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""blitter""
-type     = SLE_STRQ
+type     = VarTypes::STRQ
 var      = _ini_blitter
 def      = """"
 
 [SDTG_SSTR]
 name     = ""language""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _config_language_file
 def      = """"
 cat      = SC_BASIC
@@ -158,7 +158,7 @@ cat      = SC_BASIC
 ; workaround for implicit lengthof() in SDTG_LIST
 [SDTG_LIST]
 name     = ""resolution""
-type     = SLE_UINT32
+type     = VarTypes::U32
 length   = 2
 var      = _cur_resolution
 def      = ""0,0""
@@ -166,14 +166,14 @@ cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""screenshot_format""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _screenshot_format_name
 def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""savegame_format""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _savegame_format
 def      = """"
 cat      = SC_EXPERT
@@ -186,35 +186,35 @@ def      = false
 [SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""small_font""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _fcsettings.small.font
 def      = """"
 
 [SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""medium_font""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _fcsettings.medium.font
 def      = """"
 
 [SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""large_font""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _fcsettings.large.font
 def      = """"
 
 [SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""mono_font""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _fcsettings.mono.font
 def      = """"
 
 [SDTG_VAR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""small_size""
-type     = SLE_UINT32
+type     = VarTypes::U32
 var      = _fcsettings.small.size
 def      = 0
 min      = 0
@@ -223,7 +223,7 @@ max      = 72
 [SDTG_VAR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""medium_size""
-type     = SLE_UINT32
+type     = VarTypes::U32
 var      = _fcsettings.medium.size
 def      = 0
 min      = 0
@@ -232,7 +232,7 @@ max      = 72
 [SDTG_VAR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""large_size""
-type     = SLE_UINT32
+type     = VarTypes::U32
 var      = _fcsettings.large.size
 def      = 0
 min      = 0
@@ -241,7 +241,7 @@ max      = 72
 [SDTG_VAR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""mono_size""
-type     = SLE_UINT32
+type     = VarTypes::U32
 var      = _fcsettings.mono.size
 def      = 0
 min      = 0
@@ -261,7 +261,7 @@ def      = false
 
 [SDTG_VAR]
 name     = ""sprite_cache_size_px""
-type     = SLE_UINT32
+type     = VarTypes::U32
 var      = _sprite_cache_size
 def      = 128
 min      = 1
@@ -270,14 +270,14 @@ cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""player_face""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _company_manager_face
 def      = """"
 cat      = SC_BASIC
 
 [SDTG_VAR]
 name     = ""transparency_options""
-type     = SLE_UINT32
+type     = VarTypes::U32
 var      = _transparency_opt
 def      = 0
 min      = 0
@@ -286,7 +286,7 @@ cat      = SC_BASIC
 
 [SDTG_VAR]
 name     = ""transparency_locks""
-type     = SLE_UINT32
+type     = VarTypes::U32
 var      = _transparency_lock
 def      = 0
 min      = 0
@@ -295,7 +295,7 @@ cat      = SC_BASIC
 
 [SDTG_VAR]
 name     = ""invisibility_options""
-type     = SLE_UINT32
+type     = VarTypes::U32
 var      = _invisibility_opt
 def      = 0
 min      = 0
@@ -304,21 +304,21 @@ cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""keyboard""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _keyboard_opt[0]
 def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""keyboard_caps""
-type     = SLE_STR
+type     = VarTypes::STR
 var      = _keyboard_opt[1]
 def      = """"
 cat      = SC_EXPERT
 
 [SDTG_VAR]
 name     = ""last_newgrf_count""
-type     = SLE_UINT32
+type     = VarTypes::U32
 var      = _settings_client.gui.last_newgrf_count
 def      = 100
 min      = 0
@@ -327,7 +327,7 @@ cat      = SC_EXPERT
 
 [SDTG_VAR]
 name     = ""gui_scale""
-type     = SLE_INT32
+type     = VarTypes::I32
 var      = _gui_scale_cfg
 def      = -1
 min      = -1

--- a/src/table/settings/multimedia_settings.ini
+++ b/src/table/settings/multimedia_settings.ini
@@ -100,7 +100,7 @@ strhelp  = STR_CONFIG_SETTING_SOUND_AMBIENT_HELPTEXT
 
 [SDTC_VAR]
 var      = music.playlist
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = PlaylistChoice::All
 min      = PlaylistChoice::All
@@ -110,7 +110,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = music.music_vol
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 50
 min      = 0
@@ -120,7 +120,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = music.effect_vol
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 100
 min      = 0
@@ -130,14 +130,14 @@ cat      = SC_BASIC
 
 [SDTC_LIST]
 var      = music.custom_1
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = """"
 cat      = SC_BASIC
 
 [SDTC_LIST]
 var      = music.custom_2
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = """"
 cat      = SC_BASIC

--- a/src/table/settings/network_private_settings.ini
+++ b/src/table/settings/network_private_settings.ini
@@ -44,7 +44,7 @@ startup  = false
 
 [SDTC_SSTR]
 var      = network.client_name
-type     = SLE_STR
+type     = VarTypes::STR
 length   = NETWORK_CLIENT_NAME_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = """"
@@ -54,7 +54,7 @@ cat      = SC_BASIC
 
 [SDTC_SSTR]
 var      = network.server_name
-type     = SLE_STR
+type     = VarTypes::STR
 length   = NETWORK_NAME_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = """"
@@ -64,14 +64,14 @@ cat      = SC_BASIC
 
 [SDTC_SSTR]
 var      = network.connect_to_ip
-type     = SLE_STR
+type     = VarTypes::STR
 length   = 0
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = """"
 
 [SDTC_SSTR]
 var      = network.last_joined
-type     = SLE_STR
+type     = VarTypes::STR
 length   = 0
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = """"
@@ -79,7 +79,7 @@ cat      = SC_EXPERT
 
 [SDTC_OMANY]
 var      = network.use_relay_service
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::GuiDropdown, SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = UseRelayService::Ask
 min      = UseRelayService::Never
@@ -92,7 +92,7 @@ cat      = SC_BASIC
 
 [SDTC_OMANY]
 var      = network.participate_survey
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = ParticipateSurvey::Ask
 min      = ParticipateSurvey::Ask

--- a/src/table/settings/network_secrets_settings.ini
+++ b/src/table/settings/network_secrets_settings.ini
@@ -36,7 +36,7 @@ startup  = false
 
 [SDTC_SSTR]
 var      = network.server_password
-type     = SLE_STR
+type     = VarTypes::STR
 length   = NETWORK_PASSWORD_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = """"
@@ -46,7 +46,7 @@ cat      = SC_BASIC
 
 [SDTC_SSTR]
 var      = network.rcon_password
-type     = SLE_STR
+type     = VarTypes::STR
 length   = NETWORK_PASSWORD_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = """"
@@ -55,7 +55,7 @@ cat      = SC_BASIC
 
 [SDTC_SSTR]
 var      = network.admin_password
-type     = SLE_STR
+type     = VarTypes::STR
 length   = NETWORK_PASSWORD_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = """"
@@ -63,7 +63,7 @@ cat      = SC_BASIC
 
 [SDTC_SSTR]
 var      = network.client_secret_key
-type     = SLE_STR
+type     = VarTypes::STR
 length   = NETWORK_SECRET_KEY_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = """"
@@ -72,7 +72,7 @@ pre_cb   = [](auto) { return false; }
 
 [SDTC_SSTR]
 var      = network.client_public_key
-type     = SLE_STR
+type     = VarTypes::STR
 length   = NETWORK_SECRET_KEY_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = """"
@@ -81,14 +81,14 @@ pre_cb   = [](auto) { return false; }
 
 [SDTC_SSTR]
 var      = network.server_invite_code
-type     = SLE_STR
+type     = VarTypes::STR
 length   = NETWORK_INVITE_CODE_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = """"
 
 [SDTC_SSTR]
 var      = network.server_invite_code_secret
-type     = SLE_STR
+type     = VarTypes::STR
 length   = NETWORK_INVITE_CODE_SECRET_LENGTH
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = """"

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -47,7 +47,7 @@ startup  = false
 
 [SDTC_VAR]
 var      = network.sync_freq
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NotInConfig, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 100
 min      = 0
@@ -56,7 +56,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = network.frame_freq
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NotInConfig, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 0
 min      = 0
@@ -65,7 +65,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = network.commands_per_frame
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 2
 min      = 1
@@ -74,7 +74,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = network.commands_per_frame_server
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 16
 min      = 1
@@ -83,7 +83,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = network.max_commands_in_queue
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 16
 min      = 1
@@ -92,7 +92,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = network.bytes_per_frame
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 8
 min      = 1
@@ -101,7 +101,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = network.bytes_per_frame_burst
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 256
 min      = 1
@@ -110,7 +110,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = network.max_init_time
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 100
 min      = 0
@@ -119,7 +119,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = network.max_join_time
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 500
 min      = 0
@@ -127,7 +127,7 @@ max      = 32000
 
 [SDTC_VAR]
 var      = network.max_download_time
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 1000
 min      = 0
@@ -135,7 +135,7 @@ max      = 32000
 
 [SDTC_VAR]
 var      = network.max_password_time
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 2000
 min      = 0
@@ -143,7 +143,7 @@ max      = 32000
 
 [SDTC_VAR]
 var      = network.max_lag_time
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 500
 min      = 0
@@ -156,7 +156,7 @@ def      = true
 
 [SDTC_VAR]
 var      = network.server_port
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = NETWORK_DEFAULT_PORT
 min      = 0
@@ -165,7 +165,7 @@ cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = network.server_admin_port
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = NETWORK_ADMIN_PORT
 min      = 0
@@ -186,7 +186,7 @@ cat      = SC_EXPERT
 
 [SDTC_OMANY]
 var      = network.server_game_type
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = ServerGameType::Local
 min      = ServerGameType::Local
@@ -202,7 +202,7 @@ def      = false
 
 [SDTC_VAR]
 var      = network.autoclean_protected
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiZeroIsSpecial, SettingFlag::NetworkOnly
 def      = 36
 min      = 0
@@ -210,7 +210,7 @@ max      = 240
 
 [SDTC_VAR]
 var      = network.autoclean_novehicles
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiZeroIsSpecial, SettingFlag::NetworkOnly
 def      = 0
 min      = 0
@@ -218,7 +218,7 @@ max      = 240
 
 [SDTC_VAR]
 var      = network.max_companies
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 15
 min      = 1
@@ -228,7 +228,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = network.max_clients
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 25
 min      = 2
@@ -238,7 +238,7 @@ cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = network.restart_game_year
-type     = SLE_INT32
+type     = VarTypes::I32
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiZeroIsSpecial, SettingFlag::NetworkOnly
 def      = 0
 min      = CalendarTime::MIN_YEAR
@@ -247,7 +247,7 @@ interval = 1
 
 [SDTC_VAR]
 var      = network.restart_hours
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiZeroIsSpecial, SettingFlag::NetworkOnly
 def      = 0
 min      = 0
@@ -257,7 +257,7 @@ post_cb  = [](auto) { ChangeNetworkRestartTime(false); }
 
 [SDTC_VAR]
 var      = network.min_active_clients
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::NetworkOnly
 def      = 0
 min      = 0

--- a/src/table/settings/news_display_settings.ini
+++ b/src/table/settings/news_display_settings.ini
@@ -40,7 +40,7 @@ startup  = false
 
 [SDTC_OMANY]
 var      = news_display.arrival_player
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2
@@ -51,7 +51,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.arrival_other
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 max      = 2
@@ -62,7 +62,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.accident
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2
@@ -73,7 +73,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.accident_other
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2
@@ -84,7 +84,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.company_info
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2
@@ -95,7 +95,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.open
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 max      = 2
@@ -106,7 +106,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.close
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 max      = 2
@@ -117,7 +117,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.economy
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2
@@ -128,7 +128,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.production_player
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 max      = 2
@@ -139,7 +139,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.production_other
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 0
 max      = 2
@@ -150,7 +150,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.production_nobody
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 0
 max      = 2
@@ -161,7 +161,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.advice
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2
@@ -172,7 +172,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.new_vehicles
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2
@@ -183,7 +183,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.acceptance
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2
@@ -194,7 +194,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.subsidies
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 1
 max      = 2
@@ -205,7 +205,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
 var      = news_display.general
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 2
 max      = 2

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -82,7 +82,7 @@ to       = SaveLoadVersion::TownTolerancePauseMode
 name     = ""diff_custom""
 sdt_cmd  = SDT_INTLIST
 sle_cmd  = SaveLoadType::Array
-type     = SLE_UINT16
+type     = VarTypes::U16
 flags    = SettingFlag::NotInConfig
 var      = _old_diff_custom
 length   = 18
@@ -93,7 +93,7 @@ from     = SaveLoadVersion::TownTolerancePauseMode
 [SDTG_VAR]
 name     = ""diff_level""
 var      = _old_diff_level
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInConfig
 def      = SP_CUSTOM
 min      = SP_EASY
@@ -102,7 +102,7 @@ cat      = SC_BASIC
 
 [SDT_OMANY]
 var      = locale.currency
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NoNetworkSync
 def      = Currency::GBP
 max      = static_cast<Currency>(to_underlying(Currency::End) - 1)
@@ -112,7 +112,7 @@ cat      = SC_BASIC
 [SDTG_OMANY]
 name     = ""units""
 var      = _old_units
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInConfig
 def      = 1
 max      = 2
@@ -123,7 +123,7 @@ cat      = SC_BASIC
 # these bigger values (21-255). Invalid values will fallback to english on use and (undefined string) in GUI.
 [SDT_OMANY]
 var      = game_creation.town_name
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = 0
 max      = 255
 full     = _town_names
@@ -131,7 +131,7 @@ cat      = SC_BASIC
 
 [SDT_OMANY]
 var      = game_creation.landscape
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = 0
 max      = 3
 full     = _climates
@@ -140,7 +140,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.snow_line_height
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = DEF_SNOWLINE_HEIGHT * TILE_HEIGHT
 min      = MIN_SNOWLINE_HEIGHT * TILE_HEIGHT
 # "max" used to be MAX_SNOWLINE_HEIGHT * TILE_HEIGHT, but this would overflow the storage.
@@ -149,7 +149,7 @@ to       = SaveLoadVersion::SavePatches
 
 [SDT_OMANY]
 var      = vehicle.road_side
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = RoadVehicleDrivingSide::Right
 max      = RoadVehicleDrivingSide::Right
 full     = _roadsides

--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -60,7 +60,7 @@ strhelp  = STR_CONFIG_SETTING_REVERSE_AT_SIGNALS_HELPTEXT
 
 [SDT_VAR]
 var      = pf.wait_oneway_signal
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = 15
 min      = 2
 max      = 255
@@ -68,7 +68,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.wait_twoway_signal
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = 41
 min      = 2
 max      = 255
@@ -76,7 +76,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.wait_for_pbs_path
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Yapp
 def      = 30
 min      = 2
@@ -91,7 +91,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.path_backoff_interval
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Yapp
 def      = 20
 min      = 1
@@ -100,7 +100,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.max_search_nodes
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 10000
 min      = 500
@@ -115,7 +115,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_firstred_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 10 * YAPF_TILE_LENGTH
 min      = 0
@@ -124,7 +124,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_firstred_exit_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 100 * YAPF_TILE_LENGTH
 min      = 0
@@ -133,7 +133,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_lastred_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 10 * YAPF_TILE_LENGTH
 min      = 0
@@ -142,7 +142,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_lastred_exit_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 100 * YAPF_TILE_LENGTH
 min      = 0
@@ -151,7 +151,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_station_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 10 * YAPF_TILE_LENGTH
 min      = 0
@@ -160,7 +160,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_slope_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 2 * YAPF_TILE_LENGTH
 min      = 0
@@ -169,7 +169,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_curve45_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 1 * YAPF_TILE_LENGTH
 min      = 0
@@ -178,7 +178,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_curve90_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 6 * YAPF_TILE_LENGTH
 min      = 0
@@ -187,7 +187,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_depot_reverse_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 50 * YAPF_TILE_LENGTH
 min      = 0
@@ -196,7 +196,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_crossing_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 3 * YAPF_TILE_LENGTH
 min      = 0
@@ -205,7 +205,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_look_ahead_max_signals
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapf
 def      = 10
 min      = 1
@@ -214,7 +214,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_look_ahead_signal_p0
-type     = SLE_INT32
+type     = VarTypes::I32
 from     = SaveLoadVersion::Yapf
 def      = 500
 min      = -1000000
@@ -223,7 +223,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_look_ahead_signal_p1
-type     = SLE_INT32
+type     = VarTypes::I32
 from     = SaveLoadVersion::Yapf
 def      = -100
 min      = -1000000
@@ -232,7 +232,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_look_ahead_signal_p2
-type     = SLE_INT32
+type     = VarTypes::I32
 from     = SaveLoadVersion::Yapf
 def      = 5
 min      = -1000000
@@ -241,7 +241,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_pbs_cross_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapp
 def      = 3 * YAPF_TILE_LENGTH
 min      = 0
@@ -250,7 +250,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_pbs_station_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapp
 def      = 8 * YAPF_TILE_LENGTH
 min      = 0
@@ -259,7 +259,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_pbs_signal_back_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapp
 def      = 15 * YAPF_TILE_LENGTH
 min      = 0
@@ -268,7 +268,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_doubleslip_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Yapp
 def      = 1 * YAPF_TILE_LENGTH
 min      = 0
@@ -277,7 +277,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_longer_platform_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 8 * YAPF_TILE_LENGTH
 min      = 0
@@ -286,7 +286,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_longer_platform_per_tile_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 0 * YAPF_TILE_LENGTH
 min      = 0
@@ -295,7 +295,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_shorter_platform_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 40 * YAPF_TILE_LENGTH
 min      = 0
@@ -304,7 +304,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.rail_shorter_platform_per_tile_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 0 * YAPF_TILE_LENGTH
 min      = 0
@@ -313,7 +313,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_slope_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 2 * YAPF_TILE_LENGTH
 min      = 0
@@ -322,7 +322,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_curve_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 1 * YAPF_TILE_LENGTH
 min      = 0
@@ -331,7 +331,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_crossing_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::SaveYapfSettings
 def      = 3 * YAPF_TILE_LENGTH
 min      = 0
@@ -340,7 +340,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_stop_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::DriveThroughRoadStops
 def      = 8 * YAPF_TILE_LENGTH
 min      = 0
@@ -349,7 +349,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_stop_occupied_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::RoadStopOccupancyPenalty
 def      = 8 * YAPF_TILE_LENGTH
 min      = 0
@@ -358,7 +358,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.road_stop_bay_occupied_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::RoadStopOccupancyPenalty
 def      = 15 * YAPF_TILE_LENGTH
 min      = 0
@@ -367,7 +367,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.maximum_go_to_depot_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::MaximumDepotPenalty
 def      = 20 * YAPF_TILE_LENGTH
 min      = 0
@@ -376,7 +376,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.ship_curve45_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::ShipCurvePenalty
 def      = 1 * YAPF_TILE_LENGTH
 min      = 0
@@ -385,7 +385,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = pf.yapf.ship_curve90_penalty
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::ShipCurvePenalty
 def      = 6 * YAPF_TILE_LENGTH
 min      = 0

--- a/src/table/settings/script_settings.ini
+++ b/src/table/settings/script_settings.ini
@@ -44,7 +44,7 @@ startup  = false
 
 [SDT_VAR]
 var      = script.script_max_opcode_till_suspend
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::NoAI
 flags    = SettingFlag::NewgameOnly
 def      = 10000
@@ -58,7 +58,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = script.script_max_memory_megabytes
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::ScriptMemlimit
 flags    = SettingFlag::NewgameOnly
 def      = 1024

--- a/src/table/settings/window_settings.ini
+++ b/src/table/settings/window_settings.ini
@@ -47,14 +47,14 @@ def      = false
 
 [SDT_VAR]
 var      = pref_width
-type     = SLE_INT16
+type     = VarTypes::I16
 def      = 0
 min      = 0
 max      = 32000
 
 [SDT_VAR]
 var      = pref_height
-type     = SLE_INT16
+type     = VarTypes::I16
 def      = 0
 min      = 0
 max      = 32000

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -51,7 +51,7 @@ startup  = false
 ; these bigger values (21-255). Invalid values will fallback to english on use and (undefined string) in GUI.
 [SDT_OMANY]
 var      = game_creation.town_name
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::NoNetwork
 def      = 0
@@ -61,7 +61,7 @@ cat      = SC_BASIC
 
 [SDT_OMANY]
 var      = game_creation.landscape
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MergeOptsPats
 flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly
 def      = 0
@@ -75,7 +75,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.heightmap_height
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MapgenSettingsRevamp
 flags    = SettingFlag::NewgameOnly
 def      = MAP_HEIGHT_LIMIT_AUTO_MINIMUM
@@ -85,7 +85,7 @@ interval = 1
 
 [SDT_VAR]
 var      = game_creation.snow_line_height
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::SceneditOnly
 def      = DEF_SNOWLINE_HEIGHT
 min      = MIN_SNOWLINE_HEIGHT
@@ -98,7 +98,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.snow_coverage
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MapgenSettingsRevamp
 flags    = SettingFlag::NewgameOnly
 def      = DEF_SNOW_COVERAGE
@@ -112,7 +112,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.desert_coverage
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MapgenSettingsRevamp
 flags    = SettingFlag::NewgameOnly
 def      = DEF_DESERT_COVERAGE
@@ -126,7 +126,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.starting_year
-type     = SLE_INT32
+type     = VarTypes::I32
 def      = CalendarTime::DEF_START_YEAR
 min      = CalendarTime::MIN_YEAR
 max      = CalendarTime::MAX_YEAR
@@ -137,7 +137,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.ending_year
-type     = SLE_INT32
+type     = VarTypes::I32
 from     = SaveLoadVersion::EndingYear
 flags    = SettingFlag::GuiZeroIsSpecial
 def      = CalendarTime::DEF_END_YEAR
@@ -151,7 +151,7 @@ cat      = SC_ADVANCED
 
 [SDT_VAR]
 var      = game_creation.land_generator
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Tgp
 flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly
 def      = 1
@@ -163,7 +163,7 @@ strval   = STR_CONFIG_SETTING_LAND_GENERATOR_ORIGINAL
 
 [SDT_VAR]
 var      = game_creation.oil_refinery_limit
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Tgp
 def      = 32
 min      = 12
@@ -174,7 +174,7 @@ strhelp  = STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT
 
 [SDT_VAR]
 var      = game_creation.tgen_smoothness
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Tgp
 flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly
 def      = 1
@@ -187,7 +187,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.average_height
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly
 def      = GenworldAverageHeight::Auto
 min      = GenworldAverageHeight::Auto
@@ -199,7 +199,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.variety
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::StoreMapVariety
 flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly
 def      = 0
@@ -211,7 +211,7 @@ strval   = STR_VARIETY_NONE
 
 [SDT_VAR]
 var      = game_creation.generation_seed
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::Tgp
 flags    = SettingFlag::NotInConfig
 def      = GENERATE_NEW_SEED
@@ -221,7 +221,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = game_creation.tree_placer
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Tgp
 flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly, SettingFlag::SceneditToo
 def      = 2
@@ -234,7 +234,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.heightmap_rotation
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync, SettingFlag::GuiDropdown
 def      = 0
 min      = 0
@@ -245,7 +245,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.se_flat_world_height
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 1
 min      = 0
@@ -256,7 +256,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.map_x
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 8
 min      = MIN_MAP_SIZE_BITS
@@ -265,7 +265,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.map_y
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::NotInSave, SettingFlag::NoNetworkSync
 def      = 8
 min      = MIN_MAP_SIZE_BITS
@@ -274,7 +274,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.water_borders
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::FreeformEdges
 def      = 16
 min      = 0
@@ -282,14 +282,14 @@ max      = 16
 
 [SDT_VAR]
 var      = game_creation.water_border_presets
-type     = SLE_UINT8
+type     = VarTypes::U8
 def      = BorderFlagPresets::Random
 min      = BorderFlagPresets::Random
 max      = BorderFlagPresets::InfiniteWater
 
 [SDT_VAR]
 var      = game_creation.custom_town_number
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::CustomTownNumber
 def      = 1
 min      = 1
@@ -298,14 +298,14 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.custom_industry_number
-type     = SLE_UINT16
+type     = VarTypes::U16
 def      = 1
 min      = 1
 max      = 64000
 
 [SDT_VAR]
 var      = game_creation.custom_terrain_type
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MapgenSettingsRevamp
 flags    = SettingFlag::NewgameOnly
 def      = MAP_HEIGHT_LIMIT_AUTO_MINIMUM
@@ -315,7 +315,7 @@ interval = 1
 
 [SDT_VAR]
 var      = game_creation.custom_sea_level
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::CustomSeaLevel
 def      = CUSTOM_SEA_LEVEL_MIN_PERCENTAGE
 min      = CUSTOM_SEA_LEVEL_MIN_PERCENTAGE
@@ -324,7 +324,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = game_creation.min_river_length
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Rivers
 def      = 16
 min      = 2
@@ -333,7 +333,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = game_creation.river_route_random
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Rivers
 def      = 5
 min      = 1
@@ -342,7 +342,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = game_creation.amount_of_rivers
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::Rivers
 flags    = SettingFlag::GuiDropdown, SettingFlag::NewgameOnly
 def      = 2
@@ -354,7 +354,7 @@ strval   = STR_RIVERS_NONE
 
 [SDT_VAR]
 var      = construction.map_height_limit
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MaxBridgeMapHeight
 flags    = SettingFlag::NewgameOnly, SettingFlag::SceneditToo, SettingFlag::GuiZeroIsSpecial
 def      = 0
@@ -376,7 +376,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.command_pause_level
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::PauseLevel
 flags    = SettingFlag::GuiDropdown, SettingFlag::NoNetwork
 def      = 1
@@ -389,7 +389,7 @@ strval   = STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_NO_ACTIONS
 
 [SDT_VAR]
 var      = construction.terraform_per_64k_frames
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::TerraformLimits
 def      = 64 << 16
 min      = 0
@@ -399,7 +399,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.terraform_frame_burst
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::TerraformLimits
 def      = 4096
 min      = 0
@@ -409,7 +409,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.clear_per_64k_frames
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::TerraformLimits
 def      = 64 << 16
 min      = 0
@@ -419,7 +419,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.clear_frame_burst
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::TerraformLimits
 def      = 4096
 min      = 0
@@ -429,7 +429,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.tree_per_64k_frames
-type     = SLE_UINT32
+type     = VarTypes::U32
 from     = SaveLoadVersion::AutoreplaceWhenOldTreeLimit
 def      = 64 << 16
 min      = 0
@@ -439,7 +439,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.tree_frame_burst
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::AutoreplaceWhenOldTreeLimit
 def      = 4096
 min      = 0
@@ -449,7 +449,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.build_object_per_64k_frames
-type     = SLE_UINT32
+type     = VarTypes::U32
 def      = 32 << 16
 min      = 0
 max      = 1 << 30
@@ -458,7 +458,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.build_object_frame_burst
-type     = SLE_UINT16
+type     = VarTypes::U16
 def      = 2048
 min      = 0
 max      = 1 << 15
@@ -481,7 +481,7 @@ strhelp  = STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT
 
 [SDT_VAR]
 var      = construction.max_bridge_length
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::MaxLengthAndReverseSignals
 flags    = SettingFlag::NoNetwork
 def      = 64
@@ -494,7 +494,7 @@ strval   = STR_CONFIG_SETTING_TILE_LENGTH
 
 [SDT_VAR]
 var      = construction.max_bridge_height
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::MaxBridgeMapHeight
 flags    = SettingFlag::NoNetwork
 def      = 12
@@ -508,7 +508,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.max_tunnel_length
-type     = SLE_UINT16
+type     = VarTypes::U16
 from     = SaveLoadVersion::MaxLengthAndReverseSignals
 flags    = SettingFlag::NoNetwork
 def      = 64
@@ -521,7 +521,7 @@ strval   = STR_CONFIG_SETTING_TILE_LENGTH
 
 [SDT_VAR]
 var      = construction.train_signal_side
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::GuiDropdown, SettingFlag::NoNetwork
 def      = TrainSignalSide::RoadVehicleDrivingSide
 min      = TrainSignalSide::Left
@@ -557,7 +557,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = construction.raw_industry_construction
-type     = SLE_UINT8
+type     = VarTypes::U8
 flags    = SettingFlag::GuiDropdown
 def      = 0
 min      = 0
@@ -570,7 +570,7 @@ cat      = SC_BASIC
 
 [SDT_VAR]
 var      = construction.industry_platform
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::IndustryPlatform
 def      = 1
 min      = 0
@@ -590,7 +590,7 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 var      = construction.extra_tree_placement
-type     = SLE_UINT8
+type     = VarTypes::U8
 from     = SaveLoadVersion::DisallowTreeBuilding
 flags    = SettingFlag::GuiDropdown
 def      = 2


### PR DESCRIPTION
## Motivation / Problem

The namespace starting with `SLE_` is crowded, making searching related things difficult.


## Description

Move the `SLE_UINT32` type constants into a struct `VarTypes` and rename to make them consistent with `VarFileType`/`VarMemType`, e.g. `VarTypes::U32`. However, they remain constants so `SLE_BOOL` becomes `VarTypes::BOOL`.


## Limitations

* 1000+ lines affected.
* I'm not touching white space yet. That's something for a later PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
