### PR TITLE
Fix: Change the order that (Un)FlattenNewGRFLabel convert to/from uint32_t

### DIFF
--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -389,7 +389,7 @@ void DeserializeNetworkGameInfo(Packet &p, NetworkGameInfo &info, const GameInfo
  */
 void SerializeGRFIdentifier(Packet &p, const GRFIdentifier &grf)
 {
-	p.Send_uint32(FlattenNewGRFLabel(grf.grfid));
+	p.Send_uint32(std::byteswap(FlattenNewGRFLabel(grf.grfid)));
 	p.Send_bytes(grf.md5sum);
 }
 
@@ -400,7 +400,7 @@ void SerializeGRFIdentifier(Packet &p, const GRFIdentifier &grf)
  */
 void DeserializeGRFIdentifier(Packet &p, GRFIdentifier &grf)
 {
-	grf.grfid = UnflattenNewGRFLabel<GrfID>(p.Recv_uint32());
+	grf.grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(p.Recv_uint32()));
 	p.Recv_bytes(grf.md5sum);
 }
 

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -74,7 +74,7 @@ std::optional<std::string> ContentInfo::GetTextfile(TextfileType type) const
 			tmp = Game::GetScannerLibrary()->FindMainScript(*this, true);
 			break;
 		case ContentType::NewGRF: {
-			const GRFConfig *gc = FindGRFConfig(UnflattenNewGRFLabel<GrfID>(this->unique_id), FindGRFConfigMode::Exact, &this->md5sum);
+			const GRFConfig *gc = FindGRFConfig(UnflattenNewGRFLabel<GrfID>(std::byteswap(this->unique_id)), FindGRFConfigMode::Exact, &this->md5sum);
 			if (gc != nullptr) tmp = gc->filename;
 			break;
 		}

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -50,7 +50,7 @@ ClientNetworkContentSocketHandler _network_content_client;
 /** Check whether NewGRF content exists. @copydoc HasContentProc */
 static bool HasGRFConfig(const ContentInfo &ci, bool md5sum)
 {
-	return FindGRFConfig(UnflattenNewGRFLabel<GrfID>(ci.unique_id), md5sum ? FindGRFConfigMode::Exact : FindGRFConfigMode::Any, md5sum ? &ci.md5sum : nullptr) != nullptr;
+	return FindGRFConfig(UnflattenNewGRFLabel<GrfID>(std::byteswap(ci.unique_id)), md5sum ? FindGRFConfigMode::Exact : FindGRFConfigMode::Any, md5sum ? &ci.md5sum : nullptr) != nullptr;
 }
 
 /**

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -256,7 +256,7 @@ VehicleType GetVehicleType(GrfSpecFeature feature);
  * @return The flattened label.
  */
 template <typename T> requires std::is_base_of_v<BaseLabel, T>
-constexpr uint32_t FlattenNewGRFLabel(T label) { return label[0] << 24 | label[1] << 16 | label[2] << 8 | label[3]; }
+constexpr uint32_t FlattenNewGRFLabel(T label) { return label[0] | label[1] << 8 | label[2] << 16 | label[3] << 24; }
 
 /**
  * Unflatten a NewGRF related label from a 32 bits integer.
@@ -267,10 +267,10 @@ template <typename T> requires std::is_base_of_v<BaseLabel, T>
 constexpr T UnflattenNewGRFLabel(uint32_t value)
 {
 	uint8_t buf[]{
-		static_cast<uint8_t>(GB(value, 24, 8)),
-		static_cast<uint8_t>(GB(value, 16, 8)),
+		static_cast<uint8_t>(GB(value, 0, 8)),
 		static_cast<uint8_t>(GB(value, 8, 8)),
-		static_cast<uint8_t>(GB(value, 0, 8))
+		static_cast<uint8_t>(GB(value, 16, 8)),
+		static_cast<uint8_t>(GB(value, 24, 8))
 	};
 	return buf;
 }

--- a/src/newgrf/newgrf_act11.cpp
+++ b/src/newgrf/newgrf_act11.cpp
@@ -25,7 +25,7 @@
 static void ImportGRFSound(SoundEntry *sound)
 {
 	const GRFFile *file;
-	GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(_cur_gps.file->ReadDword()));
+	GrfID grfid = UnflattenNewGRFLabel<GrfID>(_cur_gps.file->ReadDword());
 	SoundID sound_id = _cur_gps.file->ReadWord();
 
 	file = GetFileByGRFID(grfid);

--- a/src/newgrf/newgrf_act7_9.cpp
+++ b/src/newgrf/newgrf_act7_9.cpp
@@ -251,7 +251,7 @@ static void SkipIf(ByteReader &buf)
 	} else if (param == 0x88) {
 		/* GRF ID checks */
 
