### PR TITLE
Fix: Rail depot overbuild did not handle associated reservation

### DIFF
--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -990,14 +990,20 @@ CommandCost CmdBuildTrainDepot(DoCommandFlags flags, TileIndex tile, RailType ra
 
 	/* Allow the user to rotate the depot instead of having to destroy it and build it again */
 	bool rotate_existing_depot = false;
+	Train *v = nullptr;
 	if (IsRailDepotTile(tile) && railtype == GetRailType(tile)) {
 		CommandCost ret = CheckTileOwnership(tile);
 		if (ret.Failed()) return ret;
 
-		if (dir == GetRailDepotDirection(tile)) return CommandCost();
+		DiagDirection old_dir = GetRailDepotDirection(tile);
+		if (dir == old_dir) return CommandCost();
 
 		ret = EnsureNoVehicleOnGround(tile);
 		if (ret.Failed()) return ret;
+
+		if (HasDepotReservation(tile)) {
+			v = GetTrainForReservation(tile, DiagDirToDiagTrack(old_dir));
+		}
 
 		rotate_existing_depot = true;
 	}
@@ -1015,7 +1021,10 @@ CommandCost CmdBuildTrainDepot(DoCommandFlags flags, TileIndex tile, RailType ra
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {
+		if (v != nullptr) FreeTrainTrackReservation(v);
+
 		if (rotate_existing_depot) {
+			SetDepotReservation(tile, false);
 			SetRailDepotExitDirection(tile, dir);
 		} else {
 			Depot *d = Depot::Create(tile);
@@ -1030,6 +1039,8 @@ CommandCost CmdBuildTrainDepot(DoCommandFlags flags, TileIndex tile, RailType ra
 		MarkTileDirtyByTile(tile);
 		AddSideToSignalBuffer(tile, DiagDirection::Invalid, _current_company);
 		YapfNotifyTrackLayoutChange(tile, DiagDirToDiagTrack(dir));
+
+		if (v != nullptr) TryPathReserve(v, true);
 	}
 
 	cost.AddCost(_price[Price::BuildDepotTrain]);


### PR DESCRIPTION
## Motivation / Problem

The depot overbuilding functionality in #9642 does not handle the reservation associated with rail depots.
In particular if there is a train associated with the reservation it is not updated, and otherwise the reservation on the depot tile is not cleared when the depot is rebuilt in a different orientation.

## Description

Fix the above, such that the outcome is equivalent to clearing and rebuilding the depot in the usual way using separate steps.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
