### PR TITLE
Codefix: Rename breakdown setting value string

### DIFF
--- a/src/lang/afrikaans.txt
+++ b/src/lang/afrikaans.txt
@@ -1024,9 +1024,9 @@ STR_RIVERS_MODERATE                                             :Middelmatig
 STR_RIVERS_LOT                                                  :Baie
 
 ###length 3
-STR_DISASTER_NONE                                               :Geen
-STR_DISASTER_REDUCED                                            :Verminder
-STR_DISASTER_NORMAL                                             :Normaal
+STR_BREAKDOWNS_NONE                                             :Geen
+STR_BREAKDOWNS_REDUCED                                          :Verminder
+STR_BREAKDOWNS_NORMAL                                           :Normaal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/arabic_egypt.txt
+++ b/src/lang/arabic_egypt.txt
@@ -1068,9 +1068,9 @@ STR_RIVERS_MODERATE                                             :متوسطة
 STR_RIVERS_LOT                                                  :كثيرة
 
 ###length 3
-STR_DISASTER_NONE                                               :بدون
-STR_DISASTER_REDUCED                                            :قليل
-STR_DISASTER_NORMAL                                             :طبيعي
+STR_BREAKDOWNS_NONE                                             :بدون
+STR_BREAKDOWNS_REDUCED                                          :قليل
+STR_BREAKDOWNS_NORMAL                                           :طبيعي
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :*1.5

--- a/src/lang/basque.txt
+++ b/src/lang/basque.txt
@@ -995,9 +995,9 @@ STR_RIVERS_MODERATE                                             :Ez asko ez gutx
 STR_RIVERS_LOT                                                  :Asko
 
 ###length 3
-STR_DISASTER_NONE                                               :Ezer ez
-STR_DISASTER_REDUCED                                            :Mugatua
-STR_DISASTER_NORMAL                                             :Normala
+STR_BREAKDOWNS_NONE                                             :Ezer ez
+STR_BREAKDOWNS_REDUCED                                          :Mugatua
+STR_BREAKDOWNS_NORMAL                                           :Normala
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/belarusian.txt
+++ b/src/lang/belarusian.txt
@@ -1482,9 +1482,9 @@ STR_RIVERS_MODERATE                                             :Сярэдня�
 STR_RIVERS_LOT                                                  :Вялікая
 
 ###length 3
-STR_DISASTER_NONE                                               :Выключаны
-STR_DISASTER_REDUCED                                            :Зьніжаныя
-STR_DISASTER_NORMAL                                             :Звычайныя
+STR_BREAKDOWNS_NONE                                             :Выключаны
+STR_BREAKDOWNS_REDUCED                                          :Зьніжаныя
+STR_BREAKDOWNS_NORMAL                                           :Звычайныя
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/brazilian_portuguese.txt
+++ b/src/lang/brazilian_portuguese.txt
@@ -1218,9 +1218,9 @@ STR_RIVERS_MODERATE                                             :Alguns
 STR_RIVERS_LOT                                                  :Muitos
 
 ###length 3
-STR_DISASTER_NONE                                               :Nenhuma
-STR_DISASTER_REDUCED                                            :Reduzida
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Nenhuma
+STR_BREAKDOWNS_REDUCED                                          :Reduzida
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/bulgarian.txt
+++ b/src/lang/bulgarian.txt
@@ -1180,9 +1180,9 @@ STR_RIVERS_MODERATE                                             :Средно
 STR_RIVERS_LOT                                                  :Много
 
 ###length 3
-STR_DISASTER_NONE                                               :Никакви
-STR_DISASTER_REDUCED                                            :Намалени
-STR_DISASTER_NORMAL                                             :Нормални
+STR_BREAKDOWNS_NONE                                             :Никакви
+STR_BREAKDOWNS_REDUCED                                          :Намалени
+STR_BREAKDOWNS_NORMAL                                           :Нормални
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/catalan.txt
+++ b/src/lang/catalan.txt
@@ -1218,9 +1218,9 @@ STR_RIVERS_MODERATE                                             :Normal
 STR_RIVERS_LOT                                                  :Molts
 
 ###length 3
-STR_DISASTER_NONE                                               :Cap
-STR_DISASTER_REDUCED                                            :Reduït
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Cap
+STR_BREAKDOWNS_REDUCED                                          :Reduït
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1,5

--- a/src/lang/chuvash.txt
+++ b/src/lang/chuvash.txt
@@ -526,7 +526,7 @@ STR_SEA_LEVEL_CUSTOM_PERCENTAGE                                 :Харпӑр х
 ###length 4
 
 ###length 3
-STR_DISASTER_NONE                                               :Ҫук
+STR_BREAKDOWNS_NONE                                             :Ҫук
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/croatian.txt
+++ b/src/lang/croatian.txt
@@ -1126,9 +1126,9 @@ STR_RIVERS_MODERATE                                             :Srednje
 STR_RIVERS_LOT                                                  :Puno
 
 ###length 3
