### PR TITLE
Codechange: use ContiguousContainer for SlCopy and extract VarMemType

### DIFF
--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -52,7 +52,7 @@ struct ANITChunkHandler : ChunkHandler {
 			size_t count = SlGetFieldLength() / sizeof(_animated_tiles.front());
 			_animated_tiles.clear();
 			_animated_tiles.resize(count);
-			SlCopy(_animated_tiles.data(), count, VarTypes::U32);
+			SlCopy<VarFileType::U32>(_animated_tiles);
 			return;
 		}
 

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -143,7 +143,7 @@ struct ENGSChunkHandler : ChunkHandler {
 		 * was always 256 entries. */
 		TypedIndexContainer<std::array<StringID, 256>, EngineID> names{};
 
-		SlCopy(names.data(), std::size(names), VarTypes::STRINGID);
+		SlCopy<VarFileType::StringID>(names);
 
 		/* Copy each string into the temporary engine array. */
 		for (EngineID engine = EngineID::Begin(); engine < std::size(names); ++engine) {

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -75,7 +75,7 @@ struct MAPTChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 			for (auto b : buf) Tile(i++).type() = b;
 		}
 	}
@@ -88,7 +88,7 @@ struct MAPTChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).type();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 		}
 	}
 };
@@ -102,7 +102,7 @@ struct MAPHChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 			for (auto b : buf) Tile(i++).height() = b;
 		}
 	}
@@ -115,7 +115,7 @@ struct MAPHChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).height();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 		}
 	}
 };
@@ -129,7 +129,7 @@ struct MAPOChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 			for (auto b : buf) Tile(i++).m1() = b;
 		}
 	}
@@ -142,7 +142,7 @@ struct MAPOChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).m1();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 		}
 	}
 };
@@ -172,7 +172,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 		SlSetLength(static_cast<uint32_t>(size) * sizeof(uint16_t));
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).m2();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U16);
+			SlCopy<VarFileType::U16>(buf);
 		}
 	}
 };
@@ -186,7 +186,7 @@ struct M3LOChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 			for (auto b : buf) Tile(i++).m3() = b;
 		}
 	}
@@ -199,7 +199,7 @@ struct M3LOChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).m3();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 		}
 	}
 };
@@ -213,7 +213,7 @@ struct M3HIChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 			for (auto b : buf) Tile(i++).m4() = b;
 		}
 	}
@@ -226,7 +226,7 @@ struct M3HIChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).m4();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 		}
 	}
 };
@@ -240,7 +240,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 			for (auto b : buf) Tile(i++).m5() = b;
 		}
 	}
@@ -253,7 +253,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).m5();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 		}
 	}
 };
@@ -269,7 +269,7 @@ struct MAPEChunkHandler : ChunkHandler {
 			/* Since this loads 4 tiles per read byte, amend the buffer size to suit. */
 			std::array<uint8_t, MAP_SL_BUF_SIZE / 4> buf;
 			for (TileIndex i{}; i != size;) {
-				SlCopy(buf.data(), buf.size(), VarTypes::U8);
+				SlCopy<VarFileType::U8>(buf);
 				for (auto b : buf) {
 					Tile(i++).m6() = GB(b, 0, 2);
 					Tile(i++).m6() = GB(b, 2, 2);
@@ -280,7 +280,7 @@ struct MAPEChunkHandler : ChunkHandler {
 		} else {
 			std::array<uint8_t, MAP_SL_BUF_SIZE> buf;
 			for (TileIndex i{}; i != size;) {
-				SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+				SlCopy<VarFileType::U8>(buf);
 				for (auto b : buf) Tile(i++).m6() = b;
 			}
 		}
@@ -294,7 +294,7 @@ struct MAPEChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).m6();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 		}
 	}
 };
@@ -308,7 +308,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 			for (auto b : buf) Tile(i++).m7() = b;
 		}
 	}
@@ -321,7 +321,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 		SlSetLength(size);
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).m7();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U8);
+			SlCopy<VarFileType::U8>(buf);
 		}
 	}
 };
@@ -335,7 +335,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 		uint size = Map::Size();
 
 		for (TileIndex i{}; i != size;) {
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U16);
+			SlCopy<VarFileType::U16>(buf);
 			for (auto b : buf) Tile(i++).m8() = b;
 		}
 	}
