### PR TITLE
Fix #11127: use callback for dual-headed engine purchase capacity

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -252,8 +252,8 @@ uint Engine::DetermineCapacity(const Vehicle *v, uint16_t *mail_capacity) const
 		case VehicleType::Train:
 			capacity = GetEngineProperty(this->index, PROP_TRAIN_CARGO_CAPACITY,        this->VehInfo<RailVehicleInfo>().capacity, v);
 
-			/* In purchase list add the capacity of the second head. Always use the plain property for this. */
-			if (v == nullptr && this->VehInfo<RailVehicleInfo>().railveh_type == RailVehicleType::Multihead) capacity += this->VehInfo<RailVehicleInfo>().capacity;
+			/* In purchase list multiply the capacity by 2 for dual headed engines */
+			if (v == nullptr && this->VehInfo<RailVehicleInfo>().railveh_type == RailVehicleType::Multihead) capacity *=2;
 			break;
 
 		case VehicleType::Road:


### PR DESCRIPTION
## Motivation / Problem

This fixes issue #11127, which can cause discrepancies between the displayed capacity and the actual capacity of a dual-headed engine. 

An example of this is in Iron Horse where the capacity callback is changed via a capacity parameter, resulting in an incorrect capacity being displayed when the parameter is set to a non-default value.

<img width="697" height="685" alt="image" src="https://github.com/user-attachments/assets/50291b82-a72f-4df7-ac34-6452c11baad4" />


## Description

The solution is to multiply the capacity by 2 for dual-headed engines, using the callback (if present) for both parts instead of using the property for the rear half. 

Closes #11127.

## Limitations

Possibly might break some older NewGRFs that somehow expect/rely on the previous behaviour. But I haven't found any.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