-STR_DISASTER_NONE                                               :Ništa
-STR_DISASTER_REDUCED                                            :Smanjeno
-STR_DISASTER_NORMAL                                             :Normalno
+STR_BREAKDOWNS_NONE                                             :Ništa
+STR_BREAKDOWNS_REDUCED                                          :Smanjeno
+STR_BREAKDOWNS_NORMAL                                           :Normalno
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/czech.txt
+++ b/src/lang/czech.txt
@@ -1297,9 +1297,9 @@ STR_RIVERS_MODERATE                                             :Více
 STR_RIVERS_LOT                                                  :Mnoho
 
 ###length 3
-STR_DISASTER_NONE                                               :žádné
-STR_DISASTER_REDUCED                                            :snížené
-STR_DISASTER_NORMAL                                             :běžné
+STR_BREAKDOWNS_NONE                                             :žádné
+STR_BREAKDOWNS_REDUCED                                          :snížené
+STR_BREAKDOWNS_NORMAL                                           :běžné
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :1,5x

--- a/src/lang/danish.txt
+++ b/src/lang/danish.txt
@@ -1209,9 +1209,9 @@ STR_RIVERS_MODERATE                                             :Mellem
 STR_RIVERS_LOT                                                  :Mange
 
 ###length 3
-STR_DISASTER_NONE                                               :Ingen
-STR_DISASTER_REDUCED                                            :Reduceret
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Ingen
+STR_BREAKDOWNS_REDUCED                                          :Reduceret
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/dutch.txt
+++ b/src/lang/dutch.txt
@@ -1208,9 +1208,9 @@ STR_RIVERS_MODERATE                                             :Gemiddeld
 STR_RIVERS_LOT                                                  :Veel
 
 ###length 3
-STR_DISASTER_NONE                                               :Geen
-STR_DISASTER_REDUCED                                            :Verminderd
-STR_DISASTER_NORMAL                                             :Normaal
+STR_BREAKDOWNS_NONE                                             :Geen
+STR_BREAKDOWNS_REDUCED                                          :Verminderd
+STR_BREAKDOWNS_NORMAL                                           :Normaal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1217,9 +1217,9 @@ STR_RIVERS_MODERATE                                             :Medium
 STR_RIVERS_LOT                                                  :Many
 
 ###length 3
-STR_DISASTER_NONE                                               :None
-STR_DISASTER_REDUCED                                            :Reduced
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :None
+STR_BREAKDOWNS_REDUCED                                          :Reduced
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -1217,9 +1217,9 @@ STR_RIVERS_MODERATE                                             :Medium
 STR_RIVERS_LOT                                                  :Many
 
 ###length 3
-STR_DISASTER_NONE                                               :None
-STR_DISASTER_REDUCED                                            :Reduced
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :None
+STR_BREAKDOWNS_REDUCED                                          :Reduced
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/english_US.txt
+++ b/src/lang/english_US.txt
@@ -1217,9 +1217,9 @@ STR_RIVERS_MODERATE                                             :Medium
 STR_RIVERS_LOT                                                  :Many
 
 ###length 3
-STR_DISASTER_NONE                                               :None
-STR_DISASTER_REDUCED                                            :Reduced
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :None
+STR_BREAKDOWNS_REDUCED                                          :Reduced
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/esperanto.txt
+++ b/src/lang/esperanto.txt
@@ -1305,9 +1305,9 @@ STR_RIVERS_MODERATE                                             :Mezmultaj
 STR_RIVERS_LOT                                                  :Multaj
 
 ###length 3
-STR_DISASTER_NONE                                               :Neniu
-STR_DISASTER_REDUCED                                            :Malpli
-STR_DISASTER_NORMAL                                             :Normale
+STR_BREAKDOWNS_NONE                                             :Neniu
+STR_BREAKDOWNS_REDUCED                                          :Malpli
+STR_BREAKDOWNS_NORMAL                                           :Normale
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/estonian.txt
+++ b/src/lang/estonian.txt
@@ -1274,9 +1274,9 @@ STR_RIVERS_MODERATE                                             :Keskmiselt
 STR_RIVERS_LOT                                                  :Palju
 
 ###length 3
-STR_DISASTER_NONE                                               :Ei
-STR_DISASTER_REDUCED                                            :Vähem
-STR_DISASTER_NORMAL                                             :Keskmiselt
+STR_BREAKDOWNS_NONE                                             :Ei
+STR_BREAKDOWNS_REDUCED                                          :Vähem
+STR_BREAKDOWNS_NORMAL                                           :Keskmiselt
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :1,5x

