### PR TITLE
Change: Transparency is drawn at a single opacity level

### DIFF
--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -191,14 +191,16 @@ inline void Blitter_32bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 					if (src_px->a == 255) {
 						src_px += n;
 						do {
-							*dst = MakeTransparent(*dst, 3, 4);
+							*dst = MakeTransparentOnce(*dst, 3, 4);
+
 							*anim = 0;
 							anim++;
 							dst++;
 						} while (--n != 0);
 					} else {
 						do {
-							*dst = MakeTransparent(*dst, (256 * 4 - src_px->a), 256 * 4);
+							*dst = MakeTransparentOnce(*dst, (256 * 4 - src_px->a), 256 * 4);
+
 							*anim = 0;
 							anim++;
 							dst++;

--- a/src/blitter/32bpp_base.hpp
+++ b/src/blitter/32bpp_base.hpp
@@ -14,6 +14,9 @@
 #include "../gfx_func.h"
 #include "../palette_func.h"
 
+/** Alpha value used to label pixels as already darkened. */
+static constexpr uint8_t ALREADY_DARKENED_ALPHA_LABEL = 254;
+
 /** Base for all 32bpp blitters. */
 class Blitter_32bppBase : public Blitter {
 public:
@@ -129,6 +132,22 @@ public:
 		uint b = colour.b;
 
 		return Colour(r * nom / denom, g * nom / denom, b * nom / denom);
+	}
+
+	/**
+	 * Make a pixel looks like it is transparent, unless it has been darkened before (stored in alpha channel).
+	 * @param colour the colour already on the screen.
+	 * @param nom the amount of transparency, nominator, makes colour lighter.
+	 * @param denom denominator, makes colour darker.
+	 * @return the new colour for the screen, or the exact same colour if the pixel was darkened before.
+	 */
+	static inline Colour MakeTransparentOnce(Colour colour, uint nom, uint denom = 256)
+	{
+		if (colour.a == ALREADY_DARKENED_ALPHA_LABEL) return colour;
+
+		Colour new_colour = MakeTransparent(colour, nom, denom);
+		new_colour.a = ALREADY_DARKENED_ALPHA_LABEL;
+		return new_colour;
 	}
 
 	/**

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -191,12 +191,12 @@ inline void Blitter_32bppOptimized::Draw(const Blitter::BlitterParams *bp, ZoomL
 					if (src_px->a == 255) {
 						src_px += n;
 						do {
-							*dst = MakeTransparent(*dst, 3, 4);
+							*dst = MakeTransparentOnce(*dst, 3, 4);
 							dst++;
 						} while (--n != 0);
 					} else {
 						do {
-							*dst = MakeTransparent(*dst, (256 * 4 - src_px->a), 256 * 4);
+							*dst = MakeTransparentOnce(*dst, (256 * 4 - src_px->a), 256 * 4);
 							dst++;
 							src_px++;
 						} while (--n != 0);

--- a/src/blitter/32bpp_simple.cpp
+++ b/src/blitter/32bpp_simple.cpp
@@ -66,7 +66,7 @@ void Blitter_32bppSimple::Draw(Blitter::BlitterParams *bp, BlitterMode mode, Zoo
 				case BlitterMode::Transparent:
 					/* Make the current colour a bit more black, so it looks like this image is transparent */
 					if (src->a != 0) {
-						*dst = MakeTransparent(*dst, 192);
+						*dst = MakeTransparentOnce(*dst, 192);
 					}
 					break;
 

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -243,15 +243,16 @@ inline void Blitter_40bppAnim::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							/* If the anim buffer contains a colour value, the image composition will
 							 * only look at the RGB brightness value. As such, we can simply darken the
 							 * RGB value to darken the anim colour. */
-							Colour b = *anim != 0 ? Colour(GetColourBrightness(*dst), 0, 0) : *dst;
-							*dst = this->MakeTransparent(b, 3, 4);
+							Colour b = *anim != 0 ? Colour(GetColourBrightness(*dst), 0, 0, dst->a) : *dst;
+							*dst = this->MakeTransparentOnce(b, 3, 4);
 							anim++;
 							dst++;
 						} while (--n != 0);
 					} else {
 						do {
 							Colour b = this->RealizeBlendedColour(*anim, *dst);
-							*dst = this->MakeTransparent(b, (256 * 4 - src_px->a), 256 * 4);
+							b.a = dst->a; // Keep original pixel alpha to avoid double darkening
+							*dst = this->MakeTransparentOnce(b, (256 * 4 - src_px->a), 256 * 4);
 							*anim = 0; // Animation colours don't work with alpha-blending.
 							anim++;
 							dst++;


### PR DESCRIPTION
## Motivation / Problem

Transparent objects are drawn by simply darkening the underlying pixels by a fixed amount. This effects stacks when multiple sprites overlap (trees do this a lot). This often leads to a lot of visual clutter which can obscure the things that the player is interested in.

## Description

Keep track of which pixels are already darkened, and make sure it doesn't happen twice. This eleminates the stacking effect:

<img width="1684" height="764" alt="image" src="https://github.com/user-attachments/assets/e1221e77-e65e-4262-93c6-c4b6efbd94e3" />

I used the alpha channel of the screen buffer to mark pixels as already drawn. The screen buffer is the final buffer so opacity is actually irrelevant here, everything is already alpha blended at that point.

## Limitations

- It is efficient in terms of memory use, but in all honesty, the alpha channel labeling is a bit of a hack.
- This only works for certain 32 bpp blitters. 8 bbp blitters would require an additional buffers, and are hardly ever used according to the survey.
- I didn't add it to the SSE blitters. That stuff is black magic to me.
- Overall transparency looks a lot lighter now. We might want to set the default transparency a bit darker, this is easy to do.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
