### PR TITLE
Codechange: let GrfID be a Label

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -27,6 +27,7 @@
 #include "fontcache.h"
 #include "screenshot.h"
 #include "genworld.h"
+#include "string_func.h"
 #include "strings_func.h"
 #include "viewport_func.h"
 #include "window_func.h"
@@ -2657,7 +2658,7 @@ static bool ConNewGRFProfile(std::span<std::string_view> argv)
 			bool active = selected && profiler->active;
 			TextColour tc = active ? TextColour::LightBlue : selected ? TextColour::Green : CC_INFO;
 			std::string_view statustext = active ? " (active)" : selected ? " (selected)" : "";
-			IConsolePrint(tc, "{}: [{:08X}] {}{}", i, std::byteswap(grf.grfid), grf.filename, statustext);
+			IConsolePrint(tc, "{}: [{}] {}{}", i, FormatArrayAsHex(grf.grfid), grf.filename, statustext);
 			i++;
 		}
 		return true;
@@ -2673,7 +2674,7 @@ static bool ConNewGRFProfile(std::span<std::string_view> argv)
 			}
 			const GRFFile *grf = &files[*grfnum - 1];
 			if (std::any_of(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; })) {
-				IConsolePrint(CC_WARNING, "GRF number {} [{:08X}] is already selected for profiling.", *grfnum, std::byteswap(grf->grfid));
+				IConsolePrint(CC_WARNING, "GRF number {} [{}] is already selected for profiling.", *grfnum, FormatArrayAsHex(grf->grfid));
 				continue;
 			}
 			_newgrf_profilers.emplace_back(grf);
@@ -2709,7 +2710,7 @@ static bool ConNewGRFProfile(std::span<std::string_view> argv)
 				started++;
 
 				if (!grfids.empty()) grfids += ", ";
-				format_append(grfids, "[{:08X}]", std::byteswap(pr.grffile->grfid));
+				format_append(grfids, "[{}]", FormatArrayAsHex(pr.grffile->grfid));
 			}
 		}
 		if (started > 0) {
@@ -2802,7 +2803,7 @@ static void ConDumpRoadTypes()
 	IConsolePrint(CC_DEFAULT, "    h = hidden");
 	IConsolePrint(CC_DEFAULT, "    T = buildable by towns");
 
-	std::map<uint32_t, const GRFFile *> grfs;
+	std::map<GrfID, const GRFFile *> grfs;
 	for (RoadType rt : EnumRange(ROADTYPE_END)) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
 		if (rti->label.Empty()) continue;
@@ -2812,7 +2813,7 @@ static void ConDumpRoadTypes()
 			grfid = grf->grfid;
 			grfs.emplace(grfid, grf);
 		}
-		IConsolePrint(CC_DEFAULT, "  {:02d} {} {}, Flags: {}{}{}{}{}, GRF: {:08X}, {}",
+		IConsolePrint(CC_DEFAULT, "  {:02d} {} {}, Flags: {}{}{}{}{}, GRF: {}, {}",
 				(uint)rt,
 				RoadTypeIsTram(rt) ? "Tram" : "Road",
 				rti->label.AsString(),
@@ -2821,12 +2822,12 @@ static void ConDumpRoadTypes()
 				rti->flags.Test(RoadTypeFlag::NoHouses)        ? 'X' : '-',
 				rti->flags.Test(RoadTypeFlag::Hidden)          ? 'h' : '-',
 				rti->flags.Test(RoadTypeFlag::TownBuild)       ? 'T' : '-',
-				std::byteswap(grfid),
+				FormatArrayAsHex(grfid),
 				GetStringPtr(rti->strings.name)
 		);
 	}
 	for (const auto &grf : grfs) {
-		IConsolePrint(CC_DEFAULT, "  GRF: {:08X} = {}", std::byteswap(grf.first), grf.second->filename);
+		IConsolePrint(CC_DEFAULT, "  GRF: {} = {}", FormatArrayAsHex(grf.first), grf.second->filename);
 	}
 }
 
@@ -2841,7 +2842,7 @@ static void ConDumpRailTypes()
 	IConsolePrint(CC_DEFAULT, "    a = always allow 90 degree turns");
 	IConsolePrint(CC_DEFAULT, "    d = always disallow 90 degree turns");
 
-	std::map<uint32_t, const GRFFile *> grfs;
+	std::map<GrfID, const GRFFile *> grfs;
 	for (RailType rt : EnumRange(RAILTYPE_END)) {
 		const RailTypeInfo *rti = GetRailTypeInfo(rt);
 		if (rti->label.Empty()) continue;
@@ -2851,7 +2852,7 @@ static void ConDumpRailTypes()
 			grfid = grf->grfid;
 			grfs.emplace(grfid, grf);
 		}
-		IConsolePrint(CC_DEFAULT, "  {:02d} {}, Flags: {}{}{}{}{}{}, GRF: {:08X}, {}",
+		IConsolePrint(CC_DEFAULT, "  {:02d} {}, Flags: {}{}{}{}{}{}, GRF: {}, {}",
 				(uint)rt,
 				rti->label.AsString(),
 				rti->flags.Test(RailTypeFlag::Catenary)        ? 'c' : '-',
@@ -2860,12 +2861,12 @@ static void ConDumpRailTypes()
 				rti->flags.Test(RailTypeFlag::NoSpriteCombine) ? 's' : '-',
 				rti->flags.Test(RailTypeFlag::Allow90Deg)      ? 'a' : '-',
 				rti->flags.Test(RailTypeFlag::Disallow90Deg)   ? 'd' : '-',
-				std::byteswap(grfid),
+				FormatArrayAsHex(grfid),
 				GetStringPtr(rti->strings.name)
 		);
 	}
 	for (const auto &grf : grfs) {
-		IConsolePrint(CC_DEFAULT, "  GRF: {:08X} = {}", std::byteswap(grf.first), grf.second->filename);
+		IConsolePrint(CC_DEFAULT, "  GRF: {} = {}", FormatArrayAsHex(grf.first), grf.second->filename);
 	}
 }
 
@@ -2890,7 +2891,7 @@ static void ConDumpCargoTypes()
 	IConsolePrint(CC_DEFAULT, "    i = non-potable");
 	IConsolePrint(CC_DEFAULT, "    S = special");
 
-	std::map<uint32_t, const GRFFile *> grfs;
+	std::map<GrfID, const GRFFile *> grfs;
 	for (const CargoSpec *spec : CargoSpec::Iterate()) {
 		GrfID grfid{};
 		const GRFFile *grf = spec->grffile;
@@ -2898,7 +2899,7 @@ static void ConDumpCargoTypes()
 			grfid = grf->grfid;
 			grfs.emplace(grfid, grf);
 		}
-		IConsolePrint(CC_DEFAULT, "  {:02d} Bit: {:2d}, Label: {}, Callback mask: 0x{:02X}, Cargo class: {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}, GRF: {:08X}, {}",
+		IConsolePrint(CC_DEFAULT, "  {:02d} Bit: {:2d}, Label: {}, Callback mask: 0x{:02X}, Cargo class: {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}, GRF: {}, {}",
 				spec->Index(),
 				spec->bitnum,
 				spec->label.AsString(),
@@ -2919,12 +2920,12 @@ static void ConDumpCargoTypes()
 				spec->classes.Test(CargoClass::Potable)      ? 'e' : '-',
 				spec->classes.Test(CargoClass::NonPotable)   ? 'i' : '-',
 				spec->classes.Test(CargoClass::Special)      ? 'S' : '-',
-				std::byteswap(grfid),
+				FormatArrayAsHex(grfid),
 				GetStringPtr(spec->name)
 		);
 	}
 	for (const auto &grf : grfs) {
-		IConsolePrint(CC_DEFAULT, "  GRF: {:08X} = {}", std::byteswap(grf.first), grf.second->filename);
+		IConsolePrint(CC_DEFAULT, "  GRF: {} = {}", FormatArrayAsHex(grf.first), grf.second->filename);
 	}
 }
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -766,7 +766,7 @@ void StartupOneEngine(Engine *e, const TimerGameCalendar::YearMonthDay &aging_ym
 	SetRandomSeed(_settings_game.game_creation.generation_seed ^ seed ^
 	              ei->base_intro.base() ^
 	              to_underlying(e->type) ^
-	              e->GetGRFID());
+	              FlattenNewGRFLabel(e->GetGRFID()));
 	uint32_t r = Random();
 
 	/* Don't randomise the start-date in the first two years after gamestart to ensure availability
@@ -793,7 +793,7 @@ void StartupOneEngine(Engine *e, const TimerGameCalendar::YearMonthDay &aging_ym
 	              (re->index.base() << 16) ^ (re->info.base_intro.base() << 12) ^ (re->info.decay_speed << 8) ^
 	              (re->info.lifelength.base() << 4) ^ re->info.retire_early ^
 	              to_underlying(e->type) ^
-	              e->GetGRFID());
+	              FlattenNewGRFLabel(e->GetGRFID()));
 
 	/* Base reliability defined as a percentage of UINT16_MAX. */
 	const uint16_t RELIABILITY_START = UINT16_MAX * 48 / 100;

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -11,6 +11,7 @@
 #define ENGINE_BASE_H
 
 #include "engine_type.h"
+#include "newgrf.h"
 #include "vehicle_type.h"
 #include "core/enum_type.hpp"
 #include "core/pool_type.hpp"
