### PR TITLE
Fix: Limit vehicle reliability to the model's current maximum reliability

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1327,9 +1327,9 @@ void CheckVehicleBreakdown(Vehicle *v)
 	if (_settings_game.difficulty.vehicle_breakdowns == VehicleBreakdowns::Reduced && v->current_order.IsType(OT_LOADING)) return;
 
 	/* Decrease reliability. */
-	int rel, rel_old;
-	v->reliability = rel = std::max((rel_old = v->reliability) - v->reliability_spd_dec, 0);
-	if ((rel_old >> 8) != (rel >> 8)) SetWindowDirty(WindowClass::VehicleDetails, v->index);
+	int rel_old = v->reliability;
+	v->reliability = Clamp(rel_old - v->reliability_spd_dec, 0, Engine::Get(v->engine_type)->reliability);
+	if ((rel_old >> 8) != (v->reliability >> 8)) SetWindowDirty(WindowClass::VehicleDetails, v->index);
 
 	/* Some vehicles lose reliability but won't break down. */
 	/* Breakdowns are disabled. */
@@ -1351,7 +1351,7 @@ void CheckVehicleBreakdown(Vehicle *v)
 	v->breakdown_chance = ClampTo<uint8_t>(chance);
 
 	/* Calculate reliability value to use in comparison. */
-	rel = v->reliability;
+	int rel = v->reliability;
 	if (v->type == VehicleType::Ship) rel += 0x6666;
 
 	/* Reduce the chance if the player has chosen the Reduced setting. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

It is possible for an individual vehicle's reliability to be higher than the engine's (vehicle model) reliability.

This can happen when the vehicle model's reliability decay speed is very low (perhaps only 0, so no decay) and the vehicle is getting old.

During engine reliability phase 3, the model's max reliability is ramped from max to final, regardless of decay speed.

Vehicle reliability is set to the engine's current reliability (called max in the UI) when vehicles enter a depot.

However if the vehicle's reliability never decays, then it is also quite likely that the vehicle never enters a depot, and so the vehicle's own reliability will not reduce and stays higher than the max reliability.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This change resolves this by clamping vehicle reliability to the engine's reliability when applying reliability decay in the vehicle's daily loop. This ensures the vehicle's reliability is never greater than the max reliability, but does raise the question of why it suddenly starts to get unreliable...

An alternative would be to ignore the engine's reliability when reliability decay is zero, which avoids changing game behaviour. Might be desirable for certain gameplay styles.

This issue can crop up because the default reliability decay for NewGRF-added vehicles that don't override a default vehicle is 0.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
