### PR TITLE
Codechange: Deduplicate foundation sprite code

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -397,34 +397,26 @@ std::tuple<Slope, int> GetFoundationSlope(TileIndex tile)
 	return {tileh, z};
 }
 
-
-static bool HasFoundationNW(TileIndex tile, Slope slope_here, uint z_here)
+/**
+ * Check if the tile has foundation on given edge.
+ * @param tile The tile to check.
+ * @param slope_here The slope of the \a tile.
+ * @param z_here The z of tile's foundation.
+ * @param edge The edge to check.
+ * @return \c true iff the tile has foundation on given edge.
+ */
+static bool HasFoundation(TileIndex tile, Slope slope_here, uint z_here, DiagDirection edge)
 {
-	int z_W_here = z_here;
-	int z_N_here = z_here;
-	GetSlopePixelZOnEdge(slope_here, DiagDirection::NW, z_W_here, z_N_here);
+	int z1_here = z_here;
+	int z2_here = z_here;
+	GetSlopePixelZOnEdge(slope_here, edge, z1_here, z2_here);
 
-	auto [slope, z] = GetFoundationPixelSlope(TileAddXY(tile, 0, -1));
-	int z_W = z;
-	int z_N = z;
-	GetSlopePixelZOnEdge(slope, DiagDirection::SE, z_W, z_N);
+	auto [slope, z] = GetFoundationPixelSlope(TileAddByDiagDir(tile, edge));
+	int z1 = z;
+	int z2 = z;
+	GetSlopePixelZOnEdge(slope, ChangeDiagDir(edge, DiagDirDiff::Reverse), z1, z2);
 
-	return (z_N_here > z_N) || (z_W_here > z_W);
-}
-
-
-static bool HasFoundationNE(TileIndex tile, Slope slope_here, uint z_here)
-{
-	int z_E_here = z_here;
-	int z_N_here = z_here;
-	GetSlopePixelZOnEdge(slope_here, DiagDirection::NE, z_E_here, z_N_here);
-
-	auto [slope, z] = GetFoundationPixelSlope(TileAddXY(tile, -1, 0));
-	int z_E = z;
-	int z_N = z;
-	GetSlopePixelZOnEdge(slope, DiagDirection::SW, z_E, z_N);
-
-	return (z_N_here > z_N) || (z_E_here > z_E);
+	return (z1_here > z1) || (z2_here > z2);
 }
 
 /**
@@ -440,8 +432,8 @@ uint GetFoundationSpriteBlock(TileIndex tile)
 {
 	auto [slope, z] = GetFoundationPixelSlope(tile);
 	uint block = 0;
-	if (!HasFoundationNW(tile, slope, z)) block += 1;
-	if (!HasFoundationNE(tile, slope, z)) block += 2;
+	if (!HasFoundation(tile, slope, z, DiagDirection::NW)) block += 1;
+	if (!HasFoundation(tile, slope, z, DiagDirection::NE)) block += 2;
 	return block;
 }
 

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -398,7 +398,7 @@ std::tuple<Slope, int> GetFoundationSlope(TileIndex tile)
 }
 
 
-bool HasFoundationNW(TileIndex tile, Slope slope_here, uint z_here)
+static bool HasFoundationNW(TileIndex tile, Slope slope_here, uint z_here)
 {
 	int z_W_here = z_here;
 	int z_N_here = z_here;
@@ -413,7 +413,7 @@ bool HasFoundationNW(TileIndex tile, Slope slope_here, uint z_here)
 }
 
 
-bool HasFoundationNE(TileIndex tile, Slope slope_here, uint z_here)
+static bool HasFoundationNE(TileIndex tile, Slope slope_here, uint z_here)
 {
 	int z_E_here = z_here;
 	int z_N_here = z_here;
@@ -428,6 +428,24 @@ bool HasFoundationNE(TileIndex tile, Slope slope_here, uint z_here)
 }
 
 /**
+ * Get the sprite block to use for a foundation.
+ * @param tile Tile to draw a foundation on.
+ * @return The needed block of foundations sprites.
+ * Block 0: Walls at NW and NE edge.
+ * Block 1: Wall at NE edge.
+ * Block 2: Wall at NW edge.
+ * Block 3: No walls at NW or NE edge.
+ */
+uint GetFoundationSpriteBlock(TileIndex tile)
+{
+	auto [slope, z] = GetFoundationPixelSlope(tile);
+	uint block = 0;
+	if (!HasFoundationNW(tile, slope, z)) block += 1;
+	if (!HasFoundationNE(tile, slope, z)) block += 2;
+	return block;
+}
+
+/**
  * Draw foundation \a f at tile \a ti. Updates \a ti.
  * @param ti Tile to draw foundation on
  * @param f  Foundation to draw
@@ -439,17 +457,7 @@ void DrawFoundation(TileInfo *ti, Foundation f)
 	/* Two part foundations must be drawn separately */
 	assert(f != Foundation::SteepBoth);
 
