### PR TITLE
Fix: incorrect AI API documentation

### DIFF
--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -98,7 +98,7 @@ public:
 	 *  reliability (you most likely don't want to buy it).
 	 * @param engine_id The engine to get the reliability of.
 	 * @pre IsValidEngine(engine_id).
-	 * @pre GetVehicleType(engine_id) != ScriptVehicle::VT_TRAIN || !IsWagon(engine_id).
+	 * @pre GetVehicleType(engine_id) != (ScriptVehicle::VT_TRAIN && IsWagon(engine_id)).
 	 * @return The reliability the engine has.
 	 */
 	static SQInteger GetReliability(EngineID engine_id);


### PR DESCRIPTION
## Motivation / Problem

I got confused by precondition description of:

 `GetVehicleType(engine_id) != ScriptVehicle::VT_TRAIN || !IsWagon(engine_id)`

This boolean logic is incorrect, it states that `engine_id ` must not be train type OR must not be wagon, therefore completely excluding all kinds of rail engines.

## Description

Correct logic is `GetVehicleType(engine_id) != (ScriptVehicle::VT_TRAIN && IsWagon(engine_id))`

This only excludes wagons.

## Limitations

Maybe even better would be just `!AIEngine.IsWagon(engine_id)`
