### PR TITLE
Codefix: use ubuntu-latest over ubuntu-24.04

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -23,7 +23,7 @@ jobs:
   linux:
     name: CI
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     env:
       CC: ${{ inputs.compiler }}
       CXX: ${{ inputs.cxxcompiler }}


### PR DESCRIPTION
## Motivation / Problem

The Linux CI was at some point set/migrated to ubuntu-24.04. However, that has been the latest for years and soon will not be any more. Every other CI job is running on $-latest.


## Description

Let Linux CI run on ubuntu-latest, just like all other CIs already running on ubuntu-latest (or macos/windows-latest).


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
