### PR TITLE
Codechange: use Label for CargoLabel, RailTypeLabel and RoadTypeLabel

### DIFF
--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -10,11 +10,11 @@
 #ifndef CARGO_TYPE_H
 #define CARGO_TYPE_H
 
-#include "core/strong_typedef_type.hpp"
+#include "core/label_type.hpp"
 #include "core/enum_type.hpp"
 
 /** Globally unique label of a cargo type. */
-using CargoLabel = StrongType::Typedef<uint32_t, struct CargoLabelTag, StrongType::Compare>;
+using CargoLabel = Label<struct CargoLabelTag>;
 
 /**
  * Cargo slots to indicate a cargo type within a game.
@@ -28,48 +28,48 @@ DECLARE_INCREMENT_DECREMENT_OPERATORS(CargoType)
  */
 
 /* Temperate */
-static constexpr CargoLabel CT_PASSENGERS{'PASS'};
-static constexpr CargoLabel CT_COAL{'COAL'};
-static constexpr CargoLabel CT_MAIL{'MAIL'};
-static constexpr CargoLabel CT_OIL{'OIL_'};
-static constexpr CargoLabel CT_LIVESTOCK{'LVST'};
-static constexpr CargoLabel CT_GOODS{'GOOD'};
-static constexpr CargoLabel CT_GRAIN{'GRAI'};
-static constexpr CargoLabel CT_WOOD{'WOOD'};
-static constexpr CargoLabel CT_IRON_ORE{'IORE'};
-static constexpr CargoLabel CT_STEEL{'STEL'};
-static constexpr CargoLabel CT_VALUABLES{'VALU'};
+static constexpr CargoLabel CT_PASSENGERS{"PASS"};
+static constexpr CargoLabel CT_COAL{"COAL"};
+static constexpr CargoLabel CT_MAIL{"MAIL"};
+static constexpr CargoLabel CT_OIL{"OIL_"};
+static constexpr CargoLabel CT_LIVESTOCK{"LVST"};
+static constexpr CargoLabel CT_GOODS{"GOOD"};
+static constexpr CargoLabel CT_GRAIN{"GRAI"};
+static constexpr CargoLabel CT_WOOD{"WOOD"};
+static constexpr CargoLabel CT_IRON_ORE{"IORE"};
+static constexpr CargoLabel CT_STEEL{"STEL"};
+static constexpr CargoLabel CT_VALUABLES{"VALU"};
 
 /* Arctic */
-static constexpr CargoLabel CT_WHEAT{'WHEA'};
-static constexpr CargoLabel CT_PAPER{'PAPR'};
-static constexpr CargoLabel CT_GOLD{'GOLD'};
-static constexpr CargoLabel CT_FOOD{'FOOD'};
+static constexpr CargoLabel CT_WHEAT{"WHEA"};
+static constexpr CargoLabel CT_PAPER{"PAPR"};
+static constexpr CargoLabel CT_GOLD{"GOLD"};
+static constexpr CargoLabel CT_FOOD{"FOOD"};
 
 /* Tropic */
-static constexpr CargoLabel CT_RUBBER{'RUBR'};
-static constexpr CargoLabel CT_FRUIT{'FRUT'};
-static constexpr CargoLabel CT_MAIZE{'MAIZ'};
-static constexpr CargoLabel CT_COPPER_ORE{'CORE'};
-static constexpr CargoLabel CT_WATER{'WATR'};
-static constexpr CargoLabel CT_DIAMONDS{'DIAM'};
+static constexpr CargoLabel CT_RUBBER{"RUBR"};
+static constexpr CargoLabel CT_FRUIT{"FRUT"};
+static constexpr CargoLabel CT_MAIZE{"MAIZ"};
+static constexpr CargoLabel CT_COPPER_ORE{"CORE"};
+static constexpr CargoLabel CT_WATER{"WATR"};
+static constexpr CargoLabel CT_DIAMONDS{"DIAM"};
 
 /* Toyland */
