### PR TITLE
Codechange: move SaveLoadAddrProc to SaveLoad::AddressFunction

### DIFF
--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -194,14 +194,14 @@ SaveLoadTable GetLinkGraphJobDesc()
 	/* We store the offset of each member of the #LinkGraphSettings in the
 	 * extra data of the saveload struct. Use it together with the address
 	 * of the settings struct inside the job to find the final memory address. */
-	static SaveLoadAddrProc * const proc = [](void *b, size_t extra) -> void * { return const_cast<void *>(static_cast<const void *>(reinterpret_cast<const char *>(std::addressof(static_cast<LinkGraphJob *>(b)->settings)) + extra)); };
+	static SaveLoad::AddressFunction const func = [](void *b, size_t extra) -> void * { return const_cast<void *>(static_cast<const void *>(reinterpret_cast<const char *>(std::addressof(static_cast<LinkGraphJob *>(b)->settings)) + extra)); };
 
 	/* Build the SaveLoad array on first call and don't touch it later on */
 	if (saveloads.empty()) {
 		GetSaveLoadFromSettingTable(_linkgraph_settings, saveloads);
 
 		for (auto &sl : saveloads) {
-			sl.address_proc = proc;
+			sl.address_func = func;
 		}
 
 		for (auto &sld : job_desc) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -758,17 +758,25 @@ enum class SaveLoadType : uint8_t {
 	ReferenceVector = 12, ///< Save/load a vector of #SaveLoadType::Reference elements.
 };
 
-typedef void *SaveLoadAddrProc(void *base, size_t extra);
 
 /** SaveLoad type struct. Do NOT use this directly but use the SLE_ macros defined just below! */
 struct SaveLoad {
+	/**
+	 * Function that returns the address of a variable.
+	 * @param base In case the variable comes from an object, this is the pointer to the begin of that object.
+	 *             Will be non-nullptr for objects, can be both non-nullptr and nullptr for global variables.
+	 * @param extra An extra offset to apply. Mostly 0, except for a few LinkGraph settings variables.
+	 * @return The address of the variable.
+	 */
+	using AddressFunction = void *(*)(void *base, size_t extra);
+
 	std::string name;    ///< Name of this field (optional, used for tables).
 	SaveLoadType cmd;    ///< The action to take with the saved/loaded type, All types need different action.
 	VarType conv;        ///< Type of the variable to be saved; this field combines both FileVarType and MemVarType.
 	uint16_t length;       ///< (Conditional) length of the variable (eg. arrays) (max array size is 65536 elements).
 	SaveLoadVersion version_from;   ///< Save/load the variable starting from this savegame version.
 	SaveLoadVersion version_to;     ///< Save/load the variable before this savegame version.
-	SaveLoadAddrProc *address_proc; ///< Callback proc the get the actual variable address in memory.
+	AddressFunction address_func; ///< Callback function the get the actual variable address in memory.
 	size_t extra_data;              ///< Extra data for the callback proc.
 	std::shared_ptr<SaveLoadHandler> handler; ///< Custom handler for Save/Load procs.
 };
@@ -1300,13 +1308,13 @@ inline void *GetVariableAddress(const void *object, const SaveLoad &sld)
 {
 	/* Entry is a null-variable, mostly used to read old savegames etc. */
 	if (sld.conv.mem == VarMemType::Null) {
-		assert(sld.address_proc == nullptr);
+		assert(sld.address_func == nullptr);
 		return nullptr;
 	}
 
 	/* Everything else should be a non-null pointer. */
-	assert(sld.address_proc != nullptr);
-	return sld.address_proc(const_cast<void *>(object), sld.extra_data);
+	assert(sld.address_func != nullptr);
+	return sld.address_func(const_cast<void *>(object), sld.extra_data);
 }
 
 int64_t ReadValue(const void *ptr, VarMemType conv);


### PR DESCRIPTION
## Motivation / Problem

`SaveLoadAddrProc` is created using a `typedef`. Furthermore, what is called a procedure here is called a function in the standard, so why not use that terminology?


## Description

* Make `SaveLoadAddrProc` a using, within `SaveLoad` and rename to `AddressFunction`. 
* Rename the variable to match.
* Document the type.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