--- a/src/lang/faroese.txt
+++ b/src/lang/faroese.txt
@@ -976,9 +976,9 @@ STR_RIVERS_MODERATE                                             :Miðal
 STR_RIVERS_LOT                                                  :Nógvir
 
 ###length 3
-STR_DISASTER_NONE                                               :Ongar
-STR_DISASTER_REDUCED                                            :Færri
-STR_DISASTER_NORMAL                                             :Vanligar
+STR_BREAKDOWNS_NONE                                             :Ongar
+STR_BREAKDOWNS_REDUCED                                          :Færri
+STR_BREAKDOWNS_NORMAL                                           :Vanligar
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/finnish.txt
+++ b/src/lang/finnish.txt
@@ -1217,9 +1217,9 @@ STR_RIVERS_MODERATE                                             :Keskisuuri
 STR_RIVERS_LOT                                                  :Monia
 
 ###length 3
-STR_DISASTER_NONE                                               :Ei mitään
-STR_DISASTER_REDUCED                                            :Vähennetty
-STR_DISASTER_NORMAL                                             :Tavallinen
+STR_BREAKDOWNS_NONE                                             :Ei mitään
+STR_BREAKDOWNS_REDUCED                                          :Vähennetty
+STR_BREAKDOWNS_NORMAL                                           :Tavallinen
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :× 1,5

--- a/src/lang/french.txt
+++ b/src/lang/french.txt
@@ -1211,9 +1211,9 @@ STR_RIVERS_MODERATE                                             :Modérément
 STR_RIVERS_LOT                                                  :Beaucoup
 
 ###length 3
-STR_DISASTER_NONE                                               :Aucune
-STR_DISASTER_REDUCED                                            :Réduites
-STR_DISASTER_NORMAL                                             :Normales
+STR_BREAKDOWNS_NONE                                             :Aucune
+STR_BREAKDOWNS_REDUCED                                          :Réduites
+STR_BREAKDOWNS_NORMAL                                           :Normales
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1,5

--- a/src/lang/frisian.txt
+++ b/src/lang/frisian.txt
@@ -1018,9 +1018,9 @@ STR_RIVERS_MODERATE                                             :Middel
 STR_RIVERS_LOT                                                  :In protte
 
 ###length 3
-STR_DISASTER_NONE                                               :Gjin
-STR_DISASTER_REDUCED                                            :Minder
-STR_DISASTER_NORMAL                                             :Gewoan
+STR_BREAKDOWNS_NONE                                             :Gjin
+STR_BREAKDOWNS_REDUCED                                          :Minder
+STR_BREAKDOWNS_NORMAL                                           :Gewoan
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1,5

--- a/src/lang/gaelic.txt
+++ b/src/lang/gaelic.txt
@@ -1209,9 +1209,9 @@ STR_RIVERS_MODERATE                                             :Meadhanach
 STR_RIVERS_LOT                                                  :Mòran dhiubh
 
 ###length 3
-STR_DISASTER_NONE                                               :Cha tachair seo idir
-STR_DISASTER_REDUCED                                            :Ainneamh
-STR_DISASTER_NORMAL                                             :Àbhaisteach
+STR_BREAKDOWNS_NONE                                             :Cha tachair seo idir
+STR_BREAKDOWNS_REDUCED                                          :Ainneamh
+STR_BREAKDOWNS_NORMAL                                           :Àbhaisteach
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/galician.txt
+++ b/src/lang/galician.txt
@@ -1209,9 +1209,9 @@ STR_RIVERS_MODERATE                                             :Medio
 STR_RIVERS_LOT                                                  :Moitos
 
 ###length 3
-STR_DISASTER_NONE                                               :Ningún
-STR_DISASTER_REDUCED                                            :Reducido
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Ningún
+STR_BREAKDOWNS_REDUCED                                          :Reducido
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -1209,9 +1209,9 @@ STR_RIVERS_MODERATE                                             :Einige
 STR_RIVERS_LOT                                                  :Viele
 
 ###length 3
-STR_DISASTER_NONE                                               :Keine
-STR_DISASTER_REDUCED                                            :Verringert
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Keine
+STR_BREAKDOWNS_REDUCED                                          :Verringert
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :×1,5

--- a/src/lang/greek.txt
+++ b/src/lang/greek.txt
@@ -1310,9 +1310,9 @@ STR_RIVERS_MODERATE                                             :Μεσαία
 STR_RIVERS_LOT                                                  :Πολλά
 
 ###length 3
-STR_DISASTER_NONE                                               :Καμία
-STR_DISASTER_REDUCED                                            :Μειωμένες
-STR_DISASTER_NORMAL                                             :Κανονικές
+STR_BREAKDOWNS_NONE                                             :Καμία
+STR_BREAKDOWNS_REDUCED                                          :Μειωμένες
+STR_BREAKDOWNS_NORMAL                                           :Κανονικές
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/hebrew.txt
+++ b/src/lang/hebrew.txt
@@ -1110,9 +1110,9 @@ STR_RIVERS_MODERATE                                             :בינוני
 STR_RIVERS_LOT                                                  :הרבה
 
 ###length 3
