### PR TITLE
Codechange: add Bool and Label aliases to VarFileType to denote intent

### DIFF
--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -634,11 +634,13 @@ enum class VarFileType : uint8_t {
 	 * NOTE: the SLE_FILE_NNN values are stored in the savegame! */
 	/* Value 0 is used to mark end-of-header in tables. Do not use here! */
 	I8 = 1, ///< A 8 bit signed int.
+	Bool = I8, ///< A bool is stored in an 8 bit signed integer field.
 	U8 = 2, ///< A 8 bit unsigned int.
 	I16 = 3, ///< A 16 bit signed int.
 	U16 = 4, ///< A 16 bit unsigned int.
 	I32 = 5, ///< A 32 bit signed int.
 	U32 = 6, ///< A 32 bit unsigned int.
+	Label = U32, ///< A label is stored in an 32 bit unsigned integer field.
 	I64 = 7, ///< A 64 bit signed int.
 	U64 = 8, ///< A 64 bit unsigned int.
 	StringID = 9, ///< StringID offset into strings-array.
@@ -722,7 +724,7 @@ constexpr VarType operator|(VarFileType file, VarMemType mem)
 
 /** Container for holding some default \c VarType instances. */
 struct VarTypes {
-	static constexpr VarType BOOL{ VarFileType::I8, VarMemType::Bool }; ///< Store a boolean (as int8).
+	static constexpr VarType BOOL{ VarFileType::Bool, VarMemType::Bool }; ///< Store a boolean (as int8).
 	static constexpr VarType I8{ VarFileType::I8, VarMemType::I8 }; ///< Store a 8 bits signed int.
 	static constexpr VarType U8{ VarFileType::U8, VarMemType::U8 }; ///< Store a 8 bits unsigned int.
 	static constexpr VarType I16{ VarFileType::I16, VarMemType::I16 }; ///< Store a 16 bits signed int.
@@ -735,8 +737,8 @@ struct VarTypes {
 	static constexpr VarType STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
 	static constexpr VarType STRQ{ VarFileType::String, VarMemType::StrQ }; ///< Store a string with quotes.
 	static constexpr VarType NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
-	static constexpr VarType LABEL_REVERSE{ VarFileType::U32, VarMemType::LabelReverse }; ///< Store a \c Label in reverse.
-	static constexpr VarType LABEL_FORWARD{ VarFileType::U32, VarMemType::LabelForward }; ///< Store a \c Label as-is.
+	static constexpr VarType LABEL_REVERSE{ VarFileType::Label, VarMemType::LabelReverse }; ///< Store a \c Label in reverse.
+	static constexpr VarType LABEL_FORWARD{ VarFileType::Label, VarMemType::LabelForward }; ///< Store a \c Label as-is.
 };
 
 /** Type of data saved. */


### PR DESCRIPTION
## Motivation / Problem

In the save game format there is no separate type for booleans or labels, so these are stored as `I8` and `U32` instead.

In #15897 I am working on removing the need to give the memory type, meaning that for most SaveLoad instances you only need to give the `SaveFileType`. Using `SaveFileType::I8` everywhere in the code when saving a boolean will confuse people. It would be better there is a `SaveFileType::Bool` (and similarly a `SaveFileType::Label`).


## Description

Introduce `SaveFileType::Bool` and `SaveFileType::Label` as aliases for respectively `SaveFileType::I8` and `SaveFileType::U32`.
Use these new labels for `VarTypes::BOOL` and `VarTypes::LABEL_*`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
