### PR TITLE
Change: Improve duplicate detection for company/president name changes

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -429,6 +429,44 @@ CommandCost CheckTileOwnership(TileIndex tile)
 }
 
 /**
+ * Set a company name based on type and seed, if the name is unique and shorter than the max length.
+ * @param other_names List of names that cannot be used.
+ * @param c The company of the name to set.
+ * @param t The nearby town, for news message.
+ * @param str The type of name.
+ * @param strp The random seed.
+ * @return True iff the name was set.
+ */
+static bool SetCompanyName(std::span<const std::string> other_names, Company *c, const Town *t, StringID str, uint32_t strp)
+{
+	assert(c != nullptr);
+	assert(t != nullptr);
+
+	/* Name must not be too long. */
+	std::string name = GetString(str, strp);
+	if (Utf8StringLength(name) >= MAX_LENGTH_COMPANY_NAME_CHARS) return false;
+
+	/* No companies must have this name already. */
+	if (std::ranges::find(other_names, name) != other_names.end()) return false;
+
+	c->name_1 = str;
+	c->name_2 = strp;
+
+	MarkWholeScreenDirty();
+	AI::BroadcastNewEvent(new ScriptEventCompanyRenamed(c->index, name));
+	Game::NewEvent(new ScriptEventCompanyRenamed(c->index, name));
+
+	if (!c->is_ai) return true;
+
+	auto cni = std::make_unique<CompanyNewsInformation>(STR_NEWS_COMPANY_LAUNCH_TITLE, c);
+	EncodedString headline = GetEncodedString(STR_NEWS_COMPANY_LAUNCH_DESCRIPTION, cni->company_name, t->index);
+	AddNewsItem(std::move(headline),
+		NewsType::CompanyInfo, NewsStyle::Company, {}, c->last_build_coordinate, {}, std::move(cni));
+
+	return true;
+}
+
+/**
  * Generate the name of a company from the last build coordinate.
  * @param c Company to give a name.
  */
@@ -437,51 +475,24 @@ static void GenerateCompanyName(Company *c)
 	if (c->name_1 != STR_SV_UNNAMED) return;
 	if (c->last_build_coordinate == 0) return;
 
