### PR TITLE
Codechange: make AddressFunction more const, so less casting is required

### DIFF
--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -194,7 +194,7 @@ SaveLoadTable GetLinkGraphJobDesc()
 	/* We store the offset of each member of the #LinkGraphSettings in the
 	 * extra data of the saveload struct. Use it together with the address
 	 * of the settings struct inside the job to find the final memory address. */
-	static SaveLoad::AddressFunction const func = [](void *b, size_t extra) -> void * { return const_cast<void *>(static_cast<const void *>(reinterpret_cast<const char *>(std::addressof(static_cast<LinkGraphJob *>(b)->settings)) + extra)); };
+	static SaveLoad::AddressFunction const func = [](const void *b, size_t extra) -> const void * { return reinterpret_cast<const char *>(std::addressof(static_cast<const LinkGraphJob *>(b)->settings)) + extra; };
 
 	/* Build the SaveLoad array on first call and don't touch it later on */
 	if (saveloads.empty()) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -768,7 +768,7 @@ struct SaveLoad {
 	 * @param extra An extra offset to apply. Mostly 0, except for a few LinkGraph settings variables.
 	 * @return The address of the variable.
 	 */
-	using AddressFunction = void *(*)(void *base, size_t extra);
+	using AddressFunction = const void *(*)(const void *base, size_t extra);
 
 	std::string name;    ///< Name of this field (optional, used for tables).
 	SaveLoadType cmd;    ///< The action to take with the saved/loaded type, All types need different action.
@@ -860,11 +860,11 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @note In general, it is better to use one of the SLE_* macros below.
  */
 #define SLE_GENERAL_NAME(cmd, name, base, variable, type, length, from, to, extra) \
-	SaveLoad {name, cmd, type, length, from, to, [] (void *b, size_t) -> void * { \
-		static_assert(SlCheckVarSize(cmd, type, length, sizeof(static_cast<base *>(b)->variable))); \
+	SaveLoad {name, cmd, type, length, from, to, [] (const void *b, size_t) -> const void * { \
+		static_assert(SlCheckVarSize(cmd, type, length, sizeof(static_cast<const base *>(b)->variable))); \
 		static_assert((VarType{type}.mem != VarMemType::LabelReverse && VarType{type}.mem != VarMemType::LabelForward) || std::is_base_of_v<BaseLabel, decltype(base::variable)>); \
 		assert(b != nullptr); \
-		return const_cast<void *>(static_cast<const void *>(std::addressof(static_cast<base *>(b)->variable))); \
+		return std::addressof(static_cast<const base *>(b)->variable); \
 	}, extra, nullptr}
 
 /**
@@ -1097,9 +1097,9 @@ inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t leng
  * @note In general, it is better to use one of the SLEG_* macros below.
  */
 #define SLEG_GENERAL(name, cmd, variable, type, length, from, to, extra) \
-	SaveLoad {name, cmd, type, length, from, to, [] (void *, size_t) -> void * { \
+	SaveLoad {name, cmd, type, length, from, to, [] (const void *, size_t) -> const void * { \
 		static_assert(SlCheckVarSize(cmd, type, length, sizeof(variable))); \
-		return static_cast<void *>(std::addressof(variable)); }, extra, nullptr}
+		return std::addressof(variable); }, extra, nullptr}
 
 /**
  * Storage of a global variable in some savegame versions.
@@ -1314,7 +1314,7 @@ inline void *GetVariableAddress(const void *object, const SaveLoad &sld)
 
 	/* Everything else should be a non-null pointer. */
 	assert(sld.address_func != nullptr);
-	return sld.address_func(const_cast<void *>(object), sld.extra_data);
+	return const_cast<void *>(sld.address_func(object, sld.extra_data));
 }
 
 int64_t ReadValue(const void *ptr, VarMemType conv);


### PR DESCRIPTION
## Motivation / Problem

Lots of `const_cast`s in `AddressFunction` implementations. The caller `const_cast`s the input to non-`const` and then expects non-`const` out of the function, so why not let the caller only cast the return value?

Some save-load variables are defined as `const`, so the result of `std::addressof` also becomes `const` which introduces the need for all the `const_cast`s in the current lambdas.


## Description

Make `AddressFunction` use `const void *` instead of `void *`.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
