### PR TITLE
Codechange: Use sprite array instead of magic number for snowy rocks

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -136,9 +136,7 @@ static void DrawTile_Clear(TileInfo *ti)
 		uint8_t density = GetClearDensity(ti->tile);
 		DrawGroundSprite(_clear_land_sprites_snow_desert[density] + SlopeToSpriteOffset(ti->tileh), PAL_NONE);
 		if (GetClearGround(ti->tile) == ClearGround::Rocks) {
-			/* There 4 levels of snowy overlay rocks, each with 19 sprites. */
-			++density;
-			DrawGroundSprite(SPR_OVERLAY_ROCKS_BASE + (density * 19) + SlopeToSpriteOffset(ti->tileh), PAL_NONE);
+			DrawGroundSprite(_clear_land_sprites_snowy_rocks[density] + SlopeToSpriteOffset(ti->tileh), PAL_NONE);
 		}
 
 		DrawBridgeMiddle(ti, {});

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1576,7 +1576,7 @@ static SpriteID GetRoadGroundSprite(const TileInfo *ti, Roadside roadside, const
 	/* Draw original road base sprite */
 	SpriteID image = SPR_ROAD_Y + offset;
 	if (DrawRoadAsSnowOrDesert(snow_or_desert, roadside)) {
-		image += 19;
+		image += NUM_SLOPES;
 	} else {
 		switch (roadside) {
 			case Roadside::Barren:
@@ -1588,7 +1588,7 @@ static SpriteID GetRoadGroundSprite(const TileInfo *ti, Roadside roadside, const
 				break;
 
 			default:
-				image -= 19;
+				image -= NUM_SLOPES;
 				break; // Paved
 		}
 	}
@@ -1741,7 +1741,7 @@ static void DrawTile_Road(TileInfo *ti)
 
 				Roadside roadside = GetRoadside(ti->tile);
 				if (DrawRoadAsSnowOrDesert(IsOnSnowOrDesert(ti->tile), roadside)) {
-					image += 19;
+					image += NUM_SLOPES;
 				} else {
 					switch (roadside) {
 						case Roadside::Barren:
@@ -1752,7 +1752,7 @@ static void DrawTile_Road(TileInfo *ti)
 							break;
 
 						default:
-							image -= 19;
+							image -= NUM_SLOPES;
 							break; // Paved
 					}
 				}

--- a/src/slope_type.h
+++ b/src/slope_type.h
@@ -82,6 +82,9 @@ enum Slope : uint8_t {
 };
 DECLARE_ENUM_AS_BIT_SET(Slope)
 
+/** The total number of possible slope types. */
+static constexpr uint8_t NUM_SLOPES = 19;
+
 /**
  * Helper for creating a bitset of slopes.
  * @param x The slope to convert into a bitset.

--- a/src/table/clear_land.h
+++ b/src/table/clear_land.h
@@ -91,3 +91,11 @@ static const SpriteID _clear_land_sprites_snow_desert[4] = {
 	SPR_FLAT_3_QUART_SNOW_DESERT_TILE,
 	SPR_FLAT_SNOW_DESERT_TILE,
 };
+
+/** Sprites of the flat tile base for each snow density of rocky land. */
+static const SpriteID _clear_land_sprites_snowy_rocks[4] = {
+	SPR_OVERLAY_ROCKS_1_QUART_SNOW,
+	SPR_OVERLAY_ROCKS_2_QUART_SNOW,
+	SPR_OVERLAY_ROCKS_3_QUART_SNOW,
+	SPR_OVERLAY_ROCKS_FULL_SNOW,
+};

--- a/src/table/sprites.h
+++ b/src/table/sprites.h
@@ -39,6 +39,7 @@
 #define SPRITES_H
 
 #include "../gfx_type.h"
+#include "../slope_type.h"
 
 static const SpriteID SPR_SELECT_TILE  = 752;
 static const SpriteID SPR_DOT          = 774; ///< Corner marker for lower/raise land.
@@ -357,8 +358,12 @@ static const uint16_t ROAD_WAYPOINTS_SPRITE_COUNT = 4;
 
 /** @{
  * Overlay rocks sprites. */
-static constexpr SpriteID SPR_OVERLAY_ROCKS_BASE = SPR_ROAD_WAYPOINTS_BASE + ROAD_WAYPOINTS_SPRITE_COUNT;
-static constexpr uint16_t OVERLAY_ROCKS_SPRITE_COUNT = 19 * 5; ///< Rock overlays: plain, snow 1, snow 2, snow 3 and full snow.
+static constexpr SpriteID SPR_OVERLAY_ROCKS_BASE = SPR_ROAD_WAYPOINTS_BASE + ROAD_WAYPOINTS_SPRITE_COUNT; ///< Rocks overlay with no snow.
+static constexpr SpriteID SPR_OVERLAY_ROCKS_1_QUART_SNOW = SPR_OVERLAY_ROCKS_BASE + NUM_SLOPES * 1; ///< Rocks with 1/4 snow.
+static constexpr SpriteID SPR_OVERLAY_ROCKS_2_QUART_SNOW = SPR_OVERLAY_ROCKS_BASE + NUM_SLOPES * 2; ///< Rocks with half snow density.
+static constexpr SpriteID SPR_OVERLAY_ROCKS_3_QUART_SNOW = SPR_OVERLAY_ROCKS_BASE + NUM_SLOPES * 3; ///< Rocks with 3/4 snow density.
+static constexpr SpriteID SPR_OVERLAY_ROCKS_FULL_SNOW = SPR_OVERLAY_ROCKS_BASE + NUM_SLOPES * 4; ///< Rocks with full snow density.
+static constexpr uint16_t OVERLAY_ROCKS_SPRITE_COUNT = NUM_SLOPES * 5; ///< Total number of rock overlays.
 /** @} */
 
 /** @{

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1385,14 +1385,14 @@ static void DrawTile_TunnelBridge(TileInfo *ti)
 				if (catenary_sprite_base == 0) {
 					catenary_sprite_base = SPR_TRAMWAY_TUNNEL_WIRES;
 				} else {
-					catenary_sprite_base += 19;
+					catenary_sprite_base += NUM_SLOPES;
 				}
 			} else if (tram_rti != nullptr && HasRoadCatenaryDrawn(tram_rt)) {
 				catenary_sprite_base = GetCustomRoadSprite(tram_rti, ti->tile, RoadSpriteType::CatenaryFront);
 				if (catenary_sprite_base == 0) {
 					catenary_sprite_base = SPR_TRAMWAY_TUNNEL_WIRES;
 				} else {
-					catenary_sprite_base += 19;
+					catenary_sprite_base += NUM_SLOPES;
 				}
 			}
 


### PR DESCRIPTION
## Motivation / Problem

Snowy rock overlay sprites use a bunch of magic numbers. https://github.com/OpenTTD/OpenTTD/pull/15828#issuecomment-4914573640 suggested moving this to a sprite array.

## Description

Add SpriteIDs for the flat tile of each snow density, add them to an array, and use that instead of the magic number math.

Also use the new NUM_SLOPES constant everywhere else I can find the magic number being used.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
