### PR TITLE
Fix #15826: [Network] Disable "Allow any client" option for AI companies

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1686,7 +1686,7 @@ private:
 		DropDownList list;
 		if (_network_server) list.push_back(MakeDropDownListStringItem(STR_NETWORK_CLIENT_LIST_ADMIN_COMPANY_RESET, to_underlying(DropDownAction::AdminResetCompany), NetworkCompanyHasClients(company_id)));
 		if (const Company *c = Company::GetIfValid(company_id); c != nullptr) {
-			list.push_back(MakeDropDownListStringItem(STR_NETWORK_CLIENT_LIST_ADMIN_COMPANY_ALLOW_ANY, to_underlying(DropDownAction::CompanyAllowAny), c->allow_any));
+			list.push_back(MakeDropDownListStringItem(STR_NETWORK_CLIENT_LIST_ADMIN_COMPANY_ALLOW_ANY, to_underlying(DropDownAction::CompanyAllowAny), c->allow_any || c->is_ai));
 			list.push_back(MakeDropDownListStringItem(STR_NETWORK_CLIENT_LIST_ADMIN_COMPANY_ALLOW_LISTED, to_underlying(DropDownAction::CompanyAllowListed), !c->allow_any));
 		}
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #15826.

In the multiplayer client list's company admin dropdown, "Allow any client" was selectable for AI-controlled companies, even though it has no meaningful effect there (no human client will ever try to join an AI company through this mechanism the same way).

## Description

`OnClickCompanyAdmin` in `src/network/network_gui.cpp` builds the admin dropdown list and masks (grays out) each item via a trailing bool passed to `MakeDropDownListStringItem`. The "Allow any client" item was only masked when it was already the active setting (`c->allow_any`), with no check for AI companies. This mirrors the existing pattern a few lines below in the same file, where the company join button is already disabled for AI companies via `Company::Get(company_id)->is_ai`.

This PR adds the same `is_ai` check to the "Allow any client" item's masked condition, so it's grayed out whenever it's already the active setting OR the company is AI-controlled.

## Testing

This is a one-line boolean-condition change using existing, already-typed fields (`Company::allow_any` and `Company::is_ai`, both `bool`) and an existing function signature (`MakeDropDownListStringItem`'s `masked` parameter is already `bool`), so no new types or logic paths are introduced. I was not able to run a full CMake build in this environment (no `cmake`/`ninja` available), but verified the change is syntactically and type-correct by inspecting the relevant declarations directly (`src/company_base.h` for `is_ai`/`allow_any`, `src/dropdown_func.h` for the `masked` parameter type).