### PR TITLE
Codechange: remove compiler flags allowing multi character literals

### DIFF
--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -56,11 +56,6 @@ macro(compile_flags)
             # This flag disables the broken optimisation to work around the bug
             add_compile_options(/d2ssa-rse-)
         endif()
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-            add_compile_options(
-                -Wno-multichar
-            )
-        endif()
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         add_compile_options(
             -W
@@ -77,9 +72,6 @@ macro(compile_flags)
             -Winit-self
             -Wnon-virtual-dtor
             -Wsuggest-override
-
-            # We use 'ABCD' multichar for SaveLoad chunks identifiers
-            -Wno-multichar
 
             # Prevent optimisation supposing enums are in a range specified by the standard
             # For details, see http://gcc.gnu.org/PR43680 and PR#5246.


### PR DESCRIPTION
## Motivation / Problem

Multi character literals are a non-standard feature. They 'encoding' of them is implementation defined, although we are lucky it mostly worked for us up to now, and compilers are actively warning about it except that we disabled those warnings.


## Description

Remove the disabling of warnings / enable the warnings about multi character literals.

Closes #15801.


## Limitations

~Contains #15830, #15846, #15856 and #15858~ as those remove/replace the uses of multi character literals.~


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
