### PR TITLE
Add: Climate dependent title game

### DIFF
--- a/src/genworld.h
+++ b/src/genworld.h
@@ -92,6 +92,7 @@ void ShowGenerateWorldProgress();
 void StartNewGameWithoutGUI(uint32_t seed);
 void ShowCreateScenario();
 void StartScenarioEditor();
+void SetClimateIndependentTitleGame(bool is_independent);
 
 extern bool _generating_world;
 

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -33,6 +33,7 @@
 #include "ai/ai_gui.hpp"
 #include "game/game_gui.hpp"
 #include "industry.h"
+#include "gui.h"
 #include "core/string_consumer.hpp"
 
 #include "widgets/genworld_widget.h"
@@ -401,6 +402,8 @@ static const StringID _average_height[] = {STR_CONFIG_SETTING_AVERAGE_HEIGHT_AUT
 static_assert(std::size(_num_inds) == to_underlying(IndustryDensity::End));
 
 struct GenerateLandscapeWindow : public Window {
+	static bool climate_independent_title_game; ///< Whether the loaded title game does not depend on climate.
+
 	WidgetID widget_id{};
 	uint x = 0;
 	uint y = 0;
@@ -546,6 +549,7 @@ struct GenerateLandscapeWindow : public Window {
 			case LandscapeType::Arctic:    climate_plane = 0; break;
 			case LandscapeType::Tropic:    climate_plane = 1; break;
 			case LandscapeType::Toyland:   climate_plane = 2; break;
+			default: NOT_REACHED();
 		}
 		this->GetWidget<NWidgetStacked>(WID_GL_CLIMATE_SEL_LABEL)->SetDisplayedPlane(climate_plane);
 		this->GetWidget<NWidgetStacked>(WID_GL_CLIMATE_SEL_SELECTOR)->SetDisplayedPlane(climate_plane);
@@ -662,10 +666,24 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_TEMPERATE:
 			case WID_GL_ARCTIC:
 			case WID_GL_TROPICAL:
-			case WID_GL_TOYLAND:
+			case WID_GL_TOYLAND: {
+				if (_settings_newgame.game_creation.landscape == LandscapeType(widget - WID_GL_TEMPERATE)) break;
 				SetNewLandscapeType(LandscapeType(widget - WID_GL_TEMPERATE));
 				SndClickBeep();
+				if (climate_independent_title_game || _game_mode != GameMode::Menu) break;
+
+				/* Store curent window position. */
+				int left = this->left;
+				int top = this->top;
+
+				LoadIntroGame(); // Closes all windows.
+
+				/* Reopen the generate landscape window and move it to old position. */
+				Window *w = ShowGenerateLandscape();
+				w->left = left;
+				w->top = top;
 				break;
+			}
 
 			case WID_GL_MAPSIZE_X_PULLDOWN: // Mapsize X
 				ShowDropDownList(this, BuildMapsizeDropDown(), _settings_newgame.game_creation.map_x, WID_GL_MAPSIZE_X_PULLDOWN);
@@ -1015,6 +1033,7 @@ struct GenerateLandscapeWindow : public Window {
 		this->InvalidateData();
 	}
 };
+bool GenerateLandscapeWindow::climate_independent_title_game;
 
 /** Window definition for the landscape generation window. */
 static WindowDesc _generate_landscape_desc(
@@ -1032,7 +1051,21 @@ static WindowDesc _heightmap_load_desc(
 	_nested_heightmap_load_widgets
 );
 
-static void _ShowGenerateLandscape(GenerateLandscapeWindowMode mode)
+/**
+ * Set whether each climate has its own title game.
+ * @param is_independent Whether the loaded title game does not depend on climate.
+ */
+void SetClimateIndependentTitleGame(bool is_independent)
+{
+	GenerateLandscapeWindow::climate_independent_title_game = is_independent;
+}
+
+/**
+ * Create and show a new GenerateLandscapeWindow.
+ * @param mode For what mode the window is being created.
+ * @return The new window.
+ */
+static Window *_ShowGenerateLandscape(GenerateLandscapeWindowMode mode)
 {
 	uint x = 0;
 	uint y = 0;
@@ -1044,7 +1077,7 @@ static void _ShowGenerateLandscape(GenerateLandscapeWindowMode mode)
 
 	if (mode == GLWM_HEIGHTMAP) {
 		/* If the function returns negative, it means there was a problem loading the heightmap */
-		if (!GetHeightmapDimensions(_file_to_saveload.ftype.detailed, _file_to_saveload.name, &x, &y)) return;
+		if (!GetHeightmapDimensions(_file_to_saveload.ftype.detailed, _file_to_saveload.name, &x, &y)) return nullptr;
 	}
 
 	WindowDesc &desc = (mode == GLWM_HEIGHTMAP) ? _heightmap_load_desc : _generate_landscape_desc;
@@ -1057,12 +1090,16 @@ static void _ShowGenerateLandscape(GenerateLandscapeWindowMode mode)
 	}
 
 	SetWindowDirty(WindowClass::GenerateLandscape, mode);
+	return w;
 }
 
-/** Start with a normal game. */
-void ShowGenerateLandscape()
+/**
+ * Start with a normal game.
+ * @return The new game creation window.
+ */
+Window *ShowGenerateLandscape()
 {
-	_ShowGenerateLandscape(GLWM_GENERATE);
+	return _ShowGenerateLandscape(GLWM_GENERATE);
 }
 
 /** Start with loading a heightmap. */

--- a/src/gui.h
+++ b/src/gui.h
@@ -39,7 +39,7 @@ Window *ShowBuildDocksScenToolbar();
 Window *ShowBuildAirToolbar();
 
 /* tgp_gui.cpp */
-void ShowGenerateLandscape();
+Window *ShowGenerateLandscape();
 void ShowHeightmapLoad();
 
 /* misc_gui.cpp */

--- a/src/landscape_type.h
+++ b/src/landscape_type.h
@@ -18,6 +18,7 @@ enum class LandscapeType : uint8_t {
 	Arctic = 1, ///< Landscape with snow levels.
 	Tropic = 2, ///< Landscape with distinct rainforests and deserts,
 	Toyland = 3, ///< Landscape with funky industries and vehicles.
+	End, ///< End marker.
 };
 
 /** Bitset of \c LandscapeType elements. */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -318,7 +318,7 @@ static void ShutdownGame()
  * Load the introduction game.
  * @param load_newgrfs Whether to load the NewGRFs or not.
  */
-static void LoadIntroGame(bool load_newgrfs = true)
+void LoadIntroGame(bool load_newgrfs)
 {
 	_game_mode = GameMode::Menu;
 
@@ -328,12 +328,23 @@ static void LoadIntroGame(bool load_newgrfs = true)
 	ResetWindowSystem();
 	SetupColoursAndInitialWindow();
 
+	constexpr EnumIndexArray<std::string_view, LandscapeType, LandscapeType::End> dat_file = {
+		"temperate_title.dat",
+		"arctic_title.dat",
+		"tropic_title.dat",
+		"toyland_title.dat",
+	};
+
 	/* Load the default opening screen savegame */
-	if (SaveOrLoad("opntitle.dat", SaveLoadOperation::Load, DetailedFileType::GameFile, Subdirectory::Baseset) != SaveLoadResult::Ok) {
+	SetClimateIndependentTitleGame(false);
+	if (SaveOrLoad("opntitle.dat", SaveLoadOperation::Load, DetailedFileType::GameFile, Subdirectory::Baseset) == SaveLoadResult::Ok) {
+		SetLocalCompany(CompanyID::Begin());
+		SetClimateIndependentTitleGame(true);
+	} else if (SaveOrLoad(dat_file[_settings_newgame.game_creation.landscape], SaveLoadOperation::Load, DetailedFileType::GameFile, Subdirectory::Baseset) == SaveLoadResult::Ok) {
+		SetLocalCompany(CompanyID::Begin());
+	} else {
 		GenerateWorld(GWM_EMPTY, 64, 64); // if failed loading, make empty world.
 		SetLocalCompany(COMPANY_SPECTATOR);
-	} else {
-		SetLocalCompany(CompanyID::Begin());
 	}
 
 	FixTitleGameZoom();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -810,6 +810,7 @@ int openttd_main(std::span<std::string_view> arguments)
 	DriverFactoryBase::SelectDriver(musicdriver, Driver::Type::Music);
 
 	GenerateWorld(GWM_EMPTY, 64, 64); // Make the viewport initialization happy
+	LoadGameCreationLandscape(); // Preload the _settings_newgame.game_creation.landscape, so correct title game is loaded as a background for loading settings.
 	LoadIntroGame(false);
 
 	/* ScanNewGRFFiles now has control over the scanner. */

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -93,6 +93,7 @@ void StateGameLoop();
 void HandleExitGameRequest();
 
 void SwitchToMode(SwitchMode new_mode);
+void LoadIntroGame(bool load_newgrfs = true);
 
 bool RequestNewGRFScan(struct NewGRFScanCallback *callback = nullptr);
 void GenerateSavegameId();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1396,6 +1396,21 @@ bool IsConversionNeeded(const ConfigIniFile &ini, const std::string &group, cons
 	return true;
 }
 
+/** Load only the _settings_newgame.game_creation.landscape setting from the configuration files. */
+void LoadGameCreationLandscape()
+{
+	static constexpr std::array<const std::string_view, 4> many = {"temperate", "arctic", "tropic", "toyland"};
+	ConfigIniFile generic_ini(_config_file);
+
+	const IniGroup *group = generic_ini.GetGroup("game_creation");
+	if (group == nullptr) return;
+	const IniItem *item = group->GetItem("landscape");
+	if (item == nullptr) return;
+
+	std::optional<uint8_t> load_value = OneOfManySettingDesc::ParseSingleValue(*item->value, many);
+	_settings_newgame.game_creation.landscape = LandscapeType{load_value.value_or(to_underlying(LandscapeType::Temperate))};
+}
+
 /**
  * Load the values from the configuration files
  * @param startup Load the minimal amount of the configuration to "bootstrap" the blitter and such.

--- a/src/settings_func.h
+++ b/src/settings_func.h
@@ -22,6 +22,7 @@ void IConsoleSetSetting(std::string_view name, int32_t value);
 void IConsoleGetSetting(std::string_view name, bool force_newgame = false);
 void IConsoleListSettings(std::string_view prefilter);
 
+void LoadGameCreationLandscape();
 void LoadFromConfig(bool minimal = false);
 void SaveToConfig();
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2809,6 +2809,7 @@ static bool TryBuildTownHouse(Town *t, TileIndex tile, TownExpandModes modes)
 		case LandscapeType::Arctic: zones.Set(maxz > HighestSnowLine() ? HouseZone::ClimateSubarcticAboveSnow : HouseZone::ClimateSubarcticBelowSnow); break;
 		case LandscapeType::Tropic: zones.Set(HouseZone::ClimateSubtropic); break;
 		case LandscapeType::Toyland: zones.Set(HouseZone::ClimateToyland); break;
+		default: NOT_REACHED();
 	}
 
 	/* bits 0-4 are used


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
@LordAro wanted to have 4 title games, each for one climate.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Add a fallback behavior for loading title game:
If `opntitle.dat` is not found or failed to load the the loading of climate dependent title game is attempted. 
`temperate_title.dat` for temperate climate,
`arctic_title.dat` for arctic,
`tropic_title.dat` for tropic
and `toyland_title.dat` for toyland.
If that fails then a empty map is created.

That being a fallback behavior and not default / the only one has multiple benefits:
 - The title game isn't reloaded when `opntitle.dat` is provided, which is better for low end machines like raspberry pi or fridges.
 - Users who want to have their own title game don't have to replace 4 file but only add one.
 - If there are not enough entries in title game competition then a release could have single title game as they used to.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
The AI / GS / NewGRF settings windows are closed when title game changes.
The main menu window is moved back to the center when title game changes.
It takes time to load new title game, but having 4 games running at the same time and switching the viewports will demand much more work.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
