### PR TITLE
Fix #7992: Fix catenary sprites on bridges not rendering both types

### DIFF
--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1173,8 +1173,8 @@ static void DrawBridgeRoadBits(TileIndex head_tile, int x, int y, int z, int off
 	const RoadTypeInfo *road_rti = road_rt == INVALID_ROADTYPE ? nullptr : GetRoadTypeInfo(road_rt);
 	const RoadTypeInfo *tram_rti = tram_rt == INVALID_ROADTYPE ? nullptr : GetRoadTypeInfo(tram_rt);
 
-	SpriteID seq_back[4] = { 0 };
-	bool trans_back[4] = { false };
+	SpriteID seq_back[5] = { 0 };
+	bool trans_back[5] = { false };
 	SpriteID seq_front[4] = { 0 };
 	bool trans_front[4] = { false };
 
@@ -1217,13 +1217,18 @@ static void DrawBridgeRoadBits(TileIndex head_tile, int x, int y, int z, int off
 			}
 		}
 
-		/* Road catenary takes precedence over tram */
+		/* Both the road and tram catenary sprites need to be on their own layers so they can both be drawn */
 		trans_back[3] = IsTransparencySet(TransparencyOption::Catenary);
+		trans_back[4] = IsTransparencySet(TransparencyOption::Catenary);
 		trans_front[0] = IsTransparencySet(TransparencyOption::Catenary);
+		trans_front[1] = IsTransparencySet(TransparencyOption::Catenary);
+
 		if (road_rti != nullptr && HasRoadCatenaryDrawn(road_rt)) {
 			GetBridgeRoadCatenary(road_rti, head_tile, offset, head, seq_back[3], seq_front[0]);
-		} else if (tram_rti != nullptr && HasRoadCatenaryDrawn(tram_rt)) {
-			GetBridgeRoadCatenary(tram_rti, head_tile, offset, head, seq_back[3], seq_front[0]);
+		}
+
+		if (tram_rti != nullptr && HasRoadCatenaryDrawn(tram_rt)) {
+			GetBridgeRoadCatenary(tram_rti, head_tile, offset, head, seq_back[4], seq_front[1]);
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem

As per issue https://github.com/OpenTTD/OpenTTD/issues/7992 the catenary sprites for road and tram were not combining as they do for other tile types.

## Description

Changed this by changing the else if to an if so both conditions are evaluated and by extending the size of the back sprites array so road and tram can have sperate entries.


## Limitations

From my testing this now appears to be fixed

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
