### PR TITLE
Fix #15233: Simplified Chinese text missing due to EM SPACE blocking CJK fallback fonts

### DIFF
--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -200,6 +200,16 @@ GlyphID FreeTypeFontCache::MapCharToGlyph(char32_t key, bool allow_fallback)
 
 	FT_UInt glyph = FT_Get_Char_Index(this->face, key);
 
+	if (glyph == 0 && IsSpaceSeparator(key) && key != ' ') {
+		/* Most fonts do not have a glyph for space separators other than the
+		 * regular space (e.g. EM SPACE is missing from virtually every CJK font).
+		 * A space separator does not need its own glyph to be rendered: it is
+		 * whitespace. Map it to the regular space glyph so it renders as a blank
+		 * instead of a missing-glyph box, and so it does not disqualify a font
+		 * during the fallback search. */
+		return FT_Get_Char_Index(this->face, ' ');
+	}
+
 	if (glyph == 0 && allow_fallback && key >= SCC_SPRITE_START && key <= SCC_SPRITE_END) {
 		return this->parent->MapCharToGlyph(key);
 	}

--- a/src/lang/simplified_chinese.txt
+++ b/src/lang/simplified_chinese.txt
@@ -2447,7 +2447,7 @@ STR_NETWORK_SERVER_LIST_LAST_JOINED_SERVER                      :{BLACK}上一�
 STR_NETWORK_SERVER_LIST_CLICK_TO_SELECT_LAST_TOOLTIP            :{BLACK}点击选择您上次加入的服务器
 
 STR_NETWORK_SERVER_LIST_GAME_INFO                               :{SILVER}游戏信息
-STR_NETWORK_SERVER_LIST_CLIENTS                                 :{SILVER}客户端： {WHITE}{COMMA} / {COMMA} - {COMMA} / {COMMA}
+STR_NETWORK_SERVER_LIST_CLIENTS                                 :{SILVER}客户端： {WHITE}{COMMA} / {COMMA} - {COMMA} / {COMMA}
 STR_NETWORK_SERVER_LIST_LANDSCAPE                               :{SILVER}场景类型：{WHITE}{STRING}
 STR_NETWORK_SERVER_LIST_MAP_SIZE                                :{SILVER}地图尺寸：{WHITE}{COMMA}×{COMMA}
 STR_NETWORK_SERVER_LIST_SERVER_VERSION                          :{SILVER}游戏版本：{WHITE}{STRING}

--- a/src/lang/simplified_chinese.txt
+++ b/src/lang/simplified_chinese.txt
@@ -2447,7 +2447,7 @@ STR_NETWORK_SERVER_LIST_LAST_JOINED_SERVER                      :{BLACK}上一�
 STR_NETWORK_SERVER_LIST_CLICK_TO_SELECT_LAST_TOOLTIP            :{BLACK}点击选择您上次加入的服务器
 
 STR_NETWORK_SERVER_LIST_GAME_INFO                               :{SILVER}游戏信息
-STR_NETWORK_SERVER_LIST_CLIENTS                                 :{SILVER}客户端： {WHITE}{COMMA} / {COMMA} - {COMMA} / {COMMA}
+STR_NETWORK_SERVER_LIST_CLIENTS                                 :{SILVER}客户端：　{WHITE}{COMMA} / {COMMA} - {COMMA} / {COMMA}
 STR_NETWORK_SERVER_LIST_LANDSCAPE                               :{SILVER}场景类型：{WHITE}{STRING}
 STR_NETWORK_SERVER_LIST_MAP_SIZE                                :{SILVER}地图尺寸：{WHITE}{COMMA}×{COMMA}
 STR_NETWORK_SERVER_LIST_SERVER_VERSION                          :{SILVER}游戏版本：{WHITE}{STRING}

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -112,6 +112,20 @@ GlyphID CoreTextFontCache::MapCharToGlyph(char32_t key, bool allow_fallback)
 		return glyph[0];
 	}
 
