### PR TITLE
Codechange: expose saveload.h less to the rest of the game

### DIFF
--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -18,7 +18,7 @@
 #include "source_type.h"
 #include "vehicle_type.h"
 #include "core/multimap.hpp"
-#include "saveload/saveload.h"
+#include "saveload/saveload_type.h"
 
 /** Unique identifier for a single cargo packet. */
 using CargoPacketID = PoolID<uint32_t, struct CargoPacketIDTag, 0xFFF000, 0xFFFFFF>;

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -13,7 +13,6 @@
 #include "company_base.h"
 #include "company_func.h"
 #include "currency_func.h"
-#include "saveload/saveload.h"
 #include "vehicle_base.h"
 #include "textbuf_gui.h"
 #include "window_gui.h"

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -13,7 +13,7 @@
 #include "debug.h"
 #include "engine_func.h"
 #include "landscape.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 #include "network/core/network_game_info.h"
 #include "network/network.h"
 #include "network/network_func.h"

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -15,7 +15,7 @@
 #include "music/music_driver.hpp"
 #include "sound/sound_driver.hpp"
 #include "video/video_driver.hpp"
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 #include "screenshot.h"
 #include "network/network_survey.h"
 #include "news_func.h"

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -8,7 +8,7 @@
 /** @file fios_gui.cpp GUIs for loading/saving games, scenarios, heightmaps, ... */
 
 #include "stdafx.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 #include "error.h"
 #include "gui.h"
 #include "gfx_func.h"

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -26,7 +26,7 @@
 #include "water.h"
 #include "video/video_driver.hpp"
 #include "tilehighlight_func.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 #include "void_map.h"
 #include "town.h"
 #include "newgrf.h"

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -24,7 +24,7 @@
 #include "town.h"
 #include "core/geometry_func.hpp"
 #include "core/random_func.hpp"
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 #include "progress.h"
 #include "error.h"
 #include "newgrf_townname.h"

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -14,7 +14,7 @@
 #include "strings_func.h"
 #include "void_map.h"
 #include "error.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 #include "bmp.h"
 #include "gfx_func.h"
 #include "fios.h"

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -33,7 +33,7 @@
 #include "tree_cmd.h"
 #include "company_func.h"
 #include "company_gui.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 #include "framerate_type.h"
 #include "landscape_cmd.h"
 #include "terraform_cmd.h"

--- a/src/league_cmd.cpp
+++ b/src/league_cmd.cpp
@@ -12,6 +12,7 @@
 #include "league_base.h"
 #include "command_type.h"
 #include "command_func.h"
+#include "company_base.h"
 #include "industry.h"
 #include "story_base.h"
 #include "town.h"

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -14,7 +14,7 @@
 #include "../station_base.h"
 #include "../cargotype.h"
 #include "../timer/timer_game_economy.h"
-#include "../saveload/saveload.h"
+#include "../saveload/saveload_type.h"
 #include "linkgraph_type.h"
 #include <utility>
 

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -36,7 +36,7 @@
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 
 #include "widgets/main_widget.h"
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -9,7 +9,7 @@
 
 #include "../stdafx.h"
 #include "network_gui.h"
-#include "../saveload/saveload.h"
+#include "../saveload/saveload_func.h"
 #include "../saveload/saveload_filter.h"
 #include "../command_func.h"
 #include "../console_func.h"

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -17,7 +17,7 @@
 #include "../console_func.h"
 #include "../company_base.h"
 #include "../command_func.h"
-#include "../saveload/saveload.h"
+#include "../saveload/saveload_func.h"
 #include "../saveload/saveload_filter.h"
 #include "../station_base.h"
 #include "../genworld.h"

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -15,7 +15,7 @@
 #include "tile_type.h"
 #include "vehicle_type.h"
 #include "base_consist.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_type.h"
 
 /** Unique identifier for an order backup. */
 using OrderBackupID = PoolID<uint8_t, struct OrderBackupIDTag, 255, 0xFF>;

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -18,7 +18,7 @@
 #include "station_type.h"
 #include "vehicle_type.h"
 #include "timer/timer_game_tick.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_type.h"
 
 using OrderListPool = Pool<OrderList, OrderListID, 128>;
 extern OrderListPool _orderlist_pool;

--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -12,7 +12,7 @@
 #include "../../fileio_func.h"
 #include "../../string_func.h"
 #include "../../gamelog.h"
-#include "../../saveload/saveload.h"
+#include "../../saveload/saveload_func.h"
 #include "../../video/video_driver.hpp"
 #include "macos.h"
 

--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -12,7 +12,7 @@
 #include "../../fileio_func.h"
 #include "../../string_func.h"
 #include "../../gamelog.h"
