### PR TITLE
Codechange: Annotate override manager limits as const

### DIFF
--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -38,11 +38,8 @@
  * @param invalid is the ID used to identify an invalid entity id
  */
 OverrideManagerBase::OverrideManagerBase(uint16_t offset, uint16_t maximum, uint16_t invalid)
+	: max_offset(offset), max_entities(maximum), invalid_id(invalid)
 {
-	this->max_offset = offset;
-	this->max_entities = maximum;
-	this->invalid_id = invalid;
-
 	this->mappings.resize(this->max_entities);
 	this->entity_overrides.resize(this->max_offset);
 	std::fill(this->entity_overrides.begin(), this->entity_overrides.end(), this->invalid_id);

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -202,10 +202,10 @@ protected:
 	std::vector<uint16_t> entity_overrides;
 	std::vector<GrfID> grfid_overrides;
 
-	uint16_t max_offset;   ///< what is the length of the original entity's array of specs
-	uint16_t max_entities; ///< what is the amount of entities, old and new summed
+	const uint16_t max_offset; ///< what is the length of the original entity's array of specs
+	const uint16_t max_entities; ///< what is the amount of entities, old and new summed
+	const uint16_t invalid_id; ///< ID used to detected invalid entities
 
-	uint16_t invalid_id;   ///< ID used to detected invalid entities
 	/**
 	 * Checks whether the given ID is valid in the context of this override manager.
 	 * @param testid The ID to test.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

I wasn't sure if an `OverrideManager`'s `max_offset` or `max_entities` could change. Turns out they shouldn't.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Annotate `OverrideManager` limits as `const`. Makes it clear that these values do not change.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
