### PR TITLE
Codechange: [Windows] Use SetThreadDescription over magic exception

### DIFF
--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -16,6 +16,7 @@
 #include <windows.h>
 #include <fcntl.h>
 #include <mmsystem.h>
+#include <processthreadsapi.h>
 #include <regstr.h>
 #define NO_SHOBJIDL_SORTDIRECTION /**< Avoid multiple definition of SORT_ASCENDING. */
 #include <shlobj.h> /* SHGetFolderPath */
@@ -533,36 +534,9 @@ int Win32StringContains(std::string_view str, std::string_view value, bool case_
 	return -1; // Failure indication.
 }
 
-#ifdef _MSC_VER
-/* Based on code from MSDN: https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx */
-const DWORD MS_VC_EXCEPTION = 0x406D1388;
-
-PACK_N(struct THREADNAME_INFO {
-	DWORD dwType;     ///< Must be 0x1000.
-	LPCSTR szName;    ///< Pointer to name (in user addr space).
-	DWORD dwThreadID; ///< Thread ID (-1=caller thread).
-	DWORD dwFlags;    ///< Reserved for future use, must be zero.
-}, 8);
-
-/**
- * Signal thread name to any attached debuggers.
- */
-void SetCurrentThreadName(const std::string &thread_name)
+void SetCurrentThreadName(const std::string &name)
 {
-	THREADNAME_INFO info;
-	info.dwType = 0x1000;
-	info.szName = thread_name.c_str();
-	info.dwThreadID = -1;
-	info.dwFlags = 0;
-
-#pragma warning(push)
-#pragma warning(disable: 6320 6322)
-	__try {
-		RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
-	} __except (EXCEPTION_EXECUTE_HANDLER) {
-	}
-#pragma warning(pop)
+	using SetThreadDescriptionProc = HRESULT(WINAPI *)(HANDLE, PCWSTR);
+	static const SetThreadDescriptionProc std_proc = GetKernel32Function("SetThreadDescription");
+	if (std_proc != nullptr) std_proc(GetCurrentThread(), OTTD2FS(name).c_str());
 }
-#else
-void SetCurrentThreadName(const std::string &) {}
-#endif


### PR DESCRIPTION
## Motivation / Problem

Suggestion in #15851 about using a new API instead of trying to clean up a hot mess.


## Description

Replace the magic MSVC-only exception throwing trick to set the thread name with a new API introduced in Windows 10 1607.

To not break older Windows 10 or other still supported versions for a debugging perk, the function will be loaded dynamically. After all, not setting the name isn't game breaking.

Closes #15851.


## Limitations

Breaks setting the thread name in MSVC on versions of Windows before 10-1607, as in: if you are running OpenTTD from the MSVC debugger on Windows before 10-1607, then you won't see the thread name any more.
On the other hand, with newer versions of Windows you are now able to get the thread name in the crash dump and when attaching the debugger to a running process, and other external tools might be able to show the thread name.

I am not able to test this on a Windows version sufficiently old not to have this functionality.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
