### PR TITLE
Codechange: Use sprite table instead of magic number when drawing ground sprite

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -53,9 +53,14 @@ static CommandCost ClearTile_Clear(TileIndex tile, DoCommandFlags flags)
 	return price;
 }
 
-void DrawClearLandTile(const TileInfo *ti, uint8_t set)
+/**
+ * Draw a ClearGround::Grass tile.
+ * @param ti The tile to draw.
+ * @param density The density of the dirt -> grass transition to draw.
+ */
+void DrawClearLandTile(const TileInfo *ti, uint8_t density)
 {
-	DrawGroundSprite(SPR_FLAT_BARE_LAND + SlopeToSpriteOffset(ti->tileh) + set * 19, PAL_NONE);
+	DrawGroundSprite(_clear_land_sprites_grass[density] + SlopeToSpriteOffset(ti->tileh), PAL_NONE);
 }
 
 void DrawHillyLandTile(const TileInfo *ti)

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -63,7 +63,11 @@ void DrawClearLandTile(const TileInfo *ti, uint8_t density)
 	DrawGroundSprite(_clear_land_sprites_grass[density] + SlopeToSpriteOffset(ti->tileh), PAL_NONE);
 }
 
-void DrawHillyLandTile(const TileInfo *ti)
+/**
+ * Draw a ClearGround::Rough tile.
+ * @param ti The tile to draw.
+ */
+void DrawRoughLandTile(const TileInfo *ti)
 {
 	if (ti->tileh != SLOPE_FLAT) {
 		DrawGroundSprite(SPR_FLAT_ROUGH_LAND + SlopeToSpriteOffset(ti->tileh), PAL_NONE);
@@ -147,7 +151,7 @@ static void DrawTile_Clear(TileInfo *ti)
 			break;
 
 		case ClearGround::Rough:
-			DrawHillyLandTile(ti);
+			DrawRoughLandTile(ti);
 			break;
 
 		case ClearGround::Rocks:

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -72,6 +72,10 @@ void DrawHillyLandTile(const TileInfo *ti)
 	}
 }
 
