### PR TITLE
Codechange: remove unneeded packing of ChunkHeader and WAVE_DOWNLOAD

### DIFF
--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -146,18 +146,18 @@ private:
 };
 
 /** A RIFF chunk header. */
-PACK_N(struct ChunkHeader {
+struct ChunkHeader {
 	FOURCC type;  ///< Chunk type.
 	DWORD length; ///< Length of the chunk, not including the chunk header itself.
-}, 2);
+};
 
 /** Buffer format for a DLS wave download. */
-PACK_N(struct WAVE_DOWNLOAD {
-	DMUS_DOWNLOADINFO   dlInfo;
-	ULONG               ulOffsetTable[2];
-	DMUS_WAVE           dmWave;
-	DMUS_WAVEDATA       dmWaveData;
-}, 2);
+struct WAVE_DOWNLOAD {
+	DMUS_DOWNLOADINFO dlInfo; ///< Request header for the to be downloaded wave data.
+	ULONG ulOffsetTable[2]; ///< Offsets to the \c dmWave and \c dmWaveData fields.
+	DMUS_WAVE dmWave; ///< Definition of the wave chunk to download.
+	DMUS_WAVEDATA dmWaveData; ///< The buffer the wave chunk data is written to.
+};
 
 struct PlaybackSegment {
 	uint32_t start, end;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -176,15 +176,6 @@ using namespace std::literals::string_view_literals;
 #	define PATHSEPCHAR '/'
 #endif
 
-#if defined(_MSC_VER)
-#	define PACK_N(type_dec, n) __pragma(pack(push, n)) type_dec; __pragma(pack(pop))
-#elif defined(__MINGW32__)
-#	define PRAGMA(x) _Pragma(#x)
-#	define PACK_N(type_dec, n) PRAGMA(pack(push, n)) type_dec; PRAGMA(pack(pop))
-#else
-#	define PACK_N(type_dec, n) type_dec __attribute__((__packed__, aligned(n)))
-#endif
-
 /** @def debug_inline
  * When making a (pure) debug build, the compiler will by default disable
  * inlining of functions. This has a detrimental effect on the performance of


### PR DESCRIPTION
## Motivation / Problem

https://github.com/OpenTTD/OpenTTD/blob/922d38f1c0a9d25fc0a9902cb1a5311f935dd99d/src/music/dmusic.cpp#L149-L152
Both `FOURCC` devolves into `unsigned long` and `DWORD` also devolves into `unsigned long`, which are as far as I am aware 4 bytes on all supported Windows platforms. What could be the reasoning to pack it to 2 bytes? To me it seems unneeded, because the data is already packed due to them being of the same size.

It could have to do with alignment, but we're always allocating `ChunkHeader` on the stack and then `fread`-ing data into it. So alignment shouldn't matter.


For `WAVE_DOWNLOAD` it's more complicated due to the more complex inner types. However, packing it or not makes no difference in the size of the object or the alignment of the elements of it.
See https://godbolt.org/z/xcGzvfdev for both cases for both x86 and x64.


## Description

Remove the `PACK_N` macro.


## Limitations

Does anyone still have some esoteric compilers that might behave differently?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