-STR_DISASTER_NONE                                               :ללא
-STR_DISASTER_REDUCED                                            :מופחת
-STR_DISASTER_NORMAL                                             :רגיל
+STR_BREAKDOWNS_NONE                                             :ללא
+STR_BREAKDOWNS_REDUCED                                          :מופחת
+STR_BREAKDOWNS_NORMAL                                           :רגיל
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/hindi.txt
+++ b/src/lang/hindi.txt
@@ -389,7 +389,7 @@ STR_AI_SPEED_FAST                                               :तेज़
 ###length 4
 
 ###length 3
-STR_DISASTER_NORMAL                                             :सामान्य
+STR_BREAKDOWNS_NORMAL                                           :सामान्य
 
 ###length 4
 

--- a/src/lang/hungarian.txt
+++ b/src/lang/hungarian.txt
@@ -1281,9 +1281,9 @@ STR_RIVERS_MODERATE                                             :Közepes
 STR_RIVERS_LOT                                                  :Sok
 
 ###length 3
-STR_DISASTER_NONE                                               :Nincs
-STR_DISASTER_REDUCED                                            :Ritka
-STR_DISASTER_NORMAL                                             :Normál
+STR_BREAKDOWNS_NONE                                             :Nincs
+STR_BREAKDOWNS_REDUCED                                          :Ritka
+STR_BREAKDOWNS_NORMAL                                           :Normál
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :1,5x

--- a/src/lang/icelandic.txt
+++ b/src/lang/icelandic.txt
@@ -975,9 +975,9 @@ STR_RIVERS_MODERATE                                             :Miðlungs
 STR_RIVERS_LOT                                                  :Margar
 
 ###length 3
-STR_DISASTER_NONE                                               :Ekkert
-STR_DISASTER_REDUCED                                            :Minnkað
-STR_DISASTER_NORMAL                                             :Venjulegt
+STR_BREAKDOWNS_NONE                                             :Ekkert
+STR_BREAKDOWNS_REDUCED                                          :Minnkað
+STR_BREAKDOWNS_NORMAL                                           :Venjulegt
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/indonesian.txt
+++ b/src/lang/indonesian.txt
@@ -1211,9 +1211,9 @@ STR_RIVERS_MODERATE                                             :Sedang
 STR_RIVERS_LOT                                                  :Banyak
 
 ###length 3
-STR_DISASTER_NONE                                               :Tidak pernah
-STR_DISASTER_REDUCED                                            :Dikurangi
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Tidak pernah
+STR_BREAKDOWNS_REDUCED                                          :Dikurangi
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/irish.txt
+++ b/src/lang/irish.txt
@@ -1074,9 +1074,9 @@ STR_RIVERS_MODERATE                                             :Meánach
 STR_RIVERS_LOT                                                  :Go leor
 
 ###length 3
-STR_DISASTER_NONE                                               :Gan tubaistí
-STR_DISASTER_REDUCED                                            :Laghdaithe
-STR_DISASTER_NORMAL                                             :Gnáth
+STR_BREAKDOWNS_NONE                                             :Gan tubaistí
+STR_BREAKDOWNS_REDUCED                                          :Laghdaithe
+STR_BREAKDOWNS_NORMAL                                           :Gnáth
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/italian.txt
+++ b/src/lang/italian.txt
@@ -1207,9 +1207,9 @@ STR_RIVERS_MODERATE                                             :Normali
 STR_RIVERS_LOT                                                  :Molti
 
 ###length 3
-STR_DISASTER_NONE                                               :Nessuno
-STR_DISASTER_REDUCED                                            :Ridotti
-STR_DISASTER_NORMAL                                             :Normali
+STR_BREAKDOWNS_NONE                                             :Nessuno
+STR_BREAKDOWNS_REDUCED                                          :Ridotti
+STR_BREAKDOWNS_NORMAL                                           :Normali
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1,5

--- a/src/lang/japanese.txt
+++ b/src/lang/japanese.txt
@@ -1115,9 +1115,9 @@ STR_RIVERS_MODERATE                                             :中程度
 STR_RIVERS_LOT                                                  :多い
 
 ###length 3
-STR_DISASTER_NONE                                               :なし
-STR_DISASTER_REDUCED                                            :軽減
-STR_DISASTER_NORMAL                                             :普通
+STR_BREAKDOWNS_NONE                                             :なし
+STR_BREAKDOWNS_REDUCED                                          :軽減
+STR_BREAKDOWNS_NORMAL                                           :普通
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :×1.5

