### PR TITLE
Codechange: make static inline constexpr order consistent

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -12,6 +12,7 @@ What is simple to some might appear very complicated to others. Documentation he
 * Use Foo() instead of Foo(void).
 * Prefer using "const" for reference and compound parameters when appropriate.
 * If a member function can be a const function, make it so.
+* Order of qualifiers is `static inline` / `static constexpr`, don't use `inline` with `constexpr`.
 ```c++
 void ThisIsAFunction()
 {

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -80,10 +80,10 @@ struct CommandInfo {
 };
 /* Helpers to generate the master command table from the command traits. */
 template <typename T>
-inline constexpr CommandInfo CommandFromTrait() noexcept { return { T::name, T::flags, T::type }; };
+constexpr CommandInfo CommandFromTrait() noexcept { return { T::name, T::flags, T::type }; };
 
 template <typename T, T... i>
-inline constexpr auto MakeCommandsFromTraits(std::integer_sequence<T, i...>) noexcept {
+constexpr auto MakeCommandsFromTraits(std::integer_sequence<T, i...>) noexcept {
 	return EnumIndexArray<CommandInfo, Commands, static_cast<Commands>(sizeof...(i))>{{{ CommandFromTrait<CommandTraits<static_cast<Commands>(i)>>()... }}};
 }
 

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -46,7 +46,7 @@ constexpr CommandFlags GetCommandFlags()
  * @param cmd_flags Flags from GetCommandFlags
  * @return flags for DoCommand
  */
-static constexpr inline DoCommandFlags CommandFlagsToDCFlags(CommandFlags cmd_flags)
+static constexpr DoCommandFlags CommandFlagsToDCFlags(CommandFlags cmd_flags)
 {
 	DoCommandFlags flags = {};
 	if (cmd_flags.Test(CommandFlag::NoWater)) flags.Set(DoCommandFlag::NoWater);

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -483,7 +483,7 @@ template <Commands Tcmd> struct CommandTraits;
 		static constexpr auto &proc = proc_; \
 		static constexpr CommandFlags flags = flags_; \
 		static constexpr CommandType type = type_; \
-		static inline constexpr std::string_view name = #proc_; \
+		static constexpr std::string_view name = #proc_; \
 	};
 
 /** Storage buffer for serialized command data. */

--- a/src/core/base_bitset_type.hpp
+++ b/src/core/base_bitset_type.hpp
@@ -40,7 +40,7 @@ public:
 	 * Set all bits.
 	 * @returns The bit set
 	 */
-	inline constexpr Timpl &Set()
+	constexpr Timpl &Set()
 	{
 		this->data = Tmask;
 		return static_cast<Timpl&>(*this);
@@ -53,7 +53,7 @@ public:
 	 * @returns The bit set
 	 */
 	template <typename Treturn_type = Timpl> requires std::is_base_of_v<BaseBitSet<Timpl, Tvalue_type, Tstorage, Tmask>, Treturn_type>
-	inline constexpr Treturn_type &Set(Tvalue_type value)
+	constexpr Treturn_type &Set(Tvalue_type value)
 	{
 		this->data |= (1ULL << Timpl::DecayValueType(value));
 		return static_cast<Treturn_type &>(*this);
@@ -64,7 +64,7 @@ public:
 	 * @param other Bitset of values to set.
 	 * @returns The bit set
 	 */
-	inline constexpr Timpl &Set(const Timpl &other)
+	constexpr Timpl &Set(const Timpl &other)
 	{
 		this->data |= other.data;
 		return static_cast<Timpl&>(*this);
@@ -76,7 +76,7 @@ public:
 	 * @param set true if the bit should be set, false if the bit should be reset.
 	 * @returns The EnumBitset
 	 */
-	inline constexpr Timpl &Set(Tvalue_type value, bool set)
+	constexpr Timpl &Set(Tvalue_type value, bool set)
 	{
 		return set ? this->Set(value) : this->Reset(value);
 	}
@@ -85,7 +85,7 @@ public:
 	 * Reset all bits.
 	 * @returns The bit set
 	 */
-	inline constexpr Timpl &Reset()
+	constexpr Timpl &Reset()
 	{
 		this->data = 0;
 		return static_cast<Timpl &>(*this);
@@ -96,7 +96,7 @@ public:
 	 * @param value Bit to reset.
 	 * @returns The bit set
 	 */
-	inline constexpr Timpl &Reset(Tvalue_type value)
+	constexpr Timpl &Reset(Tvalue_type value)
 	{
 		this->data &= ~(1ULL << Timpl::DecayValueType(value));
 		return static_cast<Timpl&>(*this);
@@ -107,7 +107,7 @@ public:
 	 * @param other Bitset of values to reset.
 	 * @returns The bit set
 	 */
-	inline constexpr Timpl &Reset(const Timpl &other)
+	constexpr Timpl &Reset(const Timpl &other)
 	{
 		this->data &= ~other.data;
 		return static_cast<Timpl&>(*this);
@@ -117,7 +117,7 @@ public:
 	 * Flip all bits.
 	 * @returns The bit set
 	 */
-	inline constexpr Timpl &Flip()
+	constexpr Timpl &Flip()
 	{
 		this->data ^= Tmask;
 		return static_cast<Timpl &>(*this);
@@ -128,7 +128,7 @@ public:
 	 * @param value Bit to flip.
 	 * @returns The bit set
 	 */
-	inline constexpr Timpl &Flip(Tvalue_type value)
+	constexpr Timpl &Flip(Tvalue_type value)
 	{
 		if (this->Test(value)) {
 			return this->Reset(value);
@@ -142,7 +142,7 @@ public:
 	 * @param other Bitset of values to flip.
 	 * @returns The bit set
 	 */
-	inline constexpr Timpl &Flip(const Timpl &other)
+	constexpr Timpl &Flip(const Timpl &other)
 	{
 		this->data ^= other.data;
 		return static_cast<Timpl&>(*this);
@@ -153,7 +153,7 @@ public:
 	 * @param value Bit to check.
 	 * @returns true iff the requested bit is set.
 	 */
-	inline constexpr bool Test(Tvalue_type value) const
+	constexpr bool Test(Tvalue_type value) const
 	{
 		return (this->data & (1ULL << Timpl::DecayValueType(value))) != 0;
 	}
@@ -163,7 +163,7 @@ public:
 	 * @param other BitSet of values to test.
 	 * @returns true iff all of the values are set.
 	 */
-	inline constexpr bool All(const Timpl &other) const
+	constexpr bool All(const Timpl &other) const
 	{
 		return (this->data & other.data) == other.data;
 	}
@@ -172,7 +172,7 @@ public:
 	 * Test if all of the values are set.
 	 * @returns true iff all of the values are set.
 	 */
-	inline constexpr bool All() const
+	constexpr bool All() const
 	{
 		return this->data == Tmask;
 	}
@@ -182,7 +182,7 @@ public:
 	 * @param other BitSet of values to test.
 	 * @returns true iff any of the given values are set.
 	 */
-	inline constexpr bool Any(const Timpl &other) const
+	constexpr bool Any(const Timpl &other) const
 	{
 		return (this->data & other.data) != 0;
 	}
@@ -191,7 +191,7 @@ public:
 	 * Test if any of the values are set.
 	 * @returns true iff any of the values are set.
 	 */
-	inline constexpr bool Any() const
+	constexpr bool Any() const
 	{
 		return this->data != 0;
 	}
@@ -200,29 +200,29 @@ public:
 	 * Test if none of the values are set.
 	 * @returns true iff none of the values are set.
 	 */
-	inline constexpr bool None() const
+	constexpr bool None() const
 	{
 		return this->data == 0;
 	}
 
-	inline constexpr Timpl &operator|=(const Timpl &other)
+	constexpr Timpl &operator|=(const Timpl &other)
 	{
 		this->data |= other.data;
 		return static_cast<Timpl &>(*this);
 	}
 
-	inline constexpr Timpl operator|(const Timpl &other) const
+	constexpr Timpl operator|(const Timpl &other) const
 	{
 		return Timpl{static_cast<Tstorage>(this->data | other.data)};
 	}
 
-	inline constexpr Timpl &operator&=(const Timpl &other)
+	constexpr Timpl &operator&=(const Timpl &other)
 	{
 		this->data &= other.data;
 		return static_cast<Timpl &>(*this);
 	}
 
-	inline constexpr Timpl operator&(const Timpl &other) const
+	constexpr Timpl operator&(const Timpl &other) const
 	{
 		return Timpl{static_cast<Tstorage>(this->data & other.data)};
 	}
@@ -231,7 +231,7 @@ public:
 	 * Retrieve the raw value behind this bit set.
 	 * @returns the raw value.
 	 */
-	inline constexpr Tstorage base() const noexcept
+	constexpr Tstorage base() const noexcept
 	{
 		return this->data;
 	}
@@ -240,7 +240,7 @@ public:
 	 * Test that the raw value of this bit set is valid.
 	 * @returns true iff the no bits outside the masked value are set.
 	 */
-	inline constexpr bool IsValid() const
+	constexpr bool IsValid() const
 	{
 		return (this->base() & Tmask) == this->base();
 	}

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -29,7 +29,7 @@
  * @return The selected bits, aligned to a LSB.
  */
 template <typename T>
-[[debug_inline]] inline constexpr static uint GB(const T x, const uint8_t s, const uint8_t n)
+[[debug_inline]] static inline constexpr uint GB(const T x, const uint8_t s, const uint8_t n)
 {
 	return (x >> s) & (((T)1U << n) - 1);
 }

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -29,7 +29,7 @@
  * @return The selected bits, aligned to a LSB.
  */
 template <typename T>
-[[debug_inline]] static inline constexpr uint GB(const T x, const uint8_t s, const uint8_t n)
+[[debug_inline]] static constexpr uint GB(const T x, const uint8_t s, const uint8_t n)
 {
 	return (x >> s) & (((T)1U << n) - 1);
 }
@@ -100,7 +100,7 @@ constexpr T AB(T &x, const uint8_t s, const uint8_t n, const U i)
  * @return True if the bit is set, false else.
  */
 template <typename T>
-[[debug_inline]] inline constexpr bool HasBit(const T x, const uint8_t y)
+[[debug_inline]] constexpr bool HasBit(const T x, const uint8_t y)
 {
 	return (x & ((T)1U << y)) != 0;
 }

--- a/src/core/enum_type.hpp
+++ b/src/core/enum_type.hpp
@@ -38,7 +38,7 @@ constexpr bool is_enum_incrementable_v = is_enum_incrementable<enum_type>::value
  * @return Reference to the incremented enum.
  */
 template <typename enum_type, std::enable_if_t<is_enum_incrementable_v<enum_type>, bool> = true>
-inline constexpr enum_type &operator ++(enum_type &e)
+constexpr enum_type &operator ++(enum_type &e)
 {
 	e = static_cast<enum_type>(to_underlying(e) + 1);
 	return e;
@@ -50,7 +50,7 @@ inline constexpr enum_type &operator ++(enum_type &e)
  * @return Copy of the original value.
  */
 template <typename enum_type, std::enable_if_t<is_enum_incrementable_v<enum_type>, bool> = true>
-inline constexpr enum_type operator ++(enum_type &e, int)
+constexpr enum_type operator ++(enum_type &e, int)
 {
 	enum_type e_org = e;
 	++e;
@@ -63,7 +63,7 @@ inline constexpr enum_type operator ++(enum_type &e, int)
  * @return Reference to the decremented enum.
  */
 template <typename enum_type, std::enable_if_t<is_enum_incrementable_v<enum_type>, bool> = true>
-inline constexpr enum_type &operator --(enum_type &e)
+constexpr enum_type &operator --(enum_type &e)
 {
 	e = static_cast<enum_type>(to_underlying(e) - 1);
 	return e;
@@ -75,7 +75,7 @@ inline constexpr enum_type &operator --(enum_type &e)
  * @return Copy of the original value.
  */
 template <typename enum_type, std::enable_if_t<is_enum_incrementable_v<enum_type>, bool> = true>
-inline constexpr enum_type operator --(enum_type &e, int)
+constexpr enum_type operator --(enum_type &e, int)
 {
 	enum_type e_org = e;
 	--e;
@@ -104,13 +104,13 @@ constexpr bool is_enum_sequential_v = is_enum_sequential<enum_type>::value;
  * @return The new enum.
  */
 template <typename enum_type, std::enable_if_t<is_enum_sequential_v<enum_type>, bool> = true>
-inline constexpr enum_type operator+(enum_type e, int offset)
+constexpr enum_type operator+(enum_type e, int offset)
 {
 	return static_cast<enum_type>(to_underlying(e) + offset);
 }
 
 template <typename enum_type, std::enable_if_t<is_enum_sequential_v<enum_type>, bool> = true>
-inline constexpr enum_type &operator+=(enum_type &e, int offset)
+constexpr enum_type &operator+=(enum_type &e, int offset)
 {
 	e = e + offset;
 	return e;
@@ -123,13 +123,13 @@ inline constexpr enum_type &operator+=(enum_type &e, int offset)
  * @return The new enum.
  */
 template <typename enum_type, std::enable_if_t<is_enum_sequential_v<enum_type>, bool> = true>
-inline constexpr enum_type operator-(enum_type e, int offset)
+constexpr enum_type operator-(enum_type e, int offset)
 {
 	return static_cast<enum_type>(to_underlying(e) - offset);
 }
 
 template <typename enum_type, std::enable_if_t<is_enum_sequential_v<enum_type>, bool> = true>
-inline constexpr enum_type &operator-=(enum_type &e, int offset)
+constexpr enum_type &operator-=(enum_type &e, int offset)
 {
 	e = e - offset;
 	return e;
@@ -142,7 +142,7 @@ inline constexpr enum_type &operator-=(enum_type &e, int offset)
  * @return The value of the first enum minus the value of the second enum.
  */
 template <typename enum_type, std::enable_if_t<is_enum_sequential_v<enum_type>, bool> = true>
-inline constexpr auto operator-(enum_type a, enum_type b)
+constexpr auto operator-(enum_type a, enum_type b)
 {
 	return to_underlying(a) - to_underlying(b);
 }
@@ -155,13 +155,13 @@ inline constexpr auto operator-(enum_type a, enum_type b)
 
 /** Operators to allow to work with enum as with type safe bit set in C++ */
 #define DECLARE_ENUM_AS_BIT_SET(enum_type) \
-	inline constexpr enum_type operator | (enum_type m1, enum_type m2) { return static_cast<enum_type>(to_underlying(m1) | to_underlying(m2)); } \
-	inline constexpr enum_type operator & (enum_type m1, enum_type m2) { return static_cast<enum_type>(to_underlying(m1) & to_underlying(m2)); } \
-	inline constexpr enum_type operator ^ (enum_type m1, enum_type m2) { return static_cast<enum_type>(to_underlying(m1) ^ to_underlying(m2)); } \
-	inline constexpr enum_type& operator |= (enum_type& m1, enum_type m2) { m1 = m1 | m2; return m1; } \
-	inline constexpr enum_type& operator &= (enum_type& m1, enum_type m2) { m1 = m1 & m2; return m1; } \
-	inline constexpr enum_type& operator ^= (enum_type& m1, enum_type m2) { m1 = m1 ^ m2; return m1; } \
-	inline constexpr enum_type operator ~(enum_type m) { return static_cast<enum_type>(~to_underlying(m)); }
+	constexpr enum_type operator | (enum_type m1, enum_type m2) { return static_cast<enum_type>(to_underlying(m1) | to_underlying(m2)); } \
+	constexpr enum_type operator & (enum_type m1, enum_type m2) { return static_cast<enum_type>(to_underlying(m1) & to_underlying(m2)); } \
+	constexpr enum_type operator ^ (enum_type m1, enum_type m2) { return static_cast<enum_type>(to_underlying(m1) ^ to_underlying(m2)); } \
+	constexpr enum_type& operator |= (enum_type& m1, enum_type m2) { m1 = m1 | m2; return m1; } \
+	constexpr enum_type& operator &= (enum_type& m1, enum_type m2) { m1 = m1 & m2; return m1; } \
+	constexpr enum_type& operator ^= (enum_type& m1, enum_type m2) { m1 = m1 ^ m2; return m1; } \
+	constexpr enum_type operator ~(enum_type m) { return static_cast<enum_type>(~to_underlying(m)); }
 
 /** Operator that allows this enumeration to be added to any other enumeration. */
 #define DECLARE_ENUM_AS_ADDABLE(EnumType) \
@@ -181,7 +181,7 @@ inline constexpr auto operator-(enum_type a, enum_type b)
  * @return True iff the flag is set.
  */
 template <typename T, class = typename std::enable_if_t<std::is_enum_v<T>>>
-[[debug_inline]] inline constexpr bool HasFlag(const T x, const T y)
+[[debug_inline]] constexpr bool HasFlag(const T x, const T y)
 {
 	return (x & y) == y;
 }
@@ -192,7 +192,7 @@ template <typename T, class = typename std::enable_if_t<std::is_enum_v<T>>>
  * @param y The flag to toggle.
  */
 template <typename T, class = typename std::enable_if_t<std::is_enum_v<T>>>
-[[debug_inline]] inline constexpr void ToggleFlag(T &x, const T y)
+[[debug_inline]] constexpr void ToggleFlag(T &x, const T y)
 {
 	if (HasFlag(x, y)) {
 		x &= ~y;

--- a/src/core/label_type.hpp
+++ b/src/core/label_type.hpp
@@ -16,7 +16,7 @@ struct BaseLabel : std::array<uint8_t, 4> {
 	 * Check whether the label is empty.
 	 * @return \c true iff the label is empty, i.e. all zeros.
 	 */
-	constexpr inline bool Empty() const
+	constexpr bool Empty() const
 	{
 		return std::ranges::all_of(*this, [](uint8_t b) { return b == 0; });
 	};

--- a/src/core/overflowsafe_type.hpp
+++ b/src/core/overflowsafe_type.hpp
@@ -42,10 +42,10 @@ public:
 	constexpr OverflowSafeInt(const OverflowSafeInt &other) : m_value(other.m_value) { }
 	constexpr OverflowSafeInt(const T int_) : m_value(int_) { }
 
-	inline constexpr OverflowSafeInt& operator = (const OverflowSafeInt& other) { this->m_value = other.m_value; return *this; }
-	inline constexpr OverflowSafeInt& operator = (T other) { this->m_value = other; return *this; }
+	constexpr OverflowSafeInt& operator = (const OverflowSafeInt& other) { this->m_value = other.m_value; return *this; }
+	constexpr OverflowSafeInt& operator = (T other) { this->m_value = other; return *this; }
 
-	inline constexpr OverflowSafeInt operator - () const { return OverflowSafeInt(this->m_value == T_MIN ? T_MAX : -this->m_value); }
+	constexpr OverflowSafeInt operator - () const { return OverflowSafeInt(this->m_value == T_MIN ? T_MAX : -this->m_value); }
 
 	/**
 	 * Safe implementation of addition.
@@ -53,7 +53,7 @@ public:
 	 * @return Reference to this instance.
 	 * @note when the addition would yield more than T_MAX, it will be T_MAX.
 	 */
-	inline constexpr OverflowSafeInt& operator += (const OverflowSafeInt& other)
+	constexpr OverflowSafeInt& operator += (const OverflowSafeInt& other)
 	{
 #ifdef HAS_OVERFLOW_BUILTINS
 		if (__builtin_add_overflow(this->m_value, other.m_value, &this->m_value)) [[unlikely]] {
@@ -77,7 +77,7 @@ public:
 	 * @return Reference to this instance.
 	 * @note when the subtraction would yield less than T_MIN, it will be T_MIN.
 	 */
-	inline constexpr OverflowSafeInt& operator -= (const OverflowSafeInt& other)
+	constexpr OverflowSafeInt& operator -= (const OverflowSafeInt& other)
 	{
 #ifdef HAS_OVERFLOW_BUILTINS
 		if (__builtin_sub_overflow(this->m_value, other.m_value, &this->m_value)) [[unlikely]] {
@@ -96,17 +96,17 @@ public:
 	}
 
 	/* Operators for addition and subtraction. */
-	inline constexpr OverflowSafeInt  operator +  (const OverflowSafeInt& other) const { OverflowSafeInt result = *this; result += other; return result; }
-	inline constexpr OverflowSafeInt  operator +  (const int              other) const { OverflowSafeInt result = *this; result += (int64_t)other; return result; }
-	inline constexpr OverflowSafeInt  operator +  (const uint             other) const { OverflowSafeInt result = *this; result += (int64_t)other; return result; }
-	inline constexpr OverflowSafeInt  operator -  (const OverflowSafeInt& other) const { OverflowSafeInt result = *this; result -= other; return result; }
-	inline constexpr OverflowSafeInt  operator -  (const int              other) const { OverflowSafeInt result = *this; result -= (int64_t)other; return result; }
-	inline constexpr OverflowSafeInt  operator -  (const uint             other) const { OverflowSafeInt result = *this; result -= (int64_t)other; return result; }
+	constexpr OverflowSafeInt  operator +  (const OverflowSafeInt& other) const { OverflowSafeInt result = *this; result += other; return result; }
+	constexpr OverflowSafeInt  operator +  (const int              other) const { OverflowSafeInt result = *this; result += (int64_t)other; return result; }
+	constexpr OverflowSafeInt  operator +  (const uint             other) const { OverflowSafeInt result = *this; result += (int64_t)other; return result; }
+	constexpr OverflowSafeInt  operator -  (const OverflowSafeInt& other) const { OverflowSafeInt result = *this; result -= other; return result; }
+	constexpr OverflowSafeInt  operator -  (const int              other) const { OverflowSafeInt result = *this; result -= (int64_t)other; return result; }
+	constexpr OverflowSafeInt  operator -  (const uint             other) const { OverflowSafeInt result = *this; result -= (int64_t)other; return result; }
 
-	inline constexpr OverflowSafeInt& operator ++ () { return *this += 1; }
-	inline constexpr OverflowSafeInt& operator -- () { return *this += -1; }
-	inline constexpr OverflowSafeInt operator ++ (int) { OverflowSafeInt org = *this; *this += 1; return org; }
-	inline constexpr OverflowSafeInt operator -- (int) { OverflowSafeInt org = *this; *this += -1; return org; }
+	constexpr OverflowSafeInt& operator ++ () { return *this += 1; }
+	constexpr OverflowSafeInt& operator -- () { return *this += -1; }
+	constexpr OverflowSafeInt operator ++ (int) { OverflowSafeInt org = *this; *this += 1; return org; }
+	constexpr OverflowSafeInt operator -- (int) { OverflowSafeInt org = *this; *this += -1; return org; }
 
 	/**
 	 * Safe implementation of multiplication.
@@ -115,7 +115,7 @@ public:
 	 * @note when the multiplication would yield more than T_MAX (or less than T_MIN),
 	 *       it will be T_MAX (respectively T_MIN).
 	 */
-	inline constexpr OverflowSafeInt& operator *= (const int factor)
+	constexpr OverflowSafeInt& operator *= (const int factor)
 	{
 #ifdef HAS_OVERFLOW_BUILTINS
 		const bool is_result_positive = (this->m_value < 0) == (factor < 0); // -ve * -ve == +ve
@@ -141,68 +141,68 @@ public:
 	}
 
 	/* Operators for multiplication. */
-	inline constexpr OverflowSafeInt operator * (const int64_t  factor) const { OverflowSafeInt result = *this; result *= factor; return result; }
-	inline constexpr OverflowSafeInt operator * (const int    factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
-	inline constexpr OverflowSafeInt operator * (const uint   factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
-	inline constexpr OverflowSafeInt operator * (const uint16_t factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
-	inline constexpr OverflowSafeInt operator * (const uint8_t   factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
+	constexpr OverflowSafeInt operator * (const int64_t  factor) const { OverflowSafeInt result = *this; result *= factor; return result; }
+	constexpr OverflowSafeInt operator * (const int    factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
+	constexpr OverflowSafeInt operator * (const uint   factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
+	constexpr OverflowSafeInt operator * (const uint16_t factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
+	constexpr OverflowSafeInt operator * (const uint8_t   factor) const { OverflowSafeInt result = *this; result *= (int64_t)factor; return result; }
 
 	/* Operators for division. */
-	inline constexpr OverflowSafeInt& operator /= (const int64_t            divisor)       { this->m_value /= divisor; return *this; }
-	inline constexpr OverflowSafeInt  operator /  (const OverflowSafeInt& divisor) const { OverflowSafeInt result = *this; result /= divisor.m_value; return result; }
-	inline constexpr OverflowSafeInt  operator /  (const int              divisor) const { OverflowSafeInt result = *this; result /= divisor; return result; }
-	inline constexpr OverflowSafeInt  operator /  (const uint             divisor) const { OverflowSafeInt result = *this; result /= (int)divisor; return result; }
+	constexpr OverflowSafeInt& operator /= (const int64_t            divisor)       { this->m_value /= divisor; return *this; }
+	constexpr OverflowSafeInt  operator /  (const OverflowSafeInt& divisor) const { OverflowSafeInt result = *this; result /= divisor.m_value; return result; }
+	constexpr OverflowSafeInt  operator /  (const int              divisor) const { OverflowSafeInt result = *this; result /= divisor; return result; }
+	constexpr OverflowSafeInt  operator /  (const uint             divisor) const { OverflowSafeInt result = *this; result /= (int)divisor; return result; }
 
 	/* Operators for modulo */
-	inline constexpr OverflowSafeInt& operator %= (const int  divisor)       { this->m_value %= divisor; return *this; }
-	inline constexpr OverflowSafeInt  operator %  (const int  divisor) const { OverflowSafeInt result = *this; result %= divisor; return result; }
+	constexpr OverflowSafeInt& operator %= (const int  divisor)       { this->m_value %= divisor; return *this; }
+	constexpr OverflowSafeInt  operator %  (const int  divisor) const { OverflowSafeInt result = *this; result %= divisor; return result; }
 
 	/* Operators for shifting. */
-	inline constexpr OverflowSafeInt& operator <<= (const int shift)       { this->m_value <<= shift; return *this; }
-	inline constexpr OverflowSafeInt  operator <<  (const int shift) const { OverflowSafeInt result = *this; result <<= shift; return result; }
-	inline constexpr OverflowSafeInt& operator >>= (const int shift)       { this->m_value >>= shift; return *this; }
-	inline constexpr OverflowSafeInt  operator >>  (const int shift) const { OverflowSafeInt result = *this; result >>= shift; return result; }
+	constexpr OverflowSafeInt& operator <<= (const int shift)       { this->m_value <<= shift; return *this; }
+	constexpr OverflowSafeInt  operator <<  (const int shift) const { OverflowSafeInt result = *this; result <<= shift; return result; }
+	constexpr OverflowSafeInt& operator >>= (const int shift)       { this->m_value >>= shift; return *this; }
+	constexpr OverflowSafeInt  operator >>  (const int shift) const { OverflowSafeInt result = *this; result >>= shift; return result; }
 
 	/* Operators for (in)equality when comparing overflow safe ints. */
-	inline constexpr bool operator == (const OverflowSafeInt& other) const { return this->m_value == other.m_value; }
-	inline constexpr auto operator <=>(const OverflowSafeInt& other) const { return this->m_value <=> other.m_value; }
+	constexpr bool operator == (const OverflowSafeInt& other) const { return this->m_value == other.m_value; }
+	constexpr auto operator <=>(const OverflowSafeInt& other) const { return this->m_value <=> other.m_value; }
 
 	/* Operators for (in)equality when comparing non-overflow safe ints. */
-	inline constexpr bool operator == (const int other) const { return this->m_value == other; }
-	inline constexpr auto operator <=>(const int other) const { return this->m_value <=> other; }
+	constexpr bool operator == (const int other) const { return this->m_value == other; }
+	constexpr auto operator <=>(const int other) const { return this->m_value <=> other; }
 
-	inline constexpr operator T () const { return this->m_value; }
+	constexpr operator T () const { return this->m_value; }
 
-	static inline constexpr OverflowSafeInt<T> max() { return T_MAX; }
-	static inline constexpr OverflowSafeInt<T> min() { return T_MIN; }
+	static constexpr OverflowSafeInt<T> max() { return T_MAX; }
+	static constexpr OverflowSafeInt<T> min() { return T_MIN; }
 
 	BaseType base() const noexcept { return this->m_value; }
 };
 
 
 /* Sometimes we got int64_t operator OverflowSafeInt instead of vice versa. Handle that properly. */
-template <class T> inline constexpr OverflowSafeInt<T> operator + (const int64_t a, const OverflowSafeInt<T> b) { return b + a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator - (const int64_t a, const OverflowSafeInt<T> b) { return -b + a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator * (const int64_t a, const OverflowSafeInt<T> b) { return b * a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator / (const int64_t a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
+template <class T> constexpr OverflowSafeInt<T> operator + (const int64_t a, const OverflowSafeInt<T> b) { return b + a; }
+template <class T> constexpr OverflowSafeInt<T> operator - (const int64_t a, const OverflowSafeInt<T> b) { return -b + a; }
+template <class T> constexpr OverflowSafeInt<T> operator * (const int64_t a, const OverflowSafeInt<T> b) { return b * a; }
+template <class T> constexpr OverflowSafeInt<T> operator / (const int64_t a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
 
 /* Sometimes we got int operator OverflowSafeInt instead of vice versa. Handle that properly. */
-template <class T> inline constexpr OverflowSafeInt<T> operator + (const int   a, const OverflowSafeInt<T> b) { return b + a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator - (const int   a, const OverflowSafeInt<T> b) { return -b + a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator * (const int   a, const OverflowSafeInt<T> b) { return b * a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator / (const int   a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
+template <class T> constexpr OverflowSafeInt<T> operator + (const int   a, const OverflowSafeInt<T> b) { return b + a; }
+template <class T> constexpr OverflowSafeInt<T> operator - (const int   a, const OverflowSafeInt<T> b) { return -b + a; }
+template <class T> constexpr OverflowSafeInt<T> operator * (const int   a, const OverflowSafeInt<T> b) { return b * a; }
+template <class T> constexpr OverflowSafeInt<T> operator / (const int   a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
 
 /* Sometimes we got uint operator OverflowSafeInt instead of vice versa. Handle that properly. */
-template <class T> inline constexpr OverflowSafeInt<T> operator + (const uint  a, const OverflowSafeInt<T> b) { return b + a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator - (const uint  a, const OverflowSafeInt<T> b) { return -b + a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator * (const uint  a, const OverflowSafeInt<T> b) { return b * a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator / (const uint  a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
+template <class T> constexpr OverflowSafeInt<T> operator + (const uint  a, const OverflowSafeInt<T> b) { return b + a; }
+template <class T> constexpr OverflowSafeInt<T> operator - (const uint  a, const OverflowSafeInt<T> b) { return -b + a; }
+template <class T> constexpr OverflowSafeInt<T> operator * (const uint  a, const OverflowSafeInt<T> b) { return b * a; }
+template <class T> constexpr OverflowSafeInt<T> operator / (const uint  a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
 
 /* Sometimes we got byte operator OverflowSafeInt instead of vice versa. Handle that properly. */
-template <class T> inline constexpr OverflowSafeInt<T> operator + (const uint8_t  a, const OverflowSafeInt<T> b) { return b + (uint)a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator - (const uint8_t  a, const OverflowSafeInt<T> b) { return -b + (uint)a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator * (const uint8_t  a, const OverflowSafeInt<T> b) { return b * (uint)a; }
-template <class T> inline constexpr OverflowSafeInt<T> operator / (const uint8_t  a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
+template <class T> constexpr OverflowSafeInt<T> operator + (const uint8_t  a, const OverflowSafeInt<T> b) { return b + (uint)a; }
+template <class T> constexpr OverflowSafeInt<T> operator - (const uint8_t  a, const OverflowSafeInt<T> b) { return -b + (uint)a; }
+template <class T> constexpr OverflowSafeInt<T> operator * (const uint8_t  a, const OverflowSafeInt<T> b) { return b * (uint)a; }
+template <class T> constexpr OverflowSafeInt<T> operator / (const uint8_t  a, const OverflowSafeInt<T> b) { return (OverflowSafeInt<T>)a / (int)b; }
 
 typedef OverflowSafeInt<int64_t> OverflowSafeInt64;
 typedef OverflowSafeInt<int32_t> OverflowSafeInt32;

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -141,13 +141,13 @@ public:
 		int16_t right; ///< Right-most position of glyph.
 		int16_t top; ///< Top-most position of glyph.
 
-		constexpr inline Position(int16_t left, int16_t right, int16_t top) : left(left), right(right), top(top) { }
+		constexpr Position(int16_t left, int16_t right, int16_t top) : left(left), right(right), top(top) { }
 
 		/**
 		 * Conversion from a single point to a Position.
 		 * @param pt The point to create the position for.
 		 */
-		constexpr inline Position(const Point &pt) : left(pt.x), right(pt.x), top(pt.y) { }
+		constexpr Position(const Point &pt) : left(pt.x), right(pt.x), top(pt.y) { }
 	};
 
 	/** Visual run contains data about the bit of text with the same font. */

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -374,7 +374,7 @@ struct ExtendedTextColour {
 	 * @param tc The network encoded colour.
 	 * @return The decoded colour.
 	 */
-	constexpr static ExtendedTextColour FromNetwork(uint16_t tc) { return ExtendedTextColour{static_cast<TextColour>(tc & 0xFF), ExtendedTextColourFlags(tc >> 8)}; }
+	static constexpr ExtendedTextColour FromNetwork(uint16_t tc) { return ExtendedTextColour{static_cast<TextColour>(tc & 0xFF), ExtendedTextColourFlags(tc >> 8)}; }
 
 	/**
 	 * Encode this text colour for sending over the network.

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -202,13 +202,13 @@ protected:
 		StringID tooltip; ///< Tooltip for this range.
 	};
 
-	static inline constexpr GraphScale MONTHLY_SCALE_WALLCLOCK[] = {
+	static constexpr GraphScale MONTHLY_SCALE_WALLCLOCK[] = {
 		{STR_GRAPH_LAST_24_MINUTES_TIME_LABEL, HISTORY_MONTH.total_division, ECONOMY_MONTH_MINUTES, &HISTORY_MONTH},
 		{STR_GRAPH_LAST_72_MINUTES_TIME_LABEL, HISTORY_QUARTER.total_division, ECONOMY_QUARTER_MINUTES, &HISTORY_QUARTER},
 		{STR_GRAPH_LAST_288_MINUTES_TIME_LABEL, HISTORY_YEAR.total_division, ECONOMY_YEAR_MINUTES, &HISTORY_YEAR},
 	};
 
-	static inline constexpr GraphScale MONTHLY_SCALE_CALENDAR[] = {
+	static constexpr GraphScale MONTHLY_SCALE_CALENDAR[] = {
 		{STR_GRAPH_LAST_24_MONTHS, HISTORY_MONTH.total_division, ECONOMY_MONTH_MINUTES, &HISTORY_MONTH},
 		{STR_GRAPH_LAST_24_QUARTERS, HISTORY_QUARTER.total_division, ECONOMY_QUARTER_MINUTES, &HISTORY_QUARTER},
 		{STR_GRAPH_LAST_24_YEARS, HISTORY_YEAR.total_division, ECONOMY_YEAR_MINUTES, &HISTORY_YEAR},
@@ -1727,7 +1727,7 @@ CompanyID PerformanceRatingDetailWindow::company = CompanyID::Invalid();
 /*******************************/
 
 struct IndustryProductionGraphWindow : BaseCargoGraphWindow {
-	static inline constexpr GraphRange RANGE_LABELS[] = {
+	static constexpr GraphRange RANGE_LABELS[] = {
 		{STR_GRAPH_INDUSTRY_RANGE_PRODUCED, STR_GRAPH_INDUSTRY_RANGE_PRODUCED_TOOLTIP},
 		{STR_GRAPH_INDUSTRY_RANGE_TRANSPORTED, STR_GRAPH_INDUSTRY_RANGE_TRANSPORTED_TOOLTIP},
 		{STR_GRAPH_INDUSTRY_RANGE_DELIVERED, STR_GRAPH_INDUSTRY_RANGE_DELIVERED_TOOLTIP},
@@ -1904,7 +1904,7 @@ void ShowIndustryProductionGraph(WindowNumber window_number)
 }
 
 struct TownCargoGraphWindow : BaseCargoGraphWindow {
-	static inline constexpr GraphRange RANGE_LABELS[] = {
+	static constexpr GraphRange RANGE_LABELS[] = {
 		{STR_GRAPH_TOWN_RANGE_PRODUCED, STR_GRAPH_TOWN_RANGE_PRODUCED_TOOLTIP},
 		{STR_GRAPH_TOWN_RANGE_TRANSPORTED, STR_GRAPH_TOWN_RANGE_TRANSPORTED_TOOLTIP},
 		{STR_GRAPH_TOWN_RANGE_DELIVERED, STR_GRAPH_TOWN_RANGE_DELIVERED_TOOLTIP},

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -240,7 +240,7 @@ public:
 	 * @note try to avoid using this one
 	 * @return 2^"return value" == Map::SizeX()
 	 */
-	[[debug_inline]] inline static uint LogX()
+	[[debug_inline]] static inline uint LogX()
 	{
 		return Map::log_x;
 	}
@@ -259,7 +259,7 @@ public:
 	 * Get the size of the map along the X
 	 * @return the number of tiles along the X of the map
 	 */
-	[[debug_inline]] inline static uint SizeX()
+	[[debug_inline]] static inline uint SizeX()
 	{
 		return Map::size_x;
 	}
@@ -277,7 +277,7 @@ public:
 	 * Get the size of the map
 	 * @return the number of tiles of the map
 	 */
-	[[debug_inline]] inline static uint Size()
+	[[debug_inline]] static inline uint Size()
 	{
 		return Map::size;
 	}
@@ -286,7 +286,7 @@ public:
 	 * Gets the maximum X coordinate within the map, including TileType::Void
 	 * @return the maximum X coordinate
 	 */
-	[[debug_inline]] inline static uint MaxX()
+	[[debug_inline]] static inline uint MaxX()
 	{
 		return Map::SizeX() - 1;
 	}
@@ -373,7 +373,7 @@ public:
  * @param y The y coordinate of the tile
  * @return The TileIndex calculated by the coordinate
  */
-[[debug_inline]] inline static TileIndex TileXY(uint x, uint y)
+[[debug_inline]] static inline TileIndex TileXY(uint x, uint y)
 {
 	return TileIndex{(y << Map::LogX()) + x};
 }
@@ -404,7 +404,7 @@ inline TileIndexDiff TileDiffXY(int x, int y)
  * @param y The virtual y coordinate of the tile.
  * @return The TileIndex calculated by the coordinate.
  */
-[[debug_inline]] inline static TileIndex TileVirtXY(uint x, uint y)
+[[debug_inline]] static inline TileIndex TileVirtXY(uint x, uint y)
 {
 	return TileIndex{(y >> 4 << Map::LogX()) + (x >> 4)};
 }
@@ -416,7 +416,7 @@ TileIndex TileVirtXYClampedToMap(int x, int y);
  * @param tile the tile to get the X component of
  * @return the X component
  */
-[[debug_inline]] inline static uint TileX(TileIndex tile)
+[[debug_inline]] static inline uint TileX(TileIndex tile)
 {
 	return tile.base() & Map::MaxX();
 }
@@ -426,7 +426,7 @@ TileIndex TileVirtXYClampedToMap(int x, int y);
  * @param tile the tile to get the Y component of
  * @return the Y component
  */
-[[debug_inline]] inline static uint TileY(TileIndex tile)
+[[debug_inline]] static inline uint TileY(TileIndex tile)
 {
 	return tile.base() >> Map::LogX();
 }

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -73,13 +73,13 @@ public:
 	 * Implicit conversion to the TileIndex.
 	 * @return The converted tile index.
 	 */
-	[[debug_inline]] inline constexpr operator TileIndex() const { return this->tile; }
+	[[debug_inline]] constexpr operator TileIndex() const { return this->tile; }
 
 	/**
 	 * Implicit conversion to the uint for bounds checking.
 	 * @return The (unsigned) integer representation of the tile location.
 	 */
-	[[debug_inline]] inline constexpr operator uint() const { return this->tile.base(); }
+	[[debug_inline]] constexpr operator uint() const { return this->tile.base(); }
 
 	/**
 	 * The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -102,7 +102,7 @@ static constexpr auto _callback_tuple = std::make_tuple(
 
 /* Helpers to generate the callback table from the callback list. */
 
-inline constexpr size_t _callback_tuple_size = std::tuple_size_v<decltype(_callback_tuple)>;
+constexpr size_t _callback_tuple_size = std::tuple_size_v<decltype(_callback_tuple)>;
 
 template <size_t... i>
 inline auto MakeCallbackTable(std::index_sequence<i...>) noexcept
@@ -165,7 +165,7 @@ constexpr UnpackDispatchT MakeUnpackNetworkCommand(std::index_sequence<i...>) no
 }
 
 template <typename T, T... i, size_t... j>
-inline constexpr auto MakeDispatchTable(std::integer_sequence<T, i...>, std::index_sequence<j...>) noexcept
+constexpr auto MakeDispatchTable(std::integer_sequence<T, i...>, std::index_sequence<j...>) noexcept
 {
 	return EnumIndexArray<CommandDispatch, Commands, static_cast<Commands>(sizeof...(i))>{{{ { &SanitizeCmdStrings<static_cast<Commands>(i)>, &NetworkReplaceCommandClientId<static_cast<Commands>(i)>, MakeUnpackNetworkCommand<static_cast<Commands>(i)>(std::make_index_sequence<_callback_tuple_size>{}) }... }}};
 }

--- a/src/network/network_survey.h
+++ b/src/network/network_survey.h
@@ -39,7 +39,7 @@ public:
 	 * Check whether a survey is possible.
 	 * @return \c true.
 	 */
-	constexpr static bool IsSurveyPossible()
+	static constexpr bool IsSurveyPossible()
 	{
 		return true;
 	}

--- a/src/palette_func.h
+++ b/src/palette_func.h
@@ -92,7 +92,7 @@ void SetColourGradient(Colours colour, Shade shade, PixelColour palette_colour);
  * @param level Intensity, 0 = black, 15 = white
  * @return colour
  */
-inline constexpr PixelColour GREY_SCALE(uint8_t level) { return PixelColour{level}; }
+constexpr PixelColour GREY_SCALE(uint8_t level) { return PixelColour{level}; }
 
 static constexpr PixelColour PC_BLACK              {GREY_SCALE(1)};  ///< Black palette colour.
 static constexpr PixelColour PC_DARK_GREY          {GREY_SCALE(6)};  ///< Dark grey palette colour.

--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -88,11 +88,11 @@ struct CFollowTrackT {
 		this->railtypes = railtype_override;
 	}
 
-	[[debug_inline]] inline static TransportType TT() { return Ttr_type_; }
-	[[debug_inline]] inline static bool IsWaterTT() { return TT() == TransportType::Water; }
-	[[debug_inline]] inline static bool IsRailTT() { return TT() == TransportType::Rail; }
+	[[debug_inline]] static inline TransportType TT() { return Ttr_type_; }
+	[[debug_inline]] static inline bool IsWaterTT() { return TT() == TransportType::Water; }
+	[[debug_inline]] static inline bool IsRailTT() { return TT() == TransportType::Rail; }
 	inline bool IsTram() { return IsRoadTT() && RoadTypeIsTram(RoadVehicle::From(this->veh)->roadtype); }
-	[[debug_inline]] inline static bool IsRoadTT() { return TT() == TransportType::Road; }
+	[[debug_inline]] static inline bool IsRoadTT() { return TT() == TransportType::Road; }
 	static inline bool Allow90degTurns() { return T90deg_turns_allowed_; }
 	static inline bool DoTrackMasking() { return Tmask_reserved_tracks; }
 

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -357,7 +357,7 @@ public:
 	 * @param td Trackdir of current node.
 	 * @returns true if a preferred direction, false otherwise.
 	 */
-	inline static bool IsPreferredShipDirection(TileIndex tile, Trackdir td)
+	static inline bool IsPreferredShipDirection(TileIndex tile, Trackdir td)
 	{
 		const bool odd_x = TileX(tile) & 1;
 		const bool odd_y = TileY(tile) & 1;

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -33,7 +33,7 @@ enum class RailTileType : uint8_t {
  * @pre IsTileType(t, TileType::Railway)
  * @return the RailTileType
  */
-[[debug_inline]] inline static RailTileType GetRailTileType(Tile t)
+[[debug_inline]] static inline RailTileType GetRailTileType(Tile t)
 {
 	assert(IsTileType(t, TileType::Railway));
 	return static_cast<RailTileType>(GB(t.m5(), 6, 2));
@@ -46,7 +46,7 @@ enum class RailTileType : uint8_t {
  * @pre IsTileType(t, TileType::Railway)
  * @return true if and only if the tile is normal rail (with or without signals)
  */
-[[debug_inline]] inline static bool IsPlainRail(Tile t)
+[[debug_inline]] static inline bool IsPlainRail(Tile t)
 {
 	RailTileType rtt = GetRailTileType(t);
 	return rtt == RailTileType::Normal || rtt == RailTileType::Signals;
@@ -57,7 +57,7 @@ enum class RailTileType : uint8_t {
  * @param t the tile to get the information from
  * @return true if and only if the tile is normal rail (with or without signals)
  */
-[[debug_inline]] inline static bool IsPlainRailTile(Tile t)
+[[debug_inline]] static inline bool IsPlainRailTile(Tile t)
 {
 	return IsTileType(t, TileType::Railway) && IsPlainRail(t);
 }
@@ -92,7 +92,7 @@ inline void SetHasSignals(Tile tile, bool signals)
  * @pre IsTileType(t, TileType::Railway)
  * @return true if and only if the tile is a rail depot
  */
-[[debug_inline]] inline static bool IsRailDepot(Tile t)
+[[debug_inline]] static inline bool IsRailDepot(Tile t)
 {
 	return GetRailTileType(t) == RailTileType::Depot;
 }
@@ -102,7 +102,7 @@ inline void SetHasSignals(Tile tile, bool signals)
  * @param t the tile to get the information from
  * @return true if and only if the tile is a rail depot
  */
-[[debug_inline]] inline static bool IsRailDepotTile(Tile t)
+[[debug_inline]] static inline bool IsRailDepotTile(Tile t)
 {
 	return IsTileType(t, TileType::Railway) && IsRailDepot(t);
 }

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -33,7 +33,7 @@ bool MayHaveRoad(Tile t);
  * @pre IsTileType(t, TileType::Road)
  * @return The road tile type.
  */
-[[debug_inline]] inline static RoadTileType GetRoadTileType(Tile t)
+[[debug_inline]] static inline RoadTileType GetRoadTileType(Tile t)
 {
 	assert(IsTileType(t, TileType::Road));
 	return static_cast<RoadTileType>(GB(t.m5(), 6, 2));
@@ -45,7 +45,7 @@ bool MayHaveRoad(Tile t);
  * @pre IsTileType(t, TileType::Road)
  * @return True if normal road.
  */
-[[debug_inline]] inline static bool IsNormalRoad(Tile t)
+[[debug_inline]] static inline bool IsNormalRoad(Tile t)
 {
 	return GetRoadTileType(t) == RoadTileType::Normal;
 }
@@ -55,7 +55,7 @@ bool MayHaveRoad(Tile t);
  * @param t Tile to query.
  * @return True if normal road tile.
  */
-[[debug_inline]] inline static bool IsNormalRoadTile(Tile t)
+[[debug_inline]] static inline bool IsNormalRoadTile(Tile t)
 {
 	return IsTileType(t, TileType::Road) && IsNormalRoad(t);
 }
@@ -87,7 +87,7 @@ inline bool IsLevelCrossingTile(Tile t)
  * @pre IsTileType(t, TileType::Road)
  * @return True if road depot.
  */
-[[debug_inline]] inline static bool IsRoadDepot(Tile t)
+[[debug_inline]] static inline bool IsRoadDepot(Tile t)
 {
 	return GetRoadTileType(t) == RoadTileType::Depot;
 }
@@ -97,7 +97,7 @@ inline bool IsLevelCrossingTile(Tile t)
  * @param t Tile to query.
  * @return True if road depot tile.
  */
-[[debug_inline]] inline static bool IsRoadDepotTile(Tile t)
+[[debug_inline]] static inline bool IsRoadDepotTile(Tile t)
 {
 	return IsTileType(t, TileType::Road) && IsRoadDepot(t);
 }

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -801,7 +801,7 @@ struct SaveLoadCompat {
  * @param type VarType to get size of.
  * @return size of type in bytes.
  */
-inline constexpr size_t SlVarSize(VarMemType type)
+constexpr size_t SlVarSize(VarMemType type)
 {
 	switch (type) {
 		case VarMemType::Bool: return sizeof(bool);
@@ -831,7 +831,7 @@ inline constexpr size_t SlVarSize(VarMemType type)
  * @param size Actual size of variable.
  * @return true iff the sizes match.
  */
-inline constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t length, size_t size)
+constexpr bool SlCheckVarSize(SaveLoadType cmd, VarType type, size_t length, size_t size)
 {
 	switch (cmd) {
 		case SaveLoadType::Variable: return SlVarSize(type.mem) == size;

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -185,7 +185,7 @@ public:
 
 class SlTownSupplied : public VectorSaveLoadHandler<SlTownSupplied, Town, Town::SuppliedCargo> {
 public:
-	inline static const SaveLoad description[] = {
+	static inline const SaveLoad description[] = {
 		SLE_VAR(Town::SuppliedCargo, cargo, VarTypes::U8),
 		SLEG_STRUCTLIST("history", SlTownSuppliedHistory),
 	};
@@ -228,7 +228,7 @@ public:
 class SlTownAccepted : public VectorSaveLoadHandler<SlTownAccepted, Town, Town::AcceptedCargo> {
 public:
 	/** Saveload description for handler. */
-	inline static const SaveLoad description[] = {
+	static inline const SaveLoad description[] = {
 		SLE_VAR(Town::AcceptedCargo, cargo, VarTypes::U8),
 		SLEG_STRUCTLIST("history", SlTownAcceptedHistory),
 	};

--- a/src/slope_func.h
+++ b/src/slope_func.h
@@ -21,7 +21,7 @@
  * @param corner A #Corner.
  * @return true iff corner is in a valid range.
  */
-static constexpr inline bool IsValidCorner(Corner corner)
+static constexpr bool IsValidCorner(Corner corner)
 {
 	return IsInsideMM(corner, 0, CORNER_END);
 }
@@ -33,7 +33,7 @@ static constexpr inline bool IsValidCorner(Corner corner)
  * @param s The given #Slope.
  * @return True if the slope is steep, else false.
  */
-static constexpr inline bool IsSteepSlope(Slope s)
+static constexpr bool IsSteepSlope(Slope s)
 {
 	return (s & SLOPE_STEEP) != 0;
 }
@@ -54,7 +54,7 @@ static constexpr Slope RemoveSteepSlope(Slope s)
  * @param s The given #Slope.
  * @return True if the slope is non-continuous, else false.
  */
-static constexpr inline bool IsHalftileSlope(Slope s)
+static constexpr bool IsHalftileSlope(Slope s)
 {
 	return (s & SLOPE_HALFTILE) != 0;
 }
@@ -67,7 +67,7 @@ static constexpr inline bool IsHalftileSlope(Slope s)
  * @param s A #Slope.
  * @return The slope s without its halftile slope.
  */
-static constexpr inline Slope RemoveHalftileSlope(Slope s)
+static constexpr Slope RemoveHalftileSlope(Slope s)
 {
 	return s & ~SLOPE_HALFTILE_MASK;
 }
@@ -155,7 +155,7 @@ inline Corner GetHighestSlopeCorner(Slope s)
  * @param s The #Slope.
  * @return  The corner of the leveled halftile.
  */
-static constexpr inline Corner GetHalftileSlopeCorner(Slope s)
+static constexpr Corner GetHalftileSlopeCorner(Slope s)
 {
 	assert(IsHalftileSlope(s));
 	return (Corner)((s >> 6) & 3);
@@ -167,7 +167,7 @@ static constexpr inline Corner GetHalftileSlopeCorner(Slope s)
  * @param s The #Slope.
  * @return Relative height of highest corner.
  */
-static constexpr inline int GetSlopeMaxZ(Slope s)
+static constexpr int GetSlopeMaxZ(Slope s)
 {
 	if (s == SLOPE_FLAT) return 0;
 	if (IsSteepSlope(s)) return 2;
@@ -180,7 +180,7 @@ static constexpr inline int GetSlopeMaxZ(Slope s)
  * @param s The #Slope.
  * @return Relative height of highest corner.
  */
-static constexpr inline int GetSlopeMaxPixelZ(Slope s)
+static constexpr int GetSlopeMaxPixelZ(Slope s)
 {
 	return GetSlopeMaxZ(s) * TILE_HEIGHT;
 }
@@ -281,7 +281,7 @@ inline Slope InclinedSlope(DiagDirection dir)
  * @param corner The #Corner of the halftile.
  * @return The #Slope s with the halftile slope added.
  */
-static constexpr inline Slope HalftileSlope(Slope s, Corner corner)
+static constexpr Slope HalftileSlope(Slope s, Corner corner)
 {
 	assert(IsValidCorner(corner));
 	return (Slope)(s | SLOPE_HALFTILE | (corner << 6));

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -36,8 +36,8 @@ template <class T>
 class SpriteCollMap {
 	EnumIndexArray<T, ZoomLevel, ZoomLevel::End> data{};
 public:
-	inline constexpr T &operator[](const ZoomLevel &zoom) { return this->data[zoom]; }
-	inline constexpr const T &operator[](const ZoomLevel &zoom) const { return this->data[zoom]; }
+	constexpr T &operator[](const ZoomLevel &zoom) { return this->data[zoom]; }
+	constexpr const T &operator[](const ZoomLevel &zoom) const { return this->data[zoom]; }
 
 	T &Root() { return this->data[ZoomLevel::Min]; }
 	const T &Root() const { return this->data[ZoomLevel::Min]; }

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -26,7 +26,7 @@
  * @return the height of the tile
  * @pre tile < Map::Size()
  */
-[[debug_inline]] inline static uint TileHeight(Tile tile)
+[[debug_inline]] static inline uint TileHeight(Tile tile)
 {
 	assert(tile < Map::Size());
 	return tile.height();
@@ -93,7 +93,7 @@ inline uint TilePixelHeightOutsideMap(int x, int y)
  * @return The tiletype of the tile
  * @pre tile < Map::Size()
  */
-[[debug_inline]] inline static TileType GetTileType(Tile tile)
+[[debug_inline]] static inline TileType GetTileType(Tile tile)
 {
 	assert(tile < Map::Size());
 	return TileType(GB(tile.type(), 4, TILE_TYPE_BITS));
@@ -147,7 +147,7 @@ inline void SetTileType(Tile tile, TileType type)
  * @param type The type to check against
  * @return true If the type matches against the type of the tile
  */
-[[debug_inline]] inline static bool IsTileType(Tile tile, TileType type)
+[[debug_inline]] static inline bool IsTileType(Tile tile, TileType type)
 {
 	return GetTileType(tile) == type;
 }

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -97,6 +97,6 @@ static_assert(sizeof(TileIndex) == 4);
 /**
  * The very nice invalid tile marker
  */
-inline constexpr TileIndex INVALID_TILE = TileIndex{ (uint32_t)-1 };
+constexpr TileIndex INVALID_TILE = TileIndex{ (uint32_t)-1 };
 
 #endif /* TILE_TYPE_H */


### PR DESCRIPTION
## Motivation / Problem

In what way should `static`, `inline` and `constexpr` be sequenced? It's a bit of a hodge pot at the moment.


## Description

* Make it so that `static` is before `inline` and before `constexpr`. 
* Remove `inline` in case of `constexpr`.


## Limitations

People might not like this order. However, it is the most common order.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