-	uint sprite_block = 0;
-	auto [slope, z] = GetFoundationPixelSlope(ti->tile);
-
-	/* Select the needed block of foundations sprites
-	 * Block 0: Walls at NW and NE edge
-	 * Block 1: Wall  at        NE edge
-	 * Block 2: Wall  at NW        edge
-	 * Block 3: No walls at NW or NE edge
-	 */
-	if (!HasFoundationNW(ti->tile, slope, z)) sprite_block += 1;
-	if (!HasFoundationNE(ti->tile, slope, z)) sprite_block += 2;
+	uint sprite_block = GetFoundationSpriteBlock(ti->tile);
 
 	/* Use the original slope sprites if NW and NE borders should be visible */
 	SpriteID leveled_base = (sprite_block == 0 ? (int)SPR_FOUNDATION_BASE : (SPR_SLOPES_VIRTUAL_BASE + sprite_block * TRKFOUND_BLOCK_SIZE));

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -354,14 +354,14 @@ int GetSlopeZInCorner(Slope tileh, Corner corner)
  *
  * @note If a tile has a non-continuous halftile foundation, a corner can have different heights wrt. its edges.
  *
- * @pre z1 and z2 must be initialized (typ. with TileZ). The corner heights just get added.
- *
  * @param tileh The slope of the tile.
  * @param edge The edge of interest.
- * @param z1 Gets incremented by the height of the first corner of the edge. (near corner wrt. the camera)
- * @param z2 Gets incremented by the height of the second corner of the edge. (far corner wrt. the camera)
+ * @param z The z pos of the tile.
+ * @return \a z twice.
+ * First one incremented by the height of the first corner of the edge (near corner wrt. the camera),
+ * and the second one by the height of the second corner of the edge (far corner wrt. the camera).
  */
