### PR TITLE
Fix fa4b9819c0: endianness issues with saving of labels

### DIFF
--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -37,7 +37,7 @@ struct RAILChunkHandler : ChunkHandler {
 	RAILChunkHandler() : ChunkHandler("RAIL", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::U32),
+		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::LABEL),
 	};
 
 	void Save() const override
@@ -72,7 +72,7 @@ struct ROTTChunkHandler : ChunkHandler {
 	ROTTChunkHandler() : ChunkHandler("ROTT", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::U32),
+		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::LABEL),
 		SLE_VAR(LabelObject<RoadTypeLabel>, subtype, VarTypes::U8),
 	};
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -682,6 +682,7 @@ static inline uint SlCalcConvMemLen(VarMemType conv)
 		case VarMemType::I64: return sizeof(int64_t);
 		case VarMemType::U64: return sizeof(uint64_t);
 		case VarMemType::Null: return 0;
+		case VarMemType::Label: return sizeof(BaseLabel);
 
 		case VarMemType::Str:
 		case VarMemType::StrQ:
@@ -934,6 +935,13 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 {
 	switch (_sl.action) {
 		case SaveLoadAction::Save: {
+			if (conv == VarTypes::LABEL) {
+				/* Labels are a special case. They were read little endian but stored big endian, and as such reversed. */
+				BaseLabel *label = static_cast<BaseLabel *>(ptr);
+				for (auto it = label->rbegin(); it != label->rend(); it++) SlWriteByte(*it);
+				break;
+			}
+
 			int64_t x = ReadValue(ptr, conv.mem);
 
 			/* Write the value to the file and check if its value is in the desired range */
@@ -975,6 +983,13 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 		}
 		case SaveLoadAction::LoadCheck:
 		case SaveLoadAction::Load: {
+			if (conv == VarTypes::LABEL) {
+				/* Labels are a special case. They were read little endian but stored big endian, and as such reversed. */
+				BaseLabel *label = static_cast<BaseLabel *>(ptr);
+				for (auto it = label->rbegin(); it != label->rend(); it++) *it = SlReadByte();
+				break;
+			}
+
 			int64_t x;
 			/* Read a value from the file */
 			switch (conv.file) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -683,7 +683,6 @@ enum class VarFileType : uint8_t {
 
 /** The types/structures of data we have in memory. */
 enum class VarMemType : uint8_t {
-	/* 4 bits allocated a maximum of 16 types for NumberType */
 	Bool = 0, ///< A boolean value.
 	I8 = 1, ///< A 8 bit signed int.
 	U8 = 2, ///< A 8 bit unsigned int.
@@ -697,7 +696,7 @@ enum class VarMemType : uint8_t {
 	Str = 12, ///< string pointer
 	StrQ = 13, ///< string pointer enclosed in quotes
 	Name = 14, ///< old custom name to be converted to a string pointer
-	/* 1 more possible memory-primitives */
+	Label = 15, ///< A 4 character \c Label.
 };
 
 /** Container of a variable's characteristics about a variable's storage. */
@@ -769,6 +768,7 @@ struct VarTypes {
 	static constexpr VarType STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
 	static constexpr VarType STRQ{ VarFileType::String, VarMemType::StrQ }; ///< Store a string with quotes.
 	static constexpr VarType NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
+	static constexpr VarType LABEL{ VarFileType::U32, VarMemType::Label }; ///< Store a \c Label.
 };
 
 /** Type of data saved. */
@@ -841,6 +841,7 @@ inline constexpr size_t SlVarSize(VarMemType type)
 		case VarMemType::Str: return sizeof(std::string);
 		case VarMemType::StrQ: return sizeof(std::string);
 		case VarMemType::Name: return sizeof(std::string);
+		case VarMemType::Label: return sizeof(BaseLabel);
 		default: NOT_REACHED();
 	}
 }
@@ -884,6 +885,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_GENERAL_NAME(cmd, name, base, variable, type, length, from, to, extra) \
 	SaveLoad {name, cmd, type, length, from, to, [] (void *b, size_t) -> void * { \
 		static_assert(SlCheckVarSize(cmd, type, length, sizeof(static_cast<base *>(b)->variable))); \
+		static_assert(VarType{type}.mem != VarMemType::Label || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
 		assert(b != nullptr); \
 		return const_cast<void *>(static_cast<const void *>(std::addressof(static_cast<base *>(b)->variable))); \
 	}, extra, nullptr}


### PR DESCRIPTION
## Motivation / Problem

I made a boo-boo.

`Label`s are just an array, where they used to be `uint32_t`. The save load layer wasn't updated for the road/rail type labels. This means:
* old (before fa4b9819c0) save games do not load those labels correctly on big endian machines.
* new (after fa4b9819c0) save games cannot be loaded correctly between machines of different endiannesses.


## Description

Introduce a new `VarMemType` for labels, which just copies the bytes. However, to prevent having to add afterload with a reversal of each of the labels (GrfID labels coming up), the bytes are written in reverse order to the save game and still as `uint32_t`.

I also added a `static_assert` to ensure variables of type `Label`s are only using `VarTypes::Label`.


## Limitations

The save game won't have labels in the expected order. However, if we want the labels to be in the correct order in the save game, then save game conversions (i.e. afterload) needs to be created for each of the `Labels` and at that point I would forego the `VarMemType::Label` type all together and just use `SLE_ARR` over `SLE_VAR` (and friends).

This could, also, be seen as a stop-gap solution as this implementation does not leave a trace in the save game, so revisiting the choice for `VarMemType::Label` can be easily done without much harm. It would actually be 'easier' to do it when the label conversion is done, as everything can then be wrapped up into a single save game bump.

We should also test for `std::string` for the string types and `std::is_integral` for integral types (that would've caught this issue). That's beyond the scope for this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
