### PR TITLE
Fix: potential off-by-one out of bounds read during saving

### DIFF
--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -397,15 +397,14 @@ static const SaveLoad _script_byte[] = {
 			}
 			std::string_view view;
 			sq_getstring(vm, index, view);
-			size_t len = view.size() + 1;
-			if (len >= 255) {
-				ScriptLog::Error("Maximum string length is 254 chars. No data saved.");
+			if (view.size() > 255) {
+				ScriptLog::Error("Maximum string length is 255 chars. No data saved.");
 				return false;
 			}
 			if (!test) {
-				_script_sl_byte = (uint8_t)len;
+				_script_sl_byte = static_cast<uint8_t>(view.size());
 				SlObject(nullptr, _script_byte);
-				SlCopy(const_cast<char *>(view.data()), len, VarTypes::I8);
+				SlCopy(const_cast<char *>(view.data()), view.size(), VarTypes::I8);
 			}
 			return true;
 		}
@@ -611,9 +610,9 @@ bool ScriptInstance::IsPaused()
 
 		case SQSL_STRING: {
 			SlObject(nullptr, _script_byte);
-			static char buf[std::numeric_limits<decltype(_script_sl_byte)>::max()];
-			SlCopy(buf, _script_sl_byte, VarTypes::I8);
-			if (data != nullptr) data->push_back(StrMakeValid(std::string_view(buf, _script_sl_byte)));
+			std::string buf(_script_sl_byte, '\0');
+			SlCopy(buf.data(), buf.size(), VarTypes::I8);
+			if (data != nullptr) data->push_back(StrMakeValid(std::move(buf)));
 			return true;
 		}
 


### PR DESCRIPTION
## Motivation / Problem

Script strings are stored without a terminating '\0'. We are copying length-of-view plus 1 to the save file, which implies we are storing the '\0' but that does not exist and we'll be reading a byte beyond the buffer while saving.

Since we are already storing the length, what is the point in saving the '\0'? We do not need to, and by doing so fix the out of bounds read and increase the maximum string size by 1 character.

Finally, when reading the string we allocate a static buffer with some complicated logic. This we pass to `StrMakeValid` which creates a `std::string` to then add to a list. Why not allocate the `std::string` first, and `std::move` it to `StrMakeValid` removing the need for a static buffer and preventing a copy?


## Description

Fix the above mentioned issues.


## Limitations

I think basically always the last byte that is written to the file is a `\0` from the padding during allocation. If that wasn't the case, we should have had many bug reports about weird characters being added to saved strings. Lack thereof implies, to me, that they usually are written as '\0' though as undefined behaviour.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