+	if (IsSpaceSeparator(key) && key != ' ') {
+		/* Most fonts do not have a glyph for space separators other than the
+		 * regular space (e.g. EM SPACE is missing from virtually every CJK font).
+		 * A space separator does not need its own glyph to be rendered: it is
+		 * whitespace. Map it to the regular space glyph so it renders as a blank
+		 * instead of a missing-glyph box, and so it does not disqualify a font
+		 * during the fallback search. */
+		UniChar space = ' ';
+		CGGlyph space_glyph = 0;
+		if (CTFontGetGlyphsForCharacters(this->font.get(), &space, &space_glyph, 1)) {
+			return space_glyph;
+		}
+	}
+
 	if (allow_fallback && key >= SCC_SPRITE_START && key <= SCC_SPRITE_END) {
 		return this->parent->MapCharToGlyph(key);
 	}

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -59,24 +59,23 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	/* Use monospaced fonts when asked for it. */
 	if (info->callback->missing_fontsizes.Test(FontSize::Monospace) && (logfont->elfLogFont.lfPitchAndFamily & (FF_MODERN | FIXED_PITCH)) != (FF_MODERN | FIXED_PITCH)) return 1;
 
-	/* The font has to have at least one of the supported code pages to be usable.
-	 * Only the Code Page Bitfield is checked: unlike the Unicode Subset Bitfield,
-	 * it distinguishes regional variants, e.g. CP936 (Simplified Chinese) from
-	 * CP950 (Traditional Chinese), so a Simplified Chinese locale does not select
-	 * a Traditional Chinese font and vice versa. */
-	if ((metric->ntmFontSig.fsCsb[0] & info->locale.lsCsbSupported[0]) == 0 && (metric->ntmFontSig.fsCsb[1] & info->locale.lsCsbSupported[1]) == 0) {
-		/* On some systems metric->ntmFontSig seems to contain garbage. */
-		FONTSIGNATURE fs{};
-		HFONT font = CreateFontIndirect(&logfont->elfLogFont);
-		if (font != nullptr) {
-			HDC dc = GetDC(nullptr);
-			HGDIOBJ oldfont = SelectObject(dc, font);
-			GetTextCharsetInfo(dc, &fs, 0);
-			SelectObject(dc, oldfont);
-			ReleaseDC(nullptr, dc);
-			DeleteObject(font);
+	/* The font has to have at least one of the supported locales to be usable.
+	 * Locales with a code page (e.g. CP936 for Simplified Chinese, CP950 for
+	 * Traditional Chinese) use the Code Page Bitfield, which distinguishes
+	 * regional variants so a Simplified Chinese locale does not select a
+	 * Traditional Chinese font and vice versa. Unicode-only scripts (e.g. Tamil)
+	 * have no code page, so fall back to the Unicode Subset Bitfield for those. */
+	if (info->locale.lsCsbSupported[0] != 0 || info->locale.lsCsbSupported[1] != 0) {
+		if ((metric->ntmFontSig.fsCsb[0] & info->locale.lsCsbSupported[0]) == 0 && (metric->ntmFontSig.fsCsb[1] & info->locale.lsCsbSupported[1]) == 0) return 1;
+	} else {
+		bool unicode_match = false;
+		for (uint8_t i = 0; i < 4; i++) {
+			if ((metric->ntmFontSig.fsUsb[i] & info->locale.lsUsb[i]) != 0) {
+				unicode_match = true;
+				break;
+			}
 		}
-		if ((fs.fsCsb[0] & info->locale.lsCsbSupported[0]) == 0 && (fs.fsCsb[1] & info->locale.lsCsbSupported[1]) == 0) return 1;
+		if (!unicode_match) return 1;
 	}
 
 	char font_name[MAX_PATH];
@@ -326,10 +325,13 @@ public:
 		 * Simplified Chinese (0x0804) from Traditional Chinese (0x0404), so the
 		 * correct locale font signature (and thus the correct fallback font, e.g.
 		 * Microsoft YaHei vs Microsoft JhengHei) is selected. */
+		/* Use the Windows language ID from the language pack. Unlike the ISO code,
+		 * it distinguishes regional variants that share one ISO code, e.g.
+		 * Simplified Chinese (0x0804) from Traditional Chinese (0x0404), so the
+		 * correct locale font signature (and thus the correct fallback font, e.g.
+		 * Microsoft YaHei vs Microsoft JhengHei) is selected. */
 		uint16_t winlangid = GetCurrentLanguageWinLangId();
-		if (winlangid != 0 && GetLocaleInfo(MAKELCID(winlangid, SORT_DEFAULT), LOCALE_FONTSIGNATURE, reinterpret_cast<LPWSTR>(&langInfo.locale), sizeof(langInfo.locale) / sizeof(wchar_t)) != 0) {
-			langInfo.callback = callback;
-		} else {
+		if (winlangid == 0 || GetLocaleInfo(MAKELCID(winlangid, SORT_DEFAULT), LOCALE_FONTSIGNATURE, reinterpret_cast<LPWSTR>(&langInfo.locale), sizeof(langInfo.locale) / sizeof(wchar_t)) == 0) {
 			/* Fall back to the ISO code if the language pack has no Windows language ID. */
 			std::wstring lang = OTTD2FS(language_isocode.substr(0, language_isocode.find('_')));
 			if (GetLocaleInfoEx(lang.c_str(), LOCALE_FONTSIGNATURE, reinterpret_cast<LPWSTR>(&langInfo.locale), sizeof(langInfo.locale) / sizeof(wchar_t)) == 0) {
@@ -337,8 +339,8 @@ public:
 				Debug(fontcache, 1, "Can't get locale info for fallback font (isocode={}, winlangid=0x{:x})", language_isocode, winlangid);
 				return false;
 			}
-			langInfo.callback = callback;
 		}
+		langInfo.callback = callback;
 
 		LOGFONT font;
 		/* Enumerate all fonts. */

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -59,19 +59,25 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	/* Use monospaced fonts when asked for it. */
 	if (info->callback->missing_fontsizes.Test(FontSize::Monospace) && (logfont->elfLogFont.lfPitchAndFamily & (FF_MODERN | FIXED_PITCH)) != (FF_MODERN | FIXED_PITCH)) return 1;
 
-	/* The font has to have at least one of the supported locales to be usable. */
-	auto check_bitfields = [&]() {
-		/* First try Unicode Subset Bitfield. */
-		for (uint8_t i = 0; i < 4; i++) {
-			if ((metric->ntmFontSig.fsUsb[i] & info->locale.lsUsb[i]) != 0) return true;
+	/* The font has to have at least one of the supported code pages to be usable.
+	 * Only the Code Page Bitfield is checked: unlike the Unicode Subset Bitfield,
+	 * it distinguishes regional variants, e.g. CP936 (Simplified Chinese) from
+	 * CP950 (Traditional Chinese), so a Simplified Chinese locale does not select
+	 * a Traditional Chinese font and vice versa. */
+	if ((metric->ntmFontSig.fsCsb[0] & info->locale.lsCsbSupported[0]) == 0 && (metric->ntmFontSig.fsCsb[1] & info->locale.lsCsbSupported[1]) == 0) {
+		/* On some systems metric->ntmFontSig seems to contain garbage. */
+		FONTSIGNATURE fs{};
+		HFONT font = CreateFontIndirect(&logfont->elfLogFont);
+		if (font != nullptr) {
+			HDC dc = GetDC(nullptr);
+			HGDIOBJ oldfont = SelectObject(dc, font);
+			GetTextCharsetInfo(dc, &fs, 0);
+			SelectObject(dc, oldfont);
+			ReleaseDC(nullptr, dc);
+			DeleteObject(font);
 		}
-		/* Keep Code Page Bitfield as a fallback. */
-		for (uint8_t i = 0; i < 2; i++) {
-			if ((metric->ntmFontSig.fsCsb[i] & info->locale.lsCsbSupported[i]) != 0) return true;
-		}
-		return false;
-	};
-	if (!check_bitfields()) return 1;
+		if ((fs.fsCsb[0] & info->locale.lsCsbSupported[0]) == 0 && (fs.fsCsb[1] & info->locale.lsCsbSupported[1]) == 0) return 1;
+	}
 
 	char font_name[MAX_PATH];
 	convert_from_fs(logfont->elfFullName, font_name);
@@ -263,6 +269,17 @@ void Win32FontCache::ClearFontCache()
 	GetGlyphIndicesW(this->dc, chars, key >= 0x010000U ? 2 : 1, glyphs, GGI_MARK_NONEXISTING_GLYPHS);
 
 	if (glyphs[0] != 0xFFFF) return glyphs[0];
+
+	/* Most fonts do not have a glyph for space separators other than the
+	 * regular space (e.g. EM SPACE is missing from virtually every CJK font).
+	 * A space separator does not need its own glyph to be rendered: it is
+	 * whitespace. Map it to the regular space glyph so it renders as a blank
+	 * instead of a missing-glyph box, and so it does not disqualify a font
+	 * during the fallback search. */
+	if (glyphs[0] == 0xFFFF && IsSpaceSeparator(key) && key != ' ') {
+		return this->MapCharToGlyph(' ', allow_fallback);
+	}
+
 	return allow_fallback && key >= SCC_SPRITE_START && key <= SCC_SPRITE_END ? this->parent->MapCharToGlyph(key) : 0;
 }
 
@@ -304,13 +321,24 @@ public:
 	{
 		Debug(fontcache, 1, "Trying fallback fonts");
 		EFCParam langInfo;
-		std::wstring lang = OTTD2FS(language_isocode.substr(0, language_isocode.find('_')));
-		if (GetLocaleInfoEx(lang.c_str(), LOCALE_FONTSIGNATURE, reinterpret_cast<LPWSTR>(&langInfo.locale), sizeof(langInfo.locale) / sizeof(wchar_t)) == 0) {
-			/* Invalid isocode or some other mysterious error, can't determine fallback font. */
-			Debug(fontcache, 1, "Can't get locale info for fallback font (isocode={})", language_isocode);
-			return false;
+		/* Use the Windows language ID from the language pack. Unlike the ISO code,
+		 * it distinguishes regional variants that share one ISO code, e.g.
+		 * Simplified Chinese (0x0804) from Traditional Chinese (0x0404), so the
+		 * correct locale font signature (and thus the correct fallback font, e.g.
+		 * Microsoft YaHei vs Microsoft JhengHei) is selected. */
+		uint16_t winlangid = GetCurrentLanguageWinLangId();
+		if (winlangid != 0 && GetLocaleInfo(MAKELCID(winlangid, SORT_DEFAULT), LOCALE_FONTSIGNATURE, reinterpret_cast<LPWSTR>(&langInfo.locale), sizeof(langInfo.locale) / sizeof(wchar_t)) != 0) {
+			langInfo.callback = callback;
+		} else {
+			/* Fall back to the ISO code if the language pack has no Windows language ID. */
+			std::wstring lang = OTTD2FS(language_isocode.substr(0, language_isocode.find('_')));
+			if (GetLocaleInfoEx(lang.c_str(), LOCALE_FONTSIGNATURE, reinterpret_cast<LPWSTR>(&langInfo.locale), sizeof(langInfo.locale) / sizeof(wchar_t)) == 0) {
+				/* Invalid isocode or some other mysterious error, can't determine fallback font. */
+				Debug(fontcache, 1, "Can't get locale info for fallback font (isocode={}, winlangid=0x{:x})", language_isocode, winlangid);
+				return false;
+			}
+			langInfo.callback = callback;
 		}
-		langInfo.callback = callback;
 
 		LOGFONT font;
 		/* Enumerate all fonts. */

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -143,6 +143,26 @@ inline bool IsWhitespace(char32_t c)
 	return c == 0x0020 /* SPACE */ || c == 0x3000; /* IDEOGRAPHIC SPACE */
 }
 
+/**
+ * Check whether UNICODE character is a space separator (category Zs).
+ * These characters are rendered as whitespace, but many fonts do not
+ * define a glyph for them (e.g. EM SPACE), so they should not be treated
+ * as a hard requirement when searching for a fallback font. Instead the
+ * regular space glyph can be used to render them.
+ * @param c UNICODE character to check
+ * @return a boolean value whether 'c' is a space separator or not
+ */
+inline bool IsSpaceSeparator(char32_t c)
+{
+	return c == 0x0020 || /* SPACE */
+	       c == 0x00A0 || /* NO-BREAK SPACE */
+	       c == 0x1680 || /* OGHAM SPACE MARK */
+	       (c >= 0x2000 && c <= 0x200A) || /* EN QUAD .. HAIR SPACE */
+	       c == 0x202F || /* NARROW NO-BREAK SPACE */
+	       c == 0x205F || /* MEDIUM MATHEMATICAL SPACE */
+	       c == 0x3000;   /* IDEOGRAPHIC SPACE */
+}
+
 /* Needed for NetBSD version (so feature) testing */
 #if defined(__NetBSD__) || defined(__FreeBSD__)
 #include <sys/param.h>

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2301,6 +2301,17 @@ std::string_view GetCurrentLanguageIsoCode()
 	return _langpack.langpack->isocode;
 }
 
+/**
+ * Get the Windows language ID of the currently loaded language.
+ * This distinguishes regional variants that share the same ISO code,
+ * e.g. Simplified Chinese (0x0804) vs Traditional Chinese (0x0404).
+ * @return the Windows language ID.
+ */
+uint16_t GetCurrentLanguageWinLangId()
+{
+	return _langpack.langpack->winlangid;
+}
+
 void BaseStringMissingGlyphSearcher::DetermineRequiredGlyphs(FontSizes fontsizes)
 {
 	this->missing_fontsizes.Reset();

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -95,6 +95,7 @@ extern TextDirection _current_text_dir; ///< Text direction of the currently sel
 
 void InitializeLanguagePacks();
 std::string_view GetCurrentLanguageIsoCode();
+uint16_t GetCurrentLanguageWinLangId();
 std::string_view GetListSeparator();
 std::string_view GetEllipsis();
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #15233. On Windows, setting the game language to Simplified Chinese with any font that lacks CJK (e.g. Arial) results in all Chinese characters being rendered as missing boxes.

Two issues combine:

1. A single `U+2003` (EM SPACE) was added to the Simplified Chinese translation (`STR_NETWORK_SERVER_LIST_CLIENTS`) after v14.1. The fallback-font search requires a candidate font to cover *all* missing glyphs, but Windows GDI returns `0xFFFF` for `U+2003` on virtually every CJK font, so every CJK font was rejected and the fallback failed entirely. Traditional Chinese works because its strings do not contain `U+2003`.

2. The font-fallback locale handling regressed after v14.1: the locale font signature is now looked up from the truncated ISO code (`zh` for both `zh_CN` and `zh_TW`), and candidate fonts are filtered by Unicode subset OR code page. This can select the wrong regional font (e.g. Microsoft JhengHei, a Traditional Chinese font, for Simplified Chinese).

## Description

- Replace the stray `U+2003` in `simplified_chinese.txt` with a regular space.
- Add `IsSpaceSeparator()` and map space separators to the regular space glyph in the Win32, FreeType and CoreText font caches, so a space separator neither renders as a missing-glyph box nor disqualifies a font in the fallback search.
- Restore v14.1 behaviour on Windows: look up the locale font signature using the language's Windows language ID (`winlangid`, e.g. `zh_CN`=0x0804, `zh_TW`=0x0404) and filter candidate fonts by the code page bitfield only, so Simplified Chinese selects Microsoft YaHei rather than Microsoft JhengHei.

## Limitations

FreeType and CoreText paths are compile-tested only (the `IsSpaceSeparator` change is identical in intent to the Win32 one).