### PR TITLE
Codechange: store all Labels in order, i.e. reverse the GrfID labels upon loading old saves

### DIFF
--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -155,7 +155,7 @@ struct ENGSChunkHandler : ChunkHandler {
 
 /** Save and load the mapping between the engine id in the pool, and the grf file it came from. */
 static const SaveLoad _engine_id_mapping_desc[] = {
-	SLE_VAR(EngineIDMapping, grfid, VarTypes::LABEL_REVERSE),
+	SLE_VAR(EngineIDMapping, grfid, VarTypes::LABEL),
 	SLE_VAR(EngineIDMapping, internal_id,   VarTypes::U16),
 	SLE_VAR(EngineIDMapping, type,          VarTypes::U8),
 	SLE_VAR(EngineIDMapping, substitute_id, VarTypes::U8),
@@ -200,6 +200,7 @@ struct EIDSChunkHandler : ChunkHandler {
 		while ((index = SlIterateArray()) != -1) {
 			EngineIDMapping eid;
 			SlObject(&eid, slt);
+			if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(eid.grfid);
 			_engine_mngr.SetID(eid.type, eid.internal_id, eid.grfid, eid.substitute_id, static_cast<EngineID>(index));
 		}
 	}

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -125,7 +125,7 @@ public:
 class SlGamelogGrfadd : public DefaultSaveLoadHandler<SlGamelogGrfadd, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFAdd, grfid, "grfadd.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFAdd, grfid, "grfadd.grfid", VarTypes::LABEL),
 		SLE_ARRNAME(LoggedChangeGRFAdd, md5sum, "grfadd.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfadd_sl_compat;
@@ -140,6 +140,7 @@ public:
 	{
 		if (lc->ct != GamelogChangeType::GRFAdd) return;
 		SlObject(lc, this->GetLoadDescription());
+		if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(static_cast<LoggedChangeGRFAdd *>(lc)->grfid);
 	}
 
 	void LoadCheck(LoggedChange *lc) const override { this->Load(lc); }
@@ -148,7 +149,7 @@ public:
 class SlGamelogGrfrem : public DefaultSaveLoadHandler<SlGamelogGrfrem, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", VarTypes::LABEL),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfrem_sl_compat;
 
@@ -162,6 +163,7 @@ public:
 	{
 		if (lc->ct != GamelogChangeType::GRFRem) return;
 		SlObject(lc, this->GetLoadDescription());
+		if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(static_cast<LoggedChangeGRFRemoved *>(lc)->grfid);
 	}
 
 	void LoadCheck(LoggedChange *lc) const override { this->Load(lc); }
@@ -170,7 +172,7 @@ public:
 class SlGamelogGrfcompat : public DefaultSaveLoadHandler<SlGamelogGrfcompat, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFChanged, grfid, "grfcompat.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFChanged, grfid, "grfcompat.grfid", VarTypes::LABEL),
 		SLE_ARRNAME(LoggedChangeGRFChanged, md5sum, "grfcompat.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfcompat_sl_compat;
@@ -185,6 +187,7 @@ public:
 	{
 		if (lc->ct != GamelogChangeType::GRFCompat) return;
 		SlObject(lc, this->GetLoadDescription());
+		if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(static_cast<LoggedChangeGRFChanged *>(lc)->grfid);
 	}
 
 	void LoadCheck(LoggedChange *lc) const override { this->Load(lc); }
@@ -193,7 +196,7 @@ public:
 class SlGamelogGrfparam : public DefaultSaveLoadHandler<SlGamelogGrfparam, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", VarTypes::LABEL),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfparam_sl_compat;
 
@@ -207,6 +210,7 @@ public:
 	{
 		if (lc->ct != GamelogChangeType::GRFParam) return;
 		SlObject(lc, this->GetLoadDescription());
+		if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(static_cast<LoggedChangeGRFParameterChanged *>(lc)->grfid);
 	}
 
 	void LoadCheck(LoggedChange *lc) const override { this->Load(lc); }
@@ -215,7 +219,7 @@ public:
 class SlGamelogGrfmove : public DefaultSaveLoadHandler<SlGamelogGrfmove, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFMoved, grfid, "grfmove.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFMoved, grfid, "grfmove.grfid", VarTypes::LABEL),
 		SLE_VARNAME(LoggedChangeGRFMoved, offset, "grfmove.offset", VarTypes::I32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfmove_sl_compat;
@@ -230,6 +234,7 @@ public:
 	{
 		if (lc->ct != GamelogChangeType::GRFMove) return;
 		SlObject(lc, this->GetLoadDescription());
+		if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(static_cast<LoggedChangeGRFMoved*>(lc)->grfid);
 	}
 
 	void LoadCheck(LoggedChange *lc) const override { this->Load(lc); }
@@ -239,7 +244,7 @@ class SlGamelogGrfbug : public DefaultSaveLoadHandler<SlGamelogGrfbug, LoggedCha
 public:
 	static inline const SaveLoad description[] = {
 		SLE_VARNAME(LoggedChangeGRFBug, data,  "grfbug.data",  VarTypes::U64),
-		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", VarTypes::LABEL),
 		SLE_VARNAME(LoggedChangeGRFBug, bug,   "grfbug.bug",   VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfbug_sl_compat;
@@ -254,6 +259,7 @@ public:
 	{
 		if (lc->ct != GamelogChangeType::GRFBug) return;
 		SlObject(lc, this->GetLoadDescription());
+		if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(static_cast<LoggedChangeGRFBug*>(lc)->grfid);
 	}
 
 	void LoadCheck(LoggedChange *lc) const override { this->Load(lc); }

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -37,7 +37,7 @@ struct RAILChunkHandler : ChunkHandler {
 	RAILChunkHandler() : ChunkHandler("RAIL", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::LABEL_FORWARD),
+		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::LABEL),
 	};
 
 	void Save() const override
@@ -72,7 +72,7 @@ struct ROTTChunkHandler : ChunkHandler {
 	ROTTChunkHandler() : ChunkHandler("ROTT", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::LABEL_FORWARD),
+		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::LABEL),
 		SLE_VAR(LabelObject<RoadTypeLabel>, subtype, VarTypes::U8),
 	};
 

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -19,7 +19,7 @@
 
 /** Save and load the mapping between a spec and the NewGRF it came from. */
 static const SaveLoad _newgrf_mapping_desc[] = {
-	SLE_VAR(EntityIDMapping, grfid, VarTypes::LABEL_REVERSE),
+	SLE_VAR(EntityIDMapping, grfid, VarTypes::LABEL),
 	SLE_CONDVAR(EntityIDMapping, entity_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
 	SLE_CONDVAR(EntityIDMapping, entity_id, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(EntityIDMapping, substitute_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
@@ -58,6 +58,7 @@ void NewGRFMappingChunkHandler::Load() const
 	while ((index = SlIterateArray()) != -1) {
 		if ((uint)index >= max_id) SlErrorCorrupt("Too many NewGRF entity mappings");
 		SlObject(&this->mapping.mappings[index], slt);
+		if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(this->mapping.mappings[index].grfid);
 	}
 }
 
@@ -69,7 +70,7 @@ struct NGRFChunkHandler : ChunkHandler {
 
 	static inline const SaveLoad description[] = {
 		   SLE_SSTR(GRFConfig, filename,         VarTypes::STR),
-		    SLE_VAR(GRFConfig, ident.grfid, VarTypes::LABEL_REVERSE),
+		    SLE_VAR(GRFConfig, ident.grfid, VarTypes::LABEL),
 		    SLE_ARR(GRFConfig, ident.md5sum,     VarTypes::U8,  16),
 		SLE_CONDVAR(GRFConfig, version, VarTypes::U32, SaveLoadVersion::StoreNewGRFVersion, SaveLoadVersion::MaxVersion),
 		   SLEG_ARR("param", param,              VarTypes::U32, std::size(param)),
@@ -115,6 +116,7 @@ struct NGRFChunkHandler : ChunkHandler {
 			auto c = std::make_unique<GRFConfig>();
 			SlObject(c.get(), slt);
 			if (IsSavegameVersionBefore(SaveLoadVersion::NewGRFPalette)) c->SetSuitablePalette();
+			if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(c->ident.grfid);
 			this->LoadParameters(*c);
 			AppendToGRFConfigList(grfconfig, std::move(c));
 		}

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -682,8 +682,7 @@ static inline uint SlCalcConvMemLen(VarMemType conv)
 		case VarMemType::I64: return sizeof(int64_t);
 		case VarMemType::U64: return sizeof(uint64_t);
 		case VarMemType::Null: return 0;
-		case VarMemType::LabelReverse: return sizeof(BaseLabel);
-		case VarMemType::LabelForward: return sizeof(BaseLabel);
+		case VarMemType::Label: return sizeof(BaseLabel);
 
 		case VarMemType::Str:
 		case VarMemType::StrQ:
@@ -936,14 +935,8 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 {
 	switch (_sl.action) {
 		case SaveLoadAction::Save: {
-			if (conv == VarTypes::LABEL_REVERSE) {
-				BaseLabel *label = static_cast<BaseLabel *>(ptr);
-				for (auto it = label->rbegin(); it != label->rend(); it++) SlWriteByte(*it);
-				break;
-			}
-			if (conv == VarTypes::LABEL_FORWARD) {
-				BaseLabel *label = static_cast<BaseLabel *>(ptr);
-				for (auto it = label->begin(); it != label->end(); it++) SlWriteByte(*it);
+			if (conv == VarTypes::LABEL) {
+				for (auto b : *static_cast<BaseLabel *>(ptr)) SlWriteByte(b);
 				break;
 			}
 
@@ -988,14 +981,8 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 		}
 		case SaveLoadAction::LoadCheck:
 		case SaveLoadAction::Load: {
-			if (conv == VarTypes::LABEL_REVERSE) {
-				BaseLabel *label = static_cast<BaseLabel *>(ptr);
-				for (auto it = label->rbegin(); it != label->rend(); it++) *it = SlReadByte();
-				break;
-			}
-			if (conv == VarTypes::LABEL_FORWARD) {
-				BaseLabel *label = static_cast<BaseLabel *>(ptr);
-				for (auto it = label->begin(); it != label->end(); it++) *it = SlReadByte();
+			if (conv == VarTypes::LABEL) {
+				for (auto &b : *static_cast<BaseLabel *>(ptr)) b = SlReadByte();
 				break;
 			}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -420,6 +420,7 @@ enum class SaveLoadVersion : uint16_t {
 
 	DriveBackwards, ///< Saveload version: 365, GitHub pull request: 15379\n Trains can drive backwards.
 	DepotsUnderBridges, ///< Saveload version: 366, GitHub pull request: 15836\n Allow depots under bridges.
+	LabelOrientationUnification, ///< Saveload version: 367, GitHub pull request: 15884\n Unify the orientation in which labels are written.
 
 	MaxVersion, ///< Highest possible saveload version.
 };
@@ -662,8 +663,7 @@ enum class VarMemType : uint8_t {
 	Str = 12, ///< string pointer
 	StrQ = 13, ///< string pointer enclosed in quotes
 	Name = 14, ///< old custom name to be converted to a string pointer
-	LabelReverse = 15, ///< A 4 character \c Label, stored in reverse.
-	LabelForward = 16, ///< A 4 character \c Label, stored as-is.
+	Label = 15, ///< A 4 character \c Label, stored as-is.
 };
 
 /** Container of a variable's characteristics about a variable's storage. */
@@ -735,8 +735,7 @@ struct VarTypes {
 	static constexpr VarType STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
 	static constexpr VarType STRQ{ VarFileType::String, VarMemType::StrQ }; ///< Store a string with quotes.
 	static constexpr VarType NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
-	static constexpr VarType LABEL_REVERSE{ VarFileType::U32, VarMemType::LabelReverse }; ///< Store a \c Label in reverse.
-	static constexpr VarType LABEL_FORWARD{ VarFileType::U32, VarMemType::LabelForward }; ///< Store a \c Label as-is.
+	static constexpr VarType LABEL{ VarFileType::U32, VarMemType::Label }; ///< Store a \c Label as-is.
 };
 
 /** Type of data saved. */
@@ -809,8 +808,7 @@ inline constexpr size_t SlVarSize(VarMemType type)
 		case VarMemType::Str: return sizeof(std::string);
 		case VarMemType::StrQ: return sizeof(std::string);
 		case VarMemType::Name: return sizeof(std::string);
-		case VarMemType::LabelReverse: return sizeof(BaseLabel);
-		case VarMemType::LabelForward: return sizeof(BaseLabel);
+		case VarMemType::Label: return sizeof(BaseLabel);
 		default: NOT_REACHED();
 	}
 }
@@ -854,7 +852,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_GENERAL_NAME(cmd, name, base, variable, type, length, from, to, extra) \
 	SaveLoad {name, cmd, type, length, from, to, [] (void *b, size_t) -> void * { \
 		static_assert(SlCheckVarSize(cmd, type, length, sizeof(static_cast<base *>(b)->variable))); \
-		static_assert((VarType{type}.mem != VarMemType::LabelReverse && VarType{type}.mem != VarMemType::LabelForward) || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
+		static_assert(VarType{type}.mem != VarMemType::Label || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
 		assert(b != nullptr); \
 		return const_cast<void *>(static_cast<const void *>(std::addressof(static_cast<base *>(b)->variable))); \
 	}, extra, nullptr}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -209,7 +209,7 @@ template <typename T>
 class SlStationSpecList : public VectorSaveLoadHandler<SlStationSpecList<T>, BaseStation, SpecMapping<T>> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(SpecMapping<T>, grfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(SpecMapping<T>, grfid, VarTypes::LABEL, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(SpecMapping<T>, localidx, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::NewGRFStations, SaveLoadVersion::ExtendEntityMapping),
 		SLE_CONDVAR(SpecMapping<T>, localidx, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	};
@@ -222,6 +222,15 @@ public:
 	size_t GetLength() const override
 	{
 		return IsSavegameVersionBefore(SaveLoadVersion::SaveloadListLength) ? last_num_specs : SlGetStructListLength(UINT8_MAX);
+	}
+
+	void Load(BaseStation *object) const override
+	{
+		this->VectorSaveLoadHandler<SlStationSpecList<T>, BaseStation, SpecMapping<T>>::Load(object);
+
+		if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) {
+			for (auto m : this->GetVector(object)) std::ranges::reverse(m.grfid);
+		}
 	}
 };
 

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -18,7 +18,7 @@
 
 /** Description of the data to save and load in #PersistentStorage. */
 static const SaveLoad _storage_desc[] = {
-	 SLE_CONDVAR(PersistentStorage, grfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(PersistentStorage, grfid, VarTypes::LABEL, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	 SLE_CONDARR(PersistentStorage, storage, VarFileType::U32 | VarMemType::I32, 16, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::ExtendPersistentStorage),
 	 SLE_CONDARR(PersistentStorage, storage, VarFileType::U32 | VarMemType::I32, 256, SaveLoadVersion::ExtendPersistentStorage, SaveLoadVersion::MaxVersion),
 };
@@ -49,6 +49,7 @@ struct PSACChunkHandler : ChunkHandler {
 			ps->ClearChanges();
 			SlSetArrayIndex(ps->index);
 			SlObject(ps, _storage_desc);
+			if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(ps->grfid);
 		}
 	}
 };

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -299,7 +299,7 @@ static const SaveLoad _town_desc[] = {
 	SLE_CONDVAR(Town, xy, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
 	SLE_CONDVAR(Town, xy, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Town, townnamegrfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, townnamegrfid, VarTypes::LABEL, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
 	    SLE_VAR(Town, townnametype,          VarTypes::U16),
 	    SLE_VAR(Town, townnameparts,         VarTypes::U32),
 	SLE_CONDSSTR(Town, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
@@ -409,6 +409,8 @@ struct CITYChunkHandler : ChunkHandler {
 			if (IsSavegameVersionBefore(SaveLoadVersion::TownSupplyHistory)) {
 				t->valid_history = 1U << LAST_MONTH;
 			}
+
+			if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(t->townnamegrfid);
 
 			if (t->townnamegrfid.Empty() && !IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END) && GetStringTab(t->townnametype) != TEXT_TAB_OLD_CUSTOM) {
 				SlErrorCorrupt("Invalid town name generator");

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -181,7 +181,7 @@ static const SaveLoad _old_waypoint_desc[] = {
 	SLE_CONDVAR(OldWaypoint, build_date, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::BigDates),
 	SLE_CONDVAR(OldWaypoint, build_date, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(OldWaypoint, localidx, VarTypes::U8, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(OldWaypoint, grfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, grfid, VarTypes::LABEL, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(OldWaypoint, owner, VarTypes::U8, SaveLoadVersion::NewGRFPalette, SaveLoadVersion::MaxVersion),
 };
 
@@ -200,6 +200,7 @@ struct CHKPChunkHandler : ChunkHandler {
 
 			wp->index = static_cast<OldWaypointID>(index);
 			SlObject(wp, _old_waypoint_desc);
+			if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(wp->grfid);
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem

The GrfID labels are stored in a different order than the others, and as such requires some different handling.

This causes some difficulty as I'm trying to determine the `VarMemType` based on the actual type of the variable. It's not possible to determine whether it's the 'forward' or 'reverse' memory type based of it being a `Label`. As such, it would be better to unify the order and bump the save game version.


## Description

Bump the save game version and reorder the GrfIDs.


## Limitations

The 'afterload' handling is pushed into all the ChunkHandlers as in some cases checking for GrfIDs are done really early. Sometimes right after having read some data from the save.

Any tool thinking GrfIDs were stored in one order will now be broken. However, the new order is arguably the more logical/consistent order. That is: exactly in the order as they are in the GRF.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