-static constexpr CargoLabel CT_SUGAR{'SUGR'};
-static constexpr CargoLabel CT_TOYS{'TOYS'};
-static constexpr CargoLabel CT_BATTERIES{'BATT'};
-static constexpr CargoLabel CT_CANDY{'SWET'};
-static constexpr CargoLabel CT_TOFFEE{'TOFF'};
-static constexpr CargoLabel CT_COLA{'COLA'};
-static constexpr CargoLabel CT_COTTON_CANDY{'CTCD'};
-static constexpr CargoLabel CT_BUBBLES{'BUBL'};
-static constexpr CargoLabel CT_PLASTIC{'PLST'};
-static constexpr CargoLabel CT_FIZZY_DRINKS{'FZDR'};
+static constexpr CargoLabel CT_SUGAR{"SUGR"};
+static constexpr CargoLabel CT_TOYS{"TOYS"};
+static constexpr CargoLabel CT_BATTERIES{"BATT"};
+static constexpr CargoLabel CT_CANDY{"SWET"};
+static constexpr CargoLabel CT_TOFFEE{"TOFF"};
+static constexpr CargoLabel CT_COLA{"COLA"};
+static constexpr CargoLabel CT_COTTON_CANDY{"CTCD"};
+static constexpr CargoLabel CT_BUBBLES{"BUBL"};
+static constexpr CargoLabel CT_PLASTIC{"PLST"};
+static constexpr CargoLabel CT_FIZZY_DRINKS{"FZDR"};
 
 /** Dummy label for engines that carry no cargo; they actually carry 0 passengers. */
 static constexpr CargoLabel CT_NONE = CT_PASSENGERS;
 
-static constexpr CargoLabel CT_INVALID{UINT32_MAX}; ///< Invalid cargo type.
+static constexpr CargoLabel CT_INVALID{"\xFF\xFF\xFF\xFF"}; ///< Invalid cargo type.
 
 static constexpr CargoType NUM_ORIGINAL_CARGO{12}; ///< Original number of cargo types.
 static constexpr CargoType NUM_CARGO{64}; ///< Maximum number of cargo types in a game.

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2792,22 +2792,6 @@ static bool ConFramerateWindow(std::span<std::string_view> argv)
 	return true;
 }
 