@@ -213,7 +214,7 @@ struct EngineIDMapping {
 	 * @param internal_id The internal ID within the GRF file.
 	 * @return The key.
 	 */
-	static inline uint64_t Key(GrfID grfid, uint16_t internal_id) { return static_cast<uint64_t>(grfid) << 32 | internal_id; }
+	static inline uint64_t Key(GrfID grfid, uint16_t internal_id) { return static_cast<uint64_t>(FlattenNewGRFLabel(grfid)) << 32 | internal_id; }
 
 	/**
 	 * Create a 64 bit key from this mapping.

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -110,9 +110,9 @@ void Gamelog::Reset()
 static void AddGrfInfo(std::back_insert_iterator<std::string> &output_iterator, GrfID grfid, const MD5Hash *md5sum, const GRFConfig *gc)
 {
 	if (md5sum != nullptr) {
-		fmt::format_to(output_iterator, "GRF ID {:08X}, checksum {}", std::byteswap(grfid), FormatArrayAsHex(*md5sum));
+		fmt::format_to(output_iterator, "GRF ID {}, checksum {}", FormatArrayAsHex(grfid), FormatArrayAsHex(*md5sum));
 	} else {
-		fmt::format_to(output_iterator, "GRF ID {:08X}", std::byteswap(grfid));
+		fmt::format_to(output_iterator, "GRF ID {}", FormatArrayAsHex(grfid));
 	}
 
 	if (gc != nullptr) {
@@ -282,8 +282,8 @@ void Gamelog::Print(std::function<void(const std::string &)> proc)
 {
 	/* The order of NewGRFs got changed, which might cause some other NewGRFs to behave differently. */
 	auto gm = grf_names.find(this->grfid);
-	fmt::format_to(output_iterator, "GRF order changed: {:08X} moved {} places {}",
-		std::byteswap(this->grfid), abs(this->offset), this->offset >= 0 ? "down" : "up" );
+	fmt::format_to(output_iterator, "GRF order changed: {} moved {} places {}",
+		FormatArrayAsHex(this->grfid), abs(this->offset), this->offset >= 0 ? "down" : "up" );
 	AddGrfInfo(output_iterator, this->grfid, nullptr, gm != grf_names.end() ? gm->second.gc : nullptr);
 	if (gm == grf_names.end()) fmt::format_to(output_iterator, ". Gamelog inconsistency: GrfID was never added!");
 }
@@ -294,7 +294,7 @@ void Gamelog::Print(std::function<void(const std::string &)> proc)
 	auto gm = grf_names.find(this->grfid);
 	assert(this->bug == GRFBug::VehLength);
 
-	fmt::format_to(output_iterator, "Rail vehicle changes length outside a depot: GRF ID {:08X}, internal ID 0x{:X}", std::byteswap(this->grfid), this->data);
+	fmt::format_to(output_iterator, "Rail vehicle changes length outside a depot: GRF ID {}, internal ID 0x{:X}", FormatArrayAsHex(this->grfid), this->data);
 	AddGrfInfo(output_iterator, this->grfid, nullptr, gm != grf_names.end() ? gm->second.gc : nullptr);
 	if (gm == grf_names.end()) fmt::format_to(output_iterator, ". Gamelog inconsistency: GrfID was never added!");
 }

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -13,6 +13,7 @@
 #include "../../timer/timer_game_calendar.h"
 #include "../../timer/timer_game_tick.h"
 #include "../../debug.h"
+#include "../../newgrf.h"
 #include "../../map_func.h"
 #include "../../game/game.hpp"
 #include "../../game/game_info.hpp"
@@ -388,7 +389,7 @@ void DeserializeNetworkGameInfo(Packet &p, NetworkGameInfo &info, const GameInfo
  */
 void SerializeGRFIdentifier(Packet &p, const GRFIdentifier &grf)
 {
-	p.Send_uint32(grf.grfid);
+	p.Send_uint32(FlattenNewGRFLabel(grf.grfid));
 	p.Send_bytes(grf.md5sum);
 }
 
@@ -399,7 +400,7 @@ void SerializeGRFIdentifier(Packet &p, const GRFIdentifier &grf)
  */
 void DeserializeGRFIdentifier(Packet &p, GRFIdentifier &grf)
 {
-	grf.grfid = p.Recv_uint32();
+	grf.grfid = UnflattenNewGRFLabel<GrfID>(p.Recv_uint32());
 	p.Recv_bytes(grf.md5sum);
 }
 

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -10,6 +10,7 @@
 #include "../../stdafx.h"
 #include "../../textfile_gui.h"
 #include "../../newgrf_config.h"
+#include "../../newgrf.h"
 #include "../../base_media_base.h"
 #include "../../base_media_graphics.h"
 #include "../../base_media_music.h"
@@ -73,7 +74,7 @@ std::optional<std::string> ContentInfo::GetTextfile(TextfileType type) const
 			tmp = Game::GetScannerLibrary()->FindMainScript(*this, true);
 			break;
 		case ContentType::NewGRF: {
-			const GRFConfig *gc = FindGRFConfig(std::byteswap(this->unique_id), FindGRFConfigMode::Exact, &this->md5sum);
+			const GRFConfig *gc = FindGRFConfig(UnflattenNewGRFLabel<GrfID>(this->unique_id), FindGRFConfigMode::Exact, &this->md5sum);
 			if (gc != nullptr) tmp = gc->filename;
 			break;
 		}

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -692,7 +692,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerCheckNewGRFs(Pack
 		const GRFConfig *f = FindGRFConfig(c.grfid, FindGRFConfigMode::Exact, &c.md5sum);
 		if (f == nullptr) {
 			/* We do not know this GRF, bail out of initialization */
-			Debug(grf, 0, "NewGRF {:08X} not found; checksum {}", std::byteswap(c.grfid), FormatArrayAsHex(c.md5sum));
+			Debug(grf, 0, "NewGRF {} not found; checksum {}", FormatArrayAsHex(c.grfid), FormatArrayAsHex(c.md5sum));
 			ret = NetworkRecvStatus::NewGRFMismatch;
 		}
 	}

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -14,6 +14,7 @@
 #include "../window_func.h"
 #include "../error.h"
 #include "../fileio_func.h"
+#include "../newgrf.h"
 #include "../base_media_base.h"
 #include "../base_media_graphics.h"
 #include "../base_media_music.h"
@@ -49,7 +50,7 @@ ClientNetworkContentSocketHandler _network_content_client;
 /** Check whether NewGRF content exists. @copydoc HasContentProc */
 static bool HasGRFConfig(const ContentInfo &ci, bool md5sum)
 {
-	return FindGRFConfig(std::byteswap(ci.unique_id), md5sum ? FindGRFConfigMode::Exact : FindGRFConfigMode::Any, md5sum ? &ci.md5sum : nullptr) != nullptr;
+	return FindGRFConfig(UnflattenNewGRFLabel<GrfID>(ci.unique_id), md5sum ? FindGRFConfigMode::Exact : FindGRFConfigMode::Any, md5sum ? &ci.md5sum : nullptr) != nullptr;
 }
 
 /**

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -16,6 +16,7 @@
 #include "engine_func.h"
 #include "engine_base.h"
 #include "bridge.h"
+#include "string_func.h"
 #include "town.h"
 #include "newgrf_engine.h"
 #include "newgrf_text.h"
@@ -184,12 +185,12 @@ static std::map<GrfID, GrfID> _grf_id_overrides;
  */
 void SetNewGRFOverride(GrfID source_grfid, GrfID target_grfid)
 {
-	if (target_grfid == 0) {
+	if (target_grfid.Empty()) {
 		_grf_id_overrides.erase(source_grfid);
-		GrfMsg(5, "SetNewGRFOverride: Removed override of {:X}", std::byteswap(source_grfid));
+		GrfMsg(5, "SetNewGRFOverride: Removed override of {}", FormatArrayAsHex(source_grfid));
 	} else {
 		_grf_id_overrides[source_grfid] = target_grfid;
-		GrfMsg(5, "SetNewGRFOverride: Added override of {:X} to {:X}", std::byteswap(source_grfid), std::byteswap(target_grfid));
+		GrfMsg(5, "SetNewGRFOverride: Added override of {} to {}", FormatArrayAsHex(source_grfid), FormatArrayAsHex(target_grfid));
 	}
 }
 
@@ -227,9 +228,9 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
 			scope_grfid = it->second;
 			const GRFFile *grf_match = GetFileByGRFID(scope_grfid);
 			if (grf_match == nullptr) {
-				GrfMsg(5, "Tried mapping from GRFID {:x} to {:x} but target is not loaded", std::byteswap(file->grfid), std::byteswap(scope_grfid));
+				GrfMsg(5, "Tried mapping from GRFID {} to {} but target is not loaded", FormatArrayAsHex(file->grfid), FormatArrayAsHex(scope_grfid));
 			} else {
-				GrfMsg(5, "Mapping from GRFID {:x} to {:x}", std::byteswap(file->grfid), std::byteswap(scope_grfid));
+				GrfMsg(5, "Mapping from GRFID {} to {}", FormatArrayAsHex(file->grfid), FormatArrayAsHex(scope_grfid));
 			}
 		}
 
@@ -251,7 +252,7 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
 
 		if (!e->grf_prop.HasGrfFile()) {
 			e->grf_prop.SetGRFFile(file);
-			GrfMsg(5, "Replaced engine at index {} for GRFID {:x}, type {}, index {}", e->index, std::byteswap(file->grfid), type, internal_id);
+			GrfMsg(5, "Replaced engine at index {} for GRFID {}, type {}, index {}", e->index, FormatArrayAsHex(file->grfid), type, internal_id);
 		}
 
 		return e;
@@ -282,7 +283,7 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
 		for (RailType rt : e->VehInfo<RailVehicleInfo>().railtypes) _gted[e->index].railtypelabels.push_back(GetRailTypeInfo(rt)->label);
 	}
 
-	GrfMsg(5, "Created new engine at index {} for GRFID {:x}, type {}, index {}", e->index, std::byteswap(file->grfid), type, internal_id);
+	GrfMsg(5, "Created new engine at index {} for GRFID {}, type {}, index {}", e->index, FormatArrayAsHex(file->grfid), type, internal_id);
 
 	return e;
 }
