### PR TITLE
Codefix: simplify resize logic

### DIFF
--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -51,7 +51,7 @@ struct ANITChunkHandler : ChunkHandler {
 		if (IsSavegameVersionBefore(SaveLoadVersion::RiffToArray)) {
 			size_t count = SlGetFieldLength() / sizeof(_animated_tiles.front());
 			_animated_tiles.clear();
-			_animated_tiles.resize(_animated_tiles.size() + count);
+			_animated_tiles.resize(count);
 			SlCopy(_animated_tiles.data(), count, VarTypes::U32);
 			return;
 		}


### PR DESCRIPTION
## Motivation / Problem

Me being confused, wondering why it looks like we're allocating more than what we're reading from the save file.


## Description

Remove unneeded querying of `_animated_tiles`'s size as it's set to 0 by the line before it.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
