### PR TITLE
Codechange: remove multichar literals from FillSetDetails

### DIFF
--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -48,6 +48,22 @@ const IniItem *BaseSet<T>::GetMandatoryItem(std::string_view full_filename, cons
 }
 
 /**
+ * Helper to decode a 4 character short name into an uint32_t representation.
+ * @param shortname The short name.
+ * @return The uint32_t representation.
+ */
+constexpr uint32_t DecodeShortName(std::string_view shortname)
+{
+	/* The short name is documented to be exactly 4 characters long, see docs/ob[gms]_format.txt. */
+	shortname = shortname.substr(0, 4);
+	uint32_t encoded = 0;
+	for (size_t i = 0; i < shortname.size(); i++) {
+		encoded |= static_cast<uint8_t>(shortname[i]) << (i * 8);
+	}
+	return encoded;
+}
+
+/**
  * Read the set information from a loaded ini.
  * @param ini      the ini to read from
  * @param path     the path to this ini file (for filenames)
@@ -85,9 +101,7 @@ bool BaseSet<T>::FillSetDetails(const IniFile &ini, const std::string &path, con
 
 	item = this->GetMandatoryItem(full_filename, *metadata, "shortname");
 	if (item == nullptr) return false;
-	for (uint i = 0; (*item->value)[i] != '\0' && i < 4; i++) {
-		this->shortname |= ((uint8_t)(*item->value)[i]) << (i * 8);
-	}
+	this->shortname = DecodeShortName(*item->value);
 
 	item = this->GetMandatoryItem(full_filename, *metadata, "version");
 	if (item == nullptr) return false;
@@ -111,10 +125,10 @@ bool BaseSet<T>::FillSetDetails(const IniFile &ini, const std::string &path, con
 	const IniGroup *origin = ini.GetGroup("origin");
 	auto file_names = BaseSet<T>::GetFilenames();
 	bool original_set =
-		std::byteswap(this->shortname) == 'TTDD' || // TTD DOS graphics, TTD DOS music
-		std::byteswap(this->shortname) == 'TTDW' || // TTD WIN graphics, TTD WIN music
-		std::byteswap(this->shortname) == 'TTDO' || // TTD sound
-		std::byteswap(this->shortname) == 'TTOD'; // TTO music
+		this->shortname == DecodeShortName("TTDD") || // TTD DOS graphics, TTD DOS music
+		this->shortname == DecodeShortName("TTDW") || // TTD WIN graphics, TTD WIN music
+		this->shortname == DecodeShortName("TTDO") || // TTD sound
+		this->shortname == DecodeShortName("TTOD"); // TTO music
 
 	for (uint i = 0; i < BaseSet<T>::NUM_FILES; i++) {
 		MD5File *file = &this->files[i];


### PR DESCRIPTION
## Motivation / Problem

See #15801. However, that has some open questions regarding the byte-swapping of the short name when comparing it to the converted literals.


## Description

* Move the decoding of a base set's 'short name' into a separate (`constexpr`) function.
* Use this new function to 'decode' the fixed 'original set' short names.

The `constexpr` function is completely optimised away when optimisations are turned on.


## Limitations

Only takes care of a small bit of the multichar literals, not all of them like #15801 does.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
