### PR TITLE
Fix: autoclean empty time only checked at month boundary

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -2064,6 +2064,7 @@ void NetworkServerDoMove(ClientID client_id, CompanyID company_id)
 		/* The client has joined another company. */
 		std::string company_name = GetString(STR_COMPANY_NAME, company_id);
 		NetworkServerSendChat(NetworkAction::CompanyJoin, NetworkChatDestinationType::Broadcast, 0, company_name, client_id);
+		Company::Get(company_id)->months_empty = 0; // Reset upon joining as client might not remain the whole month.
 	}
 
 	InvalidateWindowData(WindowClass::NetworkClientList, 0);


### PR DESCRIPTION
## Motivation / Problem

If you joined a company at the 2nd and left the 27th, the autoclean logic would not consider that company to have been in use for that month. That would only happen if a client is present at the start of that month.


## Description

Reset this counter when a client joins the company.


## Limitations

None I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
