### PR TITLE
Codechange: improve documentation by removing unneeded constructors/operators

### DIFF
--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -257,7 +257,7 @@ static void ParamSet(ByteReader &buf)
 
 							/* Reserve space at the current sprite ID */
 							GrfMsg(4, "ParamSet: GRM: Allocated {} sprites at {}", count, _cur_gps.spriteid);
-							_grm_sprites[GRFLocation(_cur_gps.grffile->grfid, _cur_gps.nfo_line)] = std::make_pair(_cur_gps.spriteid, count);
+							_grm_sprites[GRFLocation{_cur_gps.grffile->grfid, _cur_gps.nfo_line}] = std::make_pair(_cur_gps.spriteid, count);
 							_cur_gps.spriteid += count;
 						}
 					}
@@ -291,7 +291,7 @@ static void ParamSet(ByteReader &buf)
 							switch (op) {
 								case 0:
 									/* Return space reserved during reservation stage */
-									src1 = _grm_sprites[GRFLocation(_cur_gps.grffile->grfid, _cur_gps.nfo_line)].first;
+									src1 = _grm_sprites[GRFLocation{_cur_gps.grffile->grfid, _cur_gps.nfo_line}].first;
 									GrfMsg(4, "ParamSet: GRM: Using pre-allocated sprites at {}", src1);
 									break;
 

--- a/src/newgrf/newgrf_internal.h
+++ b/src/newgrf/newgrf_internal.h
@@ -197,21 +197,17 @@ public:
 
 extern GrfProcessingState _cur_gps;
 
+/** A location within a NewGRF, like file:line but in the context of NewGRFs. */
 struct GRFLocation {
-	uint32_t grfid;
-	uint32_t nfoline;
+	uint32_t grfid; ///< Identifier of the NewGRF this refers to.
+	uint32_t nfoline; ///< The line of NFO this refers to.
 
-	GRFLocation(uint32_t grfid, uint32_t nfoline) : grfid(grfid), nfoline(nfoline) { }
-
-	bool operator <(const GRFLocation &other) const
-	{
-		return this->grfid < other.grfid || (this->grfid == other.grfid && this->nfoline < other.nfoline);
-	}
-
-	bool operator ==(const GRFLocation &other) const
-	{
-		return this->grfid == other.grfid && this->nfoline == other.nfoline;
-	}
+	/**
+	 * Compare with another location.
+	 * @param other The other location to compare to.
+	 * @return The std::strong_ordering of the comparison.
+	 */
+	constexpr auto operator<=>(const GRFLocation &other) const = default;
 };
 
 using GRFLineToSpriteOverride = std::map<GRFLocation, std::vector<uint8_t>>;

--- a/src/newgrf/newgrf_stringmapping.cpp
+++ b/src/newgrf/newgrf_stringmapping.cpp
@@ -27,8 +27,6 @@ struct StringIDMapping {
 	uint32_t grfid; ///< Source NewGRF.
 	GRFStringID source; ///< Source grf-local GRFStringID.
 	std::function<void(StringID)> func; ///< Function for mapping result.
-
-	StringIDMapping(uint32_t grfid, GRFStringID source, std::function<void(StringID)> &&func) : grfid(grfid), source(source), func(std::move(func)) { }
 };
 
 /** Strings to be mapped during load. */

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -85,15 +85,8 @@ enum GRFPalette : uint8_t {
 
 /** Basic data to distinguish a GRF. Used in the server list window */
 struct GRFIdentifier {
-	uint32_t grfid;     ///< GRF ID (defined by Action 0x08)
-	MD5Hash md5sum;   ///< MD5 checksum of file to distinguish files with the same GRF ID (eg. newer version of GRF)
-
-	GRFIdentifier() = default;
-	GRFIdentifier(const GRFIdentifier &other) = default;
-	GRFIdentifier(GRFIdentifier &&other) = default;
-	GRFIdentifier(uint32_t grfid, const MD5Hash &md5sum) : grfid(grfid), md5sum(md5sum) {}
-
-	GRFIdentifier& operator =(const GRFIdentifier &other) = default;
+	uint32_t grfid; ///< GRF ID (defined by Action 0x08)
+	MD5Hash md5sum; ///< MD5 checksum of file to distinguish files with the same GRF ID (eg. newer version of GRF)
 
 	/**
 	 * Does the identification match the provided values?


### PR DESCRIPTION
## Motivation / Problem

Doxygen complaining on one of my PRs.


## Description

* If the constructor only sets the instance variables, it's not needed.
* If you default the default, copy, move and 'all parameter' constructor, they're not needed.
* The defaulted-assignment operator is not needed.
* If you implement `<` and `==` in a standard way, then just default implement the `<=>` operator.

Oh, and document some small bits and bobs around the removals.


## Limitations

None I'm currently aware of, except that it's limited to what Doxygen for my PR stumbled upon.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
