### PR TITLE
Codechange: improve compile time type sanity checks for the saveload variables

### DIFF
--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -103,11 +103,19 @@ using Point = Coord2D<int>;
 
 /** Dimensions (a width and height) of a rectangle in 2D */
 struct Dimension {
-	uint width;
-	uint height;
+	using value_type = uint32_t; ///< The type of the values; hack to make this look enough like a std::array for saving/loading resolutions
+	value_type width = 0; ///< The width of the rectangle.
+	value_type height = 0; ///< The height of the rectangle.
 
-	constexpr Dimension() : width(0), height(0) {}
-	constexpr Dimension(uint w, uint h) : width(w), height(h) {}
+	/** Create a 0x0 dimension. */
+	constexpr Dimension() = default;
+
+	/**
+	 * Create a dimension.
+	 * @param w The width.
+	 * @param h The height.
+	 */
+	constexpr Dimension(value_type w, value_type h) : width(w), height(h) {}
 
 	bool operator< (const Dimension &other) const
 	{

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -12,6 +12,7 @@
 #include "saveload.h"
 #include "compat/company_sl_compat.h"
 
+#include "../autoreplace_base.h"
 #include "../company_func.h"
 #include "../company_manager_face.h"
 #include "../fios.h"

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -14,6 +14,7 @@
 
 #include "../economy_func.h"
 #include "../economy_base.h"
+#include "../vehicle_base.h"
 
 #include "../safeguards.h"
 

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -13,6 +13,7 @@
 #include "compat/industry_sl_compat.h"
 
 #include "../industry.h"
+#include "../town.h"
 #include "newgrf_sl.h"
 
 #include "../safeguards.h"

--- a/src/saveload/object_sl.cpp
+++ b/src/saveload/object_sl.cpp
@@ -14,6 +14,7 @@
 
 #include "../object_base.h"
 #include "../object_map.h"
+#include "../town.h"
 #include "newgrf_sl.h"
 
 #include "../safeguards.h"

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -15,6 +15,7 @@
 #include "saveload_internal.h"
 #include "../order_backup.h"
 #include "../settings_type.h"
+#include "../vehicle_base.h"
 #include "../network/network.h"
 
 #include "../safeguards.h"

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -816,25 +816,122 @@ inline constexpr size_t SlVarSize(VarMemType type)
 }
 
 /**
- * Check if a saveload cmd/type/length entry matches the size of the variable.
- * @param cmd SaveLoadType of entry.
- * @param type VarType of entry.
- * @param length Array length of entry.
- * @param size Actual size of variable.
- * @return true iff the sizes match.
+ * Check whether the given memory type is valid for the file type.
+ * @param mem_type The way the data is stored in memory.
+ * @param file_type The way the data is stored in the save game.
+ * @return \c true iff the memory and file type are consistent with each other.
  */
-inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t length, size_t size)
+inline constexpr bool SlMemTypeValidForFileType(VarMemType mem_type, VarFileType file_type)
 {
-	switch (cmd) {
-		case SaveLoadType::Variable: return SlVarSize(type.mem) == size;
-		case SaveLoadType::Reference: return sizeof(void *) == size;
-		case SaveLoadType::String: return SlVarSize(type.mem) == size;
-		case SaveLoadType::Array: return SlVarSize(type.mem) * length <= size; // Partial load of array is permitted.
-		case SaveLoadType::Vector: return sizeof(std::vector<void *>) == size;
-		case SaveLoadType::ReferenceList: return sizeof(std::list<void *>) == size;
-		case SaveLoadType::ReferenceVector: return sizeof(std::vector<void *>) == size;
-		case SaveLoadType::SaveByte: return true;
-		default: NOT_REACHED();
+	switch (mem_type) {
+		case VarMemType::Bool: return file_type == VarFileType::I8;
+		case VarMemType::I8:
+		case VarMemType::U8:
+		case VarMemType::I16:
+		case VarMemType::U16:
+		case VarMemType::I32:
+		case VarMemType::U32:
+		case VarMemType::I64:
+		case VarMemType::U64:
+			switch (file_type) {
+				case VarFileType::I8:
+				case VarFileType::U8:
+				case VarFileType::I16:
+				case VarFileType::U16:
+				case VarFileType::I32:
+				case VarFileType::U32:
+				case VarFileType::I64:
+				case VarFileType::U64:
+					return true;
+				case VarFileType::StringID:
+					return mem_type == VarMemType::U32;
+				default:
+					return false;
+			}
+
+		case VarMemType::Null: return true;
+		case VarMemType::Str:
+		case VarMemType::StrQ: return file_type == VarFileType::String;
+		case VarMemType::Name: return file_type == VarFileType::StringID;
+		case VarMemType::LabelReverse:
+		case VarMemType::LabelForward: return file_type == VarFileType::U32;
+		default: return false;
+	}
+}
+
+/**
+ * Check whether the numeric memory types match the actual type.
+ * @tparam T The actual type of the saved variable.
+ * @param type The VarType to compare to.
+ * @return \c true iff the types match.
+ */
+template <typename T>
+constexpr bool SlVarMemTypeMatches(VarMemType type)
+{
+	if constexpr (std::is_enum_v<T>) {
+		return SlVarMemTypeMatches<std::underlying_type_t<T>>(type);
+	} else if constexpr (ConvertibleThroughBase<T>) {
+		return SlVarMemTypeMatches<typename T::BaseType>(type);
+	} else {
+		switch (type) {
+			case VarMemType::Bool: return std::is_same_v<bool, T>;
+			case VarMemType::I8: return std::is_same_v<int8_t, T>;
+			case VarMemType::U8: return std::is_same_v<uint8_t, T> || std::is_same_v<char, T>;
+			case VarMemType::I16: return std::is_same_v<int16_t, T>;
+			case VarMemType::U16: return std::is_same_v<uint16_t, T>;
+			case VarMemType::I32: return std::is_same_v<int32_t, T>;
+			case VarMemType::U32: return std::is_same_v<uint32_t, T>;
+			case VarMemType::I64: return std::is_same_v<int64_t, T>;
+			case VarMemType::U64: return std::is_same_v<uint64_t, T>;
+			case VarMemType::Str:
+			case VarMemType::StrQ:
+			case VarMemType::Name: return std::is_same_v<std::string, T>;
+			case VarMemType::LabelForward:
+			case VarMemType::LabelReverse: return std::is_base_of_v<BaseLabel, T>;
+			default: NOT_REACHED();
+		}
+	}
+}
+
+/**
+ * Helper function to check/validate the \c SaveLoadType, \c VarMemType and (array) length
+ * for the configuration of the \c SaveLoad objects desribing the save format.
+ * @tparam sl_type The basic way of referencing the data.
+ * @tparam mem_type The way the data is stored in memory for variables.
+ * @tparam T The type that we are checking.
+ * @tparam length The length of arrays.
+ */
+template <SaveLoadType sl_type, VarMemType mem_type, VarFileType file_type, typename T, size_t length = 0>
+constexpr void SlCheckMemoryType()
+{
+	if constexpr (sl_type == SaveLoadType::Variable) {
+		static_assert(SlVarMemTypeMatches<T>(mem_type));
+		static_assert(SlMemTypeValidForFileType(mem_type, file_type));
+	} else if constexpr (sl_type == SaveLoadType::Reference) {
+		static_assert(requires { typename std::remove_pointer_t<T>::Pool; });
+	} else if constexpr (sl_type == SaveLoadType::String) {
+		static_assert(std::is_same_v<std::string, T> || std::is_same_v<EncodedString, T>);
+	} else if constexpr (sl_type == SaveLoadType::Array) {
+		static_assert(SlVarSize(mem_type) * length <= sizeof(T)); // Partial setting/filling of an array is permitted.
+		if constexpr (!std::is_integral_v<typename T::value_type> && !std::is_enum_v<typename T::value_type> && !ConvertibleThroughBase<typename T::value_type>) {
+			/* Try to iterate through std::arrays in std::arrays to validate the value type. The total length is already checked. */
+			SlCheckMemoryType<SaveLoadType::Array, mem_type, file_type, typename T::value_type>();
+		} else {
+			SlCheckMemoryType<SaveLoadType::Variable, mem_type, file_type, typename T::value_type, length>();
+		}
+	} else if constexpr (sl_type == SaveLoadType::Vector) {
+		static_assert(std::is_base_of_v<std::vector<typename T::value_type>, T>);
+		SlCheckMemoryType<SaveLoadType::Variable, mem_type, file_type, typename T::value_type>();
+	} else if constexpr (sl_type == SaveLoadType::ReferenceList) {
+		static_assert(std::is_base_of_v<std::list<typename T::value_type>, T>);
+		SlCheckMemoryType<SaveLoadType::Reference, mem_type, file_type, typename T::value_type>();
+	} else if constexpr (sl_type == SaveLoadType::ReferenceVector) {
+		static_assert(std::is_base_of_v<std::vector<typename T::value_type>, T>);
+		SlCheckMemoryType<SaveLoadType::Reference, mem_type, file_type, typename T::value_type>();
+	} else if constexpr (sl_type == SaveLoadType::SaveByte) {
+		SlCheckMemoryType<SaveLoadType::Variable, VarMemType::U8, VarFileType::U8, T>();
+	} else {
+		static_assert(false); // Better than NOT_REACHED() as this triggers compile-time, NOT_REACHED() does at run time.
 	}
 }
 
@@ -853,8 +950,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  */
 #define SLE_GENERAL_NAME(cmd, name, base, variable, type, length, from, to, extra) \
 	SaveLoad {name, cmd, type, length, from, to, [] (void *b, size_t) -> void * { \
-		static_assert(SlCheckVarSize(cmd, type, length, sizeof(static_cast<base *>(b)->variable))); \
-		static_assert((VarType{type}.mem != VarMemType::LabelReverse && VarType{type}.mem != VarMemType::LabelForward) || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
+		SlCheckMemoryType<cmd, VarType{type}.mem, VarType{type}.file, std::remove_cvref_t<decltype(base::variable)>, length>(); \
 		assert(b != nullptr); \
 		return const_cast<void *>(static_cast<const void *>(std::addressof(static_cast<base *>(b)->variable))); \
 	}, extra, nullptr}
@@ -1090,7 +1186,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  */
 #define SLEG_GENERAL(name, cmd, variable, type, length, from, to, extra) \
 	SaveLoad {name, cmd, type, length, from, to, [] (void *, size_t) -> void * { \
-		static_assert(SlCheckVarSize(cmd, type, length, sizeof(variable))); \
+		SlCheckMemoryType<cmd, VarType{type}.mem, VarType{type}.file, std::remove_cvref_t<decltype(variable)>, length>(); \
 		return static_cast<void *>(std::addressof(variable)); }, extra, nullptr}
 
 /**

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -18,6 +18,7 @@
 #include "../vehicle_base.h"
 #include "../newgrf_station.h"
 #include "../newgrf_roadstop.h"
+#include "../town.h"
 #include "../timer/timer_game_calendar.h"
 
 #include "table/strings.h"


### PR DESCRIPTION
## Motivation / Problem

I made a type boo-boo with the save game format not so long ago. I rather prevent future mistakes.


## Description

Introduce compile time type sanity checks to the creation of the save load variables. This checks whether the used types for variables are as expected, e.g.:
* std::vector for the vector-ish types.
* std::list for the list-ish types.
* std::array for the arry-ish types.
* type matching the `VarMemType` for variables (and the inner type of the previously mentioned collection types).
* checking `VarMemType` vs `VarFileType`; for example a string can't be stored in a u8, but a u8 can be stored in a i64 (and vice versa).

The added includes are due to the reference type check needing more than just a pointer. It needs the whole type to ensure that it's a pool type.


## Limitations

It ain't very pretty, but quite effective.

I am hoping to be able to remove most of `VarMemType` for the saveload mappings since it can be mostly determined from the underlying type, thus making most of these validation pointless. However, that is both beyond the scope of this PR and having the validations + ensuring everything is correct before making the leap is a good intermediate step.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
