### PR TITLE
Fix #15701: Fix for the origin tiles cost not being accounted for in …

### DIFF
--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -113,6 +113,22 @@ public:
 	/** @copydoc CYapfBaseT::PfCalcCostFunc */
 	inline bool PfCalcCost(Node &n, [[maybe_unused]] const TrackFollower *follower)
 	{
+		/* If the parent node is the origin then we need to calculate the cost for this node first.
+		 * this is because the origin nodes cost was not being included in the path cost */
+		if (n.parent != nullptr && n.parent->parent == nullptr)
+		{
+			int parent_cost = Yapf().OneTileCost(n.parent->key.tile, n.parent->key.td);
+			n.parent->cost = parent_cost;
+		}
+
+		/* If the parent node is the origin then we need to calculate the cost for this node first.
+		 * this is because the origin nodes cost was not being included in the path cost */
+		if (n.parent != nullptr && n.parent->parent == nullptr)
+		{
+			int parent_cost = Yapf().OneTileCost(n.parent->key.tile, n.parent->key.td);
+			n.parent->cost = parent_cost;
+		}
+
 		int segment_cost = 0;
 		uint tiles = 0;
 		/* start at n.key.tile / n.key.td and walk to the end of segment */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

Fix for issue #15701 where path costs for road vehicles were not being calculated correctly

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

I have fixed this issue by adding a check to see if the parent node is the origin node and if it is calculate and then set the cost.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

This fix only applies to road vehicles. As I havent been able to replicate a pathing issue with either rail or ships depite rail excluding the first tile transition cost.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
