### PR TITLE
Codefix: Clean up rocky ground placement in Editor

### DIFF
--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -82,7 +82,7 @@ static void GenerateDesertArea(TileIndex end, TileIndex start)
  * @param start The start tile of the map drag.
  * @param remove If true, remove rocks instead of placing them.
  */
-static void GenerateRockyArea(TileIndex end, TileIndex start, bool remove)
+static void PlaceRockyArea(TileIndex end, TileIndex start, bool remove)
 {
 	if (_game_mode != GameMode::Editor) return;
 
@@ -150,7 +150,7 @@ bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_t
 			Command<Commands::LevelLand>::Post(STR_ERROR_CAN_T_LEVEL_LAND_HERE, CcTerraform, end_tile, start_tile, _ctrl_pressed, LevelMode::Level);
 			break;
 		case DDSP_CREATE_ROCKS:
-			GenerateRockyArea(end_tile, start_tile, _ctrl_pressed);
+			PlaceRockyArea(end_tile, start_tile, _ctrl_pressed);
 			break;
 		case DDSP_CREATE_DESERT:
 			GenerateDesertArea(end_tile, start_tile);


### PR DESCRIPTION
## Motivation / Problem

#15624 copied some things from rocky area placement in Scenario Editor, and I noticed some cleanup to do.


## Description

1. Renamed `GenerateRockyArea` to `PlaceRockyArea` because this is a player action, not part of map generation.
2. ~~Misread something else, oops~~

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
