### PR TITLE
Codechange: use GrfID over uint32_t for NewGRF IDs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -336,6 +336,7 @@ add_files(
     newgrf_town.h
     newgrf_townname.cpp
     newgrf_townname.h
+    newgrf_type.h
     news_cmd.h
     news_func.h
     news_gui.cpp

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -22,7 +22,7 @@ extern StationPool _station_pool;
 template <typename T>
 struct SpecMapping {
 	const T *spec = nullptr; ///< Custom spec.
-	uint32_t grfid = 0; ///< GRF ID of this custom spec.
+	GrfID grfid{}; ///< GRF ID of this custom spec.
 	uint16_t localidx = 0; ///< Local ID within GRF of this custom spec.
 };
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2822,7 +2822,7 @@ static void ConDumpRoadTypes()
 	for (RoadType rt : EnumRange(ROADTYPE_END)) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
 		if (rti->label == 0) continue;
-		uint32_t grfid = 0;
+		GrfID grfid{};
 		const GRFFile *grf = rti->grffile[RoadSpriteType::Ground];
 		if (grf != nullptr) {
 			grfid = grf->grfid;
@@ -2861,7 +2861,7 @@ static void ConDumpRailTypes()
 	for (RailType rt : EnumRange(RAILTYPE_END)) {
 		const RailTypeInfo *rti = GetRailTypeInfo(rt);
 		if (rti->label == 0) continue;
-		uint32_t grfid = 0;
+		GrfID grfid{};
 		const GRFFile *grf = rti->grffile[RailSpriteType::Ground];
 		if (grf != nullptr) {
 			grfid = grf->grfid;
@@ -2908,7 +2908,7 @@ static void ConDumpCargoTypes()
 
 	std::map<uint32_t, const GRFFile *> grfs;
 	for (const CargoSpec *spec : CargoSpec::Iterate()) {
-		uint32_t grfid = 0;
+		GrfID grfid{};
 		const GRFFile *grf = spec->grffile;
 		if (grf != nullptr) {
 			grfid = grf->grfid;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -591,6 +591,14 @@ EngineID EngineOverrideManager::UseUnreservedID(VehicleType type, uint16_t grf_l
 	return it->engine;
 }
 
+/**
+ * Create an override to the given engine. If the override already exists, it will be overwritten.
+ * @param type The vehicle type.
+ * @param grf_local_id The NewGRF internal identifier.
+ * @param grfid The unique identifier of the NewGRF.
+ * @param substitute_id The fallback original engine.
+ * @param engine The engine this override is for.
+ */
 void EngineOverrideManager::SetID(VehicleType type, uint16_t grf_local_id, GrfID grfid, uint8_t substitute_id, EngineID engine)
 {
 	auto &map = this->mappings[type];

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -179,10 +179,10 @@ bool Engine::IsEnabled() const
  * This is the GRF providing the Action 3.
  * @return GRF ID of the associated NewGRF.
  */
-uint32_t Engine::GetGRFID() const
+GrfID Engine::GetGRFID() const
 {
 	const GRFFile *file = this->GetGRF();
-	return file == nullptr ? 0 : file->grfid;
+	return file == nullptr ? GrfID{} : file->grfid;
 }
 
 /**
@@ -553,7 +553,7 @@ void EngineOverrideManager::ResetToDefaultMapping()
  *              If dynamic_engines is disabled, all newgrf share the same ID scope identified by INVALID_GRFID.
  * @return The engine ID if present, or EngineID::Invalid() if not.
  */
-EngineID EngineOverrideManager::GetID(VehicleType type, uint16_t grf_local_id, uint32_t grfid)
+EngineID EngineOverrideManager::GetID(VehicleType type, uint16_t grf_local_id, GrfID grfid)
 {
 	const auto &map = this->mappings[type];
 	const auto key = EngineIDMapping::Key(grfid, grf_local_id);
@@ -572,7 +572,7 @@ EngineID EngineOverrideManager::GetID(VehicleType type, uint16_t grf_local_id, u
  * @param static_access Whether to actually reserve the EngineID.
  * @return The engine ID if present and now reserved, or EngineID::Invalid() if not.
  */
-EngineID EngineOverrideManager::UseUnreservedID(VehicleType type, uint16_t grf_local_id, uint32_t grfid, bool static_access)
+EngineID EngineOverrideManager::UseUnreservedID(VehicleType type, uint16_t grf_local_id, GrfID grfid, bool static_access)
 {
 	auto &map = _engine_mngr.mappings[type];
 	const auto key = EngineIDMapping::Key(INVALID_GRFID, grf_local_id);
@@ -591,7 +591,7 @@ EngineID EngineOverrideManager::UseUnreservedID(VehicleType type, uint16_t grf_l
 	return it->engine;
 }
 
-void EngineOverrideManager::SetID(VehicleType type, uint16_t grf_local_id, uint32_t grfid, uint8_t substitute_id, EngineID engine)
+void EngineOverrideManager::SetID(VehicleType type, uint16_t grf_local_id, GrfID grfid, uint8_t substitute_id, EngineID engine)
 {
 	auto &map = this->mappings[type];
 	const auto key = EngineIDMapping::Key(grfid, grf_local_id);

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -207,11 +207,31 @@ struct EngineIDMapping {
 	uint8_t substitute_id = 0; ///< The (original) entity ID to use if this GRF is not available (currently not used)
 	EngineID engine{};
 
+	/**
+	 * Create a 64 bit key from the GRFID and internal ID for mappings.
+	 * @param grfid The NewGRF id.
+	 * @param internal_id The internal ID within the GRF file.
+	 * @return The key.
+	 */
 	static inline uint64_t Key(GrfID grfid, uint16_t internal_id) { return static_cast<uint64_t>(grfid) << 32 | internal_id; }
 
+	/**
+	 * Create a 64 bit key from this mapping.
+	 * @return The key.
+	 */
 	inline uint64_t Key() const { return Key(this->grfid, this->internal_id); }
 
+	/** Create a new mapping. */
 	EngineIDMapping() {}
+
+	/**
+	 * Create the mapping.
+	 * @param grfid The unique identifer of the NewGRF.
+	 * @param internal_id The internal identifier of the engine within the NewGRF.
+	 * @param type The vehicle type.
+	 * @param substitute_id The original vehicle to fall back to.
+	 * @param engine The engine the mapping is for.
+	 */
 	EngineIDMapping(GrfID grfid, uint16_t internal_id, VehicleType type, uint8_t substitute_id, EngineID engine)
 		: grfid(grfid), internal_id(internal_id), type(type), substitute_id(substitute_id), engine(engine) {}
 };

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -168,7 +168,7 @@ public:
 		return this->grf_prop.grffile;
 	}
 
-	uint32_t GetGRFID() const;
+	GrfID GetGRFID() const;
 
 	struct EngineTypeFilter {
 		VehicleType vt;
@@ -201,18 +201,18 @@ public:
 };
 
 struct EngineIDMapping {
-	uint32_t grfid = 0; ///< The GRF ID of the file the entity belongs to
+	GrfID grfid{}; ///< The GRF ID of the file the entity belongs to
 	uint16_t internal_id = 0; ///< The internal ID within the GRF file
 	VehicleType type{}; ///< The engine type
 	uint8_t substitute_id = 0; ///< The (original) entity ID to use if this GRF is not available (currently not used)
 	EngineID engine{};
 
-	static inline uint64_t Key(uint32_t grfid, uint16_t internal_id) { return static_cast<uint64_t>(grfid) << 32 | internal_id; }
+	static inline uint64_t Key(GrfID grfid, uint16_t internal_id) { return static_cast<uint64_t>(grfid) << 32 | internal_id; }
 
 	inline uint64_t Key() const { return Key(this->grfid, this->internal_id); }
 
 	EngineIDMapping() {}
-	EngineIDMapping(uint32_t grfid, uint16_t internal_id, VehicleType type, uint8_t substitute_id, EngineID engine)
+	EngineIDMapping(GrfID grfid, uint16_t internal_id, VehicleType type, uint8_t substitute_id, EngineID engine)
 		: grfid(grfid), internal_id(internal_id), type(type), substitute_id(substitute_id), engine(engine) {}
 };
 
@@ -229,9 +229,9 @@ struct EngineOverrideManager {
 	VehicleTypeIndexArray<std::vector<EngineIDMapping>> mappings;
 
 	void ResetToDefaultMapping();
-	EngineID GetID(VehicleType type, uint16_t grf_local_id, uint32_t grfid);
-	EngineID UseUnreservedID(VehicleType type, uint16_t grf_local_id, uint32_t grfid, bool static_access);
-	void SetID(VehicleType type, uint16_t grf_local_id, uint32_t grfid, uint8_t substitute_id, EngineID engine);
+	EngineID GetID(VehicleType type, uint16_t grf_local_id, GrfID grfid);
+	EngineID UseUnreservedID(VehicleType type, uint16_t grf_local_id, GrfID grfid, bool static_access);
+	void SetID(VehicleType type, uint16_t grf_local_id, GrfID grfid, uint8_t substitute_id, EngineID engine);
 
 	static bool ResetToCurrentNewGRFConfig();
 };

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -107,7 +107,7 @@ void Gamelog::Reset()
  * @param md5sum array of md5sum to print, if known
  * @param gc GrfConfig, if known
  */
-static void AddGrfInfo(std::back_insert_iterator<std::string> &output_iterator, uint32_t grfid, const MD5Hash *md5sum, const GRFConfig *gc)
+static void AddGrfInfo(std::back_insert_iterator<std::string> &output_iterator, GrfID grfid, const MD5Hash *md5sum, const GRFConfig *gc)
 {
 	if (md5sum != nullptr) {
 		fmt::format_to(output_iterator, "GRF ID {:08X}, checksum {}", std::byteswap(grfid), FormatArrayAsHex(*md5sum));
@@ -463,7 +463,7 @@ void Gamelog::TestMode()
  * @param bug type of bug, @see enum GRFBugs
  * @param data additional data
  */
-void Gamelog::GRFBug(uint32_t grfid, ::GRFBug bug, uint64_t data)
+void Gamelog::GRFBug(GrfID grfid, ::GRFBug bug, uint64_t data)
 {
 	assert(this->action_type == GamelogActionType::GRFBug);
 
@@ -479,7 +479,7 @@ void Gamelog::GRFBug(uint32_t grfid, ::GRFBug bug, uint64_t data)
  * @param internal_id the internal ID of whatever's broken in the NewGRF
  * @return true iff a unique record was done
  */
-bool Gamelog::GRFBugReverse(uint32_t grfid, uint16_t internal_id)
+bool Gamelog::GRFBugReverse(GrfID grfid, uint16_t internal_id)
 {
 	for (const LoggedAction &la : this->data->action) {
 		for (const auto &lc : la.change) {
@@ -514,7 +514,7 @@ static inline bool IsLoggableGrfConfig(const GRFConfig &g)
  * Logs removal of a GRF
  * @param grfid ID of removed GRF
  */
-void Gamelog::GRFRemove(uint32_t grfid)
+void Gamelog::GRFRemove(GrfID grfid)
 {
 	assert(this->action_type == GamelogActionType::Load || this->action_type == GamelogActionType::GRF);
 
@@ -551,7 +551,7 @@ void Gamelog::GRFCompatible(const GRFIdentifier &newg)
  * @param grfid GRF that is moved
  * @param offset how far it is moved, positive = moved down
  */
-void Gamelog::GRFMove(uint32_t grfid, int32_t offset)
+void Gamelog::GRFMove(GrfID grfid, int32_t offset)
 {
 	assert(this->action_type == GamelogActionType::GRF);
 
@@ -563,7 +563,7 @@ void Gamelog::GRFMove(uint32_t grfid, int32_t offset)
  * Details about parameters changed are not stored
  * @param grfid ID of GRF to store
  */
-void Gamelog::GRFParameters(uint32_t grfid)
+void Gamelog::GRFParameters(GrfID grfid)
 {
 	assert(this->action_type == GamelogActionType::GRF);
 

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -11,6 +11,7 @@
 #define GAMELOG_H
 
 #include "newgrf_config.h"
+#include "newgrf_type.h"
 
 /** The actions we log. */
 enum class GamelogActionType : uint8_t {
@@ -78,13 +79,13 @@ public:
 
 	void GRFUpdate(const GRFConfigList &oldg, const GRFConfigList &newg);
 	void GRFAddList(const GRFConfigList &newg);
-	void GRFRemove(uint32_t grfid);
+	void GRFRemove(GrfID grfid);
 	void GRFAdd(const GRFConfig &newg);
-	void GRFBug(uint32_t grfid, ::GRFBug bug, uint64_t data);
-	bool GRFBugReverse(uint32_t grfid, uint16_t internal_id);
+	void GRFBug(GrfID grfid, ::GRFBug bug, uint64_t data);
+	bool GRFBugReverse(GrfID grfid, uint16_t internal_id);
 	void GRFCompatible(const GRFIdentifier &newg);
-	void GRFMove(uint32_t grfid, int32_t offset);
-	void GRFParameters(uint32_t grfid);
+	void GRFMove(GrfID grfid, int32_t offset);
+	void GRFParameters(GrfID grfid);
 
 	void TestRevision();
 	void TestMode();

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -34,7 +34,7 @@ struct GRFPresence {
 	/** Create an empty presence. */
 	GRFPresence() = default;
 };
-using GrfIDMapping = std::map<uint32_t, GRFPresence>; ///< A mapping from \c GRFID to the \c GRFPresence.
+using GrfIDMapping = std::map<GrfID, GRFPresence>; ///< A mapping from \c GrfID to the \c GRFPresence.
 
 /** Container for any change that we deem needs to be logged. */
 struct LoggedChange {
@@ -139,11 +139,11 @@ struct LoggedChangeGRFRemoved : LoggedChange {
 	 * Create a log entry for a removed NewGRF.
 	 * @param grfid The NewGRF that is removed.
 	 */
-	LoggedChangeGRFRemoved(uint32_t grfid) :
+	LoggedChangeGRFRemoved(GrfID grfid) :
 		LoggedChange(GamelogChangeType::GRFRem), grfid(grfid) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint32_t grfid = 0; ///< ID of removed GRF
+	GrfID grfid{}; ///< ID of removed GRF
 };
 
 /** A log entry for a NewGRF that was changed. */
@@ -169,11 +169,11 @@ struct LoggedChangeGRFParameterChanged : LoggedChange {
 	 * Create a log entry for a parameter change of a NewGRF.
 	 * @param grfid The NewGRF for which the parameter is changed.
 	 */
-	LoggedChangeGRFParameterChanged(uint32_t grfid) :
+	LoggedChangeGRFParameterChanged(GrfID grfid) :
 		LoggedChange(GamelogChangeType::GRFParam), grfid(grfid) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint32_t grfid = 0; ///< ID of GRF with changed parameters
+	GrfID grfid{}; ///< ID of GRF with changed parameters
 };
 
 /** A log entry for a NewGRF that was moved. */
@@ -186,11 +186,11 @@ struct LoggedChangeGRFMoved : LoggedChange {
 	 * @param grfid The NewGRF that is moved.
 	 * @param offset The amount the NewGRF was moved.
 	 */
-	LoggedChangeGRFMoved(uint32_t grfid, int32_t offset) :
+	LoggedChangeGRFMoved(GrfID grfid, int32_t offset) :
 		LoggedChange(GamelogChangeType::GRFMove), grfid(grfid), offset(offset) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
-	uint32_t grfid = 0; ///< ID of moved GRF
+	GrfID grfid{}; ///< ID of moved GRF
 	int32_t offset = 0; ///< offset, positive = move down
 };
 
@@ -225,12 +225,12 @@ struct LoggedChangeGRFBug : LoggedChange {
 	 * @param grfid The NewGRF that is deemed buggy.
 	 * @param bug The bug that has been seen.
 	 */
-	LoggedChangeGRFBug(uint64_t data, uint32_t grfid, GRFBug bug) :
+	LoggedChangeGRFBug(uint64_t data, GrfID grfid, GRFBug bug) :
 		LoggedChange(GamelogChangeType::GRFBug), data(data), grfid(grfid), bug(bug) {}
 	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 
 	uint64_t data = 0; ///< additional data
-	uint32_t grfid = 0; ///< ID of problematic GRF
+	GrfID grfid{}; ///< ID of problematic GRF
 	GRFBug bug{}; ///< type of bug, @see enum GRFBugs
 };
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -102,7 +102,7 @@ void GrfMsgI(int severity, const std::string &msg)
  * @param grfid The grfID to obtain the file for
  * @return The file.
  */
-GRFFile *GetFileByGRFID(uint32_t grfid)
+GRFFile *GetFileByGRFID(GrfID grfid)
 {
 	auto it = std::ranges::find(_grf_files, grfid, &GRFFile::grfid);
 	if (it != std::end(_grf_files)) return &*it;
@@ -175,14 +175,14 @@ void DisableStaticNewGRFInfluencingNonStaticNewGRFs(GRFConfig &c)
 	error->data = _cur_gps.grfconfig->GetName();
 }
 
-static std::map<uint32_t, uint32_t> _grf_id_overrides;
+static std::map<GrfID, GrfID> _grf_id_overrides;
 
 /**
  * Set the override for a NewGRF
  * @param source_grfid The grfID which wants to override another NewGRF.
  * @param target_grfid The grfID which is being overridden.
  */
-void SetNewGRFOverride(uint32_t source_grfid, uint32_t target_grfid)
+void SetNewGRFOverride(GrfID source_grfid, GrfID target_grfid)
 {
 	if (target_grfid == 0) {
 		_grf_id_overrides.erase(source_grfid);
@@ -219,7 +219,7 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
 {
 	/* Hack for add-on GRFs that need to modify another GRF's engines. This lets
 	 * them use the same engine slots. */
-	uint32_t scope_grfid = INVALID_GRFID; // If not using dynamic_engines, all newgrfs share their ID range
+	GrfID scope_grfid = INVALID_GRFID; // If not using dynamic_engines, all newgrfs share their ID range
 	if (_settings_game.vehicle.dynamic_engines) {
 		/* If dynamic_engies is enabled, there can be multiple independent ID ranges. */
 		scope_grfid = file->grfid;
@@ -299,7 +299,7 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
  */
 EngineID GetNewEngineID(const GRFFile *file, VehicleType type, uint16_t internal_id)
 {
-	uint32_t scope_grfid = INVALID_GRFID; // If not using dynamic_engines, all newgrfs share their ID range
+	GrfID scope_grfid = INVALID_GRFID; // If not using dynamic_engines, all newgrfs share their ID range
 	if (_settings_game.vehicle.dynamic_engines) {
 		scope_grfid = file->grfid;
 		if (auto it = _grf_id_overrides.find(file->grfid); it != std::end(_grf_id_overrides)) {
@@ -360,7 +360,7 @@ void ConvertTTDBasePrice(uint32_t base_pointer, std::string_view error_location,
  * @param language_id The (NewGRF) language ID to get the map for.
  * @return The LanguageMap, or nullptr if it couldn't be found.
  */
-/* static */ const LanguageMap *LanguageMap::GetLanguageMap(uint32_t grfid, GRFLanguage language_id)
+/* static */ const LanguageMap *LanguageMap::GetLanguageMap(GrfID grfid, GRFLanguage language_id)
 {
 	const GRFFile *grffile = GetFileByGRFID(grfid);
 	if (grffile == nullptr) return nullptr;
@@ -1494,7 +1494,7 @@ static void FinalisePriceBaseMultipliers()
 		GRFFile &source = _grf_files[i];
 		auto it = _grf_id_overrides.find(source.grfid);
 		if (it == std::end(_grf_id_overrides)) continue;
-		uint32_t override_grfid = it->second;
+		GrfID override_grfid = it->second;
 
 		auto dest = std::ranges::find(_grf_files, override_grfid, &GRFFile::grfid);
 		if (dest == std::end(_grf_files)) continue;

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -20,8 +20,6 @@
 #include "newgrf_text_type.h"
 #include "vehicle_type.h"
 
-struct GRFConfig;
-
 /**
  * List of different canal 'features'.
  * Each feature gets an entry in the canal spritegroup table
@@ -114,8 +112,6 @@ enum class GrfSpecFeature : uint8_t {
 /** Bitset of \c GrfSpecFeature elements. */
 using GrfSpecFeatures = EnumBitSet<GrfSpecFeature, uint32_t, GrfSpecFeature::End>;
 
-static const uint32_t INVALID_GRFID = 0xFFFFFFFF;
-
 struct GRFLabel {
 	uint8_t label;
 	uint32_t nfo_line;
@@ -127,7 +123,7 @@ struct GRFLabel {
 /** Dynamic data of a loaded NewGRF */
 struct GRFFile {
 	std::string filename{};
-	uint32_t grfid = 0;
+	GrfID grfid{};
 	uint8_t grf_version = 0;
 
 	uint sound_offset = 0;
@@ -248,7 +244,7 @@ void GrfMsgI(int severity, const std::string &msg);
 
 bool GetGlobalVariable(uint8_t param, uint32_t *value, const GRFFile *grffile);
 
-StringID MapGRFStringID(uint32_t grfid, GRFStringID str);
+StringID MapGRFStringID(GrfID grfid, GRFStringID str);
 void ShowNewGRFError();
 
 GrfSpecFeature GetGrfSpecFeature(VehicleType type);

--- a/src/newgrf/newgrf_act0.cpp
+++ b/src/newgrf/newgrf_act0.cpp
@@ -256,7 +256,7 @@ static void SafeChangeInfo(ByteReader &buf)
 		if (prop == 0x11) {
 			bool is_safe = true;
 			for (uint i = 0; i < numinfo; i++) {
-				uint32_t s = buf.ReadDWord();
+				GrfID s = buf.ReadDWord();
 				buf.ReadDWord(); // dest
 				const GRFConfig *grfconfig = GetGRFConfig(s);
 				if (grfconfig != nullptr && !grfconfig->flags.Test(GRFConfigFlag::Static)) {

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -385,8 +385,8 @@ static ChangeInfoResult GlobalVarReserveInfo(uint first, uint last, int prop, By
 				break;
 
 			case 0x11: { // GRF match for engine allocation
-				uint32_t s = buf.ReadDWord();
-				uint32_t t = buf.ReadDWord();
+				GrfID s = buf.ReadDWord();
+				GrfID t = buf.ReadDWord();
 				SetNewGRFOverride(s, t);
 				break;
 			}

--- a/src/newgrf/newgrf_act11.cpp
+++ b/src/newgrf/newgrf_act11.cpp
@@ -24,7 +24,7 @@
 static void ImportGRFSound(SoundEntry *sound)
 {
 	const GRFFile *file;
-	uint32_t grfid = _cur_gps.file->ReadDword();
+	GrfID grfid = _cur_gps.file->ReadDword();
 	SoundID sound_id = _cur_gps.file->ReadWord();
 
 	file = GetFileByGRFID(grfid);

--- a/src/newgrf/newgrf_act13.cpp
+++ b/src/newgrf/newgrf_act13.cpp
@@ -31,7 +31,7 @@ static void TranslateGRFStrings(ByteReader &buf)
 	 * W   offset    First text ID
 	 * S   text...   Zero-terminated strings */
 
-	uint32_t grfid = buf.ReadDWord();
+	GrfID grfid = buf.ReadDWord();
 	const GRFConfig *c = GetGRFConfig(grfid);
 	if (c == nullptr || (c->status != GRFStatus::Initialised && c->status != GRFStatus::Activated)) {
 		GrfMsg(7, "TranslateGRFStrings: GRFID 0x{:08X} unknown, skipping action 13", std::byteswap(grfid));

--- a/src/newgrf/newgrf_act8.cpp
+++ b/src/newgrf/newgrf_act8.cpp
@@ -21,7 +21,7 @@
 static void ScanInfo(ByteReader &buf)
 {
 	uint8_t grf_version = buf.ReadByte();
-	uint32_t grfid      = buf.ReadDWord();
+	GrfID grfid = buf.ReadDWord();
 	std::string_view name = buf.ReadString();
 
 	_cur_gps.grfconfig->ident.grfid = grfid;
@@ -56,7 +56,7 @@ static void GRFInfo(ByteReader &buf)
 	 * S info          string describing the set, and e.g. author and copyright */
 
 	uint8_t version    = buf.ReadByte();
-	uint32_t grfid     = buf.ReadDWord();
+	GrfID grfid = buf.ReadDWord();
 	std::string_view name = buf.ReadString();
 
 	if (_cur_gps.stage < GrfLoadingStage::Reserve && _cur_gps.grfconfig->status != GRFStatus::Unknown) {

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -132,6 +132,15 @@ static uint32_t GetPatchVariable(uint8_t param)
 	}
 }
 
+/**
+ * Performs the GRF Resource Management, where NewGRFs can cooperatively manage sprite resources.
+ * @param grm Mapping to the NewGRF linked with a resource.
+ * @param count The number of elements to process.
+ * @param op The operation to perform.
+ * @param target The target for the operation.
+ * @param type Name of type for debug messages.
+ * @return Operation/target specific result.
+ */
 static uint32_t PerformGRM(std::span<GrfID> grm, uint16_t count, uint8_t op, uint8_t target, std::string_view type)
 {
 	uint start = 0;

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -29,15 +29,15 @@
  * Contains the GRF ID of the owner of a vehicle if it has been reserved.
  * GRM for vehicles is only used if dynamic engine allocation is disabled,
  * so 256 is the number of original engines. */
-static std::array<uint32_t, 256> _grm_engines{};
+static std::array<GrfID, 256> _grm_engines{};
 
 /** Contains the GRF ID of the owner of a cargo if it has been reserved */
-static std::array<uint32_t, NUM_CARGO * 2> _grm_cargoes{};
+static std::array<GrfID, NUM_CARGO * 2> _grm_cargoes{};
 
 void ResetGRM()
 {
-	_grm_engines.fill(0);
-	_grm_cargoes.fill(0);
+	_grm_engines.fill({});
+	_grm_cargoes.fill({});
 }
 
 /* Action 0x0D (GrfLoadingStage::SafetyScan) */
@@ -132,7 +132,7 @@ static uint32_t GetPatchVariable(uint8_t param)
 	}
 }
 
-static uint32_t PerformGRM(std::span<uint32_t> grm, uint16_t count, uint8_t op, uint8_t target, std::string_view type)
+static uint32_t PerformGRM(std::span<GrfID> grm, uint16_t count, uint8_t op, uint8_t target, std::string_view type)
 {
 	uint start = 0;
 	uint size  = 0;

--- a/src/newgrf/newgrf_acte.cpp
+++ b/src/newgrf/newgrf_acte.cpp
@@ -27,7 +27,7 @@ static void SafeGRFInhibit(ByteReader &buf)
 	uint8_t num = buf.ReadByte();
 
 	for (uint i = 0; i < num; i++) {
-		uint32_t grfid = buf.ReadDWord();
+		GrfID grfid = buf.ReadDWord();
 
 		/* GRF is unsafe it if tries to deactivate other GRFs */
 		if (grfid != _cur_gps.grfconfig->ident.grfid) {
@@ -48,7 +48,7 @@ static void GRFInhibit(ByteReader &buf)
 	uint8_t num = buf.ReadByte();
 
 	for (uint i = 0; i < num; i++) {
-		uint32_t grfid = buf.ReadDWord();
+		GrfID grfid = buf.ReadDWord();
 		GRFConfig *file = GetGRFConfig(grfid);
 
 		/* Unset activation flag */

--- a/src/newgrf/newgrf_actf.cpp
+++ b/src/newgrf/newgrf_actf.cpp
@@ -30,7 +30,7 @@ static void FeatureTownName(ByteReader &buf)
 	 * B num-parts   Number of parts in this definition
 	 * V parts       The parts */
 
-	uint32_t grfid = _cur_gps.grffile->grfid;
+	GrfID grfid = _cur_gps.grffile->grfid;
 
 	GRFTownName *townname = AddGRFTownName(grfid);
 

--- a/src/newgrf/newgrf_internal.h
+++ b/src/newgrf/newgrf_internal.h
@@ -199,7 +199,7 @@ extern GrfProcessingState _cur_gps;
 
 /** A location within a NewGRF, like file:line but in the context of NewGRFs. */
 struct GRFLocation {
-	uint32_t grfid; ///< Identifier of the NewGRF this refers to.
+	GrfID grfid; ///< Identifier of the NewGRF this refers to.
 	uint32_t nfoline; ///< The line of NFO this refers to.
 
 	/**
@@ -217,7 +217,7 @@ extern GRFLineToSpriteOverride _grf_line_to_action6_sprite_override;
 
 extern GrfMiscBits _misc_grf_features;
 
-void SetNewGRFOverride(uint32_t source_grfid, uint32_t target_grfid);
+void SetNewGRFOverride(GrfID source_grfid, GrfID target_grfid);
 GRFFile *GetCurrentGRFOverride();
 
 std::span<const CargoLabel> GetCargoTranslationTable(const GRFFile &grffile);
@@ -231,7 +231,7 @@ void MapSpriteMappingRecolour(PalSpriteID *grf_sprite);
 TileLayoutFlags ReadSpriteLayoutSprite(ByteReader &buf, bool read_flags, bool invert_action1_flag, bool use_cur_spritesets, GrfSpecFeature feature, PalSpriteID *grf_sprite, uint16_t *max_sprite_offset = nullptr, uint16_t *max_palette_offset = nullptr);
 bool ReadSpriteLayout(ByteReader &buf, uint num_building_sprites, bool use_cur_spritesets, GrfSpecFeature feature, bool allow_var10, bool no_z_position, NewGRFSpriteLayout *dts);
 
-GRFFile *GetFileByGRFID(uint32_t grfid);
+GRFFile *GetFileByGRFID(GrfID grfid);
 GRFError *DisableGrf(StringID message = {}, GRFConfig *config = nullptr);
 void DisableStaticNewGRFInfluencingNonStaticNewGRFs(GRFConfig &c);
 bool HandleChangeInfoResult(std::string_view caller, ChangeInfoResult cir, GrfSpecFeature feature, uint8_t property);

--- a/src/newgrf/newgrf_stringmapping.cpp
+++ b/src/newgrf/newgrf_stringmapping.cpp
@@ -24,7 +24,7 @@
  * Information for mapping static StringIDs.
  */
 struct StringIDMapping {
-	uint32_t grfid; ///< Source NewGRF.
+	GrfID grfid; ///< Source NewGRF.
 	GRFStringID source; ///< Source grf-local GRFStringID.
 	std::function<void(StringID)> func; ///< Function for mapping result.
 };
@@ -124,7 +124,7 @@ static StringID TTDPStringIDToOTTDStringIDMapping(GRFStringID str)
  * @param str GRF-local GRFStringID that we want to have the equivalent in OpenTTD.
  * @return The properly adjusted StringID.
  */
-StringID MapGRFStringID(uint32_t grfid, GRFStringID str)
+StringID MapGRFStringID(GrfID grfid, GRFStringID str)
 {
 	if (IsInsideMM(str.base(), 0xD800, 0x10000)) {
 		/* General text provided by NewGRF.

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -157,7 +157,7 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec &&as)
 		overridden_as->grf_prop.override_id = airport_id;
 		overridden_as->enabled = false;
 		this->entity_overrides[i] = this->invalid_id;
-		this->grfid_overrides[i] = 0;
+		this->grfid_overrides[i] = {};
 	}
 }
 
@@ -214,7 +214,7 @@ uint32_t AirportResolverObject::GetDebugID() const
 		if (value == 0) return;
 
 		/* Create storage on first modification. */
-		uint32_t grfid = (this->ro.grffile != nullptr) ? this->ro.grffile->grfid : 0;
+		GrfID grfid = (this->ro.grffile != nullptr) ? this->ro.grffile->grfid : GrfID{};
 		assert(PersistentStorage::CanAllocateItem());
 		this->st->airport.psa = PersistentStorage::Create(grfid, GrfSpecFeature::Airports, this->st->airport.tile);
 	}

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -86,7 +86,7 @@ void AirportTileOverrideManager::SetEntitySpec(AirportTileSpec &&airpts)
 		overridden_airpts->grf_prop.override_id = airpt_id;
 		overridden_airpts->enabled = false;
 		this->entity_overrides[i] = this->invalid_id;
-		this->grfid_overrides[i] = 0;
+		this->grfid_overrides[i] = {};
 	}
 }
 
@@ -126,7 +126,7 @@ static uint32_t GetNearbyAirportTileInformation(uint8_t parameter, TileIndex til
  * @param cur_grfid GRFID of the current callback
  * @return value encoded as per NFO specs
  */
-static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint32_t cur_grfid)
+static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, GrfID cur_grfid)
 {
 	if (!st->TileBelongsToAirport(tile)) {
 		return 0xFFFF;

--- a/src/newgrf_class.h
+++ b/src/newgrf_class.h
@@ -10,6 +10,7 @@
 #ifndef NEWGRF_CLASS_H
 #define NEWGRF_CLASS_H
 
+#include "newgrf_type.h"
 #include "strings_type.h"
 
 /** Base for each type of NewGRF spec to be used with NewGRFClass. */
@@ -95,7 +96,7 @@ public:
 	static uint GetUIClassCount();
 	static NewGRFClass *Get(Tindex class_index);
 
-	static const Tspec *GetByGrf(uint32_t grfid, uint16_t local_id);
+	static const Tspec *GetByGrf(GrfID grfid, uint16_t local_id);
 };
 
 #endif /* NEWGRF_CLASS_H */

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -125,7 +125,7 @@ const Tspec *NewGRFClass<Tspec, Tindex>::GetSpec(uint index) const
  * @return The spec.
  */
 template <typename Tspec, typename Tindex>
-const Tspec *NewGRFClass<Tspec, Tindex>::GetByGrf(uint32_t grfid, uint16_t local_id)
+const Tspec *NewGRFClass<Tspec, Tindex>::GetByGrf(GrfID grfid, uint16_t local_id)
 {
 	for (const auto &cls : NewGRFClass::classes) {
 		for (const auto &spec : cls.spec) {

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -57,7 +57,7 @@ OverrideManagerBase::OverrideManagerBase(uint16_t offset, uint16_t maximum, uint
  * @param grfid  ID of the grf file
  * @param entity_type original entity type
  */
-void OverrideManagerBase::Add(uint16_t local_id, uint32_t grfid, uint entity_type)
+void OverrideManagerBase::Add(uint16_t local_id, GrfID grfid, uint entity_type)
 {
 	assert(entity_type < this->max_offset);
 	/* An override can be set only once */
@@ -85,7 +85,7 @@ void OverrideManagerBase::ResetOverride()
  * @param grfid ID of the grf file
  * @return the ID of the candidate, of the Invalid flag item ID
  */
-uint16_t OverrideManagerBase::GetID(uint16_t grf_local_id, uint32_t grfid) const
+uint16_t OverrideManagerBase::GetID(uint16_t grf_local_id, GrfID grfid) const
 {
 	for (uint16_t id = 0; id < this->max_entities; id++) {
 		const EntityIDMapping *map = &this->mappings[id];
@@ -104,7 +104,7 @@ uint16_t OverrideManagerBase::GetID(uint16_t grf_local_id, uint32_t grfid) const
  * @param substitute_id is the original entity from which data is copied for the new one
  * @return the proper usable slot id, or invalid marker if none is found
  */
-uint16_t OverrideManagerBase::AddEntityID(uint16_t grf_local_id, uint32_t grfid, uint16_t substitute_id)
+uint16_t OverrideManagerBase::AddEntityID(uint16_t grf_local_id, GrfID grfid, uint16_t substitute_id)
 {
 	uint16_t id = this->GetID(grf_local_id, grfid);
 
@@ -134,7 +134,7 @@ uint16_t OverrideManagerBase::AddEntityID(uint16_t grf_local_id, uint32_t grfid,
  * @param entity_id ID of the entity being queried.
  * @return GRFID.
  */
-uint32_t OverrideManagerBase::GetGRFID(uint16_t entity_id) const
+GrfID OverrideManagerBase::GetGRFID(uint16_t entity_id) const
 {
 	return this->mappings[entity_id].grfid;
 }
@@ -177,7 +177,7 @@ void HouseOverrideManager::SetEntitySpec(HouseSpec &&hs)
 
 		overridden_hs->grf_prop.override_id = house_id;
 		this->entity_overrides[i] = this->invalid_id;
-		this->grfid_overrides[i] = 0;
+		this->grfid_overrides[i] = {};
 	}
 }
 
@@ -187,7 +187,7 @@ void HouseOverrideManager::SetEntitySpec(HouseSpec &&hs)
  * @param grfid ID of the grf file
  * @return the ID of the candidate, of the Invalid flag item ID
  */
-uint16_t IndustryOverrideManager::GetID(uint16_t grf_local_id, uint32_t grfid) const
+uint16_t IndustryOverrideManager::GetID(uint16_t grf_local_id, GrfID grfid) const
 {
 	uint16_t id = OverrideManagerBase::GetID(grf_local_id, grfid);
 	if (id != this->invalid_id) return id;
@@ -207,7 +207,7 @@ uint16_t IndustryOverrideManager::GetID(uint16_t grf_local_id, uint32_t grfid) c
  * @param substitute_id industry from which data has been copied
  * @return a free entity id (slotid) if ever one has been found, or Invalid_ID marker otherwise
  */
-uint16_t IndustryOverrideManager::AddEntityID(uint16_t grf_local_id, uint32_t grfid, uint16_t substitute_id)
+uint16_t IndustryOverrideManager::AddEntityID(uint16_t grf_local_id, GrfID grfid, uint16_t substitute_id)
 {
 	/* This entity hasn't been defined before, so give it an ID now. */
 	for (uint16_t id = 0; id < this->max_entities; id++) {
@@ -287,7 +287,7 @@ void IndustryTileOverrideManager::SetEntitySpec(IndustryTileSpec &&its)
 		overridden_its->grf_prop.override_id = indt_id;
 		overridden_its->enabled = false;
 		this->entity_overrides[i] = this->invalid_id;
-		this->grfid_overrides[i] = 0;
+		this->grfid_overrides[i] = {};
 	}
 }
 
@@ -511,7 +511,7 @@ CommandCost GetErrorMessageFromLocationCallbackResult(uint16_t cb_res, std::span
  * @param cbid Callback causing the problem.
  * @param cb_res Invalid result returned by the callback.
  */
-void ErrorUnknownCallbackResult(uint32_t grfid, uint16_t cbid, uint16_t cb_res)
+void ErrorUnknownCallbackResult(GrfID grfid, uint16_t cbid, uint16_t cb_res)
 {
 	GRFConfig *grfconfig = GetGRFConfig(grfid);
 
@@ -732,5 +732,5 @@ void SpriteLayoutProcessor::ProcessRegisters(const ResolverObject &object, uint8
 void GRFFilePropsBase::SetGRFFile(const struct GRFFile *grffile)
 {
 	this->grffile = grffile;
-	this->grfid = grffile == nullptr ? 0 : grffile->grfid;
+	this->grfid = grffile == nullptr ? GrfID{} : grffile->grfid;
 }

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -10,6 +10,7 @@
 #ifndef NEWGRF_COMMONS_H
 #define NEWGRF_COMMONS_H
 
+#include "newgrf_type.h"
 #include "sprite.h"
 #include "command_type.h"
 #include "direction_type.h"
@@ -191,7 +192,7 @@ public:
  * if the GRF containing the new entity is not available.
  */
 struct EntityIDMapping {
-	uint32_t grfid;          ///< The GRF ID of the file the entity belongs to
+	GrfID grfid; ///< The GRF ID of the file the entity belongs to
 	uint16_t entity_id; ///< The entity ID within the GRF file
 	uint16_t substitute_id; ///< The (original) entity ID to use if this GRF is not available
 };
@@ -199,7 +200,7 @@ struct EntityIDMapping {
 class OverrideManagerBase {
 protected:
 	std::vector<uint16_t> entity_overrides;
-	std::vector<uint32_t> grfid_overrides;
+	std::vector<GrfID> grfid_overrides;
 
 	uint16_t max_offset;   ///< what is the length of the original entity's array of specs
 	uint16_t max_entities; ///< what is the amount of entities, old and new summed
@@ -222,12 +223,12 @@ public:
 	void ResetOverride();
 	void ResetMapping();
 
-	void Add(uint16_t local_id, uint32_t grfid, uint entity_type);
-	virtual uint16_t AddEntityID(uint16_t grf_local_id, uint32_t grfid, uint16_t substitute_id);
+	void Add(uint16_t local_id, GrfID grfid, uint entity_type);
+	virtual uint16_t AddEntityID(uint16_t grf_local_id, GrfID grfid, uint16_t substitute_id);
 
-	uint32_t GetGRFID(uint16_t entity_id) const;
+	GrfID GetGRFID(uint16_t entity_id) const;
 	uint16_t GetSubstituteID(uint16_t entity_id) const;
-	virtual uint16_t GetID(uint16_t grf_local_id, uint32_t grfid) const;
+	virtual uint16_t GetID(uint16_t grf_local_id, GrfID grfid) const;
 
 	inline uint16_t GetMaxMapping() const { return this->max_entities; }
 	inline uint16_t GetMaxOffset() const { return this->max_offset; }
@@ -250,8 +251,8 @@ public:
 	IndustryOverrideManager(uint16_t offset, uint16_t maximum, uint16_t invalid) :
 			OverrideManagerBase(offset, maximum, invalid) {}
 
-	uint16_t AddEntityID(uint16_t grf_local_id, uint32_t grfid, uint16_t substitute_id) override;
-	uint16_t GetID(uint16_t grf_local_id, uint32_t grfid) const override;
+	uint16_t AddEntityID(uint16_t grf_local_id, GrfID grfid, uint16_t substitute_id) override;
+	uint16_t GetID(uint16_t grf_local_id, GrfID grfid) const override;
 
 	void SetEntitySpec(IndustrySpec &&inds);
 };
@@ -312,7 +313,7 @@ uint32_t GetNearbyTileInformation(TileIndex tile, bool grf_version8);
 uint32_t GetCompanyInfo(CompanyID owner, const struct Livery *l = nullptr);
 CommandCost GetErrorMessageFromLocationCallbackResult(uint16_t cb_res, std::span<const int32_t> textstack, const GRFFile *grffile, StringID default_error);
 
-void ErrorUnknownCallbackResult(uint32_t grfid, uint16_t cbid, uint16_t cb_res);
+void ErrorUnknownCallbackResult(GrfID grfid, uint16_t cbid, uint16_t cb_res);
 bool ConvertBooleanCallback(const struct GRFFile *grffile, uint16_t cbid, uint16_t cb_res);
 bool Convert8bitBooleanCallback(const struct GRFFile *grffile, uint16_t cbid, uint16_t cb_res);
 
@@ -321,7 +322,7 @@ bool Convert8bitBooleanCallback(const struct GRFFile *grffile, uint16_t cbid, ui
  */
 struct GRFFilePropsBase {
 	uint16_t local_id = 0; ///< id defined by the grf file for this entity
-	uint32_t grfid = 0; ///< grfid that introduced this entity.
+	GrfID grfid{}; ///< grfid that introduced this entity.
 	const struct GRFFile *grffile = nullptr; ///< grf file that introduced this entity
 
 	void SetGRFFile(const struct GRFFile *grffile);

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -597,7 +597,7 @@ void ScanNewGRFFiles(NewGRFScanCallback *callback)
  * @param desired_version Requested version
  * @return The matching grf, if it exists in #_all_grfs, else \c nullptr.
  */
-const GRFConfig *FindGRFConfig(uint32_t grfid, FindGRFConfigMode mode, const MD5Hash *md5sum, uint32_t desired_version)
+const GRFConfig *FindGRFConfig(GrfID grfid, FindGRFConfigMode mode, const MD5Hash *md5sum, uint32_t desired_version)
 {
 	assert((mode == FindGRFConfigMode::Exact) != (md5sum == nullptr));
 	const GRFConfig *best = nullptr;
@@ -623,7 +623,7 @@ const GRFConfig *FindGRFConfig(uint32_t grfid, FindGRFConfigMode mode, const MD5
  * @param mask  GRFID mask to allow for partial matching.
  * @return The grf config, if it exists, else \c nullptr.
  */
-GRFConfig *GetGRFConfig(uint32_t grfid, uint32_t mask)
+GRFConfig *GetGRFConfig(GrfID grfid, uint32_t mask)
 {
 	auto it = std::ranges::find_if(_grfconfig, [grfid, mask](const auto &c) { return (c->ident.grfid & mask) == (grfid & mask); });
 	if (it != std::end(_grfconfig)) return it->get();

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -85,7 +85,7 @@ enum GRFPalette : uint8_t {
 
 /** Basic data to distinguish a GRF. Used in the server list window */
 struct GRFIdentifier {
-	uint32_t grfid; ///< GRF ID (defined by Action 0x08)
+	GrfID grfid; ///< GRF ID (defined by Action 0x08)
 	MD5Hash md5sum; ///< MD5 checksum of file to distinguish files with the same GRF ID (eg. newer version of GRF)
 
 	/**
@@ -94,7 +94,7 @@ struct GRFIdentifier {
 	 * @param md5sum Expected md5sum, may be \c nullptr (in which case, do not check it).
 	 * @return the object has the provided grfid and md5sum.
 	 */
-	inline bool HasGrfIdentifier(uint32_t grfid, const MD5Hash *md5sum) const
+	inline bool HasGrfIdentifier(GrfID grfid, const MD5Hash *md5sum) const
 	{
 		if (this->grfid != grfid) return false;
 		if (md5sum == nullptr) return true;
@@ -225,8 +225,8 @@ struct NewGRFScanCallback {
 size_t GRFGetSizeOfDataSection(FileHandle &f);
 
 void ScanNewGRFFiles(NewGRFScanCallback *callback);
-const GRFConfig *FindGRFConfig(uint32_t grfid, FindGRFConfigMode mode, const MD5Hash *md5sum = nullptr, uint32_t desired_version = 0);
-GRFConfig *GetGRFConfig(uint32_t grfid, uint32_t mask = 0xFFFFFFFF);
+const GRFConfig *FindGRFConfig(GrfID grfid, FindGRFConfigMode mode, const MD5Hash *md5sum = nullptr, uint32_t desired_version = 0);
+GRFConfig *GetGRFConfig(GrfID grfid, uint32_t mask = 0xFFFFFFFF);
 void CopyGRFConfigList(GRFConfigList &dst, const GRFConfigList &src, bool init_only);
 void AppendStaticGRFConfigs(GRFConfigList &dst);
 void AppendToGRFConfigList(GRFConfigList &dst, std::unique_ptr<GRFConfig> &&el);

--- a/src/newgrf_debug.h
+++ b/src/newgrf_debug.h
@@ -32,7 +32,7 @@ struct NewGrfDebugSpritePicker {
 extern NewGrfDebugSpritePicker _newgrf_debug_sprite_picker;
 
 bool IsNewGRFInspectable(GrfSpecFeature feature, uint index);
-void ShowNewGRFInspectWindow(GrfSpecFeature feature, uint index, const uint32_t grfid = 0);
+void ShowNewGRFInspectWindow(GrfSpecFeature feature, uint index, const GrfID grfid = {});
 void InvalidateNewGRFInspectWindow(GrfSpecFeature feature, uint index);
 void InvalidateNewGRFInspectWindow(GrfSpecFeature feature, ConvertibleThroughBase auto index) { InvalidateNewGRFInspectWindow(feature, index.base()); }
 void DeleteNewGRFInspectWindow(GrfSpecFeature feature, uint index);

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -171,7 +171,7 @@ public:
 	 * @param index index to check.
 	 * @return GRFID of the item. 0 means that the item is not inspectable.
 	 */
-	virtual uint32_t GetGRFID(uint index) const = 0;
+	virtual GrfID GetGRFID(uint index) const = 0;
 
 	/**
 	 * Get the list of badges of this item.
@@ -205,7 +205,7 @@ public:
 	 * @param grfid Parameter for the PSA. Only required for items with parameters.
 	 * @return Span of the storage array or an empty span when not present.
 	 */
-	virtual const std::span<int32_t> GetPSA([[maybe_unused]] uint index, [[maybe_unused]] uint32_t grfid) const
+	virtual const std::span<int32_t> GetPSA([[maybe_unused]] uint index, [[maybe_unused]] GrfID grfid) const
 	{
 		return {};
 	}
@@ -261,7 +261,7 @@ struct NewGRFInspectWindow : Window {
 	static inline EnumIndexArray<std::array<uint32_t, 0x20>, GrfSpecFeature, GrfSpecFeature::FakeEnd> var60params{};
 
 	/** GRFID of the caller of this window, 0 if it has no caller. */
-	uint32_t caller_grfid = 0;
+	GrfID caller_grfid{};
 
 	/** For ground vehicles: Index in vehicle chain. */
 	uint chain_index = 0;
@@ -285,7 +285,7 @@ struct NewGRFInspectWindow : Window {
 	 * Set the GRFID of the item opening this window.
 	 * @param grfid GRFID of the item opening this window, or 0 if not opened by other window.
 	 */
-	void SetCallerGRFID(uint32_t grfid)
+	void SetCallerGRFID(GrfID grfid)
 	{
 		this->caller_grfid = grfid;
 		this->SetDirty();
@@ -703,7 +703,7 @@ static WindowDesc _newgrf_inspect_desc(
  * @param index   The index/identifier of the feature to inspect.
  * @param grfid   GRFID of the item opening this window, or 0 if not opened by other window.
  */
-void ShowNewGRFInspectWindow(GrfSpecFeature feature, uint index, const uint32_t grfid)
+void ShowNewGRFInspectWindow(GrfSpecFeature feature, uint index, const GrfID grfid)
 {
 	if (!IsNewGRFInspectable(feature, index)) return;
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -573,7 +573,7 @@ void ShowNewGRFTextfileWindow(Window *parent, TextfileType file_type, const GRFC
 	new NewGRFTextfileWindow(parent, file_type, c);
 }
 
-typedef std::map<uint32_t, const GRFConfig *> GrfIdMap; ///< Map of grfid to the grf config.
+typedef std::map<GrfID, const GRFConfig *> GrfIdMap; ///< Map of grfid to the grf config.
 
 /**
  * Add all grf configs from \a c into the map.

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -136,6 +136,12 @@ void ResetHouseClassIDs()
 	_class_mapping.emplace_back();
 }
 
+/**
+ * Allocate a house class for the given NewGRF and ID.
+ * @param grf_class_id The class id within the NewGRF.
+ * @param grfid The GRF this class belongs to.
+ * @return The existing allocation, or a new one when it did not exist yet.
+ */
 HouseClassID AllocateHouseClassID(uint8_t grf_class_id, GrfID grfid)
 {
 	/* Start from 1 because 0 means that no class has been assigned. */

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -136,7 +136,7 @@ void ResetHouseClassIDs()
 	_class_mapping.emplace_back();
 }
 
-HouseClassID AllocateHouseClassID(uint8_t grf_class_id, uint32_t grfid)
+HouseClassID AllocateHouseClassID(uint8_t grf_class_id, GrfID grfid)
 {
 	/* Start from 1 because 0 means that no class has been assigned. */
 	auto it = std::find_if(std::next(std::begin(_class_mapping)), std::end(_class_mapping), [grf_class_id, grfid](const HouseClassMapping &map) { return map.class_id == grf_class_id && map.grfid == grfid; });

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -85,12 +85,12 @@ struct HouseResolverObject : public SpecializedResolverObject<HouseRandomTrigger
  * need to be persistent; it just needs to keep class ids unique.
  */
 struct HouseClassMapping {
-	uint32_t grfid;     ///< The GRF ID of the file this class belongs to
+	GrfID grfid;     ///< The GRF ID of the file this class belongs to
 	uint8_t  class_id;  ///< The class id within the grf file
 };
 
 void ResetHouseClassIDs();
-HouseClassID AllocateHouseClassID(uint8_t grf_class_id, uint32_t grfid);
+HouseClassID AllocateHouseClassID(uint8_t grf_class_id, GrfID grfid);
 
 void InitializeBuildingCounts();
 void InitializeBuildingCounts(Town *t);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -38,7 +38,7 @@ IndustryTileOverrideManager _industile_mngr(NEW_INDUSTRYTILEOFFSET, NUM_INDUSTRY
  * @param grf_id The GRF of the local type.
  * @return The industry type in the global scope.
  */
-IndustryType MapNewGRFIndustryType(IndustryType grf_type, uint32_t grf_id)
+IndustryType MapNewGRFIndustryType(IndustryType grf_type, GrfID grf_id)
 {
 	if (grf_type == IT_INVALID) return IT_INVALID;
 	if (!HasBit(grf_type, 7)) return GB(grf_type, 0, 7);
@@ -54,7 +54,7 @@ IndustryType MapNewGRFIndustryType(IndustryType grf_type, uint32_t grf_id)
  * @param cur_grfid GRFID of the current callback chain
  * @return value encoded as per NFO specs
  */
-uint32_t GetIndustryIDAtOffset(TileIndex tile, const Industry *i, uint32_t cur_grfid)
+uint32_t GetIndustryIDAtOffset(TileIndex tile, const Industry *i, GrfID cur_grfid)
 {
 	if (!i->TileBelongsToIndustry(tile)) {
 		/* No industry and/or the tile does not have the same industry as the one we match it with */

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -77,13 +77,13 @@ enum class IndustryAvailabilityCallType : uint8_t {
 
 /* in newgrf_industry.cpp */
 uint16_t GetIndustryCallback(CallbackID callback, uint32_t param1, uint32_t param2, Industry *industry, IndustryType type, TileIndex tile, std::span<int32_t> regs100 = {});
-uint32_t GetIndustryIDAtOffset(TileIndex new_tile, const Industry *i, uint32_t cur_grfid);
+uint32_t GetIndustryIDAtOffset(TileIndex new_tile, const Industry *i, GrfID cur_grfid);
 void IndustryProductionCallback(Industry *ind, int reason);
 CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, size_t layout, uint32_t seed, uint16_t initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type);
 uint32_t GetIndustryProbabilityCallback(IndustryType type, IndustryAvailabilityCallType creation_type, uint32_t default_prob);
 bool IndustryTemporarilyRefusesCargo(Industry *ind, CargoType cargo_type);
 
-IndustryType MapNewGRFIndustryType(IndustryType grf_type, uint32_t grf_id);
+IndustryType MapNewGRFIndustryType(IndustryType grf_type, GrfID grfid);
 
 /* in newgrf_industrytiles.cpp*/
 uint32_t GetNearbyIndustryTileInformation(uint8_t parameter, TileIndex tile, IndustryID index, bool signed_offsets, bool grf_version8);

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -170,7 +170,7 @@ template class NewGRFClass<ObjectSpec, ObjectClassID>;
  * @param cur_grfid GRFID of the current callback chain
  * @return value encoded as per NFO specs
  */
-static uint32_t GetObjectIDAtOffset(TileIndex tile, uint32_t cur_grfid)
+static uint32_t GetObjectIDAtOffset(TileIndex tile, GrfID cur_grfid)
 {
 	if (!IsTileType(tile, TileType::Object)) {
 		return 0xFFFF;
@@ -235,7 +235,7 @@ static uint32_t GetClosestObject(TileIndex tile, ObjectType type, const Object *
  * @param current  Object for which the inquiry is made
  * @return The formatted answer to the callback : rr(reserved) cc(count) dddd(manhattan distance of closest sister)
  */
-static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &object, uint8_t local_id, uint32_t grfid, TileIndex tile, const Object *current)
+static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &object, uint8_t local_id, GrfID grfid, TileIndex tile, const Object *current)
 {
 	uint32_t grf_id = static_cast<uint32_t>(object.GetRegister(0x100)); // Get the GRFID of the definition to look for in register 100h
 	uint32_t idx;

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -166,7 +166,7 @@ uint32_t RoadStopScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] u
 
 			if (!IsAnyRoadStopTile(nearby_tile)) return 0xFFFFFFFF;
 
-			uint32_t grfid = this->st->roadstop_speclist[GetCustomRoadStopSpecIndex(this->tile)].grfid;
+			GrfID grfid = this->st->roadstop_speclist[GetCustomRoadStopSpecIndex(this->tile)].grfid;
 			bool same_orientation = GetStationGfx(this->tile) == GetStationGfx(nearby_tile);
 			bool same_station = GetStationIndex(nearby_tile) == this->st->index;
 			uint32_t res = GetStationGfx(nearby_tile) << 12 | !same_orientation << 11 | !!same_station << 10;
@@ -202,7 +202,7 @@ uint32_t RoadStopScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] u
 			if (!IsAnyRoadStopTile(nearby_tile)) return 0xFFFFFFFF;
 			if (!IsCustomRoadStopSpecIndex(nearby_tile)) return 0xFFFE;
 
-			uint32_t grfid = this->st->roadstop_speclist[GetCustomRoadStopSpecIndex(this->tile)].grfid;
+			GrfID grfid = this->st->roadstop_speclist[GetCustomRoadStopSpecIndex(this->tile)].grfid;
 
 			const auto &sm = BaseStation::GetByTile(nearby_tile)->roadstop_speclist[GetCustomRoadStopSpecIndex(nearby_tile)];
 			if (sm.grfid == grfid) {
@@ -659,7 +659,7 @@ void DeallocateSpecFromRoadStop(BaseStation *st, uint8_t specindex)
 
 	/* This specindex is no longer in use, so deallocate it */
 	st->roadstop_speclist[specindex].spec     = nullptr;
-	st->roadstop_speclist[specindex].grfid    = 0;
+	st->roadstop_speclist[specindex].grfid = {};
 	st->roadstop_speclist[specindex].localidx = 0;
 
 	/* If this was the highest spec index, reallocate */

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -371,7 +371,7 @@ TownScopeResolver *StationResolverObject::GetTown()
 
 			if (!HasStationTileRail(nearby_tile)) return 0xFFFFFFFF;
 
-			uint32_t grfid = this->st->speclist[GetCustomStationSpecIndex(this->tile)].grfid;
+			GrfID grfid = this->st->speclist[GetCustomStationSpecIndex(this->tile)].grfid;
 			bool perpendicular = GetRailStationAxis(this->tile) != GetRailStationAxis(nearby_tile);
 			bool same_station = this->st->TileBelongsToRailStation(nearby_tile);
 			uint32_t res = GB(GetStationGfx(nearby_tile), 1, 2) << 12 | !!perpendicular << 11 | !!same_station << 10;
@@ -399,7 +399,7 @@ TownScopeResolver *StationResolverObject::GetTown()
 			if (!HasStationTileRail(nearby_tile)) return 0xFFFFFFFF;
 			if (!IsCustomStationSpecIndex(nearby_tile)) return 0xFFFE;
 
-			uint32_t grfid = this->st->speclist[GetCustomStationSpecIndex(this->tile)].grfid;
+			GrfID grfid = this->st->speclist[GetCustomStationSpecIndex(this->tile)].grfid;
 
 			const auto &sm = BaseStation::GetByTile(nearby_tile)->speclist[GetCustomStationSpecIndex(nearby_tile)];
 			if (sm.grfid == grfid) {
@@ -788,7 +788,7 @@ void DeallocateSpecFromStation(BaseStation *st, uint8_t specindex)
 
 	/* This specindex is no longer in use, so deallocate it */
 	st->speclist[specindex].spec     = nullptr;
-	st->speclist[specindex].grfid    = 0;
+	st->speclist[specindex].grfid = {};
 	st->speclist[specindex].localidx = 0;
 
 	/* If this was the highest spec index, reallocate */

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -31,7 +31,7 @@ enum PersistentStorageMode : uint8_t {
  * so we have a generalised access to the virtual methods.
  */
 struct BasePersistentStorageArray {
-	uint32_t grfid = 0; ///< GRFID associated to this persistent storage. A value of zero means "default".
+	GrfID grfid{}; ///< GRFID associated to this persistent storage. A value of zero means "default".
 	GrfSpecFeature feature = GrfSpecFeature::Invalid; ///< NOSAVE: Used to identify in the owner of the array in debug output.
 	TileIndex tile = INVALID_TILE; ///< NOSAVE: Used to identify in the owner of the array in debug output.
 
@@ -198,9 +198,9 @@ extern PersistentStoragePool _persistent_storage_pool;
  * Class for pooled persistent storage of data.
  */
 struct PersistentStorage : PersistentStorageArray<int32_t, 256>, PersistentStoragePool::PoolItem<&_persistent_storage_pool> {
-	PersistentStorage(PersistentStorageID index, const uint32_t new_grfid, GrfSpecFeature feature, TileIndex tile) : PersistentStoragePool::PoolItem<&_persistent_storage_pool>(index)
+	PersistentStorage(PersistentStorageID index, GrfID grfid, GrfSpecFeature feature, TileIndex tile) : PersistentStoragePool::PoolItem<&_persistent_storage_pool>(index)
 	{
-		this->grfid = new_grfid;
+		this->grfid = grfid;
 		this->feature = feature;
 		this->tile = tile;
 	}

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -198,6 +198,13 @@ extern PersistentStoragePool _persistent_storage_pool;
  * Class for pooled persistent storage of data.
  */
 struct PersistentStorage : PersistentStorageArray<int32_t, 256>, PersistentStoragePool::PoolItem<&_persistent_storage_pool> {
+	/**
+	 * Create the pooled storage.
+	 * @param index The unique identifier of the pool item.
+	 * @param grfid The NewGRF this storage is of.
+	 * @param feature The feature associated with this storage.
+	 * @param tile The tile associated with this storage.
+	 */
 	PersistentStorage(PersistentStorageID index, GrfID grfid, GrfSpecFeature feature, TileIndex tile) : PersistentStoragePool::PoolItem<&_persistent_storage_pool>(index)
 	{
 		this->grfid = grfid;

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -48,7 +48,7 @@ using OldGRFLanguages = EnumBitSet<GRFLanguage, uint8_t>;
 struct GRFTextEntry {
 	GRFTextList textholder;
 	StringID def_string;
-	uint32_t grfid;
+	GrfID grfid;
 	GRFStringID stringid;
 };
 
@@ -213,7 +213,7 @@ struct UnmappedChoiceList {
  * @param byte80         The control code to use as replacement for the 0x80-value.
  * @return The translated string.
  */
-std::string TranslateTTDPatchCodes(uint32_t grfid, GRFLanguage language_id, bool allow_newlines, std::string_view str, StringControlCode byte80)
+std::string TranslateTTDPatchCodes(GrfID grfid, GRFLanguage language_id, bool allow_newlines, std::string_view str, StringControlCode byte80)
 {
 	/* Empty input string? Nothing to do here. */
 	if (str.empty()) return {};
@@ -477,7 +477,7 @@ static void AddGRFTextToList(GRFTextList &list, GRFLanguage langid, std::string_
  * @param text_to_add The text to add to the list.
  * @note All text-codes will be translated.
  */
-void AddGRFTextToList(GRFTextList &list, GRFLanguage langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add)
+void AddGRFTextToList(GRFTextList &list, GRFLanguage langid, GrfID grfid, bool allow_newlines, std::string_view text_to_add)
 {
 	AddGRFTextToList(list, langid, TranslateTTDPatchCodes(grfid, langid, allow_newlines, text_to_add));
 }
@@ -491,7 +491,7 @@ void AddGRFTextToList(GRFTextList &list, GRFLanguage langid, uint32_t grfid, boo
  * @param text_to_add The text to add to the list.
  * @note All text-codes will be translated.
  */
-void AddGRFTextToList(GRFTextWrapper &list, GRFLanguage langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add)
+void AddGRFTextToList(GRFTextWrapper &list, GRFLanguage langid, GrfID grfid, bool allow_newlines, std::string_view text_to_add)
 {
 	if (list == nullptr) list = std::make_shared<GRFTextList>();
 	AddGRFTextToList(*list, langid, grfid, allow_newlines, text_to_add);
@@ -519,7 +519,7 @@ void AddGRFTextToList(GRFTextWrapper &list, std::string_view text_to_add)
  * @param def_string The fallback string if a translation for this string isn't available.
  * @return The OpenTTD internal string identifier.
  */
-static StringID AddGRFString(uint32_t grfid, GRFStringID stringid, GRFLanguage langid_to_add, bool allow_newlines, std::string_view text_to_add, StringID def_string)
+static StringID AddGRFString(GrfID grfid, GRFStringID stringid, GRFLanguage langid_to_add, bool allow_newlines, std::string_view text_to_add, StringID def_string)
 {
 	auto it = std::ranges::find_if(_grf_text, [&grfid, &stringid](const GRFTextEntry &grf_text) { return grf_text.grfid == grfid && grf_text.stringid == stringid; });
 	if (it == std::end(_grf_text)) {
@@ -553,7 +553,7 @@ static StringID AddGRFString(uint32_t grfid, GRFStringID stringid, GRFLanguage l
  * @param def_string The fallback string if a translation for this string isn't available.
  * @return The OpenTTD internal string identifier.
  */
-StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid_to_add, bool new_scheme, bool allow_newlines, std::string_view text_to_add, StringID def_string)
+StringID AddGRFString(GrfID grfid, GRFStringID stringid, uint8_t langid_to_add, bool new_scheme, bool allow_newlines, std::string_view text_to_add, StringID def_string)
 {
 	if (new_scheme) return AddGRFString(grfid, stringid, static_cast<GRFLanguage>(langid_to_add), allow_newlines, text_to_add, def_string);
 
@@ -580,7 +580,7 @@ StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid_to_ad
  * @param stringid The GRF-local identifier of the string.
  * @return The string identifier, or STR_UNDEFINED when it can't be found.
  */
-StringID GetGRFStringID(uint32_t grfid, GRFStringID stringid)
+StringID GetGRFStringID(GrfID grfid, GRFStringID stringid)
 {
 	auto it = std::ranges::find_if(_grf_text, [&grfid, &stringid](const GRFTextEntry &grf_text) { return grf_text.grfid == grfid && grf_text.stringid == stringid; });
 	if (it != std::end(_grf_text)) {

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -14,15 +14,15 @@
 #include "strings_type.h"
 #include "table/control_codes.h"
 
-StringID AddGRFString(uint32_t grfid, GRFStringID stringid, uint8_t langid, bool new_scheme, bool allow_newlines, std::string_view text_to_add, StringID def_string);
-StringID GetGRFStringID(uint32_t grfid, GRFStringID stringid);
+StringID AddGRFString(GrfID grfid, GRFStringID stringid, uint8_t langid, bool new_scheme, bool allow_newlines, std::string_view text_to_add, StringID def_string);
+StringID GetGRFStringID(GrfID grfid, GRFStringID stringid);
 std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextList &text_list);
 std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextWrapper &text);
 std::string_view GetGRFStringPtr(StringIndexInTab stringid);
 void CleanUpStrings();
-std::string TranslateTTDPatchCodes(uint32_t grfid, GRFLanguage language_id, bool allow_newlines, std::string_view str, StringControlCode byte80 = SCC_NEWGRF_PRINT_WORD_STRING_ID);
-void AddGRFTextToList(GRFTextList &list, GRFLanguage langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add);
-void AddGRFTextToList(GRFTextWrapper &list, GRFLanguage langid, uint32_t grfid, bool allow_newlines, std::string_view text_to_add);
+std::string TranslateTTDPatchCodes(GrfID grfid, GRFLanguage language_id, bool allow_newlines, std::string_view str, StringControlCode byte80 = SCC_NEWGRF_PRINT_WORD_STRING_ID);
+void AddGRFTextToList(GRFTextList &list, GRFLanguage langid, GrfID grfid, bool allow_newlines, std::string_view text_to_add);
+void AddGRFTextToList(GRFTextWrapper &list, GRFLanguage langid, GrfID grfid, bool allow_newlines, std::string_view text_to_add);
 void AddGRFTextToList(GRFTextWrapper &list, std::string_view text_to_add);
 
 bool CheckGrfLangID(uint8_t lang_id, uint8_t grf_version);

--- a/src/newgrf_text_type.h
+++ b/src/newgrf_text_type.h
@@ -11,6 +11,7 @@
 #define NEWGRF_TEXT_TYPE_H
 
 #include "core/strong_typedef_type.hpp"
+#include "newgrf_type.h"
 
 /** Type for GRF-internal string IDs. */
 using GRFStringID = StrongType::Typedef<uint32_t, struct GRFStringIDTag, StrongType::Compare, StrongType::Integer>;
@@ -65,7 +66,7 @@ struct LanguageMap {
 
 	int GetMapping(int newgrf_id, bool gender) const;
 	int GetReverseMapping(int openttd_id, bool gender) const;
-	static const LanguageMap *GetLanguageMap(uint32_t grfid, GRFLanguage language_id);
+	static const LanguageMap *GetLanguageMap(GrfID grfid, GRFLanguage language_id);
 };
 
 #endif /* NEWGRF_TEXT_TYPE_H */

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -44,7 +44,7 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 		/* Get a variable from the persistent storage */
 		case 0x7C: {
 			/* Check the persistent storage for the GrfID stored in register 100h. */
-			uint32_t grfid = static_cast<uint32_t>(this->ro.GetRegister(0x100));
+			GrfID grfid = static_cast<uint32_t>(this->ro.GetRegister(0x100));
 			if (grfid == 0xFFFFFFFF) {
 				if (this->ro.grffile == nullptr) return 0;
 				grfid = this->ro.grffile->grfid;
@@ -140,7 +140,7 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 	if (this->ro.grffile == nullptr) return;
 
 	/* Check the persistent storage for the GrfID stored in register 100h. */
-	uint32_t grfid = static_cast<uint32_t>(this->ro.GetRegister(0x100));
+	GrfID grfid = static_cast<uint32_t>(this->ro.GetRegister(0x100));
 
 	/* A NewGRF can only write in the persistent storage associated to its own GRFID. */
 	if (grfid == 0xFFFFFFFF) grfid = this->ro.grffile->grfid;

--- a/src/newgrf_townname.cpp
+++ b/src/newgrf_townname.cpp
@@ -24,14 +24,14 @@
 static std::vector<GRFTownName> _grf_townnames;
 static std::vector<StringID> _grf_townname_names;
 
-GRFTownName *GetGRFTownName(uint32_t grfid)
+GRFTownName *GetGRFTownName(GrfID grfid)
 {
 	auto found = std::ranges::find(_grf_townnames, grfid, &GRFTownName::grfid);
 	if (found != std::end(_grf_townnames)) return &*found;
 	return nullptr;
 }
 
-GRFTownName *AddGRFTownName(uint32_t grfid)
+GRFTownName *AddGRFTownName(GrfID grfid)
 {
 	GRFTownName *t = GetGRFTownName(grfid);
 	if (t == nullptr) {
@@ -41,7 +41,7 @@ GRFTownName *AddGRFTownName(uint32_t grfid)
 	return t;
 }
 
-void DelGRFTownName(uint32_t grfid)
+void DelGRFTownName(GrfID grfid)
 {
 	_grf_townnames.erase(std::ranges::find(_grf_townnames, grfid, &GRFTownName::grfid));
 }
@@ -66,7 +66,7 @@ static void RandomPart(StringBuilder &builder, const GRFTownName *t, uint32_t se
 	}
 }
 
-void GRFTownNameGenerate(StringBuilder &builder, uint32_t grfid, uint16_t gen, uint32_t seed)
+void GRFTownNameGenerate(StringBuilder &builder, GrfID grfid, uint16_t gen, uint32_t seed)
 {
 	const GRFTownName *t = GetGRFTownName(grfid);
 	if (t != nullptr) {
@@ -102,14 +102,14 @@ void CleanUpGRFTownNames()
 	_grf_townnames.clear();
 }
 
-uint32_t GetGRFTownNameId(uint16_t gen)
+GrfID GetGRFTownNameId(uint16_t gen)
 {
 	for (const auto &t : _grf_townnames) {
 		if (gen < t.styles.size()) return t.grfid;
 		gen -= static_cast<uint16_t>(t.styles.size());
 	}
 	/* Fallback to no NewGRF */
-	return 0;
+	return {};
 }
 
 uint16_t GetGRFTownNameType(uint16_t gen)

--- a/src/newgrf_townname.cpp
+++ b/src/newgrf_townname.cpp
@@ -24,6 +24,11 @@
 static std::vector<GRFTownName> _grf_townnames;
 static std::vector<StringID> _grf_townname_names;
 
+/**
+ * Get the \c GRFTownName for the given GRFID.
+ * @param grfid The GRFID of the town name.
+ * @return The \c GRFTownName or \c nullptr if it does not exist.
+ */
 GRFTownName *GetGRFTownName(GrfID grfid)
 {
 	auto found = std::ranges::find(_grf_townnames, grfid, &GRFTownName::grfid);
@@ -31,6 +36,11 @@ GRFTownName *GetGRFTownName(GrfID grfid)
 	return nullptr;
 }
 
+/**
+ * Get the \c GRFTownName for the given GRFID or allocate one if it does not exist.
+ * @param grfid The GRFID of the town name.
+ * @return The \c GRFTownName.
+ */
 GRFTownName *AddGRFTownName(GrfID grfid)
 {
 	GRFTownName *t = GetGRFTownName(grfid);
@@ -41,6 +51,10 @@ GRFTownName *AddGRFTownName(GrfID grfid)
 	return t;
 }
 
+/**
+ * Remove the \c GRFTownName mapping for the given GRFID.
+ * @param grfid The NewGRF to remove for.
+ */
 void DelGRFTownName(GrfID grfid)
 {
 	_grf_townnames.erase(std::ranges::find(_grf_townnames, grfid, &GRFTownName::grfid));
@@ -66,6 +80,13 @@ static void RandomPart(StringBuilder &builder, const GRFTownName *t, uint32_t se
 	}
 }
 
+/**
+ * Construct a NewGRF town name into the builder.
+ * @param builder The string builder to write to.
+ * @param grfid The NewGRF providing the information/logic.
+ * @param gen The town name style to get from the NewGRF.
+ * @param seed The random 32 bit number to generate the town name for.
+ */
 void GRFTownNameGenerate(StringBuilder &builder, GrfID grfid, uint16_t gen, uint32_t seed)
 {
 	const GRFTownName *t = GetGRFTownName(grfid);

--- a/src/newgrf_townname.h
+++ b/src/newgrf_townname.h
@@ -10,6 +10,7 @@
 #ifndef NEWGRF_TOWNNAME_H
 #define NEWGRF_TOWNNAME_H
 
+#include "newgrf_type.h"
 #include "strings_type.h"
 
 struct NamePart {
@@ -35,16 +36,16 @@ struct TownNameStyle {
 struct GRFTownName {
 	static const uint MAX_LISTS = 128; ///< Maximum number of town name lists that can be defined per GRF.
 
-	uint32_t grfid;                                   ///< GRF ID of NewGRF.
+	GrfID grfid; ///< GRF ID of NewGRF.
 	std::vector<TownNameStyle> styles;              ///< Style names defined by the Town Name NewGRF.
 	std::vector<NamePartList> partlists[MAX_LISTS]; ///< Lists of town name parts.
 };
 
-GRFTownName *AddGRFTownName(uint32_t grfid);
-GRFTownName *GetGRFTownName(uint32_t grfid);
-void DelGRFTownName(uint32_t grfid);
+GRFTownName *AddGRFTownName(GrfID grfid);
+GRFTownName *GetGRFTownName(GrfID grfid);
+void DelGRFTownName(GrfID grfid);
 void CleanUpGRFTownNames();
-uint32_t GetGRFTownNameId(uint16_t gen);
+GrfID GetGRFTownNameId(uint16_t gen);
 uint16_t GetGRFTownNameType(uint16_t gen);
 StringID GetGRFTownNameName(uint16_t gen);
 

--- a/src/newgrf_type.h
+++ b/src/newgrf_type.h
@@ -1,0 +1,19 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file newgrf_type.h Commonly used types for the NewGRF implementation. */
+
+#ifndef NEWGRF_TYPE_H
+#define NEWGRF_TYPE_H
+
+struct GRFConfig;
+
+using GrfID = uint32_t; ///< The unique identifier of a NewGRF.
+
+static const GrfID INVALID_GRFID = 0xFFFFFFFF; ///< An invalid NewGRF.
+
+#endif /* NEWGRF_TYPE_H */

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -92,7 +92,7 @@ static void PickerLoadConfig(const IniFile &ini, PickerCallbacks &callbacks)
 			if (!ConvertHexToBytes(grfid_str, grfid_buf)) continue;
 
 			str = str.substr(grfid_pos + 1);
-			uint32_t grfid = grfid_buf[0] | (grfid_buf[1] << 8) | (grfid_buf[2] << 16) | (grfid_buf[3] << 24);
+			GrfID grfid = grfid_buf[0] | (grfid_buf[1] << 8) | (grfid_buf[2] << 16) | (grfid_buf[3] << 24);
 			uint16_t localid;
 			auto [ptr, err] = std::from_chars(str.data(), str.data() + str.size(), localid);
 

--- a/src/picker_gui.h
+++ b/src/picker_gui.h
@@ -33,7 +33,7 @@ enum class PickerFilterMode : uint8_t {
 using PickerFilterModes = EnumBitSet<PickerFilterMode, uint8_t>;
 
 struct PickerItem {
-	uint32_t grfid;
+	GrfID grfid;
 	uint16_t local_id;
 	int class_index;
 	int index;
@@ -270,7 +270,7 @@ public:
 	 */
 	PickerItem GetPickerItem(const typename T::spec_type *spec, int cls_id = -1, int id = -1) const
 	{
-		if (spec == nullptr) return {0, 0, cls_id, id};
+		if (spec == nullptr) return {GrfID{}, 0, cls_id, id};
 		return {spec->grf_prop.grfid, spec->grf_prop.local_id, spec->class_index.base(), spec->index};
 	}
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1098,7 +1098,7 @@ public:
 		for (const Station *st : Station::Iterate()) {
 			if (st->owner != _local_company) continue;
 			if (!default_added && StationUsesDefaultType(st)) {
-				items.insert({0, 0, STAT_CLASS_DFLT.base(), 0});
+				items.insert({GrfID{}, 0, STAT_CLASS_DFLT.base(), 0});
 				default_added = true;
 			}
 			for (const auto &sm : st->speclist) {
@@ -1934,7 +1934,7 @@ public:
 		for (const Waypoint *wp : Waypoint::Iterate()) {
 			if (wp->owner != _local_company || HasBit(wp->waypoint_flags, WPF_ROAD)) continue;
 			if (!default_added && StationUsesDefaultType(wp)) {
-				items.insert({0, 0, STAT_CLASS_WAYP.base(), 0});
+				items.insert({GrfID{}, 0, STAT_CLASS_WAYP.base(), 0});
 				default_added = true;
 			}
 			for (const auto &sm : wp->speclist) {

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1366,7 +1366,7 @@ public:
 			if (st->owner != _local_company) continue;
 			if (roadstoptype == RoadStopType::Truck && !st->facilities.Test(StationFacility::TruckStop)) continue;
 			if (roadstoptype == RoadStopType::Bus && !st->facilities.Test(StationFacility::BusStop)) continue;
-			items.insert({0, 0, ROADSTOP_CLASS_DFLT.base(), 0}); // We would need to scan the map to find out if default is used.
+			items.insert({GrfID{}, 0, ROADSTOP_CLASS_DFLT.base(), 0}); // We would need to scan the map to find out if default is used.
 			for (const auto &sm : st->roadstop_speclist) {
 				if (sm.spec == nullptr) continue;
 				if (roadstoptype == RoadStopType::Truck && sm.spec->stop_type != ROADSTOPTYPE_FREIGHT && sm.spec->stop_type != ROADSTOPTYPE_ALL) continue;
@@ -1791,7 +1791,7 @@ public:
 	{
 		for (const Waypoint *wp : Waypoint::Iterate()) {
 			if (wp->owner != _local_company || !HasBit(wp->waypoint_flags, WPF_ROAD)) continue;
-			items.insert({0, 0, ROADSTOP_CLASS_WAYP.base(), 0}); // We would need to scan the map to find out if default is used.
+			items.insert({GrfID{}, 0, ROADSTOP_CLASS_WAYP.base(), 0}); // We would need to scan the map to find out if default is used.
 			for (const auto &sm : wp->roadstop_speclist) {
 				if (sm.spec == nullptr) continue;
 				items.insert({sm.grfid, sm.localidx, sm.spec->class_index.base(), sm.spec->index});

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -264,7 +264,7 @@ struct INDYChunkHandler : ChunkHandler {
 			if (IsSavegameVersionBefore(SaveLoadVersion::PersistentStoragePool) && !IsSavegameVersionBefore(SaveLoadVersion::NewGRFPersistentStorage)) {
 				/* Store the old persistent storage. The GRFID will be added later. */
 				assert(PersistentStorage::CanAllocateItem());
-				i->psa = PersistentStorage::Create(0, GrfSpecFeature::Invalid, TileIndex{});
+				i->psa = PersistentStorage::Create(GrfID{}, GrfSpecFeature::Invalid, TileIndex{});
 				std::copy(std::begin(_old_ind_persistent_storage.storage), std::end(_old_ind_persistent_storage.storage), std::begin(i->psa->storage));
 			}
 			if (IsSavegameVersionBefore(SaveLoadVersion::ExtendIndustryCargoSlots)) {

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1583,7 +1583,7 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 
 				ClearGRFConfigList(_grfconfig);
 				while (len != 0) {
-					uint32_t grfid = ReadUint32(ls);
+					GrfID grfid = ReadUint32(ls);
 
 					if (ReadByte(ls) == 1) {
 						auto c = std::make_unique<GRFConfig>("TTDP game, no information");

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -35,7 +35,7 @@ struct OldWaypoint {
 	uint8_t delete_ctr;
 	TimerGameCalendar::Date build_date;
 	uint8_t localidx;
-	uint32_t grfid;
+	GrfID grfid;
 	const StationSpec *spec;
 	Owner owner;
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1116,7 +1116,7 @@ static GRFConfigList GRFLoadConfig(const IniFile &ini, std::string_view grpname,
 					if (has_md5sum) item_name = item_name.substr(md5sum_pos + 1);
 				}
 
-				uint32_t grfid = grfid_buf[0] | (grfid_buf[1] << 8) | (grfid_buf[2] << 16) | (grfid_buf[3] << 24);
+				GrfID grfid = grfid_buf[0] | (grfid_buf[1] << 8) | (grfid_buf[2] << 16) | (grfid_buf[3] << 24);
 				if (has_md5sum) {
 					const GRFConfig *s = FindGRFConfig(grfid, FindGRFConfigMode::Exact, &md5sum);
 					if (s != nullptr) c = std::make_unique<GRFConfig>(*s);

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -227,7 +227,7 @@ std::string GetStringWithArgs(StringID string, StringParameters &args);
 /* Do not leak the StringBuilder to everywhere. */
 void GenerateTownNameString(StringBuilder &builder, size_t lang, uint32_t seed);
 void GetTownName(StringBuilder &builder, const struct Town *t);
-void GRFTownNameGenerate(StringBuilder &builder, uint32_t grfid, uint16_t gen, uint32_t seed);
+void GRFTownNameGenerate(StringBuilder &builder, GrfID grfid, uint16_t gen, uint32_t seed);
 
 char32_t RemapNewGRFStringControlCode(char32_t scc, StringConsumer &consumer);
 

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -71,7 +71,7 @@ class NIHVehicle : public NIHelper {
 	const void *GetInstance(uint index)const override    { return Vehicle::Get(index); }
 	const void *GetSpec(uint index) const override       { return Vehicle::Get(index)->GetEngine(); }
 	std::string GetName(uint index) const override       { return GetString(STR_VEHICLE_NAME, index); }
-	uint32_t GetGRFID(uint index) const override                   { return Vehicle::Get(index)->GetGRFID(); }
+	GrfID GetGRFID(uint index) const override { return Vehicle::Get(index)->GetGRFID(); }
 	std::span<const BadgeID> GetBadges(uint index) const override { return Vehicle::Get(index)->GetEngine()->badges; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
@@ -135,7 +135,7 @@ class NIHStation : public NIHelper {
 	const void *GetInstance(uint ) const override        { return nullptr; }
 	const void *GetSpec(uint index) const override       { return GetStationSpec(TileIndex{index}); }
 	std::string GetName(uint index) const override       { return GetString(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT, STR_STATION_NAME, GetStationIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetStationSpec(TileIndex{index})->grf_prop.grfid : 0; }
+	GrfID GetGRFID(uint index) const override { return (this->IsInspectable(index)) ? GetStationSpec(TileIndex{index})->grf_prop.grfid : GrfID{}; }
 	std::span<const BadgeID> GetBadges(uint index) const override { return this->IsInspectable(index) ? GetStationSpec(TileIndex{index})->badges : std::span<const BadgeID>{}; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
@@ -200,7 +200,7 @@ class NIHHouse : public NIHelper {
 	const void *GetInstance(uint)const override          { return nullptr; }
 	const void *GetSpec(uint index) const override       { return HouseSpec::Get(GetHouseType(index)); }
 	std::string GetName(uint index) const override       { return GetString(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT, STR_TOWN_NAME, GetTownIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? HouseSpec::Get(GetHouseType(index))->grf_prop.grfid : 0; }
+	GrfID GetGRFID(uint index) const override { return (this->IsInspectable(index)) ? HouseSpec::Get(GetHouseType(index))->grf_prop.grfid : GrfID{}; }
 	std::span<const BadgeID> GetBadges(uint index) const override { return HouseSpec::Get(GetHouseType(index))->badges; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
@@ -250,7 +250,7 @@ class NIHIndustryTile : public NIHelper {
 	const void *GetInstance(uint)const override          { return nullptr; }
 	const void *GetSpec(uint index) const override       { return GetIndustryTileSpec(GetIndustryGfx(index)); }
 	std::string GetName(uint index) const override       { return GetString(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT, STR_INDUSTRY_NAME, GetIndustryIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetIndustryTileSpec(GetIndustryGfx(index))->grf_prop.grfid : 0; }
+	GrfID GetGRFID(uint index) const override { return (this->IsInspectable(index)) ? GetIndustryTileSpec(GetIndustryGfx(index))->grf_prop.grfid : GrfID{}; }
 	std::span<const BadgeID> GetBadges(uint index) const override { return GetIndustryTileSpec(GetIndustryGfx(index))->badges; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
@@ -362,7 +362,7 @@ class NIHIndustry : public NIHelper {
 	const void *GetInstance(uint index)const override    { return Industry::Get(index); }
 	const void *GetSpec(uint index) const override       { return GetIndustrySpec(Industry::Get(index)->type); }
 	std::string GetName(uint index) const override       { return GetString(STR_INDUSTRY_NAME, index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetIndustrySpec(Industry::Get(index)->type)->grf_prop.grfid : 0; }
+	GrfID GetGRFID(uint index) const override { return (this->IsInspectable(index)) ? GetIndustrySpec(Industry::Get(index)->type)->grf_prop.grfid : GrfID{}; }
 	std::span<const BadgeID> GetBadges(uint index) const override { return GetIndustrySpec(Industry::Get(index)->type)->badges; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
@@ -424,7 +424,7 @@ class NIHObject : public NIHelper {
 	const void *GetInstance(uint index)const override    { return Object::GetByTile(TileIndex{index}); }
 	const void *GetSpec(uint index) const override       { return ObjectSpec::GetByTile(TileIndex{index}); }
 	std::string GetName(uint index) const override       { return GetString(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT, STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT_OBJECT, INVALID_STRING_ID, index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? ObjectSpec::GetByTile(TileIndex{index})->grf_prop.grfid : 0; }
+	GrfID GetGRFID(uint index) const override { return (this->IsInspectable(index)) ? ObjectSpec::GetByTile(TileIndex{index})->grf_prop.grfid : GrfID{}; }
 	std::span<const BadgeID> GetBadges(uint index) const override { return ObjectSpec::GetByTile(TileIndex{index})->badges; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
@@ -460,7 +460,7 @@ class NIHRailType : public NIHelper {
 	const void *GetInstance(uint) const override         { return nullptr; }
 	const void *GetSpec(uint) const override             { return nullptr; }
 	std::string GetName(uint index) const override       { return GetString(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT, STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT_RAIL_TYPE, INVALID_STRING_ID, index); }
-	uint32_t GetGRFID(uint) const override               { return 0; }
+	GrfID GetGRFID(uint) const override { return {}; }
 	std::span<const BadgeID> GetBadges(uint index) const override { return GetRailTypeInfo(GetRailType(TileIndex{index}))->badges; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
@@ -496,7 +496,7 @@ class NIHAirportTile : public NIHelper {
 	const void *GetInstance(uint)const override          { return nullptr; }
 	const void *GetSpec(uint index) const override       { return AirportTileSpec::Get(GetAirportGfx(index)); }
 	std::string GetName(uint index) const override       { return GetString(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT, STR_STATION_NAME, GetStationIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? AirportTileSpec::Get(GetAirportGfx(index))->grf_prop.grfid : 0; }
+	GrfID GetGRFID(uint index) const override { return (this->IsInspectable(index)) ? AirportTileSpec::Get(GetAirportGfx(index))->grf_prop.grfid : GrfID{}; }
 	std::span<const BadgeID> GetBadges(uint index) const override { return AirportTileSpec::Get(GetAirportGfx(index))->badges; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
@@ -538,7 +538,7 @@ class NIHAirport : public NIHelper {
 	const void *GetInstance(uint index)const override    { return Station::Get(index); }
 	const void *GetSpec(uint index) const override       { return AirportSpec::Get(Station::Get(index)->airport.type); }
 	std::string GetName(uint index) const override       { return GetString(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT, STR_STATION_NAME, index, Station::Get(index)->airport.tile); }
-	uint32_t GetGRFID(uint index) const override         { return (this->IsInspectable(index)) ? AirportSpec::Get(Station::Get(index)->airport.type)->grf_prop.grfid : 0; }
+	GrfID GetGRFID(uint index) const override { return (this->IsInspectable(index)) ? AirportSpec::Get(Station::Get(index)->airport.type)->grf_prop.grfid : GrfID{}; }
 	std::span<const BadgeID> GetBadges(uint index) const override { return AirportSpec::Get(Station::Get(index)->airport.type)->badges; }
 
 	uint Resolve(uint index, uint var, uint param, bool &avail) const override
@@ -584,7 +584,7 @@ class NIHTown : public NIHelper {
 	const void *GetInstance(uint index)const override    { return Town::Get(index); }
 	const void *GetSpec(uint) const override             { return nullptr; }
 	std::string GetName(uint index) const override       { return GetString(STR_TOWN_NAME, index); }
-	uint32_t GetGRFID(uint) const override               { return 0; }
+	GrfID GetGRFID(uint) const override { return {}; }
 	bool PSAWithParameter() const override               { return true; }
 	std::span<const BadgeID> GetBadges(uint) const override { return {}; }
 
@@ -594,7 +594,7 @@ class NIHTown : public NIHelper {
 		return ro.GetScope(VarSpriteGroupScope::Self)->GetVariable(var, param, avail);
 	}
 
-	const std::span<int32_t> GetPSA(uint index, uint32_t grfid) const override
+	const std::span<int32_t> GetPSA(uint index, GrfID grfid) const override
 	{
 		Town *t = Town::Get(index);
 
@@ -631,7 +631,7 @@ class NIHRoadType : public NIHelper {
 	const void *GetInstance(uint) const override         { return nullptr; }
 	const void *GetSpec(uint) const override             { return nullptr; }
 	std::string GetName(uint index) const override       { return GetString(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT, STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT_ROAD_TYPE, INVALID_STRING_ID, index); }
-	uint32_t GetGRFID(uint) const override               { return 0; }
+	GrfID GetGRFID(uint) const override { return {}; }
 	std::span<const BadgeID> GetBadges(uint index) const override
 	{
 		RoadType rt = GetRoadType(TileIndex{index}, TRoadTramType);
@@ -701,7 +701,7 @@ class NIHRoadStop : public NIHelper {
 	const void *GetInstance(uint)const override          { return nullptr; }
 	const void *GetSpec(uint index) const override       { return GetRoadStopSpec(TileIndex{index}); }
 	std::string GetName(uint index) const override       { return GetString(STR_NEWGRF_INSPECT_CAPTION_OBJECT_AT, STR_STATION_NAME, GetStationIndex(index), index); }
-	uint32_t GetGRFID(uint index) const override           { return (this->IsInspectable(index)) ? GetRoadStopSpec(TileIndex{index})->grf_prop.grfid : 0; }
+	GrfID GetGRFID(uint index) const override { return (this->IsInspectable(index)) ? GetRoadStopSpec(TileIndex{index})->grf_prop.grfid : GrfID{}; }
 	std::span<const BadgeID> GetBadges(uint index) const override { return this->IsInspectable(index) ? GetRoadStopSpec(TileIndex{index})->badges : std::span<const BadgeID>{}; }
 
 	uint Resolve(uint index, uint var, uint32_t param, bool &avail) const override

--- a/src/town.h
+++ b/src/town.h
@@ -68,7 +68,7 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	/** @name Town name.
 	 * @{ */
-	uint32_t townnamegrfid = 0; ///< NewGRF id that contains the name. O is not used.
+	GrfID townnamegrfid{}; ///< NewGRF id that contains the name. O is not used.
 	uint16_t townnametype = 0; ///< The style of the name.
 	uint32_t townnameparts = 0; ///< Random number that give unique town name when passed to generator.
 	std::string name{}; ///< Custom town name. If empty, the town was not renamed and uses the generated name.

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1520,7 +1520,7 @@ public:
 	PickerItem GetPickerItem(int cls_id, int id) const override
 	{
 		const auto *spec = HouseSpec::Get(id);
-		if (!spec->grf_prop.HasGrfFile()) return {0, spec->Index(), cls_id, id};
+		if (!spec->grf_prop.HasGrfFile()) return {GrfID{}, spec->Index(), cls_id, id};
 		return {spec->grf_prop.grfid, spec->grf_prop.local_id, cls_id, id};
 	}
 
@@ -1579,7 +1579,7 @@ public:
 			HouseID house = static_cast<HouseID>(std::distance(id_count.begin(), it));
 			const HouseSpec *hs = HouseSpec::Get(house);
 			int class_index = GetClassIdFromHouseZone(hs->building_availability);
-			items.insert({0, house, class_index, house});
+			items.insert({GrfID{}, house, class_index, house});
 		}
 	}
 

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -32,7 +32,7 @@ TownNameParams::TownNameParams(const Town *t) :
 {
 	if (t->townnamegrfid != 0 && GetGRFTownName(t->townnamegrfid) == nullptr) {
 		/* Fallback to the first built in town name (English). */
-		this->grfid = 0;
+		this->grfid = {};
 		this->type = SPECSTR_TOWNNAME_START;
 		return;
 	}

--- a/src/townname_type.h
+++ b/src/townname_type.h
@@ -21,7 +21,7 @@ typedef std::set<std::string> TownNames;
  * Speeds things up a bit because these values are computed only once per name generation.
  */
 struct TownNameParams {
-	uint32_t grfid; ///< newgrf ID (0 if not used)
+	GrfID grfid; ///< newgrf ID (0 if not used)
 	uint16_t type;  ///< town name style
 
 	/**
@@ -31,7 +31,7 @@ struct TownNameParams {
 	TownNameParams(uint8_t town_name)
 	{
 		bool grf = town_name >= BUILTIN_TOWNNAME_GENERATOR_COUNT;
-		this->grfid = grf ? GetGRFTownNameId(town_name - BUILTIN_TOWNNAME_GENERATOR_COUNT) : 0;
+		this->grfid = grf ? GetGRFTownNameId(town_name - BUILTIN_TOWNNAME_GENERATOR_COUNT) : GrfID{};
 		this->type = grf ? GetGRFTownNameType(town_name - BUILTIN_TOWNNAME_GENERATOR_COUNT) : SPECSTR_TOWNNAME_START + town_name;
 	}
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -364,7 +364,7 @@ void VehicleLengthChanged(const Vehicle *u)
 {
 	/* show a warning once for each engine in whole game and once for each GRF after each game load */
 	const Engine *engine = u->GetEngine();
-	uint32_t grfid = engine->grf_prop.grfid;
+	GrfID grfid = engine->grf_prop.grfid;
 	GRFConfig *grfconfig = GetGRFConfig(grfid);
 	if (_gamelog.GRFBugReverse(grfid, engine->grf_prop.local_id) || !grfconfig->grf_bugs.Test(GRFBug::VehLength)) {
 		ShowNewGrfVehicleError(u->engine_type, STR_NEWGRF_BROKEN, STR_NEWGRF_BROKEN_VEHICLE_LENGTH, GRFBug::VehLength, true);
@@ -765,7 +765,7 @@ const GRFFile *Vehicle::GetGRF() const
  * This is the GRF providing the Action 3 for the engine type.
  * @return GRF ID of the associated NewGRF.
  */
-uint32_t Vehicle::GetGRFID() const
+GrfID Vehicle::GetGRFID() const
 {
 	return this->GetEngine()->GetGRFID();
 }

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -485,7 +485,7 @@ public:
 	virtual void GetImage([[maybe_unused]] Direction direction, [[maybe_unused]] EngineImageType image_type, [[maybe_unused]] VehicleSpriteSeq *result) const { result->Clear(); }
 
 	const GRFFile *GetGRF() const;
-	uint32_t GetGRFID() const;
+	GrfID GetGRFID() const;
 
 	/**
 	 * Invalidates cached NewGRF variables


### PR DESCRIPTION
## Motivation / Problem

Reduce size of future type safety PRs regarding a NewGRFs ID.


## Description

* Introduce 'newgrf_type.h' as we need to declare `GrfID` somewhere, and 'newgrf.h' won't fit as it creates a looping dependency chain.
* Replace `uint32_t` with `GrfID`.
* Use `GrfID{}` or `{}` when initialising over `0` to ease future changes.


## Limitations

* Not all instances might have been found.
* Lots of weird things happen with GrfIDs like functions sometimes returning GrfID and sometimes not.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
