### PR TITLE
Codechange: use Label for NewGRF class global ids

### DIFF
--- a/src/newgrf/newgrf_act0_objects.cpp
+++ b/src/newgrf/newgrf_act0_objects.cpp
@@ -96,7 +96,7 @@ static ChangeInfoResult ObjectChangeInfo(uint first, uint last, int prop, ByteRe
 		}
 
 		switch (prop) {
-			case 0x08: { // Class ID
+			case 0x08: // Class ID
 				/* Allocate space for this object. */
 				if (spec == nullptr) {
 					spec = std::make_unique<ObjectSpec>();
@@ -104,16 +104,12 @@ static ChangeInfoResult ObjectChangeInfo(uint first, uint last, int prop, ByteRe
 					spec->size = OBJECT_SIZE_1X1; // Default for NewGRFs that manage to not set it (1x1)
 				}
 
-				/* Swap classid because we read it in BE. */
-				uint32_t classid = buf.ReadDWord();
-				spec->class_index = ObjectClass::Allocate(std::byteswap(classid));
+				spec->class_index = ObjectClass::Allocate(buf.ReadLabel<ObjectClass::GlobalID>());
 				break;
-			}
 
-			case 0x09: { // Class name
+			case 0x09: // Class name
 				AddStringForMapping(GRFStringID{buf.ReadWord()}, [spec = spec.get()](StringID str) { ObjectClass::Get(spec->class_index)->name = str; });
 				break;
-			}
 
 			case 0x0A: // Object name
 				AddStringForMapping(GRFStringID{buf.ReadWord()}, &spec->name);

--- a/src/newgrf/newgrf_act0_roadstops.cpp
+++ b/src/newgrf/newgrf_act0_roadstops.cpp
@@ -88,15 +88,13 @@ static ChangeInfoResult RoadStopChangeInfo(uint first, uint last, int prop, Byte
 		}
 
 		switch (prop) {
-			case 0x08: { // Road Stop Class ID
+			case 0x08: // Road Stop Class ID
 				if (rs == nullptr) {
 					rs = std::make_unique<RoadStopSpec>();
 				}
 
-				uint32_t classid = buf.ReadDWord();
-				rs->class_index = RoadStopClass::Allocate(std::byteswap(classid));
+				rs->class_index = RoadStopClass::Allocate(buf.ReadLabel<RoadStopClass::GlobalID>());
 				break;
-			}
 
 			case 0x09: // Road stop type
 				rs->stop_type = (RoadStopAvailabilityType)buf.ReadByte();

--- a/src/newgrf/newgrf_act0_stations.cpp
+++ b/src/newgrf/newgrf_act0_stations.cpp
@@ -49,17 +49,14 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 		}
 
 		switch (prop) {
-			case 0x08: { // Class ID
+			case 0x08: // Class ID
 				/* Property 0x08 is special; it is where the station is allocated */
 				if (statspec == nullptr) {
 					statspec = std::make_unique<StationSpec>();
 				}
 
-				/* Swap classid because we read it in BE meaning WAYP or DFLT */
-				uint32_t classid = buf.ReadDWord();
-				statspec->class_index = StationClass::Allocate(std::byteswap(classid));
+				statspec->class_index = StationClass::Allocate(buf.ReadLabel<StationClass::GlobalID>());
 				break;
-			}
 
 			case 0x09: { // Define sprite layout
 				uint16_t tiles = buf.ReadExtendedByte();

--- a/src/newgrf/newgrf_bytereader.h
+++ b/src/newgrf/newgrf_bytereader.h
@@ -10,6 +10,7 @@
 #ifndef NEWGRF_BYTEREADER_H
 #define NEWGRF_BYTEREADER_H
 
+#include "../core/label_type.hpp"
 #include "../core/string_consumer.hpp"
 
 class OTTDByteReaderSignal { };
@@ -92,6 +93,18 @@ public:
 	{
 		/* Terminating NUL may be missing at the end of sprite. */
 		return this->consumer.ReadUntilChar('\0', StringConsumer::SKIP_ONE_SEPARATOR);
+	}
+
+	/**
+	 * Read a label.
+	 * @return The read label.
+	 */
+	template <typename T> requires std::is_base_of_v<BaseLabel, T>
+	T ReadLabel()
+	{
+		T label{};
+		std::ranges::copy(this->consumer.Read(label.size()), label.data());
+		return label;
 	}
 
 	size_t Remaining() const

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -30,10 +30,10 @@
 template <>
 /* static */ void AirportClass::InsertDefaults()
 {
-	AirportClass::Get(AirportClass::Allocate('SMAL'))->name = STR_AIRPORT_CLASS_SMALL;
-	AirportClass::Get(AirportClass::Allocate('LARG'))->name = STR_AIRPORT_CLASS_LARGE;
-	AirportClass::Get(AirportClass::Allocate('HUB_'))->name = STR_AIRPORT_CLASS_HUB;
-	AirportClass::Get(AirportClass::Allocate('HELI'))->name = STR_AIRPORT_CLASS_HELIPORTS;
+	AirportClass::Get(AirportClass::Allocate("SMAL"))->name = STR_AIRPORT_CLASS_SMALL;
+	AirportClass::Get(AirportClass::Allocate("LARG"))->name = STR_AIRPORT_CLASS_LARGE;
+	AirportClass::Get(AirportClass::Allocate("HUB_"))->name = STR_AIRPORT_CLASS_HUB;
+	AirportClass::Get(AirportClass::Allocate("HELI"))->name = STR_AIRPORT_CLASS_HELIPORTS;
 }
 
 template <>

--- a/src/newgrf_class.h
+++ b/src/newgrf_class.h
@@ -10,6 +10,7 @@
 #ifndef NEWGRF_CLASS_H
 #define NEWGRF_CLASS_H
 
+#include "core/label_type.hpp"
 #include "newgrf_type.h"
 #include "strings_type.h"
 
@@ -45,12 +46,17 @@ private:
 public:
 	using spec_type = Tspec;
 	using index_type = Tindex;
+	using GlobalID = Label<NewGRFClass<Tspec, Tindex>>; ///< Type for the global identifier of the class.
 
-	uint32_t global_id; ///< Global ID for class, e.g. 'DFLT', 'WAYP', etc.
-	StringID name;    ///< Name of this class.
+	GlobalID global_id; ///< Global ID for class, e.g. 'DFLT', 'WAYP', etc.
+	StringID name; ///< Name of this class.
 
-	/* Public constructor as emplace_back needs access. */
-	NewGRFClass(uint32_t global_id, StringID name) : global_id(global_id), name(name) { }
+	/**
+	 * Create the class.
+	 * @param global_id The globally unique identifier of the class.
+	 * @param name The name of the class.
+	 */
+	NewGRFClass(GlobalID global_id, StringID name) : global_id(global_id), name(name) { }
 
 	/**
 	 * Get read-only span of specs of this class.
@@ -90,7 +96,7 @@ public:
 	bool IsUIAvailable(uint index) const;
 
 	static void Reset();
-	static Tindex Allocate(uint32_t global_id);
+	static Tindex Allocate(GlobalID global_id);
 	static void Assign(Tspec *spec);
 	static uint GetClassCount();
 	static uint GetUIClassCount();

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -29,7 +29,7 @@ void NewGRFClass<Tspec, Tindex>::Reset()
  *       second time, this first allocation will be given.
  */
 template <typename Tspec, typename Tindex>
-Tindex NewGRFClass<Tspec, Tindex>::Allocate(uint32_t global_id)
+Tindex NewGRFClass<Tspec, Tindex>::Allocate(GlobalID global_id)
 {
 	auto found = std::ranges::find(NewGRFClass::classes, global_id, &NewGRFClass::global_id);
 

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -136,8 +136,8 @@ void ResetObjects()
 	}
 
 	/* Set class for originals. */
-	_object_specs[OBJECT_LIGHTHOUSE].class_index = ObjectClass::Allocate('LTHS');
-	_object_specs[OBJECT_TRANSMITTER].class_index = ObjectClass::Allocate('TRNS');
+	_object_specs[OBJECT_LIGHTHOUSE].class_index = ObjectClass::Allocate("LTHS");
+	_object_specs[OBJECT_TRANSMITTER].class_index = ObjectClass::Allocate("TRNS");
 
 	/* Reset any overrides that have been set. */
 	_object_mngr.ResetOverride();
@@ -146,8 +146,8 @@ void ResetObjects()
 template <>
 /* static */ void ObjectClass::InsertDefaults()
 {
-	ObjectClass::Get(ObjectClass::Allocate('LTHS'))->name = STR_OBJECT_CLASS_LTHS;
-	ObjectClass::Get(ObjectClass::Allocate('TRNS'))->name = STR_OBJECT_CLASS_TRNS;
+	ObjectClass::Get(ObjectClass::Allocate("LTHS"))->name = STR_OBJECT_CLASS_LTHS;
+	ObjectClass::Get(ObjectClass::Allocate("TRNS"))->name = STR_OBJECT_CLASS_TRNS;
 }
 
 template <>

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -25,9 +25,6 @@ struct TileInfo;
 /** The maximum amount of roadstops a single GRF is allowed to add */
 static const int NUM_ROADSTOPS_PER_GRF = UINT16_MAX - 1;
 
-static const uint32_t ROADSTOP_CLASS_LABEL_DEFAULT = 'DFLT';
-static const uint32_t ROADSTOP_CLASS_LABEL_WAYPOINT = 'WAYP';
-
 /** Class IDs for stations. */
 using RoadStopClassID = PoolID<uint16_t, struct RoadStopClassIDTag, UINT16_MAX, UINT16_MAX>;
 
@@ -164,6 +161,9 @@ struct RoadStopSpec : NewGRFSpecBase<RoadStopClassID> {
 
 using RoadStopClass = NewGRFClass<RoadStopSpec, RoadStopClassID>;
 
+static const RoadStopClass::GlobalID ROADSTOP_CLASS_LABEL_DEFAULT{"DFLT"}; ///< Class label for default road stops.
+static const RoadStopClass::GlobalID ROADSTOP_CLASS_LABEL_WAYPOINT{"WAYP"}; ///< Class label for default road waypoints.
+
 std::optional<SpriteLayoutProcessor> GetRoadStopLayout(TileInfo *ti, const RoadStopSpec *spec, BaseStation *st, StationType type, int view, std::span<int32_t> regs100 = {});
 void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec, StationType type, int view);
 
@@ -191,7 +191,7 @@ void RoadStopUpdateCachedTriggers(BaseStation *st);
  */
 inline bool IsWaypointClass(const RoadStopClass &cls)
 {
-	return cls.global_id == ROADSTOP_CLASS_LABEL_WAYPOINT || GB(cls.global_id, 24, 8) == UINT8_MAX;
+	return cls.global_id == ROADSTOP_CLASS_LABEL_WAYPOINT || cls.global_id[0] == UINT8_MAX;
 }
 
 #endif /* NEWGRF_ROADSTATION_H */

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -98,9 +98,6 @@ struct StationResolverObject : public SpecializedResolverObject<StationRandomTri
 	uint32_t GetDebugID() const override;
 };
 
-static const uint32_t STATION_CLASS_LABEL_DEFAULT = 'DFLT';
-static const uint32_t STATION_CLASS_LABEL_WAYPOINT = 'WAYP';
-
 /** Class IDs for stations. */
 using StationClassID = PoolID<uint16_t, struct StationClassIDTag, UINT16_MAX, UINT16_MAX>;
 
@@ -188,6 +185,9 @@ struct StationSpec : NewGRFSpecBase<StationClassID> {
 /** Class containing information relating to station classes. */
 using StationClass = NewGRFClass<StationSpec, StationClassID>;
 
+static const StationClass::GlobalID STATION_CLASS_LABEL_DEFAULT{"DFLT"}; ///< Class label for default rail station.
+static const StationClass::GlobalID STATION_CLASS_LABEL_WAYPOINT{"WAYP"}; ///< Class label for default rail waypoints.
+
 const StationSpec *GetStationSpec(TileIndex t);
 
 /**
@@ -208,7 +208,7 @@ inline uint16_t GetStationLayoutKey(uint8_t platforms, uint8_t length)
  */
 inline bool IsWaypointClass(const StationClass &cls)
 {
-	return cls.global_id == STATION_CLASS_LABEL_WAYPOINT || GB(cls.global_id, 24, 8) == UINT8_MAX;
+	return cls.global_id == STATION_CLASS_LABEL_WAYPOINT || cls.global_id[0] == UINT8_MAX;
 }
 
 /* Evaluate a tile's position within a station, and return the result a bitstuffed format. */


### PR DESCRIPTION
## Motivation / Problem

Multi character literals and byte-swaps when the concept of `Label` is available.


## Description

Use the `Label` concept for the global IDs for NewGRF classes.


## Limitations

There are more NewGRF things that could use `Label`, but those are for a future PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