-#include "../../saveload/saveload.h"
+#include "../../saveload/saveload_func.h"
 
 #include <setjmp.h>
 #include <signal.h>

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -15,7 +15,7 @@
 #include "../../fileio_func.h"
 #include "../../strings_func.h"
 #include "../../gamelog.h"
-#include "../../saveload/saveload.h"
+#include "../../saveload/saveload_func.h"
 #include "../../video/video_driver.hpp"
 #include "../../library_loader.h"
 

--- a/src/saveload/CMakeLists.txt
+++ b/src/saveload/CMakeLists.txt
@@ -34,7 +34,9 @@ add_files(
     saveload.cpp
     saveload.h
     saveload_filter.h
+    saveload_func.h
     saveload_internal.h
+    saveload_type.h
     settings_sl.cpp
     signs_sl.cpp
     station_sl.cpp

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -10,7 +10,9 @@
 #ifndef SAVELOAD_H
 #define SAVELOAD_H
 
+#include "saveload_type.h"
 #include "saveload_error.hpp"
+#include "saveload_func.h"
 #include "../core/label_type.hpp"
 #include "../fileio_type.h"
 #include "../fios.h"
@@ -422,24 +424,6 @@ enum class SaveLoadVersion : uint16_t {
 	MaxVersion, ///< Highest possible saveload version.
 };
 
-/** Save or load result codes. */
-enum class SaveLoadResult : uint8_t {
-	Ok, ///< completed successfully
-	Error, ///< error that was caught before internal structures were modified
-	ReInit, ///< error that was caught in the middle of updating game state, need to clear it. (can only happen during load)
-};
-
-/** Deals with the type of the savegame, independent of extension */
-struct FileToSaveLoad {
-	SaveLoadOperation file_op;       ///< File operation to perform.
-	FiosType ftype;                  ///< File type.
-	std::string name;                ///< Name of the file.
-	EncodedString title;             ///< Internal name of the game.
-
-	void SetMode(const FiosType &ft, SaveLoadOperation fop = SaveLoadOperation::Load);
-	void Set(const FiosItem &item);
-};
-
 /** Types of save games. */
 enum SavegameType : uint8_t {
 	TTD, ///< TTD savegame (can be detected incorrectly)
@@ -449,22 +433,7 @@ enum SavegameType : uint8_t {
 	TTO, ///< TTO savegame
 	Invalid = 0xFF, ///< broken savegame (used internally)
 };
-
-extern FileToSaveLoad _file_to_saveload;
-
-std::string GenerateDefaultSaveName();
 void SetSaveLoadError(StringID str);
-EncodedString GetSaveLoadErrorType();
-EncodedString GetSaveLoadErrorMessage();
-SaveLoadResult SaveOrLoad(std::string_view filename, SaveLoadOperation fop, DetailedFileType dft, Subdirectory sb, bool threaded = true);
-void WaitTillSaved();
-void ProcessAsyncSaveFinish();
-void DoExitSave();
-
-void DoAutoOrNetsave(FiosNumberedSaveName &counter);
-
-SaveLoadResult SaveWithFilter(std::shared_ptr<struct SaveFilter> writer, bool threaded);
-SaveLoadResult LoadWithFilter(std::shared_ptr<struct LoadFilter> reader);
 
 typedef void AutolengthProc(int);
 
@@ -540,9 +509,6 @@ using ChunkHandlerRef = std::reference_wrapper<const ChunkHandler>;
 
 /** A table of ChunkHandler entries. */
 using ChunkHandlerTable = std::span<const ChunkHandlerRef>;
-
-/** A table of SaveLoad entries. */
-using SaveLoadTable = std::span<const struct SaveLoad>;
 
 /** A table of SaveLoadCompat entries. */
 using SaveLoadCompatTable = std::span<const struct SaveLoadCompat>;
@@ -1366,8 +1332,6 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt);
 std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLoadCompatTable &slct);
 void SlObject(void *object, const SaveLoadTable &slt);
 
