### PR TITLE
Codechange: make StringID a strong type

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1050,24 +1050,24 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 		/* Draw the value of the currently selected sort property to the right (or left in RTL), if applicable */
 		std::string sort_prop_detail;
 
-		switch (GetEngineSortNames(type)[sort_criteria]) {
-			case STR_SORT_BY_ENGINE_ID:
+		switch (GetEngineSortNames(type)[sort_criteria].base()) {
+			case STR_SORT_BY_ENGINE_ID.base():
 				/* No extra interesting info to show in this case */
 				break;
-			case STR_SORT_BY_COST:
+			case STR_SORT_BY_COST.base():
 				sort_prop_detail = GetString(STR_PURCHASE_SORT_DETAILS_COST, e->GetCost());
 				break;
-			case STR_SORT_BY_MAX_SPEED:
+			case STR_SORT_BY_MAX_SPEED.base():
 				if (int max_speed = e->GetDisplayMaxSpeed(); max_speed != 0) {
 					sort_prop_detail = GetString(STR_PURCHASE_SORT_DETAILS_SPEED, PackVelocity(max_speed, Engine::Get(item.engine_id)->type));
 				}
 				break;
-			case STR_SORT_BY_POWER:
+			case STR_SORT_BY_POWER.base():
 				if (int power = e->GetPower(); power != 0) {
 					sort_prop_detail = GetString(STR_PURCHASE_SORT_DETAILS_POWER, power);
 				}
 				break;
-			case STR_SORT_BY_TRACTIVE_EFFORT:
+			case STR_SORT_BY_TRACTIVE_EFFORT.base():
 				/* Allow trucks, and allow trains that are not wagons */
 				if (type == VehicleType::Road || (type == VehicleType::Train && e->VehInfo<RailVehicleInfo>().railveh_type != RailVehicleType::Wagon)) {
 					auto max_te = e->GetDisplayMaxTractiveEffort();
@@ -1076,31 +1076,31 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 					}
 				}
 				break;
-			case STR_SORT_BY_INTRO_DATE: {
+			case STR_SORT_BY_INTRO_DATE.base(): {
 					TimerGameCalendar::YearMonthDay ymd = TimerGameCalendar::ConvertDateToYMD(e->intro_date);
 					sort_prop_detail = GetString(STR_PURCHASE_SORT_DETAILS_INTRO_DATE, ymd.year);
 				}
 				break;
-			case STR_SORT_BY_NAME:
+			case STR_SORT_BY_NAME.base():
 				/* No extra interesting info to show in this case */
 				break;
-			case STR_SORT_BY_RUNNING_COST:
+			case STR_SORT_BY_RUNNING_COST.base():
 				if (int running_cost = e->GetRunningCost(); running_cost != 0) {
 					sort_prop_detail = GetString(TimerGameEconomy::UsingWallclockUnits() ? STR_PURCHASE_SORT_DETAILS_RUNNINGCOST_PERIOD : STR_PURCHASE_SORT_DETAILS_RUNNINGCOST_YEAR, running_cost);
 				}
 				break;
-			case STR_SORT_BY_POWER_VS_RUNNING_COST:
+			case STR_SORT_BY_POWER_VS_RUNNING_COST.base():
 				/* NOTE: No point showing the actual values of power/running cost, because they are affected by cost factors, which make the math off */
 				if (Money rc = e->GetRunningCost(); rc != 0) {
 					sort_prop_detail = GetString(STR_PURCHASE_SORT_DETAILS_POWER_VS_RUNNING_COST, 100 * e->GetPower() / rc, /* digits for DECIMAL */ 2);
 				}
 				break;
-			case STR_SORT_BY_RELIABILITY:
+			case STR_SORT_BY_RELIABILITY.base():
 				if (auto isWagon = e->type == VehicleType::Train && e->VehInfo<RailVehicleInfo>().railveh_type == RailVehicleType::Wagon; !isWagon) {
 					sort_prop_detail = GetString(STR_PURCHASE_SORT_DETAILS_RELIABILITY, ToPercent16(e->reliability));
 				}
 				break;
-			case STR_SORT_BY_CARGO_CAPACITY: {
+			case STR_SORT_BY_CARGO_CAPACITY.base(): {
 					uint total_capacity;
 					switch (type) {
 						case VehicleType::Train:
@@ -1127,7 +1127,7 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 					}
 				}
 				break;
-			case STR_SORT_BY_RANGE:
+			case STR_SORT_BY_RANGE.base():
 				if (e->type == VehicleType::Aircraft) {
 					if (uint16_t range = e->GetRange(); range != 0) {
 						sort_prop_detail = GetString(STR_PURCHASE_SORT_DETAILS_AIRCRAFT_RANGE, range);

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -296,14 +296,14 @@ struct CheatWindow : Window {
 					/* Draw [<][>] boxes for settings of an integer-type */
 					DrawArrowButtons(button_left, y + button_y_offset, Colours::Yellow, clicked - (i * 2), true, true);
 
-					switch (ce->str) {
+					switch (ce->str.base()) {
 						/* Display date for change date cheat */
-						case STR_CHEAT_CHANGE_DATE:
+						case STR_CHEAT_CHANGE_DATE.base():
 							str = GetString(ce->str, TimerGameCalendar::date);
 							break;
 
 						/* Draw coloured flag for change company cheat */
-						case STR_CHEAT_CHANGE_COMPANY: {
+						case STR_CHEAT_CHANGE_COMPANY.base(): {
 							str = GetString(ce->str, val + 1);
 							uint offset = WidgetDimensions::scaled.hsep_indent + GetStringBoundingBox(str).width;
 							DrawCompanyIcon(_local_company, rtl ? text_right - offset - WidgetDimensions::scaled.hsep_indent : text_left + offset, y + icon_y_offset);
@@ -385,14 +385,14 @@ struct CheatWindow : Window {
 					break;
 
 				default:
-					switch (ce.str) {
+					switch (ce.str.base()) {
 						/* Display date for change date cheat */
-						case STR_CHEAT_CHANGE_DATE:
+						case STR_CHEAT_CHANGE_DATE.base():
 							width = std::max(width, GetStringBoundingBox(GetString(ce.str, TimerGameCalendar::ConvertYMDToDate(CalendarTime::MAX_YEAR, 11, 31))).width);
 							break;
 
 						/* Draw coloured flag for change company cheat */
-						case STR_CHEAT_CHANGE_COMPANY:
+						case STR_CHEAT_CHANGE_COMPANY.base():
 							width = std::max(width, GetStringBoundingBox(GetString(ce.str, MAX_COMPANIES)).width + WidgetDimensions::scaled.hsep_wide);
 							break;
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -443,7 +443,7 @@ static void GenerateCompanyName(Company *c)
 	uint32_t strp;
 	std::string name;
 	if (t->name.empty() && IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END)) {
-		str = t->townnametype - SPECSTR_TOWNNAME_START + SPECSTR_COMPANY_NAME_START;
+		str = SPECSTR_COMPANY_NAME_START + (t->townnametype - SPECSTR_TOWNNAME_START);
 		strp = t->townnameparts;
 
 verify_name:;

--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -252,6 +252,10 @@ constexpr bool IsInsideBS(const T x, const size_t base, const size_t size)
 	return static_cast<size_t>(x - base) < size;
 }
 
+/** Specialization of IsInsideBS for #ConvertibleThroughBase. @copydoc IsInsideBS(const T, const size_t, const size_t) */
+template <ConvertibleThroughBase T>
+constexpr bool IsInsideBS(const T x, const T base, const size_t size) noexcept { return IsInsideBS(x.base(), base.base(), size); }
+
 /**
  * Checks if a value is in an interval.
  *
@@ -270,6 +274,10 @@ constexpr bool IsInsideMM(const size_t x, const size_t min, const size_t max) no
 
 /** Specialization of IsInsideMM for #ConvertibleThroughBase. @copydoc IsInsideMM(const size_t, const size_t, const size_t) */
 constexpr bool IsInsideMM(const ConvertibleThroughBase auto x, const size_t min, const size_t max) noexcept { return IsInsideMM(x.base(), min, max); }
+
+/** Specialization of IsInsideMM for #ConvertibleThroughBase. @copydoc IsInsideMM(const size_t, const size_t, const size_t) */
+template <ConvertibleThroughBase T>
+constexpr bool IsInsideMM(const T x, const T min, const T max) noexcept { return IsInsideMM(x.base(), min.base(), max.base()); }
 
 /** Specialization of IsInsideMM for enums. @copydoc IsInsideMM(const size_t, const size_t, const size_t) */
 template <typename enum_type, std::enable_if_t<std::is_enum_v<enum_type>, bool> = true>

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -321,17 +321,18 @@ struct GoalQuestionWindow : public Window {
 	EncodedString question; ///< Question to ask (private copy).
 	GoalQuestionButtons buttons; ///< Buttons to display.
 	TextColour colour; ///< Colour of the question text.
+	GoalQuestionType type; ///< The type of question.
 
 	/**
 	 * Construct a new Goal Question Window.
 	 * @param desc Window description.
 	 * @param window_number Number for the window.
-	 * @param colour Colour of the question text.
+	 * @param type The type of question that is being asked.
 	 * @param buttons Buttons to display.
 	 * @param question Question to ask.
 	 */
-	GoalQuestionWindow(WindowDesc &desc, WindowNumber window_number, TextColour colour, GoalQuestionButtons buttons, const EncodedString &question)
-		: Window(desc), question(question), buttons(buttons), colour(colour)
+	GoalQuestionWindow(WindowDesc &desc, WindowNumber window_number, GoalQuestionType type, GoalQuestionButtons buttons, const EncodedString &question)
+		: Window(desc), question(question), buttons(buttons), colour(type == GoalQuestionType::Error ? TextColour::White : TextColour::Black), type(type)
 	{
 		assert(this->buttons.Count() < 4);
 
@@ -347,6 +348,9 @@ struct GoalQuestionWindow : public Window {
 	std::string GetWidgetString(WidgetID widget, StringID stringid) const override
 	{
 		switch (widget) {
+			case WID_GQ_CAPTION:
+				return GetString(STR_GOAL_QUESTION_CAPTION_QUESTION + to_underlying(this->type));
+
 			case WID_GQ_BUTTON_1:
 			case WID_GQ_BUTTON_2:
 			case WID_GQ_BUTTON_3:
@@ -390,12 +394,12 @@ struct GoalQuestionWindow : public Window {
  * @tparam btn_colour Button colour.
  * @tparam caption Window caption string.
  */
-template <Colours bg_colour, Colours btn_colour, StringID caption>
+template <Colours bg_colour, Colours btn_colour>
 struct NestedGoalWidgets {
 	static constexpr auto widgetparts = {
 		NWidget(NWID_HORIZONTAL),
 			NWidget(WWT_CLOSEBOX, bg_colour),
-			NWidget(WWT_CAPTION, bg_colour, WID_GQ_CAPTION), SetStringTip(caption, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+			NWidget(WWT_CAPTION, bg_colour, WID_GQ_CAPTION), SetStringTip(STR_NULL, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 		EndContainer(),
 		NWidget(WWT_PANEL, bg_colour),
 			NWidget(NWID_VERTICAL), SetPadding(WidgetDimensions::unscaled.modalpopup), SetPIP(0, WidgetDimensions::unscaled.vsep_wide, 0),
@@ -419,10 +423,10 @@ struct NestedGoalWidgets {
 	};
 };
 
-static constexpr auto _nested_goal_question_widgets_question = NestedGoalWidgets<Colours::LightBlue, Colours::LightBlue, STR_GOAL_QUESTION_CAPTION_QUESTION>::widgetparts;
-static constexpr auto _nested_goal_question_widgets_info     = NestedGoalWidgets<Colours::LightBlue, Colours::LightBlue, STR_GOAL_QUESTION_CAPTION_INFORMATION>::widgetparts;
-static constexpr auto _nested_goal_question_widgets_warning  = NestedGoalWidgets<Colours::Yellow,     Colours::Yellow,     STR_GOAL_QUESTION_CAPTION_WARNING>::widgetparts;
-static constexpr auto _nested_goal_question_widgets_error    = NestedGoalWidgets<Colours::Red,        Colours::Yellow,     STR_GOAL_QUESTION_CAPTION_ERROR>::widgetparts;
+static constexpr auto _nested_goal_question_widgets_question = NestedGoalWidgets<Colours::LightBlue, Colours::LightBlue>::widgetparts; ///< Widgets for a question.
+static constexpr auto _nested_goal_question_widgets_info = NestedGoalWidgets<Colours::LightBlue, Colours::LightBlue>::widgetparts; ///< Widgets for a informational message.
+static constexpr auto _nested_goal_question_widgets_warning = NestedGoalWidgets<Colours::Yellow, Colours::Yellow>::widgetparts; ///< Widgets for a warning message.
+static constexpr auto _nested_goal_question_widgets_error = NestedGoalWidgets<Colours::Red, Colours::Yellow>::widgetparts; ///< Widgets for an error message.
 
 /** Window definitions for the goal question windows. */
 static EnumIndexArray<WindowDesc, GoalQuestionType, GoalQuestionType::End> _goal_question_list_desc{{{
@@ -462,5 +466,5 @@ static EnumIndexArray<WindowDesc, GoalQuestionType, GoalQuestionType::End> _goal
 void ShowGoalQuestion(uint16_t id, GoalQuestionType type, GoalQuestionButtons buttons, const EncodedString &question)
 {
 	assert(type < GoalQuestionType::End);
-	new GoalQuestionWindow(_goal_question_list_desc[type], id, type == GoalQuestionType::Error ? TextColour::White : TextColour::Black, buttons, question);
+	new GoalQuestionWindow(_goal_question_list_desc[type], id, type, buttons, question);
 }

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -477,7 +477,7 @@ static void GetTileDesc_Industry(TileIndex tile, TileDesc &td)
 	td.owner[0] = i->owner;
 	td.str = is->name;
 	if (!IsIndustryCompleted(tile)) {
-		td.dparam = td.str;
+		td.dparam = td.str.base();
 		td.str = STR_LAI_TOWN_INDUSTRY_DESCRIPTION_UNDER_CONSTRUCTION;
 	}
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3842,6 +3842,7 @@ STR_GOALS_PROGRESS_COMPLETE                                     :{GREEN}{RAW_STR
 STR_GOALS_TOOLTIP_CLICK_ON_SERVICE_TO_CENTER                    :{BLACK}Click on goal to centre main view on industry/town/tile. Ctrl+Click to open a new viewport on industry/town/tile location
 
 # Goal question window
+###length 4
 STR_GOAL_QUESTION_CAPTION_QUESTION                              :{BLACK}Question
 STR_GOAL_QUESTION_CAPTION_INFORMATION                           :{BLACK}Information
 STR_GOAL_QUESTION_CAPTION_WARNING                               :{BLACK}Warning

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -377,7 +377,7 @@ std::optional<std::string_view> NetworkGameSocketHandler::ReceiveCommand(Packet 
 	cp.cmd     = static_cast<Commands>(p.Recv_uint16());
 	if (!IsValidCommand(cp.cmd)) return "invalid command";
 	if (GetCommandFlags(cp.cmd).Test(CommandFlag::Offline)) return "single-player only command";
-	cp.err_msg = p.Recv_uint16();
+	cp.err_msg = static_cast<StringID>(p.Recv_uint16());
 	cp.data    = _cmd_dispatch[cp.cmd].Sanitize(p.Recv_buffer());
 
 	uint8_t callback = p.Recv_uint8();
@@ -396,7 +396,7 @@ void NetworkGameSocketHandler::SendCommand(Packet &p, const CommandPacket &cp)
 {
 	p.Send_uint8(cp.company);
 	p.Send_uint16(to_underlying(cp.cmd));
-	p.Send_uint16(cp.err_msg);
+	p.Send_uint16(cp.err_msg.base());
 	p.Send_buffer(cp.data);
 
 	size_t callback = FindCallbackIndex(cp.callback);

--- a/src/newgrf/newgrf_stringmapping.cpp
+++ b/src/newgrf/newgrf_stringmapping.cpp
@@ -78,8 +78,8 @@ static StringID TTDPStringIDToOTTDStringIDMapping(GRFStringID str)
 	assert(!IsInsideMM(str.base(), 0xD000, 0xD7FF));
 
 #define TEXTID_TO_STRINGID(begin, end, stringid, stringend) \
-	static_assert(stringend - stringid == end - begin); \
-	if (str.base() >= begin && str.base() <= end) return StringID{str.base() + (stringid - begin)}
+	static_assert(stringend.base() - stringid.base() == end - begin); \
+	if (str.base() >= begin && str.base() <= end) return StringID{str.base() + (stringid.base() - begin)}
 
 	/* We have some changes in our cargo strings, resulting in some missing. */
 	TEXTID_TO_STRINGID(0x000E, 0x002D, STR_CARGO_PLURAL_NOTHING,                      STR_CARGO_PLURAL_FIZZY_DRINKS);

--- a/src/newgrf_badge.h
+++ b/src/newgrf_badge.h
@@ -23,7 +23,7 @@ public:
 	BadgeID index; ///< Index assigned to badge.
 	BadgeClassID class_index; ///< Index of class this badge belongs to.
 	BadgeFlags flags = {}; ///< Display flags
-	StringID name = 0; ///< Short name.
+	StringID name{}; ///< Short name.
 	GrfSpecFeatures features{}; ///< Bitmask of which features use this badge.
 	VariableGRFFileProps<GrfSpecFeature> grf_prop; ///< Sprite information.
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -413,7 +413,7 @@ TownScopeResolver *StationResolverObject::GetTown()
 
 		/* General station variables */
 		case 0x82: return 50;
-		case 0x84: return this->st->string_id;
+		case 0x84: return this->st->string_id.base();
 		case 0x86: return 0;
 		case 0xF0: return this->st->facilities.base();
 		case 0xFA: return ClampTo<uint16_t>(this->st->build_date - CalendarTime::DAYS_TILL_ORIGINAL_BASE_YEAR);

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -277,7 +277,7 @@ std::string TranslateTTDPatchCodes(GrfID grfid, GRFLanguage language_id, bool al
 			{
 				uint16_t string = consumer.ReadUint16LE();
 				builder.PutUtf8(SCC_NEWGRF_STRINL);
-				builder.PutUtf8(MapGRFStringID(grfid, GRFStringID{string}));
+				builder.PutUtf8(MapGRFStringID(grfid, GRFStringID{string}).base());
 				break;
 			}
 			case 0x82:
@@ -843,7 +843,7 @@ static void ProcessNewGRFStringControlCode(char32_t scc, StringConsumer &consume
 			break;
 
 		case SCC_NEWGRF_STRINL: {
-			StringID stringid = consumer.ReadUtf8(STR_NULL);
+			StringID stringid{consumer.ReadUtf8(STR_NULL.base())};
 			/* We also need to handle the substring's stack usage. */
 			HandleNewGRFStringControlCodes(GetStringPtr(stringid), stack, params);
 			break;

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1108,9 +1108,9 @@ std::tuple<CommandCost, Money> CmdRemoveLongRoad(DoCommandFlags flags, TileIndex
 				had_success = true;
 			} else {
 				/* Some errors are more equal than others. */
-				switch (last_error.GetErrorMessage()) {
-					case STR_ERROR_OWNED_BY:
-					case STR_ERROR_LOCAL_AUTHORITY_REFUSES_TO_ALLOW_THIS:
+				switch (last_error.GetErrorMessage().base()) {
+					case STR_ERROR_OWNED_BY.base():
+					case STR_ERROR_LOCAL_AUTHORITY_REFUSES_TO_ALLOW_THIS.base():
 						break;
 					default:
 						last_error = std::move(ret);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -677,7 +677,7 @@ bool AfterLoadGame()
 		}
 
 		for (Town *t : Town::Iterate()) {
-			t->name = CopyFromOldName(t->townnametype);
+			t->name = CopyFromOldName(static_cast<StringID>(t->townnametype));
 			if (!t->name.empty()) t->townnametype = SPECSTR_TOWNNAME_START + _settings_game.game_creation.town_name;
 		}
 	}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -795,7 +795,7 @@ static bool LoadOldStation(LoadgameState &ls, int num)
 			if (IsInsideBS(_old_string_id, 0x180F, 32)) {
 				st->string_id = STR_SV_STNAME + (_old_string_id - 0x180F); // automatic name
 			} else {
-				st->string_id = _old_string_id + 0x2800; // custom name
+				st->string_id = static_cast<StringID>(_old_string_id + 0x2800); // custom name
 			}
 
 			if (st->airport.blocks.Test(AirportBlock{8})) {
@@ -806,7 +806,7 @@ static bool LoadOldStation(LoadgameState &ls, int num)
 				st->airport.type = 0; // small airport
 			}
 		} else {
-			st->string_id = RemapOldStringID(_old_string_id);
+			st->string_id = RemapOldStringID(static_cast<StringID>(_old_string_id));
 		}
 	} else {
 		delete st;
@@ -1011,28 +1011,28 @@ static bool LoadOldCompany(LoadgameState &ls, int num)
 
 		/* Company name */
 		if (_old_string_id == 0 || _old_string_id == 0x4C00) {
-			_old_string_id = STR_SV_UNNAMED; // "Unnamed"
+			_old_string_id = STR_SV_UNNAMED.base(); // "Unnamed"
 		} else if (GB(_old_string_id, 8, 8) == 0x52) {
 			_old_string_id += 0x2A00; // Custom name
 		} else {
-			_old_string_id = RemapOldStringID(_old_string_id += 0x240D); // Automatic name
+			_old_string_id = RemapOldStringID(static_cast<StringID>(_old_string_id += 0x240D)).base(); // Automatic name
 		}
-		c->name_1 = _old_string_id;
+		c->name_1 = static_cast<StringID>(_old_string_id);
 
 		/* Manager name */
 		switch (_old_string_id_2) {
-			case 0x4CDA: _old_string_id_2 = SPECSTR_PRESIDENT_NAME;    break; // automatic name
-			case 0x0006: _old_string_id_2 = STR_SV_EMPTY;              break; // empty name
+			case 0x4CDA: _old_string_id_2 = SPECSTR_PRESIDENT_NAME.base(); break; // automatic name
+			case 0x0006: _old_string_id_2 = STR_SV_EMPTY.base(); break; // empty name
 			default:     _old_string_id_2 = _old_string_id_2 + 0x2A00; break; // custom name
 		}
-		c->president_name_1 = _old_string_id_2;
+		c->president_name_1 = static_cast<StringID>(_old_string_id_2);
 
 		c->colour = RemapTTOColour(c->colour);
 
 		if (num != 0) c->is_ai = true;
 	} else {
-		c->name_1 = RemapOldStringID(_old_string_id);
-		c->president_name_1 = RemapOldStringID(_old_string_id_2);
+		c->name_1 = RemapOldStringID(static_cast<StringID>(_old_string_id));
+		c->president_name_1 = RemapOldStringID(static_cast<StringID>(_old_string_id_2));
 
 		if (num == 0) {
 			/* If the first company has no name, make sure we call it UNNAMED */
@@ -1335,15 +1335,15 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 
 			switch (_old_string_id) {
 				case 0x0000: break; // empty (invalid vehicles)
-				case 0x0006: _old_string_id  = STR_SV_EMPTY;              break; // empty (special vehicles)
-				case 0x8495: _old_string_id  = STR_SV_TRAIN_NAME;         break; // "Train X"
-				case 0x8842: _old_string_id  = STR_SV_ROAD_VEHICLE_NAME;  break; // "Road Vehicle X"
-				case 0x8C3B: _old_string_id  = STR_SV_SHIP_NAME;          break; // "Ship X"
-				case 0x9047: _old_string_id  = STR_SV_AIRCRAFT_NAME;      break; // "Aircraft X"
-				default:     _old_string_id += 0x2A00;                    break; // custom name
+				case 0x0006: _old_string_id = STR_SV_EMPTY.base(); break; // empty (special vehicles)
+				case 0x8495: _old_string_id = STR_SV_TRAIN_NAME.base(); break; // "Train X"
+				case 0x8842: _old_string_id = STR_SV_ROAD_VEHICLE_NAME.base(); break; // "Road Vehicle X"
+				case 0x8C3B: _old_string_id = STR_SV_SHIP_NAME.base(); break; // "Ship X"
+				case 0x9047: _old_string_id = STR_SV_AIRCRAFT_NAME.base(); break; // "Aircraft X"
+				default: _old_string_id += 0x2A00; break; // custom name
 			}
 
-			ls.vehicle_names[_current_vehicle_id] = _old_string_id;
+			ls.vehicle_names[_current_vehicle_id] = static_cast<StringID>(_old_string_id);
 		} else {
 			/* Read the vehicle type and allocate the right vehicle */
 			switch (ReadByte(ls)) {
@@ -1360,7 +1360,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 			if (!LoadChunk(ls, v, vehicle_chunk)) return false;
 			if (v == nullptr) continue;
 
-			ls.vehicle_names[_current_vehicle_id] = RemapOldStringID(_old_string_id);
+			ls.vehicle_names[_current_vehicle_id] = RemapOldStringID(static_cast<StringID>(_old_string_id));
 
 			/* This should be consistent, else we have a big problem... */
 			if (v->index != _current_vehicle_id) {
@@ -1429,9 +1429,9 @@ static bool LoadOldSign(LoadgameState &ls, int num)
 
 	if (_old_string_id != 0) {
 		if (_savegame_type == SavegameType::TTO) {
-			if (_old_string_id != 0x140A) si->name = CopyFromOldName(_old_string_id + 0x2A00);
+			if (_old_string_id != 0x140A) si->name = CopyFromOldName(static_cast<StringID>(_old_string_id + 0x2A00));
 		} else {
-			si->name = CopyFromOldName(RemapOldStringID(_old_string_id));
+			si->name = CopyFromOldName(RemapOldStringID(static_cast<StringID>(_old_string_id)));
 		}
 		si->owner = OWNER_NONE;
 	} else {
@@ -1473,7 +1473,7 @@ static bool LoadOldEngine(LoadgameState &ls, int num)
 static bool LoadOldEngineName(LoadgameState &ls, int num)
 {
 	Engine *e = GetTempDataEngine(static_cast<EngineID>(num));
-	e->name = CopyFromOldName(RemapOldStringID(ReadUint16(ls)));
+	e->name = CopyFromOldName(RemapOldStringID(static_cast<StringID>(ReadUint16(ls))));
 	return true;
 }
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -918,7 +918,7 @@ void WriteValue(void *ptr, VarMemType conv, int64_t val)
 		case VarMemType::U32: *static_cast<uint32_t *>(ptr) = val; break;
 		case VarMemType::I64: *static_cast<int64_t *>(ptr) = val; break;
 		case VarMemType::U64: *static_cast<uint64_t *>(ptr) = val; break;
-		case VarMemType::Name: *reinterpret_cast<std::string *>(ptr) = CopyFromOldName(val); break;
+		case VarMemType::Name: *reinterpret_cast<std::string *>(ptr) = CopyFromOldName(static_cast<StringID>(val)); break;
 		case VarMemType::Null: break;
 		default: NOT_REACHED();
 	}
@@ -1010,7 +1010,7 @@ static void SlSaveLoadConv(void *ptr, VarType conv)
 				case VarFileType::U32: x = static_cast<uint32_t>(SlReadUint32()); break;
 				case VarFileType::I64: x = static_cast<int64_t>(SlReadUint64()); break;
 				case VarFileType::U64: x = static_cast<uint64_t>(SlReadUint64()); break;
-				case VarFileType::StringID: x = RemapOldStringID(static_cast<uint16_t>(SlReadUint16())); break;
+				case VarFileType::StringID: x = RemapOldStringID(static_cast<StringID>(SlReadUint16())).base(); break;
 				default: NOT_REACHED();
 			}
 

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -87,7 +87,7 @@ void MoveBuoysToWaypoints()
 		wp->build_date = build_date;
 		wp->owner      = train ? GetTileOwner(xy) : OWNER_NONE;
 
-		if (IsInsideBS(string_id, STR_SV_STNAME_BUOY, 9)) wp->town_cn = string_id - STR_SV_STNAME_BUOY;
+		if (IsInsideBS(string_id, STR_SV_STNAME_BUOY, 9)) wp->town_cn = (string_id - STR_SV_STNAME_BUOY).base();
 
 		if (train) {
 			/* When we make a rail waypoint of the station, convert the map as well. */

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -27,7 +27,7 @@ static const size_t LEN_OLD_STRINGS = 32; ///< The number of characters per stri
  */
 StringID RemapOldStringID(StringID s)
 {
-	switch (s) {
+	switch (s.base()) {
 		case 0x0006: return STR_SV_EMPTY;
 		case 0x7000: return STR_SV_UNNAMED;
 		case 0x70E4: return SPECSTR_COMPANY_NAME_START;
@@ -62,7 +62,7 @@ std::string CopyFromOldName(StringID id)
 	if (GetStringTab(id) != TEXT_TAB_OLD_CUSTOM) return std::string();
 
 	if (IsSavegameVersionBefore(SaveLoadVersion::Utf8)) {
-		const std::string &strfrom = _old_name_array[GB(id, 0, 9)];
+		const std::string &strfrom = _old_name_array[GB(id.base(), 0, 9)];
 
 		std::string result;
 		StringBuilder builder(result);
@@ -89,7 +89,7 @@ std::string CopyFromOldName(StringID id)
 		return result;
 	} else {
 		/* Name will already be in UTF-8. */
-		return StrMakeValid(_old_name_array[GB(id, 0, 9)]);
+		return StrMakeValid(_old_name_array[GB(id.base(), 0, 9)]);
 	}
 }
 

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -410,7 +410,7 @@ struct CITYChunkHandler : ChunkHandler {
 				t->valid_history = 1U << LAST_MONTH;
 			}
 
-			if (t->townnamegrfid.Empty() && !IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END) && GetStringTab(t->townnametype) != TEXT_TAB_OLD_CUSTOM) {
+			if (t->townnamegrfid.Empty() && !IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END) && GetStringTab(static_cast<StringID>(t->townnametype)) != TEXT_TAB_OLD_CUSTOM) {
 				SlErrorCorrupt("Invalid town name generator");
 			}
 		}

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -209,7 +209,7 @@ struct CHKPChunkHandler : ChunkHandler {
 			SlObject(&wp, _old_waypoint_desc);
 
 			if (IsSavegameVersionBefore(SaveLoadVersion::LinkWaypointToTown)) {
-				wp.town_cn = (wp.string_id & 0xC000) == 0xC000 ? (wp.string_id >> 8) & 0x3F : 0;
+				wp.town_cn = (wp.string_id.base() & 0xC000) == 0xC000 ? (wp.string_id.base() >> 8) & 0x3F : 0;
 				wp.town = ClosestTownFromTile(wp.xy, UINT_MAX);
 			} else if (IsSavegameVersionBefore(SaveLoadVersion::WaypointMoreLikeStation)) {
 				/* Only for versions 12 .. 122 */

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -227,7 +227,7 @@ enum class StationNaming : uint8_t {
 
 /** Information to handle station action 0 property 24 correctly */
 struct StationNameInformation {
-	std::bitset<STR_SV_STNAME_FALLBACK - STR_SV_STNAME> used_names; ///< Used default station suffixes.
+	std::bitset<(STR_SV_STNAME_FALLBACK - STR_SV_STNAME).base()> used_names; ///< Used default station suffixes.
 	std::bitset<NUM_INDUSTRYTYPES> indtypes; ///< Bit set indicating when an industry type has been found.
 
 	/**
@@ -238,7 +238,7 @@ struct StationNameInformation {
 	bool IsAvailable(StringID str) const
 	{
 		assert(IsInsideMM(str, STR_SV_STNAME, STR_SV_STNAME_FALLBACK));
-		return !this->used_names.test(str - STR_SV_STNAME);
+		return !this->used_names.test((str - STR_SV_STNAME).base());
 	}
 
 	/**
@@ -248,7 +248,7 @@ struct StationNameInformation {
 	void SetUsed(StringID str)
 	{
 		assert(IsInsideMM(str, STR_SV_STNAME, STR_SV_STNAME_FALLBACK));
-		this->used_names.set(str - STR_SV_STNAME);
+		this->used_names.set((str - STR_SV_STNAME).base());
 	}
 };
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1250,8 +1250,8 @@ StationGfx RailStationTileLayout<StationType::Rail>::Iterator::operator*() const
 /**
  * Find a nearby station that joins this station.
  * @tparam T the class to find a station for
- * @tparam error_message the error message when building a station on top of others
  * @tparam F the filter functor type
+ * @param error_message the error message when building a station on top of others
  * @param existing_station an existing station we build over
  * @param station_to_join the station to join to
  * @param adjacent whether adjacent stations are allowed
@@ -1260,8 +1260,8 @@ StationGfx RailStationTileLayout<StationType::Rail>::Iterator::operator*() const
  * @param filter The filter to remove unwanted stations.
  * @return command cost with the error or 'okay'
  */
-template <class T, StringID error_message, class F>
-CommandCost FindJoiningBaseStation(StationID existing_station, StationID station_to_join, bool adjacent, TileArea ta, T **st, F filter)
+template <class T, class F>
+CommandCost FindJoiningBaseStation(StringID error_message, StationID existing_station, StationID station_to_join, bool adjacent, TileArea ta, T **st, F filter)
 {
 	assert(*st == nullptr);
 	bool check_surrounding = true;
@@ -1307,7 +1307,7 @@ CommandCost FindJoiningBaseStation(StationID existing_station, StationID station
  */
 static CommandCost FindJoiningStation(StationID existing_station, StationID station_to_join, bool adjacent, TileArea ta, Station **st)
 {
-	return FindJoiningBaseStation<Station, STR_ERROR_MUST_REMOVE_RAILWAY_STATION_FIRST>(existing_station, station_to_join, adjacent, ta, st, [](const Station *) -> bool { return true; });
+	return FindJoiningBaseStation<Station>(STR_ERROR_MUST_REMOVE_RAILWAY_STATION_FIRST, existing_station, station_to_join, adjacent, ta, st, [](const Station *) -> bool { return true; });
 }
 
 /**
@@ -1323,9 +1323,9 @@ static CommandCost FindJoiningStation(StationID existing_station, StationID stat
 CommandCost FindJoiningWaypoint(StationID existing_waypoint, StationID waypoint_to_join, bool adjacent, TileArea ta, Waypoint **wp, bool is_road)
 {
 	if (is_road) {
-		return FindJoiningBaseStation<Waypoint, STR_ERROR_MUST_REMOVE_ROADWAYPOINT_FIRST>(existing_waypoint, waypoint_to_join, adjacent, ta, wp, [](const Waypoint *wp) -> bool { return HasBit(wp->waypoint_flags, WPF_ROAD); });
+		return FindJoiningBaseStation<Waypoint>(STR_ERROR_MUST_REMOVE_ROADWAYPOINT_FIRST, existing_waypoint, waypoint_to_join, adjacent, ta, wp, [](const Waypoint *wp) -> bool { return HasBit(wp->waypoint_flags, WPF_ROAD); });
 	} else {
-		return FindJoiningBaseStation<Waypoint, STR_ERROR_MUST_REMOVE_RAILWAYPOINT_FIRST>(existing_waypoint, waypoint_to_join, adjacent, ta, wp, [](const Waypoint *wp) -> bool { return !HasBit(wp->waypoint_flags, WPF_ROAD); });
+		return FindJoiningBaseStation<Waypoint>(STR_ERROR_MUST_REMOVE_RAILWAYPOINT_FIRST, existing_waypoint, waypoint_to_join, adjacent, ta, wp, [](const Waypoint *wp) -> bool { return !HasBit(wp->waypoint_flags, WPF_ROAD); });
 	}
 }
 
@@ -2013,7 +2013,7 @@ CommandCost RemoveRoadWaypointStop(TileIndex tile, DoCommandFlags flags, int rep
  */
 static CommandCost FindJoiningRoadStop(StationID existing_stop, StationID station_to_join, bool adjacent, TileArea ta, Station **st)
 {
-	return FindJoiningBaseStation<Station, STR_ERROR_MUST_REMOVE_ROAD_STOP_FIRST>(existing_stop, station_to_join, adjacent, ta, st, [](const Station *) -> bool { return true; });
+	return FindJoiningBaseStation<Station>(STR_ERROR_MUST_REMOVE_ROAD_STOP_FIRST, existing_stop, station_to_join, adjacent, ta, st, [](const Station *) -> bool { return true; });
 }
 
 /**

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2087,20 +2087,20 @@ struct StationViewWindow : public Window {
 	void SelectSortBy(int index)
 	{
 		_settings_client.gui.station_gui_sort_by = index;
-		switch (StationViewWindow::sort_names[index]) {
-			case STR_STATION_VIEW_WAITING_STATION:
+		switch (StationViewWindow::sort_names[index].base()) {
+			case STR_STATION_VIEW_WAITING_STATION.base():
 				this->current_mode = MODE_WAITING;
 				this->sortings[1] = this->sortings[2] = this->sortings[3] = CargoSortType::AsGrouping;
 				break;
-			case STR_STATION_VIEW_WAITING_AMOUNT:
+			case STR_STATION_VIEW_WAITING_AMOUNT.base():
 				this->current_mode = MODE_WAITING;
 				this->sortings[1] = this->sortings[2] = this->sortings[3] = CargoSortType::Count;
 				break;
-			case STR_STATION_VIEW_PLANNED_STATION:
+			case STR_STATION_VIEW_PLANNED_STATION.base():
 				this->current_mode = MODE_PLANNED;
 				this->sortings[1] = this->sortings[2] = this->sortings[3] = CargoSortType::AsGrouping;
 				break;
-			case STR_STATION_VIEW_PLANNED_AMOUNT:
+			case STR_STATION_VIEW_PLANNED_AMOUNT.base():
 				this->current_mode = MODE_PLANNED;
 				this->sortings[1] = this->sortings[2] = this->sortings[3] = CargoSortType::Count;
 				break;
@@ -2121,33 +2121,33 @@ struct StationViewWindow : public Window {
 		this->grouping_index = index;
 		_settings_client.gui.station_gui_group_order = index;
 		this->GetWidget<NWidgetCore>(WID_SV_GROUP_BY)->SetString(StationViewWindow::group_names[index]);
-		switch (StationViewWindow::group_names[index]) {
-			case STR_STATION_VIEW_GROUP_S_V_D:
+		switch (StationViewWindow::group_names[index].base()) {
+			case STR_STATION_VIEW_GROUP_S_V_D.base():
 				this->groupings[1] = GR_SOURCE;
 				this->groupings[2] = GR_NEXT;
 				this->groupings[3] = GR_DESTINATION;
 				break;
-			case STR_STATION_VIEW_GROUP_S_D_V:
+			case STR_STATION_VIEW_GROUP_S_D_V.base():
 				this->groupings[1] = GR_SOURCE;
 				this->groupings[2] = GR_DESTINATION;
 				this->groupings[3] = GR_NEXT;
 				break;
-			case STR_STATION_VIEW_GROUP_V_S_D:
+			case STR_STATION_VIEW_GROUP_V_S_D.base():
 				this->groupings[1] = GR_NEXT;
 				this->groupings[2] = GR_SOURCE;
 				this->groupings[3] = GR_DESTINATION;
 				break;
-			case STR_STATION_VIEW_GROUP_V_D_S:
+			case STR_STATION_VIEW_GROUP_V_D_S.base():
 				this->groupings[1] = GR_NEXT;
 				this->groupings[2] = GR_DESTINATION;
 				this->groupings[3] = GR_SOURCE;
 				break;
-			case STR_STATION_VIEW_GROUP_D_S_V:
+			case STR_STATION_VIEW_GROUP_D_S_V.base():
 				this->groupings[1] = GR_DESTINATION;
 				this->groupings[2] = GR_SOURCE;
 				this->groupings[3] = GR_NEXT;
 				break;
-			case STR_STATION_VIEW_GROUP_D_V_S:
+			case STR_STATION_VIEW_GROUP_D_V_S.base():
 				this->groupings[1] = GR_DESTINATION;
 				this->groupings[2] = GR_NEXT;
 				this->groupings[3] = GR_SOURCE;

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -240,7 +240,7 @@ struct HeaderFileWriter : HeaderWriter, FileWriter {
 	void WriteStringID(const std::string &name, size_t stringid) override
 	{
 		if (prev + 1 != stringid) this->output_stream << "\n";
-		fmt::print(this->output_stream, "static const StringID {} = 0x{:X};\n", name, stringid);
+		fmt::print(this->output_stream, "static constexpr StringID {}{{0x{:X}}};\n", name, stringid);
 		prev = stringid;
 		total_strings++;
 	}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -104,7 +104,7 @@ EncodedString GetEncodedStringWithArgs(StringID str, std::span<const StringParam
 	std::string result;
 	StringBuilder builder(result);
 	builder.PutUtf8(SCC_ENCODED_INTERNAL);
-	builder.PutIntegerBase(str, 16);
+	builder.PutIntegerBase(str.base(), 16);
 
 	struct visitor {
 		StringBuilder &builder;
@@ -158,7 +158,7 @@ EncodedString EncodedString::ReplaceParam(size_t param, StringParameter &&data) 
 
 	StringID str;
 	if (auto r = consumer.TryReadIntegerBase<uint32_t>(16); r.has_value()) {
-		str = *r;
+		str = static_cast<StringID>(*r);
 	} else {
 		return {};
 	}
@@ -347,7 +347,7 @@ void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters
 		case TEXT_TAB_TOWN:
 			if (IsInsideMM(string, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END) && !game_script) {
 				try {
-					GenerateTownNameString(builder, string - SPECSTR_TOWNNAME_START, args.GetNextParameter<uint32_t>());
+					GenerateTownNameString(builder, (string - SPECSTR_TOWNNAME_START).base(), args.GetNextParameter<uint32_t>());
 				} catch (const std::runtime_error &e) {
 					Debug(misc, 0, "GetStringWithArgs: {}", e.what());
 					builder += "(invalid string parameter)";
@@ -1045,7 +1045,7 @@ static void DecodeEncodedString(StringConsumer &consumer, bool game_script, Stri
 					return;
 				}
 				assert(!record.AnyBytesLeft());
-				param = MakeStringID(TEXT_TAB_GAMESCRIPT_START, StringIndexInTab(param));
+				param = MakeStringID(TEXT_TAB_GAMESCRIPT_START, StringIndexInTab(param)).base();
 				sub_args.emplace_back(param);
 				break;
 			}
@@ -1175,7 +1175,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 					break;
 
 				case SCC_NEWGRF_STRINL: {
-					StringID substr = consumer.ReadUtf8(STR_NULL);
+					StringID substr{consumer.ReadUtf8(STR_NULL.base())};
 					std::string_view ptr = GetStringPtr(substr);
 					str_stack.emplace(ptr, args.GetOffset(), next_substr_case_index); // this may invalidate "consumer"
 					next_substr_case_index = 0;
@@ -1377,12 +1377,12 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 						break;
 					}
 
-					switch (CargoSpec::Get(cargo)->units_volume) {
-						case STR_TONS:
+					switch (CargoSpec::Get(cargo)->units_volume.base()) {
+						case STR_TONS.base():
 							amount = _units_weight[_settings_game.locale.units_weight].c.ToDisplay(amount);
 							break;
 
-						case STR_LITERS:
+						case STR_LITERS.base():
 							amount = _units_volume[_settings_game.locale.units_volume].c.ToDisplay(amount);
 							break;
 
@@ -1407,8 +1407,8 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 					}
 
 					StringID cargo_str = CargoSpec::Get(cargo)->units_volume;
-					switch (cargo_str) {
-						case STR_TONS: {
+					switch (cargo_str.base()) {
+						case STR_TONS.base(): {
 							assert(_settings_game.locale.units_weight < lengthof(_units_weight));
 							const auto &x = _units_weight[_settings_game.locale.units_weight];
 							auto tmp_params = MakeParameters(x.c.ToDisplay(amount), x.decimal_places);
@@ -1416,7 +1416,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 							break;
 						}
 
-						case STR_LITERS: {
+						case STR_LITERS.base(): {
 							assert(_settings_game.locale.units_volume < lengthof(_units_volume));
 							const auto &x = _units_volume[_settings_game.locale.units_volume];
 							auto tmp_params = MakeParameters(x.c.ToDisplay(amount), x.decimal_places);
@@ -1988,23 +1988,23 @@ static void GenPresidentName(StringBuilder &builder, uint32_t seed)
 
 static bool GetSpecialNameString(StringBuilder &builder, StringID string, StringParameters &args)
 {
-	switch (string) {
-		case SPECSTR_SILLY_NAME: // Not used in new companies, but retained for old-loader savegames
+	switch (string.base()) {
+		case SPECSTR_SILLY_NAME.base(): // Not used in new companies, but retained for old-loader savegames
 			builder += _silly_company_names[std::min<size_t>(args.GetNextParameter<uint16_t>(), std::size(_silly_company_names) - 1)];
 			return true;
 
-		case SPECSTR_ANDCO_NAME: // used for Foobar & Co company names
+		case SPECSTR_ANDCO_NAME.base(): // used for Foobar & Co company names
 			GenAndCoName(builder, args.GetNextParameter<uint32_t>());
 			return true;
 
-		case SPECSTR_PRESIDENT_NAME: // President name
+		case SPECSTR_PRESIDENT_NAME.base(): // President name
 			GenPresidentName(builder, args.GetNextParameter<uint32_t>());
 			return true;
 	}
 
 	/* TownName Transport company names, with the appropriate town name. */
 	if (IsInsideMM(string, SPECSTR_COMPANY_NAME_START, SPECSTR_COMPANY_NAME_END)) {
-		GenerateTownNameString(builder, string - SPECSTR_COMPANY_NAME_START, args.GetNextParameter<uint32_t>());
+		GenerateTownNameString(builder, (string - SPECSTR_COMPANY_NAME_START).base(), args.GetNextParameter<uint32_t>());
 		builder += " Transport";
 		return true;
 	}

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -21,7 +21,7 @@
  */
 inline StringTab GetStringTab(StringID str)
 {
-	StringTab result = (StringTab)(str >> TAB_SIZE_BITS);
+	StringTab result = static_cast<StringTab>(str.base() >> TAB_SIZE_BITS);
 	if (result >= TEXT_TAB_NEWGRF_START) return TEXT_TAB_NEWGRF_START;
 	if (result >= TEXT_TAB_GAMESCRIPT_START) return TEXT_TAB_GAMESCRIPT_START;
 	return result;
@@ -34,7 +34,7 @@ inline StringTab GetStringTab(StringID str)
  */
 inline StringIndexInTab GetStringIndex(StringID str)
 {
-	return StringIndexInTab{str - (GetStringTab(str) << TAB_SIZE_BITS)};
+	return StringIndexInTab{str.base() - (GetStringTab(str) << TAB_SIZE_BITS)};
 }
 
 /**
@@ -53,7 +53,7 @@ inline StringID MakeStringID(StringTab tab, StringIndexInTab index)
 		assert(tab < TEXT_TAB_END);
 		assert(index < TAB_SIZE);
 	}
-	return (tab << TAB_SIZE_BITS) + index.base();
+	return StringID{(tab << TAB_SIZE_BITS) + index.base()};
 }
 
 /**

--- a/src/strings_type.h
+++ b/src/strings_type.h
@@ -17,8 +17,8 @@
 /**
  * Numeric value that represents a string, independent of the selected language.
  */
-typedef uint32_t StringID;
-static const StringID INVALID_STRING_ID = 0xFFFF; ///< Constant representing an invalid string (16bit in case it is used in savegames)
+using StringID = StrongType::Typedef<uint32_t, struct StringIDTag, StrongType::Compare, StrongType::Integer>;
+static constexpr StringID INVALID_STRING_ID{0xFFFF}; ///< Constant representing an invalid string (16bit in case it is used in savegames)
 static const int MAX_CHAR_LENGTH        = 4;      ///< Max. length of UTF-8 encoded unicode character
 
 /** Directions a text can go to */
@@ -58,19 +58,19 @@ static const uint TAB_SIZE_GAMESCRIPT = TAB_SIZE * 32;
 static const uint TAB_SIZE_NEWGRF     = TAB_SIZE * 256;
 
 /** The number of builtin generators for town names. */
-static constexpr uint32_t BUILTIN_TOWNNAME_GENERATOR_COUNT = 21;
+static constexpr uint16_t BUILTIN_TOWNNAME_GENERATOR_COUNT = 21;
 
 /** Special strings for town names. The town name is generated dynamically on request. */
-static constexpr StringID SPECSTR_TOWNNAME_START = 0x20C0;
-static constexpr StringID SPECSTR_TOWNNAME_END = SPECSTR_TOWNNAME_START + BUILTIN_TOWNNAME_GENERATOR_COUNT;
+static constexpr uint16_t SPECSTR_TOWNNAME_START = 0x20C0;
+static constexpr uint16_t SPECSTR_TOWNNAME_END = SPECSTR_TOWNNAME_START + BUILTIN_TOWNNAME_GENERATOR_COUNT;
 
 /** Special strings for company names on the form "TownName transport". */
-static constexpr StringID SPECSTR_COMPANY_NAME_START = 0x70EA;
-static constexpr StringID SPECSTR_COMPANY_NAME_END = SPECSTR_COMPANY_NAME_START + BUILTIN_TOWNNAME_GENERATOR_COUNT;
+static constexpr StringID SPECSTR_COMPANY_NAME_START{0x70EA};
+static constexpr StringID SPECSTR_COMPANY_NAME_END{SPECSTR_COMPANY_NAME_START + BUILTIN_TOWNNAME_GENERATOR_COUNT};
 
-static constexpr StringID SPECSTR_SILLY_NAME = 0x70E5; ///< Special string for silly company names.
-static constexpr StringID SPECSTR_ANDCO_NAME = 0x70E6; ///< Special string for Surname & Co company names.
-static constexpr StringID SPECSTR_PRESIDENT_NAME = 0x70E7; ///< Special string for the president's name.
+static constexpr StringID SPECSTR_SILLY_NAME{0x70E5}; ///< Special string for silly company names.
+static constexpr StringID SPECSTR_ANDCO_NAME{0x70E6}; ///< Special string for Surname & Co company names.
+static constexpr StringID SPECSTR_PRESIDENT_NAME{0x70E7}; ///< Special string for the president's name.
 
 using StringParameterData = std::variant<std::monostate, uint64_t, std::string>;
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -869,7 +869,7 @@ static void GetTileDesc_Town(TileIndex tile, TileDesc &td)
 	}
 
 	if (!house_completed) {
-		td.dparam = td.str;
+		td.dparam = td.str.base();
 		td.str = STR_LAI_TOWN_INDUSTRY_DESCRIPTION_UNDER_CONSTRUCTION;
 	}
 

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -49,7 +49,7 @@ static void GetTownName(StringBuilder &builder, const TownNameParams *par, uint3
 {
 	if (par->grfid.Empty()) {
 		auto tmp_params = MakeParameters(townnameparts);
-		GetStringWithArgs(builder, par->type, tmp_params);
+		GetStringWithArgs(builder, static_cast<StringID>(par->type), tmp_params);
 		return;
 	}
 

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -13,6 +13,7 @@
 #include "window_type.h"
 #include "company_type.h"
 #include "core/geometry_type.hpp"
+#include "strings_type.h"
 
 Window *FindWindowById(WindowClass cls, WindowNumber number);
 Window *FindWindowByClass(WindowClass cls);
@@ -70,5 +71,13 @@ void CloseWindowByClass(WindowClass cls, int data = 0);
 bool EditBoxInGlobalFocus();
 bool FocusedWindowIsConsole();
 Point GetCaretPosition();
+
+/**
+ * Adding a window number to a string is a common occurence to get the caption for a vehicle type.
+ * @param string The base string.
+ * @param window_number The window number to add.
+ * @return The resulting \c StringID.
+ */
+constexpr StringID operator+(StringID string, WindowNumber window_number) noexcept { return string + static_cast<int32_t>(window_number); }
 
 #endif /* WINDOW_FUNC_H */

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -790,14 +790,14 @@ public:
 	 * Automatically convert to int32_t.
 	 * @return The window number.
 	 */
-	operator int32_t() const { return value; }
+	constexpr operator int32_t() const { return value; }
 
 	/**
 	 * Automatically convert to any other type that might be requested.
 	 * @return The window number in the requested type.
 	 */
 	template <typename T> requires (std::is_enum_v<T> || std::is_class_v<T>)
-	operator T() const { return static_cast<T>(value); };
+	constexpr operator T() const { return static_cast<T>(value); };
 
 	/**
 	 * Compare the right hand side against our window number.


### PR DESCRIPTION
## Motivation / Problem

Partly type safety, especially in the realm of storing stuff in save games where having `StringID` being a strong type can make us distinguish between `StringID` and `uint32_t` variables.


## Description

* Make `StringID` a strong type.
* Make strgen emit `constexpr StringID STR_A{0xabc}` instead of `const StringID STR_A = 0xabc`.
* Make `InsideBS` specialisation where the base may also be a `ConvertibleThroughBase` type.
* Make `InsideMM` specialisation where min and max may also be a `ConvertibleThroughBase` type.
* Make `SPECSTR_TOWNNAME_START` `uint16_t` as in most cases it's used for `townnameparts` which are definitely not a `StringID`, especially in the NewGRF case. This prevents quite a few `.base()` and `static_cast<StringID>`s.
* Add an `StringID + WindowNumber` operator that does the right thing, and make `WindowNumber`'s base `constexpr`.
* Lots of `.base()` and a few `static_cast<StringID>`.
* Move caption string out of template due to most compilers not liking a strong type as parameter: 'non-type template parameter is not a structural type'


## Limitations

The oldloader is messy, but that might be just the old loader having to do weird things.

Maybe `townnameparts` should not use the `SPECSTR_TOWNNAME` things, but I'm not brave enough to disentangle that mess and it's well outside the scope for this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