@@ -1604,7 +1605,7 @@ void AddBadgeToSpecs(T &specs, GrfSpecFeature feature, Badge &badge)
 static void FinaliseBadges()
 {
 	for (const auto &file : _grf_files) {
-		Badge *badge = GetBadgeByLabel(fmt::format("newgrf/{:08x}", std::byteswap(file.grfid)));
+		Badge *badge = GetBadgeByLabel(fmt::format("newgrf/{}", FormatArrayAsHex(file.grfid)));
 		if (badge == nullptr) continue;
 
 		for (Engine *e : Engine::Iterate()) {
@@ -1814,10 +1815,10 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 		}
 
 		if (stage == GrfLoadingStage::Reserve) {
-			static const std::pair<uint32_t, uint32_t> default_grf_overrides[] = {
-				{ std::byteswap(0x44442202), std::byteswap(0x44440111) }, // UKRS addons modifies UKRS
-				{ std::byteswap(0x6D620402), std::byteswap(0x6D620401) }, // DBSetXL ECS extension modifies DBSetXL
-				{ std::byteswap(0x4D656f20), std::byteswap(0x4D656F17) }, // LV4cut modifies LV4
+			static const std::pair<GrfID, GrfID> default_grf_overrides[] = {
+				{ GrfID{"\x44\x44\x22\x02"}, GrfID{"\x44\x44\x01\x11"} }, // UKRS addons modifies UKRS
+				{ GrfID{"\x6D\x62\x04\x02"}, GrfID{"\x6D\x62\x04\x01"} }, // DBSetXL ECS extension modifies DBSetXL
+				{ GrfID{"\x4D\x65\x6f\x20"}, GrfID{"\x4D\x65\x6F\x17"} }, // LV4cut modifies LV4
 			};
 			for (const auto &grf_override : default_grf_overrides) {
 				SetNewGRFOverride(grf_override.first, grf_override.second);

--- a/src/newgrf/newgrf_act0.cpp
+++ b/src/newgrf/newgrf_act0.cpp
@@ -256,7 +256,7 @@ static void SafeChangeInfo(ByteReader &buf)
 		if (prop == 0x11) {
 			bool is_safe = true;
 			for (uint i = 0; i < numinfo; i++) {
-				GrfID s = buf.ReadDWord();
+				GrfID s = buf.ReadLabel<GrfID>();
 				buf.ReadDWord(); // dest
 				const GRFConfig *grfconfig = GetGRFConfig(s);
 				if (grfconfig != nullptr && !grfconfig->flags.Test(GRFConfigFlag::Static)) {

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -59,7 +59,7 @@ static ChangeInfoResult LoadTranslationTable(uint first, uint last, ByteReader &
 	GRFFile *grf_override = GetCurrentGRFOverride();
 	if (grf_override != nullptr) {
 		/* GRF override is present, copy the translation table to the overridden GRF as well. */
-		GrfMsg(1, "LoadTranslationTable: Copying {} translation table to override GRFID {:08X}", name, std::byteswap(grf_override->grfid));
+		GrfMsg(1, "LoadTranslationTable: Copying {} translation table to override GRFID {}", name, FormatArrayAsHex(grf_override->grfid));
 		std::vector<T> &override_table = gettable(*grf_override);
 		override_table = translation_table;
 	}
@@ -385,8 +385,8 @@ static ChangeInfoResult GlobalVarReserveInfo(uint first, uint last, int prop, By
 				break;
 
 			case 0x11: { // GRF match for engine allocation
-				GrfID s = buf.ReadDWord();
-				GrfID t = buf.ReadDWord();
+				GrfID s = buf.ReadLabel<GrfID>();
+				GrfID t = buf.ReadLabel<GrfID>();
 				SetNewGRFOverride(s, t);
 				break;
 			}

--- a/src/newgrf/newgrf_act11.cpp
+++ b/src/newgrf/newgrf_act11.cpp
@@ -12,6 +12,7 @@
 #include "../newgrf_house.h"
 #include "../newgrf_sound.h"
 #include "../spritecache.h"
+#include "../string_func.h"
 #include "newgrf_bytereader.h"
 #include "newgrf_internal.h"
 
@@ -24,7 +25,7 @@
 static void ImportGRFSound(SoundEntry *sound)
 {
 	const GRFFile *file;
-	GrfID grfid = _cur_gps.file->ReadDword();
+	GrfID grfid = UnflattenNewGRFLabel<GrfID>(_cur_gps.file->ReadDword());
 	SoundID sound_id = _cur_gps.file->ReadWord();
 
 	file = GetFileByGRFID(grfid);
@@ -38,7 +39,7 @@ static void ImportGRFSound(SoundEntry *sound)
 		return;
 	}
 
-	GrfMsg(2, "ImportGRFSound: Copying sound {} ({}) from file {:x}", sound_id, file->sound_offset + sound_id, grfid);
+	GrfMsg(2, "ImportGRFSound: Copying sound {} ({}) from file {}", sound_id, file->sound_offset + sound_id, FormatArrayAsHex(grfid));
 
 	*sound = *GetSound(file->sound_offset + sound_id);
 

--- a/src/newgrf/newgrf_act13.cpp
+++ b/src/newgrf/newgrf_act13.cpp
@@ -10,6 +10,7 @@
 #include "../stdafx.h"
 #include "../debug.h"
 #include "../newgrf_text.h"
+#include "../string_func.h"
 #include "../strings_func.h"
 #include "newgrf_bytereader.h"
 #include "newgrf_internal.h"
@@ -31,10 +32,10 @@ static void TranslateGRFStrings(ByteReader &buf)
 	 * W   offset    First text ID
 	 * S   text...   Zero-terminated strings */
 
-	GrfID grfid = buf.ReadDWord();
+	GrfID grfid = buf.ReadLabel<GrfID>();
 	const GRFConfig *c = GetGRFConfig(grfid);
 	if (c == nullptr || (c->status != GRFStatus::Initialised && c->status != GRFStatus::Activated)) {
-		GrfMsg(7, "TranslateGRFStrings: GRFID {:08X} unknown, skipping action 13", std::byteswap(grfid));
+		GrfMsg(7, "TranslateGRFStrings: GRFID {} unknown, skipping action 13", FormatArrayAsHex(grfid));
 		return;
 	}
 

--- a/src/newgrf/newgrf_act7_9.cpp
+++ b/src/newgrf/newgrf_act7_9.cpp
@@ -250,7 +250,7 @@ static void SkipIf(ByteReader &buf)
 	} else if (param == 0x88) {
 		/* GRF ID checks */
 
-		GRFConfig *c = GetGRFConfig(cond_val, mask);
+		GRFConfig *c = GetGRFConfig(UnflattenNewGRFLabel<GrfID>(cond_val), mask);
 
 		if (c != nullptr && c->flags.Test(GRFConfigFlag::Static) && !_cur_gps.grfconfig->flags.Test(GRFConfigFlag::Static) && _networking) {
 			DisableStaticNewGRFInfluencingNonStaticNewGRFs(*c);

--- a/src/newgrf/newgrf_act8.cpp
+++ b/src/newgrf/newgrf_act8.cpp
@@ -21,18 +21,18 @@
 static void ScanInfo(ByteReader &buf)
 {
 	uint8_t grf_version = buf.ReadByte();
-	GrfID grfid = buf.ReadDWord();
+	GrfID grfid = buf.ReadLabel<GrfID>();
 	std::string_view name = buf.ReadString();
 
 	_cur_gps.grfconfig->ident.grfid = grfid;
 
 	if (grf_version < 2 || grf_version > 8) {
 		_cur_gps.grfconfig->flags.Set(GRFConfigFlag::Invalid);
-		Debug(grf, 0, "{}: NewGRF \"{}\" (GRFID {:08X}) uses GRF version {}, which is incompatible with this version of OpenTTD.", _cur_gps.grfconfig->filename, StrMakeValid(name), std::byteswap(grfid), grf_version);
+		Debug(grf, 0, "{}: NewGRF \"{}\" (GRFID {}) uses GRF version {}, which is incompatible with this version of OpenTTD.", _cur_gps.grfconfig->filename, StrMakeValid(name), FormatArrayAsHex(grfid), grf_version);
 	}
 
 	/* GRF IDs starting with 0xFF are reserved for internal TTDPatch use */
-	if (GB(grfid, 0, 8) == 0xFF) _cur_gps.grfconfig->flags.Set(GRFConfigFlag::System);
+	if (grfid[0] == 0xFF) _cur_gps.grfconfig->flags.Set(GRFConfigFlag::System);
 
 	AddGRFTextToList(_cur_gps.grfconfig->name, GRFLanguage::Unspecified, grfid, false, name);
 
@@ -56,7 +56,7 @@ static void GRFInfo(ByteReader &buf)
 	 * S info          string describing the set, and e.g. author and copyright */
 
 	uint8_t version    = buf.ReadByte();
-	GrfID grfid = buf.ReadDWord();
+	GrfID grfid = buf.ReadLabel<GrfID>();
 	std::string_view name = buf.ReadString();
 
 	if (_cur_gps.stage < GrfLoadingStage::Reserve && _cur_gps.grfconfig->status != GRFStatus::Unknown) {
@@ -65,7 +65,7 @@ static void GRFInfo(ByteReader &buf)
 	}
 
 	if (_cur_gps.grffile->grfid != grfid) {
-		Debug(grf, 0, "GRFInfo: GRFID {:08X} in FILESCAN stage does not match GRFID {:08X} in INIT/RESERVE/ACTIVATION stage", std::byteswap(_cur_gps.grffile->grfid), std::byteswap(grfid));
+		Debug(grf, 0, "GRFInfo: GRFID {} in FILESCAN stage does not match GRFID {} in INIT/RESERVE/ACTIVATION stage", FormatArrayAsHex(_cur_gps.grffile->grfid), FormatArrayAsHex(grfid));
 		_cur_gps.grffile->grfid = grfid;
 	}
 
@@ -73,7 +73,7 @@ static void GRFInfo(ByteReader &buf)
 	_cur_gps.grfconfig->status = _cur_gps.stage < GrfLoadingStage::Reserve ? GRFStatus::Initialised : GRFStatus::Activated;
 
 	/* Do swap the GRFID for displaying purposes since people expect that */
-	Debug(grf, 1, "GRFInfo: Loaded GRFv{} set {:08X} - {} (palette: {}, version: {})", version, std::byteswap(grfid), StrMakeValid(name), (_cur_gps.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur_gps.grfconfig->version);
+	Debug(grf, 1, "GRFInfo: Loaded GRFv{} set {} - {} (palette: {}, version: {})", version, FormatArrayAsHex(grfid), StrMakeValid(name), (_cur_gps.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur_gps.grfconfig->version);
 }
 
 /** @copydoc GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -149,7 +149,7 @@ static uint32_t PerformGRM(std::span<GrfID> grm, uint16_t count, uint8_t op, uin
 	if (op == 6) {
 		/* Return GRFID of set that reserved ID */
 		uint32_t index = _cur_gps.grffile->GetParam(target);
-		if (index < std::size(grm)) return grm[index];
+		if (index < std::size(grm)) return FlattenNewGRFLabel(grm[index]);
 
 		GrfMsg(1, "ParamSet: GRM: Parameter {} refers to invalid {} id {}", target, type, index);
 		return 0;
@@ -159,7 +159,7 @@ static uint32_t PerformGRM(std::span<GrfID> grm, uint16_t count, uint8_t op, uin
 	if (op == 2 || op == 3) start = _cur_gps.grffile->GetParam(target);
 
 	for (uint i = start; i < std::size(grm); i++) {
-		if (grm[i] == 0) {
+		if (grm[i].Empty()) {
 			size++;
 		} else {
 			if (op == 2 || op == 3) break;
@@ -329,8 +329,9 @@ static void ParamSet(ByteReader &buf)
 			}
 		} else {
 			/* Read another GRF File's parameter */
-			const GRFFile *file = GetFileByGRFID(data);
-			GRFConfig *c = GetGRFConfig(data);
+			GrfID grfid = UnflattenNewGRFLabel<GrfID>(data);
+			const GRFFile *file = GetFileByGRFID(grfid);
+			GRFConfig *c = GetGRFConfig(grfid);
 			if (c != nullptr && c->flags.Test(GRFConfigFlag::Static) && !_cur_gps.grfconfig->flags.Test(GRFConfigFlag::Static) && _networking) {
 				/* Disable the read GRF if it is a static NewGRF. */
 				DisableStaticNewGRFInfluencingNonStaticNewGRFs(*c);

--- a/src/newgrf/newgrf_acte.cpp
+++ b/src/newgrf/newgrf_acte.cpp
@@ -27,7 +27,7 @@ static void SafeGRFInhibit(ByteReader &buf)
 	uint8_t num = buf.ReadByte();
 
 	for (uint i = 0; i < num; i++) {
-		GrfID grfid = buf.ReadDWord();
+		GrfID grfid = buf.ReadLabel<GrfID>();
 
 		/* GRF is unsafe it if tries to deactivate other GRFs */
 		if (grfid != _cur_gps.grfconfig->ident.grfid) {
@@ -48,7 +48,7 @@ static void GRFInhibit(ByteReader &buf)
 	uint8_t num = buf.ReadByte();
 
 	for (uint i = 0; i < num; i++) {
-		GrfID grfid = buf.ReadDWord();
+		GrfID grfid = buf.ReadLabel<GrfID>();
 		GRFConfig *file = GetGRFConfig(grfid);
 
 		/* Unset activation flag */

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -61,7 +61,7 @@ AirportSpec AirportSpec::specs[NUM_AIRPORTS]; ///< Airport specifications.
 	assert(type < lengthof(AirportSpec::specs));
 	const AirportSpec *as = &AirportSpec::specs[type];
 	if (type >= NEW_AIRPORT_OFFSET && !as->enabled) {
-		if (_airport_mngr.GetGRFID(type) == 0) return as;
+		if (_airport_mngr.GetGRFID(type).Empty()) return as;
 		uint8_t subst_id = _airport_mngr.GetSubstituteID(type);
 		if (subst_id == AT_INVALID) return as;
 		as = &AirportSpec::specs[subst_id];

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -76,7 +76,7 @@ void OverrideManagerBase::ResetMapping()
 void OverrideManagerBase::ResetOverride()
 {
 	std::fill(this->entity_overrides.begin(), this->entity_overrides.end(), this->invalid_id);
-	std::fill(this->grfid_overrides.begin(), this->grfid_overrides.end(), uint32_t());
+	std::fill(this->grfid_overrides.begin(), this->grfid_overrides.end(), GrfID{});
 }
 
 /**
@@ -118,7 +118,7 @@ uint16_t OverrideManagerBase::AddEntityID(uint16_t grf_local_id, GrfID grfid, ui
 	for (id = this->max_offset; id < this->max_entities; id++) {
 		EntityIDMapping *map = &this->mappings[id];
 
-		if (CheckValidNewID(id) && map->entity_id == 0 && map->grfid == 0) {
+		if (CheckValidNewID(id) && map->entity_id == 0 && map->grfid.Empty()) {
 			map->entity_id     = grf_local_id;
 			map->grfid         = grfid;
 			map->substitute_id = substitute_id;
@@ -223,7 +223,7 @@ uint16_t IndustryOverrideManager::AddEntityID(uint16_t grf_local_id, GrfID grfid
 		if (!inds->enabled && !inds->grf_prop.HasGrfFile()) {
 			EntityIDMapping *map = &this->mappings[id];
 
-			if (map->entity_id == 0 && map->grfid == 0) {
+			if (map->entity_id == 0 && map->grfid.Empty()) {
 				/* winning slot, mark it as been used */
 				map->entity_id     = grf_local_id;
 				map->grfid         = grfid;

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -304,7 +304,7 @@ bool FillGRFDetails(GRFConfig &config, bool is_static, Subdirectory subdir)
 	config.FinalizeParameterInfo();
 
 	/* Skip if the grfid is 0 (not read) or if it is an internal GRF */
-	if (config.ident.grfid == 0 || config.flags.Test(GRFConfigFlag::System)) return false;
+	if (config.ident.grfid.Empty() || config.flags.Test(GRFConfigFlag::System)) return false;
 
 	if (is_static) {
 		/* Perform a 'safety scan' for static GRFs */
@@ -438,7 +438,7 @@ GRFListCompatibility IsGoodGRFConfigList(GRFConfigList &grfconfig)
 			 * same grfid, as it most likely is compatible */
 			f = FindGRFConfig(c->ident.grfid, FindGRFConfigMode::Compatible, nullptr, c->version);
 			if (f != nullptr) {
-				Debug(grf, 1, "NewGRF {:08X} ({}) not found; checksum {}. Compatibility mode on", std::byteswap(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
+				Debug(grf, 1, "NewGRF {} ({}) not found; checksum {}. Compatibility mode on", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
 				if (!c->flags.Test(GRFConfigFlag::Compatible)) {
 					/* Preserve original_md5sum after it has been assigned */
 					c->flags.Set(GRFConfigFlag::Compatible);
@@ -451,13 +451,13 @@ GRFListCompatibility IsGoodGRFConfigList(GRFConfigList &grfconfig)
 			}
 
 			/* No compatible grf was found, mark it as disabled */
-			Debug(grf, 0, "NewGRF {:08X} ({}) not found; checksum {}", std::byteswap(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
+			Debug(grf, 0, "NewGRF {} ({}) not found; checksum {}", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
 
 			c->status = GRFStatus::NotFound;
 			res = GRFListCompatibility::NotFound;
 		} else {
 compatible_grf:
-			Debug(grf, 1, "Loading GRF {:08X} from {}", std::byteswap(f->ident.grfid), f->filename);
+			Debug(grf, 1, "Loading GRF {} from {}", FormatArrayAsHex(f->ident.grfid), f->filename);
 			/* The filename could be the filename as in the savegame. As we need
 			 * to load the GRF here, we need the correct filename, so overwrite that
 			 * in any case and set the name and info when it is not set already.
@@ -625,7 +625,7 @@ const GRFConfig *FindGRFConfig(GrfID grfid, FindGRFConfigMode mode, const MD5Has
  */
 GRFConfig *GetGRFConfig(GrfID grfid, uint32_t mask)
 {
-	auto it = std::ranges::find_if(_grfconfig, [grfid, mask](const auto &c) { return (c->ident.grfid & mask) == (grfid & mask); });
+	auto it = std::ranges::find_if(_grfconfig, [grfid, mask](const auto &c) { return (FlattenNewGRFLabel(c->ident.grfid) & mask) == (FlattenNewGRFLabel(grfid) & mask); });
 	if (it != std::end(_grfconfig)) return it->get();
 
 	return nullptr;

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -478,7 +478,7 @@ struct NewGRFInspectWindow : Window {
 		auto psa = nih.GetPSA(index, this->caller_grfid);
 		if (!psa.empty()) {
 			if (nih.PSAWithParameter()) {
-				this->DrawString(r, i++, fmt::format("Persistent storage [{:08X}]:", std::byteswap(this->caller_grfid)));
+				this->DrawString(r, i++, fmt::format("Persistent storage [{}]:", FormatArrayAsHex(this->caller_grfid)));
 			} else {
 				this->DrawString(r, i++, "Persistent storage:");
 			}

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -12,6 +12,7 @@
 #include "train.h"
 #include "roadveh.h"
 #include "company_func.h"
+#include "newgrf.h"
 #include "newgrf_badge.h"
 #include "newgrf_cargo.h"
 #include "newgrf_spritegroup.h"
@@ -421,7 +422,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 	/* Calculated vehicle parameters */
 	switch (variable) {
 		case 0x25: // Get engine GRF ID
-			return v->GetGRFID();
+			return FlattenNewGRFLabel(v->GetGRFID());
 
 		case 0x40: // Get length of consist
 			if (!HasBit(v->grf_cache.cache_valid, NCVV_POSITION_CONSIST_LENGTH)) {

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -101,7 +101,7 @@ static void ShowNewGRFInfo(const GRFConfig &c, const Rect &r, bool show_params)
 	}
 
 	/* Prepare and draw GRF ID */
-	tr.top = DrawStringMultiLine(tr, GetString(STR_NEWGRF_SETTINGS_GRF_ID, fmt::format("{:08X}", std::byteswap(c.ident.grfid))));
+	tr.top = DrawStringMultiLine(tr, GetString(STR_NEWGRF_SETTINGS_GRF_ID, FormatArrayAsHex(c.ident.grfid)));
 
 	if ((_settings_client.gui.newgrf_developer_tools || _settings_client.gui.newgrf_show_old_versions) && c.version != 0) {
 		tr.top = DrawStringMultiLine(tr, GetString(STR_NEWGRF_SETTINGS_VERSION, c.version));
@@ -1513,7 +1513,7 @@ void ShowMissingContentWindow(const GRFConfigList &list)
 		ci->type = ContentType::NewGRF;
 		ci->state = ContentInfo::State::DoesNotExist;
 		ci->name = c->GetName();
-		ci->unique_id = std::byteswap(c->ident.grfid);
+		ci->unique_id = FlattenNewGRFLabel(c->ident.grfid);
 		ci->md5sum = c->flags.Test(GRFConfigFlag::Compatible) ? c->original_md5sum : c->ident.md5sum;
 		cv.push_back(std::move(ci));
 	}

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -445,7 +445,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 			if (house_id < NEW_HOUSE_OFFSET) return 0;
 			/* Checking the grffile information via HouseSpec doesn't work
 			 * in case the newgrf was removed. */
-			return _house_mngr.GetGRFID(house_id);
+			return FlattenNewGRFLabel(_house_mngr.GetGRFID(house_id));
 		}
 
 		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, HouseSpec::Get(this->house_id)->badges, parameter);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -128,12 +128,12 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 			break;
 
 		case 0xFFFFFFFF: // current grf
-			grf_id = GetIndustrySpec(current->type)->grf_prop.grfid;
+			grf_id = FlattenNewGRFLabel(GetIndustrySpec(current->type)->grf_prop.grfid);
 			[[fallthrough]];
 
 		default: // use the grfid specified in register 100h
 			SetBit(param_set_id, 7); // bit 7 means it is not an old type
-			industry_type = MapNewGRFIndustryType(param_set_id, grf_id);
+			industry_type = MapNewGRFIndustryType(param_set_id, UnflattenNewGRFLabel<GrfID>(grf_id));
 			break;
 	}
 

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -247,11 +247,11 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 			break;
 
 		case 0xFFFFFFFF: // current grf
-			grf_id = grfid;
+			grf_id = FlattenNewGRFLabel(grfid);
 			[[fallthrough]];
 
 		default: // use the grfid specified in register 100h
-			idx = _object_mngr.GetID(local_id, grf_id);
+			idx = _object_mngr.GetID(local_id, UnflattenNewGRFLabel<GrfID>(grf_id));
 			break;
 	}
 

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -112,14 +112,14 @@ uint32_t NewGRFProfiler::Finish()
 	if (!this->active) return 0;
 
 	if (this->calls.empty()) {
-		IConsolePrint(CC_DEBUG, "Finished profile of NewGRF [{:08X}], no events collected, not writing a file.", std::byteswap(this->grffile->grfid));
+		IConsolePrint(CC_DEBUG, "Finished profile of NewGRF [{}], no events collected, not writing a file.", FormatArrayAsHex(this->grffile->grfid));
 
 		this->Abort();
 		return 0;
 	}
 
 	std::string filename = this->GetOutputFilename();
-	IConsolePrint(CC_DEBUG, "Finished profile of NewGRF [{:08X}], writing {} events to '{}'.", std::byteswap(this->grffile->grfid), this->calls.size(), filename);
+	IConsolePrint(CC_DEBUG, "Finished profile of NewGRF [{}], writing {} events to '{}'.", FormatArrayAsHex(this->grffile->grfid), this->calls.size(), filename);
 
 	uint32_t total_microseconds = 0;
 
@@ -151,7 +151,7 @@ void NewGRFProfiler::Abort()
  */
 std::string NewGRFProfiler::GetOutputFilename() const
 {
-	return fmt::format("{}grfprofile-{:%Y%m%d-%H%M}-{:08X}.csv", FiosGetScreenshotDir(), fmt::localtime(time(nullptr)), std::byteswap(this->grffile->grfid));
+	return fmt::format("{}grfprofile-{:%Y%m%d-%H%M}-{}.csv", FiosGetScreenshotDir(), fmt::localtime(time(nullptr)), FormatArrayAsHex(this->grffile->grfid));
 }
 
 /* static */ uint32_t NewGRFProfiler::FinishAll()

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -191,7 +191,7 @@ uint32_t RoadStopScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] u
 			if (!IsCustomRoadStopSpecIndex(nearby_tile)) return 0;
 
 			const auto &sm = BaseStation::GetByTile(nearby_tile)->roadstop_speclist[GetCustomRoadStopSpecIndex(nearby_tile)];
-			return sm.grfid;
+			return FlattenNewGRFLabel(sm.grfid);
 		}
 
 		/* 16 bit road stop ID of nearby tiles */
@@ -611,7 +611,7 @@ std::optional<uint8_t> AllocateSpecToRoadStop(const RoadStopSpec *spec, BaseStat
 
 	/* Try to find an unused spec slot */
 	for (i = 1; i < st->roadstop_speclist.size() && i < NUM_ROADSTOPSPECS_PER_STATION; i++) {
-		if (st->roadstop_speclist[i].spec == nullptr && st->roadstop_speclist[i].grfid == 0) break;
+		if (st->roadstop_speclist[i].spec == nullptr && st->roadstop_speclist[i].grfid.Empty()) break;
 	}
 
 	if (i == NUM_ROADSTOPSPECS_PER_STATION) {
@@ -666,7 +666,7 @@ void DeallocateSpecFromRoadStop(BaseStation *st, uint8_t specindex)
 	if (specindex == st->roadstop_speclist.size() - 1) {
 		size_t num_specs;
 		for (num_specs = st->roadstop_speclist.size() - 1; num_specs > 0; num_specs--) {
-			if (st->roadstop_speclist[num_specs].grfid != 0) break;
+			if (!st->roadstop_speclist[num_specs].grfid.Empty()) break;
 		}
 
 		if (num_specs > 0) {

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -390,7 +390,7 @@ TownScopeResolver *StationResolverObject::GetTown()
 			if (!IsCustomStationSpecIndex(nearby_tile)) return 0;
 
 			const auto &sm = BaseStation::GetByTile(nearby_tile)->speclist[GetCustomStationSpecIndex(nearby_tile)];
-			return sm.grfid;
+			return FlattenNewGRFLabel(sm.grfid);
 		}
 
 		case 0x6B: { // 16 bit Station ID of nearby tiles
@@ -732,7 +732,7 @@ std::optional<uint8_t> AllocateSpecToStation(const StationSpec *spec, BaseStatio
 	if (st == nullptr) return 1;
 
 	for (i = 1; i < st->speclist.size() && i < NUM_STATIONSSPECS_PER_STATION; i++) {
-		if (st->speclist[i].spec == nullptr && st->speclist[i].grfid == 0) break;
+		if (st->speclist[i].spec == nullptr && st->speclist[i].grfid.Empty()) break;
 	}
 
 	if (i == NUM_STATIONSSPECS_PER_STATION) {
@@ -795,7 +795,7 @@ void DeallocateSpecFromStation(BaseStation *st, uint8_t specindex)
 	if (specindex == st->speclist.size() - 1) {
 		size_t num_specs;
 		for (num_specs = st->speclist.size() - 1; num_specs > 0; num_specs--) {
-			if (st->speclist[num_specs].grfid != 0) break;
+			if (!st->speclist[num_specs].grfid.Empty()) break;
 		}
 
 		if (num_specs > 0) {

--- a/src/newgrf_storage.cpp
+++ b/src/newgrf_storage.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "newgrf_storage.h"
 #include "core/pool_func.hpp"
+#include "string_func.h"
 #include "debug.h"
 
 #include "safeguards.h"
@@ -88,7 +89,7 @@ void AddChangedPersistentStorage(BasePersistentStorageArray *storage)
 
 	/* Discard all temporary changes */
 	for (auto &it : *_changed_storage_arrays) {
-		Debug(desync, 2, "warning: discarding persistent storage changes: Feature {}, GrfID {:08X}, Tile {}", it->feature, std::byteswap(it->grfid), it->tile);
+		Debug(desync, 2, "warning: discarding persistent storage changes: Feature {}, GrfID {}, Tile {}", it->feature, FormatArrayAsHex(it->grfid), it->tile);
 		it->ClearChanges();
 	}
 	_changed_storage_arrays->clear();

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -537,7 +537,7 @@ static StringID AddGRFString(GrfID grfid, GRFStringID stringid, GRFLanguage lang
 	std::string newtext = TranslateTTDPatchCodes(grfid, langid_to_add, allow_newlines, text_to_add);
 	AddGRFTextToList(it->textholder, langid_to_add, newtext);
 
-	GrfMsg(3, "Added 0x{:X} grfid {:08X} string 0x{:X} lang 0x{:X} string '{}' ({:X})", id, std::byteswap(grfid), stringid, langid_to_add, newtext, MakeStringID(TEXT_TAB_NEWGRF_START, id));
+	GrfMsg(3, "Added 0x{:X} grfid {} string 0x{:X} lang 0x{:X} string '{}' ({:X})", id, FormatArrayAsHex(grfid), stringid, langid_to_add, newtext, MakeStringID(TEXT_TAB_NEWGRF_START, id));
 
 	return MakeStringID(TEXT_TAB_NEWGRF_START, id);
 }
@@ -639,7 +639,7 @@ std::optional<std::string_view> GetGRFStringFromGRFText(const GRFTextWrapper &te
 std::string_view GetGRFStringPtr(StringIndexInTab stringid)
 {
 	assert(stringid.base() < _grf_text.size());
-	assert(_grf_text[stringid].grfid != 0);
+	assert(!_grf_text[stringid].grfid.Empty());
 
 	auto str = GetGRFStringFromGRFText(_grf_text[stringid].textholder);
 	if (str.has_value()) return *str;

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -44,8 +44,8 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 		/* Get a variable from the persistent storage */
 		case 0x7C: {
 			/* Check the persistent storage for the GrfID stored in register 100h. */
-			GrfID grfid = static_cast<uint32_t>(this->ro.GetRegister(0x100));
-			if (grfid == 0xFFFFFFFF) {
+			GrfID grfid = UnflattenNewGRFLabel<GrfID>(this->ro.GetRegister(0x100));
+			if (grfid == INVALID_GRFID) {
 				if (this->ro.grffile == nullptr) return 0;
 				grfid = this->ro.grffile->grfid;
 			}
@@ -140,10 +140,10 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 	if (this->ro.grffile == nullptr) return;
 
 	/* Check the persistent storage for the GrfID stored in register 100h. */
-	GrfID grfid = static_cast<uint32_t>(this->ro.GetRegister(0x100));
+	GrfID grfid = UnflattenNewGRFLabel<GrfID>(this->ro.GetRegister(0x100));
 
 	/* A NewGRF can only write in the persistent storage associated to its own GRFID. */
-	if (grfid == 0xFFFFFFFF) grfid = this->ro.grffile->grfid;
+	if (grfid == INVALID_GRFID) grfid = this->ro.grffile->grfid;
 	if (grfid != this->ro.grffile->grfid) return;
 
 	/* Check if the storage exists. */

--- a/src/newgrf_type.h
+++ b/src/newgrf_type.h
@@ -10,10 +10,12 @@
 #ifndef NEWGRF_TYPE_H
 #define NEWGRF_TYPE_H
 
+#include "core/label_type.hpp"
+
 struct GRFConfig;
 
-using GrfID = uint32_t; ///< The unique identifier of a NewGRF.
+using GrfID = Label<struct GrfIDTag>; ///< The unique identifier of a NewGRF.
 
-static const GrfID INVALID_GRFID = 0xFFFFFFFF; ///< An invalid NewGRF.
+static const GrfID INVALID_GRFID{"\xFF\xFF\xFF\xFF"}; ///< An invalid NewGRF.
 
 #endif /* NEWGRF_TYPE_H */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -246,7 +246,7 @@ static void WriteSavegameInfo(const std::string &name)
 	message += "NewGRFs:\n";
 	if (_load_check_data.HasNewGrfs()) {
 		for (const auto &c : _load_check_data.grfconfig) {
-			format_append(message, "{:08X} {} {}\n", std::byteswap(c->ident.grfid),
+			format_append(message, "{} {} {}\n", FormatArrayAsHex(c->ident.grfid),
 				FormatArrayAsHex(c->flags.Test(GRFConfigFlag::Compatible) ? c->original_md5sum : c->ident.md5sum), c->filename);
 		}
 	}

--- a/src/picker_gui.cpp
+++ b/src/picker_gui.cpp
@@ -80,8 +80,7 @@ static void PickerLoadConfig(const IniFile &ini, PickerCallbacks &callbacks)
 		}
 
 		for (const IniItem &item : group.items) {
-			std::array<uint8_t, 4> grfid_buf;
-
+			GrfID grfid;
 			std::string_view str = item.name;
 
 			/* Try reading "<grfid>|<localid>" */
@@ -89,10 +88,9 @@ static void PickerLoadConfig(const IniFile &ini, PickerCallbacks &callbacks)
 			if (grfid_pos == std::string_view::npos) continue;
 
 			std::string_view grfid_str = str.substr(0, grfid_pos);
-			if (!ConvertHexToBytes(grfid_str, grfid_buf)) continue;
+			if (!ConvertHexToBytes(grfid_str, grfid)) continue;
 
 			str = str.substr(grfid_pos + 1);
-			GrfID grfid = grfid_buf[0] | (grfid_buf[1] << 8) | (grfid_buf[2] << 16) | (grfid_buf[3] << 24);
 			uint16_t localid;
 			auto [ptr, err] = std::from_chars(str.data(), str.data() + str.size(), localid);
 
@@ -119,7 +117,7 @@ static void PickerSaveConfig(IniFile &ini, const PickerCallbacks &callbacks)
 		IniGroup &group = ini.GetOrCreateGroup(collection.first == "" ? callbacks.ini_group : callbacks.ini_group + "-" + collection.first);
 		group.Clear();
 		for (const PickerItem &item : collection.second) {
-			std::string key = fmt::format("{:08X}|{}", std::byteswap(item.grfid), item.local_id);
+			std::string key = fmt::format("{}|{}", FormatArrayAsHex(item.grfid), item.local_id);
 			group.CreateItem(key);
 		}
 	}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -385,12 +385,12 @@ static void CDECL HandleSavegameLoadCrash(int signum)
 		for (const auto &c : _grfconfig) {
 			if (c->flags.Test(GRFConfigFlag::Compatible)) {
 				const GRFIdentifier &replaced = _gamelog.GetOverriddenIdentifier(*c);
-				format_append(message, "NewGRF {:08X} (checksum {}) not found.\n  Loaded NewGRF \"{}\" (checksum {}) with same GRF ID instead.\n",
-						std::byteswap(c->ident.grfid), FormatArrayAsHex(c->original_md5sum), c->filename, FormatArrayAsHex(replaced.md5sum));
+				format_append(message, "NewGRF {} (checksum {}) not found.\n  Loaded NewGRF \"{}\" (checksum {}) with same GRF ID instead.\n",
+						FormatArrayAsHex(c->ident.grfid), FormatArrayAsHex(c->original_md5sum), c->filename, FormatArrayAsHex(replaced.md5sum));
 			}
 			if (c->status == GRFStatus::NotFound) {
-				format_append(message, "NewGRF {:08X} ({}) not found; checksum {}.\n",
-						std::byteswap(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
+				format_append(message, "NewGRF {} ({}) not found; checksum {}.\n",
+						FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
 			}
 		}
 	} else {

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -155,7 +155,7 @@ struct ENGSChunkHandler : ChunkHandler {
 
 /** Save and load the mapping between the engine id in the pool, and the grf file it came from. */
 static const SaveLoad _engine_id_mapping_desc[] = {
-	SLE_VAR(EngineIDMapping, grfid,         VarTypes::U32),
+	SLE_VAR(EngineIDMapping, grfid, VarTypes::LABEL),
 	SLE_VAR(EngineIDMapping, internal_id,   VarTypes::U16),
 	SLE_VAR(EngineIDMapping, type,          VarTypes::U8),
 	SLE_VAR(EngineIDMapping, substitute_id, VarTypes::U8),

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -127,7 +127,7 @@ public:
 class SlGamelogGrfadd : public DefaultSaveLoadHandler<SlGamelogGrfadd, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFAdd, grfid,  "grfadd.grfid",  VarTypes::U32    ),
+		SLE_VARNAME(LoggedChangeGRFAdd, grfid, "grfadd.grfid", VarTypes::LABEL),
 		SLE_ARRNAME(LoggedChangeGRFAdd, md5sum, "grfadd.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfadd_sl_compat;
@@ -150,7 +150,7 @@ public:
 class SlGamelogGrfrem : public DefaultSaveLoadHandler<SlGamelogGrfrem, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", VarTypes::U32),
+		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", VarTypes::LABEL),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfrem_sl_compat;
 
@@ -172,7 +172,7 @@ public:
 class SlGamelogGrfcompat : public DefaultSaveLoadHandler<SlGamelogGrfcompat, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFChanged, grfid,  "grfcompat.grfid",  VarTypes::U32    ),
+		SLE_VARNAME(LoggedChangeGRFChanged, grfid, "grfcompat.grfid", VarTypes::LABEL),
 		SLE_ARRNAME(LoggedChangeGRFChanged, md5sum, "grfcompat.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfcompat_sl_compat;
@@ -195,7 +195,7 @@ public:
 class SlGamelogGrfparam : public DefaultSaveLoadHandler<SlGamelogGrfparam, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", VarTypes::U32),
+		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", VarTypes::LABEL),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfparam_sl_compat;
 
@@ -217,7 +217,7 @@ public:
 class SlGamelogGrfmove : public DefaultSaveLoadHandler<SlGamelogGrfmove, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFMoved, grfid,  "grfmove.grfid",  VarTypes::U32),
+		SLE_VARNAME(LoggedChangeGRFMoved, grfid, "grfmove.grfid", VarTypes::LABEL),
 		SLE_VARNAME(LoggedChangeGRFMoved, offset, "grfmove.offset", VarTypes::I32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfmove_sl_compat;
@@ -241,7 +241,7 @@ class SlGamelogGrfbug : public DefaultSaveLoadHandler<SlGamelogGrfbug, LoggedCha
 public:
 	static inline const SaveLoad description[] = {
 		SLE_VARNAME(LoggedChangeGRFBug, data,  "grfbug.data",  VarTypes::U64),
-		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", VarTypes::U32),
+		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", VarTypes::LABEL),
 		SLE_VARNAME(LoggedChangeGRFBug, bug,   "grfbug.bug",   VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfbug_sl_compat;

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -37,7 +37,7 @@ struct RAILChunkHandler : ChunkHandler {
 	RAILChunkHandler() : ChunkHandler("RAIL", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::U32),
+		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::LABEL),
 	};
 
 	void Save() const override
@@ -72,7 +72,7 @@ struct ROTTChunkHandler : ChunkHandler {
 	ROTTChunkHandler() : ChunkHandler("ROTT", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::U32),
+		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::LABEL),
 		SLE_VAR(LabelObject<RoadTypeLabel>, subtype, VarTypes::U8),
 	};
 

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -19,7 +19,7 @@
 
 /** Save and load the mapping between a spec and the NewGRF it came from. */
 static const SaveLoad _newgrf_mapping_desc[] = {
-	SLE_VAR(EntityIDMapping, grfid,         VarTypes::U32),
+	SLE_VAR(EntityIDMapping, grfid, VarTypes::LABEL),
 	SLE_CONDVAR(EntityIDMapping, entity_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
 	SLE_CONDVAR(EntityIDMapping, entity_id, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(EntityIDMapping, substitute_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
@@ -34,7 +34,7 @@ void NewGRFMappingChunkHandler::Save() const
 	SlTableHeader(_newgrf_mapping_desc);
 
 	for (uint i = 0; i < this->mapping.GetMaxMapping(); i++) {
-		if (this->mapping.mappings[i].grfid == 0 &&
+		if (this->mapping.mappings[i].grfid.Empty() &&
 			this->mapping.mappings[i].entity_id == 0) continue;
 		SlSetArrayIndex(i);
 		SlObject(&this->mapping.mappings[i], _newgrf_mapping_desc);
@@ -69,7 +69,7 @@ struct NGRFChunkHandler : ChunkHandler {
 
 	static inline const SaveLoad description[] = {
 		   SLE_SSTR(GRFConfig, filename,         VarTypes::STR),
-		    SLE_VAR(GRFConfig, ident.grfid,      VarTypes::U32),
+		    SLE_VAR(GRFConfig, ident.grfid, VarTypes::LABEL),
 		    SLE_ARR(GRFConfig, ident.md5sum,     VarTypes::U8,  16),
 		SLE_CONDVAR(GRFConfig, version, VarTypes::U32, SaveLoadVersion::StoreNewGRFVersion, SaveLoadVersion::MaxVersion),
 		   SLEG_ARR("param", param,              VarTypes::U32, std::size(param)),

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -27,6 +27,7 @@
 #include "../engine_func.h"
 #include "../company_base.h"
 #include "../disaster_vehicle.h"
+#include "../string_func.h"
 #include "../timer/timer.h"
 #include "../timer/timer_game_tick.h"
 #include "../timer/timer_game_calendar.h"
@@ -1583,13 +1584,13 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 
 				ClearGRFConfigList(_grfconfig);
 				while (len != 0) {
-					GrfID grfid = ReadUint32(ls);
+					GrfID grfid = UnflattenNewGRFLabel<GrfID>(ReadUint32(ls));
 
 					if (ReadByte(ls) == 1) {
 						auto c = std::make_unique<GRFConfig>("TTDP game, no information");
 						c->ident.grfid = grfid;
 
-						Debug(oldloader, 3, "TTDPatch game using GRF file with GRFID {:08X}", std::byteswap(c->ident.grfid));
+						Debug(oldloader, 3, "TTDPatch game using GRF file with GRFID {}", FormatArrayAsHex(c->ident.grfid));
 						AppendToGRFConfigList(_grfconfig, std::move(c));
 					}
 					len -= 5;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -682,6 +682,7 @@ static inline uint SlCalcConvMemLen(VarMemType conv)
 		case VarMemType::I64: return sizeof(int64_t);
 		case VarMemType::U64: return sizeof(uint64_t);
 		case VarMemType::Null: return 0;
+		case VarMemType::Label: return sizeof(BaseLabel);
 
 		case VarMemType::Str:
 		case VarMemType::StrQ:
@@ -934,6 +935,13 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 {
 	switch (_sl.action) {
 		case SaveLoadAction::Save: {
+			if (conv == VarTypes::LABEL) {
+				/* Labels are a special case. They were read little endian but stored big endian, and as such reversed. */
+				BaseLabel *label = static_cast<BaseLabel *>(ptr);
+				for (auto it = label->rbegin(); it != label->rend(); it++) SlWriteByte(*it);
+				break;
+			}
+
 			int64_t x = ReadValue(ptr, conv.mem);
 
 			/* Write the value to the file and check if its value is in the desired range */
@@ -975,6 +983,13 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 		}
 		case SaveLoadAction::LoadCheck:
 		case SaveLoadAction::Load: {
+			if (conv == VarTypes::LABEL) {
+				/* Labels are a special case. They were read little endian but stored big endian, and as such reversed. */
+				BaseLabel *label = static_cast<BaseLabel *>(ptr);
+				for (auto it = label->rbegin(); it != label->rend(); it++) *it = SlReadByte();
+				break;
+			}
+
 			int64_t x;
 			/* Read a value from the file */
 			switch (conv.file) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -683,7 +683,6 @@ enum class VarFileType : uint8_t {
 
 /** The types/structures of data we have in memory. */
 enum class VarMemType : uint8_t {
-	/* 4 bits allocated a maximum of 16 types for NumberType */
 	Bool = 0, ///< A boolean value.
 	I8 = 1, ///< A 8 bit signed int.
 	U8 = 2, ///< A 8 bit unsigned int.
@@ -697,7 +696,7 @@ enum class VarMemType : uint8_t {
 	Str = 12, ///< string pointer
 	StrQ = 13, ///< string pointer enclosed in quotes
 	Name = 14, ///< old custom name to be converted to a string pointer
-	/* 1 more possible memory-primitives */
+	Label = 15, ///< A 4 character \c Label.
 };
 
 /** Container of a variable's characteristics about a variable's storage. */
@@ -769,6 +768,7 @@ struct VarTypes {
 	static constexpr VarType STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
 	static constexpr VarType STRQ{ VarFileType::String, VarMemType::StrQ }; ///< Store a string with quotes.
 	static constexpr VarType NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
+	static constexpr VarType LABEL{ VarFileType::U32, VarMemType::Label }; ///< Store a \c Label.
 };
 
 /** Type of data saved. */
@@ -841,6 +841,7 @@ inline constexpr size_t SlVarSize(VarMemType type)
 		case VarMemType::Str: return sizeof(std::string);
 		case VarMemType::StrQ: return sizeof(std::string);
 		case VarMemType::Name: return sizeof(std::string);
+		case VarMemType::Label: return sizeof(BaseLabel);
 		default: NOT_REACHED();
 	}
 }
@@ -884,6 +885,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_GENERAL_NAME(cmd, name, base, variable, type, length, from, to, extra) \
 	SaveLoad {name, cmd, type, length, from, to, [] (void *b, size_t) -> void * { \
 		static_assert(SlCheckVarSize(cmd, type, length, sizeof(static_cast<base *>(b)->variable))); \
+		static_assert(VarType{type}.mem != VarMemType::Label || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
 		assert(b != nullptr); \
 		return const_cast<void *>(static_cast<const void *>(std::addressof(static_cast<base *>(b)->variable))); \
 	}, extra, nullptr}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -113,11 +113,11 @@ void AfterLoadStations()
 	/* Update the speclists of all stations to point to the currently loaded custom stations. */
 	for (BaseStation *st : BaseStation::Iterate()) {
 		for (auto &sm : GetStationSpecList<StationSpec>(st)) {
-			if (sm.grfid == 0) continue;
+			if (sm.grfid.Empty()) continue;
 			sm.spec = StationClass::GetByGrf(sm.grfid, sm.localidx);
 		}
 		for (auto &sm : GetStationSpecList<RoadStopSpec>(st)) {
-			if (sm.grfid == 0) continue;
+			if (sm.grfid.Empty()) continue;
 			sm.spec = RoadStopClass::GetByGrf(sm.grfid, sm.localidx);
 		}
 
@@ -209,7 +209,7 @@ template <typename T>
 class SlStationSpecList : public VectorSaveLoadHandler<SlStationSpecList<T>, BaseStation, SpecMapping<T>> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(SpecMapping<T>, grfid, VarTypes::U32, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(SpecMapping<T>, grfid, VarTypes::LABEL, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(SpecMapping<T>, localidx, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::NewGRFStations, SaveLoadVersion::ExtendEntityMapping),
 		SLE_CONDVAR(SpecMapping<T>, localidx, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	};
@@ -430,7 +430,7 @@ public:
 		if (IsSavegameVersionBefore(SaveLoadVersion::PersistentStoragePool) && !IsSavegameVersionBefore(SaveLoadVersion::NewGRFAirportSmoke) && st->facilities.Test(StationFacility::Airport)) {
 			/* Store the old persistent storage. The GRFID will be added later. */
 			assert(PersistentStorage::CanAllocateItem());
-			st->airport.psa = PersistentStorage::Create(0, GrfSpecFeature::Invalid, TileIndex{});
+			st->airport.psa = PersistentStorage::Create(GrfID{}, GrfSpecFeature::Invalid, TileIndex{});
 			std::copy(std::begin(_old_st_persistent_storage.storage), std::end(_old_st_persistent_storage.storage), std::begin(st->airport.psa->storage));
 		}
 

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -18,7 +18,7 @@
 
 /** Description of the data to save and load in #PersistentStorage. */
 static const SaveLoad _storage_desc[] = {
-	 SLE_CONDVAR(PersistentStorage, grfid, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(PersistentStorage, grfid, VarTypes::LABEL, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	 SLE_CONDARR(PersistentStorage, storage, VarTypes::U32, 16, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::ExtendPersistentStorage),
 	 SLE_CONDARR(PersistentStorage, storage, VarTypes::U32, 256, SaveLoadVersion::ExtendPersistentStorage, SaveLoadVersion::MaxVersion),
 };
@@ -35,7 +35,7 @@ struct PSACChunkHandler : ChunkHandler {
 
 		while ((index = SlIterateArray()) != -1) {
 			assert(PersistentStorage::CanAllocateItem());
-			PersistentStorage *ps = PersistentStorage::CreateAtIndex(PersistentStorageID(index), 0, GrfSpecFeature::Invalid, TileIndex{});
+			PersistentStorage *ps = PersistentStorage::CreateAtIndex(PersistentStorageID(index), GrfID{}, GrfSpecFeature::Invalid, TileIndex{});
 			SlObject(ps, slt);
 		}
 	}

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -299,7 +299,7 @@ static const SaveLoad _town_desc[] = {
 	SLE_CONDVAR(Town, xy, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
 	SLE_CONDVAR(Town, xy, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Town, townnamegrfid, VarTypes::U32, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, townnamegrfid, VarTypes::LABEL, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
 	    SLE_VAR(Town, townnametype,          VarTypes::U16),
 	    SLE_VAR(Town, townnameparts,         VarTypes::U32),
 	SLE_CONDSSTR(Town, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
@@ -410,7 +410,7 @@ struct CITYChunkHandler : ChunkHandler {
 				t->valid_history = 1U << LAST_MONTH;
 			}
 
-			if (t->townnamegrfid == 0 && !IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END) && GetStringTab(t->townnametype) != TEXT_TAB_OLD_CUSTOM) {
+			if (t->townnamegrfid.Empty() && !IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END) && GetStringTab(t->townnametype) != TEXT_TAB_OLD_CUSTOM) {
 				SlErrorCorrupt("Invalid town name generator");
 			}
 		}

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -181,7 +181,7 @@ static const SaveLoad _old_waypoint_desc[] = {
 	SLE_CONDVAR(OldWaypoint, build_date, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::BigDates),
 	SLE_CONDVAR(OldWaypoint, build_date, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(OldWaypoint, localidx, VarTypes::U8, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(OldWaypoint, grfid, VarTypes::U32, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, grfid, VarTypes::LABEL, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(OldWaypoint, owner, VarTypes::U8, SaveLoadVersion::NewGRFPalette, SaveLoadVersion::MaxVersion),
 };
 

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -87,7 +87,7 @@ public:
 		message += "NewGRFs:\n";
 		if (_game_mode != GameMode::Menu) {
 			for (const auto &c : _grfconfig) {
-				format_append(message, "{:08X} {} {}\n", std::byteswap(c->ident.grfid), FormatArrayAsHex(c->ident.md5sum), c->filename);
+				format_append(message, "{} {} {}\n", FormatArrayAsHex(c->ident.grfid), FormatArrayAsHex(c->ident.md5sum), c->filename);
 			}
 		}
 		message += "\nCompanies:\n";

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -161,6 +161,5 @@
 {
 	EnforcePrecondition(IT_INVALID, IsInsideBS(grf_local_id, 0x00, NUM_INDUSTRYTYPES_PER_GRF));
 
-	grfid = std::byteswap(GB(grfid, 0, 32)); // Match people's expectations.
-	return _industry_mngr.GetID(grf_local_id, grfid);
+	return _industry_mngr.GetID(grf_local_id, UnflattenNewGRFLabel<GrfID>(grfid));
 }

--- a/src/script/api/script_newgrf.cpp
+++ b/src/script/api/script_newgrf.cpp
@@ -11,6 +11,7 @@
 #include "script_newgrf.hpp"
 #include "../../core/bitmath_func.hpp"
 #include "../../newgrf_config.h"
+#include "../../newgrf.h"
 #include "../../string_func.h"
 
 #include "../../safeguards.h"
@@ -19,23 +20,23 @@ ScriptNewGRFList::ScriptNewGRFList()
 {
 	for (const auto &c : _grfconfig) {
 		if (!c->flags.Test(GRFConfigFlag::Static)) {
-			this->AddItem(std::byteswap(c->ident.grfid));
+			this->AddItem(FlattenNewGRFLabel(c->ident.grfid));
 		}
 	}
 }
 
 /* static */ bool ScriptNewGRF::IsLoaded(SQInteger grfid)
 {
-	grfid = std::byteswap(GB(grfid, 0, 32)); // Match people's expectations.
+	GrfID id = UnflattenNewGRFLabel<GrfID>(grfid);
 
-	return std::ranges::any_of(_grfconfig, [grfid](const auto &c) { return !c->flags.Test(GRFConfigFlag::Static) && c->ident.grfid == grfid; });
+	return std::ranges::any_of(_grfconfig, [id](const auto &c) { return !c->flags.Test(GRFConfigFlag::Static) && c->ident.grfid == id; });
 }
 
 /* static */ SQInteger ScriptNewGRF::GetVersion(SQInteger grfid)
 {
-	grfid = std::byteswap(GB(grfid, 0, 32)); // Match people's expectations.
+	GrfID id = UnflattenNewGRFLabel<GrfID>(grfid);
 
-	auto it = std::ranges::find_if(_grfconfig, [grfid](const auto &c) { return !c->flags.Test(GRFConfigFlag::Static) && c->ident.grfid == grfid; });
+	auto it = std::ranges::find_if(_grfconfig, [id](const auto &c) { return !c->flags.Test(GRFConfigFlag::Static) && c->ident.grfid == id; });
 	if (it != std::end(_grfconfig)) return (*it)->version;
 
 	return 0;
@@ -43,9 +44,9 @@ ScriptNewGRFList::ScriptNewGRFList()
 
 /* static */ std::optional<std::string> ScriptNewGRF::GetName(SQInteger grfid)
 {
-	grfid = std::byteswap(GB(grfid, 0, 32)); // Match people's expectations.
+	GrfID id = UnflattenNewGRFLabel<GrfID>(grfid);
 
-	auto it = std::ranges::find_if(_grfconfig, [grfid](const auto &c) { return !c->flags.Test(GRFConfigFlag::Static) && c->ident.grfid == grfid; });
+	auto it = std::ranges::find_if(_grfconfig, [id](const auto &c) { return !c->flags.Test(GRFConfigFlag::Static) && c->ident.grfid == id; });
 	if (it != std::end(_grfconfig)) return (*it)->GetName();
 
 	return std::nullopt;

--- a/src/script/api/script_objecttype.cpp
+++ b/src/script/api/script_objecttype.cpp
@@ -52,6 +52,5 @@
 {
 	EnforcePrecondition(INVALID_OBJECT_TYPE, IsInsideBS(grf_local_id, 0x00, NUM_OBJECTS_PER_GRF));
 
-	grfid = std::byteswap(GB(grfid, 0, 32)); // Match people's expectations.
-	return _object_mngr.GetID(grf_local_id, grfid);
+	return _object_mngr.GetID(grf_local_id, UnflattenNewGRFLabel<GrfID>(grfid));
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1095,7 +1095,7 @@ static GRFConfigList GRFLoadConfig(const IniFile &ini, std::string_view grpname,
 	for (const IniItem &item : group->items) {
 		std::unique_ptr<GRFConfig> c{};
 
-		std::array<uint8_t, 4> grfid_buf;
+		GrfID grfid;
 		MD5Hash md5sum;
 		std::string_view item_name = item.name;
 		bool has_md5sum = false;
@@ -1105,7 +1105,7 @@ static GRFConfigList GRFLoadConfig(const IniFile &ini, std::string_view grpname,
 		if (grfid_pos != std::string_view::npos) {
 			std::string_view grfid_str = item_name.substr(0, grfid_pos);
 
-			if (ConvertHexToBytes(grfid_str, grfid_buf)) {
+			if (ConvertHexToBytes(grfid_str, grfid)) {
 				item_name = item_name.substr(grfid_pos + 1);
 
 				auto md5sum_pos = item_name.find("|");
@@ -1116,7 +1116,6 @@ static GRFConfigList GRFLoadConfig(const IniFile &ini, std::string_view grpname,
 					if (has_md5sum) item_name = item_name.substr(md5sum_pos + 1);
 				}
 
-				GrfID grfid = grfid_buf[0] | (grfid_buf[1] << 8) | (grfid_buf[2] << 16) | (grfid_buf[3] << 24);
 				if (has_md5sum) {
 					const GRFConfig *s = FindGRFConfig(grfid, FindGRFConfigMode::Exact, &md5sum);
 					if (s != nullptr) c = std::make_unique<GRFConfig>(*s);
@@ -1284,7 +1283,7 @@ static void GRFSaveConfig(IniFile &ini, std::string_view grpname, const GRFConfi
 	group.Clear();
 
 	for (const auto &c : list) {
-		std::string key = fmt::format("{:08X}|{}|{}", std::byteswap(c->ident.grfid),
+		std::string key = fmt::format("{}|{}|{}", FormatArrayAsHex(c->ident.grfid),
 				FormatArrayAsHex(c->ident.md5sum), c->filename);
 		group.GetOrCreateItem(key).SetValue(GRFBuildParamList(*c));
 	}

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -15,6 +15,7 @@
 #include "network/network.h"
 #include "rev.h"
 #include "settings_type.h"
+#include "string_func.h"
 #include "timer/timer_game_tick.h"
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_game_economy.h"
@@ -358,7 +359,7 @@ void SurveyTimers(nlohmann::json &survey)
 void SurveyGrfs(nlohmann::json &survey)
 {
 	for (const auto &c : _grfconfig) {
-		auto grfid = fmt::format("{:08x}", std::byteswap(c->ident.grfid));
+		auto grfid = fmt::format("{}", FormatArrayAsHex(c->ident.grfid));
 		auto &grf = survey[std::move(grfid)];
 
 		grf["md5sum"] = FormatArrayAsHex(c->ident.md5sum);

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -372,7 +372,7 @@ class NIHIndustry : public NIHelper {
 		return ro.GetScope(VarSpriteGroupScope::Self)->GetVariable(var, param, avail);
 	}
 
-	const std::span<int32_t> GetPSA(uint index, uint32_t) const override
+	const std::span<int32_t> GetPSA(uint index, GrfID) const override
 	{
 		const Industry *i = (const Industry *)this->GetInstance(index);
 		if (i->psa == nullptr) return {};
@@ -548,7 +548,7 @@ class NIHAirport : public NIHelper {
 		return ro.GetScope(VarSpriteGroupScope::Self)->GetVariable(var, param, avail);
 	}
 
-	const std::span<int32_t> GetPSA(uint index, uint32_t) const override
+	const std::span<int32_t> GetPSA(uint index, GrfID) const override
 	{
 		const Station *st = (const Station *)this->GetInstance(index);
 		if (st->airport.psa == nullptr) return {};

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -1596,7 +1596,7 @@ public:
 			}
 
 			for (const auto &item : group_it->second) {
-				if (item.grfid == 0) {
+				if (item.grfid.Empty()) {
 					const HouseSpec *hs = HouseSpec::Get(item.local_id);
 					if (hs == nullptr) continue;
 					int class_index = GetClassIdFromHouseZone(hs->building_availability);

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -30,7 +30,7 @@ TownNameParams::TownNameParams(const Town *t) :
 		grfid(t->townnamegrfid), // by default, use supplied data
 		type(t->townnametype)
 {
-	if (t->townnamegrfid != 0 && GetGRFTownName(t->townnamegrfid) == nullptr) {
+	if (!t->townnamegrfid.Empty() && GetGRFTownName(t->townnamegrfid) == nullptr) {
 		/* Fallback to the first built in town name (English). */
 		this->grfid = {};
 		this->type = SPECSTR_TOWNNAME_START;
@@ -47,7 +47,7 @@ TownNameParams::TownNameParams(const Town *t) :
  */
 static void GetTownName(StringBuilder &builder, const TownNameParams *par, uint32_t townnameparts)
 {
-	if (par->grfid == 0) {
+	if (par->grfid.Empty()) {
 		auto tmp_params = MakeParameters(townnameparts);
 		GetStringWithArgs(builder, par->type, tmp_params);
 		return;


### PR DESCRIPTION
## Motivation / Problem

We have `Label`s, and there are many `std::byteswap`s related to `GrfID` in the code that we could get rid of.

Also, the `GrfID` should get some type-safety attention as well.


## Description

Use `Label` for `GrfID`.

Make writing of the `GrfID` in logs/messages consistent by always using `FormatAsHexArray` over `{:x}`, `{:X}`, `{:08X}`, etcetera.


## Limitations

In some places there is no way to avoid going through the flattened NewGRF labels due to sending that data to the NewGRF or complicated parsing that requires a read-ahead.

Contains #15866 due to the saving of `Label`s in the save game.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
