### PR TITLE
Fix #15877: Rail/road type labels are stored forwards, not in reverse.

### DIFF
--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -155,7 +155,7 @@ struct ENGSChunkHandler : ChunkHandler {
 
 /** Save and load the mapping between the engine id in the pool, and the grf file it came from. */
 static const SaveLoad _engine_id_mapping_desc[] = {
-	SLE_VAR(EngineIDMapping, grfid, VarTypes::LABEL),
+	SLE_VAR(EngineIDMapping, grfid, VarTypes::LABEL_REVERSE),
 	SLE_VAR(EngineIDMapping, internal_id,   VarTypes::U16),
 	SLE_VAR(EngineIDMapping, type,          VarTypes::U8),
 	SLE_VAR(EngineIDMapping, substitute_id, VarTypes::U8),

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -127,7 +127,7 @@ public:
 class SlGamelogGrfadd : public DefaultSaveLoadHandler<SlGamelogGrfadd, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFAdd, grfid, "grfadd.grfid", VarTypes::LABEL),
+		SLE_VARNAME(LoggedChangeGRFAdd, grfid, "grfadd.grfid", VarTypes::LABEL_REVERSE),
 		SLE_ARRNAME(LoggedChangeGRFAdd, md5sum, "grfadd.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfadd_sl_compat;
@@ -150,7 +150,7 @@ public:
 class SlGamelogGrfrem : public DefaultSaveLoadHandler<SlGamelogGrfrem, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", VarTypes::LABEL),
+		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", VarTypes::LABEL_REVERSE),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfrem_sl_compat;
 
@@ -172,7 +172,7 @@ public:
 class SlGamelogGrfcompat : public DefaultSaveLoadHandler<SlGamelogGrfcompat, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFChanged, grfid, "grfcompat.grfid", VarTypes::LABEL),
+		SLE_VARNAME(LoggedChangeGRFChanged, grfid, "grfcompat.grfid", VarTypes::LABEL_REVERSE),
 		SLE_ARRNAME(LoggedChangeGRFChanged, md5sum, "grfcompat.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfcompat_sl_compat;
@@ -195,7 +195,7 @@ public:
 class SlGamelogGrfparam : public DefaultSaveLoadHandler<SlGamelogGrfparam, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", VarTypes::LABEL),
+		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", VarTypes::LABEL_REVERSE),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfparam_sl_compat;
 
@@ -217,7 +217,7 @@ public:
 class SlGamelogGrfmove : public DefaultSaveLoadHandler<SlGamelogGrfmove, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFMoved, grfid, "grfmove.grfid", VarTypes::LABEL),
+		SLE_VARNAME(LoggedChangeGRFMoved, grfid, "grfmove.grfid", VarTypes::LABEL_REVERSE),
 		SLE_VARNAME(LoggedChangeGRFMoved, offset, "grfmove.offset", VarTypes::I32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfmove_sl_compat;
@@ -241,7 +241,7 @@ class SlGamelogGrfbug : public DefaultSaveLoadHandler<SlGamelogGrfbug, LoggedCha
 public:
 	static inline const SaveLoad description[] = {
 		SLE_VARNAME(LoggedChangeGRFBug, data,  "grfbug.data",  VarTypes::U64),
-		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", VarTypes::LABEL),
+		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", VarTypes::LABEL_REVERSE),
 		SLE_VARNAME(LoggedChangeGRFBug, bug,   "grfbug.bug",   VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfbug_sl_compat;

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -37,7 +37,7 @@ struct RAILChunkHandler : ChunkHandler {
 	RAILChunkHandler() : ChunkHandler("RAIL", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::LABEL),
+		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::LABEL_FORWARD),
 	};
 
 	void Save() const override
@@ -72,7 +72,7 @@ struct ROTTChunkHandler : ChunkHandler {
 	ROTTChunkHandler() : ChunkHandler("ROTT", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::LABEL),
+		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::LABEL_FORWARD),
 		SLE_VAR(LabelObject<RoadTypeLabel>, subtype, VarTypes::U8),
 	};
 

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -19,7 +19,7 @@
 
 /** Save and load the mapping between a spec and the NewGRF it came from. */
 static const SaveLoad _newgrf_mapping_desc[] = {
-	SLE_VAR(EntityIDMapping, grfid, VarTypes::LABEL),
+	SLE_VAR(EntityIDMapping, grfid, VarTypes::LABEL_REVERSE),
 	SLE_CONDVAR(EntityIDMapping, entity_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
 	SLE_CONDVAR(EntityIDMapping, entity_id, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(EntityIDMapping, substitute_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
@@ -69,7 +69,7 @@ struct NGRFChunkHandler : ChunkHandler {
 
 	static inline const SaveLoad description[] = {
 		   SLE_SSTR(GRFConfig, filename,         VarTypes::STR),
-		    SLE_VAR(GRFConfig, ident.grfid, VarTypes::LABEL),
+		    SLE_VAR(GRFConfig, ident.grfid, VarTypes::LABEL_REVERSE),
 		    SLE_ARR(GRFConfig, ident.md5sum,     VarTypes::U8,  16),
 		SLE_CONDVAR(GRFConfig, version, VarTypes::U32, SaveLoadVersion::StoreNewGRFVersion, SaveLoadVersion::MaxVersion),
 		   SLEG_ARR("param", param,              VarTypes::U32, std::size(param)),

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -682,7 +682,8 @@ static inline uint SlCalcConvMemLen(VarMemType conv)
 		case VarMemType::I64: return sizeof(int64_t);
 		case VarMemType::U64: return sizeof(uint64_t);
 		case VarMemType::Null: return 0;
-		case VarMemType::Label: return sizeof(BaseLabel);
+		case VarMemType::LabelReverse: return sizeof(BaseLabel);
+		case VarMemType::LabelForward: return sizeof(BaseLabel);
 
 		case VarMemType::Str:
 		case VarMemType::StrQ:
@@ -935,10 +936,14 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 {
 	switch (_sl.action) {
 		case SaveLoadAction::Save: {
-			if (conv == VarTypes::LABEL) {
-				/* Labels are a special case. They were read little endian but stored big endian, and as such reversed. */
+			if (conv == VarTypes::LABEL_REVERSE) {
 				BaseLabel *label = static_cast<BaseLabel *>(ptr);
 				for (auto it = label->rbegin(); it != label->rend(); it++) SlWriteByte(*it);
+				break;
+			}
+			if (conv == VarTypes::LABEL_FORWARD) {
+				BaseLabel *label = static_cast<BaseLabel *>(ptr);
+				for (auto it = label->begin(); it != label->end(); it++) SlWriteByte(*it);
 				break;
 			}
 
@@ -983,10 +988,14 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 		}
 		case SaveLoadAction::LoadCheck:
 		case SaveLoadAction::Load: {
-			if (conv == VarTypes::LABEL) {
-				/* Labels are a special case. They were read little endian but stored big endian, and as such reversed. */
+			if (conv == VarTypes::LABEL_REVERSE) {
 				BaseLabel *label = static_cast<BaseLabel *>(ptr);
 				for (auto it = label->rbegin(); it != label->rend(); it++) *it = SlReadByte();
+				break;
+			}
+			if (conv == VarTypes::LABEL_FORWARD) {
+				BaseLabel *label = static_cast<BaseLabel *>(ptr);
+				for (auto it = label->begin(); it != label->end(); it++) *it = SlReadByte();
 				break;
 			}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -662,7 +662,8 @@ enum class VarMemType : uint8_t {
 	Str = 12, ///< string pointer
 	StrQ = 13, ///< string pointer enclosed in quotes
 	Name = 14, ///< old custom name to be converted to a string pointer
-	Label = 15, ///< A 4 character \c Label.
+	LabelReverse = 15, ///< A 4 character \c Label, stored in reverse.
+	LabelForward = 16, ///< A 4 character \c Label, stored as-is.
 };
 
 /** Container of a variable's characteristics about a variable's storage. */
@@ -734,7 +735,8 @@ struct VarTypes {
 	static constexpr VarType STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
 	static constexpr VarType STRQ{ VarFileType::String, VarMemType::StrQ }; ///< Store a string with quotes.
 	static constexpr VarType NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
-	static constexpr VarType LABEL{ VarFileType::U32, VarMemType::Label }; ///< Store a \c Label.
+	static constexpr VarType LABEL_REVERSE{ VarFileType::U32, VarMemType::LabelReverse }; ///< Store a \c Label in reverse.
+	static constexpr VarType LABEL_FORWARD{ VarFileType::U32, VarMemType::LabelForward }; ///< Store a \c Label as-is.
 };
 
 /** Type of data saved. */
@@ -807,7 +809,8 @@ inline constexpr size_t SlVarSize(VarMemType type)
 		case VarMemType::Str: return sizeof(std::string);
 		case VarMemType::StrQ: return sizeof(std::string);
 		case VarMemType::Name: return sizeof(std::string);
-		case VarMemType::Label: return sizeof(BaseLabel);
+		case VarMemType::LabelReverse: return sizeof(BaseLabel);
+		case VarMemType::LabelForward: return sizeof(BaseLabel);
 		default: NOT_REACHED();
 	}
 }
@@ -851,7 +854,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_GENERAL_NAME(cmd, name, base, variable, type, length, from, to, extra) \
 	SaveLoad {name, cmd, type, length, from, to, [] (void *b, size_t) -> void * { \
 		static_assert(SlCheckVarSize(cmd, type, length, sizeof(static_cast<base *>(b)->variable))); \
-		static_assert(VarType{type}.mem != VarMemType::Label || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
+		static_assert((VarType{type}.mem != VarMemType::LabelReverse && VarType{type}.mem != VarMemType::LabelForward) || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
 		assert(b != nullptr); \
 		return const_cast<void *>(static_cast<const void *>(std::addressof(static_cast<base *>(b)->variable))); \
 	}, extra, nullptr}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -209,7 +209,7 @@ template <typename T>
 class SlStationSpecList : public VectorSaveLoadHandler<SlStationSpecList<T>, BaseStation, SpecMapping<T>> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(SpecMapping<T>, grfid, VarTypes::LABEL, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(SpecMapping<T>, grfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(SpecMapping<T>, localidx, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::NewGRFStations, SaveLoadVersion::ExtendEntityMapping),
 		SLE_CONDVAR(SpecMapping<T>, localidx, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	};

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -18,7 +18,7 @@
 
 /** Description of the data to save and load in #PersistentStorage. */
 static const SaveLoad _storage_desc[] = {
-	 SLE_CONDVAR(PersistentStorage, grfid, VarTypes::LABEL, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(PersistentStorage, grfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	 SLE_CONDARR(PersistentStorage, storage, VarTypes::U32, 16, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::ExtendPersistentStorage),
 	 SLE_CONDARR(PersistentStorage, storage, VarTypes::U32, 256, SaveLoadVersion::ExtendPersistentStorage, SaveLoadVersion::MaxVersion),
 };

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -299,7 +299,7 @@ static const SaveLoad _town_desc[] = {
 	SLE_CONDVAR(Town, xy, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
 	SLE_CONDVAR(Town, xy, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Town, townnamegrfid, VarTypes::LABEL, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, townnamegrfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
 	    SLE_VAR(Town, townnametype,          VarTypes::U16),
 	    SLE_VAR(Town, townnameparts,         VarTypes::U32),
 	SLE_CONDSSTR(Town, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -181,7 +181,7 @@ static const SaveLoad _old_waypoint_desc[] = {
 	SLE_CONDVAR(OldWaypoint, build_date, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::BigDates),
 	SLE_CONDVAR(OldWaypoint, build_date, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(OldWaypoint, localidx, VarTypes::U8, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(OldWaypoint, grfid, VarTypes::LABEL, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, grfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(OldWaypoint, owner, VarTypes::U8, SaveLoadVersion::NewGRFPalette, SaveLoadVersion::MaxVersion),
 };
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #15877, rail/road type labels are not loaded correctly.

This is because the new `VarMemType::Label` assumes that all labels need to be stored in reverse, however this is only true for GRF IDs (which is majority of uses)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Explicitly specify whether a label should be saved/loaded forward or reverse for backwards compatibility.

Rail and road type labels need to be stored as-is, otherwise the mappings will not be correct.

The root cause for this is that before the label changes, most labels were previously read with `buf->ReadDWord()` and then flipped with `std::byteswap`. However, GRF IDs were not byteswapped.

Since the label changes, all labels from GRF files are now read via `buf->ReadLabel()`, so GRF IDs are now loaded in the opposite order, which is why they need to reversed when reading/writing in savegames.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
