### PR TITLE
Fix #15824: for a crash when there is no track bit for a wagon or whe…

### DIFF
--- a/src/cargoaction.cpp
+++ b/src/cargoaction.cpp
@@ -93,7 +93,8 @@ template <>
 bool CargoRemoval<VehicleCargoList>::operator()(CargoPacket *cp)
 {
 	uint remove = this->Preprocess(cp);
-	this->source->RemoveFromMeta(cp, VehicleCargoList::MoveToAction::Keep, remove);
+	/* Using the get action fuction to make sure the correct metadata is removed */
+	this->source->RemoveFromMeta(cp, this->source->GetAction(), remove);
 	return this->Postprocess(cp, remove);
 }
 

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -356,6 +356,18 @@ protected:
 				this->action_counts[MoveToAction::Load] == this->count);
 	}
 
+	/**
+	 * Gets the action type that is currently represented by the metadata of the cargo packet
+	 * @return the type of action represented by this cargo packet
+	 */
+	inline MoveToAction GetAction() const
+	{
+		if (this->action_counts[MoveToAction::Load] > 0) return MoveToAction::Load;
+		if (this->action_counts[MoveToAction::Keep] > 0) return MoveToAction::Keep;
+		if (this->action_counts[MoveToAction::Deliver] > 0) return MoveToAction::Deliver;
+		return MoveToAction::Transfer;
+	}
+
 	void AddToCache(const CargoPacket *cp);
 	void RemoveFromCache(const CargoPacket *cp, uint count);
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3712,7 +3712,8 @@ static void DeleteLastWagon(Train *v)
 		trackbits = DiagDirToDiagTrack(GetTunnelBridgeDirection(tile));
 	}
 
-	Track track = TrackBitsToTrack(trackbits);
+	/* Finds the track from the track bits this handles issues where the wagon may be inside a depot gracefully */
+	Track track = FindFirstTrack(trackbits);
 	if (HasReservedTracks(tile, trackbits)) {
 		UnreserveRailTrack(tile, track);
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As reported in issue #15824 the game would crash while unloading a crashed train while unloading cargo or while partially in a depot.

## Description

I solved this issue by replacing the hardcoded action of keep with the relevant action when removing the cargo packet meta data. For the issue with wagons being partially in a depot i found using the FindFirstTrack function worked as it returns invalid if the wagon is in a depot and handles unreserving the track more gracefully.

## Limitations

None known. Testing the issue @James103 replicated showed that this fix resolved the issue.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)