### PR TITLE
Change: Move small map buttons to side of window

### DIFF
--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1937,6 +1937,121 @@ bool SmallMapWindow::show_ind_names = false;
 int SmallMapWindow::map_height_limit = -1;
 
 /**
+ * Custom container for smallmap buttons.
+ * This container can switch from a 1-column to a 2-column layout depending on the given height.
+ */
+class NWidgetSmallmapButtons : public NWidgetContainer {
+	/** Smallmap button definitions. */
+	static constexpr std::tuple<WidgetID, WidgetType, SpriteID, StringID> buttons[] = {
+		{WID_SM_ZOOM_IN, WWT_PUSHIMGBTN, SPR_IMG_ZOOMIN, STR_TOOLBAR_TOOLTIP_ZOOM_THE_VIEW_IN},
+		{WID_SM_ZOOM_OUT, WWT_PUSHIMGBTN, SPR_IMG_ZOOMOUT, STR_TOOLBAR_TOOLTIP_ZOOM_THE_VIEW_OUT},
+		{WID_SM_CENTERMAP, WWT_PUSHIMGBTN, SPR_IMG_SMALLMAP, STR_SMALLMAP_CENTER_TOOLTIP},
+		{WID_SM_TOGGLETOWNNAME, WWT_IMGBTN, SPR_IMG_TOWN, STR_SMALLMAP_TOOLTIP_TOGGLE_TOWN_NAMES_ON_OFF},
+		{INVALID_WIDGET, WWT_PANEL, SPR_EMPTY, STR_NULL}, // Resizable spacer between top and bottom halves.
+		{WID_SM_BLANK, WWT_IMGBTN, SPR_EMPTY, STR_NULL}, // Optional spacer in 2-column layout only.
+		{WID_SM_LINKSTATS, WWT_IMGBTN, SPR_IMG_CARGOFLOW, STR_SMALLMAP_TOOLTIP_SHOW_LINK_STATS_ON_MAP},
+		{WID_SM_ROUTES, WWT_IMGBTN, SPR_IMG_SHOW_ROUTES, STR_SMALLMAP_TOOLTIP_SHOW_TRANSPORT_ROUTES_ON},
+		{WID_SM_VEGETATION, WWT_IMGBTN, SPR_IMG_PLANTTREES, STR_SMALLMAP_TOOLTIP_SHOW_VEGETATION_ON_MAP},
+		{WID_SM_OWNERS, WWT_IMGBTN, SPR_IMG_COMPANY_GENERAL, STR_SMALLMAP_TOOLTIP_SHOW_LAND_OWNERS_ON_MAP},
+		{WID_SM_CONTOUR, WWT_IMGBTN, SPR_IMG_SHOW_COUNTOURS, STR_SMALLMAP_TOOLTIP_SHOW_LAND_CONTOURS_ON_MAP},
+		{WID_SM_VEHICLES, WWT_IMGBTN, SPR_IMG_SHOW_VEHICLES, STR_SMALLMAP_TOOLTIP_SHOW_VEHICLES_ON_MAP},
+		{WID_SM_INDUSTRIES, WWT_IMGBTN, SPR_IMG_INDUSTRY, STR_SMALLMAP_TOOLTIP_SHOW_INDUSTRIES_ON_MAP},
+	};
+
+	uint num_buttons; ///< The number of buttons excluding spacers.
+	Dimension button; ///< The size of a button.
+
+public:
+	/**
+	 * Construct a new NWidgetSmallmapButtons object
+	 */
+	NWidgetSmallmapButtons() : NWidgetContainer(NWID_VERTICAL)
+	{
+		for (const auto &[widget, tp, sprite, string] : buttons) {
+			if (widget == INVALID_WIDGET) {
+				auto leaf = std::make_unique<NWidgetBackground>(WWT_PANEL, Colours::Brown, widget);
+				this->Add(std::move(leaf));
+			} else {
+				auto leaf = std::make_unique<NWidgetLeaf>(tp, Colours::Brown, widget, WidgetData{.sprite = sprite}, string);
+				leaf->SetToolbarMinimalSize(1);
+				this->Add(std::move(leaf));
+			}
+		}
+	}
+
+	void SetupSmallestSize(Window *w) override
+	{
+		this->button.width = 0;
+		this->button.height = 0;
+
+		this->num_buttons = 0;
+		for (const auto &child_wid : this->children) {
+			child_wid->SetupSmallestSize(w);
+			this->button.width = std::max(this->button.width, child_wid->smallest_y + child_wid->padding.Vertical());
+			this->button.height = std::max(this->button.height, child_wid->smallest_x + child_wid->padding.Horizontal());
+			WidgetID index = child_wid->GetIndex();
+			if (index != INVALID_WIDGET && index != WID_SM_BLANK) ++this->num_buttons;
+		}
+
+		this->smallest_x = this->button.width * 2;
+		this->smallest_y = this->button.height * CeilDiv(this->num_buttons, 2);
+		this->fill_x = 0;
+		this->fill_y = 1;
+		this->resize_x = 0;
+		this->resize_y = 1;
+	}
+
+	std::pair<uint, uint> GetPreferredSizeForSize(uint given_width, uint given_height) override
+	{
+		if (given_height >= this->num_buttons * this->button.height) return {this->button.width, given_height};
+		return {given_width, given_height};
+	}
+
+	void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) override
+	{
+		assert(given_width >= this->button.width && given_height >= this->smallest_y);
+
+		this->pos_x = x;
+		this->pos_y = y;
+		this->current_x = given_width;
+		this->current_y = given_height;
+
+		uint child_x = 0;
+		uint child_y = 0;
+		uint remaining = CeilDiv(this->num_buttons, this->smallest_x == this->current_x ? 2 : 1);
+
+		for (auto &child : this->children) {
+			if (child->type == WWT_PANEL) {
+				/* Spacer widget needs to fill the remaining space. */
+				uint height = given_height - child_y - (remaining * this->button.height);
+				child->AssignSizePosition(sizing, x, y + child_y, given_width, height, rtl);
+				child_y += height;
+			} else if (given_width == this->button.width && child->GetIndex() == WID_SM_BLANK) {
+				/* Blank button only appears in 2-column layout. */
+				child->AssignSizePosition(sizing, x + child_x, y + child_y, 0, 0, rtl);
+			} else {
+				child->AssignSizePosition(sizing, x + child_x, y + child_y, child->smallest_x, child->smallest_y, rtl);
+				child_x += child->current_x;
+				if (child_x >= given_width) {
+					child_x = 0;
+					child_y += child->current_y;
+					--remaining;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Create NWidgetSMallmapButtons widget.
+	 * @return Pointer to created NWidget.
+	 */
+	static std::unique_ptr<NWidgetBase> Make()
+	{
+		return std::make_unique<NWidgetSmallmapButtons>();
+	}
+};
+
+/**
  * Custom container class for displaying smallmap with a vertically resizing legend panel.
  * The legend panel has a smallest height that depends on its width. Standard containers cannot handle this case.
  *
@@ -1947,7 +2062,7 @@ int SmallMapWindow::map_height_limit = -1;
 class NWidgetSmallmapDisplay : public NWidgetContainer {
 	const SmallMapWindow *smallmap_window = nullptr; ///< Window manager instance.
 public:
-	NWidgetSmallmapDisplay() : NWidgetContainer(NWID_VERTICAL) {}
+	NWidgetSmallmapDisplay() : NWidgetContainer(NWID_CUSTOM) {}
 
 	void SetupSmallestSize(Window *w) override
 	{
@@ -1995,52 +2110,19 @@ public:
 	}
 };
 
-/** Widget parts of the smallmap display. */
+/** Widget parts of the smallmap display and image buttons. */
 static constexpr std::initializer_list<NWidgetPart> _nested_smallmap_display = {
-	NWidget(WWT_PANEL, Colours::Brown, WID_SM_MAP_BORDER),
-		NWidget(WWT_INSET, Colours::Brown, WID_SM_MAP), SetMinimalSize(346, 140), SetResize(1, 1), SetPadding(2, 2, 2, 2), EndContainer(),
+	NWidget(NWID_HORIZONTAL),
+		NWidget(WWT_PANEL, Colours::Brown, WID_SM_MAP_BORDER),
+			NWidget(WWT_INSET, Colours::Brown, WID_SM_MAP), SetFill(1, 1), SetResize(1, 1), SetPadding(2, 2, 2, 2), EndContainer(),
+		EndContainer(),
+		NWidgetFunction(NWidgetSmallmapButtons::Make),
 	EndContainer(),
 };
 
-/** Widget parts of the smallmap legend bar + image buttons. */
+/** Widget parts of the smallmap legend bar. */
 static constexpr std::initializer_list<NWidgetPart> _nested_smallmap_bar = {
-	NWidget(WWT_PANEL, Colours::Brown),
-		NWidget(NWID_HORIZONTAL),
-			NWidget(WWT_EMPTY, Colours::Invalid, WID_SM_LEGEND), SetResize(1, 1),
-			NWidget(NWID_VERTICAL),
-				/* Top button row. */
-				NWidget(NWID_HORIZONTAL, NWidContainerFlag::EqualSize),
-					NWidget(WWT_PUSHIMGBTN, Colours::Brown, WID_SM_ZOOM_IN),
-							SetSpriteTip(SPR_IMG_ZOOMIN, STR_TOOLBAR_TOOLTIP_ZOOM_THE_VIEW_IN), SetFill(1, 1),
-					NWidget(WWT_PUSHIMGBTN, Colours::Brown, WID_SM_CENTERMAP),
-							SetSpriteTip(SPR_IMG_SMALLMAP, STR_SMALLMAP_CENTER_TOOLTIP), SetFill(1, 1),
-					NWidget(WWT_IMGBTN, Colours::Brown, WID_SM_BLANK),
-							SetSpriteTip(SPR_EMPTY), SetFill(1, 1),
-					NWidget(WWT_IMGBTN, Colours::Brown, WID_SM_CONTOUR),
-							SetSpriteTip(SPR_IMG_SHOW_COUNTOURS, STR_SMALLMAP_TOOLTIP_SHOW_LAND_CONTOURS_ON_MAP), SetFill(1, 1),
-					NWidget(WWT_IMGBTN, Colours::Brown, WID_SM_VEHICLES),
-							SetSpriteTip(SPR_IMG_SHOW_VEHICLES, STR_SMALLMAP_TOOLTIP_SHOW_VEHICLES_ON_MAP), SetFill(1, 1),
-					NWidget(WWT_IMGBTN, Colours::Brown, WID_SM_INDUSTRIES),
-							SetSpriteTip(SPR_IMG_INDUSTRY, STR_SMALLMAP_TOOLTIP_SHOW_INDUSTRIES_ON_MAP), SetFill(1, 1),
-				EndContainer(),
-				/* Bottom button row. */
-				NWidget(NWID_HORIZONTAL, NWidContainerFlag::EqualSize),
-					NWidget(WWT_PUSHIMGBTN, Colours::Brown, WID_SM_ZOOM_OUT),
-							SetSpriteTip(SPR_IMG_ZOOMOUT, STR_TOOLBAR_TOOLTIP_ZOOM_THE_VIEW_OUT), SetFill(1, 1),
-					NWidget(WWT_IMGBTN, Colours::Brown, WID_SM_TOGGLETOWNNAME),
-							SetSpriteTip(SPR_IMG_TOWN, STR_SMALLMAP_TOOLTIP_TOGGLE_TOWN_NAMES_ON_OFF), SetFill(1, 1),
-					NWidget(WWT_IMGBTN, Colours::Brown, WID_SM_LINKSTATS),
-							SetSpriteTip(SPR_IMG_CARGOFLOW, STR_SMALLMAP_TOOLTIP_SHOW_LINK_STATS_ON_MAP), SetFill(1, 1),
-					NWidget(WWT_IMGBTN, Colours::Brown, WID_SM_ROUTES),
-							SetSpriteTip(SPR_IMG_SHOW_ROUTES, STR_SMALLMAP_TOOLTIP_SHOW_TRANSPORT_ROUTES_ON), SetFill(1, 1),
-					NWidget(WWT_IMGBTN, Colours::Brown, WID_SM_VEGETATION),
-							SetSpriteTip(SPR_IMG_PLANTTREES, STR_SMALLMAP_TOOLTIP_SHOW_VEGETATION_ON_MAP), SetFill(1, 1),
-					NWidget(WWT_IMGBTN, Colours::Brown, WID_SM_OWNERS),
-							SetSpriteTip(SPR_IMG_COMPANY_GENERAL, STR_SMALLMAP_TOOLTIP_SHOW_LAND_OWNERS_ON_MAP), SetFill(1, 1),
-				EndContainer(),
-				NWidget(NWID_SPACER), SetResize(0, 1),
-			EndContainer(),
-		EndContainer(),
+	NWidget(WWT_PANEL, Colours::Brown, WID_SM_LEGEND), SetFill(1, 0), SetResize(1, 1),
 	EndContainer(),
 };
 
@@ -2065,7 +2147,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_smallmap_widgets = {
 	/* Bottom button row and resize box. */
 	NWidget(NWID_HORIZONTAL),
 		NWidget(NWID_SELECTION, Colours::Invalid, WID_SM_SELECT_BUTTONS),
-			NWidget(NWID_HORIZONTAL, NWidContainerFlag::EqualSize),
+			NWidget(NWID_HORIZONTAL),
 				NWidget(WWT_PUSHTXTBTN, Colours::Brown, WID_SM_ENABLE_ALL), SetStringTip(STR_SMALLMAP_ENABLE_ALL),
 				NWidget(WWT_PUSHTXTBTN, Colours::Brown, WID_SM_DISABLE_ALL), SetStringTip(STR_SMALLMAP_DISABLE_ALL),
 				NWidget(WWT_TEXTBTN, Colours::Brown, WID_SM_SHOW_HEIGHT), SetStringTip(STR_SMALLMAP_SHOW_HEIGHT, STR_SMALLMAP_TOOLTIP_SHOW_HEIGHT),
@@ -2087,7 +2169,7 @@ static constexpr std::initializer_list<NWidgetPart> _nested_smallmap_widgets = {
 
 /** Window definition for the smallmap window. */
 static WindowDesc _smallmap_desc(
-	WindowPosition::Automatic, "smallmap", 484, 314,
+	WindowPosition::Automatic, "smallmap", 0, 0,
 	WindowClass::SmallMap, WindowClass::None,
 	{},
 	_nested_smallmap_widgets

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1678,6 +1678,12 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, int x, int y, uint
 		child_wid->current_y = ComputeMaxSize(child_wid->smallest_y, given_height - child_wid->padding.Vertical(), vert_step);
 	}
 
+	for (const auto &child_wid : this->children) {
+		auto [pref_x, _] = child_wid->GetPreferredSizeForSize(child_wid->current_x, child_wid->current_y);
+		additional_length += child_wid->current_x - pref_x;
+		child_wid->current_x = pref_x;
+	}
+
 	/* First.5 loop: count how many children are of the biggest step size. */
 	if (flags.Test(NWidContainerFlag::BigFirst) && biggest_stepsize > 0) {
 		for (const auto &child_wid : this->children) {
@@ -1850,6 +1856,12 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, int x, int y, uint g
 
 		uint hor_step = (sizing == SizingType::Smallest) ? 1 : child_wid->GetHorizontalStepSize(sizing);
 		child_wid->current_x = ComputeMaxSize(child_wid->smallest_x, given_width - child_wid->padding.Horizontal(), hor_step);
+	}
+
+	for (const auto &child_wid : this->children) {
+		auto [_, pref_y] = child_wid->GetPreferredSizeForSize(child_wid->current_x, child_wid->current_y);
+		additional_length += child_wid->current_y - pref_y;
+		child_wid->current_y = pref_y;
 	}
 
 	/* First.5 loop: count how many children are of the biggest step size. */

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -152,6 +152,17 @@ public:
 	virtual void SetupSmallestSize(Window *w) = 0;
 	virtual void AssignSizePosition(SizingType sizing, int x, int y, uint given_width, uint given_height, bool rtl) = 0;
 
+	/**
+	 * Get a widget's preferred size for a given size.
+	 * @param given_width The given width.
+	 * @param given_height The given height.
+	 * @return pair containing preferred width and height.
+	 */
+	virtual std::pair<uint, uint> GetPreferredSizeForSize(uint given_width, uint given_height)
+	{
+		return {given_width, given_height};
+	}
+
 	virtual void FillWidgetLookup(WidgetLookup &widget_lookup);
 
 	virtual NWidgetCore *GetWidgetFromPos(int x, int y) = 0;


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

The small map window's buttons are laid out in such a way that the minimum size of the window is quite wide, and there can be quite a bit of wasted space beneath them.

<img width="942" height="494" alt="smallmap_h" src="https://github.com/user-attachments/assets/00f36de7-21d0-4e8c-9847-fe1c30ac4832" />

With an complex industry set the legend section may be taller and more space is required.

<img width="1098" height="744" alt="image" src="https://github.com/user-attachments/assets/bcb1fb51-4554-41dd-9332-6e24c7b208eb" />

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Rearrange the buttons to fill the right hand size of the window instead, next to the small map. This is similar to the layout used by the original game.

Layout with vanilla industries:

<img width="942" height="494" alt="smallmap_v" src="https://github.com/user-attachments/assets/8d725e91-b554-417f-a43b-67105ba3816c" />

As the width available for the legend is now the full width of the window, it now tends to be shorter in height.

Layout with FIRS Steel Town:

<img width="1098" height="744" alt="image" src="https://github.com/user-attachments/assets/18f041d3-f503-4700-ae7b-ffc38b9181fc" />

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Muscle-memory.
Space-bars?

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
