### PR TITLE
Fix #15961: Don't pass a temporary object to BreakIterator::setText

### DIFF
--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -435,7 +435,8 @@ std::unique_ptr<const ICUParagraphLayout::Line> ICUParagraphLayout::NextLine(int
 	if (cur_width > max_width) {
 		/* Create a break-iterator to find a good place to break lines. */
 		auto break_iterator = ICUParagraphLayoutFactory::GetBreakIterator();
-		break_iterator->setText(icu::UnicodeString(this->buff, this->buff_length));
+		icu::UnicodeString text(this->buff, this->buff_length);
+		break_iterator->setText(text);
 
 		auto overflow_run = last_run - 1;
 


### PR DESCRIPTION
The [API contract for `BreakIterator::setText`](https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/classicu_1_1BreakIterator.html#aaeda5bd245bd9d3cf093731484f5ea8c) states the following:

> The `BreakIterator` will retain a reference to the supplied string. The caller must not modify or delete the text while the `BreakIterator` retains the reference.

However, presently, OpenTTD passes a temporary `UnicodeString` object to this function. This object is destroyed as soon as the `->setText` expression was evaluated.

Therefore, this invocation violates the API contract and since the `UnicodeString` destructor deallocates the underlying memory this can cause an access to freed memory later on. To fix this, ensure that the `BreakIterator` does not outlive the `UnicodeString` by using the same lifetime for both objects.

Fixes #15961