### PR TITLE
Codechange: Use AutoRelease to manage ubidi_open/close calls

### DIFF
--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -11,6 +11,7 @@
 #include "gfx_layout_icu.h"
 
 #include "debug.h"
+#include "misc/autorelease.hpp"
 #include "strings_func.h"
 #include "language.h"
 #include "table/control_codes.h"
@@ -249,23 +250,21 @@ int ICUParagraphLayout::ICULine::GetWidth() const
  */
 std::vector<ICURun> ItemizeBidi(UChar *buff, size_t length)
 {
-	auto ubidi = ubidi_open();
+	auto ubidi = AutoRelease<UBiDi, ubidi_close>(ubidi_open());
 
 	auto parLevel = _current_text_dir == TD_RTL ? UBIDI_RTL : UBIDI_LTR;
 
 	UErrorCode err = U_ZERO_ERROR;
-	ubidi_setPara(ubidi, buff, length, parLevel, nullptr, &err);
+	ubidi_setPara(ubidi.get(), buff, length, parLevel, nullptr, &err);
 	if (U_FAILURE(err)) {
 		Debug(fontcache, 0, "Failed to set paragraph: {}", u_errorName(err));
-		ubidi_close(ubidi);
-		return std::vector<ICURun>();
+		return {};
 	}
 
-	int32_t count = ubidi_countRuns(ubidi, &err);
+	int32_t count = ubidi_countRuns(ubidi.get(), &err);
 	if (U_FAILURE(err)) {
 		Debug(fontcache, 0, "Failed to count runs: {}", u_errorName(err));
-		ubidi_close(ubidi);
-		return std::vector<ICURun>();
+		return {};
 	}
 
 	std::vector<ICURun> runs;
@@ -278,14 +277,13 @@ std::vector<ICURun> ItemizeBidi(UChar *buff, size_t length)
 
 		/* Fetch the embedding level, so we can order bidi correctly later on. */
 		UBiDiLevel level;
-		ubidi_getLogicalRun(ubidi, start_pos, &logical_pos, &level);
+		ubidi_getLogicalRun(ubidi.get(), start_pos, &logical_pos, &level);
 
 		runs.emplace_back(start_pos, logical_pos - start_pos, level);
 	}
 
 	assert(static_cast<size_t>(count) == runs.size());
 
-	ubidi_close(ubidi);
 	return runs;
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Calls to `ubidi_close()` to clean up resources on expected error conditions in `ItemizeBidi()`

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Use `AutoRelease` pointer to manage the ubidi object lifetime instead.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