-	Town *t = ClosestTownFromTile(c->last_build_coordinate, UINT_MAX);
-
-	StringID str;
-	uint32_t strp;
-	std::string name;
-	if (t->name.empty() && IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END)) {
-		str = SPECSTR_COMPANY_NAME_START + (t->townnametype - SPECSTR_TOWNNAME_START);
-		strp = t->townnameparts;
-
-verify_name:;
-		/* No companies must have this name already */
-		for (const Company *cc : Company::Iterate()) {
-			if (cc->name_1 == str && cc->name_2 == strp) goto bad_town_name;
-		}
-
-		name = GetString(str, strp);
-		if (Utf8StringLength(name) >= MAX_LENGTH_COMPANY_NAME_CHARS) goto bad_town_name;
-
-set_name:;
-		c->name_1 = str;
-		c->name_2 = strp;
-
-		MarkWholeScreenDirty();
-		AI::BroadcastNewEvent(new ScriptEventCompanyRenamed(c->index, name));
-		Game::NewEvent(new ScriptEventCompanyRenamed(c->index, name));
-
-		if (c->is_ai) {
-			auto cni = std::make_unique<CompanyNewsInformation>(STR_NEWS_COMPANY_LAUNCH_TITLE, c);
-			EncodedString headline = GetEncodedString(STR_NEWS_COMPANY_LAUNCH_DESCRIPTION, cni->company_name, t->index);
-			AddNewsItem(std::move(headline),
-				NewsType::CompanyInfo, NewsStyle::Company, {}, c->last_build_coordinate, {}, std::move(cni));
-		}
-		return;
+	/* Collect existing company names. */
+	std::vector<std::string> other_names;
+	for (const Company *cc : Company::Iterate()) {
+		if (cc != c) other_names.emplace_back(GetString(STR_COMPANY_NAME, cc->index));
 	}
-bad_town_name:;
+
+	const Town *t = ClosestTownFromTile(c->last_build_coordinate, UINT_MAX);
+
+	if (t->name.empty() && IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_END)) {
+		if (SetCompanyName(other_names, c, t, SPECSTR_COMPANY_NAME_START + (t->townnametype - SPECSTR_TOWNNAME_START), t->townnameparts)) return;
+	}
 
 	if (c->president_name_1 == SPECSTR_PRESIDENT_NAME) {
-		str = SPECSTR_ANDCO_NAME;
-		strp = c->president_name_2;
-		name = GetString(str, strp);
-		goto set_name;
-	} else {
-		str = SPECSTR_ANDCO_NAME;
-		strp = Random();
-		goto verify_name;
+		if (SetCompanyName(other_names, c, t, SPECSTR_ANDCO_NAME, c->president_name_2)) return;
+	}
+
+	for (;;) {
+		if (SetCompanyName(other_names, c, t, SPECSTR_ANDCO_NAME, Random())) return;
 	}
 }
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -553,28 +553,43 @@ static Colours GenerateCompanyColour()
 }
 
 /**
+ * Set a company's president name based on seed, if the name is unique and shorter than the max length.
+ * @param other_names List of names that cannot be used.
+ * @param c The company of the president name to set.
+ * @param seed The random seed.
+ * @return True iff the name was set.
+ */
+static bool SetPresidentName(std::span<const std::string> other_names, Company *c, uint32_t seed)
+{
+	assert(c != nullptr);
+
+	c->president_name_1 = SPECSTR_PRESIDENT_NAME;
+	c->president_name_2 = seed;
+
+	/* President name must not be too long. */
+	std::string name = GetString(STR_PRESIDENT_NAME, c->index);
+	if (Utf8StringLength(name) >= MAX_LENGTH_PRESIDENT_NAME_CHARS) return false;
+
+	/* No presidents must have this name already. */
+	if (std::ranges::find(other_names, name) != other_names.end()) return false;
+
+	return true;
+}
+
+/**
  * Generate a random president name of a company.
  * @param c Company that needs a new president name.
  */
 static void GeneratePresidentName(Company *c)
 {
+	/* Collect existing president names. */
+	std::vector<std::string> other_names;
+	for (const Company *cc : Company::Iterate()) {
+		if (cc != c) other_names.emplace_back(GetString(STR_PRESIDENT_NAME, cc->index));
+	}
+
 	for (;;) {
-restart:;
-		c->president_name_2 = Random();
-		c->president_name_1 = SPECSTR_PRESIDENT_NAME;
-
-		/* Reserve space for extra unicode character. We need to do this to be able
-		 * to detect too long president name. */
-		std::string name = GetString(STR_PRESIDENT_NAME, c->index);
-		if (Utf8StringLength(name) >= MAX_LENGTH_PRESIDENT_NAME_CHARS) continue;
-
-		for (const Company *cc : Company::Iterate()) {
-			if (c != cc) {
-				std::string other_name = GetString(STR_PRESIDENT_NAME, cc->index);
-				if (name == other_name) goto restart;
-			}
-		}
-		return;
+		if (SetPresidentName(other_names, c, Random())) return;
 	}
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Initially I started this by wanting to remove the `goto`s within `GenerateCompanyName()` and `GeneratePresidentName()`.

However after doing so I realised that, for company names at least, the duplicate name detection appears to be inadequate as it's possible for different seed values to have the same string result. This is perhaps more theoretical than practical, however.

For duplicate company names, only the string type and seed parameters are checked.

For duplicate president names, although the actual string is compared, we unnecessarily "re-fetch" the president names for each iteration.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

* Refactor both `GenerateCompanyName()` and `GeneratePresidentName()` to remove `goto`s. In particular this makes the logic of the company name generator easier to understand.
* Always test for duplicate names by comparing actual string values instead of seed parameters.
* As we always need to test for duplicate names, fetch the other names once in advance. This (probably) temporarily uses more memory but (probably) reduces CPU usage.

With the new flow it's also now clear to see that the loops are unbounded, but haven't addressed that.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
