### PR TITLE
Fix #10995: Prevent assertion failure when terraforming aqueduct ends

### DIFF
--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -415,50 +415,6 @@ CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex ti
 		if (ret.Failed()) return ret;
 		cost.AddCost(ret);
 
-		/* for aqueducts, slope of end tile must be complementary to the slope of the start tile */
-		if (transport_type == TRANSPORT_WATER && tileh_end != ComplementSlope(tileh_start)) {
-			/* Check if the tile to be terraformed is the start or end tile */
-			TileIndex terraformTile;
-			Slope terraformTileh;
-			if (tileh_start == SLOPE_N || tileh_start == SLOPE_S || tileh_start == SLOPE_W || tileh_start == SLOPE_E) {
-				terraformTile = tile_start;
-				terraformTileh = tileh_start ^ ComplementSlope(tileh_end);
-			} else {
-				terraformTile = tile_end;
-				terraformTileh = tileh_end ^ ComplementSlope(tileh_start);
-			}
-
-			/* Mark the tile as already cleared for the terraform command.
-			 * Do this for all tiles (like trees), not only objects. */
-			ClearedObjectArea *coa = FindClearedObject(terraformTile);
-			if (coa == nullptr) {
-				coa = &_cleared_object_areas.emplace_back(ClearedObjectArea{ terraformTile, TileArea(terraformTile, 1, 1) });
-			}
-
-			/* Hide the tile from the terraforming command */
-			TileIndex old_first_tile = coa->first_tile;
-			coa->first_tile = INVALID_TILE;
-
-			/* CMD_TERRAFORM_LAND may append further items to _cleared_object_areas,
-			 * however it will never erase or re-order existing items.
-			 * _cleared_object_areas is a value-type self-resizing vector, therefore appending items
-			 * may result in a backing-store re-allocation, which would invalidate the coa pointer.
-			 * The index of the coa pointer into the _cleared_object_areas vector remains valid,
-			 * and can be used safely after the CMD_TERRAFORM_LAND operation.
-			 * Deliberately clear the coa pointer to avoid leaving dangling pointers which could
-			 * inadvertently be dereferenced.
-			 */
-			ClearedObjectArea *begin = _cleared_object_areas.data();
-			assert(coa >= begin && coa < begin + _cleared_object_areas.size());
-			size_t coa_index = coa - begin;
-			assert(coa_index < UINT_MAX); // more than 2**32 cleared areas would be a bug in itself
-			coa = nullptr;
-
-			ret = std::get<0>(Command<CMD_TERRAFORM_LAND>::Do(DoCommandFlag(flags & ~DC_NO_WATER), terraformTile, terraformTileh, true));
-			_cleared_object_areas[(uint)coa_index].first_tile = old_first_tile;
-			if (ret.Failed()) return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
-			cost.AddCost(ret);
-		}
 
 		if (transport_type != TRANSPORT_WATER){
 			CommandCost terraform_cost_north = CheckBridgeSlope(BRIDGE_PIECE_NORTH, direction, tileh_start, z_start);
@@ -561,6 +517,50 @@ CommandCost CmdBuildBridge(DoCommandFlag flags, TileIndex tile_end, TileIndex ti
 	}
 
 	/* do the drill? */
+	if (transport_type == TRANSPORT_WATER && tileh_end != ComplementSlope(tileh_start)) {
+		/* Check if the tile to be terraformed is the start or end tile */
+		TileIndex terraformTile;
+		Slope terraformTileh;
+		if (tileh_start == SLOPE_N || tileh_start == SLOPE_S || tileh_start == SLOPE_W || tileh_start == SLOPE_E) {
+			terraformTile = tile_start;
+			terraformTileh = tileh_start ^ ComplementSlope(tileh_end);
+		} else {
+			terraformTile = tile_end;
+			terraformTileh = tileh_end ^ ComplementSlope(tileh_start);
+		}
+
+		/* Mark the tile as already cleared for the terraform command.
+		 * Do this for all tiles (like trees), not only objects. */
+		ClearedObjectArea *coa = FindClearedObject(terraformTile);
+		if (coa == nullptr) {
+			coa = &_cleared_object_areas.emplace_back(ClearedObjectArea{ terraformTile, TileArea(terraformTile, 1, 1) });
+		}
+
+		/* Hide the tile from the terraforming command */
+		TileIndex old_first_tile = coa->first_tile;
+		coa->first_tile = INVALID_TILE;
+
+		/* CMD_TERRAFORM_LAND may append further items to _cleared_object_areas,
+		 * however it will never erase or re-order existing items.
+		 * _cleared_object_areas is a value-type self-resizing vector, therefore appending items
+		 * may result in a backing-store re-allocation, which would invalidate the coa pointer.
+		 * The index of the coa pointer into the _cleared_object_areas vector remains valid,
+		 * and can be used safely after the CMD_TERRAFORM_LAND operation.
+		 * Deliberately clear the coa pointer to avoid leaving dangling pointers which could
+		 * inadvertently be dereferenced.
+		 */
+		ClearedObjectArea *begin = _cleared_object_areas.data();
+		assert(coa >= begin && coa < begin + _cleared_object_areas.size());
+		size_t coa_index = coa - begin;
+		assert(coa_index < UINT_MAX); // more than 2**32 cleared areas would be a bug in itself
+		coa = nullptr;
+
+		CommandCost ret = std::get<0>(Command<CMD_TERRAFORM_LAND>::Do(DoCommandFlag(flags & ~DC_NO_WATER), terraformTile, terraformTileh, true));
+		_cleared_object_areas[(uint)coa_index].first_tile = old_first_tile;
+		if (ret.Failed()) return CommandCost(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
+		cost.AddCost(ret);
+	}
+
 	if (flags & DC_EXEC) {
 		DiagDirection dir = AxisToDiagDir(direction);
 


### PR DESCRIPTION
Fixes #10995.

The original PR (#13545) placed the aqueduct terraforming logic in the middle of CmdBuildBridge. This caused a discrepancy: in TEST mode the terrain height was not changed (allowing the bridge span checks to pass), but in EXECUTE mode the terrain was raised, which caused GetTileMaxZ > z_start to fail for the first tile under the bridge span.

This patch moves the terraforming block for aqueducts to the very end of the function (just like CmdBuildTunnel), ensuring that all validation checks run against the unmodified landscape in both passes and preventing the es_test == res_exec assertion failure.