--- a/src/lang/korean.txt
+++ b/src/lang/korean.txt
@@ -1218,9 +1218,9 @@ STR_RIVERS_MODERATE                                             :적당히
 STR_RIVERS_LOT                                                  :많이
 
 ###length 3
-STR_DISASTER_NONE                                               :고장 안남
-STR_DISASTER_REDUCED                                            :적음
-STR_DISASTER_NORMAL                                             :일반
+STR_BREAKDOWNS_NONE                                             :고장 안남
+STR_BREAKDOWNS_REDUCED                                          :적음
+STR_BREAKDOWNS_NORMAL                                           :일반
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :1.5배 지급

--- a/src/lang/latin.txt
+++ b/src/lang/latin.txt
@@ -1201,9 +1201,9 @@ STR_RIVERS_MODERATE                                             :Mediocris
 STR_RIVERS_LOT                                                  :Magnus
 
 ###length 3
-STR_DISASTER_NONE                                               :Nullae
-STR_DISASTER_REDUCED                                            :Rarae
-STR_DISASTER_NORMAL                                             :Mediocres
+STR_BREAKDOWNS_NONE                                             :Nullae
+STR_BREAKDOWNS_REDUCED                                          :Rarae
+STR_BREAKDOWNS_NORMAL                                           :Mediocres
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :Sesquiplex

--- a/src/lang/latvian.txt
+++ b/src/lang/latvian.txt
@@ -1210,9 +1210,9 @@ STR_RIVERS_MODERATE                                             :Vidējs daudzum
 STR_RIVERS_LOT                                                  :Daudzas
 
 ###length 3
-STR_DISASTER_NONE                                               :Nav
-STR_DISASTER_REDUCED                                            :samazināta
-STR_DISASTER_NORMAL                                             :Parasta
+STR_BREAKDOWNS_NONE                                             :Nav
+STR_BREAKDOWNS_REDUCED                                          :samazināta
+STR_BREAKDOWNS_NORMAL                                           :Parasta
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/lithuanian.txt
+++ b/src/lang/lithuanian.txt
@@ -1356,9 +1356,9 @@ STR_RIVERS_MODERATE                                             :Vidutiniškai
 STR_RIVERS_LOT                                                  :Daug
 
 ###length 3
-STR_DISASTER_NONE                                               :Nėra
-STR_DISASTER_REDUCED                                            :Sumažintas
-STR_DISASTER_NORMAL                                             :Normalus
+STR_BREAKDOWNS_NONE                                             :Nėra
+STR_BREAKDOWNS_REDUCED                                          :Sumažintas
+STR_BREAKDOWNS_NORMAL                                           :Normalus
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/luxembourgish.txt
+++ b/src/lang/luxembourgish.txt
@@ -1210,9 +1210,9 @@ STR_RIVERS_MODERATE                                             :Mëttel
 STR_RIVERS_LOT                                                  :Vill
 
 ###length 3
-STR_DISASTER_NONE                                               :Keng
-STR_DISASTER_REDUCED                                            :Manner
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Keng
+STR_BREAKDOWNS_REDUCED                                          :Manner
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/malay.txt
+++ b/src/lang/malay.txt
@@ -979,9 +979,9 @@ STR_RIVERS_MODERATE                                             :Pertengahan
 STR_RIVERS_LOT                                                  :Banyak
 
 ###length 3
-STR_DISASTER_NONE                                               :Tiada
-STR_DISASTER_REDUCED                                            :Dikurangkan
-STR_DISASTER_NORMAL                                             :Biasa
+STR_BREAKDOWNS_NONE                                             :Tiada
+STR_BREAKDOWNS_REDUCED                                          :Dikurangkan
+STR_BREAKDOWNS_NORMAL                                           :Biasa
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/maori.txt
+++ b/src/lang/maori.txt
@@ -1217,9 +1217,9 @@ STR_RIVERS_MODERATE                                             :Wawaenga
 STR_RIVERS_LOT                                                  :Maha
 
 ###length 3
-STR_DISASTER_NONE                                               :Kore
-STR_DISASTER_REDUCED                                            :Whakapaku
-STR_DISASTER_NORMAL                                             :Taunoa
+STR_BREAKDOWNS_NONE                                             :Kore
+STR_BREAKDOWNS_REDUCED                                          :Whakapaku
+STR_BREAKDOWNS_NORMAL                                           :Taunoa
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/norwegian_bokmal.txt
+++ b/src/lang/norwegian_bokmal.txt
@@ -1212,9 +1212,9 @@ STR_RIVERS_MODERATE                                             :Middels
 STR_RIVERS_LOT                                                  :Mange
 
 ###length 3