+/**
+ * Draw the fences atop a ClearGround::Fields tile.
+ * @param ti The tile to draw.
+ */
 static void DrawClearLandFence(const TileInfo *ti)
 {
 	/* combine fences into one sprite object */

--- a/src/clear_func.h
+++ b/src/clear_func.h
@@ -12,7 +12,7 @@
 
 #include "tile_cmd.h"
 
-void DrawHillyLandTile(const TileInfo *ti);
+void DrawRoughLandTile(const TileInfo *ti);
 void DrawClearLandTile(const TileInfo *ti, uint8_t set);
 
 #endif /* CLEAR_FUNC_H */

--- a/src/table/clear_land.h
+++ b/src/table/clear_land.h
@@ -70,6 +70,14 @@ static const SpriteID _clear_land_sprites_farmland[16] = {
 	SPR_FARMLAND_HAYPACKS,
 };
 
+/** Sprites of the flat tile base for each density of clear -> grass transition. */
+static const SpriteID _clear_land_sprites_grass[4] = {
+	SPR_FLAT_BARE_LAND,
+	SPR_FLAT_1_THIRD_GRASS_TILE,
+	SPR_FLAT_2_THIRD_GRASS_TILE,
+	SPR_FLAT_GRASS_TILE,
+};
+
 static const SpriteID _clear_land_sprites_snow_desert[8] = {
 	SPR_FLAT_1_QUART_SNOW_DESERT_TILE,
 	SPR_FLAT_2_QUART_SNOW_DESERT_TILE,

--- a/src/table/clear_land.h
+++ b/src/table/clear_land.h
@@ -9,6 +9,7 @@
 
 #include "sprites.h"
 
+/** Sprites of the random variants of rough grass sprites, for flat tiles only. */
 static const SpriteID _landscape_clear_sprites_rough[8] = {
 	SPR_FLAT_ROUGH_LAND,
 	SPR_FLAT_ROUGH_LAND_1,
@@ -20,6 +21,7 @@ static const SpriteID _landscape_clear_sprites_rough[8] = {
 	SPR_FLAT_ROUGH_LAND_2,
 };
 
+/** Sprite offset for sloped fences on the southwest edge of the tile. */
 static const uint8_t _fence_mod_by_tileh_sw[32] = {
 	0, 2, 4, 0, 0, 2, 4, 0,
 	0, 2, 4, 0, 0, 2, 4, 0,
@@ -27,6 +29,7 @@ static const uint8_t _fence_mod_by_tileh_sw[32] = {
 	0, 2, 4, 2, 0, 2, 4, 0,
 };
 
+/** Sprite offset for sloped fences on the southeast edge of the tile. */
 static const uint8_t _fence_mod_by_tileh_se[32] = {
 	1, 1, 5, 5, 3, 3, 1, 1,
 	1, 1, 5, 5, 3, 3, 1, 1,
@@ -34,6 +37,7 @@ static const uint8_t _fence_mod_by_tileh_se[32] = {
 	1, 1, 5, 5, 3, 3, 3, 1,
 };
 
+/** Sprite offset for sloped fences on the northeast edge of the tile. */
 static const uint8_t _fence_mod_by_tileh_ne[32] = {
 	0, 0, 0, 0, 4, 4, 4, 4,
 	2, 2, 2, 2, 0, 0, 0, 0,
@@ -41,6 +45,7 @@ static const uint8_t _fence_mod_by_tileh_ne[32] = {
 	2, 2, 2, 2, 0, 2, 4, 0,
 };
 
+/** Sprite offset for sloped fences on the northwest edge of the tile. */
 static const uint8_t _fence_mod_by_tileh_nw[32] = {
 	1, 5, 1, 5, 1, 5, 1, 5,
 	3, 1, 3, 1, 3, 1, 3, 1,
@@ -48,7 +53,7 @@ static const uint8_t _fence_mod_by_tileh_nw[32] = {
 	3, 1, 3, 5, 3, 3, 3, 1,
 };
 
-
+/** Sprites of the flat tile base for each type of farm field fence. */
 static const SpriteID _clear_land_fence_sprites[7] = {
 	SPR_HEDGE_BUSHES,
 	SPR_HEDGE_BUSHES_WITH_GATE,
@@ -58,6 +63,7 @@ static const SpriteID _clear_land_fence_sprites[7] = {
 	SPR_HEDGE_STONE,
 };
 
+/** Sprites of the flat tile base for each state of farm fields. */
 static const SpriteID _clear_land_sprites_farmland[16] = {
 	SPR_FARMLAND_BARE,
 	SPR_FARMLAND_STATE_1,

--- a/src/table/clear_land.h
+++ b/src/table/clear_land.h
@@ -78,7 +78,8 @@ static const SpriteID _clear_land_sprites_grass[4] = {
 	SPR_FLAT_GRASS_TILE,
 };
 
-static const SpriteID _clear_land_sprites_snow_desert[8] = {
+/** Sprites of the flat tile base for each density of grass -> snow/desert transition. */
+static const SpriteID _clear_land_sprites_snow_desert[4] = {
 	SPR_FLAT_1_QUART_SNOW_DESERT_TILE,
 	SPR_FLAT_2_QUART_SNOW_DESERT_TILE,
 	SPR_FLAT_3_QUART_SNOW_DESERT_TILE,

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -645,7 +645,7 @@ static void DrawTile_Trees(TileInfo *ti)
 	switch (GetTreeGround(ti->tile)) {
 		case TreeGround::Shore: DrawShoreTile(ti->tileh); break;
 		case TreeGround::Grass: DrawClearLandTile(ti, GetTreeDensity(ti->tile)); break;
-		case TreeGround::Rough: DrawHillyLandTile(ti); break;
+		case TreeGround::Rough: DrawRoughLandTile(ti); break;
 		default: DrawGroundSprite(_clear_land_sprites_snow_desert[GetTreeDensity(ti->tile)] + SlopeToSpriteOffset(ti->tileh), PAL_NONE); break;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Ground sprites in OpenTTD after often used by referencing the sprite for the flat tile and applying an offset based on the tile slope. Clear tiles have four densities from brown dirt to green grass.

The code for drawing clear tiles does some opaque math to calculate the sprite to draw. Similar code for the snow/desert transition stores the flat tile sprite for each density in a nice table, which is a bit easier to read.

(This isn't just modernization, I need these in a sprite table for something else I'm working on. 🙂)

## Description

Create a sprite table for clear tiles, like what is done for the clear -> snow/desert transition, and get rid of the magic number.

While I'm there, document the rest of the sprite tables in the file.

## Limitations

* Does not modernize the code, just makes it consistent.
* Why are these arrays partially-initialized?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
