### PR TITLE
Fix: invalidate/update vehicle caches when vehicle is marked dirty

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1328,6 +1328,7 @@ void Aircraft::MarkDirty()
 	if (this->subtype == AIR_HELICOPTER) {
 		GetRotorImage(this, EngineImageType::OnMap, &this->Next()->Next()->sprite_cache.sprite_seq);
 	}
+	UpdateAircraftCache(this);
 }
 
 

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -403,6 +403,7 @@ void RoadVehicle::MarkDirty()
 		v->colourmap = PAL_NONE;
 		v->UpdateViewport(true, false);
 	}
+	RoadVehUpdateCache(this, true);
 	this->CargoChanged();
 }
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3056,7 +3056,7 @@ void Train::MarkDirty()
 	} while ((v = v->Next()) != nullptr);
 
 	/* need to update acceleration and cached values since the goods on the train changed. */
-	this->CargoChanged();
+	this->ConsistChanged({});
 	this->UpdateAcceleration();
 }
 


### PR DESCRIPTION
## Motivation / Problem

#15940 mentioned that running with desync debugging enabled made desyncs way more prevalent, but I can't say this is going to fix the original desync.

The main reason is NewGRFs changing statistics about vehicles when cargo is (un)loaded. Invalidating these caches cannot happen only when the vehicle is done (un)loading, as the vehicle's maximum speed is used in the cargo (un)loading logic for station rating.

In multiplayer a new client could get a different maximum speed because of the changed amount of loaded cargo in the vehicle, changing the station's rating with potential desyncs as a result. This all hinges on using a NewGRF that changes the maximum speed based on the amount of loaded cargo.


## Description

Do what ships already did, and mark the vehicle caches invalid upon cargo (un)load. In these cases `Vehicle::MarkDirty` is called, which is the perfect place to do such things.


## Limitations

The original desync of #15940 is likely not fixed.

Invalidating the caches takes time and reduces performance, but it's picking our poison. The alternative is just storing the caches, which also reduces performance in a sense.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
