### PR TITLE
Codefix: do not copy widget parts while iterating

### DIFF
--- a/src/tests/test_window_desc.cpp
+++ b/src/tests/test_window_desc.cpp
@@ -68,7 +68,7 @@ TEST_CASE("WindowDesc - ini_key validity")
 static bool IsNWidgetTreeClosed(std::span<const NWidgetPart> nwid_parts)
 {
 	int depth = 0;
-	for (const auto nwid : nwid_parts) {
+	for (const auto &nwid : nwid_parts) {
 		if (IsContainerWidgetType(nwid.type)) ++depth;
 		if (nwid.type == WPT_ENDCONTAINER) --depth;
 	}


### PR DESCRIPTION
## Motivation / Problem

```
openttd/src/tests/test_window_desc.cpp: In function ‘bool IsNWidgetTreeClosed(std::span<const NWidgetPart>)’:
openttd/src/tests/test_window_desc.cpp:71:25: warning: loop variable ‘nwid’ creates a copy from type ‘const NWidgetPart’ [-Wrange-loop-construct]
   71 |         for (const auto nwid : nwid_parts) {
      |                         ^~~~
openttd/src/tests/test_window_desc.cpp:71:25: note: use reference type to prevent copying
   71 |         for (const auto nwid : nwid_parts) {
      |                         ^~~~
      |                         &
```


## Description

Do what the compiler suggested.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