-void GetSlopePixelZOnEdge(Slope tileh, DiagDirection edge, int &z1, int &z2)
+std::tuple<int, int> GetSlopePixelZOnEdge(Slope tileh, DiagDirection edge, int z)
 {
 	static const DiagDirectionIndexArray<std::array<Slope, 4>> corners{{{
 		/*    corner     |          steep slope
@@ -372,6 +372,9 @@ void GetSlopePixelZOnEdge(Slope tileh, DiagDirection edge, int &z1, int &z2)
 		{SLOPE_W, SLOPE_N, SLOPE_STEEP_W, SLOPE_STEEP_N}, // DiagDirection::NW, z1 = W, z2 = N
 	}}};
 
+	int z1 = z;
+	int z2 = z;
+
 	Slope halftile_test = IsHalftileSlope(tileh) ? SlopeWithOneCornerRaised(GetHalftileSlopeCorner(tileh)) : SLOPE_FLAT;
 	if (halftile_test == corners[edge][0]) z2 += TILE_HEIGHT; // The slope is non-continuous in z2. z2 is on the upper side.
 	if (halftile_test == corners[edge][1]) z1 += TILE_HEIGHT; // The slope is non-continuous in z1. z1 is on the upper side.
@@ -380,6 +383,8 @@ void GetSlopePixelZOnEdge(Slope tileh, DiagDirection edge, int &z1, int &z2)
 	if ((tileh & corners[edge][1]) != 0) z2 += TILE_HEIGHT; // z2 is raised
 	if (RemoveHalftileSlope(tileh) == corners[edge][2]) z1 += TILE_HEIGHT; // z1 is highest corner of a steep slope
 	if (RemoveHalftileSlope(tileh) == corners[edge][3]) z2 += TILE_HEIGHT; // z2 is highest corner of a steep slope
+
+	return {z1, z2};
 }
 
 /**
@@ -407,14 +412,10 @@ std::tuple<Slope, int> GetFoundationSlope(TileIndex tile)
  */
 static bool HasFoundation(TileIndex tile, Slope slope_here, uint z_here, DiagDirection edge)
 {
-	int z1_here = z_here;
-	int z2_here = z_here;
-	GetSlopePixelZOnEdge(slope_here, edge, z1_here, z2_here);
+	auto [z1_here, z2_here] = GetSlopePixelZOnEdge(slope_here, edge, z_here);
 
 	auto [slope, z] = GetFoundationPixelSlope(TileAddByDiagDir(tile, edge));
-	int z1 = z;
-	int z2 = z;
-	GetSlopePixelZOnEdge(slope, ChangeDiagDir(edge, DiagDirDiff::Reverse), z1, z2);
+	auto [z1, z2] = GetSlopePixelZOnEdge(slope, ChangeDiagDir(edge, DiagDirDiff::Reverse), z);
 
 	return (z1_here > z1) || (z2_here > z2);
 }

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -41,7 +41,7 @@ std::tuple<Slope, int> GetFoundationSlope(TileIndex tile);
 uint GetPartialPixelZ(int x, int y, Slope corners);
 int GetSlopePixelZ(int x, int y, bool ground_vehicle = false);
 int GetSlopePixelZOutsideMap(int x, int y);
-void GetSlopePixelZOnEdge(Slope tileh, DiagDirection edge, int &z1, int &z2);
+std::tuple<int, int> GetSlopePixelZOnEdge(Slope tileh, DiagDirection edge, int z);
 
 /**
  * Determine the Z height of a corner relative to TileZ.

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -130,9 +130,8 @@ inline uint ApplyPixelFoundationToSlope(Foundation f, Slope &s)
 	return ApplyFoundationToSlope(f, s) * TILE_HEIGHT;
 }
 
+uint GetFoundationSpriteBlock (TileIndex tile);
 void DrawFoundation(TileInfo *ti, Foundation f);
-bool HasFoundationNW(TileIndex tile, Slope slope_here, uint z_here);
-bool HasFoundationNE(TileIndex tile, Slope slope_here, uint z_here);
 
 void DoClearSquare(TileIndex tile);
 void RunTileLoop();

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3217,11 +3217,7 @@ static bool DrawCustomStationFoundations(const StationSpec *statspec, BaseStatio
 
 	/* Station has custom foundations.
 	 * Check whether the foundation continues beyond the tile's upper sides. */
-	uint edge_info = 0;
-	auto [slope, z] = GetFoundationPixelSlope(ti->tile);
-	if (!HasFoundationNW(ti->tile, slope, z)) SetBit(edge_info, 0);
-	if (!HasFoundationNE(ti->tile, slope, z)) SetBit(edge_info, 1);
-
+	uint edge_info = GetFoundationSpriteBlock(ti->tile);
 	SpriteID image = GetCustomStationFoundationRelocation(statspec, st, ti->tile, gfx, edge_info);
 	if (image == 0) return false;
 

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1098,12 +1098,8 @@ static void DrawBridgePillars(const PalSpriteID &psid, const TileInfo *ti, Axis 
 
 	/* Determine ground height under pillars */
 	DiagDirection south_dir = AxisToDiagDir(axis);
-	int z_front_north = ti->z;
-	int z_back_north = ti->z;
-	int z_front_south = ti->z;
-	int z_back_south = ti->z;
-	GetSlopePixelZOnEdge(ti->tileh, south_dir, z_front_south, z_back_south);
-	GetSlopePixelZOnEdge(ti->tileh, ReverseDiagDir(south_dir), z_front_north, z_back_north);
+	auto [z_front_south, z_back_south] = GetSlopePixelZOnEdge(ti->tileh, south_dir, ti->z);
+	auto [z_front_north, z_back_north] = GetSlopePixelZOnEdge(ti->tileh, ReverseDiagDir(south_dir), ti->z);
 
 	/* Shared height of pillars */
 	int z_front = std::max(z_front_north, z_front_south);


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
When code is duplicated each change has to be done twice (or more).

In DrawFoundation the values of sprite_block were documented.
They were not in DrawTile_Station. 

HasFoundationNW and HasFoundationNE do the same thing but with different constants.
They both don't have doxygen comment.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Move the usage of HasFoundationNW and HasFoundationNE from DrawFoundation and DrawTile_Station
into a new helper function GetFoundationSpriteBlock.

Merge HasFoundationNW and HasFoundationNE into one function HasFoundation that now can be static.

Make GetSlopePixelZOnEdge take the initial z value (instead of two references).
Create the new z1 and z2 variables inside the helper function and return them in tuple.
This simplifies the usage of GetSlopePixelZOnEdge by removing the precondition.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
HasFoundation is a bit more complicated than HasFoundationNW or HasFoundationNE.
GetSlopePixelZOnEdge now assumes that z1 and z2 have the same value before they are incremented.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