-STR_DISASTER_NONE                                               :Ingen
-STR_DISASTER_REDUCED                                            :Redusert
-STR_DISASTER_NORMAL                                             :Normalt
+STR_BREAKDOWNS_NONE                                             :Ingen
+STR_BREAKDOWNS_REDUCED                                          :Redusert
+STR_BREAKDOWNS_NORMAL                                           :Normalt
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/norwegian_nynorsk.txt
+++ b/src/lang/norwegian_nynorsk.txt
@@ -1012,9 +1012,9 @@ STR_RIVERS_MODERATE                                             :Middels
 STR_RIVERS_LOT                                                  :Mange
 
 ###length 3
-STR_DISASTER_NONE                                               :Ingen
-STR_DISASTER_REDUCED                                            :Redusert
-STR_DISASTER_NORMAL                                             :Normalt
+STR_BREAKDOWNS_NONE                                             :Ingen
+STR_BREAKDOWNS_REDUCED                                          :Redusert
+STR_BREAKDOWNS_NORMAL                                           :Normalt
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/persian.txt
+++ b/src/lang/persian.txt
@@ -1089,9 +1089,9 @@ STR_RIVERS_MODERATE                                             :متوسط
 STR_RIVERS_LOT                                                  :زیاد
 
 ###length 3
-STR_DISASTER_NONE                                               :هیچکدام
-STR_DISASTER_REDUCED                                            :کم
-STR_DISASTER_NORMAL                                             :عادی
+STR_BREAKDOWNS_NONE                                             :هیچکدام
+STR_BREAKDOWNS_REDUCED                                          :کم
+STR_BREAKDOWNS_NORMAL                                           :عادی
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/polish.txt
+++ b/src/lang/polish.txt
@@ -1597,9 +1597,9 @@ STR_RIVERS_MODERATE                                             :Średnio
 STR_RIVERS_LOT                                                  :Dużo
 
 ###length 3
-STR_DISASTER_NONE                                               :Brak
-STR_DISASTER_REDUCED                                            :Zredukowane
-STR_DISASTER_NORMAL                                             :Normalne
+STR_BREAKDOWNS_NONE                                             :Brak
+STR_BREAKDOWNS_REDUCED                                          :Zredukowane
+STR_BREAKDOWNS_NORMAL                                           :Normalne
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/portuguese.txt
+++ b/src/lang/portuguese.txt
@@ -1218,9 +1218,9 @@ STR_RIVERS_MODERATE                                             :Alguns
 STR_RIVERS_LOT                                                  :Muitos
 
 ###length 3
-STR_DISASTER_NONE                                               :Nenhum
-STR_DISASTER_REDUCED                                            :Reduzido
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Nenhum
+STR_BREAKDOWNS_REDUCED                                          :Reduzido
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/romanian.txt
+++ b/src/lang/romanian.txt
@@ -1185,9 +1185,9 @@ STR_RIVERS_MODERATE                                             :Mediu
 STR_RIVERS_LOT                                                  :Multe
 
 ###length 3
-STR_DISASTER_NONE                                               :Deloc
-STR_DISASTER_REDUCED                                            :Redus
-STR_DISASTER_NORMAL                                             :Frecvență normală
+STR_BREAKDOWNS_NONE                                             :Deloc
+STR_BREAKDOWNS_REDUCED                                          :Redus
+STR_BREAKDOWNS_NORMAL                                           :Frecvență normală
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1,5

--- a/src/lang/russian.txt
+++ b/src/lang/russian.txt
@@ -1366,9 +1366,9 @@ STR_RIVERS_MODERATE                                             :Среднее
 STR_RIVERS_LOT                                                  :Большое
 
 ###length 3
-STR_DISASTER_NONE                                               :нет
-STR_DISASTER_REDUCED                                            :сниженная
-STR_DISASTER_NORMAL                                             :обычная
+STR_BREAKDOWNS_NONE                                             :нет
+STR_BREAKDOWNS_REDUCED                                          :сниженная
+STR_BREAKDOWNS_NORMAL                                           :обычная
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1,5

--- a/src/lang/serbian.txt
+++ b/src/lang/serbian.txt
@@ -1348,9 +1348,9 @@ STR_RIVERS_MODERATE                                             :Prosečno
 STR_RIVERS_LOT                                                  :Mnogo
 
 ###length 3
-STR_DISASTER_NONE                                               :nema
-STR_DISASTER_REDUCED                                            :redukovani
-STR_DISASTER_NORMAL                                             :normalni
+STR_BREAKDOWNS_NONE                                             :nema
+STR_BREAKDOWNS_REDUCED                                          :redukovani
+STR_BREAKDOWNS_NORMAL                                           :normalni
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/simplified_chinese.txt
+++ b/src/lang/simplified_chinese.txt
@@ -1209,9 +1209,9 @@ STR_RIVERS_MODERATE                                             :适中
 STR_RIVERS_LOT                                                  :较多
 
 ###length 3
