### PR TITLE
Codechange: use std::array over C-style arrays for saved data

### DIFF
--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -428,7 +428,7 @@ void MusicSystem::ChangePlaylistPosition(int ofs)
  */
 void MusicSystem::SaveCustomPlaylist(PlaylistChoice pl)
 {
-	uint8_t *settings_pl;
+	std::span<uint8_t> settings_pl;
 	if (pl == PlaylistChoice::Custom1) {
 		settings_pl = _settings_client.music.custom_1;
 	} else if (pl == PlaylistChoice::Custom2) {
@@ -438,7 +438,7 @@ void MusicSystem::SaveCustomPlaylist(PlaylistChoice pl)
 	}
 
 	size_t num = 0;
-	std::fill_n(settings_pl, NUM_SONGS_PLAYLIST, 0);
+	std::ranges::fill(settings_pl, 0);
 
 	for (const auto &song : this->standard_playlists[pl]) {
 		/* Music set indices in the settings playlist are 1-based, 0 means unused slot */

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -44,8 +44,8 @@ public:
 
 class SlGamelogRevision : public DefaultSaveLoadHandler<SlGamelogRevision, LoggedChange> {
 public:
-	static const size_t GAMELOG_REVISION_LENGTH = 15;
-	static char revision_text[GAMELOG_REVISION_LENGTH];
+	static const size_t GAMELOG_REVISION_LENGTH = 15; ///< Length of the old revision text length.
+	static inline std::array<char, GAMELOG_REVISION_LENGTH> revision_text; ///< Temporary location to store the old revision text.
 
 	static inline const SaveLoad description[] = {
 		 SLEG_CONDARR("revision.text", SlGamelogRevision::revision_text, VarTypes::U8, GAMELOG_REVISION_LENGTH, SaveLoadVersion::MinVersion, SaveLoadVersion::StringGamelog),
@@ -74,8 +74,6 @@ public:
 
 	void LoadCheck(LoggedChange *lc) const override { this->Load(lc); }
 };
-
-/* static */ char SlGamelogRevision::revision_text[GAMELOG_REVISION_LENGTH];
 
 class SlGamelogOldver : public DefaultSaveLoadHandler<SlGamelogOldver, LoggedChange> {
 public:

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -347,11 +347,12 @@ enum class PlaylistChoice : uint8_t {
 
 /** Settings related to music. */
 struct MusicSettings {
+	static constexpr size_t PLAYLIST_ITEMS = 33; ///< Number of items in a playlist.
 	PlaylistChoice playlist; ///< The playlist (number) to play
 	uint8_t music_vol; ///< The requested music volume
 	uint8_t effect_vol; ///< The requested effects volume
-	uint8_t custom_1[33]; ///< The order of the first custom playlist
-	uint8_t custom_2[33]; ///< The order of the second custom playlist
+	std::array<uint8_t, PLAYLIST_ITEMS> custom_1; ///< The order of the first custom playlist
+	std::array<uint8_t, PLAYLIST_ITEMS> custom_2; ///< The order of the second custom playlist
 	bool playing; ///< Whether music is playing
 	bool shuffle; ///< Whether to shuffle the music
 };

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -139,7 +139,7 @@ constexpr bool DoesMaxFitVariable(T max, VarType type) { return DoesMaxFitVariab
 	SDTG_BOOL(#var, flags, _settings_client.var, def, str, strhelp, strval, pre_check, post_callback, get_title_hook, get_help_hook, set_value_dparams_hook, get_def_hook, from, to, cat, extra, startup)
 
 #define SDTC_LIST(var, type, flags, def, from, to, cat, extra, startup)\
-	SDTG_LIST(#var, type, flags, _settings_client.var, def, lengthof(_settings_client.var), from, to, cat, extra, startup)
+	SDTG_LIST(#var, type, flags, _settings_client.var, def, std::tuple_size_v<decltype(_settings_client.var)>, from, to, cat, extra, startup)
 
 #define SDTC_SSTR(var, type, flags, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 	SDTG_SSTR(#var, type, flags, _settings_client.var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\


### PR DESCRIPTION
## Motivation / Problem

Getting rid of C-style arrays. Specifically in the realm of saved data, as to prevent having to add code for C-style arrays in #15868 (or being able to remove that).


## Description

Replace C-style arrays of revision text in the game log and the playlists with `std::array`.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
