### PR TITLE
Codechange: remove unneeded packing of THREADNAME_INFO

### DIFF
--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -535,25 +535,23 @@ int Win32StringContains(std::string_view str, std::string_view value, bool case_
 
 #ifdef _MSC_VER
 /* Based on code from MSDN: https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx */
-const DWORD MS_VC_EXCEPTION = 0x406D1388;
+constexpr DWORD MS_VC_EXCEPTION = 0x406D1388; ///< Unique identifier of a magic exception that sets a thread name in MSVC's debugger.
 
-PACK_N(struct THREADNAME_INFO {
-	DWORD dwType;     ///< Must be 0x1000.
-	LPCSTR szName;    ///< Pointer to name (in user addr space).
-	DWORD dwThreadID; ///< Thread ID (-1=caller thread).
-	DWORD dwFlags;    ///< Reserved for future use, must be zero.
-}, 8);
+/** Required information to be passed to the exception that sets the thread name in MSVC's debugger. */
+struct THREADNAME_INFO {
+	DWORD dwType = 0x1000; ///< Must be 0x1000.
+	LPCSTR szName; ///< Pointer to name (in user addr space).
+	DWORD dwThreadID = static_cast<DWORD>(-1); ///< Thread ID (-1=caller thread).
+	DWORD dwFlags = 0; ///< Reserved for future use, must be zero.
+};
 
 /**
  * Signal thread name to any attached debuggers.
+ * @param thread_name The name of the thread.
  */
 void SetCurrentThreadName(const std::string &thread_name)
 {
-	THREADNAME_INFO info;
-	info.dwType = 0x1000;
-	info.szName = thread_name.c_str();
-	info.dwThreadID = -1;
-	info.dwFlags = 0;
+	THREADNAME_INFO info{.szName = thread_name.c_str()};
 
 #pragma warning(push)
 #pragma warning(disable: 6320 6322)


### PR DESCRIPTION
## Motivation / Problem

https://github.com/OpenTTD/OpenTTD/blob/922d38f1c0a9d25fc0a9902cb1a5311f935dd99d/src/os/windows/win32.cpp#L540-L545
All the `DWORD`s are `unsigned long` and `LPCSTR` is a pointer, so 4 or 8 bytes. It is packing at 8 bytes, which seems unneeded to me as for 32 bit platforms it'll just create a 16 byte object (4x4 bytes), and on 64 bits it'll be 24 bytes (4 bytes + 4 bytes padding + 8 bytes pointer + 2x 4 bytes).

It could have to do with alignment, but we're always allocating it on the stack and then throwing it. If we don't do the packing, the stack on 64 bits Windows might be 16 byte aligned. But given that's a multiple of 8, that's okay right?


## Description

* Remove the `PACK_N`.
* Simplify construction of the object by setting the appropriate default values.
* Add some missing documentation


## Limitations

None I am aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
