### PR TITLE
Codechange: Use EnumIndexArray for smallmap lookup tables

### DIFF
--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -540,7 +540,7 @@ static inline uint32_t GetSmallMapLinkStatsPixels(TileIndex tile, TileType t)
 }
 
 /** Lookup table of minimap colours to use for each ClearGround type. */
-static constexpr uint32_t _vegetation_clear_bits[to_underlying(ClearGround::MaxSize)] = {
+static constexpr EnumIndexArray<uint32_t, ClearGround, ClearGround::MaxSize> _vegetation_clear_bits = {
 	MKCOLOUR_XXXX(PC_GRASS_LAND), ///< full grass
 	MKCOLOUR_XXXX(PC_ROUGH_LAND), ///< rough land
 	MKCOLOUR_XXXX(PC_GREY),       ///< rocks
@@ -567,7 +567,7 @@ static inline uint32_t GetSmallMapVegetationPixels(TileIndex tile, TileType t)
 				if (GetClearDensity(tile) < 3) return MKCOLOUR_XXXX(PC_BARE_LAND);
 				if (GetTropicZone(tile) == TropicZone::Rainforest) return MKCOLOUR_XXXX(PC_RAINFOREST);
 			}
-			return _vegetation_clear_bits[to_underlying(GetClearGround(tile))];
+			return _vegetation_clear_bits[GetClearGround(tile)];
 
 		case TileType::Industry:
 			return IsTileForestIndustry(tile) ? MKCOLOUR_XXXX(PC_GREEN) : MKCOLOUR_XXXX(PC_DARK_RED);

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -386,7 +386,7 @@ static inline uint32_t ApplyMask(uint32_t colour, const AndOr *mask)
 
 
 /** Colour masks for "Contour" and "Routes" modes. */
-static const EnumClassIndexContainer<std::array<AndOr, to_underlying(TileType::End) + 1>, TileType> _smallmap_contours_andor = {
+static const EnumIndexArray<AndOr, TileType, TileType::MaxSize> _smallmap_contours_andor = {
 	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::Clear
 	AndOr(MKCOLOUR_0XX0(PC_GREY), MKCOLOUR_F00F), // TileType::Railway
 	AndOr(MKCOLOUR_0XX0(PC_BLACK), MKCOLOUR_F00F), // TileType::Road
@@ -398,11 +398,10 @@ static const EnumClassIndexContainer<std::array<AndOr, to_underlying(TileType::E
 	AndOr(MKCOLOUR_XXXX(PC_DARK_RED), MKCOLOUR_0000), // TileType::Industry
 	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::TunnelBridge
 	AndOr(MKCOLOUR_0XX0(PC_DARK_RED), MKCOLOUR_F00F), // TileType::Object
-	AndOr(MKCOLOUR_0XX0(PC_GREY), MKCOLOUR_F00F),
 };
 
 /** Colour masks for "Vehicles", "Industry", and "Vegetation" modes. */
-static const EnumClassIndexContainer<std::array<AndOr, to_underlying(TileType::End) + 1>, TileType> _smallmap_vehicles_andor = {
+static const EnumIndexArray<AndOr, TileType, TileType::MaxSize> _smallmap_vehicles_andor = {
 	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::Clear
 	AndOr(MKCOLOUR_0XX0(PC_BLACK), MKCOLOUR_F00F), // TileType::Railway
 	AndOr(MKCOLOUR_0XX0(PC_BLACK), MKCOLOUR_F00F), // TileType::Road
@@ -414,11 +413,10 @@ static const EnumClassIndexContainer<std::array<AndOr, to_underlying(TileType::E
 	AndOr(MKCOLOUR_XXXX(PC_DARK_RED), MKCOLOUR_0000), // TileType::Industry
 	AndOr(MKCOLOUR_0000, MKCOLOUR_FFFF), // TileType::TunnelBridge
 	AndOr(MKCOLOUR_0XX0(PC_DARK_RED), MKCOLOUR_F00F), // TileType::Object
-	AndOr(MKCOLOUR_0XX0(PC_BLACK), MKCOLOUR_F00F),
 };
 
 /** Mapping of tile type to importance of the tile (higher number means more interesting to show). */
-static const EnumClassIndexContainer<std::array<uint8_t, to_underlying(TileType::End) + 1>, TileType> _tiletype_importance = {
+static const EnumIndexArray<uint8_t, TileType, TileType::MaxSize> _tiletype_importance = {
 	2, // TileType::Clear
 	8, // TileType::Railway
 	7, // TileType::Road
@@ -430,7 +428,6 @@ static const EnumClassIndexContainer<std::array<uint8_t, to_underlying(TileType:
 	6, // TileType::Industry
 	8, // TileType::TunnelBridge
 	2, // TileType::Object
-	0,
 };
 
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

* `_vegetation_clear_bits` is a lookup table indexed by `ClearGround`, but is currently is a plain C-style array.
* 3 lookup tables indexed by `TileType` use a custom container with an odd size due hysterical raisins.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

* Make `_vegetation_clear_bits` use an `EnumIndexArray`.
* Use a regular `EnumIndexArray` for the `TileType` lookup tables, ending on `TileType::MaxSize` instead of  `TileType::End + 1`, and remove the dummy unused entries.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
