### PR TITLE
Codechange: use Label for the SaveLoadFormatTag over multi-character-literals

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -13,6 +13,7 @@ add_files(
     geometry_func.hpp
     geometry_type.hpp
     kdtree.hpp
+    label_type.hpp
     math_func.cpp
     math_func.hpp
     multimap.hpp

--- a/src/core/label_type.hpp
+++ b/src/core/label_type.hpp
@@ -1,0 +1,43 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file label_type.hpp A type for 4 character labels/tags/ids in files that should be read/shown as is. */
+
+#ifndef LABEL_TYPE_HPP
+#define LABEL_TYPE_HPP
+
+/**
+ * A four character label/tag/id.
+ * @tparam Tag Type to distinguish labels/tags/ids of different types.
+ */
+template <typename Tag>
+struct Label : std::array<uint8_t, 4> {
+	/** Create an empty label, i.e. all zeros. */
+	constexpr Label()
+	{
+		std::ranges::fill(*this, 0);
+	}
+
+	/**
+	 * Create a label with the given 4 letter character string.
+	 * @param label The label value.
+	 * @note This defines 5 characters, but the 5th character is assumed to null-terminator.
+	 */
+	constexpr Label(const char (&label)[5])
+	{
+		std::copy(label, label + this->size(), this->begin());
+	}
+
+	/**
+	 * Default spaceship operator.
+	 * @param other The label to compare to.
+	 * @return The comparison ordering.
+	 */
+	constexpr std::strong_ordering operator<=>(const Label<Tag> &other) const = default;
+};
+
+#endif /* LABEL_TYPE_HPP */

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -29,6 +29,7 @@
 #include "../window_func.h"
 #include "../strings_func.h"
 #include "../core/endian_func.hpp"
+#include "../core/label_type.hpp"
 #include "../core/string_builder.hpp"
 #include "../core/string_consumer.hpp"
 #include "../vehicle_base.h"
@@ -2814,23 +2815,26 @@ struct LZMASaveFilter : SaveFilter {
  ************* END OF CODE *****************
  *******************************************/
 
+/** Unique 4-letter tag for the different saveload formats. */
+using SaveLoadFormatTag = Label<struct SaveLoadFormatLabelTag>;
+
 /** The format for a reader/writer type of a savegame */
 struct SaveLoadFormat {
 	std::shared_ptr<LoadFilter> (*init_load)(std::shared_ptr<LoadFilter> chain); ///< Constructor for the load filter.
 	std::shared_ptr<SaveFilter> (*init_write)(std::shared_ptr<SaveFilter> chain, uint8_t compression); ///< Constructor for the save filter.
 
 	std::string_view name; ///< name of the compressor/decompressor (debug-only)
-	uint32_t tag; ///< the 4-letter tag by which it is identified in the savegame
+	SaveLoadFormatTag tag; ///< the 4-letter tag by which it is identified in the savegame
 
 	uint8_t min_compression;                 ///< the minimum compression level of this format
 	uint8_t default_compression;             ///< the default compression level of this format
 	uint8_t max_compression;                 ///< the maximum compression level of this format
 };
 
-static const uint32_t SAVEGAME_TAG_LZO = TO_BE32('OTTD');
-static const uint32_t SAVEGAME_TAG_NONE = TO_BE32('OTTN');
-static const uint32_t SAVEGAME_TAG_ZLIB = TO_BE32('OTTZ');
-static const uint32_t SAVEGAME_TAG_LZMA = TO_BE32('OTTX');
+static const SaveLoadFormatTag SAVEGAME_TAG_LZO{"OTTD"}; ///< Tag for a game compressed with LZO
+static const SaveLoadFormatTag SAVEGAME_TAG_NONE{"OTTN"}; ///< Tag for a game without compression.
+static const SaveLoadFormatTag SAVEGAME_TAG_ZLIB{"OTTZ"}; ///< Tag for a game with zlib compression.
+static const SaveLoadFormatTag SAVEGAME_TAG_LZMA{"OTTX"}; ///< Tag for a game with lzma compression.
 
 /** The different saveload formats known/understood by OpenTTD. */
 static const SaveLoadFormat _saveload_formats[] = {
@@ -3025,8 +3029,10 @@ static SaveLoadResult SaveFileToDisk(bool threaded)
 		auto [fmt, compression] = GetSavegameFormat(_savegame_format);
 
 		/* We have written our stuff to memory, now write it to file! */
-		uint32_t hdr[2] = { fmt.tag, TO_BE32(to_underlying(SAVEGAME_VERSION) << 16) };
-		_sl.sf->Write((uint8_t*)hdr, sizeof(hdr));
+		_sl.sf->Write(fmt.tag.data(), fmt.tag.size());
+
+		uint32_t version = TO_BE32(to_underlying(SAVEGAME_VERSION) << 16);
+		_sl.sf->Write(reinterpret_cast<uint8_t *>(&version), sizeof(version));
 
 		_sl.sf = fmt.init_write(_sl.sf, compression);
 		_sl.dumper->Flush(_sl.sf);
@@ -3126,7 +3132,7 @@ SaveLoadResult SaveWithFilter(std::shared_ptr<SaveFilter> writer, bool threaded)
  * @param raw_version The raw version from the savegame header.
  * @return The SaveLoadFormat to use for attempting to open the savegame.
  */
-static const SaveLoadFormat *DetermineSaveLoadFormat(uint32_t tag, uint32_t raw_version)
+static const SaveLoadFormat *DetermineSaveLoadFormat(SaveLoadFormatTag tag, uint32_t raw_version)
 {
 	auto fmt = std::ranges::find(_saveload_formats, tag, &SaveLoadFormat::tag);
 	if (fmt != std::end(_saveload_formats)) {
@@ -3178,11 +3184,14 @@ static SaveLoadResult DoLoad(std::shared_ptr<LoadFilter> reader, bool load_check
 		_load_check_data.checkable = true;
 	}
 
-	uint32_t hdr[2];
-	if (_sl.lf->Read((uint8_t*)hdr, sizeof(hdr)) != sizeof(hdr)) SlError(STR_GAME_SAVELOAD_ERROR_FILE_NOT_READABLE);
+	SaveLoadFormatTag tag{};
+	if (_sl.lf->Read(tag.data(), tag.size()) != tag.size()) SlError(STR_GAME_SAVELOAD_ERROR_FILE_NOT_READABLE);
+
+	uint32_t version;
+	if (_sl.lf->Read(reinterpret_cast<uint8_t*>(&version), sizeof(version)) != sizeof(version)) SlError(STR_GAME_SAVELOAD_ERROR_FILE_NOT_READABLE);
 
 	/* see if we have any loader for this type. */
-	const SaveLoadFormat *fmt = DetermineSaveLoadFormat(hdr[0], hdr[1]);
+	const SaveLoadFormat *fmt = DetermineSaveLoadFormat(tag, version);
 
 	/* loader for this savegame type is not implemented? */
 	if (fmt->init_load == nullptr) {


### PR DESCRIPTION
## Motivation / Problem

Multi character literals are essentially undefined behaviour, as compilers are free to implement them as they want. By happenstance most implement it in the same way, but it'd be better to not use them at all.


## Description

Remove the multi character literals from the save game format label/tags, but using a new concept Label.

A label is a 4 character/byte array that can be constructed using a 4 character string.
It being an array gives a known order, so no bit-swapping shenanigans are needed.
The label is strongly typed, so labels/tags cannot be easily confused.

The compiler optimises the arrays/strings away when minimal optimisations are turned on. The comparisons will be just normal 32 bit compares, like what it used to be.

This add the minimum `Label` implementation needed for this PR.


## Limitations

There are way more, but those are for future PRs.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
