### PR TITLE
Codechange: always quote strings in settings, removing the need for StrQ

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -686,7 +686,6 @@ static inline uint SlCalcConvMemLen(VarMemType conv)
 		case VarMemType::LabelForward: return sizeof(BaseLabel);
 
 		case VarMemType::Str:
-		case VarMemType::StrQ:
 			return SlReadArrayLength();
 
 		case VarMemType::Name:

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -662,7 +662,6 @@ enum class VarMemType : uint8_t {
 	U64 = 8, ///< A 64 bit unsigned int.
 	Null = 9, ///< useful to write zeros in savegame.
 	Str = 12, ///< string pointer
-	StrQ = 13, ///< string pointer enclosed in quotes
 	Name = 14, ///< old custom name to be converted to a string pointer
 	LabelReverse = 15, ///< A 4 character \c Label, stored in reverse.
 	LabelForward = 16, ///< A 4 character \c Label, stored as-is.
@@ -735,7 +734,6 @@ struct VarTypes {
 	static constexpr VarType U64{ VarFileType::U64, VarMemType::U64 }; ///< Store a 64 bits unsigned int.
 	static constexpr VarType STRINGID{ VarFileType::StringID, VarMemType::U32 }; ///< Store a StringID.
 	static constexpr VarType STR{ VarFileType::String, VarMemType::Str }; ///< Store string.
-	static constexpr VarType STRQ{ VarFileType::String, VarMemType::StrQ }; ///< Store a string with quotes.
 	static constexpr VarType NAME{ VarFileType::StringID, VarMemType::Name }; ///< A string stored in the custom string array.
 	static constexpr VarType LABEL_REVERSE{ VarFileType::Label, VarMemType::LabelReverse }; ///< Store a \c Label in reverse.
 	static constexpr VarType LABEL_FORWARD{ VarFileType::Label, VarMemType::LabelForward }; ///< Store a \c Label as-is.
@@ -886,7 +884,6 @@ inline constexpr size_t SlVarSize(VarMemType type)
 		case VarMemType::U64: return sizeof(uint64_t);
 		case VarMemType::Null: return sizeof(void *);
 		case VarMemType::Str: return sizeof(std::string);
-		case VarMemType::StrQ: return sizeof(std::string);
 		case VarMemType::Name: return sizeof(std::string);
 		case VarMemType::LabelReverse: return sizeof(BaseLabel);
 		case VarMemType::LabelForward: return sizeof(BaseLabel);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -797,27 +797,15 @@ void IntSettingDesc::ResetToDefault(void *object) const
 std::string StringSettingDesc::FormatValue(const void *object) const
 {
 	const std::string &str = this->Read(object);
-	switch (this->save.conv.mem) {
-		case VarMemType::Str: return str;
-
-		case VarMemType::StrQ:
-			if (str.empty()) {
-				return str;
-			}
-			return fmt::format("\"{}\"", str);
-
-		default: NOT_REACHED();
-	}
+	if (str.empty()) return str;
+	return fmt::format("\"{}\"", str);
 }
 
-bool StringSettingDesc::IsSameValue(const IniItem *item, void *object) const
+bool StringSettingDesc::IsSameValue(const IniItem *, void *) const
 {
-	/* The ini parsing removes the quotes, which are needed to retain the spaces in STRQs,
+	/* The ini parsing removes the quotes. To retain spaces, the string needs to be quoted,
 	 * so those values are always different in the parsed ini item than they should be. */
-	if (this->save.conv.mem == VarMemType::StrQ) return false;
-
-	const std::string &str = this->Read(object);
-	return item->value->compare(str) == 0;
+	return false;
 }
 
 bool StringSettingDesc::IsDefaultValue(void *object) const
@@ -1930,10 +1918,7 @@ void SyncCompanySettings()
 bool SetSettingValue(const StringSettingDesc *sd, std::string_view value, bool force_newgame)
 {
 	assert(sd->flags.Test(SettingFlag::NoNetworkSync));
-
-	if (sd->save.conv.mem == VarMemType::StrQ && value == "(null)") {
-		value = {};
-	}
+	if (value == "(null)") value = {};
 
 	const void *object = (_game_mode == GameMode::Menu || force_newgame) ? &_settings_newgame : &_settings_game;
 	sd->AsStringSetting()->ChangeValue(object, std::string{value});

--- a/src/table/settings/currency_settings.ini
+++ b/src/table/settings/currency_settings.ini
@@ -47,7 +47,7 @@ max      = UINT16_MAX
 
 [SDT_SSTR]
 var      = separator
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 def      = "".""
 cat      = SC_BASIC
 
@@ -60,10 +60,10 @@ max      = CalendarTime::MAX_YEAR
 
 [SDT_SSTR]
 var      = prefix
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 def      = """"
 
 [SDT_SSTR]
 var      = suffix
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 def      = "" credits""

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -173,7 +173,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_IMPERIAL
 
 [SDT_SSTR]
 var      = locale.digit_group_separator
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 from     = SaveLoadVersion::DigitGroupSeparator
 flags    = SettingFlag::NoNetworkSync
 def      = """"
@@ -182,7 +182,7 @@ cat      = SC_BASIC
 
 [SDT_SSTR]
 var      = locale.digit_group_separator_currency
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 from     = SaveLoadVersion::DigitGroupSeparator
 flags    = SettingFlag::NoNetworkSync
 def      = """"
@@ -191,7 +191,7 @@ cat      = SC_BASIC
 
 [SDT_SSTR]
 var      = locale.digit_decimal_separator
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 from     = SaveLoadVersion::CumulatedInflation
 flags    = SettingFlag::NoNetworkSync
 def      = """"

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -109,42 +109,42 @@ cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""soundsset""
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 var      = BaseSounds::ini_set
 def      = """"
 cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""musicset""
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 var      = BaseMusic::ini_set
 def      = """"
 cat      = SC_BASIC
 
 [SDTG_SSTR]
 name     = ""videodriver""
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 var      = _ini_videodriver
 def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""musicdriver""
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 var      = _ini_musicdriver
 def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""sounddriver""
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 var      = _ini_sounddriver
 def      = """"
 cat      = SC_EXPERT
 
 [SDTG_SSTR]
 name     = ""blitter""
-type     = VarTypes::STRQ
+type     = VarTypes::STR
 var      = _ini_blitter
 def      = """"
 


### PR DESCRIPTION
## Motivation / Problem

The `VarMemType`, i.e. the type a variable is in memory, has `StrQ` which means that the string should be quoted. However, the need for quoting only applies when serialising to an 'ini'-file. In #15889 the suggestion was made to just quote all strings, instead of moving the knowledge whether a string needs to be quoted into `SettingsFlags`.

The main reason for this is that it allows the `VarMemType` to be deduced from the type of the variable in memory (and the `VarFileType`). That would remove the need to manually specify the `VarMemType` for the creation of `SaveLoad` objects.


## Description

Replace `VarMemType::StrQ` with `VarMemType::Str` and make all strings in settings behave as if they need to be quoted.

It reads settings from older OpenTTD without quotes fine, and likewise older OpenTTD read the newly quoted settings fine.


## Limitations

There is no inherent reason any more to have a `type` for `SDTG_SSTR`, as all instances are not `VarTypes::STR`. However, making that change is beyond the scope of this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