-/**
- * Format a label as a string.
- * If all elements are visible ASCII (excluding space) then the label will be formatted as a string of 4 characters,
- * otherwise it will be output as an 8-digit hexadecimal value.
- * @param label Label to format.
- * @return string representation of label.
- **/
-static std::string FormatLabel(uint32_t label)
-{
-	if (std::isgraph(GB(label, 24, 8)) && std::isgraph(GB(label, 16, 8)) && std::isgraph(GB(label, 8, 8)) && std::isgraph(GB(label, 0, 8))) {
-		return fmt::format("{:c}{:c}{:c}{:c}", GB(label, 24, 8), GB(label, 16, 8), GB(label, 8, 8), GB(label, 0, 8));
-	}
-
-	return fmt::format("{:08X}", label);
-}
-
 /** List all road types and their configuration. */
 static void ConDumpRoadTypes()
 {
@@ -2821,7 +2805,7 @@ static void ConDumpRoadTypes()
 	std::map<uint32_t, const GRFFile *> grfs;
 	for (RoadType rt : EnumRange(ROADTYPE_END)) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
-		if (rti->label == 0) continue;
+		if (rti->label.Empty()) continue;
 		GrfID grfid{};
 		const GRFFile *grf = rti->grffile[RoadSpriteType::Ground];
 		if (grf != nullptr) {
@@ -2831,7 +2815,7 @@ static void ConDumpRoadTypes()
 		IConsolePrint(CC_DEFAULT, "  {:02d} {} {}, Flags: {}{}{}{}{}, GRF: {:08X}, {}",
 				(uint)rt,
 				RoadTypeIsTram(rt) ? "Tram" : "Road",
-				FormatLabel(rti->label),
+				rti->label.AsString(),
 				rti->flags.Test(RoadTypeFlag::Catenary)        ? 'c' : '-',
 				rti->flags.Test(RoadTypeFlag::NoLevelCrossing) ? 'l' : '-',
 				rti->flags.Test(RoadTypeFlag::NoHouses)        ? 'X' : '-',
@@ -2860,7 +2844,7 @@ static void ConDumpRailTypes()
 	std::map<uint32_t, const GRFFile *> grfs;
 	for (RailType rt : EnumRange(RAILTYPE_END)) {
 		const RailTypeInfo *rti = GetRailTypeInfo(rt);
-		if (rti->label == 0) continue;
+		if (rti->label.Empty()) continue;
 		GrfID grfid{};
 		const GRFFile *grf = rti->grffile[RailSpriteType::Ground];
 		if (grf != nullptr) {
@@ -2869,7 +2853,7 @@ static void ConDumpRailTypes()
 		}
 		IConsolePrint(CC_DEFAULT, "  {:02d} {}, Flags: {}{}{}{}{}{}, GRF: {:08X}, {}",
 				(uint)rt,
-				FormatLabel(rti->label),
+				rti->label.AsString(),
 				rti->flags.Test(RailTypeFlag::Catenary)        ? 'c' : '-',
 				rti->flags.Test(RailTypeFlag::NoLevelCrossing) ? 'l' : '-',
 				rti->flags.Test(RailTypeFlag::Hidden)          ? 'h' : '-',
@@ -2917,7 +2901,7 @@ static void ConDumpCargoTypes()
 		IConsolePrint(CC_DEFAULT, "  {:02d} Bit: {:2d}, Label: {}, Callback mask: 0x{:02X}, Cargo class: {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}, GRF: {:08X}, {}",
 				spec->Index(),
 				spec->bitnum,
-				FormatLabel(spec->label.base()),
+				spec->label.AsString(),
 				spec->callback_mask.base(),
 				spec->classes.Test(CargoClass::Passengers)   ? 'p' : '-',
 				spec->classes.Test(CargoClass::Mail)         ? 'm' : '-',

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -701,28 +701,22 @@ static void CalculateRefitMasks()
 					_gted[engine].cargo_disallowed = {CargoClass::Liquid};
 				} else if (e->type == VehicleType::Ship) {
 					CargoLabel label = GetActiveCargoLabel(ei->cargo_label);
-					switch (label.base()) {
-						case CT_PASSENGERS.base():
-							/* Ferries */
-							_gted[engine].cargo_allowed = {CargoClass::Passengers};
-							_gted[engine].cargo_disallowed = {};
-							break;
-						case CT_OIL.base():
-							/* Tankers */
-							_gted[engine].cargo_allowed = {CargoClass::Liquid};
-							_gted[engine].cargo_disallowed = {};
-							break;
-						default:
-							/* Cargo ships */
-							if (_settings_game.game_creation.landscape == LandscapeType::Toyland) {
-								/* No tanker in toyland :( */
-								_gted[engine].cargo_allowed = {CargoClass::Mail, CargoClass::Armoured, CargoClass::Express, CargoClass::Bulk, CargoClass::PieceGoods, CargoClass::Liquid};
-								_gted[engine].cargo_disallowed = {CargoClass::Passengers};
-							} else {
-								_gted[engine].cargo_allowed = {CargoClass::Mail, CargoClass::Armoured, CargoClass::Express, CargoClass::Bulk, CargoClass::PieceGoods};
-								_gted[engine].cargo_disallowed = {CargoClass::Liquid, CargoClass::Passengers};
-							}
-							break;
+					if (label == CT_PASSENGERS) {
+						/* Ferries */
+						_gted[engine].cargo_allowed = {CargoClass::Passengers};
+						_gted[engine].cargo_disallowed = {};
+					} else if (label == CT_OIL) {
+						/* Tankers */
+						_gted[engine].cargo_allowed = {CargoClass::Liquid};
+						_gted[engine].cargo_disallowed = {};
+					} else if (_settings_game.game_creation.landscape == LandscapeType::Toyland) {
+						/* No tanker in toyland :( so include liquids in the cargo ships */
+						_gted[engine].cargo_allowed = {CargoClass::Mail, CargoClass::Armoured, CargoClass::Express, CargoClass::Bulk, CargoClass::PieceGoods, CargoClass::Liquid};
+						_gted[engine].cargo_disallowed = {CargoClass::Passengers};
+					} else {
+						/* Cargo ships */
+						_gted[engine].cargo_allowed = {CargoClass::Mail, CargoClass::Armoured, CargoClass::Express, CargoClass::Bulk, CargoClass::PieceGoods};
+						_gted[engine].cargo_disallowed = {CargoClass::Liquid, CargoClass::Passengers};
 					}
 					e->VehInfo<ShipVehicleInfo>().old_refittable = true;
 				} else if (e->type == VehicleType::Train && e->VehInfo<RailVehicleInfo>().railveh_type != RailVehicleType::Wagon) {
@@ -945,10 +939,12 @@ void FinaliseCargoArray()
 	for (CargoSpec &cs : CargoSpec::array) {
 		if (cs.town_production_effect == TownProductionEffect::Invalid) {
 			/* Set default town production effect by cargo label. */
-			switch (cs.label.base()) {
-				case CT_PASSENGERS.base(): cs.town_production_effect = TownProductionEffect::Passengers; break;
-				case CT_MAIL.base():       cs.town_production_effect = TownProductionEffect::Mail; break;
-				default:                   cs.town_production_effect = TownProductionEffect::None; break;
+			if (cs.label == CT_PASSENGERS) {
+				cs.town_production_effect = TownProductionEffect::Passengers;
+			} else if (cs.label == CT_MAIL) {
+				cs.town_production_effect = TownProductionEffect::Mail;
+			} else {
+				cs.town_production_effect = TownProductionEffect::None;
 			}
 		}
 		if (!cs.IsValid()) {

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -250,4 +250,29 @@ void ShowNewGRFError();
 GrfSpecFeature GetGrfSpecFeature(VehicleType type);
 VehicleType GetVehicleType(GrfSpecFeature feature);
 
+/**
+ * Flatten a NewGRF related label to a 32 bits integer.
+ * @param label The label to flatten.
+ * @return The flattened label.
+ */
+template <typename T> requires std::is_base_of_v<BaseLabel, T>
+constexpr uint32_t FlattenNewGRFLabel(T label) { return label[0] << 24 | label[1] << 16 | label[2] << 8 | label[3]; }
+
+/**
+ * Unflatten a NewGRF related label from a 32 bits integer.
+ * @param value The value to decode.
+ * @return The unflattened label.
+ */
+template <typename T> requires std::is_base_of_v<BaseLabel, T>
+constexpr T UnflattenNewGRFLabel(uint32_t value)
+{
+	uint8_t buf[]{
+		static_cast<uint8_t>(GB(value, 24, 8)),
+		static_cast<uint8_t>(GB(value, 16, 8)),
+		static_cast<uint8_t>(GB(value, 8, 8)),
+		static_cast<uint8_t>(GB(value, 0, 8))
+	};
+	return buf;
+}
+
 #endif /* NEWGRF_H */

--- a/src/newgrf/newgrf_act0_cargo.cpp
+++ b/src/newgrf/newgrf_act0_cargo.cpp
@@ -136,7 +136,7 @@ static ChangeInfoResult CargoReserveInfo(uint first, uint last, int prop, ByteRe
 				break;
 
 			case 0x17: // Cargo label
-				cs->label = CargoLabel{std::byteswap(buf.ReadDWord())};
+				cs->label = buf.ReadLabel<CargoLabel>();
 				BuildCargoLabelMap();
 				MaybeInstallFallbackCargoLabel(id, last, cs->label);
 				break;

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -53,7 +53,7 @@ static ChangeInfoResult LoadTranslationTable(uint first, uint last, ByteReader &
 	translation_table.clear();
 	translation_table.reserve(last);
 	for (uint id = first; id < last; ++id) {
-		translation_table.push_back(T(std::byteswap(buf.ReadDWord())));
+		translation_table.push_back(buf.ReadLabel<T>());
 	}
 
 	GRFFile *grf_override = GetCurrentGRFOverride();

--- a/src/newgrf/newgrf_act0_railtypes.cpp
+++ b/src/newgrf/newgrf_act0_railtypes.cpp
@@ -83,8 +83,7 @@ static ChangeInfoResult RailTypeChangeInfo(uint first, uint last, int prop, Byte
 				 * default rail types. */
 				int n = buf.ReadByte();
 				for (int j = 0; j != n; j++) {
-					RailTypeLabel label = buf.ReadDWord();
-					RailType resolved_rt = GetRailTypeByLabel(std::byteswap(label), false);
+					RailType resolved_rt = GetRailTypeByLabel(buf.ReadLabel<RailTypeLabel>(), false);
 					if (resolved_rt != INVALID_RAILTYPE) {
 						switch (prop) {
 							case 0x0F: rti->powered_railtypes.Set(resolved_rt);               [[fallthrough]]; // Powered implies compatible.
@@ -175,9 +174,7 @@ static ChangeInfoResult RailTypeReserveInfo(uint first, uint last, int prop, Byt
 		switch (prop) {
 			case 0x08: // Label of rail type
 			{
-				RailTypeLabel rtl = buf.ReadDWord();
-				rtl = std::byteswap(rtl);
-
+				RailTypeLabel rtl = buf.ReadLabel<RailTypeLabel>();
 				RailType rt = GetRailTypeByLabel(rtl, false);
 				if (rt == INVALID_RAILTYPE) {
 					/* Set up new rail type */
@@ -204,7 +201,7 @@ static ChangeInfoResult RailTypeReserveInfo(uint first, uint last, int prop, Byt
 				if (type_map[id] != INVALID_RAILTYPE) {
 					int n = buf.ReadByte();
 					for (int j = 0; j != n; j++) {
-						_railtypes[type_map[id]].alternate_labels.insert(std::byteswap(buf.ReadDWord()));
+						_railtypes[type_map[id]].alternate_labels.insert(buf.ReadLabel<RailTypeLabel>());
 					}
 					break;
 				}

--- a/src/newgrf/newgrf_act0_roadtypes.cpp
+++ b/src/newgrf/newgrf_act0_roadtypes.cpp
@@ -77,8 +77,7 @@ static ChangeInfoResult RoadTypeChangeInfo(uint first, uint last, int prop, Byte
 				 * default road types. */
 				int n = buf.ReadByte();
 				for (int j = 0; j != n; j++) {
-					RoadTypeLabel label = buf.ReadDWord();
-					RoadType resolved_rt = GetRoadTypeByLabel(std::byteswap(label), false);
+					RoadType resolved_rt = GetRoadTypeByLabel(buf.ReadLabel<RoadTypeLabel>(), false);
 					if (resolved_rt != INVALID_ROADTYPE) {
 						switch (prop) {
 							case 0x0F:
@@ -161,9 +160,7 @@ static ChangeInfoResult RoadTypeReserveInfo(uint first, uint last, int prop, Byt
 	for (uint id = first; id < last; ++id) {
 		switch (prop) {
 			case 0x08: { // Label of road type
-				RoadTypeLabel rtl = buf.ReadDWord();
-				rtl = std::byteswap(rtl);
-
+				RoadTypeLabel rtl = buf.ReadLabel<RoadTypeLabel>();
 				RoadType rt = GetRoadTypeByLabel(rtl, false);
 				if (rt == INVALID_ROADTYPE) {
 					/* Set up new road type */
@@ -192,7 +189,7 @@ static ChangeInfoResult RoadTypeReserveInfo(uint first, uint last, int prop, Byt
 				if (type_map[id] != INVALID_ROADTYPE) {
 					int n = buf.ReadByte();
 					for (int j = 0; j != n; j++) {
-						_roadtypes[type_map[id]].alternate_labels.insert(std::byteswap(buf.ReadDWord()));
+						_roadtypes[type_map[id]].alternate_labels.insert(buf.ReadLabel<RoadTypeLabel>());
 					}
 					break;
 				}

--- a/src/newgrf/newgrf_act3.cpp
+++ b/src/newgrf/newgrf_act3.cpp
@@ -57,11 +57,11 @@ static CargoType TranslateCargo(GrfSpecFeature feature, uint8_t ctype)
 
 	CargoType cargo_type = GetCargoTypeByLabel(cl);
 	if (!IsValidCargoType(cargo_type)) {
-		GrfMsg(5, "TranslateCargo: Cargo '{:c}{:c}{:c}{:c}' unsupported, skipping.", GB(cl.base(), 24, 8), GB(cl.base(), 16, 8), GB(cl.base(), 8, 8), GB(cl.base(), 0, 8));
+		GrfMsg(5, "TranslateCargo: Cargo '{}' unsupported, skipping.", cl.AsString());
 		return INVALID_CARGO;
 	}
 
-	GrfMsg(6, "TranslateCargo: Cargo '{:c}{:c}{:c}{:c}' mapped to cargo type {}.", GB(cl.base(), 24, 8), GB(cl.base(), 16, 8), GB(cl.base(), 8, 8), GB(cl.base(), 0, 8), cargo_type);
+	GrfMsg(6, "TranslateCargo: Cargo '{}' mapped to cargo type {}.", cl.AsString(), cargo_type);
 	return cargo_type;
 }
 

--- a/src/newgrf/newgrf_act7_9.cpp
+++ b/src/newgrf/newgrf_act7_9.cpp
@@ -217,31 +217,31 @@ static void SkipIf(ByteReader &buf)
 	if (condtype >= 0x0B) {
 		/* Tests that ignore 'param' */
 		switch (condtype) {
-			case 0x0B: result = !IsValidCargoType(GetCargoTypeByLabel(CargoLabel(std::byteswap(cond_val))));
+			case 0x0B: result = !IsValidCargoType(GetCargoTypeByLabel(UnflattenNewGRFLabel<CargoLabel>(cond_val)));
 				break;
-			case 0x0C: result = IsValidCargoType(GetCargoTypeByLabel(CargoLabel(std::byteswap(cond_val))));
+			case 0x0C: result = IsValidCargoType(GetCargoTypeByLabel(UnflattenNewGRFLabel<CargoLabel>(cond_val)));
 				break;
-			case 0x0D: result = GetRailTypeByLabel(std::byteswap(cond_val)) == INVALID_RAILTYPE;
+			case 0x0D: result = GetRailTypeByLabel(UnflattenNewGRFLabel<RailTypeLabel>(cond_val)) == INVALID_RAILTYPE;
 				break;
-			case 0x0E: result = GetRailTypeByLabel(std::byteswap(cond_val)) != INVALID_RAILTYPE;
+			case 0x0E: result = GetRailTypeByLabel(UnflattenNewGRFLabel<RailTypeLabel>(cond_val)) != INVALID_RAILTYPE;
 				break;
 			case 0x0F: {
-				RoadType rt = GetRoadTypeByLabel(std::byteswap(cond_val));
+				RoadType rt = GetRoadTypeByLabel(UnflattenNewGRFLabel<RoadTypeLabel>(cond_val));
 				result = rt == INVALID_ROADTYPE || !RoadTypeIsRoad(rt);
 				break;
 			}
 			case 0x10: {
-				RoadType rt = GetRoadTypeByLabel(std::byteswap(cond_val));
+				RoadType rt = GetRoadTypeByLabel(UnflattenNewGRFLabel<RoadTypeLabel>(cond_val));
 				result = rt != INVALID_ROADTYPE && RoadTypeIsRoad(rt);
 				break;
 			}
 			case 0x11: {
-				RoadType rt = GetRoadTypeByLabel(std::byteswap(cond_val));
+				RoadType rt = GetRoadTypeByLabel(UnflattenNewGRFLabel<RoadTypeLabel>(cond_val));
 				result = rt == INVALID_ROADTYPE || !RoadTypeIsTram(rt);
 				break;
 			}
 			case 0x12: {
-				RoadType rt = GetRoadTypeByLabel(std::byteswap(cond_val));
+				RoadType rt = GetRoadTypeByLabel(UnflattenNewGRFLabel<RoadTypeLabel>(cond_val));
 				result = rt != INVALID_ROADTYPE && RoadTypeIsTram(rt);
 				break;
 			}

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -31,7 +31,7 @@ GrfSpecFeature CargoResolverObject::GetFeature() const
 
 uint32_t CargoResolverObject::GetDebugID() const
 {
-	return this->cargospec->label.base();
+	return FlattenNewGRFLabel(this->cargospec->label);
 }
 
 /**

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -76,7 +76,7 @@ GrfSpecFeature RailTypeResolverObject::GetFeature() const
 
 uint32_t RailTypeResolverObject::GetDebugID() const
 {
-	return this->railtype_scope.rti->label;
+	return FlattenNewGRFLabel(this->railtype_scope.rti->label);
 }
 
 /**
@@ -152,7 +152,7 @@ RailType GetRailTypeTranslation(uint8_t railtype, const GRFFile *grffile)
 {
 	if (grffile == nullptr || grffile->railtype_list.empty()) {
 		/* No railtype table present. Return railtype as-is (if valid), so it works for original railtypes. */
-		if (railtype >= RAILTYPE_END || GetRailTypeInfo(static_cast<RailType>(railtype))->label == 0) return INVALID_RAILTYPE;
+		if (railtype >= RAILTYPE_END || GetRailTypeInfo(static_cast<RailType>(railtype))->label.Empty()) return INVALID_RAILTYPE;
 
 		return static_cast<RailType>(railtype);
 	} else {
@@ -205,7 +205,7 @@ void ConvertRailTypes()
 		railtype_conversion_map.push_back(rt);
 
 		/* Conversion is needed if the rail type is in a different position than the list. */
-		if (it->label != 0 && rt != std::distance(std::begin(_railtype_list), it)) needs_conversion = true;
+		if (!it->label.Empty() && rt != std::distance(std::begin(_railtype_list), it)) needs_conversion = true;
 	}
 
 	if (!needs_conversion) return;

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -122,7 +122,7 @@ GrfSpecFeature RoadTypeResolverObject::GetFeature() const
 
 uint32_t RoadTypeResolverObject::GetDebugID() const
 {
-	return this->roadtype_scope.rti->label;
+	return FlattenNewGRFLabel(this->roadtype_scope.rti->label);
 }
 
 /**
@@ -238,7 +238,7 @@ void ConvertRoadTypes()
 		roadtype_conversion_map.push_back(rt);
 
 		/* Conversion is needed if the road type is in a different position than the list. */
-		if (it->label != 0 && rt != std::distance(std::begin(_roadtype_list), it)) needs_conversion = true;
+		if (!it->label.Empty() && rt != std::distance(std::begin(_roadtype_list), it)) needs_conversion = true;
 	}
 	if (!needs_conversion) return;
 

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -108,7 +108,7 @@ RailTypes AddDateIntroducedRailTypes(RailTypes current, TimerGameCalendar::Date 
 	for (RailType rt : EnumRange(RAILTYPE_END)) {
 		const RailTypeInfo *rti = GetRailTypeInfo(rt);
 		/* Unused rail type. */
-		if (rti->label == 0) continue;
+		if (rti->label.Empty()) continue;
 
 		/* Not date introduced. */
 		if (!IsInsideMM(rti->introduction_date, 0, CalendarTime::MAX_DATE.base())) continue;
@@ -197,7 +197,7 @@ RailTypes GetRailTypes(bool introduces)
 RailType GetRailTypeByLabel(RailTypeLabel label, bool allow_alternate_labels)
 {
 	extern RailTypeInfo _railtypes[RAILTYPE_END];
-	if (label == 0) return INVALID_RAILTYPE;
+	if (label.Empty()) return INVALID_RAILTYPE;
 
 	auto it = std::ranges::find(_railtypes, label, &RailTypeInfo::label);
 	if (it == std::end(_railtypes) && allow_alternate_labels) {

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -136,7 +136,7 @@ void InitRailTypes()
 		ResolveRailTypeGUISprites(&rti);
 		_railtypes_hidden_mask.Set(rt, rti.flags.Test(RailTypeFlag::Hidden));
 
-		if (rti.label == 0) continue;
+		if (rti.label.Empty()) continue;
 		_sorted_railtypes.push_back(rt);
 	}
 	std::sort(_sorted_railtypes.begin(), _sorted_railtypes.end(), CompareRailTypes);
@@ -149,7 +149,7 @@ void InitRailTypes()
  */
 RailType AllocateRailType(RailTypeLabel label)
 {
-	auto it = std::ranges::find(_railtypes, 0, &RailTypeInfo::label);
+	auto it = std::ranges::find(_railtypes, RailTypeLabel{}, &RailTypeInfo::label);
 	if (it == std::end(_railtypes)) return INVALID_RAILTYPE;
 
 	RailTypeInfo &rti = *it;

--- a/src/rail_type.h
+++ b/src/rail_type.h
@@ -11,13 +11,14 @@
 #define RAIL_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "core/label_type.hpp"
 
-typedef uint32_t RailTypeLabel;
+using RailTypeLabel = Label<struct RailTypeLabelTag>;
 
-static const RailTypeLabel RAILTYPE_LABEL_RAIL     = 'RAIL';
-static const RailTypeLabel RAILTYPE_LABEL_ELECTRIC = 'ELRL';
-static const RailTypeLabel RAILTYPE_LABEL_MONO     = 'MONO';
-static const RailTypeLabel RAILTYPE_LABEL_MAGLEV   = 'MGLV';
+static const RailTypeLabel RAILTYPE_LABEL_RAIL{"RAIL"};
+static const RailTypeLabel RAILTYPE_LABEL_ELECTRIC{"ELRL"};
+static const RailTypeLabel RAILTYPE_LABEL_MONO{"MONO"};
+static const RailTypeLabel RAILTYPE_LABEL_MAGLEV{"MGLV"};
 
 /**
  * Enumeration for all possible railtypes.

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -124,7 +124,7 @@ bool HasRoadTypeAvail(const CompanyID company, RoadType roadtype)
 {
 	if (company == OWNER_DEITY || company == OWNER_TOWN || _game_mode == GameMode::Editor || _generating_world) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(roadtype);
-		if (rti->label == 0) return false;
+		if (rti->label.Empty()) return false;
 
 		/* Not yet introduced at this date. */
 		if (IsInsideMM(rti->introduction_date, 0, CalendarTime::MAX_DATE.base()) && rti->introduction_date > TimerGameCalendar::date) return false;
@@ -181,7 +181,7 @@ RoadTypes AddDateIntroducedRoadTypes(RoadTypes current, TimerGameCalendar::Date 
 	for (RoadType rt : EnumRange(ROADTYPE_END)) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
 		/* Unused road type. */
-		if (rti->label == 0) continue;
+		if (rti->label.Empty()) continue;
 
 		/* Not date introduced. */
 		if (!IsInsideMM(rti->introduction_date, 0, CalendarTime::MAX_DATE.base())) continue;
@@ -265,7 +265,7 @@ RoadTypes GetRoadTypes(bool introduces)
 RoadType GetRoadTypeByLabel(RoadTypeLabel label, bool allow_alternate_labels)
 {
 	extern RoadTypeInfo _roadtypes[ROADTYPE_END];
-	if (label == 0) return INVALID_ROADTYPE;
+	if (label.Empty()) return INVALID_ROADTYPE;
 
 	auto it = std::ranges::find(_roadtypes, label, &RoadTypeInfo::label);
 	if (it == std::end(_roadtypes) && allow_alternate_labels) {

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -117,7 +117,7 @@ void InitRoadTypes()
 		ResolveRoadTypeGUISprites(&rti);
 		_roadtypes_hidden_mask.Set(rt, rti.flags.Test(RoadTypeFlag::Hidden));
 
-		if (rti.label == 0) continue;
+		if (rti.label.Empty()) continue;
 		_sorted_roadtypes.push_back(rt);
 	}
 	std::sort(_sorted_roadtypes.begin(), _sorted_roadtypes.end(), CompareRoadTypes);
@@ -131,7 +131,7 @@ void InitRoadTypes()
  */
 RoadType AllocateRoadType(RoadTypeLabel label, RoadTramType rtt)
 {
-	auto it = std::ranges::find(_roadtypes, 0, &RoadTypeInfo::label);
+	auto it = std::ranges::find(_roadtypes, RoadTypeLabel{}, &RoadTypeInfo::label);
 	if (it == std::end(_roadtypes)) return INVALID_ROADTYPE;
 
 	RoadTypeInfo &rti = *it;

--- a/src/road_type.h
+++ b/src/road_type.h
@@ -11,11 +11,12 @@
 #define ROAD_TYPE_H
 
 #include "core/enum_type.hpp"
+#include "core/label_type.hpp"
 
-typedef uint32_t RoadTypeLabel;
+using RoadTypeLabel = Label<struct RoadTypeLabelTag>;
 
-static const RoadTypeLabel ROADTYPE_LABEL_ROAD = 'ROAD';
-static const RoadTypeLabel ROADTYPE_LABEL_TRAM = 'ELRL';
+static const RoadTypeLabel ROADTYPE_LABEL_ROAD{"ROAD"};
+static const RoadTypeLabel ROADTYPE_LABEL_TRAM{"ELRL"};
 
 /**
  * The different roadtypes we support

--- a/src/script/api/script_cargo.cpp
+++ b/src/script/api/script_cargo.cpp
@@ -40,14 +40,7 @@
 {
 	if (!IsValidCargo(cargo_type)) return std::nullopt;
 	const CargoSpec *cargo = ::CargoSpec::Get(cargo_type);
-
-	/* cargo->label is a uint32_t packing a 4 character non-terminated string,
-	 * like "PASS", "COAL", "OIL_". New ones can be defined by NewGRFs */
-	std::string cargo_label;
-	for (uint i = 0; i < sizeof(cargo->label); i++) {
-		cargo_label.push_back(GB(cargo->label.base(), (uint8_t)(sizeof(cargo->label) - i - 1) * 8, 8));
-	}
-	return cargo_label;
+	return cargo->label.AsString();
 }
 
 /* static */ bool ScriptCargo::IsFreight(CargoType cargo_type)


### PR DESCRIPTION
## Motivation / Problem

Multi character literals and byte-swaps when the concept of `Label` is available.


## Description

Use the `Label` concept for `CargoLabel`, `RailTypeLabel` and `RoadTypeLabel`.

Change some switches on `CargoLabel` (three cases and further if-statements in the default case) into a chained `if`-`else if`, because you can't switch on labels.

Introduce some helper functions to flatten/unflatten the labels. This is needed because I do not want to push labels down into the action 2 variables, and because in some functions parameters are interpreted differently depending on the context but the data needs to be read before as the context is trailing the field which sometimes is a label..

Replace `{:c}{:c}{:c}{:c}` formatting codes and passing 4 GB-extracted bytes with `AsString`. This will yield the same when printing if all characters/bytes are printable (and not space), otherwise it will print the 8-character hex-string of the label. Instead of emitting bytes to the log/console that aren't valid UTF-8.


## Limitations

There are more NewGRF things that could use `Label`, but those are for a future PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
