### PR TITLE
Codechange: do not use SlCopy to skip bytes that should not be read any more

### DIFF
--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -23,10 +23,9 @@ struct PRICChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		/* Old games store 49 base prices, very old games store them as int32_t */
-		VarFileType vt = IsSavegameVersionBefore(SaveLoadVersion::UnifyCurrency) ? VarFileType::I32 : VarFileType::I64;
-		SlCopy(nullptr, 49, vt | VarMemType::Null);
-		SlCopy(nullptr, 49, VarFileType::U16 | VarMemType::Null);
+		size_t num_prices = 49;
+		size_t record_size = (IsSavegameVersionBefore(SaveLoadVersion::UnifyCurrency) ? sizeof(uint32_t) : sizeof(uint64_t)) + sizeof(uint16_t);
+		SlSkipBytes(num_prices * record_size);
 	}
 };
 
@@ -36,10 +35,9 @@ struct CAPRChunkHandler : ChunkHandler {
 
 	void Load() const override
 	{
-		uint num_cargo = IsSavegameVersionBefore(SaveLoadVersion::NewGRFCargo) ? 12 : IsSavegameVersionBefore(SaveLoadVersion::ExtendCargotypes) ? 32 : NUM_CARGO;
-		VarFileType vt = IsSavegameVersionBefore(SaveLoadVersion::UnifyCurrency) ? VarFileType::I32 : VarFileType::I64;
-		SlCopy(nullptr, num_cargo, vt | VarMemType::Null);
-		SlCopy(nullptr, num_cargo, VarFileType::U16 | VarMemType::Null);
+		size_t num_cargo = IsSavegameVersionBefore(SaveLoadVersion::NewGRFCargo) ? 12 : IsSavegameVersionBefore(SaveLoadVersion::ExtendCargotypes) ? 32 : NUM_CARGO;
+		size_t record_size = sizeof(uint16_t) + (IsSavegameVersionBefore(SaveLoadVersion::UnifyCurrency) ? sizeof(uint32_t) : sizeof(uint64_t));
+		SlSkipBytes(num_cargo * record_size);
 	}
 };
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1261,6 +1261,7 @@ static void SlCopyInternal(void *object, size_t length, VarType conv)
  */
 void SlCopy(void *object, size_t length, VarType conv)
 {
+	assert(object != nullptr); // Use SlSkipBytes instead
 	if (_sl.action == SaveLoadAction::Ptrs || _sl.action == SaveLoadAction::Null) return;
 
 	/* Automatically calculate the length? */


### PR DESCRIPTION
## Motivation / Problem

It's a waste of resources to decode bytes into 16, 32 or 64 bit integers to then just throw them away.


## Description

Just count the number of bytes and skip them instead.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
