### PR TITLE
Codechange: store all Labels in 'GrfID' order

### DIFF
--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -155,7 +155,7 @@ struct ENGSChunkHandler : ChunkHandler {
 
 /** Save and load the mapping between the engine id in the pool, and the grf file it came from. */
 static const SaveLoad _engine_id_mapping_desc[] = {
-	SLE_VAR(EngineIDMapping, grfid, VarTypes::LABEL_REVERSE),
+	SLE_VAR(EngineIDMapping, grfid, VarTypes::LABEL),
 	SLE_VAR(EngineIDMapping, internal_id,   VarTypes::U16),
 	SLE_VAR(EngineIDMapping, type,          VarTypes::U8),
 	SLE_VAR(EngineIDMapping, substitute_id, VarTypes::U8),

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -125,7 +125,7 @@ public:
 class SlGamelogGrfadd : public DefaultSaveLoadHandler<SlGamelogGrfadd, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFAdd, grfid, "grfadd.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFAdd, grfid, "grfadd.grfid", VarTypes::LABEL),
 		SLE_ARRNAME(LoggedChangeGRFAdd, md5sum, "grfadd.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfadd_sl_compat;
@@ -148,7 +148,7 @@ public:
 class SlGamelogGrfrem : public DefaultSaveLoadHandler<SlGamelogGrfrem, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", VarTypes::LABEL),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfrem_sl_compat;
 
@@ -170,7 +170,7 @@ public:
 class SlGamelogGrfcompat : public DefaultSaveLoadHandler<SlGamelogGrfcompat, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFChanged, grfid, "grfcompat.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFChanged, grfid, "grfcompat.grfid", VarTypes::LABEL),
 		SLE_ARRNAME(LoggedChangeGRFChanged, md5sum, "grfcompat.md5sum", VarTypes::U8,  16),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfcompat_sl_compat;
@@ -193,7 +193,7 @@ public:
 class SlGamelogGrfparam : public DefaultSaveLoadHandler<SlGamelogGrfparam, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", VarTypes::LABEL),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfparam_sl_compat;
 
@@ -215,7 +215,7 @@ public:
 class SlGamelogGrfmove : public DefaultSaveLoadHandler<SlGamelogGrfmove, LoggedChange> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_VARNAME(LoggedChangeGRFMoved, grfid, "grfmove.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFMoved, grfid, "grfmove.grfid", VarTypes::LABEL),
 		SLE_VARNAME(LoggedChangeGRFMoved, offset, "grfmove.offset", VarTypes::I32),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfmove_sl_compat;
@@ -239,7 +239,7 @@ class SlGamelogGrfbug : public DefaultSaveLoadHandler<SlGamelogGrfbug, LoggedCha
 public:
 	static inline const SaveLoad description[] = {
 		SLE_VARNAME(LoggedChangeGRFBug, data,  "grfbug.data",  VarTypes::U64),
-		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", VarTypes::LABEL_REVERSE),
+		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", VarTypes::LABEL),
 		SLE_VARNAME(LoggedChangeGRFBug, bug,   "grfbug.bug",   VarTypes::U8),
 	};
 	static inline const SaveLoadCompatTable compat_description = _gamelog_grfbug_sl_compat;

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -37,7 +37,7 @@ struct RAILChunkHandler : ChunkHandler {
 	RAILChunkHandler() : ChunkHandler("RAIL", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::LABEL_FORWARD),
+		SLE_VAR(LabelObject<RailTypeLabel>, label, VarTypes::LABEL),
 	};
 
 	void Save() const override
@@ -63,6 +63,7 @@ struct RAILChunkHandler : ChunkHandler {
 
 		while (SlIterateArray() != -1) {
 			SlObject(&lo, slt);
+			 if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(lo.label);
 			_railtype_list.push_back(lo);
 		}
 	}
@@ -72,7 +73,7 @@ struct ROTTChunkHandler : ChunkHandler {
 	ROTTChunkHandler() : ChunkHandler("ROTT", ChunkType::Table) {}
 
 	static inline const SaveLoad description[] = {
-		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::LABEL_FORWARD),
+		SLE_VAR(LabelObject<RoadTypeLabel>, label, VarTypes::LABEL),
 		SLE_VAR(LabelObject<RoadTypeLabel>, subtype, VarTypes::U8),
 	};
 
@@ -101,6 +102,7 @@ struct ROTTChunkHandler : ChunkHandler {
 
 		while (SlIterateArray() != -1) {
 			SlObject(&lo, slt);
+			 if (IsSavegameVersionBefore(SaveLoadVersion::LabelOrientationUnification)) std::ranges::reverse(lo.label);
 			_roadtype_list.push_back(lo);
 		}
 	}

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -19,7 +19,7 @@
 
 /** Save and load the mapping between a spec and the NewGRF it came from. */
 static const SaveLoad _newgrf_mapping_desc[] = {
-	SLE_VAR(EntityIDMapping, grfid, VarTypes::LABEL_REVERSE),
+	SLE_VAR(EntityIDMapping, grfid, VarTypes::LABEL),
 	SLE_CONDVAR(EntityIDMapping, entity_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
 	SLE_CONDVAR(EntityIDMapping, entity_id, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(EntityIDMapping, substitute_id, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MinVersion, SaveLoadVersion::ExtendEntityMapping),
@@ -69,7 +69,7 @@ struct NGRFChunkHandler : ChunkHandler {
 
 	static inline const SaveLoad description[] = {
 		   SLE_SSTR(GRFConfig, filename,         VarTypes::STR),
-		    SLE_VAR(GRFConfig, ident.grfid, VarTypes::LABEL_REVERSE),
+		    SLE_VAR(GRFConfig, ident.grfid, VarTypes::LABEL),
 		    SLE_ARR(GRFConfig, ident.md5sum,     VarTypes::U8,  16),
 		SLE_CONDVAR(GRFConfig, version, VarTypes::U32, SaveLoadVersion::StoreNewGRFVersion, SaveLoadVersion::MaxVersion),
 		   SLEG_ARR("param", param,              VarTypes::U32, std::size(param)),

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -682,8 +682,7 @@ static inline uint SlCalcConvMemLen(VarMemType conv)
 		case VarMemType::I64: return sizeof(int64_t);
 		case VarMemType::U64: return sizeof(uint64_t);
 		case VarMemType::Null: return 0;
-		case VarMemType::LabelReverse: return sizeof(BaseLabel);
-		case VarMemType::LabelForward: return sizeof(BaseLabel);
+		case VarMemType::Label: return sizeof(BaseLabel);
 
 		case VarMemType::Str:
 			return SlReadArrayLength();
@@ -935,14 +934,11 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 {
 	switch (_sl.action) {
 		case SaveLoadAction::Save: {
-			if (conv == VarTypes::LABEL_REVERSE) {
+			if (conv == VarTypes::LABEL) {
+				/* Labels are written in reverse order as that is the way GrfIDs used to be written.
+				 * Changing the order means changing external applications that extract this data. */
 				BaseLabel *label = static_cast<BaseLabel *>(ptr);
 				for (auto it = label->rbegin(); it != label->rend(); it++) SlWriteByte(*it);
-				break;
-			}
-			if (conv == VarTypes::LABEL_FORWARD) {
-				BaseLabel *label = static_cast<BaseLabel *>(ptr);
-				for (auto it = label->begin(); it != label->end(); it++) SlWriteByte(*it);
 				break;
 			}
 
@@ -987,14 +983,13 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 		}
 		case SaveLoadAction::LoadCheck:
 		case SaveLoadAction::Load: {
-			if (conv == VarTypes::LABEL_REVERSE) {
+			if (conv == VarTypes::LABEL) {
+				/* Labels are written in reverse order as that is the way GrfIDs used to be written.
+				 * Changing the order means changing external applications that extract this data.
+				 * The road/rail type labels were in forward order. They are fixed when needed in
+				 * their respective loaders. */
 				BaseLabel *label = static_cast<BaseLabel *>(ptr);
 				for (auto it = label->rbegin(); it != label->rend(); it++) *it = SlReadByte();
-				break;
-			}
-			if (conv == VarTypes::LABEL_FORWARD) {
-				BaseLabel *label = static_cast<BaseLabel *>(ptr);
-				for (auto it = label->begin(); it != label->end(); it++) *it = SlReadByte();
 				break;
 			}
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -682,8 +682,7 @@ static inline uint SlCalcConvMemLen(VarMemType conv)
 		case VarMemType::I64: return sizeof(int64_t);
 		case VarMemType::U64: return sizeof(uint64_t);
 		case VarMemType::Null: return 0;
-		case VarMemType::LabelReverse: return sizeof(BaseLabel);
-		case VarMemType::LabelForward: return sizeof(BaseLabel);
+		case VarMemType::Label: return sizeof(BaseLabel);
 
 		case VarMemType::Str:
 		case VarMemType::StrQ:
@@ -936,14 +935,11 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 {
 	switch (_sl.action) {
 		case SaveLoadAction::Save: {
-			if (conv == VarTypes::LABEL_REVERSE) {
+			if (conv == VarTypes::LABEL) {
+				/* Labels are written in reverse order as that is the way GrfIDs used to be written.
+				 * Changing the order means changing external applications that extract this data. */
 				BaseLabel *label = static_cast<BaseLabel *>(ptr);
 				for (auto it = label->rbegin(); it != label->rend(); it++) SlWriteByte(*it);
-				break;
-			}
-			if (conv == VarTypes::LABEL_FORWARD) {
-				BaseLabel *label = static_cast<BaseLabel *>(ptr);
-				for (auto it = label->begin(); it != label->end(); it++) SlWriteByte(*it);
 				break;
 			}
 
@@ -988,14 +984,13 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 		}
 		case SaveLoadAction::LoadCheck:
 		case SaveLoadAction::Load: {
-			if (conv == VarTypes::LABEL_REVERSE) {
+			if (conv == VarTypes::LABEL) {
+				/* Labels are written in reverse order as that is the way GrfIDs used to be written.
+				 * Changing the order means changing external applications that extract this data.
+				 * The road/rail type labels were in forward order. They are fixed when needed in
+				 * their respective loaders. */
 				BaseLabel *label = static_cast<BaseLabel *>(ptr);
 				for (auto it = label->rbegin(); it != label->rend(); it++) *it = SlReadByte();
-				break;
-			}
-			if (conv == VarTypes::LABEL_FORWARD) {
-				BaseLabel *label = static_cast<BaseLabel *>(ptr);
-				for (auto it = label->begin(); it != label->end(); it++) *it = SlReadByte();
 				break;
 			}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -420,6 +420,7 @@ enum class SaveLoadVersion : uint16_t {
 
 	DriveBackwards, ///< Saveload version: 365, GitHub pull request: 15379\n Trains can drive backwards.
 	DepotsUnderBridges, ///< Saveload version: 366, GitHub pull request: 15836\n Allow depots under bridges.
+	LabelOrientationUnification, ///< Saveload version: 367, GitHub pull request: 15888\n Unify the orientation in which labels are written.
 
 	MaxVersion, ///< Highest possible saveload version.
 };
@@ -663,8 +664,7 @@ enum class VarMemType : uint8_t {
 	Null = 9, ///< useful to write zeros in savegame.
 	Str = 12, ///< string pointer
 	Name = 14, ///< old custom name to be converted to a string pointer
-	LabelReverse = 15, ///< A 4 character \c Label, stored in reverse.
-	LabelForward = 16, ///< A 4 character \c Label, stored as-is.
+	Label = 15, ///< A 4 character \c Label, stored as-is.
 };
 
 /** Container of a variable's characteristics about a variable's storage. */
@@ -735,8 +735,7 @@ struct VarTypes {
 	static constexpr VarType STRINGID{ VarFileType::StringID, VarMemType::U32 }; ///< Store a StringID.
 	static constexpr VarType STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
 	static constexpr VarType NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
-	static constexpr VarType LABEL_REVERSE{ VarFileType::Label, VarMemType::LabelReverse }; ///< Store a \c Label in reverse.
-	static constexpr VarType LABEL_FORWARD{ VarFileType::Label, VarMemType::LabelForward }; ///< Store a \c Label as-is.
+	static constexpr VarType LABEL{ VarFileType::U32, VarMemType::Label }; ///< Store a \c Label as-is.
 };
 
 /** Type of data saved. */
@@ -885,8 +884,7 @@ constexpr size_t SlVarSize(VarMemType type)
 		case VarMemType::Null: return sizeof(void *);
 		case VarMemType::Str: return sizeof(std::string);
 		case VarMemType::Name: return sizeof(std::string);
-		case VarMemType::LabelReverse: return sizeof(BaseLabel);
-		case VarMemType::LabelForward: return sizeof(BaseLabel);
+		case VarMemType::Label: return sizeof(BaseLabel);
 		default: NOT_REACHED();
 	}
 }
@@ -930,7 +928,7 @@ constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t length, siz
 #define SLE_GENERAL_NAME(cmd, name, base, variable, type, length, from, to, extra) \
 	SaveLoad {name, cmd, type, length, from, to, [] (const void *b, size_t) -> const void * { \
 		static_assert(SlCheckVarSize(cmd, type, length, sizeof(static_cast<const base *>(b)->variable))); \
-		static_assert((VarType{type}.mem != VarMemType::LabelReverse && VarType{type}.mem != VarMemType::LabelForward) || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
+		static_assert(VarType{type}.mem != VarMemType::Label || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
 		assert(b != nullptr); \
 		return std::addressof(static_cast<const base *>(b)->variable); \
 	}, extra, nullptr}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -420,6 +420,7 @@ enum class SaveLoadVersion : uint16_t {
 
 	DriveBackwards, ///< Saveload version: 365, GitHub pull request: 15379\n Trains can drive backwards.
 	DepotsUnderBridges, ///< Saveload version: 366, GitHub pull request: 15836\n Allow depots under bridges.
+	LabelOrientationUnification, ///< Saveload version: 367, GitHub pull request: 15888\n Unify the orientation in which labels are written.
 
 	MaxVersion, ///< Highest possible saveload version.
 };
@@ -664,8 +665,7 @@ enum class VarMemType : uint8_t {
 	Str = 12, ///< string pointer
 	StrQ = 13, ///< string pointer enclosed in quotes
 	Name = 14, ///< old custom name to be converted to a string pointer
-	LabelReverse = 15, ///< A 4 character \c Label, stored in reverse.
-	LabelForward = 16, ///< A 4 character \c Label, stored as-is.
+	Label = 15, ///< A 4 character \c Label, stored as-is.
 };
 
 /** Container of a variable's characteristics about a variable's storage. */
@@ -737,8 +737,7 @@ struct VarTypes {
 	static constexpr VarType STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
 	static constexpr VarType STRQ{ VarFileType::String, VarMemType::StrQ }; ///< Store a string with quotes.
 	static constexpr VarType NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
-	static constexpr VarType LABEL_REVERSE{ VarFileType::Label, VarMemType::LabelReverse }; ///< Store a \c Label in reverse.
-	static constexpr VarType LABEL_FORWARD{ VarFileType::Label, VarMemType::LabelForward }; ///< Store a \c Label as-is.
+	static constexpr VarType LABEL{ VarFileType::U32, VarMemType::Label }; ///< Store a \c Label as-is.
 };
 
 /** Type of data saved. */
@@ -819,8 +818,7 @@ inline constexpr size_t SlVarSize(VarMemType type)
 		case VarMemType::Str: return sizeof(std::string);
 		case VarMemType::StrQ: return sizeof(std::string);
 		case VarMemType::Name: return sizeof(std::string);
-		case VarMemType::LabelReverse: return sizeof(BaseLabel);
-		case VarMemType::LabelForward: return sizeof(BaseLabel);
+		case VarMemType::Label: return sizeof(BaseLabel);
 		default: NOT_REACHED();
 	}
 }
@@ -864,7 +862,7 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
 #define SLE_GENERAL_NAME(cmd, name, base, variable, type, length, from, to, extra) \
 	SaveLoad {name, cmd, type, length, from, to, [] (const void *b, size_t) -> const void * { \
 		static_assert(SlCheckVarSize(cmd, type, length, sizeof(static_cast<const base *>(b)->variable))); \
-		static_assert((VarType{type}.mem != VarMemType::LabelReverse && VarType{type}.mem != VarMemType::LabelForward) || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
+		static_assert(VarType{type}.mem != VarMemType::Label || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
 		assert(b != nullptr); \
 		return std::addressof(static_cast<const base *>(b)->variable); \
 	}, extra, nullptr}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -209,7 +209,7 @@ template <typename T>
 class SlStationSpecList : public VectorSaveLoadHandler<SlStationSpecList<T>, BaseStation, SpecMapping<T>> {
 public:
 	static inline const SaveLoad description[] = {
-		SLE_CONDVAR(SpecMapping<T>, grfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
+		SLE_CONDVAR(SpecMapping<T>, grfid, VarTypes::LABEL, SaveLoadVersion::NewGRFStations, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(SpecMapping<T>, localidx, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::NewGRFStations, SaveLoadVersion::ExtendEntityMapping),
 		SLE_CONDVAR(SpecMapping<T>, localidx, VarTypes::U16, SaveLoadVersion::ExtendEntityMapping, SaveLoadVersion::MaxVersion),
 	};

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -18,7 +18,7 @@
 
 /** Description of the data to save and load in #PersistentStorage. */
 static const SaveLoad _storage_desc[] = {
-	 SLE_CONDVAR(PersistentStorage, grfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
+	 SLE_CONDVAR(PersistentStorage, grfid, VarTypes::LABEL, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	 SLE_CONDARR(PersistentStorage, storage, VarFileType::U32 | VarMemType::I32, 16, SaveLoadVersion::PersistentStoragePool, SaveLoadVersion::ExtendPersistentStorage),
 	 SLE_CONDARR(PersistentStorage, storage, VarFileType::U32 | VarMemType::I32, 256, SaveLoadVersion::ExtendPersistentStorage, SaveLoadVersion::MaxVersion),
 };

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -299,7 +299,7 @@ static const SaveLoad _town_desc[] = {
 	SLE_CONDVAR(Town, xy, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
 	SLE_CONDVAR(Town, xy, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 
-	SLE_CONDVAR(Town, townnamegrfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(Town, townnamegrfid, VarTypes::LABEL, SaveLoadVersion::NewGRFTownNames, SaveLoadVersion::MaxVersion),
 	    SLE_VAR(Town, townnametype,          VarTypes::U16),
 	    SLE_VAR(Town, townnameparts,         VarTypes::U32),
 	SLE_CONDSSTR(Town, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -181,7 +181,7 @@ static const SaveLoad _old_waypoint_desc[] = {
 	SLE_CONDVAR(OldWaypoint, build_date, VarFileType::U16 | VarMemType::I32, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::BigDates),
 	SLE_CONDVAR(OldWaypoint, build_date, VarTypes::I32, SaveLoadVersion::BigDates, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(OldWaypoint, localidx, VarTypes::U8, SaveLoadVersion::BiggerStationVariables, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(OldWaypoint, grfid, VarTypes::LABEL_REVERSE, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
+	SLE_CONDVAR(OldWaypoint, grfid, VarTypes::LABEL, SaveLoadVersion::StoreWaypointIdInMap, SaveLoadVersion::MaxVersion),
 	SLE_CONDVAR(OldWaypoint, owner, VarTypes::U8, SaveLoadVersion::NewGRFPalette, SaveLoadVersion::MaxVersion),
 };
 


### PR DESCRIPTION
## Motivation / Problem

Basically the same as #15884, however the conclusion in there was that a lot of external tools might need to be amended. So, even though it's more correct to store in the nominal order, it might be better to store it in the reverse / 'GrfID' order when thinking about interoperability.


## Description

The order of 'GrfID' labels are reversed in the saves to their nominal order. The order of rail/road type labels are in the same order in saves.

The choice to not go for the nominal order, but 'GrfID'/reverse order stems from the impact on external tools. There are way more tools that interpret the GrfIDs from the saves than there are tools that inspect the rail/road type labels. As such, the 'GrfID' order is the lesser evil in unifying label order.


## Limitations

Afterload stuff in the chunk loader, but doing it in afterload will be too late.

Using the reverse instead of nominal order requires extra documentation/logic, but not having to change `GrfID` removes a lot of things that need to be reversed so that probably evens out.

Which version is better? This one of #15884?

Closes #15884 if this gets merged.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