-STR_DISASTER_NONE                                               :没有
-STR_DISASTER_REDUCED                                            :较少
-STR_DISASTER_NORMAL                                             :正常
+STR_BREAKDOWNS_NONE                                             :没有
+STR_BREAKDOWNS_REDUCED                                          :较少
+STR_BREAKDOWNS_NORMAL                                           :正常
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :1.5 倍

--- a/src/lang/slovak.txt
+++ b/src/lang/slovak.txt
@@ -1240,9 +1240,9 @@ STR_RIVERS_MODERATE                                             :Stredne
 STR_RIVERS_LOT                                                  :Veľa
 
 ###length 3
-STR_DISASTER_NONE                                               :Žiadne
-STR_DISASTER_REDUCED                                            :Obmedzené
-STR_DISASTER_NORMAL                                             :Normálne
+STR_BREAKDOWNS_NONE                                             :Žiadne
+STR_BREAKDOWNS_REDUCED                                          :Obmedzené
+STR_BREAKDOWNS_NORMAL                                           :Normálne
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/slovenian.txt
+++ b/src/lang/slovenian.txt
@@ -1161,9 +1161,9 @@ STR_RIVERS_MODERATE                                             :Srednje
 STR_RIVERS_LOT                                                  :Mnogo
 
 ###length 3
-STR_DISASTER_NONE                                               :Brez
-STR_DISASTER_REDUCED                                            :Zmanjšano
-STR_DISASTER_NORMAL                                             :Normalno
+STR_BREAKDOWNS_NONE                                             :Brez
+STR_BREAKDOWNS_REDUCED                                          :Zmanjšano
+STR_BREAKDOWNS_NORMAL                                           :Normalno
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1,5

--- a/src/lang/spanish.txt
+++ b/src/lang/spanish.txt
@@ -1209,9 +1209,9 @@ STR_RIVERS_MODERATE                                             :Medio
 STR_RIVERS_LOT                                                  :Muchos
 
 ###length 3
-STR_DISASTER_NONE                                               :Ninguno
-STR_DISASTER_REDUCED                                            :Reducidos
-STR_DISASTER_NORMAL                                             :Normales
+STR_BREAKDOWNS_NONE                                             :Ninguno
+STR_BREAKDOWNS_REDUCED                                          :Reducidos
+STR_BREAKDOWNS_NORMAL                                           :Normales
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/spanish_MX.txt
+++ b/src/lang/spanish_MX.txt
@@ -1204,9 +1204,9 @@ STR_RIVERS_MODERATE                                             :Medio
 STR_RIVERS_LOT                                                  :Muchos
 
 ###length 3
-STR_DISASTER_NONE                                               :Ninguno
-STR_DISASTER_REDUCED                                            :Reducidos
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Ninguno
+STR_BREAKDOWNS_REDUCED                                          :Reducidos
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/swedish.txt
+++ b/src/lang/swedish.txt
@@ -1217,9 +1217,9 @@ STR_RIVERS_MODERATE                                             :Mellan
 STR_RIVERS_LOT                                                  :Många
 
 ###length 3
-STR_DISASTER_NONE                                               :Ingen
-STR_DISASTER_REDUCED                                            :Reducerad
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Ingen
+STR_BREAKDOWNS_REDUCED                                          :Reducerad
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/tamil.txt
+++ b/src/lang/tamil.txt
@@ -1133,9 +1133,9 @@ STR_RIVERS_MODERATE                                             :நடுத்
 STR_RIVERS_LOT                                                  :பல
 
 ###length 3
-STR_DISASTER_NONE                                               :ஒன்றுமில்லை
-STR_DISASTER_REDUCED                                            :குறைக்கப்பட்ட
-STR_DISASTER_NORMAL                                             :இயல்பான
+STR_BREAKDOWNS_NONE                                             :ஒன்றுமில்லை
+STR_BREAKDOWNS_REDUCED                                          :குறைக்கப்பட்ட
+STR_BREAKDOWNS_NORMAL                                           :இயல்பான
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/thai.txt
+++ b/src/lang/thai.txt
@@ -1017,9 +1017,9 @@ STR_RIVERS_MODERATE                                             :ปานกล
 STR_RIVERS_LOT                                                  :หลาย
 
 ###length 3
-STR_DISASTER_NONE                                               :ไม่มี
-STR_DISASTER_REDUCED                                            :ภาวะลดลง
-STR_DISASTER_NORMAL                                             :ภาวะปกติ
+STR_BREAKDOWNS_NONE                                             :ไม่มี
+STR_BREAKDOWNS_REDUCED                                          :ภาวะลดลง
+STR_BREAKDOWNS_NORMAL                                           :ภาวะปกติ
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :1.5 เท่า

--- a/src/lang/traditional_chinese.txt
+++ b/src/lang/traditional_chinese.txt
@@ -1217,9 +1217,9 @@ STR_RIVERS_MODERATE                                             :適量
 STR_RIVERS_LOT                                                  :多
 
 ###length 3