-bool SaveloadCrashWithMissingNewGRFs();
-
 /**
  * Read in bytes from the file/data structure but don't do
  * anything with them, discarding them in effect
@@ -1377,9 +1341,6 @@ inline void SlSkipBytes(size_t length)
 {
 	for (; length != 0; length--) SlReadByte();
 }
-
-extern std::string _savegame_format;
-extern bool _do_autosave;
 
 /**
  * Default handler for saving/loading a vector to/from disk.

--- a/src/saveload/saveload_func.h
+++ b/src/saveload/saveload_func.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file saveload_func.h Functions related to saving and loading games. */
+
+#ifndef SAVELOAD_FUNC_H
+#define SAVELOAD_FUNC_H
+
+#include "saveload_type.h"
+#include "../fileio_type.h"
+#include "../fios.h"
+
+/** Deals with the type of the savegame, independent of extension */
+struct FileToSaveLoad {
+	SaveLoadOperation file_op;       ///< File operation to perform.
+	FiosType ftype;                  ///< File type.
+	std::string name;                ///< Name of the file.
+	EncodedString title;             ///< Internal name of the game.
+
+	void SetMode(const FiosType &ft, SaveLoadOperation fop = SaveLoadOperation::Load);
+	void Set(const FiosItem &item);
+};
+
+extern FileToSaveLoad _file_to_saveload;
+
+std::string GenerateDefaultSaveName();
+EncodedString GetSaveLoadErrorType();
+EncodedString GetSaveLoadErrorMessage();
+SaveLoadResult SaveOrLoad(std::string_view filename, SaveLoadOperation fop, DetailedFileType dft, Subdirectory sb, bool threaded = true);
+void WaitTillSaved();
+void ProcessAsyncSaveFinish();
+void DoExitSave();
+
+void DoAutoOrNetsave(FiosNumberedSaveName &counter);
+
+SaveLoadResult SaveWithFilter(std::shared_ptr<struct SaveFilter> writer, bool threaded);
+SaveLoadResult LoadWithFilter(std::shared_ptr<struct LoadFilter> reader);
+
+bool SaveloadCrashWithMissingNewGRFs();
+
+extern std::string _savegame_format;
+extern bool _do_autosave;
+
+#endif /* SAVELOAD_FUNC_H */

--- a/src/saveload/saveload_type.h
+++ b/src/saveload/saveload_type.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file saveload_type.h Types often used outside the saveload code related to saving and loading games. */
+
+#ifndef SAVELOAD_TYPE_H
+#define SAVELOAD_TYPE_H
+
+/** Save or load result codes. */
+enum class SaveLoadResult : uint8_t {
+	Ok, ///< completed successfully
+	Error, ///< error that was caught before internal structures were modified
+	ReInit, ///< error that was caught in the middle of updating game state, need to clear it. (can only happen during load)
+};
+
+/** A table of SaveLoad entries. */
+using SaveLoadTable = std::span<const struct SaveLoad>;
+
+#endif /* SAVELOAD_TYPE_H */

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -16,7 +16,7 @@
 #include "screenshot_gui.h"
 #include "blitter/factory.hpp"
 #include "zoom_func.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 #include "company_func.h"
 #include "strings_func.h"
 #include "error.h"

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -19,7 +19,7 @@
 #include "news_gui.h"
 #include "company_gui.h"
 #include "window_gui.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_func.h"
 #include "window_func.h"
 #include "statusbar_gui.h"
 #include "toolbar_gui.h"

--- a/src/timer/timer_game_calendar.cpp
+++ b/src/timer/timer_game_calendar.cpp
@@ -19,6 +19,7 @@
 
 #include "../stdafx.h"
 #include "../openttd.h"
+#include "../settings_type.h"
 #include "timer.h"
 #include "timer_game_calendar.h"
 #include "../vehicle_base.h"

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -15,6 +15,7 @@
 #include "command_type.h"
 #include "order_base.h"
 #include "cargopacket.h"
+#include "newgrf_type.h"
 #include "texteff.hpp"
 #include "engine_type.h"
 #include "order_func.h"
@@ -22,7 +23,7 @@
 #include "group_type.h"
 #include "base_consist.h"
 #include "network/network.h"
-#include "saveload/saveload.h"
+#include "saveload/saveload_type.h"
 #include "timer/timer_game_calendar.h"
 
 const uint TILE_AXIAL_DISTANCE = 192; ///< Logical length of the tile in any DiagDirection used in vehicle movement.

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -19,7 +19,7 @@
 #include "../fios.h"
 #include "../blitter/factory.hpp"
 #include "../company_func.h"
-#include "../saveload/saveload.h"
+#include "../saveload/saveload_func.h"
 #include "../thread.h"
 #include "../window_func.h"
 #include <iostream>

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -10,7 +10,7 @@
 #include "../stdafx.h"
 #include "../gfx_func.h"
 #include "../blitter/factory.hpp"
-#include "../saveload/saveload.h"
+#include "../saveload/saveload_func.h"
 #include "../window_func.h"
 #include "null_v.h"
 


### PR DESCRIPTION
## Motivation / Problem

Any change to saveload.h has to recompile 215 files. About 150 of those are to befriend some save load helpers and about 40 of them are the actual saveload code.


## Description

Introduce `saveload_type.h` and `saveload_func.h`, and use it in most the 'main' files that included `saveload.h`.
Fix compilation by adding transitively included headers.

Now touching `saveload.h` 'only' compiles 53 files instead of 215.

## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
