### PR TITLE
Fix #15902: NewGRF GRF ID checks failing

### DIFF
--- a/src/newgrf/newgrf_act11.cpp
+++ b/src/newgrf/newgrf_act11.cpp
@@ -25,7 +25,7 @@
 static void ImportGRFSound(SoundEntry *sound)
 {
 	const GRFFile *file;
-	GrfID grfid = UnflattenNewGRFLabel<GrfID>(_cur_gps.file->ReadDword());
+	GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(_cur_gps.file->ReadDword()));
 	SoundID sound_id = _cur_gps.file->ReadWord();
 
 	file = GetFileByGRFID(grfid);

--- a/src/newgrf/newgrf_act7_9.cpp
+++ b/src/newgrf/newgrf_act7_9.cpp
@@ -16,6 +16,7 @@
 #include "../rail.h"
 #include "../road.h"
 #include "../settings_type.h"
+#include "../string_func.h"
 #include "newgrf_bytereader.h"
 #include "newgrf_internal.h"
 
@@ -250,7 +251,8 @@ static void SkipIf(ByteReader &buf)
 	} else if (param == 0x88) {
 		/* GRF ID checks */
 
-		GRFConfig *c = GetGRFConfig(UnflattenNewGRFLabel<GrfID>(cond_val), mask);
+		GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(cond_val));
+		GRFConfig *c = GetGRFConfig(grfid, std::byteswap(mask));
 
 		if (c != nullptr && c->flags.Test(GRFConfigFlag::Static) && !_cur_gps.grfconfig->flags.Test(GRFConfigFlag::Static) && _networking) {
 			DisableStaticNewGRFInfluencingNonStaticNewGRFs(*c);
@@ -258,7 +260,7 @@ static void SkipIf(ByteReader &buf)
 		}
 
 		if (condtype != 10 && c == nullptr) {
-			GrfMsg(7, "SkipIf: GRFID 0x{:08X} unknown, skipping test", std::byteswap(cond_val));
+			GrfMsg(7, "SkipIf: GRFID {} unknown, skipping test", FormatArrayAsHex(grfid));
 			return;
 		}
 

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -329,7 +329,7 @@ static void ParamSet(ByteReader &buf)
 			}
 		} else {
 			/* Read another GRF File's parameter */
-			GrfID grfid = UnflattenNewGRFLabel<GrfID>(data);
+			GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(data));
 			const GRFFile *file = GetFileByGRFID(grfid);
 			GRFConfig *c = GetGRFConfig(grfid);
 			if (c != nullptr && c->flags.Test(GRFConfigFlag::Static) && !_cur_gps.grfconfig->flags.Test(GRFConfigFlag::Static) && _networking) {

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -237,7 +237,7 @@ static uint32_t GetClosestObject(TileIndex tile, ObjectType type, const Object *
  */
 static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &object, uint8_t local_id, GrfID grfid, TileIndex tile, const Object *current)
 {
-	uint32_t grf_id = static_cast<uint32_t>(object.GetRegister(0x100)); // Get the GRFID of the definition to look for in register 100h
+	uint32_t grf_id = std::byteswap(static_cast<uint32_t>(object.GetRegister(0x100))); // Get the GRFID of the definition to look for in register 100h
 	uint32_t idx;
 
 	/* Determine what will be the object type to look for */

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -44,7 +44,7 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 		/* Get a variable from the persistent storage */
 		case 0x7C: {
 			/* Check the persistent storage for the GrfID stored in register 100h. */
-			GrfID grfid = UnflattenNewGRFLabel<GrfID>(this->ro.GetRegister(0x100));
+			GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(this->ro.GetRegister(0x100)));
 			if (grfid == INVALID_GRFID) {
 				if (this->ro.grffile == nullptr) return 0;
 				grfid = this->ro.grffile->grfid;
@@ -140,7 +140,7 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 	if (this->ro.grffile == nullptr) return;
 
 	/* Check the persistent storage for the GrfID stored in register 100h. */
-	GrfID grfid = UnflattenNewGRFLabel<GrfID>(this->ro.GetRegister(0x100));
+	GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(this->ro.GetRegister(0x100)));
 
 	/* A NewGRF can only write in the persistent storage associated to its own GRFID. */
 	if (grfid == INVALID_GRFID) grfid = this->ro.grffile->grfid;

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1584,7 +1584,7 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 
 				ClearGRFConfigList(_grfconfig);
 				while (len != 0) {
-					GrfID grfid = UnflattenNewGRFLabel<GrfID>(ReadUint32(ls));
+					GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(ReadUint32(ls)));
 
 					if (ReadByte(ls) == 1) {
 						auto c = std::make_unique<GRFConfig>("TTDP game, no information");


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #15902, since 9a02ac21e8f417665f6ef0df7ec07364c8262e18 GRF IDs are loaded in reverse order via `buf.ReadLabel<GrfID>()`

However some GRF IDs still come indirectly via values loaded by `buf.ReadDword()`, so the value needs to be manually reversed.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Reverse all values passed to `UnflattenNewGRFLabel<GrfID>()` when the value comes from NewGRF.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Not fully tested, but resolves the specific issue in #15902

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
