### PR TITLE
Codechange: Check costs instead of bank balance in marine and airport regression

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -227,7 +227,7 @@ function Regression::Airport()
 		print("  GetAirportNumHelipads(" + i + "):         " + AIAirport.GetAirportNumHelipads(i));
 	}
 
-	print("  GetBankBalance():     " + AICompany.GetBankBalance(AICompany.COMPANY_SELF));
+	local accounting = AIAccounting();
 	print("  GetPrice():           " + AIAirport.GetPrice(0));
 	print("  BuildAirport():       " + AIAirport.BuildAirport(32116, 0, AIStation.STATION_JOIN_ADJACENT));
 	print("  IsHangarTile():       " + AIAirport.IsHangarTile(32116));
@@ -237,12 +237,13 @@ function Regression::Airport()
 	print("  IsHangarTile():       " + AIAirport.IsHangarTile(32119));
 	print("  IsAirportTile():      " + AIAirport.IsAirportTile(32119));
 	print("  GetAirportType():     " + AIAirport.GetAirportType(32119));
-	print("  GetBankBalance():     " + AICompany.GetBankBalance(AICompany.COMPANY_SELF));
+	print("  GetCosts():           " + accounting.GetCosts());
 
+	accounting.ResetCosts();
 	print("  RemoveAirport():      " + AIAirport.RemoveAirport(32118));
 	print("  IsHangarTile():       " + AIAirport.IsHangarTile(32119));
 	print("  IsAirportTile():      " + AIAirport.IsAirportTile(32119));
-	print("  GetBankBalance():     " + AICompany.GetBankBalance(AICompany.COMPANY_SELF));
+	print("  GetCosts():           " + accounting.GetCosts());
 	print("  BuildAirport():       " + AIAirport.BuildAirport(32116, 0, AIStation.STATION_JOIN_ADJACENT));
 }
 
@@ -1167,7 +1168,7 @@ function Regression::Marine()
 	print("  IsLockTile():         " + AIMarine.IsLockTile(32116));
 	print("  IsCanalTile():        " + AIMarine.IsCanalTile(32116));
 
-	print("  GetBankBalance():     " + AICompany.GetBankBalance(AICompany.COMPANY_SELF));
+	local accounting = AIAccounting();
 	print("  BuildWaterDepot():    " + AIMarine.BuildWaterDepot(28479, 28478));
 	print("  BuildDock():          " + AIMarine.BuildDock(29253, AIStation.STATION_JOIN_ADJACENT));
 	print("  BuildBuoy():          " + AIMarine.BuildBuoy(28481));
@@ -1180,7 +1181,7 @@ function Regression::Marine()
 	print("  IsBuoyTile():         " + AIMarine.IsBuoyTile(28481));
 	print("  IsLockTile():         " + AIMarine.IsLockTile(28487));
 	print("  IsCanalTile():        " + AIMarine.IsCanalTile(32127));
-	print("  GetBankBalance():     " + AICompany.GetBankBalance(AICompany.COMPANY_SELF));
+	print("  GetCosts():           " + accounting.GetCosts());
 
 	local list = AIWaypointList(AIWaypoint.WAYPOINT_BUOY);
 	print("");
@@ -1196,6 +1197,7 @@ function Regression::Marine()
 	}
 	print("");
 
+	accounting.ResetCosts();
 	print("  RemoveWaterDepot():   " + AIMarine.RemoveWaterDepot(28479));
 	print("  RemoveDock():         " + AIMarine.RemoveDock(29253));
 	print("  RemoveBuoy():         " + AIMarine.RemoveBuoy(28481));
@@ -1206,7 +1208,7 @@ function Regression::Marine()
 	print("  IsBuoyTile():         " + AIMarine.IsBuoyTile(28481));
 	print("  IsLockTile():         " + AIMarine.IsLockTile(28487));
 	print("  IsCanalTile():        " + AIMarine.IsCanalTile(32127));
-	print("  GetBankBalance():     " + AICompany.GetBankBalance(AICompany.COMPANY_SELF));
+	print("  GetCosts():           " + accounting.GetCosts());
 
 	print("  BuildWaterDepot():    " + AIMarine.BuildWaterDepot(28479, 28480));
 	print("  BuildDock():          " + AIMarine.BuildDock(29253, AIStation.STATION_JOIN_ADJACENT));

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1643,7 +1643,6 @@ ERROR: IsEnd() is invalid as Begin() is never called
   GetAirportHeight(9):              -1
   GetAirportCoverageRadius(9):      -1
   GetAirportNumHelipads(9):         -1
-  GetBankBalance():     1999999790
   GetPrice():           5400
   BuildAirport():       true
   IsHangarTile():       false
@@ -1653,11 +1652,11 @@ ERROR: IsEnd() is invalid as Begin() is never called
   IsHangarTile():       true
   IsAirportTile():      true
   GetAirportType():     0
-  GetBankBalance():     1999989890
+  GetCosts():           9900
   RemoveAirport():      true
   IsHangarTile():       false
   IsAirportTile():      false
-  GetBankBalance():     1999989626
+  GetCosts():           264
   BuildAirport():       true
 
 --Bridge--
@@ -8413,7 +8412,6 @@ ERROR: IsEnd() is invalid as Begin() is never called
   IsBuoyTile():         false
   IsLockTile():         false
   IsCanalTile():        false
-  GetBankBalance():     1999979304
   BuildWaterDepot():    true
   BuildDock():          true
   BuildBuoy():          true
@@ -8426,7 +8424,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   IsBuoyTile():         true
   IsLockTile():         true
   IsCanalTile():        true
-  GetBankBalance():     1999964680
+  GetCosts():           14624
 
 --AIWaypointList(BUOY)--
   Count():             1
@@ -8445,7 +8443,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   IsBuoyTile():         false
   IsLockTile():         false
   IsCanalTile():        false
-  GetBankBalance():     1999959285
+  GetCosts():           5395
   BuildWaterDepot():    true
   BuildDock():          true
   BuildBuoy():          true
@@ -10940,7 +10938,7 @@ CALLSTACK WITH LOCALS
 *FUNCTION [Valuate()] Valuate line [5]
   [args] ARRAY
   [this] INSTANCE
-*FUNCTION [Start()] regression/main.nut line [2491]
+*FUNCTION [Start()] regression/main.nut line [2493]
   [Infinite] CLOSURE
   [list] INSTANCE
   [this] INSTANCE


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Comment in https://github.com/OpenTTD/OpenTTD/pull/15935.
Regression::Airport() and Regression::Marine() print out the bank balance which is a big number and vary on time and other tests. 

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Uses AIAccounting instead of AICompany::GetBankBalance.
This prints only the cost of methods called inside that part of regression. Those values are easier to compare and vary only on do commands cost executed since creation of AIAccounting object.

The AICompany::GetBankBalance is still tested in Regression::Company, wich is called in the very beginning where it returns values preety in decimal base. That prettiness is preserved by loan calls/tests.

Interchangeability of AIAccounting with AICompany::GetBankBalance is tested in Regression::Vehicle() where returned costs are compared.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
The current behaviour was introduced by initial [NoAI branch](https://github.com/OpenTTD/OpenTTD/commit/a3dd7506d377b1434f913bd65c019eed52b64b6e#diff-2e8eba9581ebd5f3badcf4ea06b10128b7c51c83bdf57dd0acc782dcde62c318), wich contained both AIAccounting and AICompany::GetBankBalance.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