-STR_DISASTER_NONE                                               :無
-STR_DISASTER_REDUCED                                            :減少
-STR_DISASTER_NORMAL                                             :普通
+STR_BREAKDOWNS_NONE                                             :無
+STR_BREAKDOWNS_REDUCED                                          :減少
+STR_BREAKDOWNS_NORMAL                                           :普通
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/turkish.txt
+++ b/src/lang/turkish.txt
@@ -1218,9 +1218,9 @@ STR_RIVERS_MODERATE                                             :Orta
 STR_RIVERS_LOT                                                  :Çok
 
 ###length 3
-STR_DISASTER_NONE                                               :Hiç
-STR_DISASTER_REDUCED                                            :Azaltılmış
-STR_DISASTER_NORMAL                                             :Normal
+STR_BREAKDOWNS_NONE                                             :Hiç
+STR_BREAKDOWNS_REDUCED                                          :Azaltılmış
+STR_BREAKDOWNS_NORMAL                                           :Normal
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/ukrainian.txt
+++ b/src/lang/ukrainian.txt
@@ -1345,9 +1345,9 @@ STR_RIVERS_MODERATE                                             :середнь�
 STR_RIVERS_LOT                                                  :багато
 
 ###length 3
-STR_DISASTER_NONE                                               :відкл.
-STR_DISASTER_REDUCED                                            :знижено
-STR_DISASTER_NORMAL                                             :нормально
+STR_BREAKDOWNS_NONE                                             :відкл.
+STR_BREAKDOWNS_REDUCED                                          :знижено
+STR_BREAKDOWNS_NORMAL                                           :нормально
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/urdu.txt
+++ b/src/lang/urdu.txt
@@ -972,9 +972,9 @@ STR_RIVERS_MODERATE                                             :درمیانے
 STR_RIVERS_LOT                                                  :بہت سے
 
 ###length 3
-STR_DISASTER_NONE                                               :کوئی نہیں
-STR_DISASTER_REDUCED                                            :کم
-STR_DISASTER_NORMAL                                             :نارمل
+STR_BREAKDOWNS_NONE                                             :کوئی نہیں
+STR_BREAKDOWNS_REDUCED                                          :کم
+STR_BREAKDOWNS_NORMAL                                           :نارمل
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/vietnamese.txt
+++ b/src/lang/vietnamese.txt
@@ -1210,9 +1210,9 @@ STR_RIVERS_MODERATE                                             :Bình Thường
 STR_RIVERS_LOT                                                  :Nhiều
 
 ###length 3
-STR_DISASTER_NONE                                               :Không Có
-STR_DISASTER_REDUCED                                            :Giảm
-STR_DISASTER_NORMAL                                             :Thường
+STR_BREAKDOWNS_NONE                                             :Không Có
+STR_BREAKDOWNS_REDUCED                                          :Giảm
+STR_BREAKDOWNS_NORMAL                                           :Thường
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/lang/welsh.txt
+++ b/src/lang/welsh.txt
@@ -1209,9 +1209,9 @@ STR_RIVERS_MODERATE                                             :Cymhedrol
 STR_RIVERS_LOT                                                  :Llawer
 
 ###length 3
-STR_DISASTER_NONE                                               :Dim
-STR_DISASTER_REDUCED                                            :Llai
-STR_DISASTER_NORMAL                                             :Arferol
+STR_BREAKDOWNS_NONE                                             :Dim
+STR_BREAKDOWNS_REDUCED                                          :Llai
+STR_BREAKDOWNS_NORMAL                                           :Arferol
 
 ###length 4
 STR_SUBSIDY_X1_5                                                :x1.5

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -183,7 +183,7 @@ min      = VehicleBreakdowns::None
 max      = VehicleBreakdowns::Normal
 str      = STR_CONFIG_SETTING_VEHICLE_BREAKDOWNS
 strhelp  = STR_CONFIG_SETTING_VEHICLE_BREAKDOWNS_HELPTEXT
-strval   = STR_DISASTER_NONE
+strval   = STR_BREAKDOWNS_NONE
 cat      = SC_BASIC
 
 [SDT_VAR]


### PR DESCRIPTION
## Motivation / Problem

The value strings for the vehicle breakdowns setting have the prefix `DISASTER`, but the strings are only used for breakdowns. Disasters are boolean settings, so they have no value strings.

(I am working on something that touches these strings, but this is wrong so I see no reason why we shouldn't just fix it anyway.)

## Description

Rename the strings in all languages to say `BREAKDOWNS` without changing their contents. (As per the [eints docs](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md#i-want-to-change-the-str_xxx-string-identifier-for-code-style-reasons-without-changing-the-english-text), this is allowed.)


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
