### PR TITLE
Codechange: Use ByteReader position to check industry definition size

### DIFF
--- a/src/newgrf/newgrf_act0_industries.cpp
+++ b/src/newgrf/newgrf_act0_industries.cpp
@@ -403,8 +403,8 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 
 			case 0x0A: { // Set industry layout(s)
 				uint8_t new_num_layouts = buf.ReadByte();
-				uint32_t definition_size = buf.ReadDWord();
-				uint32_t bytes_read = 0;
+				size_t definition_size = buf.ReadDWord();
+				size_t definition_end = definition_size + buf.GetBytesRead();
 				std::vector<IndustryTileLayout> new_layouts;
 				IndustryTileLayout layout;
 
@@ -412,22 +412,20 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 					layout.clear();
 
 					for (uint k = 0;; k++) {
-						if (bytes_read >= definition_size) {
+						if (definition_end < buf.GetBytesRead()) {
 							GrfMsg(3, "IndustriesChangeInfo: Incorrect size for industry tile layout definition for industry {}.", id);
 							/* Avoid warning twice */
-							definition_size = UINT32_MAX;
+							definition_end = SIZE_MAX;
 						}
 
 						IndustryTileLayoutTile &it = layout.emplace_back();
 
 						it.ti.x = buf.ReadByte(); // Offsets from northernmost tile
-						++bytes_read;
 
 						if (it.ti.x == 0xFE && k == 0) {
 							/* This means we have to borrow the layout from an old industry */
 							IndustryType type = buf.ReadByte();
 							uint8_t laynbr = buf.ReadByte();
-							bytes_read += 2;
 
 							if (type >= lengthof(_origin_industry_specs)) {
 								GrfMsg(1, "IndustriesChangeInfo: Invalid original industry number for layout import, industry {}", id);
@@ -444,7 +442,6 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 						}
 
 						it.ti.y = buf.ReadByte(); // Or table definition finalisation
-						++bytes_read;
 
 						if (it.ti.x == 0 && it.ti.y == 0x80) {
 							/* Terminator, remove and finish up */
@@ -453,12 +450,10 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 						}
 
 						it.gfx = buf.ReadByte();
-						++bytes_read;
 
 						if (it.gfx == 0xFE) {
 							/* Use a new tile from this GRF */
 							int local_tile_id = buf.ReadWord();
-							bytes_read += 2;
 
 							/* Read the ID from the _industile_mngr. */
 							int tempid = _industile_mngr.GetID(local_tile_id, _cur_gps.grffile->grfid);

--- a/src/newgrf/newgrf_bytereader.h
+++ b/src/newgrf/newgrf_bytereader.h
@@ -123,6 +123,14 @@ public:
 		if (result.size() != len) throw OTTDByteReaderSignal();
 	}
 
+	/**
+	 * Get number of already read bytes.
+	 * @return The number of bytes read so far.
+	 */
+	size_t GetBytesRead() const
+	{
+		return this->consumer.GetBytesRead();
+	}
 };
 
 #endif /* NEWGRF_BYTEREADER_H */


### PR DESCRIPTION


<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

NewGRF industry tile layouts use byte-by-byte accounting alongside `ReadByte()` and `ReadWord()` calls to check if the layout has not overrun the requested size. This is a bit tedious.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

The byte reader already tracks its own position, so use the underlying `ByteReader` consumer's `GetBytesRead()` function instead, comparing against the expected end position.

Avoids manually accounting for each byte that has been read.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
