### PR TITLE
Codechange: Do not allow size_t indexing for Slope indexed arrays

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -87,9 +87,9 @@ const EnumIndexArray<const TileTypeProcs *, TileType, TileType::MaxSize> _tile_t
 };
 
 /** landscape slope => sprite */
-extern const uint8_t _slope_to_sprite_offset[32] = {
+extern const SlopeIndexArray<uint8_t> _slope_to_sprite_offset = {
 	0, 1, 2, 3, 4, 5, 6,  7, 8, 9, 10, 11, 12, 13, 14, 0,
-	0, 0, 0, 0, 0, 0, 0, 16, 0, 0,  0, 17,  0, 15, 18, 0,
+	0, 0, 0, 0, 0, 0, 0, 16, 0, 0,  0, 17,  0, 15, 18,
 };
 
 static const uint TILE_UPDATE_FREQUENCY_LOG = 8;  ///< The logarithm of how many ticks it takes between tile updates (log base 2).

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -178,7 +178,9 @@ RailType AllocateRailType(RailTypeLabel label)
 	return rt;
 }
 
-static const uint8_t _track_sloped_sprites[14] = {
+/** Lookup table to convert tile's slope into corresponding track sprite offset. */
+static constexpr NonSteepSlopeIndexArray<uint8_t> _track_sloped_sprites = {
+	0xFF, // Dummy value to prevent `index - 1` while accesing.
 	14, 15, 22, 13,
 	 0, 21, 17, 12,
 	23,  0, 18, 20,
@@ -257,7 +259,7 @@ static CommandCost CheckTrackCombination(TileIndex tile, TrackBits to_build)
 
 
 /** Valid TrackBits on a specific (non-steep)-slope without foundation */
-static const TrackBits _valid_tracks_without_foundation[15] = {
+static constexpr NonSteepSlopeIndexArray<TrackBits> _valid_tracks_without_foundation = {
 	TRACK_BIT_ALL,
 	Track::Right,
 	Track::Upper,
@@ -279,7 +281,7 @@ static const TrackBits _valid_tracks_without_foundation[15] = {
 };
 
 /** Valid TrackBits on a specific (non-steep)-slope with leveled foundation */
-static const TrackBits _valid_tracks_on_leveled_foundation[15] = {
+static constexpr NonSteepSlopeIndexArray<TrackBits> _valid_tracks_on_leveled_foundation = {{{
 	{},
 	Track::Left,
 	Track::Lower,
@@ -298,7 +300,7 @@ static const TrackBits _valid_tracks_on_leveled_foundation[15] = {
 	{Track::Y, Track::Upper, Track::Right},
 	TRACK_BIT_ALL,
 	TRACK_BIT_ALL,
-};
+}}};
 
 /**
  * Checks if a track combination is valid on a specific slope and returns the needed foundation.
@@ -2327,7 +2329,7 @@ static void DrawTrackBits(TileInfo *ti, TrackBits track)
 	} else {
 		if (ti->tileh != SLOPE_FLAT) {
 			/* track on non-flat ground */
-			image = _track_sloped_sprites[ti->tileh - 1] + rti->base_sprites.track_y;
+			image = _track_sloped_sprites[ti->tileh] + rti->base_sprites.track_y;
 		} else {
 			/* track on flat ground */
 			switch (track.base()) {
@@ -2386,14 +2388,14 @@ static void DrawTrackBits(TileInfo *ti, TrackBits track)
 			if (ti->tileh == SLOPE_FLAT || ti->tileh == SLOPE_ELEVATED) {
 				DrawGroundSprite(rti->base_sprites.single_x, PALETTE_CRASH);
 			} else {
-				DrawGroundSprite(_track_sloped_sprites[ti->tileh - 1] + rti->base_sprites.single_sloped - 20, PALETTE_CRASH);
+				DrawGroundSprite(_track_sloped_sprites[ti->tileh] + rti->base_sprites.single_sloped - 20, PALETTE_CRASH);
 			}
 		}
 		if (pbs.Test(Track::Y)) {
 			if (ti->tileh == SLOPE_FLAT || ti->tileh == SLOPE_ELEVATED) {
 				DrawGroundSprite(rti->base_sprites.single_y, PALETTE_CRASH);
 			} else {
-				DrawGroundSprite(_track_sloped_sprites[ti->tileh - 1] + rti->base_sprites.single_sloped - 20, PALETTE_CRASH);
+				DrawGroundSprite(_track_sloped_sprites[ti->tileh] + rti->base_sprites.single_sloped - 20, PALETTE_CRASH);
 			}
 		}
 		if (pbs.Test(Track::Upper)) DrawGroundSprite(rti->base_sprites.single_n, PALETTE_CRASH, nullptr, 0, ti->tileh & SLOPE_N ? -(int)TILE_HEIGHT : 0);
@@ -2407,7 +2409,7 @@ static void DrawTrackBits(TileInfo *ti, TrackBits track)
 
 		/* Draw higher halftile-overlay: Use the sloped sprites with three corners raised. They probably best fit the lightning. */
 		Slope fake_slope = SlopeWithThreeCornersRaised(OppositeCorner(halftile_corner));
-		image = _track_sloped_sprites[fake_slope - 1] + rti->base_sprites.track_y;
+		image = _track_sloped_sprites[fake_slope] + rti->base_sprites.track_y;
 		pal = PAL_NONE;
 		switch (rgt) {
 			case RailGroundType::Barren: pal = PALETTE_TO_BARE_LAND; break;

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -192,9 +192,9 @@ void UpdateCompanyRoadInfrastructure(RoadType rt, Owner o, int count)
 }
 
 /** Invalid RoadBits on slopes.  */
-static const RoadBits _invalid_tileh_slopes_road[2][15] = {
+static const std::array<NonSteepSlopeIndexArray<RoadBits>, 2> _invalid_tileh_slopes_road = {{
 	/* The inverse of the mixable RoadBits on a leveled slope */
-	{
+	{{{
 		{}, // SLOPE_FLAT
 		{RoadBit::NE, RoadBit::SE}, // SLOPE_W
 		{RoadBit::NE, RoadBit::NW}, // SLOPE_S
@@ -214,10 +214,10 @@ static const RoadBits _invalid_tileh_slopes_road[2][15] = {
 		RoadBit::SW, // SLOPE_NE
 		{}, // SLOPE_SEN
 		{}, // SLOPE_NWS
-	},
+	}}},
 	/* The inverse of the allowed straight roads on a slope
 	 * (with and without a foundation). */
-	{
+	{{{
 		{}, // SLOPE_FLAT
 		{}, // SLOPE_W (Foundation)
 		{}, // SLOPE_S (Foundation)
@@ -237,8 +237,8 @@ static const RoadBits _invalid_tileh_slopes_road[2][15] = {
 		ROAD_Y, // SLOPE_NE
 		ROAD_ALL, // SLOPE_SEN
 		ROAD_ALL, // SLOPE_NW
-	}
-};
+	}}}
+}};
 
 static Foundation GetRoadFoundation(Slope tileh, RoadBits bits);
 
@@ -1307,7 +1307,9 @@ static Foundation GetRoadFoundation(Slope tileh, RoadBits bits)
 	return (bits == ROAD_X ? Foundation::InclinedX : Foundation::InclinedY);
 }
 
-const uint8_t _road_sloped_sprites[14] = {
+/** Lookup table to convert tile's slope into corresponding road sprite offset. */
+static constexpr NonSteepSlopeIndexArray<uint8_t> _road_sloped_sprites = {
+	0xFF, // Dummy value to prevent `index - 1` while accesing.
 	0,  0,  2,  0,
 	0,  1,  0,  0,
 	3,  0,  0,  0,
@@ -1401,8 +1403,8 @@ void DrawRoadTypeCatenary(const TileInfo *ti, RoadType rt, RoadBits rb)
 		if (front != 0) front += GetRoadSpriteOffset(ti->tileh, rb);
 		if (back != 0) back += GetRoadSpriteOffset(ti->tileh, rb);
 	} else if (ti->tileh != SLOPE_FLAT) {
-		back  = SPR_TRAMWAY_BACK_WIRES_SLOPED  + _road_sloped_sprites[ti->tileh - 1];
-		front = SPR_TRAMWAY_FRONT_WIRES_SLOPED + _road_sloped_sprites[ti->tileh - 1];
+		back = SPR_TRAMWAY_BACK_WIRES_SLOPED + _road_sloped_sprites[ti->tileh];
+		front = SPR_TRAMWAY_FRONT_WIRES_SLOPED + _road_sloped_sprites[ti->tileh];
 	} else {
 		back  = SPR_TRAMWAY_BASE + _road_backpole_sprites_1[rb.base()];
 		front = SPR_TRAMWAY_BASE + _road_frontwire_sprites_1[rb.base()];

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -270,7 +270,7 @@ static int32_t LookupWithBuildOnSlopes(::Slope slope, const Array<RoadPartOrient
 	 * same but are only rotated. So to reduce the amount of lookup work that
 	 * needs to be done the data is made uniform.
 	 * This means rotating the existing parts. */
-	static const uint8_t base_rotates[] = {0, 0, 1, 0, 2, 0, 1, 0, 3, 3, 2, 3, 2, 2, 1};
+	static constexpr NonSteepSlopeIndexArray<uint8_t> base_rotates = {0, 0, 1, 0, 2, 0, 1, 0, 3, 3, 2, 3, 2, 2, 1};
 
 	if (slope >= SLOPE_ELEVATED) {
 		/* This slope is an invalid slope, so ignore it. */

--- a/src/slope_func.h
+++ b/src/slope_func.h
@@ -422,7 +422,7 @@ inline Foundation SpecialRailFoundation(Corner corner)
  */
 inline uint SlopeToSpriteOffset(Slope s)
 {
-	extern const uint8_t _slope_to_sprite_offset[32];
+	extern const SlopeIndexArray<uint8_t> _slope_to_sprite_offset;
 	return _slope_to_sprite_offset[s];
 }
 

--- a/src/slope_type.h
+++ b/src/slope_type.h
@@ -83,6 +83,24 @@ enum Slope : uint8_t {
 DECLARE_ENUM_AS_BIT_SET(Slope)
 
 /**
+ * Array with \c Slope as index.
+ * @note Remove halftile form the slope before accessing an element.
+ * @note Elevated steep slope (e.g. value 31) is an invalid slope because it does not define which corner is steep.
+ * @tparam T the type contained within the array.
+ */
+template <typename T>
+using SlopeIndexArray = EnumClassIndexContainer<std::array<T, SLOPE_STEEP | SLOPE_ELEVATED>, Slope>;
+
+/**
+ * Array with non steep \c Slope as index.
+ * @note Remove halftile form the slope before accessing an element.
+ * @note SLOPE_ELEVATED is just SLOPE_FLAT with height increased by one, therefore it is not a valid index.
+ * @tparam T the type contained within the array.
+ */
+template <typename T>
+using NonSteepSlopeIndexArray = EnumClassIndexContainer<std::array<T, SLOPE_ELEVATED>, Slope>;
+
+/**
  * Helper for creating a bitset of slopes.
  * @param x The slope to convert into a bitset.
  */

--- a/src/table/autorail.h
+++ b/src/table/autorail.h
@@ -22,7 +22,7 @@
  * Table maps each of the six rail directions and tileh combinations to a sprite offset.
  * Invalid entries are required to make sure that this array can be quickly accessed.
  */
-static const int _autorail_slope_sprite_offsets[][6] = {
+static constexpr SlopeIndexArray<std::array<int, 6>> _autorail_slope_sprite_offsets = {{{
 /* type   0        1        2        3        4        5 */
 	{       0,       8,      16,      25,      34,      42 }, // tileh = 0
 	{       5,      13, RED(22), RED(31),      35,      42 }, // tileh = 1
@@ -55,7 +55,7 @@ static const int _autorail_slope_sprite_offsets[][6] = {
 	{       0,       1,       2,       3,       4,       5 }, // invalid (28)
 	{       3,      14,      18,      26, RED(41), RED(49) }, // tileh = 29
 	{       4,      12, RED(21), RED(30),      37,      45 }  // tileh = 30
-};
+}}};
 #undef RED
 
 

--- a/src/table/clear_land.h
+++ b/src/table/clear_land.h
@@ -22,35 +22,35 @@ static const SpriteID _landscape_clear_sprites_rough[8] = {
 };
 
 /** Sprite offset for sloped fences on the southwest edge of the tile. */
-static const uint8_t _fence_mod_by_tileh_sw[32] = {
+static constexpr SlopeIndexArray<uint8_t> _fence_mod_by_tileh_sw = {
 	0, 2, 4, 0, 0, 2, 4, 0,
 	0, 2, 4, 0, 0, 2, 4, 0,
 	0, 2, 4, 0, 0, 2, 4, 4,
-	0, 2, 4, 2, 0, 2, 4, 0,
+	0, 2, 4, 2, 0, 2, 4,
 };
 
 /** Sprite offset for sloped fences on the southeast edge of the tile. */
-static const uint8_t _fence_mod_by_tileh_se[32] = {
+static constexpr SlopeIndexArray<uint8_t> _fence_mod_by_tileh_se = {
 	1, 1, 5, 5, 3, 3, 1, 1,
 	1, 1, 5, 5, 3, 3, 1, 1,
 	1, 1, 5, 5, 3, 3, 1, 5,
-	1, 1, 5, 5, 3, 3, 3, 1,
+	1, 1, 5, 5, 3, 3, 3,
 };
 
 /** Sprite offset for sloped fences on the northeast edge of the tile. */
-static const uint8_t _fence_mod_by_tileh_ne[32] = {
+static constexpr SlopeIndexArray<uint8_t> _fence_mod_by_tileh_ne = {
 	0, 0, 0, 0, 4, 4, 4, 4,
 	2, 2, 2, 2, 0, 0, 0, 0,
 	0, 0, 0, 0, 4, 4, 4, 4,
-	2, 2, 2, 2, 0, 2, 4, 0,
+	2, 2, 2, 2, 0, 2, 4,
 };
 
 /** Sprite offset for sloped fences on the northwest edge of the tile. */
-static const uint8_t _fence_mod_by_tileh_nw[32] = {
+static constexpr SlopeIndexArray<uint8_t> _fence_mod_by_tileh_nw = {
 	1, 5, 1, 5, 1, 5, 1, 5,
 	3, 1, 3, 1, 3, 1, 3, 1,
 	1, 5, 1, 5, 1, 5, 1, 5,
-	3, 1, 3, 5, 3, 3, 3, 1,
+	3, 1, 3, 5, 3, 3, 3,
 };
 
 /** Sprites of the flat tile base for each type of farm field fence. */

--- a/src/table/track_data.h
+++ b/src/table/track_data.h
@@ -90,7 +90,8 @@ extern const CornerIndexArray<TrackBits> _corner_to_trackbits{
 	Track::Left, Track::Lower, Track::Right, Track::Upper,
 };
 
-extern const TrackdirBits _uphill_trackdirs[] = {
+/** Lookup table to convert tile's slope into corresponding track directions for going uphill. */
+extern const SlopeIndexArray<TrackdirBits> _uphill_trackdirs = {{{
 	{}, // 0 SLOPE_FLAT
 	{Trackdir::X_SW, Trackdir::Y_NW}, // 1 SLOPE_W   -> inclined for diagonal track
 	{Trackdir::X_SW, Trackdir::Y_SE}, // 2 SLOPE_S   -> inclined for diagonal track
@@ -122,4 +123,4 @@ extern const TrackdirBits _uphill_trackdirs[] = {
 	{}, // 28 invalid
 	{Trackdir::X_NE, Trackdir::Y_NW}, // 29 SLOPE_STEEP_N -> inclined for diagonal track
 	{Trackdir::X_NE, Trackdir::Y_SE}, // 30 SLOPE_STEEP_E -> inclined for diagonal track
-};
+}}};

--- a/src/track_func.h
+++ b/src/track_func.h
@@ -595,7 +595,7 @@ inline bool IsStraightRoadTrackdir(Trackdir dir)
 inline bool IsUphillTrackdir(Slope slope, Trackdir dir)
 {
 	assert(IsValidTrackdirForRoadVehicle(dir));
-	extern const TrackdirBits _uphill_trackdirs[];
+	extern const SlopeIndexArray<TrackdirBits> _uphill_trackdirs;
 	return _uphill_trackdirs[RemoveHalftileSlope(slope)].Test(dir);
 }
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -49,7 +49,7 @@
 /**
  * Describes from which directions a specific slope can be flooded (if the tile is floodable at all).
  */
-static const Directions _flood_from_dirs[] = {
+static const NonSteepSlopeIndexArray<Directions> _flood_from_dirs = {{{
 	{Direction::NW, Direction::SW, Direction::SE, Direction::NE}, // SLOPE_FLAT
 	{Direction::NE, Direction::SE}, // SLOPE_W
 	{Direction::NW, Direction::NE}, // SLOPE_S
@@ -65,7 +65,7 @@ static const Directions _flood_from_dirs[] = {
 	{Direction::SW}, // SLOPE_NE
 	{Direction::S, Direction::SW, Direction::SE}, // SLOPE_ENW, SLOPE_STEEP_N
 	{Direction::W, Direction::SW, Direction::NW}, // SLOPE_SEN, SLOPE_STEEP_E
-};
+}}};
 
 /**
  * Marks tile dirty if it is a canal or river tile.
@@ -951,9 +951,9 @@ void DrawShoreTile(Slope tileh)
 {
 	/* Converts the enum Slope into an offset based on SPR_SHORE_BASE.
 	 * This allows to calculate the proper sprite to display for this Slope */
-	static const uint8_t tileh_to_shoresprite[32] = {
+	static constexpr SlopeIndexArray<uint8_t> tileh_to_shoresprite = {
 		0, 1, 2, 3, 4, 16, 6, 7, 8, 9, 17, 11, 12, 13, 14, 0,
-		0, 0, 0, 0, 0,  0, 0, 0, 0, 0,  0,  5,  0, 10, 15, 0,
+		0, 0, 0, 0, 0,  0, 0, 0, 0, 0,  0,  5,  0, 10, 15,
 	};
 
 	assert(!IsHalftileSlope(tileh)); // Halftile slopes need to get handled earlier.
@@ -1382,7 +1382,7 @@ void ConvertGroundTilesIntoWaterTiles()
 /** @copydoc GetTileTrackStatusProc */
 static TrackStatus GetTileTrackStatus_Water(TileIndex tile, TransportType mode, [[maybe_unused]] RoadTramType sub_mode, [[maybe_unused]] DiagDirection side)
 {
-	static const TrackBits coast_tracks[] = {{}, Track::Right, Track::Upper, {}, Track::Left, {}, {}, {}, Track::Lower, {}, {}, {}, {}, {}, {}, {}};
+	static constexpr NonSteepSlopeIndexArray<TrackBits> coast_tracks = {{{{}, Track::Right, Track::Upper, {}, Track::Left, {}, {}, {}, Track::Lower, {}, {}, {}, {}, {}, {}}}};
 
 	TrackBits ts;
 
@@ -1390,7 +1390,7 @@ static TrackStatus GetTileTrackStatus_Water(TileIndex tile, TransportType mode, 
 
 	switch (GetWaterTileType(tile)) {
 		case WaterTileType::Clear: ts = IsTileFlat(tile) ? TRACK_BIT_ALL : TrackBits{}; break;
-		case WaterTileType::Coast: ts = coast_tracks[GetTileSlope(tile) & 0xF]; break;
+		case WaterTileType::Coast: ts = coast_tracks[GetTileSlope(tile) & SLOPE_ELEVATED]; break;
 		case WaterTileType::Lock: ts = DiagDirToDiagTrack(GetLockDirection(tile)); break;
 		case WaterTileType::Depot: ts = AxisToTrack(GetShipDepotAxis(tile)); break;
 		default: return {};


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Type safety.

Arrays that are indexed by a type should not be accesed by an other type.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Create a new type `SlopeIndexArray` that is `EnumClassIndexContainer` because `Slope` hasn't been yet converted to BitSet and is still an enum.
And use that type for arrays that are indexed by `Slope`.

Add some doxygen comments where they are missing.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
