### PR TITLE
Fix #15849: Rivers don't fill small seas with original land gen

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1405,7 +1405,8 @@ static std::tuple<bool, bool> FlowRiver(TileIndex spring, TileIndex begin, uint 
 
 		int height_end;
 		if (IsTileFlat(end, &height_end) && (height_end < height_begin || (height_end == height_begin && IsWaterTile(end)))) {
-			if (IsWaterTile(end) && GetWaterClass(end) == WaterClass::Sea) {
+			/* We don't want rivers to flow into tiny bits of sea, so we fill them, unless using the original land generator. */
+			if (_settings_game.game_creation.land_generator != LG_ORIGINAL && IsWaterTile(end) && GetWaterClass(end) == WaterClass::Sea) {
 				/* If we've found the sea, make sure it's large enough. Scale by the map size but set a cap to avoid performance issues on large maps. */
 				const uint MAX_SEA_SIZE_THRESHOLD = 1024;
 				const uint SEA_SIZE_THRESHOLD = std::min(static_cast<uint>(2 * std::sqrt(Map::SizeX() * Map::SizeY())), MAX_SEA_SIZE_THRESHOLD);
@@ -1424,7 +1425,7 @@ static std::tuple<bool, bool> FlowRiver(TileIndex spring, TileIndex begin, uint 
 					}
 				}
 			} else {
-				/* We've found a river. */
+				/* We've found a river, or a sea if using the original land generator. */
 				found = true;
 				break;
 			}


### PR DESCRIPTION
## Motivation / Problem

#14797 changed river generation so that if it tries to end in a small sea (which looks silly), instead the sea is filled and the river keeps flowing.

#15849 asserts that this shouldn't happen when using the original map generator. I don't have a strong opinion, but it's an easy change.


## Description

Only fill small seas if we're not using the original map generator.

Closes #15849.

## Limitations

~~Untested.~~ [Tested](https://github.com/OpenTTD/OpenTTD/pull/15852#issuecomment-4990530911)

#15849 is just an opinion, since rivers didn't exist in TTD. 🤷 


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
