### PR TITLE
Codechange: remove support for ICC (Intel's deprecated compiler)

### DIFF
--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -126,18 +126,6 @@ macro(compile_flags)
                 endif()
             endif()
         endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-        add_compile_options(
-            -Wall
-            # warning #873: function ... ::operator new ... has no corresponding operator delete ...
-            -wd873
-            # warning #1292: unknown attribute "fallthrough"
-            -wd1292
-            # warning #1899: multicharacter character literal (potential portability problem)
-            -wd1899
-            # warning #2160: anonymous union qualifier is ignored
-            -wd2160
-        )
     else()
         message(FATAL_ERROR "No warning flags are set for this compiler yet; please consider creating a Pull Request to add support for this compiler.")
     endif()

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -189,12 +189,6 @@ void SurveyCompiler(nlohmann::json &survey)
 #if defined(_MSC_VER)
 	survey["name"] = "MSVC";
 	survey["version"] = _MSC_VER;
-#elif defined(__ICC) && defined(__GNUC__)
-	survey["name"] = "ICC";
-	survey["version"] = __ICC;
-#	if defined(__GNUC__)
-		survey["extra"] = fmt::format("GCC {}.{}.{} mode", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
-#	endif
 #elif defined(__GNUC__)
 	survey["name"] = "GCC";
 	survey["version"] = fmt::format("{}.{}.{}", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);


### PR DESCRIPTION
## Motivation / Problem

Intel's C compiler (icc) has been deprecated long and removed in 2024 from Intel's compiler package. The compiler does not support C++20, and because it's removed from development never will.

Intel's successor compiler (icx) does not support C++20 yet, is based on LLVM and has very different compiler flags. It also does not set `__ICC`.

For me C++20 supports means supporting `std::ranges`, which they simply do not according to: https://godbolt.org/z/E7oveYcGb


## Description

Remove ICC support.


## Limitations

Might want to consider this a change, but... given we require C++20 for years already and nobody complained there are no users. I consider it a codechange as we're essentially removing dead code and not actively removing ICC support as that was already (by proxy) removed when requiring C++20.

Conflicts with #15859, as that also removes a single ICC compiler flag.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