-		GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(cond_val));
+		GrfID grfid = UnflattenNewGRFLabel<GrfID>(cond_val);
 		GRFConfig *c = GetGRFConfig(grfid, std::byteswap(mask));
 
 		if (c != nullptr && c->flags.Test(GRFConfigFlag::Static) && !_cur_gps.grfconfig->flags.Test(GRFConfigFlag::Static) && _networking) {

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -329,7 +329,7 @@ static void ParamSet(ByteReader &buf)
 			}
 		} else {
 			/* Read another GRF File's parameter */
-			GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(data));
+			GrfID grfid = UnflattenNewGRFLabel<GrfID>(data);
 			const GRFFile *file = GetFileByGRFID(grfid);
 			GRFConfig *c = GetGRFConfig(grfid);
 			if (c != nullptr && c->flags.Test(GRFConfigFlag::Static) && !_cur_gps.grfconfig->flags.Test(GRFConfigFlag::Static) && _networking) {

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1513,7 +1513,7 @@ void ShowMissingContentWindow(const GRFConfigList &list)
 		ci->type = ContentType::NewGRF;
 		ci->state = ContentInfo::State::DoesNotExist;
 		ci->name = c->GetName();
-		ci->unique_id = FlattenNewGRFLabel(c->ident.grfid);
+		ci->unique_id = std::byteswap(FlattenNewGRFLabel(c->ident.grfid));
 		ci->md5sum = c->flags.Test(GRFConfigFlag::Compatible) ? c->original_md5sum : c->ident.md5sum;
 		cv.push_back(std::move(ci));
 	}

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -237,7 +237,7 @@ static uint32_t GetClosestObject(TileIndex tile, ObjectType type, const Object *
  */
 static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &object, uint8_t local_id, GrfID grfid, TileIndex tile, const Object *current)
 {
-	uint32_t grf_id = std::byteswap(static_cast<uint32_t>(object.GetRegister(0x100))); // Get the GRFID of the definition to look for in register 100h
+	uint32_t grf_id = static_cast<uint32_t>(object.GetRegister(0x100)); // Get the GRFID of the definition to look for in register 100h
 	uint32_t idx;
 
 	/* Determine what will be the object type to look for */

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -44,7 +44,7 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 		/* Get a variable from the persistent storage */
 		case 0x7C: {
 			/* Check the persistent storage for the GrfID stored in register 100h. */
-			GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(this->ro.GetRegister(0x100)));
+			GrfID grfid = UnflattenNewGRFLabel<GrfID>(this->ro.GetRegister(0x100));
 			if (grfid == INVALID_GRFID) {
 				if (this->ro.grffile == nullptr) return 0;
 				grfid = this->ro.grffile->grfid;
@@ -140,7 +140,7 @@ static uint16_t TownHistoryHelper(const Town *t, CargoLabel label, uint period, 
 	if (this->ro.grffile == nullptr) return;
 
 	/* Check the persistent storage for the GrfID stored in register 100h. */
-	GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(this->ro.GetRegister(0x100)));
+	GrfID grfid = UnflattenNewGRFLabel<GrfID>(this->ro.GetRegister(0x100));
 
 	/* A NewGRF can only write in the persistent storage associated to its own GRFID. */
 	if (grfid == INVALID_GRFID) grfid = this->ro.grffile->grfid;

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1584,7 +1584,7 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 
 				ClearGRFConfigList(_grfconfig);
 				while (len != 0) {
-					GrfID grfid = UnflattenNewGRFLabel<GrfID>(std::byteswap(ReadUint32(ls)));
+					GrfID grfid = UnflattenNewGRFLabel<GrfID>(ReadUint32(ls));
 
 					if (ReadByte(ls) == 1) {
 						auto c = std::make_unique<GRFConfig>("TTDP game, no information");

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -161,5 +161,5 @@
 {
 	EnforcePrecondition(IT_INVALID, IsInsideBS(grf_local_id, 0x00, NUM_INDUSTRYTYPES_PER_GRF));
 
-	return _industry_mngr.GetID(grf_local_id, UnflattenNewGRFLabel<GrfID>(grfid));
+	return _industry_mngr.GetID(grf_local_id, UnflattenNewGRFLabel<GrfID>(std::byteswap(static_cast<uint32_t>(grfid))));
 }

--- a/src/script/api/script_newgrf.cpp
+++ b/src/script/api/script_newgrf.cpp
@@ -20,21 +20,21 @@ ScriptNewGRFList::ScriptNewGRFList()
 {
 	for (const auto &c : _grfconfig) {
 		if (!c->flags.Test(GRFConfigFlag::Static)) {
-			this->AddItem(FlattenNewGRFLabel(c->ident.grfid));
+			this->AddItem(std::byteswap(FlattenNewGRFLabel(c->ident.grfid)));
 		}
 	}
 }
 
 /* static */ bool ScriptNewGRF::IsLoaded(SQInteger grfid)
 {
-	GrfID id = UnflattenNewGRFLabel<GrfID>(grfid);
+	GrfID id = UnflattenNewGRFLabel<GrfID>(std::byteswap(static_cast<uint32_t>(grfid)));
 
 	return std::ranges::any_of(_grfconfig, [id](const auto &c) { return !c->flags.Test(GRFConfigFlag::Static) && c->ident.grfid == id; });
 }
 
 /* static */ SQInteger ScriptNewGRF::GetVersion(SQInteger grfid)
 {
-	GrfID id = UnflattenNewGRFLabel<GrfID>(grfid);
+	GrfID id = UnflattenNewGRFLabel<GrfID>(std::byteswap(static_cast<uint32_t>(grfid)));
 
 	auto it = std::ranges::find_if(_grfconfig, [id](const auto &c) { return !c->flags.Test(GRFConfigFlag::Static) && c->ident.grfid == id; });
 	if (it != std::end(_grfconfig)) return (*it)->version;
@@ -44,7 +44,7 @@ ScriptNewGRFList::ScriptNewGRFList()
 
 /* static */ std::optional<std::string> ScriptNewGRF::GetName(SQInteger grfid)
 {
-	GrfID id = UnflattenNewGRFLabel<GrfID>(grfid);
+	GrfID id = UnflattenNewGRFLabel<GrfID>(std::byteswap(static_cast<uint32_t>(grfid)));
 
 	auto it = std::ranges::find_if(_grfconfig, [id](const auto &c) { return !c->flags.Test(GRFConfigFlag::Static) && c->ident.grfid == id; });
 	if (it != std::end(_grfconfig)) return (*it)->GetName();

--- a/src/script/api/script_objecttype.cpp
+++ b/src/script/api/script_objecttype.cpp
@@ -52,5 +52,5 @@
 {
 	EnforcePrecondition(INVALID_OBJECT_TYPE, IsInsideBS(grf_local_id, 0x00, NUM_OBJECTS_PER_GRF));
 
-	return _object_mngr.GetID(grf_local_id, UnflattenNewGRFLabel<GrfID>(grfid));
+	return _object_mngr.GetID(grf_local_id, UnflattenNewGRFLabel<GrfID>(std::byteswap(static_cast<uint32_t>(grfid))));
 }


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Fixes #15917
Fixes #15902

The most common usage for this function is to convert a DWord from NewGRF into a label.

Unfortunately currently requires additional `std::byteswap()` calls, which in theory `FlattenNewGRFLabel<>()` was intended to avoid.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Instead of adding `std::byteswap()`s for the most common case, converting from NewGRF dwords, change the order that `(Un)FlattenNewGRFLabel()` read. Now only the rare case, sending over the network, requires a `std::byteswap()`.

This does not change the internal representation of a `Label` type, as `ByteReader`'s `ReadLabel()` is not affected.

This reverts commit 9140a7ad4a44fb0eca5607bd098143c3caac2c68

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