@@ -348,7 +348,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 		SlSetLength(static_cast<uint32_t>(size) * sizeof(uint16_t));
 		for (TileIndex i{}; i != size;) {
 			for (auto &b : buf) b = Tile(i++).m8();
-			SlCopy(buf.data(), MAP_SL_BUF_SIZE, VarTypes::U16);
+			SlCopy<VarFileType::U16>(buf);
 		}
 	}
 };

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -174,7 +174,7 @@ struct ORDRChunkHandler : ChunkHandler {
 				len /= sizeof(uint16_t);
 				std::vector<uint16_t> orders(len);
 
-				SlCopy(&orders[0], len, VarTypes::U16);
+				SlCopy<VarFileType::U16>(orders);
 
 				for (size_t i = 0; i < len; ++i) {
 					auto &item = AllocateOldOrder(i);
@@ -184,7 +184,7 @@ struct ORDRChunkHandler : ChunkHandler {
 				len /= sizeof(uint32_t);
 				std::vector<uint32_t> orders(len);
 
-				SlCopy(&orders[0], len, VarTypes::U32);
+				SlCopy<VarFileType::U32>(orders);
 
 				for (size_t i = 0; i < len; ++i) {
 					auto &item = AllocateOldOrder(i);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -779,6 +779,75 @@ struct SaveLoad {
 	AddressFunction address_func; ///< Callback function the get the actual variable address in memory.
 	size_t extra_data;              ///< Extra data for the callback proc.
 	std::shared_ptr<SaveLoadHandler> handler; ///< Custom handler for Save/Load procs.
+
+	/**
+	 * Check whether the given file type is stored as a simple number.
+	 * @param file_type The file type to check.
+	 * @return \c true iff signed or unsigned 8, 16, 32 or 64 bit integer.
+	 */
+	static constexpr bool IsIntegralFileType(VarFileType file_type)
+	{
+		switch (file_type) {
+			case VarFileType::I8:
+			case VarFileType::U8:
+			case VarFileType::I16:
+			case VarFileType::U16:
+			case VarFileType::I32:
+			case VarFileType::U32:
+			case VarFileType::I64:
+			case VarFileType::U64:
+				return true;
+
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Determine the \c VarMemType type given the variable's \c decltype and occasionally the file type to distinguish options.
+	 * If feasible a sanity check is do to check the file type against the variable's \c decltype, for example to prevent a bool to be saved as string.
+	 * @tparam T The variable's \c decltype.
+	 * @tparam file_type The way this variable will be/is stored in the save file.
+	 * @return The \c VarMemType.
+	 * @note file_type is a template parameter to be able to perform all type checks at compile time.
+	 */
+	template <typename T, VarFileType file_type>
+	static constexpr VarMemType DetermineMemType()
+	{
+		if constexpr (std::is_same_v<StringID, T>) {
+			static_assert(file_type == VarFileType::StringID);
+			static_assert(sizeof(T) == sizeof(uint32_t));
+			return VarMemType::U32;
+		} else if constexpr (std::is_same_v<int8_t, T>) {
+			static_assert(IsIntegralFileType(file_type));
+			return VarMemType::I8;
+		} else if constexpr (std::is_same_v<uint8_t, T> || std::is_same_v<char, T>) {
+			static_assert(IsIntegralFileType(file_type));
+			return VarMemType::U8;
+		} else if constexpr (std::is_same_v<int16_t, T>) {
+			static_assert(IsIntegralFileType(file_type));
+			return VarMemType::I16;
+		} else if constexpr (std::is_same_v<uint16_t, T>) {
+			static_assert(IsIntegralFileType(file_type));
+			return VarMemType::U16;
+		} else if constexpr (std::is_same_v<int32_t, T>) {
+			static_assert(IsIntegralFileType(file_type));
+			return VarMemType::I32;
+		} else if constexpr (std::is_same_v<uint32_t, T>) {
+			static_assert(IsIntegralFileType(file_type));
+			return VarMemType::U32;
+		} else if constexpr (std::is_same_v<int64_t, T>) {
+			static_assert(IsIntegralFileType(file_type));
+			return VarMemType::I64;
+		} else if constexpr (std::is_same_v<uint64_t, T>) {
+			static_assert(IsIntegralFileType(file_type));
+			return VarMemType::U64;
+		} else if constexpr (ConvertibleThroughBase<T>) {
+			return DetermineMemType<typename T::BaseType, file_type>();
+		} else {
+			static_assert(false, "The given type is not supported");
+		}
+	}
 };
 
 /**
@@ -1342,6 +1411,19 @@ void SlCopy(void *object, size_t length, VarType conv);
 std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt);
 std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLoadCompatTable &slct);
 void SlObject(void *object, const SaveLoadTable &slt);
+
+/**
+ * Copy the data from the collection to the save, or from the save into the collection depending on the save-load state.
+ * @tparam file_type The way the data is stored in the save file.
+ * @tparam T The type of the collection, to get the \c value_type from.
+ * @param collection The 'ContiguousContainer' with data to save, or to load the data into.
+ */
+template <VarFileType file_type, typename T>
+static inline void SlCopy(T &collection)
+{
+	std::span span{collection}; // Let std::span worry about what is passed being a contiguous container.
+	SlCopy(span.data(), span.size(), file_type | SaveLoad::DetermineMemType<std::remove_const_t<typename T::value_type>, file_type>());
+}
 
 /**
  * Read in bytes from the file/data structure but don't do

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -611,7 +611,7 @@ bool ScriptInstance::IsPaused()
 		case SQSL_STRING: {
 			SlObject(nullptr, _script_byte);
 			std::string buf(_script_sl_byte, '\0');
-			SlCopy(buf.data(), buf.size(), VarTypes::I8);
+			SlCopy<VarFileType::I8>(buf);
 			if (data != nullptr) data->push_back(StrMakeValid(std::move(buf)));
 			return true;
 		}


### PR DESCRIPTION
## Motivation / Problem

* Use C++ containers over bare C-arrays.
* Pass containers instead of pointer + size.
* Remove hassle of keeping `VarMemType` in check.


## Description

Almost everything that is passed to `SlCopy` is a C++ container, so add a function to handle them directly.

Furthermore take some of the `VarMemType` determination/validation code from #15897 and make use of that to determine the `VarMemType`. This means we only need to pass the `VarFileType` to `SlCopy`.


## Limitations

The C++ standard is talking about `ContiguousContainer` as a requirement, but sadly that's not something that can be checked at compile time as there's no concept of that in the type traits. Having said that, `std::span` should be doing these checks already in some capacity as it requires a `ContiguousContainer`, so it'll just go through `std::span` for the checks.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
