### PR TITLE
Codechange: Use enums for debug facility and severity.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,7 @@ add_files(
     date_gui.h
     debug.cpp
     debug.h
+    debug_type.h
     dedicated.cpp
     depot.cpp
     depot_base.h

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -199,14 +199,14 @@ static constexpr PerformanceElement GetAIPerformanceElement(CompanyID company)
 	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (_settings_game.script_config.ai[c] != nullptr && _settings_game.script_config.ai[c]->HasScript()) {
 			if (!_settings_game.script_config.ai[c]->ResetInfo(true)) {
-				Debug(script, Severity::Critical, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.ai[c]->GetName());
+				Debug(Facility::Script, Severity::Critical, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.ai[c]->GetName());
 				_settings_game.script_config.ai[c]->Change(std::nullopt);
 			}
 		}
 
 		if (_settings_newgame.script_config.ai[c] != nullptr && _settings_newgame.script_config.ai[c]->HasScript()) {
 			if (!_settings_newgame.script_config.ai[c]->ResetInfo(false)) {
-				Debug(script, Severity::Critical, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.ai[c]->GetName());
+				Debug(Facility::Script, Severity::Critical, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.ai[c]->GetName());
 				_settings_newgame.script_config.ai[c]->Change(std::nullopt);
 			}
 		}

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -199,14 +199,14 @@ static constexpr PerformanceElement GetAIPerformanceElement(CompanyID company)
 	for (CompanyID c = CompanyID::Begin(); c < MAX_COMPANIES; ++c) {
 		if (_settings_game.script_config.ai[c] != nullptr && _settings_game.script_config.ai[c]->HasScript()) {
 			if (!_settings_game.script_config.ai[c]->ResetInfo(true)) {
-				Debug(script, 0, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.ai[c]->GetName());
+				Debug(script, Severity::Critical, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.ai[c]->GetName());
 				_settings_game.script_config.ai[c]->Change(std::nullopt);
 			}
 		}
 
 		if (_settings_newgame.script_config.ai[c] != nullptr && _settings_newgame.script_config.ai[c]->HasScript()) {
 			if (!_settings_newgame.script_config.ai[c]->ResetInfo(false)) {
-				Debug(script, 0, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.ai[c]->GetName());
+				Debug(script, Severity::Critical, "After a reload, the AI by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.ai[c]->GetName());
 				_settings_newgame.script_config.ai[c]->Change(std::nullopt);
 			}
 		}

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -54,7 +54,7 @@ void AIScannerInfo::RegisterAPI(class Squirrel &engine)
 AIInfo *AIScannerInfo::SelectRandomAI() const
 {
 	if (_game_mode == GameMode::Menu) {
-		Debug(script, 0, "The intro game should not use AI, loading 'dummy' AI.");
+		Debug(script, Severity::Critical, "The intro game should not use AI, loading 'dummy' AI.");
 		return this->info_dummy.get();
 	}
 
@@ -63,7 +63,7 @@ AIInfo *AIScannerInfo::SelectRandomAI() const
 
 	uint num_random_ais = std::ranges::distance(random_ais);
 	if (num_random_ais == 0) {
-		Debug(script, 0, "No suitable AI found, loading 'dummy' AI.");
+		Debug(script, Severity::Critical, "No suitable AI found, loading 'dummy' AI.");
 		return this->info_dummy.get();
 	}
 

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -54,7 +54,7 @@ void AIScannerInfo::RegisterAPI(class Squirrel &engine)
 AIInfo *AIScannerInfo::SelectRandomAI() const
 {
 	if (_game_mode == GameMode::Menu) {
-		Debug(script, Severity::Critical, "The intro game should not use AI, loading 'dummy' AI.");
+		Debug(Facility::Script, Severity::Critical, "The intro game should not use AI, loading 'dummy' AI.");
 		return this->info_dummy.get();
 	}
 
@@ -63,7 +63,7 @@ AIInfo *AIScannerInfo::SelectRandomAI() const
 
 	uint num_random_ais = std::ranges::distance(random_ais);
 	if (num_random_ais == 0) {
-		Debug(script, Severity::Critical, "No suitable AI found, loading 'dummy' AI.");
+		Debug(Facility::Script, Severity::Critical, "No suitable AI found, loading 'dummy' AI.");
 		return this->info_dummy.get();
 	}
 

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1823,7 +1823,7 @@ static bool AirportMove(Aircraft *v, const AirportFTAClass *apc)
 {
 	/* error handling */
 	if (v->pos >= apc->nofelements) {
-		Debug(misc, 0, "[Ap] position {} is not valid for current airport. Max position is {}", v->pos, apc->nofelements - 1);
+		Debug(misc, Severity::Critical, "[Ap] position {} is not valid for current airport. Max position is {}", v->pos, apc->nofelements - 1);
 		assert(v->pos < apc->nofelements);
 	}
 
@@ -1862,7 +1862,7 @@ static bool AirportMove(Aircraft *v, const AirportFTAClass *apc)
 		current = current->next.get();
 	} while (current != nullptr);
 
-	Debug(misc, 0, "[Ap] cannot move further on Airport! (pos {} state {}) for vehicle {}", v->pos, v->state, v->index);
+	Debug(misc, Severity::Critical, "[Ap] cannot move further on Airport! (pos {} state {}) for vehicle {}", v->pos, v->state, v->index);
 	NOT_REACHED();
 }
 

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1823,7 +1823,7 @@ static bool AirportMove(Aircraft *v, const AirportFTAClass *apc)
 {
 	/* error handling */
 	if (v->pos >= apc->nofelements) {
-		Debug(misc, Severity::Critical, "[Ap] position {} is not valid for current airport. Max position is {}", v->pos, apc->nofelements - 1);
+		Debug(Facility::Misc, Severity::Critical, "[Ap] position {} is not valid for current airport. Max position is {}", v->pos, apc->nofelements - 1);
 		assert(v->pos < apc->nofelements);
 	}
 
@@ -1862,7 +1862,7 @@ static bool AirportMove(Aircraft *v, const AirportFTAClass *apc)
 		current = current->next.get();
 	} while (current != nullptr);
 
-	Debug(misc, Severity::Critical, "[Ap] cannot move further on Airport! (pos {} state {}) for vehicle {}", v->pos, v->state, v->index);
+	Debug(Facility::Misc, Severity::Critical, "[Ap] cannot move further on Airport! (pos {} state {}) for vehicle {}", v->pos, v->state, v->index);
 	NOT_REACHED();
 }
 

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -10,6 +10,7 @@
 #ifndef BASE_MEDIA_BASE_H
 #define BASE_MEDIA_BASE_H
 
+#include "debug_type.h"
 #include "fileio_func.h"
 #include "textfile_type.h"
 #include "textfile_gui.h"
@@ -93,7 +94,7 @@ struct BaseSet {
 		return BaseSet<T>::NUM_FILES - this->valid_files;
 	}
 
-	void LogError(std::string_view full_filename, std::string_view detail, int level = 0) const;
+	void LogError(std::string_view full_filename, std::string_view detail, Severity severity = {}) const;
 	const IniItem *GetMandatoryItem(std::string_view full_filename, const IniGroup &group, std::string_view name) const;
 
 	bool FillSetDetails(const IniFile &ini, const std::string &path, const std::string &full_filename, bool allow_empty_filename = true);

--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -26,8 +26,8 @@ extern void CheckExternalFiles();
 template <class T>
 void BaseSet<T>::LogError(std::string_view full_filename, std::string_view detail, Severity severity) const
 {
-	Debug(misc, severity, "Loading base {}set details failed: {}", BaseSet<T>::SET_TYPE, full_filename);
-	Debug(misc, severity, "  {}", detail);
+	Debug(Facility::Misc, severity, "Loading base {}set details failed: {}", BaseSet<T>::SET_TYPE, full_filename);
+	Debug(Facility::Misc, severity, "  {}", detail);
 }
 
 /**
@@ -200,7 +200,7 @@ bool BaseSet<T>::FillSetDetails(const IniFile &ini, const std::string &path, con
 template <class Tbase_set>
 bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_length, const std::string &)
 {
-	Debug(misc, Severity::Error, "Checking {} for base {} set", filename, BaseSet<Tbase_set>::SET_TYPE);
+	Debug(Facility::Misc, Severity::Error, "Checking {} for base {} set", filename, BaseSet<Tbase_set>::SET_TYPE);
 
 	auto set = std::make_unique<Tbase_set>();
 	IniFile ini{};
@@ -222,7 +222,7 @@ bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_
 		if (((*existing)->valid_files == set->valid_files && (*existing)->version >= set->version) ||
 				(*existing)->valid_files > set->valid_files) {
 
-			Debug(misc, Severity::Error, "Not adding {} ({}) as base {} set (duplicate, {})", set->name, fmt::join(set->version, "."),
+			Debug(Facility::Misc, Severity::Error, "Not adding {} ({}) as base {} set (duplicate, {})", set->name, fmt::join(set->version, "."),
 					BaseSet<Tbase_set>::SET_TYPE,
 					(*existing)->valid_files > set->valid_files ? "fewer valid files" : "lower version");
 
@@ -238,16 +238,16 @@ bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_
 		/* Keep baseset configuration, if compatible */
 		set->CopyCompatibleConfig(**existing);
 
-		Debug(misc, Severity::Error, "Removing {} ({}) as base {} set (duplicate, {})", (*existing)->name, fmt::join((*existing)->version, "."), BaseSet<Tbase_set>::SET_TYPE,
+		Debug(Facility::Misc, Severity::Error, "Removing {} ({}) as base {} set (duplicate, {})", (*existing)->name, fmt::join((*existing)->version, "."), BaseSet<Tbase_set>::SET_TYPE,
 				(*existing)->valid_files < set->valid_files ? "fewer valid files" : "lower version");
 
 		/* Existing set is worse, move it to duplicates and replace with the current set. */
 		duplicate_sets.push_back(std::move(*existing));
 
-		Debug(misc, Severity::Error, "Adding {} ({}) as base {} set", set->name, fmt::join(set->version, "."), BaseSet<Tbase_set>::SET_TYPE);
+		Debug(Facility::Misc, Severity::Error, "Adding {} ({}) as base {} set", set->name, fmt::join(set->version, "."), BaseSet<Tbase_set>::SET_TYPE);
 		*existing = std::move(set);
 	} else {
-		Debug(misc, Severity::Error, "Adding {} ({}) as base {} set", set->name, set->version, BaseSet<Tbase_set>::SET_TYPE);
+		Debug(Facility::Misc, Severity::Error, "Adding {} ({}) as base {} set", set->name, set->version, BaseSet<Tbase_set>::SET_TYPE);
 		available_sets.push_back(std::move(set));
 	}
 

--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -21,13 +21,13 @@ extern void CheckExternalFiles();
  * Log error from reading basesets.
  * @param full_filename the full filename of the loaded file
  * @param detail detail log message
- * @param level debug level
+ * @param severity debug severity
  */
 template <class T>
-void BaseSet<T>::LogError(std::string_view full_filename, std::string_view detail, int level) const
+void BaseSet<T>::LogError(std::string_view full_filename, std::string_view detail, Severity severity) const
 {
-	Debug(misc, level, "Loading base {}set details failed: {}", BaseSet<T>::SET_TYPE, full_filename);
-	Debug(misc, level, "  {}", detail);
+	Debug(misc, severity, "Loading base {}set details failed: {}", BaseSet<T>::SET_TYPE, full_filename);
+	Debug(misc, severity, "  {}", detail);
 }
 
 /**
@@ -165,7 +165,7 @@ bool BaseSet<T>::FillSetDetails(const IniFile &ini, const std::string &path, con
 		item = origin != nullptr ? origin->GetItem(filename) : nullptr;
 		if (item == nullptr) item = origin != nullptr ? origin->GetItem("default") : nullptr;
 		if (item == nullptr || !item->value.has_value()) {
-			this->LogError(full_filename, fmt::format("origin.{} field missing", filename), 1);
+			this->LogError(full_filename, fmt::format("origin.{} field missing", filename), Severity::Error);
 			file->missing_warning.clear();
 		} else {
 			file->missing_warning = item->value.value();
@@ -183,13 +183,13 @@ bool BaseSet<T>::FillSetDetails(const IniFile &ini, const std::string &path, con
 
 			case MD5File::ChecksumResult::Mismatch:
 				/* This is normal for original sample.cat, which either matches with orig_dos or orig_win. */
-				this->LogError(full_filename, fmt::format("MD5 checksum mismatch for: {}", filename), original_set ? 1 : 0);
+				this->LogError(full_filename, fmt::format("MD5 checksum mismatch for: {}", filename), original_set ? Severity::Error : Severity::Critical);
 				this->found_files++;
 				break;
 
 			case MD5File::ChecksumResult::NoFile:
 				/* Missing files is normal for the original basesets. Use lower debug level */
-				this->LogError(full_filename, fmt::format("File is missing: {}", filename), original_set ? 1 : 0);
+				this->LogError(full_filename, fmt::format("File is missing: {}", filename), original_set ? Severity::Error : Severity::Critical);
 				break;
 		}
 	}
@@ -200,7 +200,7 @@ bool BaseSet<T>::FillSetDetails(const IniFile &ini, const std::string &path, con
 template <class Tbase_set>
 bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_length, const std::string &)
 {
-	Debug(misc, 1, "Checking {} for base {} set", filename, BaseSet<Tbase_set>::SET_TYPE);
+	Debug(misc, Severity::Error, "Checking {} for base {} set", filename, BaseSet<Tbase_set>::SET_TYPE);
 
 	auto set = std::make_unique<Tbase_set>();
 	IniFile ini{};
@@ -222,7 +222,7 @@ bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_
 		if (((*existing)->valid_files == set->valid_files && (*existing)->version >= set->version) ||
 				(*existing)->valid_files > set->valid_files) {
 
-			Debug(misc, 1, "Not adding {} ({}) as base {} set (duplicate, {})", set->name, fmt::join(set->version, "."),
+			Debug(misc, Severity::Error, "Not adding {} ({}) as base {} set (duplicate, {})", set->name, fmt::join(set->version, "."),
 					BaseSet<Tbase_set>::SET_TYPE,
 					(*existing)->valid_files > set->valid_files ? "fewer valid files" : "lower version");
 
@@ -238,16 +238,16 @@ bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_
 		/* Keep baseset configuration, if compatible */
 		set->CopyCompatibleConfig(**existing);
 
-		Debug(misc, 1, "Removing {} ({}) as base {} set (duplicate, {})", (*existing)->name, fmt::join((*existing)->version, "."), BaseSet<Tbase_set>::SET_TYPE,
+		Debug(misc, Severity::Error, "Removing {} ({}) as base {} set (duplicate, {})", (*existing)->name, fmt::join((*existing)->version, "."), BaseSet<Tbase_set>::SET_TYPE,
 				(*existing)->valid_files < set->valid_files ? "fewer valid files" : "lower version");
 
 		/* Existing set is worse, move it to duplicates and replace with the current set. */
 		duplicate_sets.push_back(std::move(*existing));
 
-		Debug(misc, 1, "Adding {} ({}) as base {} set", set->name, fmt::join(set->version, "."), BaseSet<Tbase_set>::SET_TYPE);
+		Debug(misc, Severity::Error, "Adding {} ({}) as base {} set", set->name, fmt::join(set->version, "."), BaseSet<Tbase_set>::SET_TYPE);
 		*existing = std::move(set);
 	} else {
-		Debug(misc, 1, "Adding {} ({}) as base {} set", set->name, set->version, BaseSet<Tbase_set>::SET_TYPE);
+		Debug(misc, Severity::Error, "Adding {} ({}) as base {} set", set->name, set->version, BaseSet<Tbase_set>::SET_TYPE);
 		available_sets.push_back(std::move(set));
 	}
 

--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -318,7 +318,7 @@ void Blitter_32bppAnim::DrawColourMappingRect(void *dst, int width, int height, 
 		return;
 	}
 
-	Debug(misc, Severity::Critical, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
+	Debug(Facility::Misc, Severity::Critical, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
 }
 
 void Blitter_32bppAnim::SetPixel(void *video, int x, int y, PixelColour colour)

--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -318,7 +318,7 @@ void Blitter_32bppAnim::DrawColourMappingRect(void *dst, int width, int height, 
 		return;
 	}
 
-	Debug(misc, 0, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
+	Debug(misc, Severity::Critical, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
 }
 
 void Blitter_32bppAnim::SetPixel(void *video, int x, int y, PixelColour colour)

--- a/src/blitter/32bpp_simple.cpp
+++ b/src/blitter/32bpp_simple.cpp
@@ -112,7 +112,7 @@ void Blitter_32bppSimple::DrawColourMappingRect(void *dst, int width, int height
 		return;
 	}
 
-	Debug(misc, Severity::Critical, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
+	Debug(Facility::Misc, Severity::Critical, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
 }
 
 Sprite *Blitter_32bppSimple::Encode(SpriteType, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)

--- a/src/blitter/32bpp_simple.cpp
+++ b/src/blitter/32bpp_simple.cpp
@@ -112,7 +112,7 @@ void Blitter_32bppSimple::DrawColourMappingRect(void *dst, int width, int height
 		return;
 	}
 
-	Debug(misc, 0, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
+	Debug(misc, Severity::Critical, "32bpp blitter doesn't know how to draw this colour table ('{}')", pal);
 }
 
 Sprite *Blitter_32bppSimple::Encode(SpriteType, const SpriteLoader::SpriteCollection &sprite, SpriteAllocator &allocator)

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -68,7 +68,7 @@ protected:
 			 */
 			blitters.insert(Blitters::value_type(this->name, this));
 		} else {
-			Debug(driver, Severity::Error, "Not registering blitter {} as it is not usable", name);
+			Debug(Facility::Driver, Severity::Error, "Not registering blitter {} as it is not usable", name);
 		}
 	}
 
@@ -102,7 +102,7 @@ public:
 
 		GetActiveBlitter() = b->CreateInstance();
 
-		Debug(driver, Severity::Error, "Successfully {} blitter '{}'", name.empty() ? "probed" : "loaded", GetCurrentBlitter()->GetName());
+		Debug(Facility::Driver, Severity::Error, "Successfully {} blitter '{}'", name.empty() ? "probed" : "loaded", GetCurrentBlitter()->GetName());
 		return GetCurrentBlitter();
 	}
 

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -68,7 +68,7 @@ protected:
 			 */
 			blitters.insert(Blitters::value_type(this->name, this));
 		} else {
-			Debug(driver, 1, "Not registering blitter {} as it is not usable", name);
+			Debug(driver, Severity::Error, "Not registering blitter {} as it is not usable", name);
 		}
 	}
 
@@ -102,7 +102,7 @@ public:
 
 		GetActiveBlitter() = b->CreateInstance();
 
-		Debug(driver, 1, "Successfully {} blitter '{}'", name.empty() ? "probed" : "loaded", GetCurrentBlitter()->GetName());
+		Debug(driver, Severity::Error, "Successfully {} blitter '{}'", name.empty() ? "probed" : "loaded", GetCurrentBlitter()->GetName());
 		return GetCurrentBlitter();
 	}
 

--- a/src/cachecheck.cpp
+++ b/src/cachecheck.cpp
@@ -37,7 +37,7 @@ void CheckCaches()
 {
 	/* Return here so it is easy to add checks that are run
 	 * always to aid testing of caches. */
-	if (_debug_desync_level <= 1) return;
+	if (_debug_desync_level <= Severity::Error) return;
 
 	/* Check the town caches. */
 	std::vector<TownCache> old_town_caches;
@@ -51,7 +51,7 @@ void CheckCaches()
 	uint i = 0;
 	for (Town *t : Town::Iterate()) {
 		if (old_town_caches[i] != t->cache) {
-			Debug(desync, 2, "warning: town cache mismatch: town {}", t->index);
+			Debug(desync, Severity::Warning, "warning: town cache mismatch: town {}", t->index);
 		}
 		i++;
 	}
@@ -65,7 +65,7 @@ void CheckCaches()
 	i = 0;
 	for (const Company *c : Company::Iterate()) {
 		if (old_infrastructure[i] != c->infrastructure) {
-			Debug(desync, 2, "warning: infrastructure cache mismatch: company {}", c->index);
+			Debug(desync, Severity::Warning, "warning: infrastructure cache mismatch: company {}", c->index);
 		}
 		i++;
 	}
@@ -115,23 +115,23 @@ void CheckCaches()
 		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
 			FillNewGRFVehicleCache(u);
 			if (grf_cache[length] != u->grf_cache) {
-				Debug(desync, 2, "warning: newgrf cache mismatch: type {}, vehicle {}, company {}, unit number {}, wagon {}", v->type, v->index, v->owner, v->unitnumber, length);
+				Debug(desync, Severity::Warning, "warning: newgrf cache mismatch: type {}, vehicle {}, company {}, unit number {}, wagon {}", v->type, v->index, v->owner, v->unitnumber, length);
 			}
 			if (veh_cache[length] != u->vcache) {
-				Debug(desync, 2, "warning: vehicle cache mismatch: type {}, vehicle {}, company {}, unit number {}, wagon {}", v->type, v->index, v->owner, v->unitnumber, length);
+				Debug(desync, Severity::Warning, "warning: vehicle cache mismatch: type {}, vehicle {}, company {}, unit number {}, wagon {}", v->type, v->index, v->owner, v->unitnumber, length);
 			}
 			switch (u->type) {
 				case VehicleType::Train:
 					if (gro_cache[length] != Train::From(u)->gcache) {
-						Debug(desync, 2, "warning: train ground vehicle cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
+						Debug(desync, Severity::Warning, "warning: train ground vehicle cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
 					}
 					if (tra_cache[length] != Train::From(u)->tcache) {
-						Debug(desync, 2, "warning: train cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
+						Debug(desync, Severity::Warning, "warning: train cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
 					}
 					break;
 				case VehicleType::Road:
 					if (gro_cache[length] != RoadVehicle::From(u)->gcache) {
-						Debug(desync, 2, "warning: road vehicle ground vehicle cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
+						Debug(desync, Severity::Warning, "warning: road vehicle ground vehicle cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
 					}
 					break;
 				default:
@@ -188,11 +188,11 @@ void CheckCaches()
 		}
 		UpdateStationDockingTiles(st);
 		if (ta.tile != st->docking_station.tile || ta.w != st->docking_station.w || ta.h != st->docking_station.h) {
-			Debug(desync, 2, "warning: station docking mismatch: station {}, company {}", st->index, st->owner);
+			Debug(desync, Severity::Warning, "warning: station docking mismatch: station {}, company {}", st->index, st->owner);
 		}
 		for (TileIndex tile : ta) {
 			if (docking_tiles[tile] != IsDockingTile(tile)) {
-				Debug(desync, 2, "warning: docking tile mismatch: tile {}", tile);
+				Debug(desync, Severity::Warning, "warning: docking tile mismatch: tile {}", tile);
 			}
 		}
 	}
@@ -203,7 +203,7 @@ void CheckCaches()
 	i = 0;
 	for (Station *st : Station::Iterate()) {
 		if (st->industries_near != old_station_industries_near[i]) {
-			Debug(desync, 2, "warning: station industries near mismatch: station {}", st->index);
+			Debug(desync, Severity::Warning, "warning: station industries near mismatch: station {}", st->index);
 		}
 		i++;
 	}
@@ -212,14 +212,14 @@ void CheckCaches()
 	i = 0;
 	for (Town *t : Town::Iterate()) {
 		if (t->stations_near != old_town_stations_near[i]) {
-			Debug(desync, 2, "warning: town stations near mismatch: town {}", t->index);
+			Debug(desync, Severity::Warning, "warning: town stations near mismatch: town {}", t->index);
 		}
 		i++;
 	}
 	i = 0;
 	for (Industry *ind : Industry::Iterate()) {
 		if (ind->stations_near != old_industry_stations_near[i]) {
-			Debug(desync, 2, "warning: industry stations near mismatch: industry {}", ind->index);
+			Debug(desync, Severity::Warning, "warning: industry stations near mismatch: industry {}", ind->index);
 		}
 		i++;
 	}
@@ -230,13 +230,13 @@ void CheckCaches()
 
 		/* Check that the last vehicle is actually last. */
 		if (v->Last()->Next() != nullptr) {
-			Debug(desync, 2, "warning: vehicle cache mismatch, last vehicle must not have a next vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
+			Debug(desync, Severity::Warning, "warning: vehicle cache mismatch, last vehicle must not have a next vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
 		}
 
 		/* Ensure that all vehicles in the chain have the same last vehicle. */
 		for (Vehicle *u = v; u != nullptr; u = u->Next()) {
 			if (u->Last() != v->Last()) {
-				Debug(desync, 2, "warning: vehicle cache mismatch, all vehicles in chain must have same last vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
+				Debug(desync, Severity::Warning, "warning: vehicle cache mismatch, all vehicles in chain must have same last vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
 			}
 		}
 	}

--- a/src/cachecheck.cpp
+++ b/src/cachecheck.cpp
@@ -37,7 +37,7 @@ void CheckCaches()
 {
 	/* Return here so it is easy to add checks that are run
 	 * always to aid testing of caches. */
-	if (_debug_desync_level <= Severity::Error) return;
+	if (!IsVisibleSeverity(Facility::Desync, Severity::Warning)) return;
 
 	/* Check the town caches. */
 	std::vector<TownCache> old_town_caches;
@@ -51,7 +51,7 @@ void CheckCaches()
 	uint i = 0;
 	for (Town *t : Town::Iterate()) {
 		if (old_town_caches[i] != t->cache) {
-			Debug(desync, Severity::Warning, "warning: town cache mismatch: town {}", t->index);
+			Debug(Facility::Desync, Severity::Warning, "warning: town cache mismatch: town {}", t->index);
 		}
 		i++;
 	}
@@ -65,7 +65,7 @@ void CheckCaches()
 	i = 0;
 	for (const Company *c : Company::Iterate()) {
 		if (old_infrastructure[i] != c->infrastructure) {
-			Debug(desync, Severity::Warning, "warning: infrastructure cache mismatch: company {}", c->index);
+			Debug(Facility::Desync, Severity::Warning, "warning: infrastructure cache mismatch: company {}", c->index);
 		}
 		i++;
 	}
@@ -115,23 +115,23 @@ void CheckCaches()
 		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {
 			FillNewGRFVehicleCache(u);
 			if (grf_cache[length] != u->grf_cache) {
-				Debug(desync, Severity::Warning, "warning: newgrf cache mismatch: type {}, vehicle {}, company {}, unit number {}, wagon {}", v->type, v->index, v->owner, v->unitnumber, length);
+				Debug(Facility::Desync, Severity::Warning, "warning: newgrf cache mismatch: type {}, vehicle {}, company {}, unit number {}, wagon {}", v->type, v->index, v->owner, v->unitnumber, length);
 			}
 			if (veh_cache[length] != u->vcache) {
-				Debug(desync, Severity::Warning, "warning: vehicle cache mismatch: type {}, vehicle {}, company {}, unit number {}, wagon {}", v->type, v->index, v->owner, v->unitnumber, length);
+				Debug(Facility::Desync, Severity::Warning, "warning: vehicle cache mismatch: type {}, vehicle {}, company {}, unit number {}, wagon {}", v->type, v->index, v->owner, v->unitnumber, length);
 			}
 			switch (u->type) {
 				case VehicleType::Train:
 					if (gro_cache[length] != Train::From(u)->gcache) {
-						Debug(desync, Severity::Warning, "warning: train ground vehicle cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
+						Debug(Facility::Desync, Severity::Warning, "warning: train ground vehicle cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
 					}
 					if (tra_cache[length] != Train::From(u)->tcache) {
-						Debug(desync, Severity::Warning, "warning: train cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
+						Debug(Facility::Desync, Severity::Warning, "warning: train cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
 					}
 					break;
 				case VehicleType::Road:
 					if (gro_cache[length] != RoadVehicle::From(u)->gcache) {
-						Debug(desync, Severity::Warning, "warning: road vehicle ground vehicle cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
+						Debug(Facility::Desync, Severity::Warning, "warning: road vehicle ground vehicle cache mismatch: vehicle {}, company {}, unit number {}, wagon {}", v->index, v->owner, v->unitnumber, length);
 					}
 					break;
 				default:
@@ -188,11 +188,11 @@ void CheckCaches()
 		}
 		UpdateStationDockingTiles(st);
 		if (ta.tile != st->docking_station.tile || ta.w != st->docking_station.w || ta.h != st->docking_station.h) {
-			Debug(desync, Severity::Warning, "warning: station docking mismatch: station {}, company {}", st->index, st->owner);
+			Debug(Facility::Desync, Severity::Warning, "warning: station docking mismatch: station {}, company {}", st->index, st->owner);
 		}
 		for (TileIndex tile : ta) {
 			if (docking_tiles[tile] != IsDockingTile(tile)) {
-				Debug(desync, Severity::Warning, "warning: docking tile mismatch: tile {}", tile);
+				Debug(Facility::Desync, Severity::Warning, "warning: docking tile mismatch: tile {}", tile);
 			}
 		}
 	}
@@ -203,7 +203,7 @@ void CheckCaches()
 	i = 0;
 	for (Station *st : Station::Iterate()) {
 		if (st->industries_near != old_station_industries_near[i]) {
-			Debug(desync, Severity::Warning, "warning: station industries near mismatch: station {}", st->index);
+			Debug(Facility::Desync, Severity::Warning, "warning: station industries near mismatch: station {}", st->index);
 		}
 		i++;
 	}
@@ -212,14 +212,14 @@ void CheckCaches()
 	i = 0;
 	for (Town *t : Town::Iterate()) {
 		if (t->stations_near != old_town_stations_near[i]) {
-			Debug(desync, Severity::Warning, "warning: town stations near mismatch: town {}", t->index);
+			Debug(Facility::Desync, Severity::Warning, "warning: town stations near mismatch: town {}", t->index);
 		}
 		i++;
 	}
 	i = 0;
 	for (Industry *ind : Industry::Iterate()) {
 		if (ind->stations_near != old_industry_stations_near[i]) {
-			Debug(desync, Severity::Warning, "warning: industry stations near mismatch: industry {}", ind->index);
+			Debug(Facility::Desync, Severity::Warning, "warning: industry stations near mismatch: industry {}", ind->index);
 		}
 		i++;
 	}
@@ -230,13 +230,13 @@ void CheckCaches()
 
 		/* Check that the last vehicle is actually last. */
 		if (v->Last()->Next() != nullptr) {
-			Debug(desync, Severity::Warning, "warning: vehicle cache mismatch, last vehicle must not have a next vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
+			Debug(Facility::Desync, Severity::Warning, "warning: vehicle cache mismatch, last vehicle must not have a next vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
 		}
 
 		/* Ensure that all vehicles in the chain have the same last vehicle. */
 		for (Vehicle *u = v; u != nullptr; u = u->Next()) {
 			if (u->Last() != v->Last()) {
-				Debug(desync, Severity::Warning, "warning: vehicle cache mismatch, all vehicles in chain must have same last vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
+				Debug(Facility::Desync, Severity::Warning, "warning: vehicle cache mismatch, all vehicles in chain must have same last vehicle: type {}, vehicle {}, company {}, unit number {}, invalid 'Last()'", v->type, v->index, v->owner, v->unitnumber);
 			}
 		}
 	}

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -259,7 +259,7 @@ void CommandHelperBase::InternalPostResult(CommandCost &res, TileIndex tile, boo
  */
 void CommandHelperBase::LogCommandExecution(Commands cmd, StringID err_message, const CommandDataBuffer &args, bool failed)
 {
-	Debug(desync, 1, "{}: {:08x}; {:02x}; {:02x}; {:08x}; {:08x}; {} ({})", failed ? "cmdf" : "cmd", (uint32_t)TimerGameEconomy::date.base(), TimerGameEconomy::date_fract, _current_company, cmd, err_message, FormatArrayAsHex(args), GetCommandName(cmd));
+	Debug(desync, Severity::Error, "{}: {:08x}; {:02x}; {:02x}; {:08x}; {:08x}; {} ({})", failed ? "cmdf" : "cmd", (uint32_t)TimerGameEconomy::date.base(), TimerGameEconomy::date_fract, _current_company, cmd, err_message, FormatArrayAsHex(args), GetCommandName(cmd));
 }
 
 /**
@@ -324,7 +324,7 @@ std::tuple<bool, bool, bool> CommandHelperBase::InternalExecuteValidateTestAndPr
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_COMMAND);
 	}
 
-	return { false, _debug_desync_level >= 1, send_net };
+	return { false, _debug_desync_level >= Severity::Error, send_net };
 }
 
 /**

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -259,7 +259,7 @@ void CommandHelperBase::InternalPostResult(CommandCost &res, TileIndex tile, boo
  */
 void CommandHelperBase::LogCommandExecution(Commands cmd, StringID err_message, const CommandDataBuffer &args, bool failed)
 {
-	Debug(desync, Severity::Error, "{}: {:08x}; {:02x}; {:02x}; {:08x}; {:08x}; {} ({})", failed ? "cmdf" : "cmd", (uint32_t)TimerGameEconomy::date.base(), TimerGameEconomy::date_fract, _current_company, cmd, err_message, FormatArrayAsHex(args), GetCommandName(cmd));
+	Debug(Facility::Desync, Severity::Error, "{}: {:08x}; {:02x}; {:02x}; {:08x}; {:08x}; {} ({})", failed ? "cmdf" : "cmd", (uint32_t)TimerGameEconomy::date.base(), TimerGameEconomy::date_fract, _current_company, cmd, err_message, FormatArrayAsHex(args), GetCommandName(cmd));
 }
 
 /**
@@ -324,7 +324,7 @@ std::tuple<bool, bool, bool> CommandHelperBase::InternalExecuteValidateTestAndPr
 		BasePersistentStorageArray::SwitchMode(PSM_ENTER_COMMAND);
 	}
 
-	return { false, _debug_desync_level >= Severity::Error, send_net };
+	return { false, IsVisibleSeverity(Facility::Desync, Severity::Error), send_net };
 }
 
 /**

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -184,7 +184,7 @@ static std::string RemoveUnderscores(std::string name)
  */
 static void IConsoleAliasExec(const IConsoleAlias *alias, std::span<std::string> tokens, uint recurse_count)
 {
-	Debug(console, 6, "Requested command is an alias; parsing...");
+	Debug(console, Severity::Debug2, "Requested command is an alias; parsing...");
 
 	if (recurse_count > ICON_MAX_RECURSE) {
 		IConsolePrint(CC_ERROR, "Too many alias expansions, recursion limit reached.");
@@ -272,7 +272,7 @@ void IConsoleCmdExec(std::string_view command_string, const uint recurse_count)
 {
 	if (command_string[0] == '#') return; // comments
 
-	Debug(console, 4, "Executing cmdline: '{}'", command_string);
+	Debug(console, Severity::Info, "Executing cmdline: '{}'", command_string);
 
 	std::string buffer;
 	StringBuilder builder{buffer};
@@ -331,7 +331,7 @@ void IConsoleCmdExec(std::string_view command_string, const uint recurse_count)
 	}
 
 	for (size_t i = 0; i < tokens.size(); i++) {
-		Debug(console, 8, "Token {} is: '{}'", i, tokens[i]);
+		Debug(console, Severity::Trace2, "Token {} is: '{}'", i, tokens[i]);
 	}
 
 	if (tokens.empty() || tokens[0].empty()) return; // don't execute empty commands

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -184,7 +184,7 @@ static std::string RemoveUnderscores(std::string name)
  */
 static void IConsoleAliasExec(const IConsoleAlias *alias, std::span<std::string> tokens, uint recurse_count)
 {
-	Debug(console, Severity::Debug2, "Requested command is an alias; parsing...");
+	Debug(Facility::Console, Severity::Debug2, "Requested command is an alias; parsing...");
 
 	if (recurse_count > ICON_MAX_RECURSE) {
 		IConsolePrint(CC_ERROR, "Too many alias expansions, recursion limit reached.");
@@ -272,7 +272,7 @@ void IConsoleCmdExec(std::string_view command_string, const uint recurse_count)
 {
 	if (command_string[0] == '#') return; // comments
 
-	Debug(console, Severity::Info, "Executing cmdline: '{}'", command_string);
+	Debug(Facility::Console, Severity::Info, "Executing cmdline: '{}'", command_string);
 
 	std::string buffer;
 	StringBuilder builder{buffer};
@@ -331,7 +331,7 @@ void IConsoleCmdExec(std::string_view command_string, const uint recurse_count)
 	}
 
 	for (size_t i = 0; i < tokens.size(); i++) {
-		Debug(console, Severity::Trace2, "Token {} is: '{}'", i, tokens[i]);
+		Debug(Facility::Console, Severity::Trace2, "Token {} is: '{}'", i, tokens[i]);
 	}
 
 	if (tokens.empty() || tokens[0].empty()) return; // don't execute empty commands

--- a/src/core/backup_type.hpp
+++ b/src/core/backup_type.hpp
@@ -48,7 +48,7 @@ struct Backup {
 		if (this->valid) {
 			/* We cannot assert here, as missing restoration is 'normal' when exceptions are thrown.
 			 * Exceptions are especially used to abort world generation. */
-			Debug(misc, Severity::Critical, "{}:{}: Backed-up value was not restored!", this->location.file_name(), this->location.line());
+			Debug(Facility::Misc, Severity::Critical, "{}:{}: Backed-up value was not restored!", this->location.file_name(), this->location.line());
 			this->Restore();
 		}
 	}

--- a/src/core/backup_type.hpp
+++ b/src/core/backup_type.hpp
@@ -48,7 +48,7 @@ struct Backup {
 		if (this->valid) {
 			/* We cannot assert here, as missing restoration is 'normal' when exceptions are thrown.
 			 * Exceptions are especially used to abort world generation. */
-			Debug(misc, 0, "{}:{}: Backed-up value was not restored!", this->location.file_name(), this->location.line());
+			Debug(misc, Severity::Critical, "{}:{}: Backed-up value was not restored!", this->location.file_name(), this->location.line());
 			this->Restore();
 		}
 	}

--- a/src/core/random_func.cpp
+++ b/src/core/random_func.cpp
@@ -72,7 +72,7 @@ void SetRandomSeed(uint32_t seed)
 uint32_t Random(const std::source_location location)
 {
 	if (_networking && (!_network_server || (NetworkClientSocket::IsValidID(0) && NetworkClientSocket::Get(0)->status != NetworkClientSocket::ClientStatus::Inactive))) {
-		Debug(random, 0, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, _current_company, location.file_name(), location.line());
+		Debug(random, Severity::Critical, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, _current_company, location.file_name(), location.line());
 	}
 
 	return _random.Next();
@@ -121,7 +121,7 @@ void RandomBytesWithFallback(std::span<uint8_t> buf)
 #endif
 
 	static bool warned_once = false;
-	Debug(misc, warned_once ? 1 : 0, "Cryptographically-strong random generator unavailable; using fallback");
+	Debug(misc, warned_once ? Severity::Error : Severity::Critical, "Cryptographically-strong random generator unavailable; using fallback");
 	warned_once = true;
 
 	for (uint i = 0; i < buf.size(); i++) {

--- a/src/core/random_func.cpp
+++ b/src/core/random_func.cpp
@@ -72,7 +72,7 @@ void SetRandomSeed(uint32_t seed)
 uint32_t Random(const std::source_location location)
 {
 	if (_networking && (!_network_server || (NetworkClientSocket::IsValidID(0) && NetworkClientSocket::Get(0)->status != NetworkClientSocket::ClientStatus::Inactive))) {
-		Debug(random, Severity::Critical, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, _current_company, location.file_name(), location.line());
+		Debug(Facility::Random, Severity::Critical, "{:08x}; {:02x}; {:04x}; {:02x}; {}:{}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _frame_counter, _current_company, location.file_name(), location.line());
 	}
 
 	return _random.Next();
@@ -121,7 +121,7 @@ void RandomBytesWithFallback(std::span<uint8_t> buf)
 #endif
 
 	static bool warned_once = false;
-	Debug(misc, warned_once ? Severity::Error : Severity::Critical, "Cryptographically-strong random generator unavailable; using fallback");
+	Debug(Facility::Misc, warned_once ? Severity::Error : Severity::Critical, "Cryptographically-strong random generator unavailable; using fallback");
 	warned_once = true;
 
 	for (uint i = 0; i < buf.size(); i++) {

--- a/src/core/random_func.cpp
+++ b/src/core/random_func.cpp
@@ -120,9 +120,9 @@ void RandomBytesWithFallback(std::span<uint8_t> buf)
 #	warning "No cryptographically-strong random generator available; using a fallback instead"
 #endif
 
-	static bool warned_once = false;
-	Debug(Facility::Misc, warned_once ? Severity::Error : Severity::Critical, "Cryptographically-strong random generator unavailable; using fallback");
-	warned_once = true;
+	static Severity severity = Severity::Critical;
+	Debug(Facility::Misc, severity, "Cryptographically-strong random generator unavailable; using fallback");
+	severity = Severity::Error;
 
 	for (uint i = 0; i < buf.size(); i++) {
 		buf[i] = static_cast<uint8_t>(InteractiveRandom());

--- a/src/core/string_consumer.cpp
+++ b/src/core/string_consumer.cpp
@@ -35,7 +35,7 @@
 #if defined(STRGEN) || defined(SETTINGSGEN)
 	FatalErrorI(std::move(msg));
 #else
-	DebugPrint("misc", 0, std::move(msg));
+	DebugPrint("misc", Severity::Critical, std::move(msg));
 #endif
 }
 

--- a/src/core/string_consumer.cpp
+++ b/src/core/string_consumer.cpp
@@ -35,7 +35,7 @@
 #if defined(STRGEN) || defined(SETTINGSGEN)
 	FatalErrorI(std::move(msg));
 #else
-	DebugPrint("misc", Severity::Critical, std::move(msg));
+	DebugPrint(Facility::Misc, Severity::Critical, std::move(msg));
 #endif
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -28,7 +28,7 @@
 
 /** Element in the queue of debug messages that have to be passed to either NetworkAdminConsole or IConsolePrint.*/
 struct QueuedDebugItem {
-	std::string_view level;   ///< The used debug level.
+	Facility facility; ///< The facility of the message.
 	std::string message; ///< The actual formatted message.
 };
 std::atomic<bool> _debug_remote_console; ///< Whether we need to send data to either NetworkAdminConsole or IConsolePrint.
@@ -36,50 +36,27 @@ std::mutex _debug_remote_console_mutex; ///< Mutex to guard the queue of debug m
 std::vector<QueuedDebugItem> _debug_remote_console_queue; ///< Queue for debug messages to be passed to NetworkAdminConsole or IConsolePrint.
 std::vector<QueuedDebugItem> _debug_remote_console_queue_spare; ///< Spare queue to swap with _debug_remote_console_queue.
 
-Severity _debug_driver_level;
-Severity _debug_grf_level;
-Severity _debug_map_level;
-Severity _debug_misc_level;
-Severity _debug_net_level;
-Severity _debug_sprite_level;
-Severity _debug_oldloader_level;
-Severity _debug_yapf_level;
-Severity _debug_fontcache_level;
-Severity _debug_script_level;
-Severity _debug_sl_level;
-Severity _debug_gamelog_level;
-Severity _debug_desync_level;
-Severity _debug_console_level;
-#ifdef RANDOM_DEBUG
-Severity _debug_random_level;
-#endif
+/** Severity level for each debug facility. */
+EnumIndexArray<Severity, Facility, Facility::End> _debug_level;
 
-struct DebugLevel {
-	std::string_view name;
-	Severity &level;
+/** Name for each debug facility. */
+static EnumIndexArray<std::string_view, Facility, Facility::End> _debug_facilities = {
+	"driver", // Facility::Driver
+	"grf", // Facility::Grf
+	"map", // Facility::Map
+	"misc", // Facility::Misc
+	"net", // Facility::Net
+	"sprite", // Facility::Sprite
+	"oldloader", // Facility::Oldloader
+	"yapf", // Facility::Yapf
+	"fontcache", // Facility::Fontcache
+	"script", // Facility::Script
+	"sl", // Facility::Sl
+	"gamelog", // Facility::Gamelog
+	"desync", // Facility::Desync
+	"console", // Facility::Console
+	"random", // Facility::Random
 };
-
-#define DEBUG_LEVEL(x) { #x, _debug_##x##_level }
-static const std::initializer_list<DebugLevel> _debug_levels{
-	DEBUG_LEVEL(driver),
-	DEBUG_LEVEL(grf),
-	DEBUG_LEVEL(map),
-	DEBUG_LEVEL(misc),
-	DEBUG_LEVEL(net),
-	DEBUG_LEVEL(sprite),
-	DEBUG_LEVEL(oldloader),
-	DEBUG_LEVEL(yapf),
-	DEBUG_LEVEL(fontcache),
-	DEBUG_LEVEL(script),
-	DEBUG_LEVEL(sl),
-	DEBUG_LEVEL(gamelog),
-	DEBUG_LEVEL(desync),
-	DEBUG_LEVEL(console),
-#ifdef RANDOM_DEBUG
-	DEBUG_LEVEL(random),
-#endif
-};
-#undef DEBUG_LEVEL
 
 /**
  * Dump the available debug facility names in the help text.
@@ -88,13 +65,13 @@ static const std::initializer_list<DebugLevel> _debug_levels{
 void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_iterator)
 {
 	bool written = false;
-	for (const auto &debug_level : _debug_levels) {
+	for (Facility facility : EnumRange(Facility::End)) {
 		if (!written) {
 			fmt::format_to(output_iterator, "List of debug facility names:\n");
 		} else {
 			fmt::format_to(output_iterator, ", ");
 		}
-		fmt::format_to(output_iterator, "{}", debug_level.name);
+		fmt::format_to(output_iterator, "{}", _debug_facilities[facility]);
 		written = true;
 	}
 	if (written) {
@@ -104,20 +81,20 @@ void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_itera
 
 /**
  * Internal function for outputting the debug line.
- * @param category The category/classification of the debug message.
+ * @param facility The facility category/classification of the debug message.
  * @param severity The severity of the debug level; lower is more likely to be shown.
  * @param message The message to output.
  */
-void DebugPrint(std::string_view category, Severity severity, std::string &&message)
+void DebugPrint(Facility facility, Severity severity, std::string &&message)
 {
-	if (category == "desync" && severity != Severity::Critical) {
+	if (facility == Facility::Desync && severity != Severity::Critical) {
 		static auto f = FioFOpenFile("commands-out.log", "wb", Subdirectory::Autosave);
 		if (!f.has_value()) return;
 
 		fmt::print(*f, "{}{}\n", GetLogPrefix(true), message);
 		fflush(*f);
 #ifdef RANDOM_DEBUG
-	} else if (category == "random") {
+	} else if (facility == Facility::Random) {
 		static auto f = FioFOpenFile("random-out.log", "wb", Subdirectory::Autosave);
 		if (!f.has_value()) return;
 
@@ -125,12 +102,12 @@ void DebugPrint(std::string_view category, Severity severity, std::string &&mess
 		fflush(*f);
 #endif
 	} else {
-		fmt::print(stderr, "{}dbg: [{}:{}] {}\n", GetLogPrefix(true), category, severity, message);
+		fmt::print(stderr, "{}dbg: [{}:{}] {}\n", GetLogPrefix(true), _debug_facilities[facility], severity, message);
 
 		if (_debug_remote_console.load()) {
 			/* Only add to the queue when there is at least one consumer of the data. */
 			std::lock_guard<std::mutex> lock(_debug_remote_console_mutex);
-			_debug_remote_console_queue.emplace_back(category, std::move(message));
+			_debug_remote_console_queue.emplace_back(facility, std::move(message));
 		}
 	}
 }
@@ -146,15 +123,13 @@ void SetDebugString(std::string_view s, SetDebugStringErrorFunc error_func)
 {
 	StringConsumer consumer{s};
 
-	/* Store planned changes into map during parse */
-	std::map<std::string_view, Severity> new_levels;
+	/* Store planned changes into a temporary array during parse */
+	auto new_debug_level = _debug_level;
 
 	/* Global debugging level? */
 	auto level = consumer.TryReadIntegerBase<int>(10);
 	if (level.has_value()) {
-		for (const auto &debug_level : _debug_levels) {
-			new_levels[debug_level.name] = static_cast<Severity>(*level);
-		}
+		new_debug_level.fill(static_cast<Severity>(*level));
 	}
 
 	static const std::string_view lowercase_letters{"abcdefghijklmnopqrstuvwxyz"};
@@ -167,8 +142,8 @@ void SetDebugString(std::string_view s, SetDebugStringErrorFunc error_func)
 
 		/* Find the level by name. */
 		std::string_view key = consumer.ReadUntilCharNotIn(lowercase_letters);
-		auto it = std::ranges::find(_debug_levels, key, &DebugLevel::name);
-		if (it == std::end(_debug_levels)) {
+		auto it = std::ranges::find(_debug_facilities, key);
+		if (it == std::end(_debug_facilities)) {
 			error_func(fmt::format("Unknown debug level '{}'", key));
 			return;
 		}
@@ -182,16 +157,11 @@ void SetDebugString(std::string_view s, SetDebugStringErrorFunc error_func)
 			return;
 		}
 
-		new_levels[it->name] = static_cast<Severity>(*level);
+		new_debug_level[static_cast<Facility>(std::distance(_debug_facilities.begin(), it))] = static_cast<Severity>(*level);
 	}
 
 	/* Apply the changes after parse is successful */
-	for (const auto &debug_level : _debug_levels) {
-		const auto &nl = new_levels.find(debug_level.name);
-		if (nl != new_levels.end()) {
-			debug_level.level = nl->second;
-		}
-	}
+	_debug_level = new_debug_level;
 }
 
 /**
@@ -202,9 +172,9 @@ void SetDebugString(std::string_view s, SetDebugStringErrorFunc error_func)
 std::string GetDebugString()
 {
 	std::string result;
-	for (const auto &debug_level : _debug_levels) {
+	for (Facility facility : EnumRange(Facility::End)) {
 		if (!result.empty()) result += ", ";
-		format_append(result, "{}={}", debug_level.name, debug_level.level);
+		format_append(result, "{}={}", _debug_facilities[facility], _debug_level[facility]);
 	}
 	return result;
 }
@@ -244,8 +214,8 @@ void DebugSendRemoteMessages()
 	}
 
 	for (auto &item : _debug_remote_console_queue_spare) {
-		NetworkAdminConsole(item.level, item.message);
-		if (_settings_client.gui.developer >= 2) IConsolePrint(CC_DEBUG, "dbg: [{}] {}", item.level, item.message);
+		NetworkAdminConsole(_debug_facilities[item.facility], item.message);
+		if (_settings_client.gui.developer >= 2) IConsolePrint(CC_DEBUG, "dbg: [{}] {}", _debug_facilities[item.facility], item.message);
 	}
 
 	_debug_remote_console_queue_spare.clear();

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -36,30 +36,30 @@ std::mutex _debug_remote_console_mutex; ///< Mutex to guard the queue of debug m
 std::vector<QueuedDebugItem> _debug_remote_console_queue; ///< Queue for debug messages to be passed to NetworkAdminConsole or IConsolePrint.
 std::vector<QueuedDebugItem> _debug_remote_console_queue_spare; ///< Spare queue to swap with _debug_remote_console_queue.
 
-int _debug_driver_level;
-int _debug_grf_level;
-int _debug_map_level;
-int _debug_misc_level;
-int _debug_net_level;
-int _debug_sprite_level;
-int _debug_oldloader_level;
-int _debug_yapf_level;
-int _debug_fontcache_level;
-int _debug_script_level;
-int _debug_sl_level;
-int _debug_gamelog_level;
-int _debug_desync_level;
-int _debug_console_level;
+Severity _debug_driver_level;
+Severity _debug_grf_level;
+Severity _debug_map_level;
+Severity _debug_misc_level;
+Severity _debug_net_level;
+Severity _debug_sprite_level;
+Severity _debug_oldloader_level;
+Severity _debug_yapf_level;
+Severity _debug_fontcache_level;
+Severity _debug_script_level;
+Severity _debug_sl_level;
+Severity _debug_gamelog_level;
+Severity _debug_desync_level;
+Severity _debug_console_level;
 #ifdef RANDOM_DEBUG
-int _debug_random_level;
+Severity _debug_random_level;
 #endif
 
 struct DebugLevel {
 	std::string_view name;
-	int *level;
+	Severity &level;
 };
 
-#define DEBUG_LEVEL(x) { #x, &_debug_##x##_level }
+#define DEBUG_LEVEL(x) { #x, _debug_##x##_level }
 static const std::initializer_list<DebugLevel> _debug_levels{
 	DEBUG_LEVEL(driver),
 	DEBUG_LEVEL(grf),
@@ -105,12 +105,12 @@ void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_itera
 /**
  * Internal function for outputting the debug line.
  * @param category The category/classification of the debug message.
- * @param level The severity of the debug level; lower is more likely to be shown.
+ * @param severity The severity of the debug level; lower is more likely to be shown.
  * @param message The message to output.
  */
-void DebugPrint(std::string_view category, int level, std::string &&message)
+void DebugPrint(std::string_view category, Severity severity, std::string &&message)
 {
-	if (category == "desync" && level != 0) {
+	if (category == "desync" && severity != Severity::Critical) {
 		static auto f = FioFOpenFile("commands-out.log", "wb", Subdirectory::Autosave);
 		if (!f.has_value()) return;
 
@@ -125,7 +125,7 @@ void DebugPrint(std::string_view category, int level, std::string &&message)
 		fflush(*f);
 #endif
 	} else {
-		fmt::print(stderr, "{}dbg: [{}:{}] {}\n", GetLogPrefix(true), category, level, message);
+		fmt::print(stderr, "{}dbg: [{}:{}] {}\n", GetLogPrefix(true), category, severity, message);
 
 		if (_debug_remote_console.load()) {
 			/* Only add to the queue when there is at least one consumer of the data. */
@@ -147,13 +147,13 @@ void SetDebugString(std::string_view s, SetDebugStringErrorFunc error_func)
 	StringConsumer consumer{s};
 
 	/* Store planned changes into map during parse */
-	std::map<std::string_view, int> new_levels;
+	std::map<std::string_view, Severity> new_levels;
 
 	/* Global debugging level? */
 	auto level = consumer.TryReadIntegerBase<int>(10);
 	if (level.has_value()) {
 		for (const auto &debug_level : _debug_levels) {
-			new_levels[debug_level.name] = *level;
+			new_levels[debug_level.name] = static_cast<Severity>(*level);
 		}
 	}
 
@@ -182,14 +182,14 @@ void SetDebugString(std::string_view s, SetDebugStringErrorFunc error_func)
 			return;
 		}
 
-		new_levels[it->name] = *level;
+		new_levels[it->name] = static_cast<Severity>(*level);
 	}
 
 	/* Apply the changes after parse is successful */
 	for (const auto &debug_level : _debug_levels) {
 		const auto &nl = new_levels.find(debug_level.name);
 		if (nl != new_levels.end()) {
-			*debug_level.level = nl->second;
+			debug_level.level = nl->second;
 		}
 	}
 }
@@ -204,7 +204,7 @@ std::string GetDebugString()
 	std::string result;
 	for (const auto &debug_level : _debug_levels) {
 		if (!result.empty()) result += ", ";
-		format_append(result, "{}={}", debug_level.name, *debug_level.level);
+		format_append(result, "{}={}", debug_level.name, debug_level.level);
 	}
 	return result;
 }

--- a/src/debug.h
+++ b/src/debug.h
@@ -12,47 +12,34 @@
 
 #include "cpu.h"
 #include <chrono>
+#include "debug_type.h"
 #include "core/format.hpp"
-
-/* Debugging messages policy:
- * These should be the severities used for direct Debug() calls
- * maximum debugging level should be 10 if really deep, deep
- * debugging is needed.
- * (there is room for exceptions, but you have to have a good cause):
- * 0   - errors or severe warnings
- * 1   - other non-fatal, non-severe warnings
- * 2   - crude progress indicator of functionality
- * 3   - important debugging messages (function entry)
- * 4   - debugging messages (crude loop status, etc.)
- * 5   - detailed debugging information
- * 6.. - extremely detailed spamming
- */
 
 /**
  * Output a line of debugging information.
  * @param category The category of debug information.
- * @param level The maximum debug level this message should be shown at. When the debug level for this category is set lower, then the message will not be shown.
+ * @param severity The maximum debug level this message should be shown at. When the debug level for this category is set lower, then the message will not be shown.
  * @param format_string The formatting string of the message.
  */
-#define Debug(category, level, format_string, ...) do { if ((level) == 0 || _debug_ ## category ## _level >= (level)) DebugPrint(#category, level, fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__)); } while (false)
-void DebugPrint(std::string_view category, int level, std::string &&message);
+#define Debug(category, severity, format_string, ...) do { if ((severity) == Severity::Critical || _debug_ ## category ## _level >= (severity)) DebugPrint(#category, severity, fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__)); } while (false)
+void DebugPrint(std::string_view category, Severity severity, std::string &&message);
 
-extern int _debug_driver_level;
-extern int _debug_grf_level;
-extern int _debug_map_level;
-extern int _debug_misc_level;
-extern int _debug_net_level;
-extern int _debug_sprite_level;
-extern int _debug_oldloader_level;
-extern int _debug_yapf_level;
-extern int _debug_fontcache_level;
-extern int _debug_script_level;
-extern int _debug_sl_level;
-extern int _debug_gamelog_level;
-extern int _debug_desync_level;
-extern int _debug_console_level;
+extern Severity _debug_driver_level;
+extern Severity _debug_grf_level;
+extern Severity _debug_map_level;
+extern Severity _debug_misc_level;
+extern Severity _debug_net_level;
+extern Severity _debug_sprite_level;
+extern Severity _debug_oldloader_level;
+extern Severity _debug_yapf_level;
+extern Severity _debug_fontcache_level;
+extern Severity _debug_script_level;
+extern Severity _debug_sl_level;
+extern Severity _debug_gamelog_level;
+extern Severity _debug_desync_level;
+extern Severity _debug_console_level;
 #ifdef RANDOM_DEBUG
-extern int _debug_random_level;
+extern Severity _debug_random_level;
 #endif
 
 void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_iterator);
@@ -101,7 +88,7 @@ struct TicToc {
 
 		void OutputAndReset(const std::string_view prefix = "")
 		{
-			Debug(misc, 0, "[{}] [{}] {} calls in {} us [avg: {:.1f} us]", prefix, this->name, this->count, this->chrono_sum, this->chrono_sum / static_cast<double>(this->count));
+			Debug(misc, Severity::Critical, "[{}] [{}] {} calls in {} us [avg: {:.1f} us]", prefix, this->name, this->count, this->chrono_sum, this->chrono_sum / static_cast<double>(this->count));
 			this->count = 0;
 			this->chrono_sum = 0;
 		}

--- a/src/debug.h
+++ b/src/debug.h
@@ -13,34 +13,29 @@
 #include "cpu.h"
 #include <chrono>
 #include "debug_type.h"
+#include "core/enum_type.hpp"
 #include "core/format.hpp"
 
 /**
+ * Test if debug severity is visible for the given facility.
+ * @param facility The debug facility.
+ * @param severity The debug severity.
+ * @return \c true iff the debug severity level for the facility is visible.
+ */
+inline bool IsVisibleSeverity(Facility facility, Severity severity)
+{
+	extern EnumIndexArray<Severity, Facility, Facility::End> _debug_level;
+	return _debug_level[facility] >= severity;
+}
+
+/**
  * Output a line of debugging information.
- * @param category The category of debug information.
+ * @param facility The debug facility.
  * @param severity The maximum debug level this message should be shown at. When the debug level for this category is set lower, then the message will not be shown.
  * @param format_string The formatting string of the message.
  */
-#define Debug(category, severity, format_string, ...) do { if ((severity) == Severity::Critical || _debug_ ## category ## _level >= (severity)) DebugPrint(#category, severity, fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__)); } while (false)
-void DebugPrint(std::string_view category, Severity severity, std::string &&message);
-
-extern Severity _debug_driver_level;
-extern Severity _debug_grf_level;
-extern Severity _debug_map_level;
-extern Severity _debug_misc_level;
-extern Severity _debug_net_level;
-extern Severity _debug_sprite_level;
-extern Severity _debug_oldloader_level;
-extern Severity _debug_yapf_level;
-extern Severity _debug_fontcache_level;
-extern Severity _debug_script_level;
-extern Severity _debug_sl_level;
-extern Severity _debug_gamelog_level;
-extern Severity _debug_desync_level;
-extern Severity _debug_console_level;
-#ifdef RANDOM_DEBUG
-extern Severity _debug_random_level;
-#endif
+#define Debug(facility, severity, format_string, ...) do { if ((severity) == Severity::Critical || IsVisibleSeverity((facility), (severity))) DebugPrint(facility, severity, fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__)); } while (false)
+void DebugPrint(Facility facility, Severity severity, std::string &&message);
 
 void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_iterator);
 using SetDebugStringErrorFunc = void(std::string_view);
@@ -88,7 +83,7 @@ struct TicToc {
 
 		void OutputAndReset(const std::string_view prefix = "")
 		{
-			Debug(misc, Severity::Critical, "[{}] [{}] {} calls in {} us [avg: {:.1f} us]", prefix, this->name, this->count, this->chrono_sum, this->chrono_sum / static_cast<double>(this->count));
+			Debug(Facility::Misc, Severity::Critical, "[{}] [{}] {} calls in {} us [avg: {:.1f} us]", prefix, this->name, this->count, this->chrono_sum, this->chrono_sum / static_cast<double>(this->count));
 			this->count = 0;
 			this->chrono_sum = 0;
 		}

--- a/src/debug_type.h
+++ b/src/debug_type.h
@@ -24,4 +24,24 @@ enum class Severity : uint8_t {
 	Trace3, ///< Trace information #3.
 };
 
+/** Debug facilities. */
+enum class Facility : uint8_t {
+	Driver, ///< Driver message facility.
+	Grf, ///< Grf message facility.
+	Map, ///< Map message facility.
+	Misc, ///< Misc message facility.
+	Net, ///< Net message facility.
+	Sprite, ///< Sprite message facility.
+	Oldloader, ///< Oldloader message facility.
+	Yapf, ///< Yapf message facility.
+	Fontcache, ///< Fontcache message facility.
+	Script, ///< Script message facility.
+	Sl, ///< Saveload message facility.
+	Gamelog, ///< Gamelog message facility.
+	Desync, ///< Desync message facility.
+	Console, ///< Console message facility.
+	Random, ///< Random message facility.
+	End, ///< End marker.
+};
+
 #endif /* DEBUG_TYPE_H */

--- a/src/debug_type.h
+++ b/src/debug_type.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0>.
+ */
+
+/** @file debug_type.h Types related to debugging. */
+
+#ifndef DEBUG_TYPE_H
+#define DEBUG_TYPE_H
+
+/** Debug message severity levels. */
+enum class Severity : uint8_t {
+	Critical, ///< Critical, user should know about this.
+	Error, ///< Error, but we are recovering.
+	Warning, ///< Warning, wrong but okay if you don't know.
+	Notice, ///< Notice.
+	Info, ///< Info, information you might care about.
+	Debug1, ///< Debug #1 - High level debug messages.
+	Debug2, ///< Debug #2 - Low level debug messages.
+	Trace1, ///< Trace information #1.
+	Trace2, ///< Trace information #2.
+	Trace3, ///< Trace information #3.
+};
+
+#endif /* DEBUG_TYPE_H */

--- a/src/dedicated.cpp
+++ b/src/dedicated.cpp
@@ -50,8 +50,8 @@ void DedicatedFork()
 
 		default:
 			/* We're the parent */
-			Debug(net, 0, "Loading dedicated server...");
-			Debug(net, 0, "  - Forked to background with pid {}", pid);
+			Debug(net, Severity::Critical, "Loading dedicated server...");
+			Debug(net, Severity::Critical, "  - Forked to background with pid {}", pid);
 			exit(0);
 	}
 }

--- a/src/dedicated.cpp
+++ b/src/dedicated.cpp
@@ -50,8 +50,8 @@ void DedicatedFork()
 
 		default:
 			/* We're the parent */
-			Debug(net, Severity::Critical, "Loading dedicated server...");
-			Debug(net, Severity::Critical, "  - Forked to background with pid {}", pid);
+			Debug(Facility::Net, Severity::Critical, "Loading dedicated server...");
+			Debug(Facility::Net, Severity::Critical, "  - Forked to background with pid {}", pid);
 			exit(0);
 	}
 }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -131,7 +131,7 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 					if (!filename.empty()) {
 						FioRemove(filename);
 
-						Debug(driver, Severity::Error, "Probing {} driver '{}' skipped due to earlier crash", GetDriverTypeName(type), d->name);
+						Debug(Facility::Driver, Severity::Error, "Probing {} driver '{}' skipped due to earlier crash", GetDriverTypeName(type), d->name);
 
 						_video_hw_accel = false;
 						ErrorMessageData msg(GetEncodedString(STR_VIDEO_DRIVER_ERROR), GetEncodedString(STR_VIDEO_DRIVER_ERROR_HARDWARE_ACCELERATION_CRASH), true);
@@ -149,13 +149,13 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 
 				auto err = newd->Start({});
 				if (!err) {
-					Debug(driver, Severity::Error, "Successfully probed {} driver '{}'", GetDriverTypeName(type), d->name);
+					Debug(Facility::Driver, Severity::Error, "Successfully probed {} driver '{}'", GetDriverTypeName(type), d->name);
 					GetActiveDriver(type) = std::move(newd);
 					return true;
 				}
 
 				GetActiveDriver(type) = std::move(oldd);
-				Debug(driver, Severity::Error, "Probing {} driver '{}' failed with error: {}", GetDriverTypeName(type), d->name, *err);
+				Debug(Facility::Driver, Severity::Error, "Probing {} driver '{}' failed with error: {}", GetDriverTypeName(type), d->name, *err);
 
 				if (type == Driver::Type::Video && _video_hw_accel && d->UsesHardwareAcceleration()) {
 					_video_hw_accel = false;
@@ -194,7 +194,7 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 				UserError("Unable to load driver '{}'. The error was: {}", d->name, *err);
 			}
 
-			Debug(driver, Severity::Error, "Successfully loaded {} driver '{}'", GetDriverTypeName(type), d->name);
+			Debug(Facility::Driver, Severity::Error, "Successfully loaded {} driver '{}'", GetDriverTypeName(type), d->name);
 			GetActiveDriver(type) = std::move(newd);
 			return true;
 		}

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -131,7 +131,7 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 					if (!filename.empty()) {
 						FioRemove(filename);
 
-						Debug(driver, 1, "Probing {} driver '{}' skipped due to earlier crash", GetDriverTypeName(type), d->name);
+						Debug(driver, Severity::Error, "Probing {} driver '{}' skipped due to earlier crash", GetDriverTypeName(type), d->name);
 
 						_video_hw_accel = false;
 						ErrorMessageData msg(GetEncodedString(STR_VIDEO_DRIVER_ERROR), GetEncodedString(STR_VIDEO_DRIVER_ERROR_HARDWARE_ACCELERATION_CRASH), true);
@@ -149,13 +149,13 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 
 				auto err = newd->Start({});
 				if (!err) {
-					Debug(driver, 1, "Successfully probed {} driver '{}'", GetDriverTypeName(type), d->name);
+					Debug(driver, Severity::Error, "Successfully probed {} driver '{}'", GetDriverTypeName(type), d->name);
 					GetActiveDriver(type) = std::move(newd);
 					return true;
 				}
 
 				GetActiveDriver(type) = std::move(oldd);
-				Debug(driver, 1, "Probing {} driver '{}' failed with error: {}", GetDriverTypeName(type), d->name, *err);
+				Debug(driver, Severity::Error, "Probing {} driver '{}' failed with error: {}", GetDriverTypeName(type), d->name, *err);
 
 				if (type == Driver::Type::Video && _video_hw_accel && d->UsesHardwareAcceleration()) {
 					_video_hw_accel = false;
@@ -194,7 +194,7 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 				UserError("Unable to load driver '{}'. The error was: {}", d->name, *err);
 			}
 
-			Debug(driver, 1, "Successfully loaded {} driver '{}'", GetDriverTypeName(type), d->name);
+			Debug(driver, Severity::Error, "Successfully loaded {} driver '{}'", GetDriverTypeName(type), d->name);
 			GetActiveDriver(type) = std::move(newd);
 			return true;
 		}

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -337,9 +337,9 @@ bool FioRemove(const std::string &filename)
 	std::error_code error_code;
 	if (!std::filesystem::remove(path, error_code)) {
 		if (error_code) {
-			Debug(misc, 0, "Removing {} failed: {}", filename, error_code.message());
+			Debug(misc, Severity::Critical, "Removing {} failed: {}", filename, error_code.message());
 		} else {
-			Debug(misc, 0, "Removing {} failed: file does not exist", filename);
+			Debug(misc, Severity::Critical, "Removing {} failed: file does not exist", filename);
 		}
 		return false;
 	}
@@ -396,7 +396,7 @@ uint TarScanner::DoScan(Subdirectory sd)
  */
 /* static */ uint TarScanner::DoScan(TarScanner::Modes modes)
 {
-	Debug(misc, 2, "Scanning for tars");
+	Debug(misc, Severity::Warning, "Scanning for tars");
 	TarScanner fs;
 	uint num = 0;
 	if (modes.Test(TarScanner::Mode::Baseset)) {
@@ -417,7 +417,7 @@ uint TarScanner::DoScan(Subdirectory sd)
 		num += fs.DoScan(Subdirectory::Scenario);
 		num += fs.DoScan(Subdirectory::Heightmap);
 	}
-	Debug(misc, 2, "Scan complete, found {} files", num);
+	Debug(misc, Severity::Warning, "Scan complete, found {} files", num);
 	return num;
 }
 
@@ -507,7 +507,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 			/* If we have only zeros in the block, it can be an end-of-file indicator */
 			if (std::all_of(th.name, last_of_th, [](auto c) { return c == 0; })) continue;
 
-			Debug(misc, 0, "The file '{}' isn't a valid tar-file", filename);
+			Debug(misc, Severity::Critical, "The file '{}' isn't a valid tar-file", filename);
 			return false;
 		}
 
@@ -528,7 +528,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 		if (!size.empty()) {
 			auto value = ParseInteger<size_t>(size, 8);
 			if (!value.has_value()) {
-				Debug(misc, 0, "The file '{}' has an invalid size for '{}'", filename, name);
+				Debug(misc, Severity::Critical, "The file '{}' has an invalid size for '{}'", filename, name);
 				fclose(f);
 				return false;
 			}
@@ -549,7 +549,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 				/* Convert to lowercase and our PATHSEPCHAR */
 				SimplifyFileName(name);
 
-				Debug(misc, 6, "Found file in tar: {} ({} bytes, {} offset)", name, skip, pos);
+				Debug(misc, Severity::Debug2, "Found file in tar: {} ({} bytes, {} offset)", name, skip, pos);
 				if (_tar_filelist[this->subdir].insert(TarFileList::value_type(filename_base + PATHSEPCHAR + name, entry)).second) num++;
 
 				break;
@@ -559,7 +559,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 			case '2': { // symbolic links
 				std::string link = ExtractString(th.linkname);
 
-				Debug(misc, 5, "Ignoring link in tar: {} -> {}", name, link);
+				Debug(misc, Severity::Debug1, "Ignoring link in tar: {} -> {}", name, link);
 				break;
 			}
 
@@ -568,7 +568,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 				SimplifyFileName(name);
 
 				/* Store the first directory name we detect */
-				Debug(misc, 6, "Found dir in tar: {}", name);
+				Debug(misc, Severity::Debug2, "Found dir in tar: {}", name);
 				if (_tar_list[this->subdir][filename].empty()) _tar_list[this->subdir][filename] = std::move(name);
 				break;
 
@@ -580,13 +580,13 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 		/* Skip to the next block.. */
 		skip = Align(skip, 512);
 		if (fseek(f, skip, SEEK_CUR) < 0) {
-			Debug(misc, 0, "The file '{}' can't be read as a valid tar-file", filename);
+			Debug(misc, Severity::Critical, "The file '{}' can't be read as a valid tar-file", filename);
 			return false;
 		}
 		pos += skip;
 	}
 
-	Debug(misc, 4, "Found tar '{}' with {} new files", filename, num);
+	Debug(misc, Severity::Info, "Found tar '{}' with {} new files", filename, num);
 
 	return true;
 }
@@ -606,7 +606,7 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 
 	/* The file doesn't have a sub directory! */
 	if (it->second.empty()) {
-		Debug(misc, 3, "Extracting {} failed; archive rejected, the contents must be in a sub directory", tar_filename);
+		Debug(misc, Severity::Notice, "Extracting {} failed; archive rejected, the contents must be in a sub directory", tar_filename);
 		return false;
 	}
 
@@ -615,7 +615,7 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 	if (p == std::string::npos) return false;
 
 	const std::string dirname = tar_filename.substr(0, p);
-	Debug(misc, 8, "Extracting {} to directory {}", tar_filename, dirname);
+	Debug(misc, Severity::Trace2, "Extracting {} to directory {}", tar_filename, dirname);
 	FioCreateDirectory(dirname);
 
 	for (auto &it2 : _tar_filelist[subdir]) {
@@ -626,20 +626,20 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 		name.remove_prefix(name.find_last_of(PATHSEPCHAR) + 1);
 		std::string filename = fmt::format("{}{}{}", dirname, PATHSEP, name);
 
-		Debug(misc, 9, "  extracting {}", filename);
+		Debug(misc, Severity::Trace3, "  extracting {}", filename);
 
 		/* First open the file in the .tar. */
 		size_t to_copy = 0;
 		auto in = FioFOpenFileTar(it2.second, &to_copy);
 		if (!in.has_value()) {
-			Debug(misc, 6, "Extracting {} failed; could not open {}", filename, tar_filename);
+			Debug(misc, Severity::Debug2, "Extracting {} failed; could not open {}", filename, tar_filename);
 			return false;
 		}
 
 		/* Now open the 'output' file. */
 		auto out = FileHandle::Open(filename, "wb");
 		if (!out.has_value()) {
-			Debug(misc, 6, "Extracting {} failed; could not open {}", filename, filename);
+			Debug(misc, Severity::Debug2, "Extracting {} failed; could not open {}", filename, filename);
 			return false;
 		}
 
@@ -652,12 +652,12 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 		}
 
 		if (to_copy != 0) {
-			Debug(misc, 6, "Extracting {} failed; still {} bytes to copy", filename, to_copy);
+			Debug(misc, Severity::Debug2, "Extracting {} failed; still {} bytes to copy", filename, to_copy);
 			return false;
 		}
 	}
 
-	Debug(misc, 9, "  extraction successful");
+	Debug(misc, Severity::Trace3, "  extraction successful");
 	return true;
 }
 
@@ -700,7 +700,7 @@ static bool ChangeWorkingDirectoryToExecutable(std::string_view exe)
 	path.erase(pos);
 
 	if (chdir(path.c_str()) != 0) {
-		Debug(misc, 0, "Directory with the binary does not exist?");
+		Debug(misc, Severity::Critical, "Directory with the binary does not exist?");
 		return false;
 	}
 
@@ -857,7 +857,7 @@ void DetermineBasePaths(std::string_view exe)
 	if (cwd[0] != '\0') {
 		/* Go back to the current working directory. */
 		if (chdir(cwd) != 0) {
-			Debug(misc, 0, "Failed to return to working directory!");
+			Debug(misc, Severity::Critical, "Failed to return to working directory!");
 		}
 	}
 
@@ -953,7 +953,7 @@ void DeterminePaths(std::string_view exe, bool only_local_path)
 
 	for (Searchpath sp : _valid_searchpaths) {
 		if (sp == Searchpath::WorkingDir && !_do_scan_working_directory) continue;
-		Debug(misc, 3, "{} added as search path", _searchpaths[sp]);
+		Debug(misc, Severity::Notice, "{} added as search path", _searchpaths[sp]);
 	}
 
 	std::string config_dir;
@@ -986,7 +986,7 @@ void DeterminePaths(std::string_view exe, bool only_local_path)
 		_config_file = config_dir + "openttd.cfg";
 	}
 
-	Debug(misc, 1, "{} found as config directory", config_dir);
+	Debug(misc, Severity::Error, "{} found as config directory", config_dir);
 
 	_highscore_file = config_dir + "hs.dat";
 	extern std::string _hotkeys_file;
@@ -1024,7 +1024,7 @@ void DeterminePaths(std::string_view exe, bool only_local_path)
 	FioCreateDirectory(_personal_dir);
 #endif
 
-	Debug(misc, 1, "{} found as personal directory", _personal_dir);
+	Debug(misc, Severity::Error, "{} found as personal directory", _personal_dir);
 
 	static const Subdirectory default_subdirs[] = {
 		Subdirectory::Save, Subdirectory::Autosave, Subdirectory::Scenario, Subdirectory::Heightmap, Subdirectory::Baseset, Subdirectory::NewGrf, Subdirectory::Ai, Subdirectory::AiLibrary, Subdirectory::Gs, Subdirectory::GsLibrary, Subdirectory::Screenshot, Subdirectory::SocialIntegration
@@ -1036,7 +1036,7 @@ void DeterminePaths(std::string_view exe, bool only_local_path)
 
 	/* If we have network we make a directory for the autodownloading of content */
 	_searchpaths[Searchpath::AutodownloadDir] = _personal_dir + "content_download" PATHSEP;
-	Debug(misc, 3, "{} added as search path", _searchpaths[Searchpath::AutodownloadDir]);
+	Debug(misc, Severity::Notice, "{} added as search path", _searchpaths[Searchpath::AutodownloadDir]);
 	FioCreateDirectory(_searchpaths[Searchpath::AutodownloadDir]);
 	FillValidSearchPaths(only_local_path);
 
@@ -1136,7 +1136,7 @@ static uint ScanPath(FileScanner *fs, std::string_view extension, const std::fil
 		}
 	}
 	if (error_code) {
-		Debug(misc, 9, "Unable to read directory {}: {}", path.string(), error_code.message());
+		Debug(misc, Severity::Trace3, "Unable to read directory {}: {}", path.string(), error_code.message());
 	}
 
 	return num;

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -337,9 +337,9 @@ bool FioRemove(const std::string &filename)
 	std::error_code error_code;
 	if (!std::filesystem::remove(path, error_code)) {
 		if (error_code) {
-			Debug(misc, Severity::Critical, "Removing {} failed: {}", filename, error_code.message());
+			Debug(Facility::Misc, Severity::Critical, "Removing {} failed: {}", filename, error_code.message());
 		} else {
-			Debug(misc, Severity::Critical, "Removing {} failed: file does not exist", filename);
+			Debug(Facility::Misc, Severity::Critical, "Removing {} failed: file does not exist", filename);
 		}
 		return false;
 	}
@@ -396,7 +396,7 @@ uint TarScanner::DoScan(Subdirectory sd)
  */
 /* static */ uint TarScanner::DoScan(TarScanner::Modes modes)
 {
-	Debug(misc, Severity::Warning, "Scanning for tars");
+	Debug(Facility::Misc, Severity::Warning, "Scanning for tars");
 	TarScanner fs;
 	uint num = 0;
 	if (modes.Test(TarScanner::Mode::Baseset)) {
@@ -417,7 +417,7 @@ uint TarScanner::DoScan(Subdirectory sd)
 		num += fs.DoScan(Subdirectory::Scenario);
 		num += fs.DoScan(Subdirectory::Heightmap);
 	}
-	Debug(misc, Severity::Warning, "Scan complete, found {} files", num);
+	Debug(Facility::Misc, Severity::Warning, "Scan complete, found {} files", num);
 	return num;
 }
 
@@ -507,7 +507,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 			/* If we have only zeros in the block, it can be an end-of-file indicator */
 			if (std::all_of(th.name, last_of_th, [](auto c) { return c == 0; })) continue;
 
-			Debug(misc, Severity::Critical, "The file '{}' isn't a valid tar-file", filename);
+			Debug(Facility::Misc, Severity::Critical, "The file '{}' isn't a valid tar-file", filename);
 			return false;
 		}
 
@@ -528,7 +528,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 		if (!size.empty()) {
 			auto value = ParseInteger<size_t>(size, 8);
 			if (!value.has_value()) {
-				Debug(misc, Severity::Critical, "The file '{}' has an invalid size for '{}'", filename, name);
+				Debug(Facility::Misc, Severity::Critical, "The file '{}' has an invalid size for '{}'", filename, name);
 				fclose(f);
 				return false;
 			}
@@ -549,7 +549,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 				/* Convert to lowercase and our PATHSEPCHAR */
 				SimplifyFileName(name);
 
-				Debug(misc, Severity::Debug2, "Found file in tar: {} ({} bytes, {} offset)", name, skip, pos);
+				Debug(Facility::Misc, Severity::Debug2, "Found file in tar: {} ({} bytes, {} offset)", name, skip, pos);
 				if (_tar_filelist[this->subdir].insert(TarFileList::value_type(filename_base + PATHSEPCHAR + name, entry)).second) num++;
 
 				break;
@@ -559,7 +559,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 			case '2': { // symbolic links
 				std::string link = ExtractString(th.linkname);
 
-				Debug(misc, Severity::Debug1, "Ignoring link in tar: {} -> {}", name, link);
+				Debug(Facility::Misc, Severity::Debug1, "Ignoring link in tar: {} -> {}", name, link);
 				break;
 			}
 
@@ -568,7 +568,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 				SimplifyFileName(name);
 
 				/* Store the first directory name we detect */
-				Debug(misc, Severity::Debug2, "Found dir in tar: {}", name);
+				Debug(Facility::Misc, Severity::Debug2, "Found dir in tar: {}", name);
 				if (_tar_list[this->subdir][filename].empty()) _tar_list[this->subdir][filename] = std::move(name);
 				break;
 
@@ -580,13 +580,13 @@ bool TarScanner::AddFile(const std::string &filename, size_t, [[maybe_unused]] c
 		/* Skip to the next block.. */
 		skip = Align(skip, 512);
 		if (fseek(f, skip, SEEK_CUR) < 0) {
-			Debug(misc, Severity::Critical, "The file '{}' can't be read as a valid tar-file", filename);
+			Debug(Facility::Misc, Severity::Critical, "The file '{}' can't be read as a valid tar-file", filename);
 			return false;
 		}
 		pos += skip;
 	}
 
-	Debug(misc, Severity::Info, "Found tar '{}' with {} new files", filename, num);
+	Debug(Facility::Misc, Severity::Info, "Found tar '{}' with {} new files", filename, num);
 
 	return true;
 }
@@ -606,7 +606,7 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 
 	/* The file doesn't have a sub directory! */
 	if (it->second.empty()) {
-		Debug(misc, Severity::Notice, "Extracting {} failed; archive rejected, the contents must be in a sub directory", tar_filename);
+		Debug(Facility::Misc, Severity::Notice, "Extracting {} failed; archive rejected, the contents must be in a sub directory", tar_filename);
 		return false;
 	}
 
@@ -615,7 +615,7 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 	if (p == std::string::npos) return false;
 
 	const std::string dirname = tar_filename.substr(0, p);
-	Debug(misc, Severity::Trace2, "Extracting {} to directory {}", tar_filename, dirname);
+	Debug(Facility::Misc, Severity::Trace2, "Extracting {} to directory {}", tar_filename, dirname);
 	FioCreateDirectory(dirname);
 
 	for (auto &it2 : _tar_filelist[subdir]) {
@@ -626,20 +626,20 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 		name.remove_prefix(name.find_last_of(PATHSEPCHAR) + 1);
 		std::string filename = fmt::format("{}{}{}", dirname, PATHSEP, name);
 
-		Debug(misc, Severity::Trace3, "  extracting {}", filename);
+		Debug(Facility::Misc, Severity::Trace3, "  extracting {}", filename);
 
 		/* First open the file in the .tar. */
 		size_t to_copy = 0;
 		auto in = FioFOpenFileTar(it2.second, &to_copy);
 		if (!in.has_value()) {
-			Debug(misc, Severity::Debug2, "Extracting {} failed; could not open {}", filename, tar_filename);
+			Debug(Facility::Misc, Severity::Debug2, "Extracting {} failed; could not open {}", filename, tar_filename);
 			return false;
 		}
 
 		/* Now open the 'output' file. */
 		auto out = FileHandle::Open(filename, "wb");
 		if (!out.has_value()) {
-			Debug(misc, Severity::Debug2, "Extracting {} failed; could not open {}", filename, filename);
+			Debug(Facility::Misc, Severity::Debug2, "Extracting {} failed; could not open {}", filename, filename);
 			return false;
 		}
 
@@ -652,12 +652,12 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 		}
 
 		if (to_copy != 0) {
-			Debug(misc, Severity::Debug2, "Extracting {} failed; still {} bytes to copy", filename, to_copy);
+			Debug(Facility::Misc, Severity::Debug2, "Extracting {} failed; still {} bytes to copy", filename, to_copy);
 			return false;
 		}
 	}
 
-	Debug(misc, Severity::Trace3, "  extraction successful");
+	Debug(Facility::Misc, Severity::Trace3, "  extraction successful");
 	return true;
 }
 
@@ -700,7 +700,7 @@ static bool ChangeWorkingDirectoryToExecutable(std::string_view exe)
 	path.erase(pos);
 
 	if (chdir(path.c_str()) != 0) {
-		Debug(misc, Severity::Critical, "Directory with the binary does not exist?");
+		Debug(Facility::Misc, Severity::Critical, "Directory with the binary does not exist?");
 		return false;
 	}
 
@@ -857,7 +857,7 @@ void DetermineBasePaths(std::string_view exe)
 	if (cwd[0] != '\0') {
 		/* Go back to the current working directory. */
 		if (chdir(cwd) != 0) {
-			Debug(misc, Severity::Critical, "Failed to return to working directory!");
+			Debug(Facility::Misc, Severity::Critical, "Failed to return to working directory!");
 		}
 	}
 
@@ -953,7 +953,7 @@ void DeterminePaths(std::string_view exe, bool only_local_path)
 
 	for (Searchpath sp : _valid_searchpaths) {
 		if (sp == Searchpath::WorkingDir && !_do_scan_working_directory) continue;
-		Debug(misc, Severity::Notice, "{} added as search path", _searchpaths[sp]);
+		Debug(Facility::Misc, Severity::Notice, "{} added as search path", _searchpaths[sp]);
 	}
 
 	std::string config_dir;
@@ -986,7 +986,7 @@ void DeterminePaths(std::string_view exe, bool only_local_path)
 		_config_file = config_dir + "openttd.cfg";
 	}
 
-	Debug(misc, Severity::Error, "{} found as config directory", config_dir);
+	Debug(Facility::Misc, Severity::Error, "{} found as config directory", config_dir);
 
 	_highscore_file = config_dir + "hs.dat";
 	extern std::string _hotkeys_file;
@@ -1024,7 +1024,7 @@ void DeterminePaths(std::string_view exe, bool only_local_path)
 	FioCreateDirectory(_personal_dir);
 #endif
 
-	Debug(misc, Severity::Error, "{} found as personal directory", _personal_dir);
+	Debug(Facility::Misc, Severity::Error, "{} found as personal directory", _personal_dir);
 
 	static const Subdirectory default_subdirs[] = {
 		Subdirectory::Save, Subdirectory::Autosave, Subdirectory::Scenario, Subdirectory::Heightmap, Subdirectory::Baseset, Subdirectory::NewGrf, Subdirectory::Ai, Subdirectory::AiLibrary, Subdirectory::Gs, Subdirectory::GsLibrary, Subdirectory::Screenshot, Subdirectory::SocialIntegration
@@ -1036,7 +1036,7 @@ void DeterminePaths(std::string_view exe, bool only_local_path)
 
 	/* If we have network we make a directory for the autodownloading of content */
 	_searchpaths[Searchpath::AutodownloadDir] = _personal_dir + "content_download" PATHSEP;
-	Debug(misc, Severity::Notice, "{} added as search path", _searchpaths[Searchpath::AutodownloadDir]);
+	Debug(Facility::Misc, Severity::Notice, "{} added as search path", _searchpaths[Searchpath::AutodownloadDir]);
 	FioCreateDirectory(_searchpaths[Searchpath::AutodownloadDir]);
 	FillValidSearchPaths(only_local_path);
 
@@ -1136,7 +1136,7 @@ static uint ScanPath(FileScanner *fs, std::string_view extension, const std::fil
 		}
 	}
 	if (error_code) {
-		Debug(misc, Severity::Trace3, "Unable to read directory {}: {}", path.string(), error_code.message());
+		Debug(Facility::Misc, Severity::Trace3, "Unable to read directory {}: {}", path.string(), error_code.message());
 	}
 
 	return num;

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -259,7 +259,7 @@ static std::string GetFontCacheFontName(FontSize fs)
 	}
 
 	if (matching_chars < glyphs.size()) {
-		Debug(fontcache, Severity::Error, "Font \"{}\" misses {} glyphs", name, glyphs.size() - matching_chars);
+		Debug(Facility::Fontcache, Severity::Error, "Font \"{}\" misses {} glyphs", name, glyphs.size() - matching_chars);
 		return false;
 	}
 

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -259,7 +259,7 @@ static std::string GetFontCacheFontName(FontSize fs)
 	}
 
 	if (matching_chars < glyphs.size()) {
-		Debug(fontcache, 1, "Font \"{}\" misses {} glyphs", name, glyphs.size() - matching_chars);
+		Debug(fontcache, Severity::Error, "Font \"{}\" misses {} glyphs", name, glyphs.size() - matching_chars);
 		return false;
 	}
 

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -107,7 +107,7 @@ void FreeTypeFontCache::SetFontSize(int pixels)
 		this->height       = this->ascender - this->descender;
 	} else {
 		/* Both FT_Set_Pixel_Sizes and FT_Select_Size failed. */
-		Debug(fontcache, 0, "Font size selection failed. Using FontCache defaults.");
+		Debug(fontcache, Severity::Critical, "Font size selection failed. Using FontCache defaults.");
 	}
 }
 
@@ -230,7 +230,7 @@ public:
 				return nullptr;
 			}
 
-			Debug(fontcache, 2, "Initialized");
+			Debug(fontcache, Severity::Warning, "Initialized");
 		}
 
 		FT_Face face = nullptr;
@@ -275,7 +275,7 @@ public:
 private:
 	static std::unique_ptr<FontCache> LoadFont(FontSize fs, FT_Face face, std::string_view font_name, uint size)
 	{
-		Debug(fontcache, 2, "Requested '{}', using '{} {}'", font_name, face->family_name, face->style_name);
+		Debug(fontcache, Severity::Warning, "Requested '{}', using '{} {}'", font_name, face->family_name, face->style_name);
 
 		/* Attempt to select the unicode character map */
 		FT_Error error = FT_Select_Charmap(face, ft_encoding_unicode);

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -107,7 +107,7 @@ void FreeTypeFontCache::SetFontSize(int pixels)
 		this->height       = this->ascender - this->descender;
 	} else {
 		/* Both FT_Set_Pixel_Sizes and FT_Select_Size failed. */
-		Debug(fontcache, Severity::Critical, "Font size selection failed. Using FontCache defaults.");
+		Debug(Facility::Fontcache, Severity::Critical, "Font size selection failed. Using FontCache defaults.");
 	}
 }
 
@@ -230,7 +230,7 @@ public:
 				return nullptr;
 			}
 
-			Debug(fontcache, Severity::Warning, "Initialized");
+			Debug(Facility::Fontcache, Severity::Warning, "Initialized");
 		}
 
 		FT_Face face = nullptr;
@@ -275,7 +275,7 @@ public:
 private:
 	static std::unique_ptr<FontCache> LoadFont(FontSize fs, FT_Face face, std::string_view font_name, uint size)
 	{
-		Debug(fontcache, Severity::Warning, "Requested '{}', using '{} {}'", font_name, face->family_name, face->style_name);
+		Debug(Facility::Fontcache, Severity::Warning, "Requested '{}', using '{} {}'", font_name, face->family_name, face->style_name);
 
 		/* Attempt to select the unicode character map */
 		FT_Error error = FT_Select_Charmap(face, ft_encoding_unicode);

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -153,7 +153,7 @@
 	 *  the GameConfig. If not, remove the Game from the list. */
 	if (_settings_game.script_config.game != nullptr && _settings_game.script_config.game->HasScript()) {
 		if (!_settings_game.script_config.game->ResetInfo(true)) {
-			Debug(script, Severity::Critical, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.game->GetName());
+			Debug(Facility::Script, Severity::Critical, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.game->GetName());
 			_settings_game.script_config.game->Change(std::nullopt);
 			if (Game::instance != nullptr) Game::ResetInstance();
 		} else if (Game::instance != nullptr) {
@@ -162,7 +162,7 @@
 	}
 	if (_settings_newgame.script_config.game != nullptr && _settings_newgame.script_config.game->HasScript()) {
 		if (!_settings_newgame.script_config.game->ResetInfo(false)) {
-			Debug(script, Severity::Critical, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.game->GetName());
+			Debug(Facility::Script, Severity::Critical, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.game->GetName());
 			_settings_newgame.script_config.game->Change(std::nullopt);
 		}
 	}

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -153,7 +153,7 @@
 	 *  the GameConfig. If not, remove the Game from the list. */
 	if (_settings_game.script_config.game != nullptr && _settings_game.script_config.game->HasScript()) {
 		if (!_settings_game.script_config.game->ResetInfo(true)) {
-			Debug(script, 0, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.game->GetName());
+			Debug(script, Severity::Critical, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_game.script_config.game->GetName());
 			_settings_game.script_config.game->Change(std::nullopt);
 			if (Game::instance != nullptr) Game::ResetInstance();
 		} else if (Game::instance != nullptr) {
@@ -162,7 +162,7 @@
 	}
 	if (_settings_newgame.script_config.game != nullptr && _settings_newgame.script_config.game->HasScript()) {
 		if (!_settings_newgame.script_config.game->ResetInfo(false)) {
-			Debug(script, 0, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.game->GetName());
+			Debug(script, Severity::Critical, "After a reload, the GameScript by the name '{}' was no longer found, and removed from the list.", _settings_newgame.script_config.game->GetName());
 			_settings_newgame.script_config.game->Change(std::nullopt);
 		}
 	}

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -27,19 +27,19 @@
 
 void CDECL StrgenWarningI(const std::string &msg)
 {
-	Debug(script, 0, "{}:{}: warning: {}", _strgen.file, _strgen.cur_line, msg);
+	Debug(script, Severity::Critical, "{}:{}: warning: {}", _strgen.file, _strgen.cur_line, msg);
 	_strgen.warnings++;
 }
 
 void CDECL StrgenErrorI(const std::string &msg)
 {
-	Debug(script, 0, "{}:{}: error: {}", _strgen.file, _strgen.cur_line, msg);
+	Debug(script, Severity::Critical, "{}:{}: error: {}", _strgen.file, _strgen.cur_line, msg);
 	_strgen.errors++;
 }
 
 void CDECL StrgenFatalI(const std::string &msg)
 {
-	Debug(script, 0, "{}:{}: FATAL: {}", _strgen.file, _strgen.cur_line, msg);
+	Debug(script, Severity::Critical, "{}:{}: FATAL: {}", _strgen.file, _strgen.cur_line, msg);
 	throw std::exception();
 }
 

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -27,19 +27,19 @@
 
 void CDECL StrgenWarningI(const std::string &msg)
 {
-	Debug(script, Severity::Critical, "{}:{}: warning: {}", _strgen.file, _strgen.cur_line, msg);
+	Debug(Facility::Script, Severity::Critical, "{}:{}: warning: {}", _strgen.file, _strgen.cur_line, msg);
 	_strgen.warnings++;
 }
 
 void CDECL StrgenErrorI(const std::string &msg)
 {
-	Debug(script, Severity::Critical, "{}:{}: error: {}", _strgen.file, _strgen.cur_line, msg);
+	Debug(Facility::Script, Severity::Critical, "{}:{}: error: {}", _strgen.file, _strgen.cur_line, msg);
 	_strgen.errors++;
 }
 
 void CDECL StrgenFatalI(const std::string &msg)
 {
-	Debug(script, Severity::Critical, "{}:{}: FATAL: {}", _strgen.file, _strgen.cur_line, msg);
+	Debug(Facility::Script, Severity::Critical, "{}:{}: FATAL: {}", _strgen.file, _strgen.cur_line, msg);
 	throw std::exception();
 }
 

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -82,7 +82,7 @@ void Gamelog::StopAction()
 	this->current_action = nullptr;
 	this->action_type = GamelogActionType::None;
 
-	if (print) this->PrintDebug(5);
+	if (print) this->PrintDebug(Severity::Debug1);
 }
 
 void Gamelog::StopAnyAction()
@@ -317,12 +317,12 @@ void Gamelog::PrintConsole()
  * Prints gamelog to debug output. Code is executed even when
  * there will be no output. It is called very seldom, so it
  * doesn't matter that much. At least it gives more uniform code...
- * @param level debug level we need to print stuff
+ * @param severity debug severity level we need to print stuff
  */
-void Gamelog::PrintDebug(int level)
+void Gamelog::PrintDebug(Severity severity)
 {
-	this->Print([level](const std::string &s) {
-		Debug(gamelog, level, "{}", s);
+	this->Print([severity](const std::string &s) {
+		Debug(gamelog, severity, "{}", s);
 	});
 }
 

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -322,7 +322,7 @@ void Gamelog::PrintConsole()
 void Gamelog::PrintDebug(Severity severity)
 {
 	this->Print([severity](const std::string &s) {
-		Debug(gamelog, severity, "{}", s);
+		Debug(Facility::Gamelog, severity, "{}", s);
 	});
 }
 

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -10,6 +10,7 @@
 #ifndef GAMELOG_H
 #define GAMELOG_H
 
+#include "debug_type.h"
 #include "newgrf_config.h"
 #include "newgrf_type.h"
 
@@ -66,7 +67,7 @@ public:
 	void Reset();
 
 	void Print(std::function<void(const std::string &)> proc);
-	void PrintDebug(int level);
+	void PrintDebug(Severity severity);
 	void PrintConsole();
 
 	void Emergency();

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -102,7 +102,7 @@ static void _GenerateWorld()
 
 	try {
 		_generating_world = true;
-		if (_network_dedicated) Debug(net, Severity::Notice, "Generating map, please wait...");
+		if (_network_dedicated) Debug(Facility::Net, Severity::Notice, "Generating map, please wait...");
 		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
 		_random.SetSeed(_settings_game.game_creation.generation_seed);
 		SetGeneratingWorldProgress(GenWorldProgress::Init, 2);
@@ -212,10 +212,10 @@ static void _GenerateWorld()
 
 		ShowNewGRFError();
 
-		if (_network_dedicated) Debug(net, Severity::Notice, "Map generated, starting game");
-		Debug(desync, Severity::Error, "new_map: {:08x}", _settings_game.game_creation.generation_seed);
+		if (_network_dedicated) Debug(Facility::Net, Severity::Notice, "Map generated, starting game");
+		Debug(Facility::Desync, Severity::Error, "new_map: {:08x}", _settings_game.game_creation.generation_seed);
 
-		if (_debug_desync_level > Severity::Critical) {
+		if (IsVisibleSeverity(Facility::Desync, Severity::Error)) {
 			std::string name = fmt::format("dmp_cmds_{:08x}_{:08x}.sav", _settings_game.game_creation.generation_seed, TimerGameEconomy::date);
 			SaveOrLoad(name, SaveLoadOperation::Save, DetailedFileType::GameFile, Subdirectory::Autosave, false);
 		}
@@ -227,7 +227,7 @@ static void _GenerateWorld()
 
 		if (_network_dedicated) {
 			/* Exit the game to prevent a return to main menu.  */
-			Debug(net, Severity::Critical, "Generating map failed; closing server");
+			Debug(Facility::Net, Severity::Critical, "Generating map failed; closing server");
 			_exit_game = true;
 		} else {
 			SwitchToMode(_switch_mode);

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -102,7 +102,7 @@ static void _GenerateWorld()
 
 	try {
 		_generating_world = true;
-		if (_network_dedicated) Debug(net, 3, "Generating map, please wait...");
+		if (_network_dedicated) Debug(net, Severity::Notice, "Generating map, please wait...");
 		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
 		_random.SetSeed(_settings_game.game_creation.generation_seed);
 		SetGeneratingWorldProgress(GenWorldProgress::Init, 2);
@@ -212,10 +212,10 @@ static void _GenerateWorld()
 
 		ShowNewGRFError();
 
-		if (_network_dedicated) Debug(net, 3, "Map generated, starting game");
-		Debug(desync, 1, "new_map: {:08x}", _settings_game.game_creation.generation_seed);
+		if (_network_dedicated) Debug(net, Severity::Notice, "Map generated, starting game");
+		Debug(desync, Severity::Error, "new_map: {:08x}", _settings_game.game_creation.generation_seed);
 
-		if (_debug_desync_level > 0) {
+		if (_debug_desync_level > Severity::Critical) {
 			std::string name = fmt::format("dmp_cmds_{:08x}_{:08x}.sav", _settings_game.game_creation.generation_seed, TimerGameEconomy::date);
 			SaveOrLoad(name, SaveLoadOperation::Save, DetailedFileType::GameFile, Subdirectory::Autosave, false);
 		}
@@ -227,7 +227,7 @@ static void _GenerateWorld()
 
 		if (_network_dedicated) {
 			/* Exit the game to prevent a return to main menu.  */
-			Debug(net, 0, "Generating map failed; closing server");
+			Debug(net, Severity::Critical, "Generating map failed; closing server");
 			_exit_game = true;
 		} else {
 			SwitchToMode(_switch_mode);

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1521,7 +1521,7 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 		/* Never show steps smaller than 2%, even if it is a mod 5% */
 		if (GenWorldStatus::percent <= last_percent + 2) return;
 
-		Debug(net, Severity::Notice, "Map generation percentage complete: {}", GenWorldStatus::percent);
+		Debug(Facility::Net, Severity::Notice, "Map generation percentage complete: {}", GenWorldStatus::percent);
 		last_percent = GenWorldStatus::percent;
 
 		return;

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1521,7 +1521,7 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 		/* Never show steps smaller than 2%, even if it is a mod 5% */
 		if (GenWorldStatus::percent <= last_percent + 2) return;
 
-		Debug(net, 3, "Map generation percentage complete: {}", GenWorldStatus::percent);
+		Debug(net, Severity::Notice, "Map generation percentage complete: {}", GenWorldStatus::percent);
 		last_percent = GenWorldStatus::percent;
 
 		return;

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1788,7 +1788,7 @@ bool ToggleFullScreen(bool fs)
 {
 	bool result = VideoDriver::GetInstance()->ToggleFullscreen(fs);
 	if (_fullscreen != fs && _resolutions.empty()) {
-		Debug(driver, 0, "Could not find a suitable fullscreen resolution");
+		Debug(driver, Severity::Critical, "Could not find a suitable fullscreen resolution");
 	}
 	return result;
 }

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1788,7 +1788,7 @@ bool ToggleFullScreen(bool fs)
 {
 	bool result = VideoDriver::GetInstance()->ToggleFullscreen(fs);
 	if (_fullscreen != fs && _resolutions.empty()) {
-		Debug(driver, Severity::Critical, "Could not find a suitable fullscreen resolution");
+		Debug(Facility::Driver, Severity::Critical, "Could not find a suitable fullscreen resolution");
 	}
 	return result;
 }

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -257,13 +257,13 @@ std::vector<ICURun> ItemizeBidi(UChar *buff, size_t length)
 	UErrorCode err = U_ZERO_ERROR;
 	ubidi_setPara(ubidi.get(), buff, length, parLevel, nullptr, &err);
 	if (U_FAILURE(err)) {
-		Debug(fontcache, Severity::Critical, "Failed to set paragraph: {}", u_errorName(err));
+		Debug(Facility::Fontcache, Severity::Critical, "Failed to set paragraph: {}", u_errorName(err));
 		return {};
 	}
 
 	int32_t count = ubidi_countRuns(ubidi.get(), &err);
 	if (U_FAILURE(err)) {
-		Debug(fontcache, Severity::Critical, "Failed to count runs: {}", u_errorName(err));
+		Debug(Facility::Fontcache, Severity::Critical, "Failed to count runs: {}", u_errorName(err));
 		return {};
 	}
 

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -257,13 +257,13 @@ std::vector<ICURun> ItemizeBidi(UChar *buff, size_t length)
 	UErrorCode err = U_ZERO_ERROR;
 	ubidi_setPara(ubidi.get(), buff, length, parLevel, nullptr, &err);
 	if (U_FAILURE(err)) {
-		Debug(fontcache, 0, "Failed to set paragraph: {}", u_errorName(err));
+		Debug(fontcache, Severity::Critical, "Failed to set paragraph: {}", u_errorName(err));
 		return {};
 	}
 
 	int32_t count = ubidi_countRuns(ubidi.get(), &err);
 	if (U_FAILURE(err)) {
-		Debug(fontcache, 0, "Failed to count runs: {}", u_errorName(err));
+		Debug(fontcache, Severity::Critical, "Failed to count runs: {}", u_errorName(err));
 		return {};
 	}
 

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -49,7 +49,7 @@ static uint LoadGrfFile(const std::string &filename, SpriteID load_index, bool n
 
 	SpriteFile &file = OpenCachedSpriteFile(filename, Subdirectory::Baseset, needs_palette_remap);
 
-	Debug(sprite, 2, "Reading grf-file '{}'", filename);
+	Debug(sprite, Severity::Warning, "Reading grf-file '{}'", filename);
 
 	uint8_t container_ver = file.GetContainerVersion();
 	if (container_ver == 0) UserError("Base grf '{}' is corrupt", filename);
@@ -67,7 +67,7 @@ static uint LoadGrfFile(const std::string &filename, SpriteID load_index, bool n
 			UserError("Too many sprites. Recompile with higher MAX_SPRITES value or remove some custom GRF files.");
 		}
 	}
-	Debug(sprite, 2, "Currently {} sprites are loaded", load_index);
+	Debug(sprite, Severity::Warning, "Currently {} sprites are loaded", load_index);
 
 	return load_index - load_index_org;
 }
@@ -84,7 +84,7 @@ static void LoadGrfFileIndexed(const std::string &filename, std::span<const std:
 
 	SpriteFile &file = OpenCachedSpriteFile(filename, Subdirectory::Baseset, needs_palette_remap);
 
-	Debug(sprite, 2, "Reading indexed grf-file '{}'", filename);
+	Debug(sprite, Severity::Warning, "Reading indexed grf-file '{}'", filename);
 
 	uint8_t container_ver = file.GetContainerVersion();
 	if (container_ver == 0) UserError("Base grf '{}' is corrupt", filename);
@@ -115,7 +115,7 @@ void CheckExternalFiles()
 
 	const GraphicsSet *used_set = BaseGraphics::GetUsedSet();
 
-	Debug(grf, 1, "Using the {} base graphics set", used_set->name);
+	Debug(grf, Severity::Error, "Using the {} base graphics set", used_set->name);
 
 	std::string error_msg;
 	auto output_iterator = std::back_inserter(error_msg);
@@ -214,9 +214,9 @@ static void LoadSpriteTables()
 	LoadNewGRF(SPR_NEWGRFS_BASE, 2);
 
 	uint total_extra_graphics = SPR_NEWGRFS_BASE - SPR_OPENTTD_BASE;
-	Debug(sprite, 4, "Checking sprites from fallback grf");
+	Debug(sprite, Severity::Info, "Checking sprites from fallback grf");
 	_missing_extra_graphics = GetSpriteCountForFile(default_filename, SPR_OPENTTD_BASE, SPR_NEWGRFS_BASE);
-	Debug(sprite, 1, "{} extra sprites, {} from baseset, {} from fallback", total_extra_graphics, total_extra_graphics - _missing_extra_graphics, _missing_extra_graphics);
+	Debug(sprite, Severity::Error, "{} extra sprites, {} from baseset, {} from fallback", total_extra_graphics, total_extra_graphics - _missing_extra_graphics, _missing_extra_graphics);
 
 	/* The original baseset extra graphics intentionally make use of the fallback graphics.
 	 * Let's say everything which provides less than 500 sprites misses the rest intentionally. */
@@ -232,10 +232,10 @@ static void RealChangeBlitter(std::string_view repl_blitter)
 	std::string_view cur_blitter = BlitterFactory::GetCurrentBlitter()->GetName();
 	if (cur_blitter == repl_blitter) return;
 
-	Debug(driver, 1, "Switching blitter from '{}' to '{}'... ", cur_blitter, repl_blitter);
+	Debug(driver, Severity::Error, "Switching blitter from '{}' to '{}'... ", cur_blitter, repl_blitter);
 	Blitter *new_blitter = BlitterFactory::SelectBlitter(repl_blitter);
 	if (new_blitter == nullptr) NOT_REACHED();
-	Debug(driver, 1, "Successfully switched to {}.", repl_blitter);
+	Debug(driver, Severity::Error, "Successfully switched to {}.", repl_blitter);
 
 	if (!VideoDriver::GetInstance()->AfterBlitterChange()) {
 		/* Failed to switch blitter, let's hope we can return to the old one. */
@@ -333,7 +333,7 @@ void CheckBlitter()
 /** Initialise and load all the sprites. */
 void GfxLoadSprites()
 {
-	Debug(sprite, 2, "Loading sprite set {}", _settings_game.game_creation.landscape);
+	Debug(sprite, Severity::Warning, "Loading sprite set {}", _settings_game.game_creation.landscape);
 
 	SwitchNewGRFBlitter();
 	VideoDriver::GetInstance()->ClearSystemSprites();

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -49,7 +49,7 @@ static uint LoadGrfFile(const std::string &filename, SpriteID load_index, bool n
 
 	SpriteFile &file = OpenCachedSpriteFile(filename, Subdirectory::Baseset, needs_palette_remap);
 
-	Debug(sprite, Severity::Warning, "Reading grf-file '{}'", filename);
+	Debug(Facility::Sprite, Severity::Warning, "Reading grf-file '{}'", filename);
 
 	uint8_t container_ver = file.GetContainerVersion();
 	if (container_ver == 0) UserError("Base grf '{}' is corrupt", filename);
@@ -67,7 +67,7 @@ static uint LoadGrfFile(const std::string &filename, SpriteID load_index, bool n
 			UserError("Too many sprites. Recompile with higher MAX_SPRITES value or remove some custom GRF files.");
 		}
 	}
-	Debug(sprite, Severity::Warning, "Currently {} sprites are loaded", load_index);
+	Debug(Facility::Sprite, Severity::Warning, "Currently {} sprites are loaded", load_index);
 
 	return load_index - load_index_org;
 }
@@ -84,7 +84,7 @@ static void LoadGrfFileIndexed(const std::string &filename, std::span<const std:
 
 	SpriteFile &file = OpenCachedSpriteFile(filename, Subdirectory::Baseset, needs_palette_remap);
 
-	Debug(sprite, Severity::Warning, "Reading indexed grf-file '{}'", filename);
+	Debug(Facility::Sprite, Severity::Warning, "Reading indexed grf-file '{}'", filename);
 
 	uint8_t container_ver = file.GetContainerVersion();
 	if (container_ver == 0) UserError("Base grf '{}' is corrupt", filename);
@@ -115,7 +115,7 @@ void CheckExternalFiles()
 
 	const GraphicsSet *used_set = BaseGraphics::GetUsedSet();
 
-	Debug(grf, Severity::Error, "Using the {} base graphics set", used_set->name);
+	Debug(Facility::Grf, Severity::Error, "Using the {} base graphics set", used_set->name);
 
 	std::string error_msg;
 	auto output_iterator = std::back_inserter(error_msg);
@@ -214,9 +214,9 @@ static void LoadSpriteTables()
 	LoadNewGRF(SPR_NEWGRFS_BASE, 2);
 
 	uint total_extra_graphics = SPR_NEWGRFS_BASE - SPR_OPENTTD_BASE;
-	Debug(sprite, Severity::Info, "Checking sprites from fallback grf");
+	Debug(Facility::Sprite, Severity::Info, "Checking sprites from fallback grf");
 	_missing_extra_graphics = GetSpriteCountForFile(default_filename, SPR_OPENTTD_BASE, SPR_NEWGRFS_BASE);
-	Debug(sprite, Severity::Error, "{} extra sprites, {} from baseset, {} from fallback", total_extra_graphics, total_extra_graphics - _missing_extra_graphics, _missing_extra_graphics);
+	Debug(Facility::Sprite, Severity::Error, "{} extra sprites, {} from baseset, {} from fallback", total_extra_graphics, total_extra_graphics - _missing_extra_graphics, _missing_extra_graphics);
 
 	/* The original baseset extra graphics intentionally make use of the fallback graphics.
 	 * Let's say everything which provides less than 500 sprites misses the rest intentionally. */
@@ -232,10 +232,10 @@ static void RealChangeBlitter(std::string_view repl_blitter)
 	std::string_view cur_blitter = BlitterFactory::GetCurrentBlitter()->GetName();
 	if (cur_blitter == repl_blitter) return;
 
-	Debug(driver, Severity::Error, "Switching blitter from '{}' to '{}'... ", cur_blitter, repl_blitter);
+	Debug(Facility::Driver, Severity::Error, "Switching blitter from '{}' to '{}'... ", cur_blitter, repl_blitter);
 	Blitter *new_blitter = BlitterFactory::SelectBlitter(repl_blitter);
 	if (new_blitter == nullptr) NOT_REACHED();
-	Debug(driver, Severity::Error, "Successfully switched to {}.", repl_blitter);
+	Debug(Facility::Driver, Severity::Error, "Successfully switched to {}.", repl_blitter);
 
 	if (!VideoDriver::GetInstance()->AfterBlitterChange()) {
 		/* Failed to switch blitter, let's hope we can return to the old one. */
@@ -333,7 +333,7 @@ void CheckBlitter()
 /** Initialise and load all the sprites. */
 void GfxLoadSprites()
 {
-	Debug(sprite, Severity::Warning, "Loading sprite set {}", _settings_game.game_creation.landscape);
+	Debug(Facility::Sprite, Severity::Warning, "Loading sprite set {}", _settings_game.game_creation.landscape);
 
 	SwitchNewGRFBlitter();
 	VideoDriver::GetInstance()->ClearSystemSprites();

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -52,7 +52,7 @@ void UpdateGroupChildren()
 		if (pg == nullptr || pg->owner != g->owner || pg->vehicle_type != g->vehicle_type) {
 			/* Due to a bug, groups which should have been deleted could be left with an invalid parent.
 			 * Keep the group but clear the invalid parent so that the game is recoverable. */
-			Debug(misc, 2, "Group {} has invalid parent {}", g->index, g->parent);
+			Debug(misc, Severity::Warning, "Group {} has invalid parent {}", g->index, g->parent);
 			g->parent = GroupID::Invalid();
 		} else {
 			pg->children.insert(g->index);

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -52,7 +52,7 @@ void UpdateGroupChildren()
 		if (pg == nullptr || pg->owner != g->owner || pg->vehicle_type != g->vehicle_type) {
 			/* Due to a bug, groups which should have been deleted could be left with an invalid parent.
 			 * Keep the group but clear the invalid parent so that the game is recoverable. */
-			Debug(misc, Severity::Warning, "Group {} has invalid parent {}", g->index, g->parent);
+			Debug(Facility::Misc, Severity::Warning, "Group {} has invalid parent {}", g->index, g->parent);
 			g->parent = GroupID::Invalid();
 		} else {
 			pg->children.insert(g->index);

--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -128,7 +128,7 @@ void SaveToHighScore()
 					fwrite(hs.name.data(), name_length, 1, fp) > 1 || // Yes... could be 0 bytes too
 					fwrite(&hs.score, sizeof(hs.score), 1, fp) != 1 ||
 					fwrite("  ", 2, 1, fp) != 1) { // Used to be hs.title, not saved anymore; compatibility
-				Debug(misc, Severity::Error, "Could not save highscore.");
+				Debug(Facility::Misc, Severity::Error, "Could not save highscore.");
 				return;
 			}
 		}
@@ -155,7 +155,7 @@ void LoadFromHighScore()
 					fread(buffer, name_length, 1, fp) > 1 || // Yes... could be 0 bytes too
 					fread(&hs.score, sizeof(hs.score), 1, fp) !=  1 ||
 					fseek(fp, 2, SEEK_CUR) == -1) { // Used to be hs.title, not saved anymore; compatibility
-				Debug(misc, Severity::Error, "Highscore corrupted");
+				Debug(Facility::Misc, Severity::Error, "Highscore corrupted");
 				return;
 			}
 			hs.name = StrMakeValid(std::string_view(buffer, name_length));

--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -128,7 +128,7 @@ void SaveToHighScore()
 					fwrite(hs.name.data(), name_length, 1, fp) > 1 || // Yes... could be 0 bytes too
 					fwrite(&hs.score, sizeof(hs.score), 1, fp) != 1 ||
 					fwrite("  ", 2, 1, fp) != 1) { // Used to be hs.title, not saved anymore; compatibility
-				Debug(misc, 1, "Could not save highscore.");
+				Debug(misc, Severity::Error, "Could not save highscore.");
 				return;
 			}
 		}
@@ -155,7 +155,7 @@ void LoadFromHighScore()
 					fread(buffer, name_length, 1, fp) > 1 || // Yes... could be 0 bytes too
 					fread(&hs.score, sizeof(hs.score), 1, fp) !=  1 ||
 					fseek(fp, 2, SEEK_CUR) == -1) { // Used to be hs.title, not saved anymore; compatibility
-				Debug(misc, 1, "Highscore corrupted");
+				Debug(misc, Severity::Error, "Highscore corrupted");
 				return;
 			}
 			hs.name = StrMakeValid(std::string_view(buffer, name_length));

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -91,7 +91,7 @@ bool IniFile::SaveToDisk(const std::string &filename)
 	std::error_code ec;
 	std::filesystem::rename(OTTD2FS(file_new), OTTD2FS(filename), ec);
 	if (ec) {
-		Debug(misc, 0, "Renaming {} to {} failed; configuration not saved: {}", file_new, filename, ec.message());
+		Debug(misc, Severity::Critical, "Renaming {} to {} failed; configuration not saved: {}", file_new, filename, ec.message());
 	}
 
 #ifdef __EMSCRIPTEN__

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -91,7 +91,7 @@ bool IniFile::SaveToDisk(const std::string &filename)
 	std::error_code ec;
 	std::filesystem::rename(OTTD2FS(file_new), OTTD2FS(filename), ec);
 	if (ec) {
-		Debug(misc, Severity::Critical, "Renaming {} to {} failed; configuration not saved: {}", file_new, filename, ec.message());
+		Debug(Facility::Misc, Severity::Critical, "Renaming {} to {} failed; configuration not saved: {}", file_new, filename, ec.message());
 	}
 
 #ifdef __EMSCRIPTEN__

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -45,7 +45,7 @@
 		FatalError("Invalid map size");
 	}
 
-	Debug(map, 1, "Allocating map of size {}x{}", size_x, size_y);
+	Debug(map, Severity::Error, "Allocating map of size {}x{}", size_x, size_y);
 
 	Map::log_x = FindFirstBit(size_x);
 	Map::log_y = FindFirstBit(size_y);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -45,7 +45,7 @@
 		FatalError("Invalid map size");
 	}
 
-	Debug(map, Severity::Error, "Allocating map of size {}x{}", size_x, size_y);
+	Debug(Facility::Map, Severity::Error, "Allocating map of size {}x{}", size_x, size_y);
 
 	Map::log_x = FindFirstBit(size_x);
 	Map::log_y = FindFirstBit(size_y);

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -112,17 +112,17 @@ public:
 #else
 		static constexpr Severity severity = Severity::Error;
 #endif
-		Debug(misc, severity, "TILE: {0} (0x{0:x}) ({1},{2})", (TileIndex)tile, TileX(tile), TileY(tile));
-		Debug(misc, severity, "type   = 0x{:x}", tile.type());
-		Debug(misc, severity, "height = 0x{:x}", tile.height());
-		Debug(misc, severity, "m1     = 0x{:x}", tile.m1());
-		Debug(misc, severity, "m2     = 0x{:x}", tile.m2());
-		Debug(misc, severity, "m3     = 0x{:x}", tile.m3());
-		Debug(misc, severity, "m4     = 0x{:x}", tile.m4());
-		Debug(misc, severity, "m5     = 0x{:x}", tile.m5());
-		Debug(misc, severity, "m6     = 0x{:x}", tile.m6());
-		Debug(misc, severity, "m7     = 0x{:x}", tile.m7());
-		Debug(misc, severity, "m8     = 0x{:x}", tile.m8());
+		Debug(Facility::Misc, severity, "TILE: {0} (0x{0:x}) ({1},{2})", (TileIndex)tile, TileX(tile), TileY(tile));
+		Debug(Facility::Misc, severity, "type   = 0x{:x}", tile.type());
+		Debug(Facility::Misc, severity, "height = 0x{:x}", tile.height());
+		Debug(Facility::Misc, severity, "m1     = 0x{:x}", tile.m1());
+		Debug(Facility::Misc, severity, "m2     = 0x{:x}", tile.m2());
+		Debug(Facility::Misc, severity, "m3     = 0x{:x}", tile.m3());
+		Debug(Facility::Misc, severity, "m4     = 0x{:x}", tile.m4());
+		Debug(Facility::Misc, severity, "m5     = 0x{:x}", tile.m5());
+		Debug(Facility::Misc, severity, "m6     = 0x{:x}", tile.m6());
+		Debug(Facility::Misc, severity, "m7     = 0x{:x}", tile.m7());
+		Debug(Facility::Misc, severity, "m8     = 0x{:x}", tile.m8());
 
 		PrintWaterRegionDebugInfo(tile);
 	}

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -108,24 +108,23 @@ public:
 		this->InitNested();
 
 #if defined(_DEBUG)
-#	define LANDINFOD_LEVEL 0
+		static constexpr Severity severity = Severity::Critical;
 #else
-#	define LANDINFOD_LEVEL 1
+		static constexpr Severity severity = Severity::Error;
 #endif
-		Debug(misc, LANDINFOD_LEVEL, "TILE: {0} (0x{0:x}) ({1},{2})", (TileIndex)tile, TileX(tile), TileY(tile));
-		Debug(misc, LANDINFOD_LEVEL, "type   = 0x{:x}", tile.type());
-		Debug(misc, LANDINFOD_LEVEL, "height = 0x{:x}", tile.height());
-		Debug(misc, LANDINFOD_LEVEL, "m1     = 0x{:x}", tile.m1());
-		Debug(misc, LANDINFOD_LEVEL, "m2     = 0x{:x}", tile.m2());
-		Debug(misc, LANDINFOD_LEVEL, "m3     = 0x{:x}", tile.m3());
-		Debug(misc, LANDINFOD_LEVEL, "m4     = 0x{:x}", tile.m4());
-		Debug(misc, LANDINFOD_LEVEL, "m5     = 0x{:x}", tile.m5());
-		Debug(misc, LANDINFOD_LEVEL, "m6     = 0x{:x}", tile.m6());
-		Debug(misc, LANDINFOD_LEVEL, "m7     = 0x{:x}", tile.m7());
-		Debug(misc, LANDINFOD_LEVEL, "m8     = 0x{:x}", tile.m8());
+		Debug(misc, severity, "TILE: {0} (0x{0:x}) ({1},{2})", (TileIndex)tile, TileX(tile), TileY(tile));
+		Debug(misc, severity, "type   = 0x{:x}", tile.type());
+		Debug(misc, severity, "height = 0x{:x}", tile.height());
+		Debug(misc, severity, "m1     = 0x{:x}", tile.m1());
+		Debug(misc, severity, "m2     = 0x{:x}", tile.m2());
+		Debug(misc, severity, "m3     = 0x{:x}", tile.m3());
+		Debug(misc, severity, "m4     = 0x{:x}", tile.m4());
+		Debug(misc, severity, "m5     = 0x{:x}", tile.m5());
+		Debug(misc, severity, "m6     = 0x{:x}", tile.m6());
+		Debug(misc, severity, "m7     = 0x{:x}", tile.m7());
+		Debug(misc, severity, "m8     = 0x{:x}", tile.m8());
 
 		PrintWaterRegionDebugInfo(tile);
-#undef LANDINFOD_LEVEL
 	}
 
 	void OnInit() override

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -139,13 +139,13 @@ bool MusicSet::FillSetDetails(const IniFile &ini, const std::string &path, const
 				this->songinfo[i].filetype = MTT_MPSMIDI;
 				auto value = ParseInteger(*item->value);
 				if (!value.has_value()) {
-					Debug(misc, Severity::Critical, "Invalid base music set song index: {}/{}", filename, *item->value);
+					Debug(Facility::Misc, Severity::Critical, "Invalid base music set song index: {}/{}", filename, *item->value);
 					continue;
 				}
 				this->songinfo[i].cat_index = *value;
 				auto songname = GetMusicCatEntryName(filename, this->songinfo[i].cat_index);
 				if (!songname.has_value()) {
-					Debug(misc, Severity::Critical, "Base music set song missing from CAT file: {}/{}", filename, this->songinfo[i].cat_index);
+					Debug(Facility::Misc, Severity::Critical, "Base music set song missing from CAT file: {}/{}", filename, this->songinfo[i].cat_index);
 					continue;
 				}
 				this->songinfo[i].songname = *songname;
@@ -177,7 +177,7 @@ bool MusicSet::FillSetDetails(const IniFile &ini, const std::string &path, const
 				if (item != nullptr && item->value.has_value() && !item->value->empty()) {
 					this->songinfo[i].songname = item->value.value();
 				} else {
-					Debug(misc, Severity::Critical, "Base music set song name missing: {}", filename);
+					Debug(Facility::Misc, Severity::Critical, "Base music set song name missing: {}", filename);
 					return false;
 				}
 			}

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -139,13 +139,13 @@ bool MusicSet::FillSetDetails(const IniFile &ini, const std::string &path, const
 				this->songinfo[i].filetype = MTT_MPSMIDI;
 				auto value = ParseInteger(*item->value);
 				if (!value.has_value()) {
-					Debug(misc, 0, "Invalid base music set song index: {}/{}", filename, *item->value);
+					Debug(misc, Severity::Critical, "Invalid base music set song index: {}/{}", filename, *item->value);
 					continue;
 				}
 				this->songinfo[i].cat_index = *value;
 				auto songname = GetMusicCatEntryName(filename, this->songinfo[i].cat_index);
 				if (!songname.has_value()) {
-					Debug(misc, 0, "Base music set song missing from CAT file: {}/{}", filename, this->songinfo[i].cat_index);
+					Debug(misc, Severity::Critical, "Base music set song missing from CAT file: {}/{}", filename, this->songinfo[i].cat_index);
 					continue;
 				}
 				this->songinfo[i].songname = *songname;
@@ -177,7 +177,7 @@ bool MusicSet::FillSetDetails(const IniFile &ini, const std::string &path, const
 				if (item != nullptr && item->value.has_value() && !item->value->empty()) {
 					this->songinfo[i].songname = item->value.value();
 				} else {
-					Debug(misc, 0, "Base music set song name missing: {}", filename);
+					Debug(misc, Severity::Critical, "Base music set song name missing: {}", filename);
 					return false;
 				}
 			}

--- a/src/music/allegro_m.cpp
+++ b/src/music/allegro_m.cpp
@@ -29,20 +29,20 @@ extern int _allegro_instance_count;
 std::optional<std::string_view> MusicDriver_Allegro::Start(const StringList &)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
-		Debug(driver, Severity::Critical, "allegro: install_allegro failed '{}'", allegro_error);
+		Debug(Facility::Driver, Severity::Critical, "allegro: install_allegro failed '{}'", allegro_error);
 		return "Failed to set up Allegro";
 	}
 	_allegro_instance_count++;
 
 	/* Initialise the sound */
 	if (install_sound(DIGI_AUTODETECT, MIDI_AUTODETECT, nullptr) != 0) {
-		Debug(driver, Severity::Critical, "allegro: install_sound failed '{}'", allegro_error);
+		Debug(Facility::Driver, Severity::Critical, "allegro: install_sound failed '{}'", allegro_error);
 		return "Failed to set up Allegro sound";
 	}
 
 	/* Okay, there's no soundcard */
 	if (midi_card == MIDI_NONE) {
-		Debug(driver, Severity::Critical, "allegro: no midi card found");
+		Debug(Facility::Driver, Severity::Critical, "allegro: no midi card found");
 		return "No sound card found";
 	}
 

--- a/src/music/allegro_m.cpp
+++ b/src/music/allegro_m.cpp
@@ -29,20 +29,20 @@ extern int _allegro_instance_count;
 std::optional<std::string_view> MusicDriver_Allegro::Start(const StringList &)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
-		Debug(driver, 0, "allegro: install_allegro failed '{}'", allegro_error);
+		Debug(driver, Severity::Critical, "allegro: install_allegro failed '{}'", allegro_error);
 		return "Failed to set up Allegro";
 	}
 	_allegro_instance_count++;
 
 	/* Initialise the sound */
 	if (install_sound(DIGI_AUTODETECT, MIDI_AUTODETECT, nullptr) != 0) {
-		Debug(driver, 0, "allegro: install_sound failed '{}'", allegro_error);
+		Debug(driver, Severity::Critical, "allegro: install_sound failed '{}'", allegro_error);
 		return "Failed to set up Allegro sound";
 	}
 
 	/* Okay, there's no soundcard */
 	if (midi_card == MIDI_NONE) {
-		Debug(driver, 0, "allegro: no midi card found");
+		Debug(driver, Severity::Critical, "allegro: no midi card found");
 		return "No sound card found";
 	}
 

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -60,7 +60,7 @@ static void DoSetVolume()
 		}
 	}
 	if (output_unit == nullptr) {
-		Debug(driver, Severity::Error, "cocoa_m: Failed to get output node to set volume");
+		Debug(Facility::Driver, Severity::Error, "cocoa_m: Failed to get output node to set volume");
 		return;
 	}
 
@@ -112,7 +112,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 {
 	std::string filename = MidiFile::GetSMFFile(song);
 
-	Debug(driver, Severity::Warning, "cocoa_m: trying to play '{}'", filename);
+	Debug(Facility::Driver, Severity::Warning, "cocoa_m: trying to play '{}'", filename);
 
 	this->StopSong();
 	if (_sequence != nullptr) {
@@ -123,7 +123,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	if (filename.empty()) return;
 
 	if (NewMusicSequence(&_sequence) != noErr) {
-		Debug(driver, Severity::Critical, "cocoa_m: Failed to create music sequence");
+		Debug(Facility::Driver, Severity::Critical, "cocoa_m: Failed to create music sequence");
 		return;
 	}
 
@@ -131,7 +131,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	CFAutoRelease<CFURLRef> url(CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8*)os_file.data(), os_file.length(), false));
 
 	if (MusicSequenceFileLoad(_sequence, url.get(), kMusicSequenceFile_AnyType, 0) != noErr) {
-		Debug(driver, Severity::Critical, "cocoa_m: Failed to load MIDI file");
+		Debug(Facility::Driver, Severity::Critical, "cocoa_m: Failed to load MIDI file");
 		return;
 	}
 
@@ -141,7 +141,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	MusicSequenceGetAUGraph(_sequence, &graph);
 	AUGraphOpen(graph);
 	if (AUGraphInitialize(graph) != noErr) {
-		Debug(driver, Severity::Critical, "cocoa_m: Failed to initialize AU graph");
+		Debug(Facility::Driver, Severity::Critical, "cocoa_m: Failed to initialize AU graph");
 		return;
 	}
 
@@ -166,7 +166,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	if (MusicPlayerStart(_player) != noErr) return;
 	_playing = true;
 
-	Debug(driver, Severity::Notice, "cocoa_m: playing '{}'", filename);
+	Debug(Facility::Driver, Severity::Notice, "cocoa_m: playing '{}'", filename);
 }
 
 

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -60,7 +60,7 @@ static void DoSetVolume()
 		}
 	}
 	if (output_unit == nullptr) {
-		Debug(driver, 1, "cocoa_m: Failed to get output node to set volume");
+		Debug(driver, Severity::Error, "cocoa_m: Failed to get output node to set volume");
 		return;
 	}
 
@@ -112,7 +112,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 {
 	std::string filename = MidiFile::GetSMFFile(song);
 
-	Debug(driver, 2, "cocoa_m: trying to play '{}'", filename);
+	Debug(driver, Severity::Warning, "cocoa_m: trying to play '{}'", filename);
 
 	this->StopSong();
 	if (_sequence != nullptr) {
@@ -123,7 +123,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	if (filename.empty()) return;
 
 	if (NewMusicSequence(&_sequence) != noErr) {
-		Debug(driver, 0, "cocoa_m: Failed to create music sequence");
+		Debug(driver, Severity::Critical, "cocoa_m: Failed to create music sequence");
 		return;
 	}
 
@@ -131,7 +131,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	CFAutoRelease<CFURLRef> url(CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8*)os_file.data(), os_file.length(), false));
 
 	if (MusicSequenceFileLoad(_sequence, url.get(), kMusicSequenceFile_AnyType, 0) != noErr) {
-		Debug(driver, 0, "cocoa_m: Failed to load MIDI file");
+		Debug(driver, Severity::Critical, "cocoa_m: Failed to load MIDI file");
 		return;
 	}
 
@@ -141,7 +141,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	MusicSequenceGetAUGraph(_sequence, &graph);
 	AUGraphOpen(graph);
 	if (AUGraphInitialize(graph) != noErr) {
-		Debug(driver, 0, "cocoa_m: Failed to initialize AU graph");
+		Debug(driver, Severity::Critical, "cocoa_m: Failed to initialize AU graph");
 		return;
 	}
 
@@ -166,7 +166,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	if (MusicPlayerStart(_player) != noErr) return;
 	_playing = true;
 
-	Debug(driver, 3, "cocoa_m: playing '{}'", filename);
+	Debug(driver, Severity::Notice, "cocoa_m: playing '{}'", filename);
 }
 
 

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -273,7 +273,7 @@ bool DLSFile::ReadDLSRegion(FileHandle &f, DWORD list_length, std::vector<DLSReg
 				break;
 
 			default:
-				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+				Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 				fseek(f, chunk.length, SEEK_CUR);
 				break;
 		}
@@ -296,11 +296,11 @@ bool DLSFile::ReadDLSRegionList(FileHandle &f, DWORD list_length, DLSInstrument 
 			if (list_type == FOURCC_RGN) {
 				this->ReadDLSRegion(f, chunk.length - sizeof(list_type), instrument.regions);
 			} else {
-				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
+				Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
 				fseek(f, chunk.length - sizeof(list_type), SEEK_CUR);
 			}
 		} else {
-			Debug(driver, Severity::Trace1, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+			Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 			fseek(f, chunk.length, SEEK_CUR);
 		}
 	}
@@ -342,7 +342,7 @@ bool DLSFile::ReadDLSInstrument(FileHandle &f, DWORD list_length)
 				break;
 
 			default:
-				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+				Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 				fseek(f, chunk.length, SEEK_CUR);
 				break;
 		}
@@ -363,15 +363,15 @@ bool DLSFile::ReadDLSInstrumentList(FileHandle &f, DWORD list_length)
 			if (fread(&list_type, sizeof(list_type), 1, f) != 1) return false;
 
 			if (list_type == FOURCC_INS) {
-				Debug(driver, Severity::Debug2, "DLS: Reading instrument {}", (int)instruments.size());
+				Debug(Facility::Driver, Severity::Debug2, "DLS: Reading instrument {}", (int)instruments.size());
 
 				if (!this->ReadDLSInstrument(f, chunk.length - sizeof(list_type))) return false;
 			} else {
-				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
+				Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
 				fseek(f, chunk.length - sizeof(list_type), SEEK_CUR);
 			}
 		} else {
-			Debug(driver, Severity::Trace1, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+			Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 			fseek(f, chunk.length, SEEK_CUR);
 		}
 	}
@@ -428,7 +428,7 @@ bool DLSFile::ReadDLSWave(FileHandle &f, DWORD list_length, long offset)
 				break;
 
 			default:
-				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+				Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 				fseek(f, chunk.length, SEEK_CUR);
 				break;
 		}
@@ -453,15 +453,15 @@ bool DLSFile::ReadDLSWaveList(FileHandle &f, DWORD list_length)
 			if (fread(&list_type, sizeof(list_type), 1, f) != 1) return false;
 
 			if (list_type == FOURCC_wave) {
-				Debug(driver, Severity::Debug2, "DLS: Reading wave {}", waves.size());
+				Debug(Facility::Driver, Severity::Debug2, "DLS: Reading wave {}", waves.size());
 
 				if (!this->ReadDLSWave(f, chunk.length - sizeof(list_type), chunk_offset - base_offset)) return false;
 			} else {
-				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
+				Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
 				fseek(f, chunk.length - sizeof(list_type), SEEK_CUR);
 			}
 		} else {
-			Debug(driver, Severity::Trace1, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+			Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 			fseek(f, chunk.length, SEEK_CUR);
 		}
 	}
@@ -471,7 +471,7 @@ bool DLSFile::ReadDLSWaveList(FileHandle &f, DWORD list_length)
 
 bool DLSFile::LoadFile(std::string_view file)
 {
-	Debug(driver, Severity::Warning, "DMusic: Try to load DLS file {}", file);
+	Debug(Facility::Driver, Severity::Warning, "DMusic: Try to load DLS file {}", file);
 
 	auto of = FileHandle::Open(file, "rb");
 	if (!of.has_value()) return false;
@@ -486,7 +486,7 @@ bool DLSFile::LoadFile(std::string_view file)
 
 	hdr.length -= sizeof(FOURCC);
 
-	Debug(driver, Severity::Warning, "DMusic: Parsing DLS file");
+	Debug(Facility::Driver, Severity::Warning, "DMusic: Parsing DLS file");
 
 	DLSHEADER header{};
 
@@ -534,7 +534,7 @@ bool DLSFile::LoadFile(std::string_view file)
 				break;
 
 			default:
-				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+				Debug(Facility::Driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 				fseek(f, chunk.length, SEEK_CUR);
 				break;
 		}
@@ -629,7 +629,7 @@ static void TransmitNotesOff(IDirectMusicBuffer *buffer, REFERENCE_TIME block_ti
 
 static void MidiThreadProc()
 {
-	Debug(driver, Severity::Warning, "DMusic: Entering playback thread");
+	Debug(Facility::Driver, Severity::Warning, "DMusic: Entering playback thread");
 
 	REFERENCE_TIME last_volume_time = 0; // timestamp of the last volume change
 	REFERENCE_TIME block_time = 0;       // timestamp of the last block sent to the port
@@ -661,7 +661,7 @@ static void MidiThreadProc()
 		}
 
 		if (_playback.do_stop) {
-			Debug(driver, Severity::Warning, "DMusic thread: Stopping playback");
+			Debug(Facility::Driver, Severity::Warning, "DMusic thread: Stopping playback");
 
 			/* Turn all notes off and wait a bit to allow the messages to be handled. */
 			clock->GetTime(&cur_time);
@@ -676,7 +676,7 @@ static void MidiThreadProc()
 
 		if (wfso == WAIT_OBJECT_0) {
 			if (_playback.do_start) {
-				Debug(driver, Severity::Warning, "DMusic thread: Starting playback");
+				Debug(Facility::Driver, Severity::Warning, "DMusic thread: Starting playback");
 				{
 					/* New scope to limit the time the mutex is locked. */
 					std::lock_guard<std::mutex> lock(_thread_mutex);
@@ -716,14 +716,14 @@ static void MidiThreadProc()
 					preload_bytes += block.data.size();
 					if (block.ticktime >= current_segment.start) {
 						if (current_segment.loop) {
-							Debug(driver, Severity::Warning, "DMusic: timer: loop from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
+							Debug(Facility::Driver, Severity::Warning, "DMusic: timer: loop from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
 							current_segment.start_block = bl;
 							break;
 						} else {
 							/* Skip the transmission delay compensation performed in the Win32 MIDI driver.
 							 * The DMusic driver will most likely be used with the MS softsynth, which is not subject to transmission delays.
 							 */
-							Debug(driver, Severity::Warning, "DMusic: timer: start from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
+							Debug(Facility::Driver, Severity::Warning, "DMusic: timer: start from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
 							playback_start_time -= block.realtime * MIDITIME_TO_REFTIME;
 							break;
 						}
@@ -738,7 +738,7 @@ static void MidiThreadProc()
 			/* Check for volume change. */
 			if (current_volume != _playback.new_volume) {
 				if (current_time - last_volume_time > 10 * MS_TO_REFTIME) {
-					Debug(driver, Severity::Warning, "DMusic thread: volume change");
+					Debug(Facility::Driver, Severity::Warning, "DMusic thread: volume change");
 					current_volume = _playback.new_volume;
 					last_volume_time = current_time;
 					for (int ch = 0; ch < 16; ch++) {
@@ -756,7 +756,7 @@ static void MidiThreadProc()
 				/* check that block isn't at end-of-song override */
 				if (current_segment.end > 0 && block.ticktime >= current_segment.end) {
 					if (current_segment.loop) {
-						Debug(driver, Severity::Warning, "DMusic thread: Looping song");
+						Debug(Facility::Driver, Severity::Warning, "DMusic thread: Looping song");
 						current_block = current_segment.start_block;
 						playback_start_time = current_time - current_file.blocks[current_block].realtime * MIDITIME_TO_REFTIME;
 					} else {
@@ -770,13 +770,13 @@ static void MidiThreadProc()
 				if (block.realtime * MIDITIME_TO_REFTIME > playback_time +  3 *_playback.preload_time * MS_TO_REFTIME) {
 					/* Stop the thread loop until we are at the preload time of the next block. */
 					next_timeout = Clamp((block.realtime * MIDITIME_TO_REFTIME - playback_time) / MS_TO_REFTIME - _playback.preload_time, 0, 1000);
-					Debug(driver, Severity::Trace3, "DMusic thread: Next event in {} ms (music {}, ref {})", next_timeout, block.realtime * MIDITIME_TO_REFTIME, playback_time);
+					Debug(Facility::Driver, Severity::Trace3, "DMusic thread: Next event in {} ms (music {}, ref {})", next_timeout, block.realtime * MIDITIME_TO_REFTIME, playback_time);
 					break;
 				}
 
 				/* Timestamp of the current block. */
 				block_time = playback_start_time + block.realtime * MIDITIME_TO_REFTIME;
-				Debug(driver, Severity::Trace3, "DMusic thread: Streaming block {} (cur={}, block={})", current_block, current_time / MS_TO_REFTIME, block_time / MS_TO_REFTIME);
+				Debug(Facility::Driver, Severity::Trace3, "DMusic thread: Streaming block {} (cur={}, block={})", current_block, current_time / MS_TO_REFTIME, block_time / MS_TO_REFTIME);
 
 				const uint8_t *data = block.data.data();
 				size_t remaining = block.data.size();
@@ -869,7 +869,7 @@ static void MidiThreadProc()
 		}
 	}
 
-	Debug(driver, Severity::Warning, "DMusic: Exiting playback thread");
+	Debug(Facility::Driver, Severity::Warning, "DMusic: Exiting playback thread");
 
 	/* Turn all notes off and wait a bit to allow the messages to be handled by real hardware. */
 	clock->GetTime(&cur_time);
@@ -912,7 +912,7 @@ static std::optional<std::string_view> LoadDefaultDLSFile(std::optional<std::str
 				if (SUCCEEDED(RegQueryValueEx(hkDM, L"GMFilePath", nullptr, nullptr, (LPBYTE)dls_path, &buf_size))) {
 					wchar_t expand_path[MAX_PATH * 2];
 					ExpandEnvironmentStrings(dls_path, expand_path, static_cast<DWORD>(std::size(expand_path)));
-					if (!dls_file.LoadFile(FS2OTTD(expand_path))) Debug(driver, Severity::Error, "Failed to load default GM DLS file from registry");
+					if (!dls_file.LoadFile(FS2OTTD(expand_path))) Debug(Facility::Driver, Severity::Error, "Failed to load default GM DLS file from registry");
 				}
 				RegCloseKey(hkDM);
 			}
@@ -1133,17 +1133,17 @@ std::optional<std::string_view> MusicDriver_DMusic::Start(const StringList &parm
 	_playback.preload_time = GetDriverParamInt(parm, "preload", 50);
 
 	int pIdx = GetDriverParamInt(parm, "port", -1);
-	if (_debug_driver_level >= Severity::Error) {
+	if (IsVisibleSeverity(Facility::Driver, Severity::Error)) {
 		/* Print all valid output ports. */
 		char desc[DMUS_MAX_DESCRIPTION];
 
 		DMUS_PORTCAPS caps{};
 		caps.dwSize = sizeof(DMUS_PORTCAPS);
 
-		Debug(driver, Severity::Error, "Detected DirectMusic ports:");
+		Debug(Facility::Driver, Severity::Error, "Detected DirectMusic ports:");
 		for (int i = 0; _music->EnumPort(i, &caps) == S_OK; i++) {
 			if (caps.dwClass == DMUS_PC_OUTPUTCLASS) {
-				Debug(driver, Severity::Error, " {}: {}{}", i, convert_from_fs(caps.wszDescription, desc), i == pIdx ? " (selected)" : "");
+				Debug(Facility::Driver, Severity::Error, " {}: {}{}", i, convert_from_fs(caps.wszDescription, desc), i == pIdx ? " (selected)" : "");
 			}
 		}
 	}

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -273,7 +273,7 @@ bool DLSFile::ReadDLSRegion(FileHandle &f, DWORD list_length, std::vector<DLSReg
 				break;
 
 			default:
-				Debug(driver, 7, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 				fseek(f, chunk.length, SEEK_CUR);
 				break;
 		}
@@ -296,11 +296,11 @@ bool DLSFile::ReadDLSRegionList(FileHandle &f, DWORD list_length, DLSInstrument 
 			if (list_type == FOURCC_RGN) {
 				this->ReadDLSRegion(f, chunk.length - sizeof(list_type), instrument.regions);
 			} else {
-				Debug(driver, 7, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
+				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
 				fseek(f, chunk.length - sizeof(list_type), SEEK_CUR);
 			}
 		} else {
-			Debug(driver, 7, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+			Debug(driver, Severity::Trace1, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 			fseek(f, chunk.length, SEEK_CUR);
 		}
 	}
@@ -342,7 +342,7 @@ bool DLSFile::ReadDLSInstrument(FileHandle &f, DWORD list_length)
 				break;
 
 			default:
-				Debug(driver, 7, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 				fseek(f, chunk.length, SEEK_CUR);
 				break;
 		}
@@ -363,15 +363,15 @@ bool DLSFile::ReadDLSInstrumentList(FileHandle &f, DWORD list_length)
 			if (fread(&list_type, sizeof(list_type), 1, f) != 1) return false;
 
 			if (list_type == FOURCC_INS) {
-				Debug(driver, 6, "DLS: Reading instrument {}", (int)instruments.size());
+				Debug(driver, Severity::Debug2, "DLS: Reading instrument {}", (int)instruments.size());
 
 				if (!this->ReadDLSInstrument(f, chunk.length - sizeof(list_type))) return false;
 			} else {
-				Debug(driver, 7, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
+				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
 				fseek(f, chunk.length - sizeof(list_type), SEEK_CUR);
 			}
 		} else {
-			Debug(driver, 7, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+			Debug(driver, Severity::Trace1, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 			fseek(f, chunk.length, SEEK_CUR);
 		}
 	}
@@ -428,7 +428,7 @@ bool DLSFile::ReadDLSWave(FileHandle &f, DWORD list_length, long offset)
 				break;
 
 			default:
-				Debug(driver, 7, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 				fseek(f, chunk.length, SEEK_CUR);
 				break;
 		}
@@ -453,15 +453,15 @@ bool DLSFile::ReadDLSWaveList(FileHandle &f, DWORD list_length)
 			if (fread(&list_type, sizeof(list_type), 1, f) != 1) return false;
 
 			if (list_type == FOURCC_wave) {
-				Debug(driver, 6, "DLS: Reading wave {}", waves.size());
+				Debug(driver, Severity::Debug2, "DLS: Reading wave {}", waves.size());
 
 				if (!this->ReadDLSWave(f, chunk.length - sizeof(list_type), chunk_offset - base_offset)) return false;
 			} else {
-				Debug(driver, 7, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
+				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown list chunk of type {}{}{}{}", (char)(list_type & 0xFF), (char)((list_type >> 8) & 0xFF), (char)((list_type >> 16) & 0xFF), (char)((list_type >> 24) & 0xFF));
 				fseek(f, chunk.length - sizeof(list_type), SEEK_CUR);
 			}
 		} else {
-			Debug(driver, 7, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+			Debug(driver, Severity::Trace1, "DLS: Ignoring chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 			fseek(f, chunk.length, SEEK_CUR);
 		}
 	}
@@ -471,7 +471,7 @@ bool DLSFile::ReadDLSWaveList(FileHandle &f, DWORD list_length)
 
 bool DLSFile::LoadFile(std::string_view file)
 {
-	Debug(driver, 2, "DMusic: Try to load DLS file {}", file);
+	Debug(driver, Severity::Warning, "DMusic: Try to load DLS file {}", file);
 
 	auto of = FileHandle::Open(file, "rb");
 	if (!of.has_value()) return false;
@@ -486,7 +486,7 @@ bool DLSFile::LoadFile(std::string_view file)
 
 	hdr.length -= sizeof(FOURCC);
 
-	Debug(driver, 2, "DMusic: Parsing DLS file");
+	Debug(driver, Severity::Warning, "DMusic: Parsing DLS file");
 
 	DLSHEADER header{};
 
@@ -534,7 +534,7 @@ bool DLSFile::LoadFile(std::string_view file)
 				break;
 
 			default:
-				Debug(driver, 7, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
+				Debug(driver, Severity::Trace1, "DLS: Ignoring unknown chunk {}{}{}{}", (char)(chunk.type & 0xFF), (char)((chunk.type >> 8) & 0xFF), (char)((chunk.type >> 16) & 0xFF), (char)((chunk.type >> 24) & 0xFF));
 				fseek(f, chunk.length, SEEK_CUR);
 				break;
 		}
@@ -629,7 +629,7 @@ static void TransmitNotesOff(IDirectMusicBuffer *buffer, REFERENCE_TIME block_ti
 
 static void MidiThreadProc()
 {
-	Debug(driver, 2, "DMusic: Entering playback thread");
+	Debug(driver, Severity::Warning, "DMusic: Entering playback thread");
 
 	REFERENCE_TIME last_volume_time = 0; // timestamp of the last volume change
 	REFERENCE_TIME block_time = 0;       // timestamp of the last block sent to the port
@@ -661,7 +661,7 @@ static void MidiThreadProc()
 		}
 
 		if (_playback.do_stop) {
-			Debug(driver, 2, "DMusic thread: Stopping playback");
+			Debug(driver, Severity::Warning, "DMusic thread: Stopping playback");
 
 			/* Turn all notes off and wait a bit to allow the messages to be handled. */
 			clock->GetTime(&cur_time);
@@ -676,7 +676,7 @@ static void MidiThreadProc()
 
 		if (wfso == WAIT_OBJECT_0) {
 			if (_playback.do_start) {
-				Debug(driver, 2, "DMusic thread: Starting playback");
+				Debug(driver, Severity::Warning, "DMusic thread: Starting playback");
 				{
 					/* New scope to limit the time the mutex is locked. */
 					std::lock_guard<std::mutex> lock(_thread_mutex);
@@ -716,14 +716,14 @@ static void MidiThreadProc()
 					preload_bytes += block.data.size();
 					if (block.ticktime >= current_segment.start) {
 						if (current_segment.loop) {
-							Debug(driver, 2, "DMusic: timer: loop from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
+							Debug(driver, Severity::Warning, "DMusic: timer: loop from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
 							current_segment.start_block = bl;
 							break;
 						} else {
 							/* Skip the transmission delay compensation performed in the Win32 MIDI driver.
 							 * The DMusic driver will most likely be used with the MS softsynth, which is not subject to transmission delays.
 							 */
-							Debug(driver, 2, "DMusic: timer: start from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
+							Debug(driver, Severity::Warning, "DMusic: timer: start from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
 							playback_start_time -= block.realtime * MIDITIME_TO_REFTIME;
 							break;
 						}
@@ -738,7 +738,7 @@ static void MidiThreadProc()
 			/* Check for volume change. */
 			if (current_volume != _playback.new_volume) {
 				if (current_time - last_volume_time > 10 * MS_TO_REFTIME) {
-					Debug(driver, 2, "DMusic thread: volume change");
+					Debug(driver, Severity::Warning, "DMusic thread: volume change");
 					current_volume = _playback.new_volume;
 					last_volume_time = current_time;
 					for (int ch = 0; ch < 16; ch++) {
@@ -756,7 +756,7 @@ static void MidiThreadProc()
 				/* check that block isn't at end-of-song override */
 				if (current_segment.end > 0 && block.ticktime >= current_segment.end) {
 					if (current_segment.loop) {
-						Debug(driver, 2, "DMusic thread: Looping song");
+						Debug(driver, Severity::Warning, "DMusic thread: Looping song");
 						current_block = current_segment.start_block;
 						playback_start_time = current_time - current_file.blocks[current_block].realtime * MIDITIME_TO_REFTIME;
 					} else {
@@ -770,13 +770,13 @@ static void MidiThreadProc()
 				if (block.realtime * MIDITIME_TO_REFTIME > playback_time +  3 *_playback.preload_time * MS_TO_REFTIME) {
 					/* Stop the thread loop until we are at the preload time of the next block. */
 					next_timeout = Clamp((block.realtime * MIDITIME_TO_REFTIME - playback_time) / MS_TO_REFTIME - _playback.preload_time, 0, 1000);
-					Debug(driver, 9, "DMusic thread: Next event in {} ms (music {}, ref {})", next_timeout, block.realtime * MIDITIME_TO_REFTIME, playback_time);
+					Debug(driver, Severity::Trace3, "DMusic thread: Next event in {} ms (music {}, ref {})", next_timeout, block.realtime * MIDITIME_TO_REFTIME, playback_time);
 					break;
 				}
 
 				/* Timestamp of the current block. */
 				block_time = playback_start_time + block.realtime * MIDITIME_TO_REFTIME;
-				Debug(driver, 9, "DMusic thread: Streaming block {} (cur={}, block={})", current_block, current_time / MS_TO_REFTIME, block_time / MS_TO_REFTIME);
+				Debug(driver, Severity::Trace3, "DMusic thread: Streaming block {} (cur={}, block={})", current_block, current_time / MS_TO_REFTIME, block_time / MS_TO_REFTIME);
 
 				const uint8_t *data = block.data.data();
 				size_t remaining = block.data.size();
@@ -869,7 +869,7 @@ static void MidiThreadProc()
 		}
 	}
 
-	Debug(driver, 2, "DMusic: Exiting playback thread");
+	Debug(driver, Severity::Warning, "DMusic: Exiting playback thread");
 
 	/* Turn all notes off and wait a bit to allow the messages to be handled by real hardware. */
 	clock->GetTime(&cur_time);
@@ -912,7 +912,7 @@ static std::optional<std::string_view> LoadDefaultDLSFile(std::optional<std::str
 				if (SUCCEEDED(RegQueryValueEx(hkDM, L"GMFilePath", nullptr, nullptr, (LPBYTE)dls_path, &buf_size))) {
 					wchar_t expand_path[MAX_PATH * 2];
 					ExpandEnvironmentStrings(dls_path, expand_path, static_cast<DWORD>(std::size(expand_path)));
-					if (!dls_file.LoadFile(FS2OTTD(expand_path))) Debug(driver, 1, "Failed to load default GM DLS file from registry");
+					if (!dls_file.LoadFile(FS2OTTD(expand_path))) Debug(driver, Severity::Error, "Failed to load default GM DLS file from registry");
 				}
 				RegCloseKey(hkDM);
 			}
@@ -1133,17 +1133,17 @@ std::optional<std::string_view> MusicDriver_DMusic::Start(const StringList &parm
 	_playback.preload_time = GetDriverParamInt(parm, "preload", 50);
 
 	int pIdx = GetDriverParamInt(parm, "port", -1);
-	if (_debug_driver_level > 0) {
+	if (_debug_driver_level >= Severity::Error) {
 		/* Print all valid output ports. */
 		char desc[DMUS_MAX_DESCRIPTION];
 
 		DMUS_PORTCAPS caps{};
 		caps.dwSize = sizeof(DMUS_PORTCAPS);
 
-		Debug(driver, 1, "Detected DirectMusic ports:");
+		Debug(driver, Severity::Error, "Detected DirectMusic ports:");
 		for (int i = 0; _music->EnumPort(i, &caps) == S_OK; i++) {
 			if (caps.dwClass == DMUS_PC_OUTPUTCLASS) {
-				Debug(driver, 1, " {}: {}{}", i, convert_from_fs(caps.wszDescription, desc), i == pIdx ? " (selected)" : "");
+				Debug(driver, Severity::Error, " {}: {}{}", i, convert_from_fs(caps.wszDescription, desc), i == pIdx ? " (selected)" : "");
 			}
 		}
 	}

--- a/src/music/extmidi.cpp
+++ b/src/music/extmidi.cpp
@@ -97,7 +97,7 @@ bool MusicDriver_ExtMidi::IsSongPlaying()
 
 void MusicDriver_ExtMidi::SetVolume(uint8_t)
 {
-	Debug(driver, Severity::Error, "extmidi: set volume not implemented");
+	Debug(Facility::Driver, Severity::Error, "extmidi: set volume not implemented");
 }
 
 void MusicDriver_ExtMidi::DoPlay()
@@ -121,7 +121,7 @@ void MusicDriver_ExtMidi::DoPlay()
 		}
 
 		case -1:
-			Debug(driver, Severity::Critical, "extmidi: couldn't fork: {}", strerror(errno));
+			Debug(Facility::Driver, Severity::Critical, "extmidi: couldn't fork: {}", strerror(errno));
 			[[fallthrough]];
 
 		default:
@@ -162,7 +162,7 @@ void MusicDriver_ExtMidi::DoStop()
 
 	if (KillWait(this->pid, SIGTERM)) return;
 
-	Debug(driver, Severity::Critical, "extmidi: gracefully stopping failed, trying the hard way");
+	Debug(Facility::Driver, Severity::Critical, "extmidi: gracefully stopping failed, trying the hard way");
 	/* Gracefully stopping failed. Do it the hard way
 	 * and wait till the process finally died. */
 	kill(this->pid, SIGKILL);

--- a/src/music/extmidi.cpp
+++ b/src/music/extmidi.cpp
@@ -97,7 +97,7 @@ bool MusicDriver_ExtMidi::IsSongPlaying()
 
 void MusicDriver_ExtMidi::SetVolume(uint8_t)
 {
-	Debug(driver, 1, "extmidi: set volume not implemented");
+	Debug(driver, Severity::Error, "extmidi: set volume not implemented");
 }
 
 void MusicDriver_ExtMidi::DoPlay()
@@ -121,7 +121,7 @@ void MusicDriver_ExtMidi::DoPlay()
 		}
 
 		case -1:
-			Debug(driver, 0, "extmidi: couldn't fork: {}", strerror(errno));
+			Debug(driver, Severity::Critical, "extmidi: couldn't fork: {}", strerror(errno));
 			[[fallthrough]];
 
 		default:
@@ -162,7 +162,7 @@ void MusicDriver_ExtMidi::DoStop()
 
 	if (KillWait(this->pid, SIGTERM)) return;
 
-	Debug(driver, 0, "extmidi: gracefully stopping failed, trying the hard way");
+	Debug(driver, Severity::Critical, "extmidi: gracefully stopping failed, trying the hard way");
 	/* Gracefully stopping failed. Do it the hard way
 	 * and wait till the process finally died. */
 	kill(this->pid, SIGKILL);

--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -64,12 +64,12 @@ static void RenderMusicStream(int16_t *buffer, size_t samples)
 static void load_and_execute_config_file(fluid_cmd_handler_t *cmd_handler, const char *config_file)
 {
 	if (std::filesystem::exists(config_file)) {
-		Debug(driver, Severity::Warning, "Fluidsynth: Attempting to load config file '{}'", config_file);
+		Debug(Facility::Driver, Severity::Warning, "Fluidsynth: Attempting to load config file '{}'", config_file);
 		if (fluid_source(cmd_handler, config_file) < 0) {
-			Debug(driver, Severity::Critical, "Fluidsynth: Failed to execute command configuration file '{}'", config_file);
+			Debug(Facility::Driver, Severity::Critical, "Fluidsynth: Failed to execute command configuration file '{}'", config_file);
 		}
 	} else {
-		Debug(driver, Severity::Error, "Fluidsynth: Failed to load config file '{}' - file doesn't exist", config_file);
+		Debug(Facility::Driver, Severity::Error, "Fluidsynth: Failed to load config file '{}' - file doesn't exist", config_file);
 	}
 }
 
@@ -80,7 +80,7 @@ std::optional<std::string_view> MusicDriver_FluidSynth::Start(const StringList &
 	auto sfont_name = GetDriverParam(param, "soundfont");
 	int sfont_id;
 
-	Debug(driver, Severity::Error, "Fluidsynth: sf {}", sfont_name.has_value() ? *sfont_name : "(null)");
+	Debug(Facility::Driver, Severity::Error, "Fluidsynth: sf {}", sfont_name.has_value() ? *sfont_name : "(null)");
 
 	/* Create the settings. */
 	_midi.settings = new_fluid_settings();
@@ -104,7 +104,7 @@ std::optional<std::string_view> MusicDriver_FluidSynth::Start(const StringList &
 	/* Install the music render routine and set up the samplerate */
 	uint32_t samplerate = MxSetMusicSource(RenderMusicStream);
 	fluid_settings_setnum(_midi.settings, "synth.sample-rate", samplerate);
-	Debug(driver, Severity::Error, "Fluidsynth: samplerate {:.0f}", (float)samplerate);
+	Debug(Facility::Driver, Severity::Error, "Fluidsynth: samplerate {:.0f}", (float)samplerate);
 
 	/* Create the synthesizer. */
 	_midi.synth = new_fluid_synth(_midi.settings);
@@ -181,18 +181,18 @@ void MusicDriver_FluidSynth::PlaySong(const MusicSongInfo &song)
 
 	_midi.player = new_fluid_player(_midi.synth);
 	if (_midi.player == nullptr) {
-		Debug(driver, Severity::Critical, "Could not create midi player");
+		Debug(Facility::Driver, Severity::Critical, "Could not create midi player");
 		return;
 	}
 
 	if (fluid_player_add(_midi.player, filename.c_str()) != FLUID_OK) {
-		Debug(driver, Severity::Critical, "Could not open music file");
+		Debug(Facility::Driver, Severity::Critical, "Could not open music file");
 		delete_fluid_player(_midi.player);
 		_midi.player = nullptr;
 		return;
 	}
 	if (fluid_player_play(_midi.player) != FLUID_OK) {
-		Debug(driver, Severity::Critical, "Could not start midi player");
+		Debug(Facility::Driver, Severity::Critical, "Could not start midi player");
 		delete_fluid_player(_midi.player);
 		_midi.player = nullptr;
 		return;
@@ -229,6 +229,6 @@ void MusicDriver_FluidSynth::SetVolume(uint8_t vol)
 	/* Set gain using OpenTTD's volume, as a number between 0 and max_gain. */
 	double gain = (1.0 * vol) / 128.0 * _midi.max_gain;
 	if (fluid_settings_setnum(_midi.settings, "synth.gain", gain) != FLUID_OK) {
-		Debug(driver, Severity::Critical, "Could not set volume");
+		Debug(Facility::Driver, Severity::Critical, "Could not set volume");
 	}
 }

--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -64,12 +64,12 @@ static void RenderMusicStream(int16_t *buffer, size_t samples)
 static void load_and_execute_config_file(fluid_cmd_handler_t *cmd_handler, const char *config_file)
 {
 	if (std::filesystem::exists(config_file)) {
-		Debug(driver, 2, "Fluidsynth: Attempting to load config file '{}'", config_file);
+		Debug(driver, Severity::Warning, "Fluidsynth: Attempting to load config file '{}'", config_file);
 		if (fluid_source(cmd_handler, config_file) < 0) {
-			Debug(driver, 0, "Fluidsynth: Failed to execute command configuration file '{}'", config_file);
+			Debug(driver, Severity::Critical, "Fluidsynth: Failed to execute command configuration file '{}'", config_file);
 		}
 	} else {
-		Debug(driver, 1, "Fluidsynth: Failed to load config file '{}' - file doesn't exist", config_file);
+		Debug(driver, Severity::Error, "Fluidsynth: Failed to load config file '{}' - file doesn't exist", config_file);
 	}
 }
 
@@ -80,7 +80,7 @@ std::optional<std::string_view> MusicDriver_FluidSynth::Start(const StringList &
 	auto sfont_name = GetDriverParam(param, "soundfont");
 	int sfont_id;
 
-	Debug(driver, 1, "Fluidsynth: sf {}", sfont_name.has_value() ? *sfont_name : "(null)");
+	Debug(driver, Severity::Error, "Fluidsynth: sf {}", sfont_name.has_value() ? *sfont_name : "(null)");
 
 	/* Create the settings. */
 	_midi.settings = new_fluid_settings();
@@ -104,7 +104,7 @@ std::optional<std::string_view> MusicDriver_FluidSynth::Start(const StringList &
 	/* Install the music render routine and set up the samplerate */
 	uint32_t samplerate = MxSetMusicSource(RenderMusicStream);
 	fluid_settings_setnum(_midi.settings, "synth.sample-rate", samplerate);
-	Debug(driver, 1, "Fluidsynth: samplerate {:.0f}", (float)samplerate);
+	Debug(driver, Severity::Error, "Fluidsynth: samplerate {:.0f}", (float)samplerate);
 
 	/* Create the synthesizer. */
 	_midi.synth = new_fluid_synth(_midi.settings);
@@ -181,18 +181,18 @@ void MusicDriver_FluidSynth::PlaySong(const MusicSongInfo &song)
 
 	_midi.player = new_fluid_player(_midi.synth);
 	if (_midi.player == nullptr) {
-		Debug(driver, 0, "Could not create midi player");
+		Debug(driver, Severity::Critical, "Could not create midi player");
 		return;
 	}
 
 	if (fluid_player_add(_midi.player, filename.c_str()) != FLUID_OK) {
-		Debug(driver, 0, "Could not open music file");
+		Debug(driver, Severity::Critical, "Could not open music file");
 		delete_fluid_player(_midi.player);
 		_midi.player = nullptr;
 		return;
 	}
 	if (fluid_player_play(_midi.player) != FLUID_OK) {
-		Debug(driver, 0, "Could not start midi player");
+		Debug(driver, Severity::Critical, "Could not start midi player");
 		delete_fluid_player(_midi.player);
 		_midi.player = nullptr;
 		return;
@@ -229,6 +229,6 @@ void MusicDriver_FluidSynth::SetVolume(uint8_t vol)
 	/* Set gain using OpenTTD's volume, as a number between 0 and max_gain. */
 	double gain = (1.0 * vol) / 128.0 * _midi.max_gain;
 	if (fluid_settings_setnum(_midi.settings, "synth.gain", gain) != FLUID_OK) {
-		Debug(driver, 0, "Could not set volume");
+		Debug(driver, Severity::Critical, "Could not set volume");
 	}
 }

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -117,7 +117,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 
 	/* check for stop */
 	if (_midi.do_stop) {
-		Debug(driver, Severity::Warning, "Win32-MIDI: timer: do_stop is set");
+		Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: timer: do_stop is set");
 		midiOutReset(_midi.midi_out);
 		_midi.playing = false;
 		_midi.do_stop = false;
@@ -130,7 +130,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 		if (timeGetTime() - _midi.playback_start_time < 50) {
 			return;
 		}
-		Debug(driver, Severity::Warning, "Win32-MIDI: timer: do_start step {}", _midi.do_start);
+		Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: timer: do_start step {}", _midi.do_start);
 
 		if (_midi.do_start == 1) {
 			/* Send "all notes off" */
@@ -170,7 +170,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 		}
 	} else if (!_midi.playing) {
 		/* not playing, stop the timer */
-		Debug(driver, Severity::Warning, "Win32-MIDI: timer: not playing, stopping timer");
+		Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: timer: not playing, stopping timer");
 		timeKillEvent(uTimerID);
 		_midi.timer_id = 0;
 		return;
@@ -179,7 +179,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 	/* check for volume change */
 	if (_midi.current_volume != _midi.new_volume) {
 		if (volume_throttle == 0) {
-			Debug(driver, Severity::Warning, "Win32-MIDI: timer: volume change");
+			Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: timer: volume change");
 			_midi.current_volume = _midi.new_volume;
 			volume_throttle = 20 / _midi.time_period;
 			for (int ch = 0; ch < 16; ch++) {
@@ -202,7 +202,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 			preload_bytes += block.data.size();
 			if (block.ticktime >= _midi.current_segment.start) {
 				if (_midi.current_segment.loop) {
-					Debug(driver, Severity::Warning, "Win32-MIDI: timer: loop from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
+					Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: timer: loop from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
 					_midi.current_segment.start_block = bl;
 					break;
 				} else {
@@ -211,7 +211,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 					 * which have a bitrate of 31,250 bits/sec, and transmit 1+8+1 start/data/stop bits per byte.
 					 * The delay compensation is needed to avoid time-compression of following messages.
 					 */
-					Debug(driver, Severity::Warning, "Win32-MIDI: timer: start from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
+					Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: timer: start from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
 					_midi.playback_start_time -= block.realtime / 1000 - (DWORD)(preload_bytes * 1000 / 3125);
 					break;
 				}
@@ -324,11 +324,11 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 
 void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 {
-	Debug(driver, Severity::Warning, "Win32-MIDI: PlaySong: entry");
+	Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: PlaySong: entry");
 
 	MidiFile new_song;
 	if (!new_song.LoadSong(song)) return;
-	Debug(driver, Severity::Warning, "Win32-MIDI: PlaySong: Loaded song");
+	Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: PlaySong: Loaded song");
 
 	std::lock_guard<std::mutex> mutex_lock(_midi.lock);
 
@@ -337,21 +337,21 @@ void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 	_midi.next_segment.end = song.override_end;
 	_midi.next_segment.loop = song.loop;
 
-	Debug(driver, Severity::Warning, "Win32-MIDI: PlaySong: setting flag");
+	Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: PlaySong: setting flag");
 	_midi.do_stop = _midi.playing;
 	_midi.do_start = 1;
 
 	if (_midi.timer_id == 0) {
-		Debug(driver, Severity::Warning, "Win32-MIDI: PlaySong: starting timer");
+		Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: PlaySong: starting timer");
 		_midi.timer_id = timeSetEvent(_midi.time_period, _midi.time_period, TimerCallback, (DWORD_PTR)this, TIME_PERIODIC | TIME_CALLBACK_FUNCTION);
 	}
 }
 
 void MusicDriver_Win32::StopSong()
 {
-	Debug(driver, Severity::Warning, "Win32-MIDI: StopSong: entry");
+	Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: StopSong: entry");
 	std::lock_guard<std::mutex> mutex_lock(_midi.lock);
-	Debug(driver, Severity::Warning, "Win32-MIDI: StopSong: setting flag");
+	Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: StopSong: setting flag");
 	_midi.do_stop = true;
 }
 
@@ -368,16 +368,16 @@ void MusicDriver_Win32::SetVolume(uint8_t vol)
 
 std::optional<std::string_view> MusicDriver_Win32::Start(const StringList &parm)
 {
-	Debug(driver, Severity::Warning, "Win32-MIDI: Start: initializing");
+	Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: Start: initializing");
 
 	int resolution = GetDriverParamInt(parm, "resolution", 5);
 	uint port = (uint)GetDriverParamInt(parm, "port", UINT_MAX);
 	auto portname = GetDriverParam(parm, "portname");
 
 	/* Enumerate ports either for selecting port by name, or for debug output */
-	if (portname.has_value() || _debug_driver_level >= Severity::Error) {
+	if (portname.has_value() || IsVisibleSeverity(Facility::Driver, Severity::Error)) {
 		uint numports = midiOutGetNumDevs();
-		Debug(driver, Severity::Error, "Win32-MIDI: Found {} output devices:", numports);
+		Debug(Facility::Driver, Severity::Error, "Win32-MIDI: Found {} output devices:", numports);
 		for (uint tryport = 0; tryport < numports; tryport++) {
 			MIDIOUTCAPS moc{};
 			if (midiOutGetDevCaps(tryport, &moc, sizeof(moc)) == MMSYSERR_NOERROR) {
@@ -388,7 +388,7 @@ std::optional<std::string_view> MusicDriver_Win32::Start(const StringList &parm)
 				 * If multiple ports have the same name, this will select the last matching port, and the debug output will be confusing. */
 				if (portname.has_value() && *portname == tryportname) port = tryport;
 
-				Debug(driver, Severity::Error, "MIDI port {:2d}: {}{}", tryport, tryportname, (tryport == port) ? " [selected]" : "");
+				Debug(Facility::Driver, Severity::Error, "MIDI port {:2d}: {}{}", tryport, tryportname, (tryport == port) ? " [selected]" : "");
 			}
 		}
 	}
@@ -414,7 +414,7 @@ std::optional<std::string_view> MusicDriver_Win32::Start(const StringList &parm)
 		_midi.time_period = std::min(std::max((UINT)resolution, timecaps.wPeriodMin), timecaps.wPeriodMax);
 		if (timeBeginPeriod(_midi.time_period) == MMSYSERR_NOERROR) {
 			/* success */
-			Debug(driver, Severity::Warning, "Win32-MIDI: Start: timer resolution is {}", _midi.time_period);
+			Debug(Facility::Driver, Severity::Warning, "Win32-MIDI: Start: timer resolution is {}", _midi.time_period);
 			return std::nullopt;
 		}
 	}

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -117,7 +117,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 
 	/* check for stop */
 	if (_midi.do_stop) {
-		Debug(driver, 2, "Win32-MIDI: timer: do_stop is set");
+		Debug(driver, Severity::Warning, "Win32-MIDI: timer: do_stop is set");
 		midiOutReset(_midi.midi_out);
 		_midi.playing = false;
 		_midi.do_stop = false;
@@ -130,7 +130,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 		if (timeGetTime() - _midi.playback_start_time < 50) {
 			return;
 		}
-		Debug(driver, 2, "Win32-MIDI: timer: do_start step {}", _midi.do_start);
+		Debug(driver, Severity::Warning, "Win32-MIDI: timer: do_start step {}", _midi.do_start);
 
 		if (_midi.do_start == 1) {
 			/* Send "all notes off" */
@@ -170,7 +170,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 		}
 	} else if (!_midi.playing) {
 		/* not playing, stop the timer */
-		Debug(driver, 2, "Win32-MIDI: timer: not playing, stopping timer");
+		Debug(driver, Severity::Warning, "Win32-MIDI: timer: not playing, stopping timer");
 		timeKillEvent(uTimerID);
 		_midi.timer_id = 0;
 		return;
@@ -179,7 +179,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 	/* check for volume change */
 	if (_midi.current_volume != _midi.new_volume) {
 		if (volume_throttle == 0) {
-			Debug(driver, 2, "Win32-MIDI: timer: volume change");
+			Debug(driver, Severity::Warning, "Win32-MIDI: timer: volume change");
 			_midi.current_volume = _midi.new_volume;
 			volume_throttle = 20 / _midi.time_period;
 			for (int ch = 0; ch < 16; ch++) {
@@ -202,7 +202,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 			preload_bytes += block.data.size();
 			if (block.ticktime >= _midi.current_segment.start) {
 				if (_midi.current_segment.loop) {
-					Debug(driver, 2, "Win32-MIDI: timer: loop from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
+					Debug(driver, Severity::Warning, "Win32-MIDI: timer: loop from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
 					_midi.current_segment.start_block = bl;
 					break;
 				} else {
@@ -211,7 +211,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 					 * which have a bitrate of 31,250 bits/sec, and transmit 1+8+1 start/data/stop bits per byte.
 					 * The delay compensation is needed to avoid time-compression of following messages.
 					 */
-					Debug(driver, 2, "Win32-MIDI: timer: start from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
+					Debug(driver, Severity::Warning, "Win32-MIDI: timer: start from block {} (ticktime {}, realtime {:.3f}, bytes {})", bl, block.ticktime, block.realtime / 1000.0, preload_bytes);
 					_midi.playback_start_time -= block.realtime / 1000 - (DWORD)(preload_bytes * 1000 / 3125);
 					break;
 				}
@@ -324,11 +324,11 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR
 
 void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 {
-	Debug(driver, 2, "Win32-MIDI: PlaySong: entry");
+	Debug(driver, Severity::Warning, "Win32-MIDI: PlaySong: entry");
 
 	MidiFile new_song;
 	if (!new_song.LoadSong(song)) return;
-	Debug(driver, 2, "Win32-MIDI: PlaySong: Loaded song");
+	Debug(driver, Severity::Warning, "Win32-MIDI: PlaySong: Loaded song");
 
 	std::lock_guard<std::mutex> mutex_lock(_midi.lock);
 
@@ -337,21 +337,21 @@ void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 	_midi.next_segment.end = song.override_end;
 	_midi.next_segment.loop = song.loop;
 
-	Debug(driver, 2, "Win32-MIDI: PlaySong: setting flag");
+	Debug(driver, Severity::Warning, "Win32-MIDI: PlaySong: setting flag");
 	_midi.do_stop = _midi.playing;
 	_midi.do_start = 1;
 
 	if (_midi.timer_id == 0) {
-		Debug(driver, 2, "Win32-MIDI: PlaySong: starting timer");
+		Debug(driver, Severity::Warning, "Win32-MIDI: PlaySong: starting timer");
 		_midi.timer_id = timeSetEvent(_midi.time_period, _midi.time_period, TimerCallback, (DWORD_PTR)this, TIME_PERIODIC | TIME_CALLBACK_FUNCTION);
 	}
 }
 
 void MusicDriver_Win32::StopSong()
 {
-	Debug(driver, 2, "Win32-MIDI: StopSong: entry");
+	Debug(driver, Severity::Warning, "Win32-MIDI: StopSong: entry");
 	std::lock_guard<std::mutex> mutex_lock(_midi.lock);
-	Debug(driver, 2, "Win32-MIDI: StopSong: setting flag");
+	Debug(driver, Severity::Warning, "Win32-MIDI: StopSong: setting flag");
 	_midi.do_stop = true;
 }
 
@@ -368,16 +368,16 @@ void MusicDriver_Win32::SetVolume(uint8_t vol)
 
 std::optional<std::string_view> MusicDriver_Win32::Start(const StringList &parm)
 {
-	Debug(driver, 2, "Win32-MIDI: Start: initializing");
+	Debug(driver, Severity::Warning, "Win32-MIDI: Start: initializing");
 
 	int resolution = GetDriverParamInt(parm, "resolution", 5);
 	uint port = (uint)GetDriverParamInt(parm, "port", UINT_MAX);
 	auto portname = GetDriverParam(parm, "portname");
 
 	/* Enumerate ports either for selecting port by name, or for debug output */
-	if (portname.has_value() || _debug_driver_level > 0) {
+	if (portname.has_value() || _debug_driver_level >= Severity::Error) {
 		uint numports = midiOutGetNumDevs();
-		Debug(driver, 1, "Win32-MIDI: Found {} output devices:", numports);
+		Debug(driver, Severity::Error, "Win32-MIDI: Found {} output devices:", numports);
 		for (uint tryport = 0; tryport < numports; tryport++) {
 			MIDIOUTCAPS moc{};
 			if (midiOutGetDevCaps(tryport, &moc, sizeof(moc)) == MMSYSERR_NOERROR) {
@@ -388,7 +388,7 @@ std::optional<std::string_view> MusicDriver_Win32::Start(const StringList &parm)
 				 * If multiple ports have the same name, this will select the last matching port, and the debug output will be confusing. */
 				if (portname.has_value() && *portname == tryportname) port = tryport;
 
-				Debug(driver, 1, "MIDI port {:2d}: {}{}", tryport, tryportname, (tryport == port) ? " [selected]" : "");
+				Debug(driver, Severity::Error, "MIDI port {:2d}: {}{}", tryport, tryportname, (tryport == port) ? " [selected]" : "");
 			}
 		}
 	}
@@ -414,7 +414,7 @@ std::optional<std::string_view> MusicDriver_Win32::Start(const StringList &parm)
 		_midi.time_period = std::min(std::max((UINT)resolution, timecaps.wPeriodMin), timecaps.wPeriodMax);
 		if (timeBeginPeriod(_midi.time_period) == MMSYSERR_NOERROR) {
 			/* success */
-			Debug(driver, 2, "Win32-MIDI: Start: timer resolution is {}", _midi.time_period);
+			Debug(driver, Severity::Warning, "Win32-MIDI: Start: timer resolution is {}", _midi.time_period);
 			return std::nullopt;
 		}
 	}

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -227,9 +227,9 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 	auto end = std::chrono::steady_clock::now();
 	std::chrono::seconds duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);
 	if (!_resolve_timeout_error_message_shown && duration >= std::chrono::seconds(5)) {
-		Debug(net, 0, "getaddrinfo for hostname \"{}\", port {}, address family {} and socket type {} took {} seconds",
+		Debug(net, Severity::Critical, "getaddrinfo for hostname \"{}\", port {}, address family {} and socket type {} took {} seconds",
 				this->hostname, port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), duration.count());
-		Debug(net, 0, "  this is likely an issue in the DNS name resolver's configuration causing it to time out");
+		Debug(net, Severity::Critical, "  this is likely an issue in the DNS name resolver's configuration causing it to time out");
 		_resolve_timeout_error_message_shown = true;
 	}
 
@@ -238,7 +238,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 
 	if (e != 0) {
 		if (func != ResolveLoopProc) {
-			Debug(net, 0, "getaddrinfo for hostname \"{}\", port {}, address family {} and socket type {} failed: {}",
+			Debug(net, Severity::Critical, "getaddrinfo for hostname \"{}\", port {}, address family {} and socket type {} failed: {}",
 				this->hostname, port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), FS2OTTD(gai_strerror(e)));
 		}
 		return INVALID_SOCKET;
@@ -297,32 +297,32 @@ static SOCKET ListenLoopProc(addrinfo *runp)
 	if (sock == INVALID_SOCKET) {
 		std::string_view type = NetworkAddress::SocketTypeAsString(runp->ai_socktype);
 		std::string_view family = NetworkAddress::AddressFamilyAsString(runp->ai_family);
-		Debug(net, 0, "Could not create {} {} socket: {}", type, family, NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Could not create {} {} socket: {}", type, family, NetworkError::GetLast().AsString());
 		return INVALID_SOCKET;
 	}
 
 	if (runp->ai_socktype == SOCK_STREAM && !SetNoDelay(sock)) {
-		Debug(net, 1, "Setting no-delay mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Error, "Setting no-delay mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
 	if (!SetReusePort(sock)) {
-		Debug(net, 0, "Setting reuse-address mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Setting reuse-address mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
 	int on = 1;
 	if (runp->ai_family == AF_INET6 &&
 			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char *>(&on), sizeof(on)) == -1) {
-		Debug(net, 3, "Could not disable IPv4 over IPv6: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Notice, "Could not disable IPv4 over IPv6: {}", NetworkError::GetLast().AsString());
 	}
 
 	if (bind(sock, runp->ai_addr, (int)runp->ai_addrlen) != 0) {
-		Debug(net, 0, "Could not bind socket on {}: {}", address, NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Could not bind socket on {}: {}", address, NetworkError::GetLast().AsString());
 		closesocket(sock);
 		return INVALID_SOCKET;
 	}
 
 	if (runp->ai_socktype != SOCK_DGRAM && listen(sock, 1) != 0) {
-		Debug(net, 0, "Could not listen on socket: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Could not listen on socket: {}", NetworkError::GetLast().AsString());
 		closesocket(sock);
 		return INVALID_SOCKET;
 	}
@@ -330,10 +330,10 @@ static SOCKET ListenLoopProc(addrinfo *runp)
 	/* Connection succeeded */
 
 	if (!SetNonBlocking(sock)) {
-		Debug(net, 0, "Setting non-blocking mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Setting non-blocking mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
-	Debug(net, 3, "Listening on {}", address);
+	Debug(net, Severity::Notice, "Listening on {}", address);
 	return sock;
 }
 
@@ -399,7 +399,7 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
 	sockaddr_storage addr = {};
 	socklen_t addr_len = sizeof(addr);
 	if (getpeername(sock, (sockaddr *)&addr, &addr_len) != 0) {
-		Debug(net, 0, "Failed to get address of the peer: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Failed to get address of the peer: {}", NetworkError::GetLast().AsString());
 		return NetworkAddress();
 	}
 	return NetworkAddress(addr, addr_len);
@@ -415,7 +415,7 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
 	sockaddr_storage addr = {};
 	socklen_t addr_len = sizeof(addr);
 	if (getsockname(sock, (sockaddr *)&addr, &addr_len) != 0) {
-		Debug(net, 0, "Failed to get address of the socket: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Failed to get address of the socket: {}", NetworkError::GetLast().AsString());
 		return NetworkAddress();
 	}
 	return NetworkAddress(addr, addr_len);

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -227,9 +227,9 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 	auto end = std::chrono::steady_clock::now();
 	std::chrono::seconds duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);
 	if (!_resolve_timeout_error_message_shown && duration >= std::chrono::seconds(5)) {
-		Debug(net, Severity::Critical, "getaddrinfo for hostname \"{}\", port {}, address family {} and socket type {} took {} seconds",
+		Debug(Facility::Net, Severity::Critical, "getaddrinfo for hostname \"{}\", port {}, address family {} and socket type {} took {} seconds",
 				this->hostname, port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), duration.count());
-		Debug(net, Severity::Critical, "  this is likely an issue in the DNS name resolver's configuration causing it to time out");
+		Debug(Facility::Net, Severity::Critical, "  this is likely an issue in the DNS name resolver's configuration causing it to time out");
 		_resolve_timeout_error_message_shown = true;
 	}
 
@@ -238,7 +238,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 
 	if (e != 0) {
 		if (func != ResolveLoopProc) {
-			Debug(net, Severity::Critical, "getaddrinfo for hostname \"{}\", port {}, address family {} and socket type {} failed: {}",
+			Debug(Facility::Net, Severity::Critical, "getaddrinfo for hostname \"{}\", port {}, address family {} and socket type {} failed: {}",
 				this->hostname, port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), FS2OTTD(gai_strerror(e)));
 		}
 		return INVALID_SOCKET;
@@ -297,32 +297,32 @@ static SOCKET ListenLoopProc(addrinfo *runp)
 	if (sock == INVALID_SOCKET) {
 		std::string_view type = NetworkAddress::SocketTypeAsString(runp->ai_socktype);
 		std::string_view family = NetworkAddress::AddressFamilyAsString(runp->ai_family);
-		Debug(net, Severity::Critical, "Could not create {} {} socket: {}", type, family, NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Could not create {} {} socket: {}", type, family, NetworkError::GetLast().AsString());
 		return INVALID_SOCKET;
 	}
 
 	if (runp->ai_socktype == SOCK_STREAM && !SetNoDelay(sock)) {
-		Debug(net, Severity::Error, "Setting no-delay mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Error, "Setting no-delay mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
 	if (!SetReusePort(sock)) {
-		Debug(net, Severity::Critical, "Setting reuse-address mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Setting reuse-address mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
 	int on = 1;
 	if (runp->ai_family == AF_INET6 &&
 			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char *>(&on), sizeof(on)) == -1) {
-		Debug(net, Severity::Notice, "Could not disable IPv4 over IPv6: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Notice, "Could not disable IPv4 over IPv6: {}", NetworkError::GetLast().AsString());
 	}
 
 	if (bind(sock, runp->ai_addr, (int)runp->ai_addrlen) != 0) {
-		Debug(net, Severity::Critical, "Could not bind socket on {}: {}", address, NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Could not bind socket on {}: {}", address, NetworkError::GetLast().AsString());
 		closesocket(sock);
 		return INVALID_SOCKET;
 	}
 
 	if (runp->ai_socktype != SOCK_DGRAM && listen(sock, 1) != 0) {
-		Debug(net, Severity::Critical, "Could not listen on socket: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Could not listen on socket: {}", NetworkError::GetLast().AsString());
 		closesocket(sock);
 		return INVALID_SOCKET;
 	}
@@ -330,10 +330,10 @@ static SOCKET ListenLoopProc(addrinfo *runp)
 	/* Connection succeeded */
 
 	if (!SetNonBlocking(sock)) {
-		Debug(net, Severity::Critical, "Setting non-blocking mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Setting non-blocking mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
-	Debug(net, Severity::Notice, "Listening on {}", address);
+	Debug(Facility::Net, Severity::Notice, "Listening on {}", address);
 	return sock;
 }
 
@@ -399,7 +399,7 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
 	sockaddr_storage addr = {};
 	socklen_t addr_len = sizeof(addr);
 	if (getpeername(sock, (sockaddr *)&addr, &addr_len) != 0) {
-		Debug(net, Severity::Critical, "Failed to get address of the peer: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Failed to get address of the peer: {}", NetworkError::GetLast().AsString());
 		return NetworkAddress();
 	}
 	return NetworkAddress(addr, addr_len);
@@ -415,7 +415,7 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
 	sockaddr_storage addr = {};
 	socklen_t addr_len = sizeof(addr);
 	if (getsockname(sock, (sockaddr *)&addr, &addr_len) != 0) {
-		Debug(net, Severity::Critical, "Failed to get address of the socket: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Failed to get address of the socket: {}", NetworkError::GetLast().AsString());
 		return NetworkAddress();
 	}
 	return NetworkAddress(addr, addr_len);

--- a/src/network/core/core.cpp
+++ b/src/network/core/core.cpp
@@ -25,9 +25,9 @@ bool NetworkCoreInitialize()
 #ifdef _WIN32
 	{
 		WSADATA wsa;
-		Debug(net, Severity::Debug1, "Loading windows socket library");
+		Debug(Facility::Net, Severity::Debug1, "Loading windows socket library");
 		if (WSAStartup(MAKEWORD(2, 0), &wsa) != 0) {
-			Debug(net, Severity::Critical, "WSAStartup failed, network unavailable");
+			Debug(Facility::Net, Severity::Critical, "WSAStartup failed, network unavailable");
 			return false;
 		}
 	}

--- a/src/network/core/core.cpp
+++ b/src/network/core/core.cpp
@@ -25,9 +25,9 @@ bool NetworkCoreInitialize()
 #ifdef _WIN32
 	{
 		WSADATA wsa;
-		Debug(net, 5, "Loading windows socket library");
+		Debug(net, Severity::Debug1, "Loading windows socket library");
 		if (WSAStartup(MAKEWORD(2, 0), &wsa) != 0) {
-			Debug(net, 0, "WSAStartup failed, network unavailable");
+			Debug(net, Severity::Critical, "WSAStartup failed, network unavailable");
 			return false;
 		}
 	}

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -86,10 +86,10 @@ void NetworkFindBroadcastIPs(NetworkAddressList *broadcast)
 	NetworkFindBroadcastIPsInternal(broadcast);
 
 	/* Now display to the debug all the detected ips */
-	Debug(net, 3, "Detected broadcast addresses:");
+	Debug(net, Severity::Notice, "Detected broadcast addresses:");
 	int i = 0;
 	for (NetworkAddress &addr : *broadcast) {
 		addr.SetPort(NETWORK_DEFAULT_PORT);
-		Debug(net, 3, "  {}) {}", i++, addr.GetHostname());
+		Debug(net, Severity::Notice, "  {}) {}", i++, addr.GetHostname());
 	}
 }

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -86,10 +86,10 @@ void NetworkFindBroadcastIPs(NetworkAddressList *broadcast)
 	NetworkFindBroadcastIPsInternal(broadcast);
 
 	/* Now display to the debug all the detected ips */
-	Debug(net, Severity::Notice, "Detected broadcast addresses:");
+	Debug(Facility::Net, Severity::Notice, "Detected broadcast addresses:");
 	int i = 0;
 	for (NetworkAddress &addr : *broadcast) {
 		addr.SetPort(NETWORK_DEFAULT_PORT);
-		Debug(net, Severity::Notice, "  {}) {}", i++, addr.GetHostname());
+		Debug(Facility::Net, Severity::Notice, "  {}) {}", i++, addr.GetHostname());
 	}
 }

--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -132,7 +132,7 @@ void CurlSetOption(CURL *curl, auto option, auto value)
 {
 	CURLcode res = curl_easy_setopt(curl, option, value);
 	if (res != CURLE_OK) {
-		Debug(net, Severity::Critical, "Could not execute curl_easy_setopt for {} [{}]", option, res);
+		Debug(Facility::Net, Severity::Critical, "Could not execute curl_easy_setopt for {} [{}]", option, res);
 	}
 }
 
@@ -161,7 +161,7 @@ void HttpThread()
 		curl_easy_reset(curl);
 		curl_slist *headers = nullptr;
 
-		if (_debug_net_level >= Severity::Debug1) {
+		if (IsVisibleSeverity(Facility::Net, Severity::Debug1)) {
 			CurlSetOption(curl, CURLOPT_VERBOSE, 1L);
 		}
 
@@ -205,7 +205,7 @@ void HttpThread()
 
 		/* Setup our (C-style) callback function which we pipe back into the callback. */
 		CurlSetOption(curl, CURLOPT_WRITEFUNCTION, +[](char *ptr, size_t size, size_t nmemb, void *userdata) -> size_t {
-			Debug(net, Severity::Debug2, "HTTP callback: {} bytes", size * nmemb);
+			Debug(Facility::Net, Severity::Debug2, "HTTP callback: {} bytes", size * nmemb);
 			HTTPThreadSafeCallback *callback = static_cast<HTTPThreadSafeCallback *>(userdata);
 
 			/* Copy the buffer out of CURL. OnReceiveData() will free it when done. */
@@ -234,14 +234,14 @@ void HttpThread()
 		curl_slist_free_all(headers);
 
 		if (res == CURLE_OK) {
-			Debug(net, Severity::Error, "HTTP request succeeded");
+			Debug(Facility::Net, Severity::Error, "HTTP request succeeded");
 			request->callback.OnReceiveData(nullptr, 0);
 		} else {
 			long status_code = 0;
 			curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
 
 			/* No need to be verbose about rate limiting. */
-			Debug(net, (request->callback.cancelled || _http_thread_exit || status_code == HTTP_429_TOO_MANY_REQUESTS) ? Severity::Error : Severity::Critical, "HTTP request failed: status_code: {}, error: {}", status_code, curl_easy_strerror(res));
+			Debug(Facility::Net, (request->callback.cancelled || _http_thread_exit || status_code == HTTP_429_TOO_MANY_REQUESTS) ? Severity::Error : Severity::Critical, "HTTP request failed: status_code: {}, error: {}", status_code, curl_easy_strerror(res));
 			request->callback.OnFailure();
 		}
 
@@ -276,12 +276,12 @@ void NetworkHTTPInitialize()
 			}
 		}
 	}
-	Debug(net, Severity::Notice, "Using certificate file: {}", _http_ca_file.empty() ? "none" : _http_ca_file);
-	Debug(net, Severity::Notice, "Using certificate path: {}", _http_ca_path.empty() ? "none" : _http_ca_path);
+	Debug(Facility::Net, Severity::Notice, "Using certificate file: {}", _http_ca_file.empty() ? "none" : _http_ca_file);
+	Debug(Facility::Net, Severity::Notice, "Using certificate path: {}", _http_ca_path.empty() ? "none" : _http_ca_path);
 
 	/* Tell the user why HTTPS will not be working. */
 	if (_http_ca_file.empty() && _http_ca_path.empty()) {
-		Debug(net, Severity::Critical, "No certificate files or directories found, HTTPS will not work!");
+		Debug(Facility::Net, Severity::Critical, "No certificate files or directories found, HTTPS will not work!");
 	}
 #endif /* UNIX */
 

--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -132,7 +132,7 @@ void CurlSetOption(CURL *curl, auto option, auto value)
 {
 	CURLcode res = curl_easy_setopt(curl, option, value);
 	if (res != CURLE_OK) {
-		Debug(net, 0, "Could not execute curl_easy_setopt for {} [{}]", option, res);
+		Debug(net, Severity::Critical, "Could not execute curl_easy_setopt for {} [{}]", option, res);
 	}
 }
 
@@ -161,7 +161,7 @@ void HttpThread()
 		curl_easy_reset(curl);
 		curl_slist *headers = nullptr;
 
-		if (_debug_net_level >= 5) {
+		if (_debug_net_level >= Severity::Debug1) {
 			CurlSetOption(curl, CURLOPT_VERBOSE, 1L);
 		}
 
@@ -205,7 +205,7 @@ void HttpThread()
 
 		/* Setup our (C-style) callback function which we pipe back into the callback. */
 		CurlSetOption(curl, CURLOPT_WRITEFUNCTION, +[](char *ptr, size_t size, size_t nmemb, void *userdata) -> size_t {
-			Debug(net, 6, "HTTP callback: {} bytes", size * nmemb);
+			Debug(net, Severity::Debug2, "HTTP callback: {} bytes", size * nmemb);
 			HTTPThreadSafeCallback *callback = static_cast<HTTPThreadSafeCallback *>(userdata);
 
 			/* Copy the buffer out of CURL. OnReceiveData() will free it when done. */
@@ -234,14 +234,14 @@ void HttpThread()
 		curl_slist_free_all(headers);
 
 		if (res == CURLE_OK) {
-			Debug(net, 1, "HTTP request succeeded");
+			Debug(net, Severity::Error, "HTTP request succeeded");
 			request->callback.OnReceiveData(nullptr, 0);
 		} else {
 			long status_code = 0;
 			curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
 
 			/* No need to be verbose about rate limiting. */
-			Debug(net, (request->callback.cancelled || _http_thread_exit || status_code == HTTP_429_TOO_MANY_REQUESTS) ? 1 : 0, "HTTP request failed: status_code: {}, error: {}", status_code, curl_easy_strerror(res));
+			Debug(net, (request->callback.cancelled || _http_thread_exit || status_code == HTTP_429_TOO_MANY_REQUESTS) ? Severity::Error : Severity::Critical, "HTTP request failed: status_code: {}, error: {}", status_code, curl_easy_strerror(res));
 			request->callback.OnFailure();
 		}
 
@@ -276,12 +276,12 @@ void NetworkHTTPInitialize()
 			}
 		}
 	}
-	Debug(net, 3, "Using certificate file: {}", _http_ca_file.empty() ? "none" : _http_ca_file);
-	Debug(net, 3, "Using certificate path: {}", _http_ca_path.empty() ? "none" : _http_ca_path);
+	Debug(net, Severity::Notice, "Using certificate file: {}", _http_ca_file.empty() ? "none" : _http_ca_file);
+	Debug(net, Severity::Notice, "Using certificate path: {}", _http_ca_path.empty() ? "none" : _http_ca_path);
 
 	/* Tell the user why HTTPS will not be working. */
 	if (_http_ca_file.empty() && _http_ca_path.empty()) {
-		Debug(net, 0, "No certificate files or directories found, HTTPS will not work!");
+		Debug(net, Severity::Critical, "No certificate files or directories found, HTTPS will not work!");
 	}
 #endif /* UNIX */
 

--- a/src/network/core/http_winhttp.cpp
+++ b/src/network/core/http_winhttp.cpp
@@ -122,7 +122,7 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 		case WINHTTP_CALLBACK_STATUS_REDIRECT:
 			/* Make sure we are not in a redirect loop. */
 			if (this->depth++ > 5) {
-				Debug(net, 0, "HTTP request failed: too many redirects");
+				Debug(net, Severity::Critical, "HTTP request failed: too many redirects");
 				this->callback.OnFailure();
 				this->finished = true;
 				return;
@@ -140,12 +140,12 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 			DWORD status_code = 0;
 			DWORD status_code_size = sizeof(status_code);
 			WinHttpQueryHeaders(this->request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, &status_code, &status_code_size, WINHTTP_NO_HEADER_INDEX);
-			Debug(net, 3, "HTTP request status code: {}", status_code);
+			Debug(net, Severity::Notice, "HTTP request status code: {}", status_code);
 
 			/* If there is any error, we simply abort the request. */
 			if (status_code >= 400) {
 				/* No need to be verbose about rate limiting. */
-				Debug(net, status_code == HTTP_429_TOO_MANY_REQUESTS ? 1 : 0, "HTTP request failed: status-code {}", status_code);
+				Debug(net, status_code == HTTP_429_TOO_MANY_REQUESTS ? Severity::Error : Severity::Critical, "HTTP request failed: status-code {}", status_code);
 				this->callback.OnFailure();
 				this->finished = true;
 				return;
@@ -167,14 +167,14 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 		} break;
 
 		case WINHTTP_CALLBACK_STATUS_READ_COMPLETE:
-			Debug(net, 6, "HTTP callback: {} bytes", length);
+			Debug(net, Severity::Debug2, "HTTP callback: {} bytes", length);
 
 			this->callback.OnReceiveData(std::unique_ptr<char[]>(static_cast<char *>(info)), length);
 
 			if (length == 0) {
 				/* Next step: no more data available: request is finished. */
 				this->finished = true;
-				Debug(net, 1, "HTTP request succeeded");
+				Debug(net, Severity::Error, "HTTP request succeeded");
 			} else {
 				/* Next step: query for more data. */
 				WinHttpQueryDataAvailable(this->request, nullptr);
@@ -184,13 +184,13 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 
 		case WINHTTP_CALLBACK_STATUS_SECURE_FAILURE:
 		case WINHTTP_CALLBACK_STATUS_REQUEST_ERROR:
-			Debug(net, 0, "HTTP request failed: {}", GetLastErrorAsString());
+			Debug(net, Severity::Critical, "HTTP request failed: {}", GetLastErrorAsString());
 			this->callback.OnFailure();
 			this->finished = true;
 			break;
 
 		default:
-			Debug(net, 0, "HTTP request failed: unexpected callback code 0x{:x}", code);
+			Debug(net, Severity::Critical, "HTTP request failed: unexpected callback code 0x{:x}", code);
 			this->callback.OnFailure();
 			this->finished = true;
 			return;
@@ -221,7 +221,7 @@ static void CALLBACK StaticWinHttpCallback(HINTERNET, DWORD_PTR context, DWORD c
  */
 void NetworkHTTPRequest::Connect()
 {
-	Debug(net, 1, "HTTP request to {}", std::string(uri.begin(), uri.end()));
+	Debug(net, Severity::Error, "HTTP request to {}", std::string(uri.begin(), uri.end()));
 
 	URL_COMPONENTS url_components = {};
 	wchar_t scheme[32];
@@ -241,7 +241,7 @@ void NetworkHTTPRequest::Connect()
 	/* Create the HTTP connection. */
 	this->connection = WinHttpConnect(_winhttp_session, url_components.lpszHostName, url_components.nPort, 0);
 	if (this->connection == nullptr) {
-		Debug(net, 0, "HTTP request failed: {}", GetLastErrorAsString());
+		Debug(net, Severity::Critical, "HTTP request failed: {}", GetLastErrorAsString());
 		this->callback.OnFailure();
 		this->finished = true;
 		return;
@@ -251,7 +251,7 @@ void NetworkHTTPRequest::Connect()
 	if (this->request == nullptr) {
 		WinHttpCloseHandle(this->connection);
 
-		Debug(net, 0, "HTTP request failed: {}", GetLastErrorAsString());
+		Debug(net, Severity::Critical, "HTTP request failed: {}", GetLastErrorAsString());
 		this->callback.OnFailure();
 		this->finished = true;
 		return;
@@ -275,7 +275,7 @@ void NetworkHTTPRequest::Connect()
 bool NetworkHTTPRequest::Receive()
 {
 	if (this->callback.cancelled && !this->finished) {
-		Debug(net, 1, "HTTP request failed: cancelled by user");
+		Debug(net, Severity::Error, "HTTP request failed: cancelled by user");
 		this->callback.OnFailure();
 		this->finished = true;
 		/* Fall-through, as we are waiting for IsQueueEmpty() to happen. */

--- a/src/network/core/http_winhttp.cpp
+++ b/src/network/core/http_winhttp.cpp
@@ -122,7 +122,7 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 		case WINHTTP_CALLBACK_STATUS_REDIRECT:
 			/* Make sure we are not in a redirect loop. */
 			if (this->depth++ > 5) {
-				Debug(net, Severity::Critical, "HTTP request failed: too many redirects");
+				Debug(Facility::Net, Severity::Critical, "HTTP request failed: too many redirects");
 				this->callback.OnFailure();
 				this->finished = true;
 				return;
@@ -140,12 +140,12 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 			DWORD status_code = 0;
 			DWORD status_code_size = sizeof(status_code);
 			WinHttpQueryHeaders(this->request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, &status_code, &status_code_size, WINHTTP_NO_HEADER_INDEX);
-			Debug(net, Severity::Notice, "HTTP request status code: {}", status_code);
+			Debug(Facility::Net, Severity::Notice, "HTTP request status code: {}", status_code);
 
 			/* If there is any error, we simply abort the request. */
 			if (status_code >= 400) {
 				/* No need to be verbose about rate limiting. */
-				Debug(net, status_code == HTTP_429_TOO_MANY_REQUESTS ? Severity::Error : Severity::Critical, "HTTP request failed: status-code {}", status_code);
+				Debug(Facility::Net, status_code == HTTP_429_TOO_MANY_REQUESTS ? Severity::Error : Severity::Critical, "HTTP request failed: status-code {}", status_code);
 				this->callback.OnFailure();
 				this->finished = true;
 				return;
@@ -167,14 +167,14 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 		} break;
 
 		case WINHTTP_CALLBACK_STATUS_READ_COMPLETE:
-			Debug(net, Severity::Debug2, "HTTP callback: {} bytes", length);
+			Debug(Facility::Net, Severity::Debug2, "HTTP callback: {} bytes", length);
 
 			this->callback.OnReceiveData(std::unique_ptr<char[]>(static_cast<char *>(info)), length);
 
 			if (length == 0) {
 				/* Next step: no more data available: request is finished. */
 				this->finished = true;
-				Debug(net, Severity::Error, "HTTP request succeeded");
+				Debug(Facility::Net, Severity::Error, "HTTP request succeeded");
 			} else {
 				/* Next step: query for more data. */
 				WinHttpQueryDataAvailable(this->request, nullptr);
@@ -184,13 +184,13 @@ void NetworkHTTPRequest::WinHttpCallback(DWORD code, void *info, DWORD length)
 
 		case WINHTTP_CALLBACK_STATUS_SECURE_FAILURE:
 		case WINHTTP_CALLBACK_STATUS_REQUEST_ERROR:
-			Debug(net, Severity::Critical, "HTTP request failed: {}", GetLastErrorAsString());
+			Debug(Facility::Net, Severity::Critical, "HTTP request failed: {}", GetLastErrorAsString());
 			this->callback.OnFailure();
 			this->finished = true;
 			break;
 
 		default:
-			Debug(net, Severity::Critical, "HTTP request failed: unexpected callback code 0x{:x}", code);
+			Debug(Facility::Net, Severity::Critical, "HTTP request failed: unexpected callback code 0x{:x}", code);
 			this->callback.OnFailure();
 			this->finished = true;
 			return;
@@ -221,7 +221,7 @@ static void CALLBACK StaticWinHttpCallback(HINTERNET, DWORD_PTR context, DWORD c
  */
 void NetworkHTTPRequest::Connect()
 {
-	Debug(net, Severity::Error, "HTTP request to {}", std::string(uri.begin(), uri.end()));
+	Debug(Facility::Net, Severity::Error, "HTTP request to {}", std::string(uri.begin(), uri.end()));
 
 	URL_COMPONENTS url_components = {};
 	wchar_t scheme[32];
@@ -241,7 +241,7 @@ void NetworkHTTPRequest::Connect()
 	/* Create the HTTP connection. */
 	this->connection = WinHttpConnect(_winhttp_session, url_components.lpszHostName, url_components.nPort, 0);
 	if (this->connection == nullptr) {
-		Debug(net, Severity::Critical, "HTTP request failed: {}", GetLastErrorAsString());
+		Debug(Facility::Net, Severity::Critical, "HTTP request failed: {}", GetLastErrorAsString());
 		this->callback.OnFailure();
 		this->finished = true;
 		return;
@@ -251,7 +251,7 @@ void NetworkHTTPRequest::Connect()
 	if (this->request == nullptr) {
 		WinHttpCloseHandle(this->connection);
 
-		Debug(net, Severity::Critical, "HTTP request failed: {}", GetLastErrorAsString());
+		Debug(Facility::Net, Severity::Critical, "HTTP request failed: {}", GetLastErrorAsString());
 		this->callback.OnFailure();
 		this->finished = true;
 		return;
@@ -275,7 +275,7 @@ void NetworkHTTPRequest::Connect()
 bool NetworkHTTPRequest::Receive()
 {
 	if (this->callback.cancelled && !this->finished) {
-		Debug(net, Severity::Error, "HTTP request failed: cancelled by user");
+		Debug(Facility::Net, Severity::Error, "HTTP request failed: cancelled by user");
 		this->callback.OnFailure();
 		this->finished = true;
 		/* Fall-through, as we are waiting for IsQueueEmpty() to happen. */

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -78,7 +78,7 @@ std::string_view GetNetworkRevisionString()
 			network_revision.replace(hash_end, std::string::npos, githash_suffix);
 		}
 		assert(network_revision.size() < NETWORK_REVISION_LENGTH); // size does not include terminator, constant does, hence strictly less than
-		Debug(net, Severity::Notice, "Network revision name: {}", network_revision);
+		Debug(Facility::Net, Severity::Notice, "Network revision name: {}", network_revision);
 	}
 
 	return network_revision;

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -78,7 +78,7 @@ std::string_view GetNetworkRevisionString()
 			network_revision.replace(hash_end, std::string::npos, githash_suffix);
 		}
 		assert(network_revision.size() < NETWORK_REVISION_LENGTH); // size does not include terminator, constant does, hence strictly less than
-		Debug(net, 3, "Network revision name: {}", network_revision);
+		Debug(net, Severity::Notice, "Network revision name: {}", network_revision);
 	}
 
 	return network_revision;

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -86,7 +86,7 @@ SendPacketsState NetworkTCPSocketHandler::SendPackets(bool closing_down)
 			if (!err.WouldBlock()) {
 				/* Something went wrong.. close client! */
 				if (!closing_down) {
-					Debug(net, Severity::Critical, "Send failed: {}", err.AsString());
+					Debug(Facility::Net, Severity::Critical, "Send failed: {}", err.AsString());
 					this->CloseConnection();
 				}
 				return SendPacketsState::Closed;
@@ -135,7 +135,7 @@ std::unique_ptr<Packet> NetworkTCPSocketHandler::ReceivePacket()
 				NetworkError err = NetworkError::GetLast();
 				if (!err.WouldBlock()) {
 					/* Something went wrong... */
-					if (!err.IsConnectionReset()) Debug(net, Severity::Critical, "Recv failed: {}", err.AsString());
+					if (!err.IsConnectionReset()) Debug(Facility::Net, Severity::Critical, "Recv failed: {}", err.AsString());
 					this->CloseConnection();
 					return nullptr;
 				}
@@ -163,7 +163,7 @@ std::unique_ptr<Packet> NetworkTCPSocketHandler::ReceivePacket()
 			NetworkError err = NetworkError::GetLast();
 			if (!err.WouldBlock()) {
 				/* Something went wrong... */
-				if (!err.IsConnectionReset()) Debug(net, Severity::Critical, "Recv failed: {}", err.AsString());
+				if (!err.IsConnectionReset()) Debug(Facility::Net, Severity::Critical, "Recv failed: {}", err.AsString());
 				this->CloseConnection();
 				return nullptr;
 			}
@@ -178,7 +178,7 @@ std::unique_ptr<Packet> NetworkTCPSocketHandler::ReceivePacket()
 	}
 
 	if (!p.PrepareToRead()) {
-		Debug(net, Severity::Critical, "Invalid packet received (too small / decryption error)");
+		Debug(Facility::Net, Severity::Critical, "Invalid packet received (too small / decryption error)");
 		this->CloseConnection();
 		return nullptr;
 	}

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -86,7 +86,7 @@ SendPacketsState NetworkTCPSocketHandler::SendPackets(bool closing_down)
 			if (!err.WouldBlock()) {
 				/* Something went wrong.. close client! */
 				if (!closing_down) {
-					Debug(net, 0, "Send failed: {}", err.AsString());
+					Debug(net, Severity::Critical, "Send failed: {}", err.AsString());
 					this->CloseConnection();
 				}
 				return SendPacketsState::Closed;
@@ -135,7 +135,7 @@ std::unique_ptr<Packet> NetworkTCPSocketHandler::ReceivePacket()
 				NetworkError err = NetworkError::GetLast();
 				if (!err.WouldBlock()) {
 					/* Something went wrong... */
-					if (!err.IsConnectionReset()) Debug(net, 0, "Recv failed: {}", err.AsString());
+					if (!err.IsConnectionReset()) Debug(net, Severity::Critical, "Recv failed: {}", err.AsString());
 					this->CloseConnection();
 					return nullptr;
 				}
@@ -163,7 +163,7 @@ std::unique_ptr<Packet> NetworkTCPSocketHandler::ReceivePacket()
 			NetworkError err = NetworkError::GetLast();
 			if (!err.WouldBlock()) {
 				/* Something went wrong... */
-				if (!err.IsConnectionReset()) Debug(net, 0, "Recv failed: {}", err.AsString());
+				if (!err.IsConnectionReset()) Debug(net, Severity::Critical, "Recv failed: {}", err.AsString());
 				this->CloseConnection();
 				return nullptr;
 			}
@@ -178,7 +178,7 @@ std::unique_ptr<Packet> NetworkTCPSocketHandler::ReceivePacket()
 	}
 
 	if (!p.PrepareToRead()) {
-		Debug(net, 0, "Invalid packet received (too small / decryption error)");
+		Debug(net, Severity::Critical, "Invalid packet received (too small / decryption error)");
 		this->CloseConnection();
 		return nullptr;
 	}

--- a/src/network/core/tcp_admin.cpp
+++ b/src/network/core/tcp_admin.cpp
@@ -80,7 +80,7 @@ NetworkRecvStatus NetworkAdminSocketHandler::HandlePacket(Packet &p)
 		case PacketAdminType::ServerEnableEncryption: return this->ReceiveServerEnableEncryption(p);
 
 		default:
-			Debug(net, Severity::Critical, "[tcp/admin] Received invalid packet type {} from '{}' ({})", type, this->admin_name, this->admin_version);
+			Debug(Facility::Net, Severity::Critical, "[tcp/admin] Received invalid packet type {} from '{}' ({})", type, this->admin_name, this->admin_version);
 			this->CloseConnection();
 			return NetworkRecvStatus::MalformedPacket;
 	}
@@ -111,7 +111,7 @@ NetworkRecvStatus NetworkAdminSocketHandler::ReceivePackets()
  */
 NetworkRecvStatus NetworkAdminSocketHandler::ReceiveInvalidPacket(PacketAdminType type)
 {
-	Debug(net, Severity::Critical, "[tcp/admin] Received illegal packet type {} from admin {} ({})", type, this->admin_name, this->admin_version);
+	Debug(Facility::Net, Severity::Critical, "[tcp/admin] Received illegal packet type {} from admin {} ({})", type, this->admin_name, this->admin_version);
 	return NetworkRecvStatus::MalformedPacket;
 }
 

--- a/src/network/core/tcp_admin.cpp
+++ b/src/network/core/tcp_admin.cpp
@@ -80,7 +80,7 @@ NetworkRecvStatus NetworkAdminSocketHandler::HandlePacket(Packet &p)
 		case PacketAdminType::ServerEnableEncryption: return this->ReceiveServerEnableEncryption(p);
 
 		default:
-			Debug(net, 0, "[tcp/admin] Received invalid packet type {} from '{}' ({})", type, this->admin_name, this->admin_version);
+			Debug(net, Severity::Critical, "[tcp/admin] Received invalid packet type {} from '{}' ({})", type, this->admin_name, this->admin_version);
 			this->CloseConnection();
 			return NetworkRecvStatus::MalformedPacket;
 	}
@@ -111,7 +111,7 @@ NetworkRecvStatus NetworkAdminSocketHandler::ReceivePackets()
  */
 NetworkRecvStatus NetworkAdminSocketHandler::ReceiveInvalidPacket(PacketAdminType type)
 {
-	Debug(net, 0, "[tcp/admin] Received illegal packet type {} from admin {} ({})", type, this->admin_name, this->admin_version);
+	Debug(net, Severity::Critical, "[tcp/admin] Received illegal packet type {} from admin {} ({})", type, this->admin_name, this->admin_version);
 	return NetworkRecvStatus::MalformedPacket;
 }
 

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -89,37 +89,37 @@ void TCPConnecter::Connect(addrinfo *address)
 {
 	SOCKET sock = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
 	if (sock == INVALID_SOCKET) {
-		Debug(net, Severity::Critical, "Could not create {} {} socket: {}", NetworkAddress::SocketTypeAsString(address->ai_socktype), NetworkAddress::AddressFamilyAsString(address->ai_family), NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Could not create {} {} socket: {}", NetworkAddress::SocketTypeAsString(address->ai_socktype), NetworkAddress::AddressFamilyAsString(address->ai_family), NetworkError::GetLast().AsString());
 		return;
 	}
 
 	if (!SetReusePort(sock)) {
-		Debug(net, Severity::Critical, "Setting reuse-port mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Setting reuse-port mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
 	if (this->bind_address.GetPort() > 0) {
 		if (bind(sock, (const sockaddr *)this->bind_address.GetAddress(), this->bind_address.GetAddressLength()) != 0) {
-			Debug(net, Severity::Error, "Could not bind socket on {}: {}", this->bind_address.GetAddressAsString(), NetworkError::GetLast().AsString());
+			Debug(Facility::Net, Severity::Error, "Could not bind socket on {}: {}", this->bind_address.GetAddressAsString(), NetworkError::GetLast().AsString());
 			closesocket(sock);
 			return;
 		}
 	}
 
 	if (!SetNoDelay(sock)) {
-		Debug(net, Severity::Error, "Setting TCP_NODELAY failed: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Error, "Setting TCP_NODELAY failed: {}", NetworkError::GetLast().AsString());
 	}
 	if (!SetNonBlocking(sock)) {
-		Debug(net, Severity::Critical, "Setting non-blocking mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Critical, "Setting non-blocking mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
 	NetworkAddress network_address = NetworkAddress(address->ai_addr, (int)address->ai_addrlen);
-	Debug(net, Severity::Debug1, "Attempting to connect to {}", network_address.GetAddressAsString());
+	Debug(Facility::Net, Severity::Debug1, "Attempting to connect to {}", network_address.GetAddressAsString());
 
 	int err = connect(sock, address->ai_addr, (int)address->ai_addrlen);
 	if (err != 0 && !NetworkError::GetLast().IsConnectInProgress()) {
 		closesocket(sock);
 
-		Debug(net, Severity::Error, "Could not connect to {}: {}", network_address.GetAddressAsString(), NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Error, "Could not connect to {}: {}", network_address.GetAddressAsString(), NetworkError::GetLast().AsString());
 		return;
 	}
 
@@ -197,13 +197,13 @@ void TCPConnecter::OnResolved(addrinfo *ai)
 		}
 	}
 
-	if (_debug_net_level >= Severity::Debug2) {
+	if (IsVisibleSeverity(Facility::Net, Severity::Debug2)) {
 		if (this->addresses.empty()) {
-			Debug(net, Severity::Debug2, "{} did not resolve", this->connection_string);
+			Debug(Facility::Net, Severity::Debug2, "{} did not resolve", this->connection_string);
 		} else {
-			Debug(net, Severity::Debug2, "{} resolved in:", this->connection_string);
+			Debug(Facility::Net, Severity::Debug2, "{} resolved in:", this->connection_string);
 			for (const auto &address : this->addresses) {
-				Debug(net, Severity::Debug2, "- {}", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString());
+				Debug(Facility::Net, Severity::Debug2, "- {}", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString());
 			}
 		}
 	}
@@ -238,13 +238,13 @@ void TCPConnecter::Resolve()
 	auto end = std::chrono::steady_clock::now();
 	auto duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);
 	if (!getaddrinfo_timeout_error_shown && duration >= std::chrono::seconds(5)) {
-		Debug(net, Severity::Critical, "getaddrinfo() for address \"{}\" took {} seconds", this->connection_string, duration.count());
-		Debug(net, Severity::Critical, "  This is likely an issue in the DNS name resolver's configuration causing it to time out");
+		Debug(Facility::Net, Severity::Critical, "getaddrinfo() for address \"{}\" took {} seconds", this->connection_string, duration.count());
+		Debug(Facility::Net, Severity::Critical, "  This is likely an issue in the DNS name resolver's configuration causing it to time out");
 		getaddrinfo_timeout_error_shown = true;
 	}
 
 	if (error != 0) {
-		Debug(net, Severity::Critical, "Failed to resolve DNS for {}", this->connection_string);
+		Debug(Facility::Net, Severity::Critical, "Failed to resolve DNS for {}", this->connection_string);
 		this->status = Status::Failure;
 		return;
 	}
@@ -326,7 +326,7 @@ bool TCPConnecter::CheckActivity()
 	/* select() failed; hopefully next try it doesn't. */
 	if (n < 0) {
 		/* select() normally never fails; so hopefully it works next try! */
-		Debug(net, Severity::Error, "select() failed: {}", NetworkError::GetLast().AsString());
+		Debug(Facility::Net, Severity::Error, "select() failed: {}", NetworkError::GetLast().AsString());
 		return false;
 	}
 
@@ -343,7 +343,7 @@ bool TCPConnecter::CheckActivity()
 
 		/* More than 3 seconds no socket reported activity, and there are no
 		 * more address to try. Timeout the attempt. */
-		Debug(net, Severity::Critical, "Timeout while connecting to {}", this->connection_string);
+		Debug(Facility::Net, Severity::Critical, "Timeout while connecting to {}", this->connection_string);
 
 		for (const auto &socket : this->sockets) {
 			closesocket(socket);
@@ -362,7 +362,7 @@ bool TCPConnecter::CheckActivity()
 	for (auto it = this->sockets.begin(); it != this->sockets.end(); /* nothing */) {
 		NetworkError socket_error = GetSocketError(*it);
 		if (socket_error.HasError()) {
-			Debug(net, Severity::Error, "Could not connect to {}: {}", this->sock_to_address[*it].GetAddressAsString(), socket_error.AsString());
+			Debug(Facility::Net, Severity::Error, "Could not connect to {}: {}", this->sock_to_address[*it].GetAddressAsString(), socket_error.AsString());
 			closesocket(*it);
 			this->sock_to_address.erase(*it);
 			it = this->sockets.erase(it);
@@ -389,8 +389,8 @@ bool TCPConnecter::CheckActivity()
 		it = this->sockets.erase(it);
 	}
 
-	Debug(net, Severity::Notice, "Connected to {}", this->connection_string);
-	Debug(net, Severity::Debug1, "- using {}", NetworkAddress::GetPeerName(connected_socket));
+	Debug(Facility::Net, Severity::Notice, "Connected to {}", this->connection_string);
+	Debug(Facility::Net, Severity::Debug1, "- using {}", NetworkAddress::GetPeerName(connected_socket));
 
 	this->OnConnect(connected_socket);
 	this->status = Status::Connected;

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -89,37 +89,37 @@ void TCPConnecter::Connect(addrinfo *address)
 {
 	SOCKET sock = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
 	if (sock == INVALID_SOCKET) {
-		Debug(net, 0, "Could not create {} {} socket: {}", NetworkAddress::SocketTypeAsString(address->ai_socktype), NetworkAddress::AddressFamilyAsString(address->ai_family), NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Could not create {} {} socket: {}", NetworkAddress::SocketTypeAsString(address->ai_socktype), NetworkAddress::AddressFamilyAsString(address->ai_family), NetworkError::GetLast().AsString());
 		return;
 	}
 
 	if (!SetReusePort(sock)) {
-		Debug(net, 0, "Setting reuse-port mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Setting reuse-port mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
 	if (this->bind_address.GetPort() > 0) {
 		if (bind(sock, (const sockaddr *)this->bind_address.GetAddress(), this->bind_address.GetAddressLength()) != 0) {
-			Debug(net, 1, "Could not bind socket on {}: {}", this->bind_address.GetAddressAsString(), NetworkError::GetLast().AsString());
+			Debug(net, Severity::Error, "Could not bind socket on {}: {}", this->bind_address.GetAddressAsString(), NetworkError::GetLast().AsString());
 			closesocket(sock);
 			return;
 		}
 	}
 
 	if (!SetNoDelay(sock)) {
-		Debug(net, 1, "Setting TCP_NODELAY failed: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Error, "Setting TCP_NODELAY failed: {}", NetworkError::GetLast().AsString());
 	}
 	if (!SetNonBlocking(sock)) {
-		Debug(net, 0, "Setting non-blocking mode failed: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Critical, "Setting non-blocking mode failed: {}", NetworkError::GetLast().AsString());
 	}
 
 	NetworkAddress network_address = NetworkAddress(address->ai_addr, (int)address->ai_addrlen);
-	Debug(net, 5, "Attempting to connect to {}", network_address.GetAddressAsString());
+	Debug(net, Severity::Debug1, "Attempting to connect to {}", network_address.GetAddressAsString());
 
 	int err = connect(sock, address->ai_addr, (int)address->ai_addrlen);
 	if (err != 0 && !NetworkError::GetLast().IsConnectInProgress()) {
 		closesocket(sock);
 
-		Debug(net, 1, "Could not connect to {}: {}", network_address.GetAddressAsString(), NetworkError::GetLast().AsString());
+		Debug(net, Severity::Error, "Could not connect to {}: {}", network_address.GetAddressAsString(), NetworkError::GetLast().AsString());
 		return;
 	}
 
@@ -197,13 +197,13 @@ void TCPConnecter::OnResolved(addrinfo *ai)
 		}
 	}
 
-	if (_debug_net_level >= 6) {
+	if (_debug_net_level >= Severity::Debug2) {
 		if (this->addresses.empty()) {
-			Debug(net, 6, "{} did not resolve", this->connection_string);
+			Debug(net, Severity::Debug2, "{} did not resolve", this->connection_string);
 		} else {
-			Debug(net, 6, "{} resolved in:", this->connection_string);
+			Debug(net, Severity::Debug2, "{} resolved in:", this->connection_string);
 			for (const auto &address : this->addresses) {
-				Debug(net, 6, "- {}", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString());
+				Debug(net, Severity::Debug2, "- {}", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString());
 			}
 		}
 	}
@@ -238,13 +238,13 @@ void TCPConnecter::Resolve()
 	auto end = std::chrono::steady_clock::now();
 	auto duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);
 	if (!getaddrinfo_timeout_error_shown && duration >= std::chrono::seconds(5)) {
-		Debug(net, 0, "getaddrinfo() for address \"{}\" took {} seconds", this->connection_string, duration.count());
-		Debug(net, 0, "  This is likely an issue in the DNS name resolver's configuration causing it to time out");
+		Debug(net, Severity::Critical, "getaddrinfo() for address \"{}\" took {} seconds", this->connection_string, duration.count());
+		Debug(net, Severity::Critical, "  This is likely an issue in the DNS name resolver's configuration causing it to time out");
 		getaddrinfo_timeout_error_shown = true;
 	}
 
 	if (error != 0) {
-		Debug(net, 0, "Failed to resolve DNS for {}", this->connection_string);
+		Debug(net, Severity::Critical, "Failed to resolve DNS for {}", this->connection_string);
 		this->status = Status::Failure;
 		return;
 	}
@@ -326,7 +326,7 @@ bool TCPConnecter::CheckActivity()
 	/* select() failed; hopefully next try it doesn't. */
 	if (n < 0) {
 		/* select() normally never fails; so hopefully it works next try! */
-		Debug(net, 1, "select() failed: {}", NetworkError::GetLast().AsString());
+		Debug(net, Severity::Error, "select() failed: {}", NetworkError::GetLast().AsString());
 		return false;
 	}
 
@@ -343,7 +343,7 @@ bool TCPConnecter::CheckActivity()
 
 		/* More than 3 seconds no socket reported activity, and there are no
 		 * more address to try. Timeout the attempt. */
-		Debug(net, 0, "Timeout while connecting to {}", this->connection_string);
+		Debug(net, Severity::Critical, "Timeout while connecting to {}", this->connection_string);
 
 		for (const auto &socket : this->sockets) {
 			closesocket(socket);
@@ -362,7 +362,7 @@ bool TCPConnecter::CheckActivity()
 	for (auto it = this->sockets.begin(); it != this->sockets.end(); /* nothing */) {
 		NetworkError socket_error = GetSocketError(*it);
 		if (socket_error.HasError()) {
-			Debug(net, 1, "Could not connect to {}: {}", this->sock_to_address[*it].GetAddressAsString(), socket_error.AsString());
+			Debug(net, Severity::Error, "Could not connect to {}: {}", this->sock_to_address[*it].GetAddressAsString(), socket_error.AsString());
 			closesocket(*it);
 			this->sock_to_address.erase(*it);
 			it = this->sockets.erase(it);
@@ -389,10 +389,8 @@ bool TCPConnecter::CheckActivity()
 		it = this->sockets.erase(it);
 	}
 
-	Debug(net, 3, "Connected to {}", this->connection_string);
-	if (_debug_net_level >= 5) {
-		Debug(net, 5, "- using {}", NetworkAddress::GetPeerName(connected_socket));
-	}
+	Debug(net, Severity::Notice, "Connected to {}", this->connection_string);
+	Debug(net, Severity::Debug1, "- using {}", NetworkAddress::GetPeerName(connected_socket));
 
 	this->OnConnect(connected_socket);
 	this->status = Status::Connected;

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -116,7 +116,7 @@ bool NetworkContentSocketHandler::HandlePacket(Packet &p)
 		case PacketContentType::ServerContent: return this->ReceiveServerContent(p);
 
 		default:
-			Debug(net, 0, "[tcp/content] Received invalid packet type {}", type);
+			Debug(net, Severity::Critical, "[tcp/content] Received invalid packet type {}", type);
 			return false;
 	}
 }
@@ -165,7 +165,7 @@ bool NetworkContentSocketHandler::ReceivePackets()
  */
 bool NetworkContentSocketHandler::ReceiveInvalidPacket(PacketContentType type)
 {
-	Debug(net, 0, "[tcp/content] Received illegal packet type {}", type);
+	Debug(net, Severity::Critical, "[tcp/content] Received illegal packet type {}", type);
 	return false;
 }
 

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -116,7 +116,7 @@ bool NetworkContentSocketHandler::HandlePacket(Packet &p)
 		case PacketContentType::ServerContent: return this->ReceiveServerContent(p);
 
 		default:
-			Debug(net, Severity::Critical, "[tcp/content] Received invalid packet type {}", type);
+			Debug(Facility::Net, Severity::Critical, "[tcp/content] Received invalid packet type {}", type);
 			return false;
 	}
 }
@@ -165,7 +165,7 @@ bool NetworkContentSocketHandler::ReceivePackets()
  */
 bool NetworkContentSocketHandler::ReceiveInvalidPacket(PacketContentType type)
 {
-	Debug(net, Severity::Critical, "[tcp/content] Received illegal packet type {}", type);
+	Debug(Facility::Net, Severity::Critical, "[tcp/content] Received illegal packet type {}", type);
 	return false;
 }
 

--- a/src/network/core/tcp_coordinator.cpp
+++ b/src/network/core/tcp_coordinator.cpp
@@ -44,7 +44,7 @@ bool NetworkCoordinatorSocketHandler::HandlePacket(Packet &p)
 		case PacketCoordinatorType::GameCoordinatorTurnConnect: return this->ReceiveGameCoordinatorTurnConnect(p);
 
 		default:
-			Debug(net, Severity::Critical, "[tcp/coordinator] Received invalid packet type {}", type);
+			Debug(Facility::Net, Severity::Critical, "[tcp/coordinator] Received invalid packet type {}", type);
 			return false;
 	}
 }
@@ -80,7 +80,7 @@ bool NetworkCoordinatorSocketHandler::ReceivePackets()
  */
 bool NetworkCoordinatorSocketHandler::ReceiveInvalidPacket(PacketCoordinatorType type)
 {
-	Debug(net, Severity::Critical, "[tcp/coordinator] Received illegal packet type {}", type);
+	Debug(Facility::Net, Severity::Critical, "[tcp/coordinator] Received illegal packet type {}", type);
 	return false;
 }
 

--- a/src/network/core/tcp_coordinator.cpp
+++ b/src/network/core/tcp_coordinator.cpp
@@ -44,7 +44,7 @@ bool NetworkCoordinatorSocketHandler::HandlePacket(Packet &p)
 		case PacketCoordinatorType::GameCoordinatorTurnConnect: return this->ReceiveGameCoordinatorTurnConnect(p);
 
 		default:
-			Debug(net, 0, "[tcp/coordinator] Received invalid packet type {}", type);
+			Debug(net, Severity::Critical, "[tcp/coordinator] Received invalid packet type {}", type);
 			return false;
 	}
 }
@@ -80,7 +80,7 @@ bool NetworkCoordinatorSocketHandler::ReceivePackets()
  */
 bool NetworkCoordinatorSocketHandler::ReceiveInvalidPacket(PacketCoordinatorType type)
 {
-	Debug(net, 0, "[tcp/coordinator] Received illegal packet type {}", type);
+	Debug(net, Severity::Critical, "[tcp/coordinator] Received illegal packet type {}", type);
 	return false;
 }
 

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -107,7 +107,7 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet &p)
 		case PacketGameType::ServerConfigurationUpdate: return this->ReceiveServerConfigurationUpdate(p);
 
 		default:
-			Debug(net, 0, "[tcp/game] Received invalid packet type {} from client {}", type, this->client_id);
+			Debug(net, Severity::Critical, "[tcp/game] Received invalid packet type {} from client {}", type, this->client_id);
 			this->CloseConnection();
 			return NetworkRecvStatus::MalformedPacket;
 	}
@@ -138,7 +138,7 @@ NetworkRecvStatus NetworkGameSocketHandler::ReceivePackets()
  */
 NetworkRecvStatus NetworkGameSocketHandler::ReceiveInvalidPacket(PacketGameType type)
 {
-	Debug(net, 0, "[tcp/game] Received illegal packet type {} from client {}", type, this->client_id);
+	Debug(net, Severity::Critical, "[tcp/game] Received illegal packet type {} from client {}", type, this->client_id);
 	return NetworkRecvStatus::MalformedPacket;
 }
 

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -107,7 +107,7 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet &p)
 		case PacketGameType::ServerConfigurationUpdate: return this->ReceiveServerConfigurationUpdate(p);
 
 		default:
-			Debug(net, Severity::Critical, "[tcp/game] Received invalid packet type {} from client {}", type, this->client_id);
+			Debug(Facility::Net, Severity::Critical, "[tcp/game] Received invalid packet type {} from client {}", type, this->client_id);
 			this->CloseConnection();
 			return NetworkRecvStatus::MalformedPacket;
 	}
@@ -138,7 +138,7 @@ NetworkRecvStatus NetworkGameSocketHandler::ReceivePackets()
  */
 NetworkRecvStatus NetworkGameSocketHandler::ReceiveInvalidPacket(PacketGameType type)
 {
-	Debug(net, Severity::Critical, "[tcp/game] Received illegal packet type {} from client {}", type, this->client_id);
+	Debug(Facility::Net, Severity::Critical, "[tcp/game] Received illegal packet type {} from client {}", type, this->client_id);
 	return NetworkRecvStatus::MalformedPacket;
 }
 

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -45,10 +45,10 @@ public:
 				Packet p(nullptr, Tban_packet);
 				p.PrepareToSend();
 
-				Debug(net, Severity::Warning, "[{}] Banned ip tried to join ({}), refused", Tsocket::GetName(), entry);
+				Debug(Facility::Net, Severity::Warning, "[{}] Banned ip tried to join ({}), refused", Tsocket::GetName(), entry);
 
 				if (p.TransferOut(SocketSender{s}) < 0) {
-					Debug(net, Severity::Critical, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
+					Debug(Facility::Net, Severity::Critical, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
 				}
 				closesocket(s);
 				return false;
@@ -63,7 +63,7 @@ public:
 			p.PrepareToSend();
 
 			if (p.TransferOut(SocketSender{s}) < 0) {
-				Debug(net, Severity::Critical, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
+				Debug(Facility::Net, Severity::Critical, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
 			}
 			closesocket(s);
 
@@ -91,7 +91,7 @@ public:
 			SetNonBlocking(s); // XXX error handling?
 
 			NetworkAddress address(sin, sin_len);
-			Debug(net, Severity::Notice, "[{}] Client connected from {} on frame {}", Tsocket::GetName(), address.GetHostname(), _frame_counter);
+			Debug(Facility::Net, Severity::Notice, "[{}] Client connected from {} on frame {}", Tsocket::GetName(), address.GetHostname(), _frame_counter);
 
 			SetNoDelay(s); // XXX error handling?
 
@@ -158,7 +158,7 @@ public:
 		}
 
 		if (sockets.empty()) {
-			Debug(net, Severity::Critical, "Could not start network: could not create listening socket");
+			Debug(Facility::Net, Severity::Critical, "Could not start network: could not create listening socket");
 			ShowNetworkError(STR_NETWORK_ERROR_SERVER_START);
 			return false;
 		}
@@ -173,7 +173,7 @@ public:
 			closesocket(s.first);
 		}
 		sockets.clear();
-		Debug(net, Severity::Debug1, "[{}] Closed listeners", Tsocket::GetName());
+		Debug(Facility::Net, Severity::Debug1, "[{}] Closed listeners", Tsocket::GetName());
 	}
 };
 

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -45,10 +45,10 @@ public:
 				Packet p(nullptr, Tban_packet);
 				p.PrepareToSend();
 
-				Debug(net, 2, "[{}] Banned ip tried to join ({}), refused", Tsocket::GetName(), entry);
+				Debug(net, Severity::Warning, "[{}] Banned ip tried to join ({}), refused", Tsocket::GetName(), entry);
 
 				if (p.TransferOut(SocketSender{s}) < 0) {
-					Debug(net, 0, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
+					Debug(net, Severity::Critical, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
 				}
 				closesocket(s);
 				return false;
@@ -63,7 +63,7 @@ public:
 			p.PrepareToSend();
 
 			if (p.TransferOut(SocketSender{s}) < 0) {
-				Debug(net, 0, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
+				Debug(net, Severity::Critical, "[{}] send failed: {}", Tsocket::GetName(), NetworkError::GetLast().AsString());
 			}
 			closesocket(s);
 
@@ -91,7 +91,7 @@ public:
 			SetNonBlocking(s); // XXX error handling?
 
 			NetworkAddress address(sin, sin_len);
-			Debug(net, 3, "[{}] Client connected from {} on frame {}", Tsocket::GetName(), address.GetHostname(), _frame_counter);
+			Debug(net, Severity::Notice, "[{}] Client connected from {} on frame {}", Tsocket::GetName(), address.GetHostname(), _frame_counter);
 
 			SetNoDelay(s); // XXX error handling?
 
@@ -158,7 +158,7 @@ public:
 		}
 
 		if (sockets.empty()) {
-			Debug(net, 0, "Could not start network: could not create listening socket");
+			Debug(net, Severity::Critical, "Could not start network: could not create listening socket");
 			ShowNetworkError(STR_NETWORK_ERROR_SERVER_START);
 			return false;
 		}
@@ -173,7 +173,7 @@ public:
 			closesocket(s.first);
 		}
 		sockets.clear();
-		Debug(net, 5, "[{}] Closed listeners", Tsocket::GetName());
+		Debug(net, Severity::Debug1, "[{}] Closed listeners", Tsocket::GetName());
 	}
 };
 

--- a/src/network/core/tcp_stun.cpp
+++ b/src/network/core/tcp_stun.cpp
@@ -20,7 +20,7 @@
  */
 bool NetworkStunSocketHandler::ReceiveInvalidPacket(PacketStunType type)
 {
-	Debug(net, Severity::Critical, "[tcp/stun] Received illegal packet type {}", type);
+	Debug(Facility::Net, Severity::Critical, "[tcp/stun] Received illegal packet type {}", type);
 	return false;
 }
 

--- a/src/network/core/tcp_stun.cpp
+++ b/src/network/core/tcp_stun.cpp
@@ -20,7 +20,7 @@
  */
 bool NetworkStunSocketHandler::ReceiveInvalidPacket(PacketStunType type)
 {
-	Debug(net, 0, "[tcp/stun] Received illegal packet type {}", type);
+	Debug(net, Severity::Critical, "[tcp/stun] Received illegal packet type {}", type);
 	return false;
 }
 

--- a/src/network/core/tcp_turn.cpp
+++ b/src/network/core/tcp_turn.cpp
@@ -30,7 +30,7 @@ bool NetworkTurnSocketHandler::HandlePacket(Packet &p)
 		case PacketTurnType::ServerConnected: return this->ReceiveServerConnected(p);
 
 		default:
-			Debug(net, 0, "[tcp/turn] Received invalid packet type {}", type);
+			Debug(net, Severity::Critical, "[tcp/turn] Received invalid packet type {}", type);
 			return false;
 	}
 }
@@ -59,7 +59,7 @@ bool NetworkTurnSocketHandler::ReceivePackets()
  */
 bool NetworkTurnSocketHandler::ReceiveInvalidPacket(PacketTurnType type)
 {
-	Debug(net, 0, "[tcp/turn] Received illegal packet type {}", type);
+	Debug(net, Severity::Critical, "[tcp/turn] Received illegal packet type {}", type);
 	return false;
 }
 

--- a/src/network/core/tcp_turn.cpp
+++ b/src/network/core/tcp_turn.cpp
@@ -30,7 +30,7 @@ bool NetworkTurnSocketHandler::HandlePacket(Packet &p)
 		case PacketTurnType::ServerConnected: return this->ReceiveServerConnected(p);
 
 		default:
-			Debug(net, Severity::Critical, "[tcp/turn] Received invalid packet type {}", type);
+			Debug(Facility::Net, Severity::Critical, "[tcp/turn] Received invalid packet type {}", type);
 			return false;
 	}
 }
@@ -59,7 +59,7 @@ bool NetworkTurnSocketHandler::ReceivePackets()
  */
 bool NetworkTurnSocketHandler::ReceiveInvalidPacket(PacketTurnType type)
 {
-	Debug(net, Severity::Critical, "[tcp/turn] Received illegal packet type {}", type);
+	Debug(Facility::Net, Severity::Critical, "[tcp/turn] Received illegal packet type {}", type);
 	return false;
 }
 

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -87,7 +87,7 @@ void NetworkUDPSocketHandler::SendPacket(Packet &p, NetworkAddress &recv, bool a
 			/* Enable broadcast */
 			unsigned long val = 1;
 			if (setsockopt(s.first, SOL_SOCKET, SO_BROADCAST, (char *) &val, sizeof(val)) < 0) {
-				Debug(net, Severity::Error, "Setting broadcast mode failed: {}", NetworkError::GetLast().AsString());
+				Debug(Facility::Net, Severity::Error, "Setting broadcast mode failed: {}", NetworkError::GetLast().AsString());
 			}
 		}
 
@@ -95,10 +95,10 @@ void NetworkUDPSocketHandler::SendPacket(Packet &p, NetworkAddress &recv, bool a
 		ssize_t res = p.TransferOut([&](std::span<const uint8_t> buffer) {
 			return sendto(s.first, reinterpret_cast<const char *>(buffer.data()), static_cast<int>(buffer.size()), 0, reinterpret_cast<const struct sockaddr *>(send.GetAddress()), send.GetAddressLength());
 		});
-		Debug(net, Severity::Trace1, "sendto({})", send.GetAddressAsString());
+		Debug(Facility::Net, Severity::Trace1, "sendto({})", send.GetAddressAsString());
 
 		/* Check for any errors, but ignore it otherwise */
-		if (res == -1) Debug(net, Severity::Error, "sendto({}) failed: {}", send.GetAddressAsString(), NetworkError::GetLast().AsString());
+		if (res == -1) Debug(Facility::Net, Severity::Error, "sendto({}) failed: {}", send.GetAddressAsString(), NetworkError::GetLast().AsString());
 
 		if (!all) break;
 	}
@@ -135,11 +135,11 @@ void NetworkUDPSocketHandler::ReceivePackets()
 			/* If the size does not match the packet must be corrupted.
 			 * Otherwise it will be marked as corrupted later on. */
 			if (!p.ParsePacketSize() || static_cast<size_t>(nbytes) != p.Size()) {
-				Debug(net, Severity::Error, "Received a packet with mismatching size from {}", address.GetAddressAsString());
+				Debug(Facility::Net, Severity::Error, "Received a packet with mismatching size from {}", address.GetAddressAsString());
 				continue;
 			}
 			if (!p.PrepareToRead()) {
-				Debug(net, Severity::Error, "Invalid packet received (too small / decryption error)");
+				Debug(Facility::Net, Severity::Error, "Invalid packet received (too small / decryption error)");
 				continue;
 			}
 
@@ -166,7 +166,7 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet &p, NetworkAddress &client_
 		case PacketUDPType::ServerResponse: this->ReceiveServerResponse(p, client_addr); break;
 
 		default:
-			Debug(net, Severity::Critical, "[udp] Received invalid packet type {} from {}", type, client_addr.GetAddressAsString());
+			Debug(Facility::Net, Severity::Critical, "[udp] Received invalid packet type {} from {}", type, client_addr.GetAddressAsString());
 			break;
 	}
 }
@@ -178,7 +178,7 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet &p, NetworkAddress &client_
  */
 void NetworkUDPSocketHandler::ReceiveInvalidPacket(PacketUDPType type, NetworkAddress &client_addr)
 {
-	Debug(net, Severity::Critical, "[udp] Received packet type {} on wrong port from {}", type, client_addr.GetAddressAsString());
+	Debug(Facility::Net, Severity::Critical, "[udp] Received packet type {} on wrong port from {}", type, client_addr.GetAddressAsString());
 }
 
 void NetworkUDPSocketHandler::ReceiveClientFindServer(Packet &, NetworkAddress &client_addr) { this->ReceiveInvalidPacket(PacketUDPType::ClientFindServer, client_addr); }

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -87,7 +87,7 @@ void NetworkUDPSocketHandler::SendPacket(Packet &p, NetworkAddress &recv, bool a
 			/* Enable broadcast */
 			unsigned long val = 1;
 			if (setsockopt(s.first, SOL_SOCKET, SO_BROADCAST, (char *) &val, sizeof(val)) < 0) {
-				Debug(net, 1, "Setting broadcast mode failed: {}", NetworkError::GetLast().AsString());
+				Debug(net, Severity::Error, "Setting broadcast mode failed: {}", NetworkError::GetLast().AsString());
 			}
 		}
 
@@ -95,10 +95,10 @@ void NetworkUDPSocketHandler::SendPacket(Packet &p, NetworkAddress &recv, bool a
 		ssize_t res = p.TransferOut([&](std::span<const uint8_t> buffer) {
 			return sendto(s.first, reinterpret_cast<const char *>(buffer.data()), static_cast<int>(buffer.size()), 0, reinterpret_cast<const struct sockaddr *>(send.GetAddress()), send.GetAddressLength());
 		});
-		Debug(net, 7, "sendto({})", send.GetAddressAsString());
+		Debug(net, Severity::Trace1, "sendto({})", send.GetAddressAsString());
 
 		/* Check for any errors, but ignore it otherwise */
-		if (res == -1) Debug(net, 1, "sendto({}) failed: {}", send.GetAddressAsString(), NetworkError::GetLast().AsString());
+		if (res == -1) Debug(net, Severity::Error, "sendto({}) failed: {}", send.GetAddressAsString(), NetworkError::GetLast().AsString());
 
 		if (!all) break;
 	}
@@ -135,11 +135,11 @@ void NetworkUDPSocketHandler::ReceivePackets()
 			/* If the size does not match the packet must be corrupted.
 			 * Otherwise it will be marked as corrupted later on. */
 			if (!p.ParsePacketSize() || static_cast<size_t>(nbytes) != p.Size()) {
-				Debug(net, 1, "Received a packet with mismatching size from {}", address.GetAddressAsString());
+				Debug(net, Severity::Error, "Received a packet with mismatching size from {}", address.GetAddressAsString());
 				continue;
 			}
 			if (!p.PrepareToRead()) {
-				Debug(net, 1, "Invalid packet received (too small / decryption error)");
+				Debug(net, Severity::Error, "Invalid packet received (too small / decryption error)");
 				continue;
 			}
 
@@ -166,7 +166,7 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet &p, NetworkAddress &client_
 		case PacketUDPType::ServerResponse: this->ReceiveServerResponse(p, client_addr); break;
 
 		default:
-			Debug(net, 0, "[udp] Received invalid packet type {} from {}", type, client_addr.GetAddressAsString());
+			Debug(net, Severity::Critical, "[udp] Received invalid packet type {} from {}", type, client_addr.GetAddressAsString());
 			break;
 	}
 }
@@ -178,7 +178,7 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet &p, NetworkAddress &client_
  */
 void NetworkUDPSocketHandler::ReceiveInvalidPacket(PacketUDPType type, NetworkAddress &client_addr)
 {
-	Debug(net, 0, "[udp] Received packet type {} on wrong port from {}", type, client_addr.GetAddressAsString());
+	Debug(net, Severity::Critical, "[udp] Received packet type {} on wrong port from {}", type, client_addr.GetAddressAsString());
 }
 
 void NetworkUDPSocketHandler::ReceiveClientFindServer(Packet &, NetworkAddress &client_addr) { this->ReceiveInvalidPacket(PacketUDPType::ClientFindServer, client_addr); }

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -286,7 +286,7 @@ void NetworkTextMessage(NetworkAction action, ExtendedTextColour colour, bool se
 		default: builder += GetString(STR_NETWORK_CHAT_ALL, name, str); break;
 	}
 
-	Debug(desync, 1, "msg: {:08x}; {:02x}; {}", TimerGameEconomy::date, TimerGameEconomy::date_fract, message);
+	Debug(desync, Severity::Error, "msg: {:08x}; {:02x}; {}", TimerGameEconomy::date, TimerGameEconomy::date_fract, message);
 	IConsolePrint(colour, message);
 	NetworkAddChatMessage(colour, _settings_client.gui.network_chat_timeout, message);
 }
@@ -665,7 +665,7 @@ public:
 
 	void OnFailure() override
 	{
-		Debug(net, 9, "Query::OnFailure(): connection_string={}", this->connection_string);
+		Debug(net, Severity::Trace3, "Query::OnFailure(): connection_string={}", this->connection_string);
 
 		NetworkGame *item = NetworkGameListAddItem(connection_string);
 		item->status = NetworkGameStatus::Offline;
@@ -676,7 +676,7 @@ public:
 
 	void OnConnect(SOCKET s) override
 	{
-		Debug(net, 9, "Query::OnConnect(): connection_string={}", this->connection_string);
+		Debug(net, Severity::Trace3, "Query::OnConnect(): connection_string={}", this->connection_string);
 
 		QueryNetworkGameSocketHandler::QueryServer(s, this->connection_string);
 	}
@@ -690,7 +690,7 @@ void NetworkQueryServer(std::string_view connection_string)
 {
 	if (!_network_available) return;
 
-	Debug(net, 9, "NetworkQueryServer(): connection_string={}", connection_string);
+	Debug(net, Severity::Trace3, "NetworkQueryServer(): connection_string={}", connection_string);
 
 	/* Mark the entry as refreshing, so the GUI can show the refresh is pending. */
 	NetworkGame *item = NetworkGameListAddItem(connection_string);
@@ -773,14 +773,14 @@ public:
 
 	void OnFailure() override
 	{
-		Debug(net, 9, "Client::OnFailure(): connection_string={}", this->connection_string);
+		Debug(net, Severity::Trace3, "Client::OnFailure(): connection_string={}", this->connection_string);
 
 		ShowNetworkError(STR_NETWORK_ERROR_NOCONNECTION);
 	}
 
 	void OnConnect(SOCKET s) override
 	{
-		Debug(net, 9, "Client::OnConnect(): connection_string={}", this->connection_string);
+		Debug(net, Severity::Trace3, "Client::OnConnect(): connection_string={}", this->connection_string);
 
 		_networking = true;
 		_network_own_client_id = ClientID{};
@@ -808,7 +808,7 @@ public:
  */
 bool NetworkClientConnectGame(std::string_view connection_string, CompanyID default_company, const std::string &join_server_password)
 {
-	Debug(net, 9, "NetworkClientConnectGame(): connection_string={}", connection_string);
+	Debug(net, Severity::Trace3, "NetworkClientConnectGame(): connection_string={}", connection_string);
 
 	CompanyID join_as = default_company;
 	std::string resolved_connection_string = ServerAddress::Parse(connection_string, NETWORK_DEFAULT_PORT, &join_as).connection_string;
@@ -845,7 +845,7 @@ void NetworkClientJoinGame()
 	NetworkInitialize();
 
 	_settings_client.network.last_joined = _network_join.connection_string;
-	Debug(net, 9, "status = Connecting");
+	Debug(net, Severity::Trace3, "status = Connecting");
 	_network_join_status = NetworkJoinStatus::Connecting;
 	ShowJoinStatusWindow();
 
@@ -904,14 +904,14 @@ static void CheckClientAndServerName()
 	static const std::string fallback_client_name = "Unnamed Client";
 	StrTrimInPlace(_settings_client.network.client_name);
 	if (_settings_client.network.client_name.empty() || _settings_client.network.client_name == fallback_client_name) {
-		Debug(net, 1, "No \"client_name\" has been set, using \"{}\" instead. Please set this now using the \"name <new name>\" command", fallback_client_name);
+		Debug(net, Severity::Error, "No \"client_name\" has been set, using \"{}\" instead. Please set this now using the \"name <new name>\" command", fallback_client_name);
 		_settings_client.network.client_name = fallback_client_name;
 	}
 
 	static const std::string fallback_server_name = "Unnamed Server";
 	StrTrimInPlace(_settings_client.network.server_name);
 	if (_settings_client.network.server_name.empty() || _settings_client.network.server_name == fallback_server_name) {
-		Debug(net, 1, "No \"server_name\" has been set, using \"{}\" instead. Please set this now using the \"server_name <new name>\" command", fallback_server_name);
+		Debug(net, Severity::Error, "No \"server_name\" has been set, using \"{}\" instead. Please set this now using the \"server_name <new name>\" command", fallback_server_name);
 		_settings_client.network.server_name = fallback_server_name;
 	}
 }
@@ -934,17 +934,17 @@ bool NetworkServerStart()
 	NetworkDisconnect(false);
 	NetworkInitialize(false);
 	NetworkUDPInitialize();
-	Debug(net, 5, "Starting listeners for clients");
+	Debug(net, Severity::Debug1, "Starting listeners for clients");
 	if (!ServerNetworkGameSocketHandler::Listen(_settings_client.network.server_port)) return false;
 
 	/* Only listen for admins when the authentication is configured. */
 	if (_settings_client.network.AdminAuthenticationConfigured()) {
-		Debug(net, 5, "Starting listeners for admins");
+		Debug(net, Severity::Debug1, "Starting listeners for admins");
 		if (!ServerNetworkAdminSocketHandler::Listen(_settings_client.network.server_admin_port)) return false;
 	}
 
 	/* Try to start UDP-server */
-	Debug(net, 5, "Starting listeners for incoming server queries");
+	Debug(net, Severity::Debug1, "Starting listeners for incoming server queries");
 	NetworkUDPServerListen();
 
 	_network_server = true;
@@ -1141,7 +1141,7 @@ void NetworkGameLoop()
 			/* We don't want to log multiple times if paused. */
 			static TimerGameEconomy::Date last_log;
 			if (last_log != TimerGameEconomy::date) {
-				Debug(desync, 1, "sync: {:08x}; {:02x}; {:08x}; {:08x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _random.state[0], _random.state[1]);
+				Debug(desync, Severity::Error, "sync: {:08x}; {:02x}; {:08x}; {:08x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _random.state[0], _random.state[1]);
 				last_log = TimerGameEconomy::date;
 			}
 		}
@@ -1155,7 +1155,7 @@ void NetworkGameLoop()
 		static bool check_sync_state = false;
 		static uint32_t sync_state[2];
 		if (!f.has_value() && next_date == 0) {
-			Debug(desync, 0, "Cannot open commands.log");
+			Debug(desync, Severity::Critical, "Cannot open commands.log");
 			next_date = TimerGameEconomy::Date(1);
 		}
 
@@ -1163,15 +1163,15 @@ void NetworkGameLoop()
 			if (TimerGameEconomy::date == next_date && TimerGameEconomy::date_fract == next_date_fract) {
 				if (cp != nullptr) {
 					NetworkSendCommand(cp->cmd, cp->err_msg, nullptr, cp->company, cp->data);
-					Debug(desync, 0, "Injecting: {:08x}; {:02x}; {:02x}; {:08x}; {} ({})", TimerGameEconomy::date, TimerGameEconomy::date_fract, _current_company.base(), cp->cmd, FormatArrayAsHex(cp->data), GetCommandName(cp->cmd));
+					Debug(desync, Severity::Critical, "Injecting: {:08x}; {:02x}; {:02x}; {:08x}; {} ({})", TimerGameEconomy::date, TimerGameEconomy::date_fract, _current_company.base(), cp->cmd, FormatArrayAsHex(cp->data), GetCommandName(cp->cmd));
 					delete cp;
 					cp = nullptr;
 				}
 				if (check_sync_state) {
 					if (sync_state[0] == _random.state[0] && sync_state[1] == _random.state[1]) {
-						Debug(desync, 0, "Sync check: {:08x}; {:02x}; match", TimerGameEconomy::date, TimerGameEconomy::date_fract);
+						Debug(desync, Severity::Critical, "Sync check: {:08x}; {:02x}; match", TimerGameEconomy::date, TimerGameEconomy::date_fract);
 					} else {
-						Debug(desync, 0, "Sync check: {:08x}; {:02x}; mismatch expected {{{:08x}, {:08x}}}, got {{{:08x}, {:08x}}}",
+						Debug(desync, Severity::Critical, "Sync check: {:08x}; {:02x}; mismatch expected {{{:08x}, {:08x}}}, got {{{:08x}, {:08x}}}",
 									TimerGameEconomy::date, TimerGameEconomy::date_fract, sync_state[0], sync_state[1], _random.state[0], _random.state[1]);
 						NOT_REACHED();
 					}
@@ -1181,7 +1181,7 @@ void NetworkGameLoop()
 
 			/* Skip all entries in the command-log till we caught up with the current game again. */
 			if (TimerGameEconomy::date > next_date || (TimerGameEconomy::date == next_date && TimerGameEconomy::date_fract > next_date_fract)) {
-				Debug(desync, 0, "Skipping to next command at {:08x}:{:02x}", next_date, next_date_fract);
+				Debug(desync, Severity::Critical, "Skipping to next command at {:08x}:{:02x}", next_date, next_date_fract);
 				if (cp != nullptr) {
 					delete cp;
 					cp = nullptr;
@@ -1233,7 +1233,7 @@ void NetworkGameLoop()
 				bool valid = consumer.ReadIf("; ");
 				next_date_fract = consumer.ReadIntegerBase<uint32_t>(16);
 				assert(valid);
-				Debug(desync, 0, "Injecting pause for join at {:08x}:{:02x}; please join when paused", next_date, next_date_fract);
+				Debug(desync, Severity::Critical, "Injecting pause for join at {:08x}:{:02x}; please join when paused", next_date, next_date_fract);
 				cp = new CommandPacket();
 				cp->company = COMPANY_SPECTATOR;
 				cp->cmd = Commands::Pause;
@@ -1255,16 +1255,16 @@ void NetworkGameLoop()
 				/* A message that is not very important to the log playback, but part of the log. */
 #ifndef DEBUG_FAILED_DUMP_COMMANDS
 			} else if (consumer.ReadIf("cmdf: ")) {
-				Debug(desync, 0, "Skipping replay of failed command: {}", consumer.Read(StringConsumer::npos));
+				Debug(desync, Severity::Critical, "Skipping replay of failed command: {}", consumer.Read(StringConsumer::npos));
 #endif
 			} else {
 				/* Can't parse a line; what's wrong here? */
-				Debug(desync, 0, "Trying to parse: {}", consumer.Read(StringConsumer::npos));
+				Debug(desync, Severity::Critical, "Trying to parse: {}", consumer.Read(StringConsumer::npos));
 				NOT_REACHED();
 			}
 		}
 		if (f.has_value() && feof(*f)) {
-			Debug(desync, 0, "End of commands.log");
+			Debug(desync, Severity::Critical, "End of commands.log");
 			f.reset();
 		}
 #endif /* DEBUG_DUMP_COMMANDS */
@@ -1322,7 +1322,7 @@ void NetworkGameLoop()
 /** This tries to launch the network for a given OS */
 void NetworkStartUp()
 {
-	Debug(net, 3, "Starting network");
+	Debug(net, Severity::Notice, "Starting network");
 
 	/* Network is available */
 	_network_available = NetworkCoreInitialize();
@@ -1332,7 +1332,7 @@ void NetworkStartUp()
 
 	NetworkInitialize();
 	NetworkUDPInitialize();
-	Debug(net, 3, "Network online, multiplayer available");
+	Debug(net, Severity::Notice, "Network online, multiplayer available");
 	NetworkFindBroadcastIPs(&_broadcast_list);
 	NetworkHTTPInitialize();
 }
@@ -1344,7 +1344,7 @@ void NetworkShutDown()
 	NetworkHTTPUninitialize();
 	NetworkUDPClose();
 
-	Debug(net, 3, "Shutting down network");
+	Debug(net, Severity::Notice, "Shutting down network");
 
 	_network_available = false;
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -286,7 +286,7 @@ void NetworkTextMessage(NetworkAction action, ExtendedTextColour colour, bool se
 		default: builder += GetString(STR_NETWORK_CHAT_ALL, name, str); break;
 	}
 
-	Debug(desync, Severity::Error, "msg: {:08x}; {:02x}; {}", TimerGameEconomy::date, TimerGameEconomy::date_fract, message);
+	Debug(Facility::Desync, Severity::Error, "msg: {:08x}; {:02x}; {}", TimerGameEconomy::date, TimerGameEconomy::date_fract, message);
 	IConsolePrint(colour, message);
 	NetworkAddChatMessage(colour, _settings_client.gui.network_chat_timeout, message);
 }
@@ -665,7 +665,7 @@ public:
 
 	void OnFailure() override
 	{
-		Debug(net, Severity::Trace3, "Query::OnFailure(): connection_string={}", this->connection_string);
+		Debug(Facility::Net, Severity::Trace3, "Query::OnFailure(): connection_string={}", this->connection_string);
 
 		NetworkGame *item = NetworkGameListAddItem(connection_string);
 		item->status = NetworkGameStatus::Offline;
@@ -676,7 +676,7 @@ public:
 
 	void OnConnect(SOCKET s) override
 	{
-		Debug(net, Severity::Trace3, "Query::OnConnect(): connection_string={}", this->connection_string);
+		Debug(Facility::Net, Severity::Trace3, "Query::OnConnect(): connection_string={}", this->connection_string);
 
 		QueryNetworkGameSocketHandler::QueryServer(s, this->connection_string);
 	}
@@ -690,7 +690,7 @@ void NetworkQueryServer(std::string_view connection_string)
 {
 	if (!_network_available) return;
 
-	Debug(net, Severity::Trace3, "NetworkQueryServer(): connection_string={}", connection_string);
+	Debug(Facility::Net, Severity::Trace3, "NetworkQueryServer(): connection_string={}", connection_string);
 
 	/* Mark the entry as refreshing, so the GUI can show the refresh is pending. */
 	NetworkGame *item = NetworkGameListAddItem(connection_string);
@@ -773,14 +773,14 @@ public:
 
 	void OnFailure() override
 	{
-		Debug(net, Severity::Trace3, "Client::OnFailure(): connection_string={}", this->connection_string);
+		Debug(Facility::Net, Severity::Trace3, "Client::OnFailure(): connection_string={}", this->connection_string);
 
 		ShowNetworkError(STR_NETWORK_ERROR_NOCONNECTION);
 	}
 
 	void OnConnect(SOCKET s) override
 	{
-		Debug(net, Severity::Trace3, "Client::OnConnect(): connection_string={}", this->connection_string);
+		Debug(Facility::Net, Severity::Trace3, "Client::OnConnect(): connection_string={}", this->connection_string);
 
 		_networking = true;
 		_network_own_client_id = ClientID{};
@@ -808,7 +808,7 @@ public:
  */
 bool NetworkClientConnectGame(std::string_view connection_string, CompanyID default_company, const std::string &join_server_password)
 {
-	Debug(net, Severity::Trace3, "NetworkClientConnectGame(): connection_string={}", connection_string);
+	Debug(Facility::Net, Severity::Trace3, "NetworkClientConnectGame(): connection_string={}", connection_string);
 
 	CompanyID join_as = default_company;
 	std::string resolved_connection_string = ServerAddress::Parse(connection_string, NETWORK_DEFAULT_PORT, &join_as).connection_string;
@@ -845,7 +845,7 @@ void NetworkClientJoinGame()
 	NetworkInitialize();
 
 	_settings_client.network.last_joined = _network_join.connection_string;
-	Debug(net, Severity::Trace3, "status = Connecting");
+	Debug(Facility::Net, Severity::Trace3, "status = Connecting");
 	_network_join_status = NetworkJoinStatus::Connecting;
 	ShowJoinStatusWindow();
 
@@ -904,14 +904,14 @@ static void CheckClientAndServerName()
 	static const std::string fallback_client_name = "Unnamed Client";
 	StrTrimInPlace(_settings_client.network.client_name);
 	if (_settings_client.network.client_name.empty() || _settings_client.network.client_name == fallback_client_name) {
-		Debug(net, Severity::Error, "No \"client_name\" has been set, using \"{}\" instead. Please set this now using the \"name <new name>\" command", fallback_client_name);
+		Debug(Facility::Net, Severity::Error, "No \"client_name\" has been set, using \"{}\" instead. Please set this now using the \"name <new name>\" command", fallback_client_name);
 		_settings_client.network.client_name = fallback_client_name;
 	}
 
 	static const std::string fallback_server_name = "Unnamed Server";
 	StrTrimInPlace(_settings_client.network.server_name);
 	if (_settings_client.network.server_name.empty() || _settings_client.network.server_name == fallback_server_name) {
-		Debug(net, Severity::Error, "No \"server_name\" has been set, using \"{}\" instead. Please set this now using the \"server_name <new name>\" command", fallback_server_name);
+		Debug(Facility::Net, Severity::Error, "No \"server_name\" has been set, using \"{}\" instead. Please set this now using the \"server_name <new name>\" command", fallback_server_name);
 		_settings_client.network.server_name = fallback_server_name;
 	}
 }
@@ -934,17 +934,17 @@ bool NetworkServerStart()
 	NetworkDisconnect(false);
 	NetworkInitialize(false);
 	NetworkUDPInitialize();
-	Debug(net, Severity::Debug1, "Starting listeners for clients");
+	Debug(Facility::Net, Severity::Debug1, "Starting listeners for clients");
 	if (!ServerNetworkGameSocketHandler::Listen(_settings_client.network.server_port)) return false;
 
 	/* Only listen for admins when the authentication is configured. */
 	if (_settings_client.network.AdminAuthenticationConfigured()) {
-		Debug(net, Severity::Debug1, "Starting listeners for admins");
+		Debug(Facility::Net, Severity::Debug1, "Starting listeners for admins");
 		if (!ServerNetworkAdminSocketHandler::Listen(_settings_client.network.server_admin_port)) return false;
 	}
 
 	/* Try to start UDP-server */
-	Debug(net, Severity::Debug1, "Starting listeners for incoming server queries");
+	Debug(Facility::Net, Severity::Debug1, "Starting listeners for incoming server queries");
 	NetworkUDPServerListen();
 
 	_network_server = true;
@@ -1141,7 +1141,7 @@ void NetworkGameLoop()
 			/* We don't want to log multiple times if paused. */
 			static TimerGameEconomy::Date last_log;
 			if (last_log != TimerGameEconomy::date) {
-				Debug(desync, Severity::Error, "sync: {:08x}; {:02x}; {:08x}; {:08x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _random.state[0], _random.state[1]);
+				Debug(Facility::Desync, Severity::Error, "sync: {:08x}; {:02x}; {:08x}; {:08x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, _random.state[0], _random.state[1]);
 				last_log = TimerGameEconomy::date;
 			}
 		}
@@ -1155,7 +1155,7 @@ void NetworkGameLoop()
 		static bool check_sync_state = false;
 		static uint32_t sync_state[2];
 		if (!f.has_value() && next_date == 0) {
-			Debug(desync, Severity::Critical, "Cannot open commands.log");
+			Debug(Facility::Desync, Severity::Critical, "Cannot open commands.log");
 			next_date = TimerGameEconomy::Date(1);
 		}
 
@@ -1163,15 +1163,15 @@ void NetworkGameLoop()
 			if (TimerGameEconomy::date == next_date && TimerGameEconomy::date_fract == next_date_fract) {
 				if (cp != nullptr) {
 					NetworkSendCommand(cp->cmd, cp->err_msg, nullptr, cp->company, cp->data);
-					Debug(desync, Severity::Critical, "Injecting: {:08x}; {:02x}; {:02x}; {:08x}; {} ({})", TimerGameEconomy::date, TimerGameEconomy::date_fract, _current_company.base(), cp->cmd, FormatArrayAsHex(cp->data), GetCommandName(cp->cmd));
+					Debug(Facility::Desync, Severity::Critical, "Injecting: {:08x}; {:02x}; {:02x}; {:08x}; {} ({})", TimerGameEconomy::date, TimerGameEconomy::date_fract, _current_company.base(), cp->cmd, FormatArrayAsHex(cp->data), GetCommandName(cp->cmd));
 					delete cp;
 					cp = nullptr;
 				}
 				if (check_sync_state) {
 					if (sync_state[0] == _random.state[0] && sync_state[1] == _random.state[1]) {
-						Debug(desync, Severity::Critical, "Sync check: {:08x}; {:02x}; match", TimerGameEconomy::date, TimerGameEconomy::date_fract);
+						Debug(Facility::Desync, Severity::Critical, "Sync check: {:08x}; {:02x}; match", TimerGameEconomy::date, TimerGameEconomy::date_fract);
 					} else {
-						Debug(desync, Severity::Critical, "Sync check: {:08x}; {:02x}; mismatch expected {{{:08x}, {:08x}}}, got {{{:08x}, {:08x}}}",
+						Debug(Facility::Desync, Severity::Critical, "Sync check: {:08x}; {:02x}; mismatch expected {{{:08x}, {:08x}}}, got {{{:08x}, {:08x}}}",
 									TimerGameEconomy::date, TimerGameEconomy::date_fract, sync_state[0], sync_state[1], _random.state[0], _random.state[1]);
 						NOT_REACHED();
 					}
@@ -1181,7 +1181,7 @@ void NetworkGameLoop()
 
 			/* Skip all entries in the command-log till we caught up with the current game again. */
 			if (TimerGameEconomy::date > next_date || (TimerGameEconomy::date == next_date && TimerGameEconomy::date_fract > next_date_fract)) {
-				Debug(desync, Severity::Critical, "Skipping to next command at {:08x}:{:02x}", next_date, next_date_fract);
+				Debug(Facility::Desync, Severity::Critical, "Skipping to next command at {:08x}:{:02x}", next_date, next_date_fract);
 				if (cp != nullptr) {
 					delete cp;
 					cp = nullptr;
@@ -1233,7 +1233,7 @@ void NetworkGameLoop()
 				bool valid = consumer.ReadIf("; ");
 				next_date_fract = consumer.ReadIntegerBase<uint32_t>(16);
 				assert(valid);
-				Debug(desync, Severity::Critical, "Injecting pause for join at {:08x}:{:02x}; please join when paused", next_date, next_date_fract);
+				Debug(Facility::Desync, Severity::Critical, "Injecting pause for join at {:08x}:{:02x}; please join when paused", next_date, next_date_fract);
 				cp = new CommandPacket();
 				cp->company = COMPANY_SPECTATOR;
 				cp->cmd = Commands::Pause;
@@ -1255,16 +1255,16 @@ void NetworkGameLoop()
 				/* A message that is not very important to the log playback, but part of the log. */
 #ifndef DEBUG_FAILED_DUMP_COMMANDS
 			} else if (consumer.ReadIf("cmdf: ")) {
-				Debug(desync, Severity::Critical, "Skipping replay of failed command: {}", consumer.Read(StringConsumer::npos));
+				Debug(Facility::Desync, Severity::Critical, "Skipping replay of failed command: {}", consumer.Read(StringConsumer::npos));
 #endif
 			} else {
 				/* Can't parse a line; what's wrong here? */
-				Debug(desync, Severity::Critical, "Trying to parse: {}", consumer.Read(StringConsumer::npos));
+				Debug(Facility::Desync, Severity::Critical, "Trying to parse: {}", consumer.Read(StringConsumer::npos));
 				NOT_REACHED();
 			}
 		}
 		if (f.has_value() && feof(*f)) {
-			Debug(desync, Severity::Critical, "End of commands.log");
+			Debug(Facility::Desync, Severity::Critical, "End of commands.log");
 			f.reset();
 		}
 #endif /* DEBUG_DUMP_COMMANDS */
@@ -1322,7 +1322,7 @@ void NetworkGameLoop()
 /** This tries to launch the network for a given OS */
 void NetworkStartUp()
 {
-	Debug(net, Severity::Notice, "Starting network");
+	Debug(Facility::Net, Severity::Notice, "Starting network");
 
 	/* Network is available */
 	_network_available = NetworkCoreInitialize();
@@ -1332,7 +1332,7 @@ void NetworkStartUp()
 
 	NetworkInitialize();
 	NetworkUDPInitialize();
-	Debug(net, Severity::Notice, "Network online, multiplayer available");
+	Debug(Facility::Net, Severity::Notice, "Network online, multiplayer available");
 	NetworkFindBroadcastIPs(&_broadcast_list);
 	NetworkHTTPInitialize();
 }
@@ -1344,7 +1344,7 @@ void NetworkShutDown()
 	NetworkHTTPUninitialize();
 	NetworkUDPClose();
 
-	Debug(net, Severity::Notice, "Shutting down network");
+	Debug(Facility::Net, Severity::Notice, "Shutting down network");
 
 	_network_available = false;
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -77,7 +77,7 @@ ServerNetworkAdminSocketHandler::ServerNetworkAdminSocketHandler(AdminID index, 
  */
 ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
 {
-	Debug(net, 3, "[admin] '{}' ({}) has disconnected", this->admin_name, this->admin_version);
+	Debug(net, Severity::Notice, "[admin] '{}' ({}) has disconnected", this->admin_name, this->admin_version);
 	if (_redirect_console_to_admin == this->index) _redirect_console_to_admin = AdminID::Invalid();
 
 	if (this->update_frequency[AdminUpdateType::Console].Test(AdminUpdateFrequency::Automatic)) {
@@ -100,7 +100,7 @@ ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
 {
 	for (ServerNetworkAdminSocketHandler *as : ServerNetworkAdminSocketHandler::Iterate()) {
 		if (as->status <= AdminStatus::Authenticate && std::chrono::steady_clock::now() > as->connect_time + ADMIN_AUTHORISATION_TIMEOUT) {
-			Debug(net, 2, "[admin] Admin did not send its authorisation within {} seconds", std::chrono::duration_cast<std::chrono::seconds>(ADMIN_AUTHORISATION_TIMEOUT).count());
+			Debug(net, Severity::Warning, "[admin] Admin did not send its authorisation within {} seconds", std::chrono::duration_cast<std::chrono::seconds>(ADMIN_AUTHORISATION_TIMEOUT).count());
 			as->CloseConnection(true);
 			continue;
 		}
@@ -142,7 +142,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendError(NetworkErrorCode er
 
 	std::string error_message = GetString(GetNetworkErrorMsg(error));
 
-	Debug(net, 1, "[admin] The admin '{}' ({}) made an error and has been disconnected: '{}'", this->admin_name, this->admin_version, error_message);
+	Debug(net, Severity::Error, "[admin] The admin '{}' ({}) made an error and has been disconnected: '{}'", this->admin_name, this->admin_version, error_message);
 
 	return this->CloseConnection(true);
 }
@@ -520,7 +520,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminRemoteConsoleComm
 
 	std::string command = p.Recv_string(NETWORK_RCONCOMMAND_LENGTH);
 
-	Debug(net, 3, "[admin] Rcon command from '{}' ({}): {}", this->admin_name, this->admin_version, command);
+	Debug(net, Severity::Notice, "[admin] Rcon command from '{}' ({}): {}", this->admin_name, this->admin_version, command);
 
 	_redirect_console_to_admin = this->index;
 	IConsoleCmdExec(command);
@@ -534,7 +534,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminGameScript(Packet
 
 	std::string json = p.Recv_string(NETWORK_GAMESCRIPT_JSON_LENGTH);
 
-	Debug(net, 6, "[admin] GameScript JSON from '{}' ({}): {}", this->admin_name, this->admin_version, json);
+	Debug(net, Severity::Debug2, "[admin] GameScript JSON from '{}' ({}): {}", this->admin_name, this->admin_version, json);
 
 	Game::NewEvent(new ScriptEventAdminPort(json));
 	return NetworkRecvStatus::Okay;
@@ -546,7 +546,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminPing(Packet &p)
 
 	uint32_t d1 = p.Recv_uint32();
 
-	Debug(net, 6, "[admin] Ping from '{}' ({}): {}", this->admin_name, this->admin_version, d1);
+	Debug(net, Severity::Debug2, "[admin] Ping from '{}' ({}): {}", this->admin_name, this->admin_version, d1);
 
 	return this->SendPong(d1);
 }
@@ -686,7 +686,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminJoin(Packet &p)
 		return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
-	Debug(net, 3, "[admin] '{}' ({}) has connected", this->admin_name, this->admin_version);
+	Debug(net, Severity::Notice, "[admin] '{}' ({}) has connected", this->admin_name, this->admin_version);
 
 	return this->SendProtocol();
 }
@@ -706,7 +706,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminUpdateFrequency(P
 
 	if (type >= AdminUpdateType::End || !_admin_update_type_frequencies[type].All(freq)) {
 		/* The server does not know of this UpdateType. */
-		Debug(net, 1, "[admin] Not supported update frequency {} ({}) from '{}' ({})", type, freq, this->admin_name, this->admin_version);
+		Debug(net, Severity::Error, "[admin] Not supported update frequency {} ({}) from '{}' ({})", type, freq, this->admin_name, this->admin_version);
 		return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
@@ -777,7 +777,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminPoll(Packet &p)
 
 		default:
 			/* An unsupported "poll" update type. */
-			Debug(net, 1, "[admin] Not supported poll {} ({}) from '{}' ({}).", type, d1, this->admin_name, this->admin_version);
+			Debug(net, Severity::Error, "[admin] Not supported poll {} ({}) from '{}' ({}).", type, d1, this->admin_name, this->admin_version);
 			return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
@@ -803,7 +803,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminChat(Packet &p)
 			break;
 
 		default:
-			Debug(net, 1, "[admin] Invalid chat action {} from admin '{}' ({}).", action, this->admin_name, this->admin_version);
+			Debug(net, Severity::Error, "[admin] Invalid chat action {} from admin '{}' ({}).", action, this->admin_name, this->admin_version);
 			return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
@@ -820,7 +820,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminExternalChat(Pack
 	std::string msg = p.Recv_string(NETWORK_CHAT_LENGTH);
 
 	if (!IsValidConsoleColour(colour)) {
-		Debug(net, 1, "[admin] Not supported chat colour {} ({}, {}, {}) from '{}' ({}).", colour.ToNetwork(), source, user, msg, this->admin_name, this->admin_version);
+		Debug(net, Severity::Error, "[admin] Not supported chat colour {} ({}, {}, {}) from '{}' ({}).", colour.ToNetwork(), source, user, msg, this->admin_name, this->admin_version);
 		return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
@@ -853,7 +853,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminJoinSecure(Packet
 	if (!handler->CanBeUsed()) return this->SendError(NetworkErrorCode::NoAuthenticationMethodAvailable);
 
 	this->authentication_handler = std::move(handler);
-	Debug(net, 3, "[admin] '{}' ({}) has connected", this->admin_name, this->admin_version);
+	Debug(net, Severity::Notice, "[admin] '{}' ({}) has connected", this->admin_name, this->admin_version);
 
 	return this->SendAuthRequest();
 }
@@ -866,7 +866,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendAuthRequest()
 {
 	this->status = AdminStatus::Authenticate;
 
-	Debug(net, 6, "[admin] '{}' ({}) authenticating using {}", this->admin_name, this->admin_version, this->authentication_handler->GetName());
+	Debug(net, Severity::Debug2, "[admin] '{}' ({}) authenticating using {}", this->admin_name, this->admin_version, this->authentication_handler->GetName());
 
 	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerAuthenticationRequest);
 	this->authentication_handler->SendRequest(*p);
@@ -897,7 +897,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminAuthenticationRes
 
 	switch (this->authentication_handler->ReceiveResponse(p)) {
 		case NetworkAuthenticationServerHandler::ResponseResult::Authenticated:
-			Debug(net, 3, "[admin] '{}' ({}) authenticated", this->admin_name, this->admin_version);
+			Debug(net, Severity::Notice, "[admin] '{}' ({}) authenticated", this->admin_name, this->admin_version);
 
 			this->SendEnableEncryption();
 
@@ -907,12 +907,12 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminAuthenticationRes
 			return this->SendProtocol();
 
 		case NetworkAuthenticationServerHandler::ResponseResult::RetryNextMethod:
-			Debug(net, 6, "[admin] '{}' ({}) authentication failed, trying next method", this->admin_name, this->admin_version);
+			Debug(net, Severity::Debug2, "[admin] '{}' ({}) authentication failed, trying next method", this->admin_name, this->admin_version);
 			return this->SendAuthRequest();
 
 		case NetworkAuthenticationServerHandler::ResponseResult::NotAuthenticated:
 		default:
-			Debug(net, 3, "[admin] '{}' ({}) authentication failed", this->admin_name, this->admin_version);
+			Debug(net, Severity::Notice, "[admin] '{}' ({}) authentication failed", this->admin_name, this->admin_version);
 			return this->SendError(NetworkErrorCode::WrongPassword);
 	}
 }
@@ -985,7 +985,7 @@ void NetworkAdminClientError(ClientID client_id, NetworkErrorCode error_code)
 void NetworkAdminCompanyNew(const Company *company)
 {
 	if (company == nullptr) {
-		Debug(net, 1, "[admin] Empty company given for update");
+		Debug(net, Severity::Error, "[admin] Empty company given for update");
 		return;
 	}
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -77,7 +77,7 @@ ServerNetworkAdminSocketHandler::ServerNetworkAdminSocketHandler(AdminID index, 
  */
 ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
 {
-	Debug(net, Severity::Notice, "[admin] '{}' ({}) has disconnected", this->admin_name, this->admin_version);
+	Debug(Facility::Net, Severity::Notice, "[admin] '{}' ({}) has disconnected", this->admin_name, this->admin_version);
 	if (_redirect_console_to_admin == this->index) _redirect_console_to_admin = AdminID::Invalid();
 
 	if (this->update_frequency[AdminUpdateType::Console].Test(AdminUpdateFrequency::Automatic)) {
@@ -100,7 +100,7 @@ ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
 {
 	for (ServerNetworkAdminSocketHandler *as : ServerNetworkAdminSocketHandler::Iterate()) {
 		if (as->status <= AdminStatus::Authenticate && std::chrono::steady_clock::now() > as->connect_time + ADMIN_AUTHORISATION_TIMEOUT) {
-			Debug(net, Severity::Warning, "[admin] Admin did not send its authorisation within {} seconds", std::chrono::duration_cast<std::chrono::seconds>(ADMIN_AUTHORISATION_TIMEOUT).count());
+			Debug(Facility::Net, Severity::Warning, "[admin] Admin did not send its authorisation within {} seconds", std::chrono::duration_cast<std::chrono::seconds>(ADMIN_AUTHORISATION_TIMEOUT).count());
 			as->CloseConnection(true);
 			continue;
 		}
@@ -142,7 +142,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendError(NetworkErrorCode er
 
 	std::string error_message = GetString(GetNetworkErrorMsg(error));
 
-	Debug(net, Severity::Error, "[admin] The admin '{}' ({}) made an error and has been disconnected: '{}'", this->admin_name, this->admin_version, error_message);
+	Debug(Facility::Net, Severity::Error, "[admin] The admin '{}' ({}) made an error and has been disconnected: '{}'", this->admin_name, this->admin_version, error_message);
 
 	return this->CloseConnection(true);
 }
@@ -520,7 +520,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminRemoteConsoleComm
 
 	std::string command = p.Recv_string(NETWORK_RCONCOMMAND_LENGTH);
 
-	Debug(net, Severity::Notice, "[admin] Rcon command from '{}' ({}): {}", this->admin_name, this->admin_version, command);
+	Debug(Facility::Net, Severity::Notice, "[admin] Rcon command from '{}' ({}): {}", this->admin_name, this->admin_version, command);
 
 	_redirect_console_to_admin = this->index;
 	IConsoleCmdExec(command);
@@ -534,7 +534,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminGameScript(Packet
 
 	std::string json = p.Recv_string(NETWORK_GAMESCRIPT_JSON_LENGTH);
 
-	Debug(net, Severity::Debug2, "[admin] GameScript JSON from '{}' ({}): {}", this->admin_name, this->admin_version, json);
+	Debug(Facility::Net, Severity::Debug2, "[admin] GameScript JSON from '{}' ({}): {}", this->admin_name, this->admin_version, json);
 
 	Game::NewEvent(new ScriptEventAdminPort(json));
 	return NetworkRecvStatus::Okay;
@@ -546,7 +546,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminPing(Packet &p)
 
 	uint32_t d1 = p.Recv_uint32();
 
-	Debug(net, Severity::Debug2, "[admin] Ping from '{}' ({}): {}", this->admin_name, this->admin_version, d1);
+	Debug(Facility::Net, Severity::Debug2, "[admin] Ping from '{}' ({}): {}", this->admin_name, this->admin_version, d1);
 
 	return this->SendPong(d1);
 }
@@ -686,7 +686,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminJoin(Packet &p)
 		return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
-	Debug(net, Severity::Notice, "[admin] '{}' ({}) has connected", this->admin_name, this->admin_version);
+	Debug(Facility::Net, Severity::Notice, "[admin] '{}' ({}) has connected", this->admin_name, this->admin_version);
 
 	return this->SendProtocol();
 }
@@ -706,7 +706,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminUpdateFrequency(P
 
 	if (type >= AdminUpdateType::End || !_admin_update_type_frequencies[type].All(freq)) {
 		/* The server does not know of this UpdateType. */
-		Debug(net, Severity::Error, "[admin] Not supported update frequency {} ({}) from '{}' ({})", type, freq, this->admin_name, this->admin_version);
+		Debug(Facility::Net, Severity::Error, "[admin] Not supported update frequency {} ({}) from '{}' ({})", type, freq, this->admin_name, this->admin_version);
 		return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
@@ -777,7 +777,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminPoll(Packet &p)
 
 		default:
 			/* An unsupported "poll" update type. */
-			Debug(net, Severity::Error, "[admin] Not supported poll {} ({}) from '{}' ({}).", type, d1, this->admin_name, this->admin_version);
+			Debug(Facility::Net, Severity::Error, "[admin] Not supported poll {} ({}) from '{}' ({}).", type, d1, this->admin_name, this->admin_version);
 			return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
@@ -803,7 +803,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminChat(Packet &p)
 			break;
 
 		default:
-			Debug(net, Severity::Error, "[admin] Invalid chat action {} from admin '{}' ({}).", action, this->admin_name, this->admin_version);
+			Debug(Facility::Net, Severity::Error, "[admin] Invalid chat action {} from admin '{}' ({}).", action, this->admin_name, this->admin_version);
 			return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
@@ -820,7 +820,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminExternalChat(Pack
 	std::string msg = p.Recv_string(NETWORK_CHAT_LENGTH);
 
 	if (!IsValidConsoleColour(colour)) {
-		Debug(net, Severity::Error, "[admin] Not supported chat colour {} ({}, {}, {}) from '{}' ({}).", colour.ToNetwork(), source, user, msg, this->admin_name, this->admin_version);
+		Debug(Facility::Net, Severity::Error, "[admin] Not supported chat colour {} ({}, {}, {}) from '{}' ({}).", colour.ToNetwork(), source, user, msg, this->admin_name, this->admin_version);
 		return this->SendError(NetworkErrorCode::IllegalPacket);
 	}
 
@@ -853,7 +853,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminJoinSecure(Packet
 	if (!handler->CanBeUsed()) return this->SendError(NetworkErrorCode::NoAuthenticationMethodAvailable);
 
 	this->authentication_handler = std::move(handler);
-	Debug(net, Severity::Notice, "[admin] '{}' ({}) has connected", this->admin_name, this->admin_version);
+	Debug(Facility::Net, Severity::Notice, "[admin] '{}' ({}) has connected", this->admin_name, this->admin_version);
 
 	return this->SendAuthRequest();
 }
@@ -866,7 +866,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendAuthRequest()
 {
 	this->status = AdminStatus::Authenticate;
 
-	Debug(net, Severity::Debug2, "[admin] '{}' ({}) authenticating using {}", this->admin_name, this->admin_version, this->authentication_handler->GetName());
+	Debug(Facility::Net, Severity::Debug2, "[admin] '{}' ({}) authenticating using {}", this->admin_name, this->admin_version, this->authentication_handler->GetName());
 
 	auto p = std::make_unique<Packet>(this, PacketAdminType::ServerAuthenticationRequest);
 	this->authentication_handler->SendRequest(*p);
@@ -897,7 +897,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminAuthenticationRes
 
 	switch (this->authentication_handler->ReceiveResponse(p)) {
 		case NetworkAuthenticationServerHandler::ResponseResult::Authenticated:
-			Debug(net, Severity::Notice, "[admin] '{}' ({}) authenticated", this->admin_name, this->admin_version);
+			Debug(Facility::Net, Severity::Notice, "[admin] '{}' ({}) authenticated", this->admin_name, this->admin_version);
 
 			this->SendEnableEncryption();
 
@@ -907,12 +907,12 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::ReceiveAdminAuthenticationRes
 			return this->SendProtocol();
 
 		case NetworkAuthenticationServerHandler::ResponseResult::RetryNextMethod:
-			Debug(net, Severity::Debug2, "[admin] '{}' ({}) authentication failed, trying next method", this->admin_name, this->admin_version);
+			Debug(Facility::Net, Severity::Debug2, "[admin] '{}' ({}) authentication failed, trying next method", this->admin_name, this->admin_version);
 			return this->SendAuthRequest();
 
 		case NetworkAuthenticationServerHandler::ResponseResult::NotAuthenticated:
 		default:
-			Debug(net, Severity::Notice, "[admin] '{}' ({}) authentication failed", this->admin_name, this->admin_version);
+			Debug(Facility::Net, Severity::Notice, "[admin] '{}' ({}) authentication failed", this->admin_name, this->admin_version);
 			return this->SendError(NetworkErrorCode::WrongPassword);
 	}
 }
@@ -985,7 +985,7 @@ void NetworkAdminClientError(ClientID client_id, NetworkErrorCode error_code)
 void NetworkAdminCompanyNew(const Company *company)
 {
 	if (company == nullptr) {
-		Debug(net, Severity::Error, "[admin] Empty company given for update");
+		Debug(Facility::Net, Severity::Error, "[admin] Empty company given for update");
 		return;
 	}
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -123,7 +123,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 	assert(this->sock != INVALID_SOCKET);
 
 	if (!this->HasClientQuit()) {
-		Debug(net, Severity::Notice, "Closed client connection {}", this->client_id);
+		Debug(Facility::Net, Severity::Notice, "Closed client connection {}", this->client_id);
 
 		this->SendPackets(true);
 
@@ -237,8 +237,8 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 			if (_sync_seed_1 != _random.state[0]) {
 #endif
 				ShowNetworkError(STR_NETWORK_ERROR_DESYNC);
-				Debug(desync, Severity::Error, "sync_err: {:08x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract);
-				Debug(net, Severity::Critical, "Sync error detected");
+				Debug(Facility::Desync, Severity::Error, "sync_err: {:08x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract);
+				Debug(Facility::Net, Severity::Critical, "Sync error detected");
 				my_client->ClientError(NetworkRecvStatus::Desync);
 				return false;
 			}
@@ -253,7 +253,7 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 
 			_sync_frame = 0;
 		} else if (_sync_frame < _frame_counter) {
-			Debug(net, Severity::Error, "Missed frame for sync-test: {} / {}", _sync_frame, _frame_counter);
+			Debug(Facility::Net, Severity::Error, "Missed frame for sync-test: {} / {}", _sync_frame, _frame_counter);
 			_sync_frame = 0;
 		}
 	}
@@ -286,11 +286,11 @@ NetworkJoinInfo _network_join;
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
 {
-	Debug(net, Severity::Trace3, "Client::SendJoin()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendJoin()");
 
-	Debug(net, Severity::Trace3, "Client::status = JOIN");
+	Debug(Facility::Net, Severity::Trace3, "Client::status = JOIN");
 	my_client->status = ServerStatus::Join;
-	Debug(net, Severity::Trace3, "Client::join_status = Authorizing");
+	Debug(Facility::Net, Severity::Trace3, "Client::join_status = Authorizing");
 	_network_join_status = NetworkJoinStatus::Authorizing;
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
@@ -308,7 +308,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendIdentify()
 {
-	Debug(net, Severity::Trace3, "Client::SendIdentify()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendIdentify()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientIdentify);
 	p->Send_string(_settings_client.network.client_name); // Client name
@@ -323,7 +323,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendIdentify()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendNewGRFsOk()
 {
-	Debug(net, Severity::Trace3, "Client::SendNewGRFsOk()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendNewGRFsOk()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientNewGRFsChecked);
 	my_client->SendPacket(std::move(p));
@@ -336,7 +336,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendNewGRFsOk()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendAuthResponse()
 {
-	Debug(net, Severity::Trace3, "Client::SendAuthResponse()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendAuthResponse()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientAuthenticationResponse);
 	my_client->authentication_handler->SendResponse(*p);
@@ -351,9 +351,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendAuthResponse()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendGetMap()
 {
-	Debug(net, Severity::Trace3, "Client::SendGetMap()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendGetMap()");
 
-	Debug(net, Severity::Trace3, "Client::status = MAP_WAIT");
+	Debug(Facility::Net, Severity::Trace3, "Client::status = MAP_WAIT");
 	my_client->status = ServerStatus::MapWait;
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientGetMap);
@@ -367,9 +367,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendGetMap()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendMapOk()
 {
-	Debug(net, Severity::Trace3, "Client::SendMapOk()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendMapOk()");
 
-	Debug(net, Severity::Trace3, "Client::status = ACTIVE");
+	Debug(Facility::Net, Severity::Trace3, "Client::status = ACTIVE");
 	my_client->status = ServerStatus::Active;
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientMapOk);
@@ -383,7 +383,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendMapOk()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendAck()
 {
-	Debug(net, Severity::Trace3, "Client::SendAck()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendAck()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientAck);
 
@@ -400,7 +400,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendAck()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendCommand(const CommandPacket &cp)
 {
-	Debug(net, Severity::Trace3, "Client::SendCommand(): cmd={}", cp.cmd);
+	Debug(Facility::Net, Severity::Trace3, "Client::SendCommand(): cmd={}", cp.cmd);
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientCommand);
 	my_client->NetworkGameSocketHandler::SendCommand(*p, cp);
@@ -420,7 +420,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendCommand(const CommandPacke
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendChat(NetworkAction action, NetworkChatDestinationType type, int dest, std::string_view msg, int64_t data)
 {
-	Debug(net, Severity::Trace3, "Client::SendChat(): action={}, type={}, dest={}", action, type, dest);
+	Debug(Facility::Net, Severity::Trace3, "Client::SendChat(): action={}, type={}, dest={}", action, type, dest);
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientChat);
 
@@ -441,7 +441,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendChat(NetworkAction action,
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendError(NetworkErrorCode errorno)
 {
-	Debug(net, Severity::Trace3, "Client::SendError(): errorno={}", errorno);
+	Debug(Facility::Net, Severity::Trace3, "Client::SendError(): errorno={}", errorno);
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientError);
 
@@ -457,7 +457,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendError(NetworkErrorCode err
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendSetName(const std::string &name)
 {
-	Debug(net, Severity::Trace3, "Client::SendSetName()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendSetName()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientSetName);
 
@@ -472,7 +472,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendSetName(const std::string 
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendQuit()
 {
-	Debug(net, Severity::Trace3, "Client::SendQuit()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendQuit()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientQuit);
 
@@ -488,7 +488,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendQuit()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendRCon(std::string_view pass, std::string_view command)
 {
-	Debug(net, Severity::Trace3, "Client::SendRCon()");
+	Debug(Facility::Net, Severity::Trace3, "Client::SendRCon()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientRemoteConsoleCommand);
 	p->Send_string(pass);
@@ -504,7 +504,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendRCon(std::string_view pass
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendMove(CompanyID company)
 {
-	Debug(net, Severity::Trace3, "Client::SendMove(): company={}", company);
+	Debug(Facility::Net, Severity::Trace3, "Client::SendMove(): company={}", company);
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientMove);
 	p->Send_uint8(company);
@@ -531,7 +531,7 @@ extern bool SafeLoad(const std::string &filename, SaveLoadOperation fop, Detaile
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerFull(Packet &)
 {
-	Debug(net, Severity::Trace3, "Client::ReceiveServerFull()");
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerFull()");
 
 	/* We try to join a server which is full */
 	ShowErrorMessage(GetEncodedString(STR_NETWORK_ERROR_SERVER_FULL), {}, WarningLevel::Critical);
@@ -541,7 +541,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerFull(Packet &)
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerBanned(Packet &)
 {
-	Debug(net, Severity::Trace3, "Client::ReceiveServerBanned()");
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerBanned()");
 
 	/* We try to join a server where we are banned */
 	ShowErrorMessage(GetEncodedString(STR_NETWORK_ERROR_SERVER_BANNED), {}, WarningLevel::Critical);
@@ -558,7 +558,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerClientInfo(Packet
 	ClientID client_id = (ClientID)p.Recv_uint32();
 	CompanyID playas = (CompanyID)p.Recv_uint8();
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerClientInfo(): client_id={}, playas={}", client_id, playas);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerClientInfo(): client_id={}, playas={}", client_id, playas);
 
 	std::string name = p.Recv_string(NETWORK_NAME_LENGTH);
 	std::string public_key = p.Recv_string(NETWORK_PUBLIC_KEY_LENGTH);
@@ -656,7 +656,7 @@ static StringID GetLongNetworkErrorString(NetworkErrorCode error)
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerError(Packet &p)
 {
 	NetworkErrorCode error = static_cast<NetworkErrorCode>(p.Recv_uint8());
-	Debug(net, Severity::Trace3, "Client::ReceiveServerError(): error={}", error);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerError(): error={}", error);
 
 	StringID err = GetLongNetworkErrorString(error);
 	/* In case of kicking a client, we assume there is a kick message in the packet if we can read one byte */
@@ -681,7 +681,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerCheckNewGRFs(Pack
 	uint grf_count = p.Recv_uint8();
 	NetworkRecvStatus ret = NetworkRecvStatus::Okay;
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerCheckNewGRFs(): grf_count={}", grf_count);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerCheckNewGRFs(): grf_count={}", grf_count);
 
 	/* Check all GRFs */
 	for (; grf_count > 0; grf_count--) {
@@ -692,7 +692,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerCheckNewGRFs(Pack
 		const GRFConfig *f = FindGRFConfig(c.grfid, FindGRFConfigMode::Exact, &c.md5sum);
 		if (f == nullptr) {
 			/* We do not know this GRF, bail out of initialization */
-			Debug(grf, Severity::Critical, "NewGRF {} not found; checksum {}", FormatArrayAsHex(c.grfid), FormatArrayAsHex(c.md5sum));
+			Debug(Facility::Grf, Severity::Critical, "NewGRF {} not found; checksum {}", FormatArrayAsHex(c.grfid), FormatArrayAsHex(c.md5sum));
 			ret = NetworkRecvStatus::NewGRFMismatch;
 		}
 	}
@@ -723,10 +723,10 @@ class ClientGamePasswordRequestHandler : public NetworkAuthenticationPasswordReq
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerAuthenticationRequest(Packet &p)
 {
 	if (this->status != ServerStatus::Join && this->status != ServerStatus::AuthGame) return NetworkRecvStatus::MalformedPacket;
-	Debug(net, Severity::Trace3, "Client::status = AUTH_GAME");
+	Debug(Facility::Net, Severity::Trace3, "Client::status = AUTH_GAME");
 	this->status = ServerStatus::AuthGame;
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerAuthenticationRequest()");
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerAuthenticationRequest()");
 
 	if (this->authentication_handler == nullptr) {
 		this->authentication_handler = NetworkAuthenticationClientHandler::Create(std::make_shared<ClientGamePasswordRequestHandler>(),
@@ -749,7 +749,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerEnableEncryption(
 {
 	if (this->status != ServerStatus::AuthGame || this->authentication_handler == nullptr) return NetworkRecvStatus::MalformedPacket;
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerEnableEncryption()");
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerEnableEncryption()");
 
 	if (!this->authentication_handler->ReceiveEnableEncryption(p)) return NetworkRecvStatus::MalformedPacket;
 
@@ -757,7 +757,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerEnableEncryption(
 	this->send_encryption_handler = this->authentication_handler->CreateClientToServerEncryptionHandler();
 	this->authentication_handler = nullptr;
 
-	Debug(net, Severity::Trace3, "Client::status = ENCRYPTED");
+	Debug(Facility::Net, Severity::Trace3, "Client::status = ENCRYPTED");
 	this->status = ServerStatus::Encrypted;
 
 	return this->SendIdentify();
@@ -766,12 +766,12 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerEnableEncryption(
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerWelcome(Packet &p)
 {
 	if (this->status < ServerStatus::Encrypted || this->status >= ServerStatus::Authorized) return NetworkRecvStatus::MalformedPacket;
-	Debug(net, Severity::Trace3, "Client::status = AUTHORIZED");
+	Debug(Facility::Net, Severity::Trace3, "Client::status = AUTHORIZED");
 	this->status = ServerStatus::Authorized;
 
 	_network_own_client_id = (ClientID)p.Recv_uint32();
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerWelcome(): client_id={}", _network_own_client_id);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerWelcome(): client_id={}", _network_own_client_id);
 
 	/* Start receiving the map */
 	return SendGetMap();
@@ -782,10 +782,10 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerWaitForMap(Packet
 	/* We set the internal wait state when requesting the map. */
 	if (this->status != ServerStatus::MapWait) return NetworkRecvStatus::MalformedPacket;
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerWaitForMap()");
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerWaitForMap()");
 
 	/* But... only now we set the join status to waiting, instead of requesting. */
-	Debug(net, Severity::Trace3, "Client::join_status = Waiting");
+	Debug(Facility::Net, Severity::Trace3, "Client::join_status = Waiting");
 	_network_join_status = NetworkJoinStatus::Waiting;
 	_network_join_waiting = p.Recv_uint8();
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
@@ -796,7 +796,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerWaitForMap(Packet
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapBegin(Packet &p)
 {
 	if (this->status < ServerStatus::Authorized || this->status >= ServerStatus::Map) return NetworkRecvStatus::MalformedPacket;
-	Debug(net, Severity::Trace3, "Client::status = MAP");
+	Debug(Facility::Net, Severity::Trace3, "Client::status = MAP");
 	this->status = ServerStatus::Map;
 
 	if (this->savegame != nullptr) return NetworkRecvStatus::MalformedPacket;
@@ -805,12 +805,12 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapBegin(Packet &
 
 	_frame_counter = _frame_counter_server = _frame_counter_max = p.Recv_uint32();
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerMapBegin(): frame_counter={}", _frame_counter);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerMapBegin(): frame_counter={}", _frame_counter);
 
 	_network_join_bytes = 0;
 	_network_join_bytes_total = 0;
 
-	Debug(net, Severity::Trace3, "Client::join_status = Downloading");
+	Debug(Facility::Net, Severity::Trace3, "Client::join_status = Downloading");
 	_network_join_status = NetworkJoinStatus::Downloading;
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
@@ -825,7 +825,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapSize(Packet &p
 	_network_join_bytes_total = p.Recv_uint32();
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerMapSize(): bytes_total={}", _network_join_bytes_total);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerMapSize(): bytes_total={}", _network_join_bytes_total);
 
 	return NetworkRecvStatus::Okay;
 }
@@ -849,9 +849,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapDone(Packet &)
 	if (this->status != ServerStatus::Map) return NetworkRecvStatus::MalformedPacket;
 	if (this->savegame == nullptr) return NetworkRecvStatus::MalformedPacket;
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerMapDone()");
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerMapDone()");
 
-	Debug(net, Severity::Trace3, "Client::join_status = Processing");
+	Debug(Facility::Net, Severity::Trace3, "Client::join_status = Processing");
 	_network_join_status = NetworkJoinStatus::Processing;
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
@@ -893,7 +893,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapDone(Packet &)
 		if (_network_join.company != COMPANY_SPECTATOR) {
 			/* We have arrived and ready to start playing; send a command to make a new company;
 			 * the server will give us a client-id and let us in */
-			Debug(net, Severity::Trace3, "Client::join_status = Registering");
+			Debug(Facility::Net, Severity::Trace3, "Client::join_status = Registering");
 			_network_join_status = NetworkJoinStatus::Registering;
 			ShowJoinStatusWindow();
 			Command<Commands::CompanyControl>::Post(CompanyCtrlAction::New, CompanyID::Invalid(), CompanyRemoveReason::None, _network_own_client_id);
@@ -936,7 +936,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerFrame(Packet &p)
 	 *  We do this only once per day, to save some bandwidth ;) */
 	if (!_network_first_time && last_ack_frame < _frame_counter) {
 		last_ack_frame = _frame_counter + Ticks::DAY_TICKS;
-		Debug(net, Severity::Trace1, "Sent ACK at {}", _frame_counter);
+		Debug(Facility::Net, Severity::Trace1, "Sent ACK at {}", _frame_counter);
 		SendAck();
 	}
 
@@ -953,7 +953,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerSync(Packet &p)
 	_sync_seed_2 = p.Recv_uint32();
 #endif
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerSync(): sync_frame={}, sync_seed_1={}", _sync_frame, _sync_seed_1);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerSync(): sync_frame={}, sync_seed_1={}", _sync_frame, _sync_seed_1);
 
 	return NetworkRecvStatus::Okay;
 }
@@ -967,7 +967,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerCommand(Packet &p
 	cp.frame    = p.Recv_uint32();
 	cp.my_cmd   = p.Recv_bool();
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerCommand(): cmd={}, frame={}", cp.cmd, cp.frame);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerCommand(): cmd={}, frame={}", cp.cmd, cp.frame);
 
 	if (err.has_value()) {
 		IConsolePrint(CC_WARNING, "Dropping server connection due to {}.", *err);
@@ -992,7 +992,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerChat(Packet &p)
 	std::string msg = p.Recv_string(NETWORK_CHAT_LENGTH);
 	int64_t data = p.Recv_uint64();
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerChat(): action={}, client_id={}, self_send={}", action, client_id, self_send);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerChat(): action={}, client_id={}, self_send={}", action, client_id, self_send);
 
 	ci_to = NetworkClientInfo::GetByClientID(client_id);
 	if (ci_to == nullptr) return NetworkRecvStatus::Okay;
@@ -1038,7 +1038,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerExternalChat(Pack
 	std::string user = p.Recv_string(NETWORK_CHAT_LENGTH);
 	std::string msg = p.Recv_string(NETWORK_CHAT_LENGTH);
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerExternalChat(): source={}", source);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerExternalChat(): source={}", source);
 
 	if (!IsValidConsoleColour(colour)) return NetworkRecvStatus::MalformedPacket;
 
@@ -1053,7 +1053,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerErrorQuit(Packet 
 
 	ClientID client_id = (ClientID)p.Recv_uint32();
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerErrorQuit(): client_id={}", client_id);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerErrorQuit(): client_id={}", client_id);
 
 	NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
 	if (ci != nullptr) {
@@ -1072,14 +1072,14 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerQuit(Packet &p)
 
 	ClientID client_id = (ClientID)p.Recv_uint32();
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerQuit(): client_id={}", client_id);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerQuit(): client_id={}", client_id);
 
 	NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
 	if (ci != nullptr) {
 		NetworkTextMessage(NetworkAction::ClientLeave, CC_DEFAULT, false, ci->client_name, "", STR_NETWORK_MESSAGE_CLIENT_LEAVING);
 		delete ci;
 	} else {
-		Debug(net, Severity::Error, "Unknown client ({}) is leaving the game", client_id);
+		Debug(Facility::Net, Severity::Error, "Unknown client ({}) is leaving the game", client_id);
 	}
 
 	InvalidateWindowData(WindowClass::NetworkClientList, 0);
@@ -1094,7 +1094,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerClientJoined(Pack
 
 	ClientID client_id = (ClientID)p.Recv_uint32();
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerClientJoined(): client_id={}", client_id);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerClientJoined(): client_id={}", client_id);
 
 	NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
 	if (ci != nullptr) {
@@ -1108,7 +1108,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerClientJoined(Pack
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerShutdown(Packet &)
 {
-	Debug(net, Severity::Trace3, "Client::ReceiveServerShutdown()");
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerShutdown()");
 
 	/* Only when we're trying to join we really
 	 * care about the server shutting down. */
@@ -1123,7 +1123,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerShutdown(Packet &
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerNewGame(Packet &)
 {
-	Debug(net, Severity::Trace3, "Client::ReceiveServerNewGame()");
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerNewGame()");
 
 	/* Only when we're trying to join we really
 	 * care about the server shutting down. */
@@ -1144,7 +1144,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerRemoteConsoleComm
 {
 	if (this->status < ServerStatus::Authorized) return NetworkRecvStatus::MalformedPacket;
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerRemoteConsoleCommand()");
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerRemoteConsoleCommand()");
 
 	ExtendedTextColour colour = ExtendedTextColour::FromNetwork(p.Recv_uint16());
 	if (!IsValidConsoleColour(colour)) return NetworkRecvStatus::MalformedPacket;
@@ -1164,11 +1164,11 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMove(Packet &p)
 	ClientID client_id{p.Recv_uint32()};
 	CompanyID company_id{p.Recv_uint8()};
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerMove(): client_id={}, company_id={}", client_id, company_id);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerMove(): client_id={}, company_id={}", client_id, company_id);
 
 	if (client_id == ClientID::Invalid) {
 		/* definitely an invalid client id, debug message and do nothing. */
-		Debug(net, Severity::Error, "Received invalid client index = 0");
+		Debug(Facility::Net, Severity::Error, "Received invalid client index = 0");
 		return NetworkRecvStatus::MalformedPacket;
 	}
 
@@ -1195,7 +1195,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerConfigurationUpda
 
 	InvalidateWindowData(WindowClass::NetworkClientList, 0);
 
-	Debug(net, Severity::Trace3, "Client::ReceiveServerConfigurationUpdate(): max_companies={}", _network_server_max_companies);
+	Debug(Facility::Net, Severity::Trace3, "Client::ReceiveServerConfigurationUpdate(): max_companies={}", _network_server_max_companies);
 
 	return NetworkRecvStatus::Okay;
 }
@@ -1239,7 +1239,7 @@ void NetworkClient_Connected()
 	_frame_counter_server = 0;
 	last_ack_frame = 0;
 
-	Debug(net, Severity::Trace3, "Client::NetworkClient_Connected()");
+	Debug(Facility::Net, Severity::Trace3, "Client::NetworkClient_Connected()");
 
 	/* Request the game-info */
 	MyClient::SendJoin();

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -123,7 +123,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 	assert(this->sock != INVALID_SOCKET);
 
 	if (!this->HasClientQuit()) {
-		Debug(net, 3, "Closed client connection {}", this->client_id);
+		Debug(net, Severity::Notice, "Closed client connection {}", this->client_id);
 
 		this->SendPackets(true);
 
@@ -237,8 +237,8 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 			if (_sync_seed_1 != _random.state[0]) {
 #endif
 				ShowNetworkError(STR_NETWORK_ERROR_DESYNC);
-				Debug(desync, 1, "sync_err: {:08x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract);
-				Debug(net, 0, "Sync error detected");
+				Debug(desync, Severity::Error, "sync_err: {:08x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract);
+				Debug(net, Severity::Critical, "Sync error detected");
 				my_client->ClientError(NetworkRecvStatus::Desync);
 				return false;
 			}
@@ -253,7 +253,7 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 
 			_sync_frame = 0;
 		} else if (_sync_frame < _frame_counter) {
-			Debug(net, 1, "Missed frame for sync-test: {} / {}", _sync_frame, _frame_counter);
+			Debug(net, Severity::Error, "Missed frame for sync-test: {} / {}", _sync_frame, _frame_counter);
 			_sync_frame = 0;
 		}
 	}
@@ -286,11 +286,11 @@ NetworkJoinInfo _network_join;
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
 {
-	Debug(net, 9, "Client::SendJoin()");
+	Debug(net, Severity::Trace3, "Client::SendJoin()");
 
-	Debug(net, 9, "Client::status = JOIN");
+	Debug(net, Severity::Trace3, "Client::status = JOIN");
 	my_client->status = ServerStatus::Join;
-	Debug(net, 9, "Client::join_status = Authorizing");
+	Debug(net, Severity::Trace3, "Client::join_status = Authorizing");
 	_network_join_status = NetworkJoinStatus::Authorizing;
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
@@ -308,7 +308,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendIdentify()
 {
-	Debug(net, 9, "Client::SendIdentify()");
+	Debug(net, Severity::Trace3, "Client::SendIdentify()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientIdentify);
 	p->Send_string(_settings_client.network.client_name); // Client name
@@ -323,7 +323,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendIdentify()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendNewGRFsOk()
 {
-	Debug(net, 9, "Client::SendNewGRFsOk()");
+	Debug(net, Severity::Trace3, "Client::SendNewGRFsOk()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientNewGRFsChecked);
 	my_client->SendPacket(std::move(p));
@@ -336,7 +336,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendNewGRFsOk()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendAuthResponse()
 {
-	Debug(net, 9, "Client::SendAuthResponse()");
+	Debug(net, Severity::Trace3, "Client::SendAuthResponse()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientAuthenticationResponse);
 	my_client->authentication_handler->SendResponse(*p);
@@ -351,9 +351,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendAuthResponse()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendGetMap()
 {
-	Debug(net, 9, "Client::SendGetMap()");
+	Debug(net, Severity::Trace3, "Client::SendGetMap()");
 
-	Debug(net, 9, "Client::status = MAP_WAIT");
+	Debug(net, Severity::Trace3, "Client::status = MAP_WAIT");
 	my_client->status = ServerStatus::MapWait;
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientGetMap);
@@ -367,9 +367,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendGetMap()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendMapOk()
 {
-	Debug(net, 9, "Client::SendMapOk()");
+	Debug(net, Severity::Trace3, "Client::SendMapOk()");
 
-	Debug(net, 9, "Client::status = ACTIVE");
+	Debug(net, Severity::Trace3, "Client::status = ACTIVE");
 	my_client->status = ServerStatus::Active;
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientMapOk);
@@ -383,7 +383,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendMapOk()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendAck()
 {
-	Debug(net, 9, "Client::SendAck()");
+	Debug(net, Severity::Trace3, "Client::SendAck()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientAck);
 
@@ -400,7 +400,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendAck()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendCommand(const CommandPacket &cp)
 {
-	Debug(net, 9, "Client::SendCommand(): cmd={}", cp.cmd);
+	Debug(net, Severity::Trace3, "Client::SendCommand(): cmd={}", cp.cmd);
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientCommand);
 	my_client->NetworkGameSocketHandler::SendCommand(*p, cp);
@@ -420,7 +420,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendCommand(const CommandPacke
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendChat(NetworkAction action, NetworkChatDestinationType type, int dest, std::string_view msg, int64_t data)
 {
-	Debug(net, 9, "Client::SendChat(): action={}, type={}, dest={}", action, type, dest);
+	Debug(net, Severity::Trace3, "Client::SendChat(): action={}, type={}, dest={}", action, type, dest);
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientChat);
 
@@ -441,7 +441,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendChat(NetworkAction action,
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendError(NetworkErrorCode errorno)
 {
-	Debug(net, 9, "Client::SendError(): errorno={}", errorno);
+	Debug(net, Severity::Trace3, "Client::SendError(): errorno={}", errorno);
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientError);
 
@@ -457,7 +457,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendError(NetworkErrorCode err
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendSetName(const std::string &name)
 {
-	Debug(net, 9, "Client::SendSetName()");
+	Debug(net, Severity::Trace3, "Client::SendSetName()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientSetName);
 
@@ -472,7 +472,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendSetName(const std::string 
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendQuit()
 {
-	Debug(net, 9, "Client::SendQuit()");
+	Debug(net, Severity::Trace3, "Client::SendQuit()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientQuit);
 
@@ -488,7 +488,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendQuit()
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendRCon(std::string_view pass, std::string_view command)
 {
-	Debug(net, 9, "Client::SendRCon()");
+	Debug(net, Severity::Trace3, "Client::SendRCon()");
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientRemoteConsoleCommand);
 	p->Send_string(pass);
@@ -504,7 +504,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendRCon(std::string_view pass
  */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendMove(CompanyID company)
 {
-	Debug(net, 9, "Client::SendMove(): company={}", company);
+	Debug(net, Severity::Trace3, "Client::SendMove(): company={}", company);
 
 	auto p = std::make_unique<Packet>(my_client, PacketGameType::ClientMove);
 	p->Send_uint8(company);
@@ -531,7 +531,7 @@ extern bool SafeLoad(const std::string &filename, SaveLoadOperation fop, Detaile
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerFull(Packet &)
 {
-	Debug(net, 9, "Client::ReceiveServerFull()");
+	Debug(net, Severity::Trace3, "Client::ReceiveServerFull()");
 
 	/* We try to join a server which is full */
 	ShowErrorMessage(GetEncodedString(STR_NETWORK_ERROR_SERVER_FULL), {}, WarningLevel::Critical);
@@ -541,7 +541,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerFull(Packet &)
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerBanned(Packet &)
 {
-	Debug(net, 9, "Client::ReceiveServerBanned()");
+	Debug(net, Severity::Trace3, "Client::ReceiveServerBanned()");
 
 	/* We try to join a server where we are banned */
 	ShowErrorMessage(GetEncodedString(STR_NETWORK_ERROR_SERVER_BANNED), {}, WarningLevel::Critical);
@@ -558,7 +558,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerClientInfo(Packet
 	ClientID client_id = (ClientID)p.Recv_uint32();
 	CompanyID playas = (CompanyID)p.Recv_uint8();
 
-	Debug(net, 9, "Client::ReceiveServerClientInfo(): client_id={}, playas={}", client_id, playas);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerClientInfo(): client_id={}, playas={}", client_id, playas);
 
 	std::string name = p.Recv_string(NETWORK_NAME_LENGTH);
 	std::string public_key = p.Recv_string(NETWORK_PUBLIC_KEY_LENGTH);
@@ -656,7 +656,7 @@ static StringID GetLongNetworkErrorString(NetworkErrorCode error)
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerError(Packet &p)
 {
 	NetworkErrorCode error = static_cast<NetworkErrorCode>(p.Recv_uint8());
-	Debug(net, 9, "Client::ReceiveServerError(): error={}", error);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerError(): error={}", error);
 
 	StringID err = GetLongNetworkErrorString(error);
 	/* In case of kicking a client, we assume there is a kick message in the packet if we can read one byte */
@@ -681,7 +681,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerCheckNewGRFs(Pack
 	uint grf_count = p.Recv_uint8();
 	NetworkRecvStatus ret = NetworkRecvStatus::Okay;
 
-	Debug(net, 9, "Client::ReceiveServerCheckNewGRFs(): grf_count={}", grf_count);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerCheckNewGRFs(): grf_count={}", grf_count);
 
 	/* Check all GRFs */
 	for (; grf_count > 0; grf_count--) {
@@ -692,7 +692,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerCheckNewGRFs(Pack
 		const GRFConfig *f = FindGRFConfig(c.grfid, FindGRFConfigMode::Exact, &c.md5sum);
 		if (f == nullptr) {
 			/* We do not know this GRF, bail out of initialization */
-			Debug(grf, 0, "NewGRF {} not found; checksum {}", FormatArrayAsHex(c.grfid), FormatArrayAsHex(c.md5sum));
+			Debug(grf, Severity::Critical, "NewGRF {} not found; checksum {}", FormatArrayAsHex(c.grfid), FormatArrayAsHex(c.md5sum));
 			ret = NetworkRecvStatus::NewGRFMismatch;
 		}
 	}
@@ -723,10 +723,10 @@ class ClientGamePasswordRequestHandler : public NetworkAuthenticationPasswordReq
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerAuthenticationRequest(Packet &p)
 {
 	if (this->status != ServerStatus::Join && this->status != ServerStatus::AuthGame) return NetworkRecvStatus::MalformedPacket;
-	Debug(net, 9, "Client::status = AUTH_GAME");
+	Debug(net, Severity::Trace3, "Client::status = AUTH_GAME");
 	this->status = ServerStatus::AuthGame;
 
-	Debug(net, 9, "Client::ReceiveServerAuthenticationRequest()");
+	Debug(net, Severity::Trace3, "Client::ReceiveServerAuthenticationRequest()");
 
 	if (this->authentication_handler == nullptr) {
 		this->authentication_handler = NetworkAuthenticationClientHandler::Create(std::make_shared<ClientGamePasswordRequestHandler>(),
@@ -749,7 +749,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerEnableEncryption(
 {
 	if (this->status != ServerStatus::AuthGame || this->authentication_handler == nullptr) return NetworkRecvStatus::MalformedPacket;
 
-	Debug(net, 9, "Client::ReceiveServerEnableEncryption()");
+	Debug(net, Severity::Trace3, "Client::ReceiveServerEnableEncryption()");
 
 	if (!this->authentication_handler->ReceiveEnableEncryption(p)) return NetworkRecvStatus::MalformedPacket;
 
@@ -757,7 +757,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerEnableEncryption(
 	this->send_encryption_handler = this->authentication_handler->CreateClientToServerEncryptionHandler();
 	this->authentication_handler = nullptr;
 
-	Debug(net, 9, "Client::status = ENCRYPTED");
+	Debug(net, Severity::Trace3, "Client::status = ENCRYPTED");
 	this->status = ServerStatus::Encrypted;
 
 	return this->SendIdentify();
@@ -766,12 +766,12 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerEnableEncryption(
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerWelcome(Packet &p)
 {
 	if (this->status < ServerStatus::Encrypted || this->status >= ServerStatus::Authorized) return NetworkRecvStatus::MalformedPacket;
-	Debug(net, 9, "Client::status = AUTHORIZED");
+	Debug(net, Severity::Trace3, "Client::status = AUTHORIZED");
 	this->status = ServerStatus::Authorized;
 
 	_network_own_client_id = (ClientID)p.Recv_uint32();
 
-	Debug(net, 9, "Client::ReceiveServerWelcome(): client_id={}", _network_own_client_id);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerWelcome(): client_id={}", _network_own_client_id);
 
 	/* Start receiving the map */
 	return SendGetMap();
@@ -782,10 +782,10 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerWaitForMap(Packet
 	/* We set the internal wait state when requesting the map. */
 	if (this->status != ServerStatus::MapWait) return NetworkRecvStatus::MalformedPacket;
 
-	Debug(net, 9, "Client::ReceiveServerWaitForMap()");
+	Debug(net, Severity::Trace3, "Client::ReceiveServerWaitForMap()");
 
 	/* But... only now we set the join status to waiting, instead of requesting. */
-	Debug(net, 9, "Client::join_status = Waiting");
+	Debug(net, Severity::Trace3, "Client::join_status = Waiting");
 	_network_join_status = NetworkJoinStatus::Waiting;
 	_network_join_waiting = p.Recv_uint8();
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
@@ -796,7 +796,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerWaitForMap(Packet
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapBegin(Packet &p)
 {
 	if (this->status < ServerStatus::Authorized || this->status >= ServerStatus::Map) return NetworkRecvStatus::MalformedPacket;
-	Debug(net, 9, "Client::status = MAP");
+	Debug(net, Severity::Trace3, "Client::status = MAP");
 	this->status = ServerStatus::Map;
 
 	if (this->savegame != nullptr) return NetworkRecvStatus::MalformedPacket;
@@ -805,12 +805,12 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapBegin(Packet &
 
 	_frame_counter = _frame_counter_server = _frame_counter_max = p.Recv_uint32();
 
-	Debug(net, 9, "Client::ReceiveServerMapBegin(): frame_counter={}", _frame_counter);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerMapBegin(): frame_counter={}", _frame_counter);
 
 	_network_join_bytes = 0;
 	_network_join_bytes_total = 0;
 
-	Debug(net, 9, "Client::join_status = Downloading");
+	Debug(net, Severity::Trace3, "Client::join_status = Downloading");
 	_network_join_status = NetworkJoinStatus::Downloading;
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
@@ -825,7 +825,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapSize(Packet &p
 	_network_join_bytes_total = p.Recv_uint32();
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
-	Debug(net, 9, "Client::ReceiveServerMapSize(): bytes_total={}", _network_join_bytes_total);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerMapSize(): bytes_total={}", _network_join_bytes_total);
 
 	return NetworkRecvStatus::Okay;
 }
@@ -849,9 +849,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapDone(Packet &)
 	if (this->status != ServerStatus::Map) return NetworkRecvStatus::MalformedPacket;
 	if (this->savegame == nullptr) return NetworkRecvStatus::MalformedPacket;
 
-	Debug(net, 9, "Client::ReceiveServerMapDone()");
+	Debug(net, Severity::Trace3, "Client::ReceiveServerMapDone()");
 
-	Debug(net, 9, "Client::join_status = Processing");
+	Debug(net, Severity::Trace3, "Client::join_status = Processing");
 	_network_join_status = NetworkJoinStatus::Processing;
 	SetWindowDirty(WindowClass::NetworkStatus, NetworkStatusWindowNumber::Join);
 
@@ -893,7 +893,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMapDone(Packet &)
 		if (_network_join.company != COMPANY_SPECTATOR) {
 			/* We have arrived and ready to start playing; send a command to make a new company;
 			 * the server will give us a client-id and let us in */
-			Debug(net, 9, "Client::join_status = Registering");
+			Debug(net, Severity::Trace3, "Client::join_status = Registering");
 			_network_join_status = NetworkJoinStatus::Registering;
 			ShowJoinStatusWindow();
 			Command<Commands::CompanyControl>::Post(CompanyCtrlAction::New, CompanyID::Invalid(), CompanyRemoveReason::None, _network_own_client_id);
@@ -936,7 +936,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerFrame(Packet &p)
 	 *  We do this only once per day, to save some bandwidth ;) */
 	if (!_network_first_time && last_ack_frame < _frame_counter) {
 		last_ack_frame = _frame_counter + Ticks::DAY_TICKS;
-		Debug(net, 7, "Sent ACK at {}", _frame_counter);
+		Debug(net, Severity::Trace1, "Sent ACK at {}", _frame_counter);
 		SendAck();
 	}
 
@@ -953,7 +953,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerSync(Packet &p)
 	_sync_seed_2 = p.Recv_uint32();
 #endif
 
-	Debug(net, 9, "Client::ReceiveServerSync(): sync_frame={}, sync_seed_1={}", _sync_frame, _sync_seed_1);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerSync(): sync_frame={}, sync_seed_1={}", _sync_frame, _sync_seed_1);
 
 	return NetworkRecvStatus::Okay;
 }
@@ -967,7 +967,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerCommand(Packet &p
 	cp.frame    = p.Recv_uint32();
 	cp.my_cmd   = p.Recv_bool();
 
-	Debug(net, 9, "Client::ReceiveServerCommand(): cmd={}, frame={}", cp.cmd, cp.frame);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerCommand(): cmd={}, frame={}", cp.cmd, cp.frame);
 
 	if (err.has_value()) {
 		IConsolePrint(CC_WARNING, "Dropping server connection due to {}.", *err);
@@ -992,7 +992,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerChat(Packet &p)
 	std::string msg = p.Recv_string(NETWORK_CHAT_LENGTH);
 	int64_t data = p.Recv_uint64();
 
-	Debug(net, 9, "Client::ReceiveServerChat(): action={}, client_id={}, self_send={}", action, client_id, self_send);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerChat(): action={}, client_id={}, self_send={}", action, client_id, self_send);
 
 	ci_to = NetworkClientInfo::GetByClientID(client_id);
 	if (ci_to == nullptr) return NetworkRecvStatus::Okay;
@@ -1038,7 +1038,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerExternalChat(Pack
 	std::string user = p.Recv_string(NETWORK_CHAT_LENGTH);
 	std::string msg = p.Recv_string(NETWORK_CHAT_LENGTH);
 
-	Debug(net, 9, "Client::ReceiveServerExternalChat(): source={}", source);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerExternalChat(): source={}", source);
 
 	if (!IsValidConsoleColour(colour)) return NetworkRecvStatus::MalformedPacket;
 
@@ -1053,7 +1053,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerErrorQuit(Packet 
 
 	ClientID client_id = (ClientID)p.Recv_uint32();
 
-	Debug(net, 9, "Client::ReceiveServerErrorQuit(): client_id={}", client_id);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerErrorQuit(): client_id={}", client_id);
 
 	NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
 	if (ci != nullptr) {
@@ -1072,14 +1072,14 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerQuit(Packet &p)
 
 	ClientID client_id = (ClientID)p.Recv_uint32();
 
-	Debug(net, 9, "Client::ReceiveServerQuit(): client_id={}", client_id);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerQuit(): client_id={}", client_id);
 
 	NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
 	if (ci != nullptr) {
 		NetworkTextMessage(NetworkAction::ClientLeave, CC_DEFAULT, false, ci->client_name, "", STR_NETWORK_MESSAGE_CLIENT_LEAVING);
 		delete ci;
 	} else {
-		Debug(net, 1, "Unknown client ({}) is leaving the game", client_id);
+		Debug(net, Severity::Error, "Unknown client ({}) is leaving the game", client_id);
 	}
 
 	InvalidateWindowData(WindowClass::NetworkClientList, 0);
@@ -1094,7 +1094,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerClientJoined(Pack
 
 	ClientID client_id = (ClientID)p.Recv_uint32();
 
-	Debug(net, 9, "Client::ReceiveServerClientJoined(): client_id={}", client_id);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerClientJoined(): client_id={}", client_id);
 
 	NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
 	if (ci != nullptr) {
@@ -1108,7 +1108,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerClientJoined(Pack
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerShutdown(Packet &)
 {
-	Debug(net, 9, "Client::ReceiveServerShutdown()");
+	Debug(net, Severity::Trace3, "Client::ReceiveServerShutdown()");
 
 	/* Only when we're trying to join we really
 	 * care about the server shutting down. */
@@ -1123,7 +1123,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerShutdown(Packet &
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerNewGame(Packet &)
 {
-	Debug(net, 9, "Client::ReceiveServerNewGame()");
+	Debug(net, Severity::Trace3, "Client::ReceiveServerNewGame()");
 
 	/* Only when we're trying to join we really
 	 * care about the server shutting down. */
@@ -1144,7 +1144,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerRemoteConsoleComm
 {
 	if (this->status < ServerStatus::Authorized) return NetworkRecvStatus::MalformedPacket;
 
-	Debug(net, 9, "Client::ReceiveServerRemoteConsoleCommand()");
+	Debug(net, Severity::Trace3, "Client::ReceiveServerRemoteConsoleCommand()");
 
 	ExtendedTextColour colour = ExtendedTextColour::FromNetwork(p.Recv_uint16());
 	if (!IsValidConsoleColour(colour)) return NetworkRecvStatus::MalformedPacket;
@@ -1164,11 +1164,11 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerMove(Packet &p)
 	ClientID client_id{p.Recv_uint32()};
 	CompanyID company_id{p.Recv_uint8()};
 
-	Debug(net, 9, "Client::ReceiveServerMove(): client_id={}, company_id={}", client_id, company_id);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerMove(): client_id={}, company_id={}", client_id, company_id);
 
 	if (client_id == ClientID::Invalid) {
 		/* definitely an invalid client id, debug message and do nothing. */
-		Debug(net, 1, "Received invalid client index = 0");
+		Debug(net, Severity::Error, "Received invalid client index = 0");
 		return NetworkRecvStatus::MalformedPacket;
 	}
 
@@ -1195,7 +1195,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::ReceiveServerConfigurationUpda
 
 	InvalidateWindowData(WindowClass::NetworkClientList, 0);
 
-	Debug(net, 9, "Client::ReceiveServerConfigurationUpdate(): max_companies={}", _network_server_max_companies);
+	Debug(net, Severity::Trace3, "Client::ReceiveServerConfigurationUpdate(): max_companies={}", _network_server_max_companies);
 
 	return NetworkRecvStatus::Okay;
 }
@@ -1239,7 +1239,7 @@ void NetworkClient_Connected()
 	_frame_counter_server = 0;
 	last_ack_frame = 0;
 
-	Debug(net, 9, "Client::NetworkClient_Connected()");
+	Debug(net, Severity::Trace3, "Client::NetworkClient_Connected()");
 
 	/* Request the game-info */
 	MyClient::SendJoin();

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -401,7 +401,7 @@ void NetworkGameSocketHandler::SendCommand(Packet &p, const CommandPacket &cp)
 
 	size_t callback = FindCallbackIndex(cp.callback);
 	if (callback > UINT8_MAX || _cmd_dispatch[cp.cmd].Unpack[callback] == nullptr) {
-		Debug(net, Severity::Critical, "Unknown callback for command; no callback sent (command: {})", cp.cmd);
+		Debug(Facility::Net, Severity::Critical, "Unknown callback for command; no callback sent (command: {})", cp.cmd);
 		callback = 0; // _callback_table[0] == nullptr
 	}
 	p.Send_uint8 ((uint8_t)callback);

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -401,7 +401,7 @@ void NetworkGameSocketHandler::SendCommand(Packet &p, const CommandPacket &cp)
 
 	size_t callback = FindCallbackIndex(cp.callback);
 	if (callback > UINT8_MAX || _cmd_dispatch[cp.cmd].Unpack[callback] == nullptr) {
-		Debug(net, 0, "Unknown callback for command; no callback sent (command: {})", cp.cmd);
+		Debug(net, Severity::Critical, "Unknown callback for command; no callback sent (command: {})", cp.cmd);
 		callback = 0; // _callback_table[0] == nullptr
 	}
 	p.Send_uint8 ((uint8_t)callback);

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -128,7 +128,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorError(Packet &
 {
 	NetworkCoordinatorErrorType error = static_cast<NetworkCoordinatorErrorType>(p.Recv_uint8());
 	std::string detail = p.Recv_string(NETWORK_ERROR_DETAIL_LENGTH);
-	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorError({}, {})", error, detail);
+	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorError({}, {})", error, detail);
 
 	switch (error) {
 		case NetworkCoordinatorErrorType::Unknown:
@@ -169,7 +169,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorError(Packet &
 			return false;
 
 		default:
-			Debug(net, 0, "Invalid error type {} received from Game Coordinator", error);
+			Debug(net, Severity::Critical, "Invalid error type {} received from Game Coordinator", error);
 			this->CloseConnection();
 			return false;
 	}
@@ -183,7 +183,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorRegisterAck(Pa
 	_settings_client.network.server_invite_code = p.Recv_string(NETWORK_INVITE_CODE_LENGTH);
 	_settings_client.network.server_invite_code_secret = p.Recv_string(NETWORK_INVITE_CODE_SECRET_LENGTH);
 	_network_server_connection_type = static_cast<ConnectionType>(p.Recv_uint8());
-	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorRegisterAck({}, {})", _settings_client.network.server_invite_code, _network_server_connection_type);
+	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorRegisterAck({}, {})", _settings_client.network.server_invite_code, _network_server_connection_type);
 
 	if (_network_server_connection_type == ConnectionType::Isolated) {
 		ShowErrorMessage(
@@ -222,14 +222,14 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorRegisterAck(Pa
 			default: game_type = "Unknown"; break; // Should never happen, but don't fail if it does.
 		}
 
-		Debug(net, 3, "----------------------------------------");
-		Debug(net, 3, "Your server is now registered with the Game Coordinator:");
-		Debug(net, 3, "  Game type:       {}", game_type);
-		Debug(net, 3, "  Connection type: {}", connection_type);
-		Debug(net, 3, "  Invite code:     {}", _network_server_invite_code);
-		Debug(net, 3, "----------------------------------------");
+		Debug(net, Severity::Notice, "----------------------------------------");
+		Debug(net, Severity::Notice, "Your server is now registered with the Game Coordinator:");
+		Debug(net, Severity::Notice, "  Game type:       {}", game_type);
+		Debug(net, Severity::Notice, "  Connection type: {}", connection_type);
+		Debug(net, Severity::Notice, "  Invite code:     {}", _network_server_invite_code);
+		Debug(net, Severity::Notice, "----------------------------------------");
 	} else {
-		Debug(net, 3, "Game Coordinator registered our server with invite code '{}'", _network_server_invite_code);
+		Debug(net, Severity::Notice, "Game Coordinator registered our server with invite code '{}'", _network_server_invite_code);
 	}
 
 	return true;
@@ -238,7 +238,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorRegisterAck(Pa
 bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorListing(Packet &p)
 {
 	uint8_t servers = p.Recv_uint16();
-	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorListing({})", servers);
+	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorListing({})", servers);
 
 	/* End of list; we can now remove all expired items from the list. */
 	if (servers == 0) {
@@ -272,7 +272,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnecting(Pac
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
 	std::string invite_code = p.Recv_string(NETWORK_INVITE_CODE_LENGTH);
-	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorConnecting({}, {})", token, invite_code);
+	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorConnecting({}, {})", token, invite_code);
 
 	/* Find the connecter based on the invite code. */
 	auto connecter_pre_it = this->connecter_pre.find(invite_code);
@@ -291,7 +291,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnecting(Pac
 bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnectFailed(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
-	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorConnectFailed({})", token);
+	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorConnectFailed({})", token);
 	this->CloseToken(token);
 
 	return true;
@@ -303,7 +303,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorDirectConnect(
 	uint8_t tracking_number = p.Recv_uint8();
 	std::string hostname = p.Recv_string(NETWORK_HOSTNAME_LENGTH);
 	uint16_t port = p.Recv_uint16();
-	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorDirectConnect({}, {}, {}, {})", token, tracking_number, hostname, port);
+	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorDirectConnect({}, {}, {}, {})", token, tracking_number, hostname, port);
 
 	/* Ensure all other pending connection attempts are killed. */
 	if (this->game_connecter != nullptr) {
@@ -318,7 +318,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorDirectConnect(
 bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorStunRequest(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
-	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorStunRequest({})", token);
+	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorStunRequest({})", token);
 
 	this->stun_handlers[token][AF_INET6] = ClientNetworkStunSocketHandler::Stun(token, AF_INET6);
 	this->stun_handlers[token][AF_INET] = ClientNetworkStunSocketHandler::Stun(token, AF_INET);
@@ -364,7 +364,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorNewGRFLookup(P
 	this->newgrf_lookup_table_cursor = p.Recv_uint32();
 
 	uint16_t newgrfs = p.Recv_uint16();
-	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorNewGRFLookup({}, {})", this->newgrf_lookup_table_cursor, newgrfs);
+	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorNewGRFLookup({}, {})", this->newgrf_lookup_table_cursor, newgrfs);
 	for (; newgrfs> 0; newgrfs--) {
 		uint32_t index = p.Recv_uint32();
 		DeserializeGRFIdentifierWithName(p, this->newgrf_lookup_table[index]);
@@ -378,7 +378,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorTurnConnect(Pa
 	uint8_t tracking_number = p.Recv_uint8();
 	std::string ticket = p.Recv_string(NETWORK_TOKEN_LENGTH);
 	std::string connection_string = p.Recv_string(NETWORK_HOSTNAME_PORT_LENGTH);
-	Debug(net, 9, "Coordinator::ReceiveGameCoordinatorTurnConnect({}, {}, {}, {})", token, tracking_number, ticket, connection_string);
+	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorTurnConnect({}, {}, {}, {})", token, tracking_number, ticket, connection_string);
 
 	/* Ensure all other pending connection attempts are killed. */
 	if (this->game_connecter != nullptr) {
@@ -483,7 +483,7 @@ void ClientNetworkCoordinatorSocketHandler::Register()
 		p->Send_string(_settings_client.network.server_invite_code_secret);
 	}
 
-	Debug(net, 9, "Coordinator::SendRegister({}, {}, {})", _settings_client.network.server_game_type, _settings_client.network.server_port, _settings_client.network.server_invite_code);
+	Debug(net, Severity::Trace3, "Coordinator::SendRegister({}, {}, {})", _settings_client.network.server_game_type, _settings_client.network.server_port, _settings_client.network.server_invite_code);
 	this->SendPacket(std::move(p));
 }
 
@@ -492,13 +492,13 @@ void ClientNetworkCoordinatorSocketHandler::Register()
  */
 void ClientNetworkCoordinatorSocketHandler::SendServerUpdate()
 {
-	Debug(net, 6, "Sending server update to Game Coordinator");
+	Debug(net, Severity::Debug2, "Sending server update to Game Coordinator");
 
 	auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ServerUpdate, TCP_MTU);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	SerializeNetworkGameInfo(*p, GetCurrentNetworkServerGameInfo(), this->next_update.time_since_epoch() != std::chrono::nanoseconds::zero());
 
-	Debug(net, 9, "Coordinator::SendServerUpdate()");
+	Debug(net, Severity::Trace3, "Coordinator::SendServerUpdate()");
 	this->SendPacket(std::move(p));
 
 	this->next_update = std::chrono::steady_clock::now() + NETWORK_COORDINATOR_DELAY_BETWEEN_UPDATES;
@@ -519,7 +519,7 @@ void ClientNetworkCoordinatorSocketHandler::GetListing()
 	p->Send_string(_openttd_revision);
 	p->Send_uint32(this->newgrf_lookup_table_cursor);
 
-	Debug(net, 9, "Coordinator::SendGetListing({}, {})", _openttd_revision, this->newgrf_lookup_table_cursor);
+	Debug(net, Severity::Trace3, "Coordinator::SendGetListing({}, {})", _openttd_revision, this->newgrf_lookup_table_cursor);
 	this->SendPacket(std::move(p));
 }
 
@@ -550,7 +550,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectToServer(std::string_view inv
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(invite_code);
 
-	Debug(net, 9, "Coordinator::SendConnectToClient({})", invite_code);
+	Debug(net, Severity::Trace3, "Coordinator::SendConnectToClient({})", invite_code);
 	this->SendPacket(std::move(p));
 }
 
@@ -569,7 +569,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectFailure(std::string_view toke
 	p->Send_string(token);
 	p->Send_uint8(tracking_number);
 
-	Debug(net, 9, "Coordinator::SendConnectFailure({}, {})", token, tracking_number);
+	Debug(net, Severity::Trace3, "Coordinator::SendConnectFailure({}, {})", token, tracking_number);
 	this->SendPacket(std::move(p));
 
 	/* We do not close the associated connecter here yet, as the
@@ -592,7 +592,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(std::string_view toke
 
 	if (_network_server) {
 		if (!ServerNetworkGameSocketHandler::ValidateClient(sock, address)) return;
-		Debug(net, 3, "[{}] Client connected from {} on frame {}", ServerNetworkGameSocketHandler::GetName(), address.GetHostname(), _frame_counter);
+		Debug(net, Severity::Notice, "[{}] Client connected from {} on frame {}", ServerNetworkGameSocketHandler::GetName(), address.GetHostname(), _frame_counter);
 		ServerNetworkGameSocketHandler::AcceptConnection(sock, address);
 	} else {
 		/* The client informs the Game Coordinator about the success. The server
@@ -600,7 +600,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(std::string_view toke
 		auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ClientConnected);
 		p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 		p->Send_string(token);
-		Debug(net, 9, "Coordinator::SendConnectSuccess({})", token);
+		Debug(net, Severity::Trace3, "Coordinator::SendConnectSuccess({})", token);
 		this->SendPacket(std::move(p));
 
 		/* Find the connecter; it can happen it no longer exist, in cases where
@@ -634,7 +634,7 @@ void ClientNetworkCoordinatorSocketHandler::StunResult(std::string_view token, u
 	p->Send_string(token);
 	p->Send_uint8(family);
 	p->Send_bool(result);
-	Debug(net, 9, "Coordinator::SendStunResult({}, {}, {})", token, family, result);
+	Debug(net, Severity::Trace3, "Coordinator::SendStunResult({}, {}, {})", token, family, result);
 	this->SendPacket(std::move(p));
 }
 
@@ -776,7 +776,7 @@ void ClientNetworkCoordinatorSocketHandler::SendReceive()
 			return;
 		}
 
-		Debug(net, 1, "Connection with Game Coordinator lost; reconnecting...");
+		Debug(net, Severity::Error, "Connection with Game Coordinator lost; reconnecting...");
 		this->Register();
 		return;
 	}

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -128,7 +128,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorError(Packet &
 {
 	NetworkCoordinatorErrorType error = static_cast<NetworkCoordinatorErrorType>(p.Recv_uint8());
 	std::string detail = p.Recv_string(NETWORK_ERROR_DETAIL_LENGTH);
-	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorError({}, {})", error, detail);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorError({}, {})", error, detail);
 
 	switch (error) {
 		case NetworkCoordinatorErrorType::Unknown:
@@ -169,7 +169,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorError(Packet &
 			return false;
 
 		default:
-			Debug(net, Severity::Critical, "Invalid error type {} received from Game Coordinator", error);
+			Debug(Facility::Net, Severity::Critical, "Invalid error type {} received from Game Coordinator", error);
 			this->CloseConnection();
 			return false;
 	}
@@ -183,7 +183,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorRegisterAck(Pa
 	_settings_client.network.server_invite_code = p.Recv_string(NETWORK_INVITE_CODE_LENGTH);
 	_settings_client.network.server_invite_code_secret = p.Recv_string(NETWORK_INVITE_CODE_SECRET_LENGTH);
 	_network_server_connection_type = static_cast<ConnectionType>(p.Recv_uint8());
-	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorRegisterAck({}, {})", _settings_client.network.server_invite_code, _network_server_connection_type);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorRegisterAck({}, {})", _settings_client.network.server_invite_code, _network_server_connection_type);
 
 	if (_network_server_connection_type == ConnectionType::Isolated) {
 		ShowErrorMessage(
@@ -222,14 +222,14 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorRegisterAck(Pa
 			default: game_type = "Unknown"; break; // Should never happen, but don't fail if it does.
 		}
 
-		Debug(net, Severity::Notice, "----------------------------------------");
-		Debug(net, Severity::Notice, "Your server is now registered with the Game Coordinator:");
-		Debug(net, Severity::Notice, "  Game type:       {}", game_type);
-		Debug(net, Severity::Notice, "  Connection type: {}", connection_type);
-		Debug(net, Severity::Notice, "  Invite code:     {}", _network_server_invite_code);
-		Debug(net, Severity::Notice, "----------------------------------------");
+		Debug(Facility::Net, Severity::Notice, "----------------------------------------");
+		Debug(Facility::Net, Severity::Notice, "Your server is now registered with the Game Coordinator:");
+		Debug(Facility::Net, Severity::Notice, "  Game type:       {}", game_type);
+		Debug(Facility::Net, Severity::Notice, "  Connection type: {}", connection_type);
+		Debug(Facility::Net, Severity::Notice, "  Invite code:     {}", _network_server_invite_code);
+		Debug(Facility::Net, Severity::Notice, "----------------------------------------");
 	} else {
-		Debug(net, Severity::Notice, "Game Coordinator registered our server with invite code '{}'", _network_server_invite_code);
+		Debug(Facility::Net, Severity::Notice, "Game Coordinator registered our server with invite code '{}'", _network_server_invite_code);
 	}
 
 	return true;
@@ -238,7 +238,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorRegisterAck(Pa
 bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorListing(Packet &p)
 {
 	uint8_t servers = p.Recv_uint16();
-	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorListing({})", servers);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorListing({})", servers);
 
 	/* End of list; we can now remove all expired items from the list. */
 	if (servers == 0) {
@@ -272,7 +272,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnecting(Pac
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
 	std::string invite_code = p.Recv_string(NETWORK_INVITE_CODE_LENGTH);
-	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorConnecting({}, {})", token, invite_code);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorConnecting({}, {})", token, invite_code);
 
 	/* Find the connecter based on the invite code. */
 	auto connecter_pre_it = this->connecter_pre.find(invite_code);
@@ -291,7 +291,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnecting(Pac
 bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorConnectFailed(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
-	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorConnectFailed({})", token);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorConnectFailed({})", token);
 	this->CloseToken(token);
 
 	return true;
@@ -303,7 +303,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorDirectConnect(
 	uint8_t tracking_number = p.Recv_uint8();
 	std::string hostname = p.Recv_string(NETWORK_HOSTNAME_LENGTH);
 	uint16_t port = p.Recv_uint16();
-	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorDirectConnect({}, {}, {}, {})", token, tracking_number, hostname, port);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorDirectConnect({}, {}, {}, {})", token, tracking_number, hostname, port);
 
 	/* Ensure all other pending connection attempts are killed. */
 	if (this->game_connecter != nullptr) {
@@ -318,7 +318,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorDirectConnect(
 bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorStunRequest(Packet &p)
 {
 	std::string token = p.Recv_string(NETWORK_TOKEN_LENGTH);
-	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorStunRequest({})", token);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorStunRequest({})", token);
 
 	this->stun_handlers[token][AF_INET6] = ClientNetworkStunSocketHandler::Stun(token, AF_INET6);
 	this->stun_handlers[token][AF_INET] = ClientNetworkStunSocketHandler::Stun(token, AF_INET);
@@ -364,7 +364,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorNewGRFLookup(P
 	this->newgrf_lookup_table_cursor = p.Recv_uint32();
 
 	uint16_t newgrfs = p.Recv_uint16();
-	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorNewGRFLookup({}, {})", this->newgrf_lookup_table_cursor, newgrfs);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorNewGRFLookup({}, {})", this->newgrf_lookup_table_cursor, newgrfs);
 	for (; newgrfs> 0; newgrfs--) {
 		uint32_t index = p.Recv_uint32();
 		DeserializeGRFIdentifierWithName(p, this->newgrf_lookup_table[index]);
@@ -378,7 +378,7 @@ bool ClientNetworkCoordinatorSocketHandler::ReceiveGameCoordinatorTurnConnect(Pa
 	uint8_t tracking_number = p.Recv_uint8();
 	std::string ticket = p.Recv_string(NETWORK_TOKEN_LENGTH);
 	std::string connection_string = p.Recv_string(NETWORK_HOSTNAME_PORT_LENGTH);
-	Debug(net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorTurnConnect({}, {}, {}, {})", token, tracking_number, ticket, connection_string);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::ReceiveGameCoordinatorTurnConnect({}, {}, {}, {})", token, tracking_number, ticket, connection_string);
 
 	/* Ensure all other pending connection attempts are killed. */
 	if (this->game_connecter != nullptr) {
@@ -483,7 +483,7 @@ void ClientNetworkCoordinatorSocketHandler::Register()
 		p->Send_string(_settings_client.network.server_invite_code_secret);
 	}
 
-	Debug(net, Severity::Trace3, "Coordinator::SendRegister({}, {}, {})", _settings_client.network.server_game_type, _settings_client.network.server_port, _settings_client.network.server_invite_code);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::SendRegister({}, {}, {})", _settings_client.network.server_game_type, _settings_client.network.server_port, _settings_client.network.server_invite_code);
 	this->SendPacket(std::move(p));
 }
 
@@ -492,13 +492,13 @@ void ClientNetworkCoordinatorSocketHandler::Register()
  */
 void ClientNetworkCoordinatorSocketHandler::SendServerUpdate()
 {
-	Debug(net, Severity::Debug2, "Sending server update to Game Coordinator");
+	Debug(Facility::Net, Severity::Debug2, "Sending server update to Game Coordinator");
 
 	auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ServerUpdate, TCP_MTU);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	SerializeNetworkGameInfo(*p, GetCurrentNetworkServerGameInfo(), this->next_update.time_since_epoch() != std::chrono::nanoseconds::zero());
 
-	Debug(net, Severity::Trace3, "Coordinator::SendServerUpdate()");
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::SendServerUpdate()");
 	this->SendPacket(std::move(p));
 
 	this->next_update = std::chrono::steady_clock::now() + NETWORK_COORDINATOR_DELAY_BETWEEN_UPDATES;
@@ -519,7 +519,7 @@ void ClientNetworkCoordinatorSocketHandler::GetListing()
 	p->Send_string(_openttd_revision);
 	p->Send_uint32(this->newgrf_lookup_table_cursor);
 
-	Debug(net, Severity::Trace3, "Coordinator::SendGetListing({}, {})", _openttd_revision, this->newgrf_lookup_table_cursor);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::SendGetListing({}, {})", _openttd_revision, this->newgrf_lookup_table_cursor);
 	this->SendPacket(std::move(p));
 }
 
@@ -550,7 +550,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectToServer(std::string_view inv
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(invite_code);
 
-	Debug(net, Severity::Trace3, "Coordinator::SendConnectToClient({})", invite_code);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::SendConnectToClient({})", invite_code);
 	this->SendPacket(std::move(p));
 }
 
@@ -569,7 +569,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectFailure(std::string_view toke
 	p->Send_string(token);
 	p->Send_uint8(tracking_number);
 
-	Debug(net, Severity::Trace3, "Coordinator::SendConnectFailure({}, {})", token, tracking_number);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::SendConnectFailure({}, {})", token, tracking_number);
 	this->SendPacket(std::move(p));
 
 	/* We do not close the associated connecter here yet, as the
@@ -592,7 +592,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(std::string_view toke
 
 	if (_network_server) {
 		if (!ServerNetworkGameSocketHandler::ValidateClient(sock, address)) return;
-		Debug(net, Severity::Notice, "[{}] Client connected from {} on frame {}", ServerNetworkGameSocketHandler::GetName(), address.GetHostname(), _frame_counter);
+		Debug(Facility::Net, Severity::Notice, "[{}] Client connected from {} on frame {}", ServerNetworkGameSocketHandler::GetName(), address.GetHostname(), _frame_counter);
 		ServerNetworkGameSocketHandler::AcceptConnection(sock, address);
 	} else {
 		/* The client informs the Game Coordinator about the success. The server
@@ -600,7 +600,7 @@ void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(std::string_view toke
 		auto p = std::make_unique<Packet>(this, PacketCoordinatorType::ClientConnected);
 		p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 		p->Send_string(token);
-		Debug(net, Severity::Trace3, "Coordinator::SendConnectSuccess({})", token);
+		Debug(Facility::Net, Severity::Trace3, "Coordinator::SendConnectSuccess({})", token);
 		this->SendPacket(std::move(p));
 
 		/* Find the connecter; it can happen it no longer exist, in cases where
@@ -634,7 +634,7 @@ void ClientNetworkCoordinatorSocketHandler::StunResult(std::string_view token, u
 	p->Send_string(token);
 	p->Send_uint8(family);
 	p->Send_bool(result);
-	Debug(net, Severity::Trace3, "Coordinator::SendStunResult({}, {}, {})", token, family, result);
+	Debug(Facility::Net, Severity::Trace3, "Coordinator::SendStunResult({}, {}, {})", token, family, result);
 	this->SendPacket(std::move(p));
 }
 
@@ -776,7 +776,7 @@ void ClientNetworkCoordinatorSocketHandler::SendReceive()
 			return;
 		}
 
-		Debug(net, Severity::Error, "Connection with Game Coordinator lost; reconnecting...");
+		Debug(Facility::Net, Severity::Error, "Connection with Game Coordinator lost; reconnecting...");
 		this->Register();
 		return;
 	}

--- a/src/network/network_crypto.cpp
+++ b/src/network/network_crypto.cpp
@@ -202,7 +202,7 @@ X25519AuthenticationHandler::X25519AuthenticationHandler(const X25519SecretKey &
 bool X25519AuthenticationHandler::ReceiveRequest(Packet &p)
 {
 	if (p.RemainingBytesToTransfer() != X25519_KEY_SIZE + X25519_NONCE_SIZE) {
-		Debug(net, 1, "[crypto] Received auth response of illegal size; authentication aborted.");
+		Debug(net, Severity::Error, "[crypto] Received auth response of illegal size; authentication aborted.");
 		return false;
 	}
 
@@ -221,7 +221,7 @@ bool X25519AuthenticationHandler::SendResponse(Packet &p, std::string_view deriv
 {
 	if (!this->derived_keys.Exchange(this->peer_public_key, X25519KeyExchangeSide::CLIENT,
 			this->our_secret_key, this->our_public_key, derived_key_extra_payload)) {
-		Debug(net, 0, "[crypto] Peer sent an illegal public key; authentication aborted.");
+		Debug(net, Severity::Critical, "[crypto] Peer sent an illegal public key; authentication aborted.");
 		return false;
 	}
 
@@ -288,7 +288,7 @@ std::unique_ptr<NetworkEncryptionHandler> X25519AuthenticationHandler::CreateSer
 NetworkAuthenticationServerHandler::ResponseResult X25519AuthenticationHandler::ReceiveResponse(Packet &p, std::string_view derived_key_extra_payload)
 {
 	if (p.RemainingBytesToTransfer() != X25519_KEY_SIZE + X25519_MAC_SIZE + X25519_KEY_EXCHANGE_MESSAGE_SIZE) {
-		Debug(net, 1, "[crypto] Received auth response of illegal size; authentication aborted.");
+		Debug(net, Severity::Error, "[crypto] Received auth response of illegal size; authentication aborted.");
 		return NetworkAuthenticationServerHandler::ResponseResult::NotAuthenticated;
 	}
 
@@ -301,7 +301,7 @@ NetworkAuthenticationServerHandler::ResponseResult X25519AuthenticationHandler::
 
 	if (!this->derived_keys.Exchange(this->peer_public_key, X25519KeyExchangeSide::SERVER,
 			this->our_secret_key, this->our_public_key, derived_key_extra_payload)) {
-		Debug(net, 0, "[crypto] Peer sent an illegal public key; authentication aborted.");
+		Debug(net, Severity::Critical, "[crypto] Peer sent an illegal public key; authentication aborted.");
 		return NetworkAuthenticationServerHandler::ResponseResult::NotAuthenticated;
 	}
 
@@ -339,9 +339,9 @@ NetworkAuthenticationServerHandler::ResponseResult X25519AuthenticationHandler::
 	X25519SecretKey key{};
 	if (!ConvertHexToBytes(secret_key, key)) {
 		if (secret_key.empty()) {
-			Debug(net, 3, "[crypto] Creating a new random key");
+			Debug(net, Severity::Notice, "[crypto] Creating a new random key");
 		} else {
-			Debug(net, 0, "[crypto] Found invalid secret key, creating a new random key");
+			Debug(net, Severity::Critical, "[crypto] Found invalid secret key, creating a new random key");
 		}
 		key = X25519SecretKey::CreateRandom();
 		secret_key = FormatArrayAsHex(key);
@@ -371,13 +371,13 @@ NetworkAuthenticationServerHandler::ResponseResult X25519AuthenticationHandler::
 
 	this->current_handler = it->get();
 
-	Debug(net, 9, "Received {} authentication request", this->GetName());
+	Debug(net, Severity::Trace3, "Received {} authentication request", this->GetName());
 	return this->current_handler->ReceiveRequest(p);
 }
 
 /* virtual */ bool CombinedAuthenticationClientHandler::SendResponse(struct Packet &p)
 {
-	Debug(net, 9, "Sending {} authentication response", this->GetName());
+	Debug(net, Severity::Trace3, "Sending {} authentication response", this->GetName());
 
 	return this->current_handler->SendResponse(p);
 }
@@ -407,7 +407,7 @@ void CombinedAuthenticationServerHandler::Add(CombinedAuthenticationServerHandle
 
 /* virtual */ void CombinedAuthenticationServerHandler::SendRequest(struct Packet &p)
 {
-	Debug(net, 9, "Sending {} authentication request", this->GetName());
+	Debug(net, Severity::Trace3, "Sending {} authentication request", this->GetName());
 
 	p.Send_uint8(to_underlying(this->handlers.back()->GetAuthenticationMethod()));
 	this->handlers.back()->SendRequest(p);
@@ -415,7 +415,7 @@ void CombinedAuthenticationServerHandler::Add(CombinedAuthenticationServerHandle
 
 /* virtual */ NetworkAuthenticationServerHandler::ResponseResult CombinedAuthenticationServerHandler::ReceiveResponse(struct Packet &p)
 {
-	Debug(net, 9, "Receiving {} authentication response", this->GetName());
+	Debug(net, Severity::Trace3, "Receiving {} authentication response", this->GetName());
 
 	ResponseResult result = this->handlers.back()->ReceiveResponse(p);
 	if (result != ResponseResult::NotAuthenticated) return result;

--- a/src/network/network_crypto.cpp
+++ b/src/network/network_crypto.cpp
@@ -202,7 +202,7 @@ X25519AuthenticationHandler::X25519AuthenticationHandler(const X25519SecretKey &
 bool X25519AuthenticationHandler::ReceiveRequest(Packet &p)
 {
 	if (p.RemainingBytesToTransfer() != X25519_KEY_SIZE + X25519_NONCE_SIZE) {
-		Debug(net, Severity::Error, "[crypto] Received auth response of illegal size; authentication aborted.");
+		Debug(Facility::Net, Severity::Error, "[crypto] Received auth response of illegal size; authentication aborted.");
 		return false;
 	}
 
@@ -221,7 +221,7 @@ bool X25519AuthenticationHandler::SendResponse(Packet &p, std::string_view deriv
 {
 	if (!this->derived_keys.Exchange(this->peer_public_key, X25519KeyExchangeSide::CLIENT,
 			this->our_secret_key, this->our_public_key, derived_key_extra_payload)) {
-		Debug(net, Severity::Critical, "[crypto] Peer sent an illegal public key; authentication aborted.");
+		Debug(Facility::Net, Severity::Critical, "[crypto] Peer sent an illegal public key; authentication aborted.");
 		return false;
 	}
 
@@ -288,7 +288,7 @@ std::unique_ptr<NetworkEncryptionHandler> X25519AuthenticationHandler::CreateSer
 NetworkAuthenticationServerHandler::ResponseResult X25519AuthenticationHandler::ReceiveResponse(Packet &p, std::string_view derived_key_extra_payload)
 {
 	if (p.RemainingBytesToTransfer() != X25519_KEY_SIZE + X25519_MAC_SIZE + X25519_KEY_EXCHANGE_MESSAGE_SIZE) {
-		Debug(net, Severity::Error, "[crypto] Received auth response of illegal size; authentication aborted.");
+		Debug(Facility::Net, Severity::Error, "[crypto] Received auth response of illegal size; authentication aborted.");
 		return NetworkAuthenticationServerHandler::ResponseResult::NotAuthenticated;
 	}
 
@@ -301,7 +301,7 @@ NetworkAuthenticationServerHandler::ResponseResult X25519AuthenticationHandler::
 
 	if (!this->derived_keys.Exchange(this->peer_public_key, X25519KeyExchangeSide::SERVER,
 			this->our_secret_key, this->our_public_key, derived_key_extra_payload)) {
-		Debug(net, Severity::Critical, "[crypto] Peer sent an illegal public key; authentication aborted.");
+		Debug(Facility::Net, Severity::Critical, "[crypto] Peer sent an illegal public key; authentication aborted.");
 		return NetworkAuthenticationServerHandler::ResponseResult::NotAuthenticated;
 	}
 
@@ -339,9 +339,9 @@ NetworkAuthenticationServerHandler::ResponseResult X25519AuthenticationHandler::
 	X25519SecretKey key{};
 	if (!ConvertHexToBytes(secret_key, key)) {
 		if (secret_key.empty()) {
-			Debug(net, Severity::Notice, "[crypto] Creating a new random key");
+			Debug(Facility::Net, Severity::Notice, "[crypto] Creating a new random key");
 		} else {
-			Debug(net, Severity::Critical, "[crypto] Found invalid secret key, creating a new random key");
+			Debug(Facility::Net, Severity::Critical, "[crypto] Found invalid secret key, creating a new random key");
 		}
 		key = X25519SecretKey::CreateRandom();
 		secret_key = FormatArrayAsHex(key);
@@ -371,13 +371,13 @@ NetworkAuthenticationServerHandler::ResponseResult X25519AuthenticationHandler::
 
 	this->current_handler = it->get();
 
-	Debug(net, Severity::Trace3, "Received {} authentication request", this->GetName());
+	Debug(Facility::Net, Severity::Trace3, "Received {} authentication request", this->GetName());
 	return this->current_handler->ReceiveRequest(p);
 }
 
 /* virtual */ bool CombinedAuthenticationClientHandler::SendResponse(struct Packet &p)
 {
-	Debug(net, Severity::Trace3, "Sending {} authentication response", this->GetName());
+	Debug(Facility::Net, Severity::Trace3, "Sending {} authentication response", this->GetName());
 
 	return this->current_handler->SendResponse(p);
 }
@@ -407,7 +407,7 @@ void CombinedAuthenticationServerHandler::Add(CombinedAuthenticationServerHandle
 
 /* virtual */ void CombinedAuthenticationServerHandler::SendRequest(struct Packet &p)
 {
-	Debug(net, Severity::Trace3, "Sending {} authentication request", this->GetName());
+	Debug(Facility::Net, Severity::Trace3, "Sending {} authentication request", this->GetName());
 
 	p.Send_uint8(to_underlying(this->handlers.back()->GetAuthenticationMethod()));
 	this->handlers.back()->SendRequest(p);
@@ -415,7 +415,7 @@ void CombinedAuthenticationServerHandler::Add(CombinedAuthenticationServerHandle
 
 /* virtual */ NetworkAuthenticationServerHandler::ResponseResult CombinedAuthenticationServerHandler::ReceiveResponse(struct Packet &p)
 {
-	Debug(net, Severity::Trace3, "Receiving {} authentication response", this->GetName());
+	Debug(Facility::Net, Severity::Trace3, "Receiving {} authentication response", this->GetName());
 
 	ResponseResult result = this->handlers.back()->ReceiveResponse(p);
 	if (result != ResponseResult::NotAuthenticated) return result;

--- a/src/network/network_query.cpp
+++ b/src/network/network_query.cpp
@@ -44,7 +44,7 @@ bool QueryNetworkGameSocketHandler::CheckConnection()
 
 	/* If there was no response in 5 seconds, terminate the query. */
 	if (lag > std::chrono::seconds(5)) {
-		Debug(net, Severity::Critical, "Timeout while waiting for response from {}", this->connection_string);
+		Debug(Facility::Net, Severity::Critical, "Timeout while waiting for response from {}", this->connection_string);
 		this->CloseConnection(NetworkRecvStatus::ConnectionLost);
 		return false;
 	}
@@ -81,7 +81,7 @@ void QueryNetworkGameSocketHandler::Send()
  */
 NetworkRecvStatus QueryNetworkGameSocketHandler::SendGameInfo()
 {
-	Debug(net, Severity::Trace3, "Query::SendGameInfo()");
+	Debug(Facility::Net, Severity::Trace3, "Query::SendGameInfo()");
 
 	this->SendPacket(std::make_unique<Packet>(this, PacketGameType::ClientGameInfo));
 	return NetworkRecvStatus::Okay;
@@ -89,7 +89,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::SendGameInfo()
 
 NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerFull(Packet &)
 {
-	Debug(net, Severity::Trace3, "Query::ReceiveServerFull()");
+	Debug(Facility::Net, Severity::Trace3, "Query::ReceiveServerFull()");
 
 	NetworkGame *item = NetworkGameListAddItem(this->connection_string);
 	item->status = NetworkGameStatus::Full;
@@ -102,7 +102,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerFull(Packet &)
 
 NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerBanned(Packet &)
 {
-	Debug(net, Severity::Trace3, "Query::ReceiveServerBanned()");
+	Debug(Facility::Net, Severity::Trace3, "Query::ReceiveServerBanned()");
 
 	NetworkGame *item = NetworkGameListAddItem(this->connection_string);
 	item->status = NetworkGameStatus::Banned;
@@ -115,7 +115,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerBanned(Packet &)
 
 NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerGameInfo(Packet &p)
 {
-	Debug(net, Severity::Trace3, "Query::ReceiveServerGameInfo()");
+	Debug(Facility::Net, Severity::Trace3, "Query::ReceiveServerGameInfo()");
 
 	NetworkGame *item = NetworkGameListAddItem(this->connection_string);
 
@@ -138,7 +138,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerError(Packet &p)
 {
 	NetworkErrorCode error = static_cast<NetworkErrorCode>(p.Recv_uint8());
 
-	Debug(net, Severity::Trace3, "Query::ReceiveServerError(): error={}", error);
+	Debug(Facility::Net, Severity::Trace3, "Query::ReceiveServerError(): error={}", error);
 
 	NetworkGame *item = NetworkGameListAddItem(this->connection_string);
 

--- a/src/network/network_query.cpp
+++ b/src/network/network_query.cpp
@@ -44,7 +44,7 @@ bool QueryNetworkGameSocketHandler::CheckConnection()
 
 	/* If there was no response in 5 seconds, terminate the query. */
 	if (lag > std::chrono::seconds(5)) {
-		Debug(net, 0, "Timeout while waiting for response from {}", this->connection_string);
+		Debug(net, Severity::Critical, "Timeout while waiting for response from {}", this->connection_string);
 		this->CloseConnection(NetworkRecvStatus::ConnectionLost);
 		return false;
 	}
@@ -81,7 +81,7 @@ void QueryNetworkGameSocketHandler::Send()
  */
 NetworkRecvStatus QueryNetworkGameSocketHandler::SendGameInfo()
 {
-	Debug(net, 9, "Query::SendGameInfo()");
+	Debug(net, Severity::Trace3, "Query::SendGameInfo()");
 
 	this->SendPacket(std::make_unique<Packet>(this, PacketGameType::ClientGameInfo));
 	return NetworkRecvStatus::Okay;
@@ -89,7 +89,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::SendGameInfo()
 
 NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerFull(Packet &)
 {
-	Debug(net, 9, "Query::ReceiveServerFull()");
+	Debug(net, Severity::Trace3, "Query::ReceiveServerFull()");
 
 	NetworkGame *item = NetworkGameListAddItem(this->connection_string);
 	item->status = NetworkGameStatus::Full;
@@ -102,7 +102,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerFull(Packet &)
 
 NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerBanned(Packet &)
 {
-	Debug(net, 9, "Query::ReceiveServerBanned()");
+	Debug(net, Severity::Trace3, "Query::ReceiveServerBanned()");
 
 	NetworkGame *item = NetworkGameListAddItem(this->connection_string);
 	item->status = NetworkGameStatus::Banned;
@@ -115,7 +115,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerBanned(Packet &)
 
 NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerGameInfo(Packet &p)
 {
-	Debug(net, 9, "Query::ReceiveServerGameInfo()");
+	Debug(net, Severity::Trace3, "Query::ReceiveServerGameInfo()");
 
 	NetworkGame *item = NetworkGameListAddItem(this->connection_string);
 
@@ -138,7 +138,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::ReceiveServerError(Packet &p)
 {
 	NetworkErrorCode error = static_cast<NetworkErrorCode>(p.Recv_uint8());
 
-	Debug(net, 9, "Query::ReceiveServerError(): error={}", error);
+	Debug(net, Severity::Trace3, "Query::ReceiveServerError(): error={}", error);
 
 	NetworkGame *item = NetworkGameListAddItem(this->connection_string);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -195,7 +195,7 @@ ServerNetworkGameSocketHandler::ServerNetworkGameSocketHandler(ClientPoolID inde
 	this->client_id = _network_client_id++;
 	this->receive_limit = _settings_client.network.bytes_per_frame_burst;
 
-	Debug(net, 9, "client[{}] status = INACTIVE", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] status = INACTIVE", this->client_id);
 
 	/* The Socket and Info pools need to be the same in size. After all,
 	 * each Socket will be associated with at most one Info object. As
@@ -271,7 +271,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 	}
 
 	NetworkAdminClientError(this->client_id, NetworkErrorCode::ConnectionLost);
-	Debug(net, 3, "[{}] Client #{} closed connection", ServerNetworkGameSocketHandler::GetName(), this->client_id);
+	Debug(net, Severity::Notice, "[{}] Client #{} closed connection", ServerNetworkGameSocketHandler::GetName(), this->client_id);
 
 	/* We just lost one client :( */
 	if (this->status >= ClientStatus::Authorized) _network_game_info.clients_on--;
@@ -327,7 +327,7 @@ static void NetworkHandleCommandQueue(NetworkClientSocket *cs);
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendClientInfo(NetworkClientInfo *ci)
 {
-	Debug(net, 9, "client[{}] SendClientInfo(): client_id={}", this->client_id, ci->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendClientInfo(): client_id={}", this->client_id, ci->client_id);
 
 	if (ci->client_id != ClientID::Invalid) {
 		auto p = std::make_unique<Packet>(this, PacketGameType::ServerClientInfo);
@@ -347,7 +347,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendClientInfo(NetworkClientIn
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendGameInfo()
 {
-	Debug(net, 9, "client[{}] SendGameInfo()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendGameInfo()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerGameInfo, TCP_MTU);
 	SerializeNetworkGameInfo(*p, GetCurrentNetworkServerGameInfo());
@@ -365,7 +365,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendGameInfo()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode error, std::string_view reason)
 {
-	Debug(net, 9, "client[{}] SendError(): error={}", this->client_id, error);
+	Debug(net, Severity::Trace3, "client[{}] SendError(): error={}", this->client_id, error);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerError);
 
@@ -379,7 +379,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 	if (this->status >= ClientStatus::Authorized) {
 		std::string client_name = this->GetClientName();
 
-		Debug(net, 1, "'{}' made an error and has been disconnected: {}", client_name, GetString(strid));
+		Debug(net, Severity::Error, "'{}' made an error and has been disconnected: {}", client_name, GetString(strid));
 
 		if (error == NetworkErrorCode::Kicked && !reason.empty()) {
 			NetworkTextMessage(NetworkAction::ClientKicked, CC_DEFAULT, false, client_name, reason, strid);
@@ -400,7 +400,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 
 		NetworkAdminClientError(this->client_id, error);
 	} else {
-		Debug(net, 1, "Client {} made an error and has been disconnected: {}", this->client_id, GetString(strid));
+		Debug(net, Severity::Error, "Client {} made an error and has been disconnected: {}", this->client_id, GetString(strid));
 	}
 
 	/* The client made a mistake, so drop the connection now! */
@@ -413,12 +413,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGRFCheck()
 {
-	Debug(net, 9, "client[{}] SendNewGRFCheck()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendNewGRFCheck()", this->client_id);
 
 	/* Invalid packet when status is anything but ClientStatus::Identify. */
 	if (this->status != ClientStatus::Identify) return this->CloseConnection(NetworkRecvStatus::MalformedPacket);
 
-	Debug(net, 9, "client[{}] status = NEWGRFS_CHECK", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] status = NEWGRFS_CHECK", this->client_id);
 	this->status = ClientStatus::NewGRFsCheck;
 
 	if (_grfconfig.empty()) {
@@ -445,12 +445,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGRFCheck()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendAuthRequest()
 {
-	Debug(net, 9, "client[{}] SendAuthRequest()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendAuthRequest()", this->client_id);
 
 	/* Invalid packet when status is anything but ClientStatus::Inactive or ClientStatus::AuthGame. */
 	if (this->status != ClientStatus::Inactive && status != ClientStatus::AuthGame) return this->CloseConnection(NetworkRecvStatus::MalformedPacket);
 
-	Debug(net, 9, "client[{}] status = AUTH_GAME", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] status = AUTH_GAME", this->client_id);
 	this->status = ClientStatus::AuthGame;
 
 	/* Reset 'lag' counters */
@@ -473,7 +473,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendAuthRequest()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendEnableEncryption()
 {
-	Debug(net, 9, "client[{}] SendEnableEncryption()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendEnableEncryption()", this->client_id);
 
 	/* Invalid packet when status is anything but ClientStatus::AuthGame. */
 	if (this->status != ClientStatus::AuthGame) return this->CloseConnection(NetworkRecvStatus::MalformedPacket);
@@ -490,12 +490,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendEnableEncryption()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendWelcome()
 {
-	Debug(net, 9, "client[{}] SendWelcome()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendWelcome()", this->client_id);
 
 	/* Invalid packet when status is anything but ClientStatus::NewGRFsCheck. */
 	if (this->status != ClientStatus::NewGRFsCheck) return this->CloseConnection(NetworkRecvStatus::MalformedPacket);
 
-	Debug(net, 9, "client[{}] status = AUTHORIZED", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] status = AUTHORIZED", this->client_id);
 	this->status = ClientStatus::Authorized;
 
 	/* Reset 'lag' counters */
@@ -523,7 +523,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendWelcome()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendWait()
 {
-	Debug(net, 9, "client[{}] SendWait()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendWait()", this->client_id);
 
 	int waiting = 1; // current player getting the map counts as 1
 
@@ -545,7 +545,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendWait()
  */
 void ServerNetworkGameSocketHandler::CheckNextClientToSendMap(NetworkClientSocket *ignore_cs)
 {
-	Debug(net, 9, "client[{}] CheckNextClientToSendMap()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] CheckNextClientToSendMap()", this->client_id);
 
 	/* Find the best candidate for joining, i.e. the first joiner. */
 	NetworkClientSocket *best = nullptr;
@@ -584,7 +584,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 	}
 
 	if (this->status == ClientStatus::Authorized) {
-		Debug(net, 9, "client[{}] SendMap(): first_packet", this->client_id);
+		Debug(net, Severity::Trace3, "client[{}] SendMap(): first_packet", this->client_id);
 
 		WaitTillSaved();
 		this->savegame = std::make_shared<PacketWriter>(this);
@@ -595,7 +595,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 		this->SendPacket(std::move(p));
 
 		NetworkSyncCommandQueue(this);
-		Debug(net, 9, "client[{}] status = MAP", this->client_id);
+		Debug(net, Severity::Trace3, "client[{}] status = MAP", this->client_id);
 		this->status = ClientStatus::Map;
 		/* Mark the start of download */
 		this->last_frame = _frame_counter;
@@ -608,7 +608,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 	if (this->status == ClientStatus::Map) {
 		bool last_packet = this->savegame->TransferToNetworkQueue();
 		if (last_packet) {
-			Debug(net, 9, "client[{}] SendMap(): last_packet", this->client_id);
+			Debug(net, Severity::Trace3, "client[{}] SendMap(): last_packet", this->client_id);
 
 			/* Done reading, make sure saving is done as well */
 			this->savegame->Destroy();
@@ -616,7 +616,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 
 			/* Set the status to DONE_MAP, no we will wait for the client
 			 *  to send it is ready (maybe that happens like never ;)) */
-			Debug(net, 9, "client[{}] status = DONE_MAP", this->client_id);
+			Debug(net, Severity::Trace3, "client[{}] status = DONE_MAP", this->client_id);
 			this->status = ClientStatus::DoneMap;
 
 			this->CheckNextClientToSendMap();
@@ -632,7 +632,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendJoin(ClientID client_id)
 {
-	Debug(net, 9, "client[{}] SendJoin(): client_id={}", this->client_id, client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendJoin(): client_id={}", this->client_id, client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerClientJoined);
 
@@ -674,7 +674,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendFrame()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendSync()
 {
-	Debug(net, 9, "client[{}] SendSync(), frame_counter={}, sync_seed_1={}", this->client_id, _frame_counter, _sync_seed_1);
+	Debug(net, Severity::Trace3, "client[{}] SendSync(), frame_counter={}, sync_seed_1={}", this->client_id, _frame_counter, _sync_seed_1);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerSync);
 	p->Send_uint32(_frame_counter);
@@ -694,7 +694,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendSync()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendCommand(const CommandPacket &cp)
 {
-	Debug(net, 9, "client[{}] SendCommand(): cmd={}", this->client_id, cp.cmd);
+	Debug(net, Severity::Trace3, "client[{}] SendCommand(): cmd={}", this->client_id, cp.cmd);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerCommand);
 
@@ -717,7 +717,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendCommand(const CommandPacke
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendChat(NetworkAction action, ClientID client_id, bool self_send, std::string_view msg, int64_t data)
 {
-	Debug(net, 9, "client[{}] SendChat(): action={}, client_id={}, self_send={}", this->client_id, action, client_id, self_send);
+	Debug(net, Severity::Trace3, "client[{}] SendChat(): action={}, client_id={}, self_send={}", this->client_id, action, client_id, self_send);
 
 	if (this->status < ClientStatus::PreActive) return NetworkRecvStatus::Okay;
 
@@ -743,7 +743,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendChat(NetworkAction action,
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendExternalChat(std::string_view source, ExtendedTextColour colour, std::string_view user, std::string_view msg)
 {
-	Debug(net, 9, "client[{}] SendExternalChat(): source={}", this->client_id, source);
+	Debug(net, Severity::Trace3, "client[{}] SendExternalChat(): source={}", this->client_id, source);
 
 	if (this->status < ClientStatus::PreActive) return NetworkRecvStatus::Okay;
 
@@ -766,7 +766,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendExternalChat(std::string_v
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendErrorQuit(ClientID client_id, NetworkErrorCode errorno)
 {
-	Debug(net, 9, "client[{}] SendErrorQuit(): client_id={}, errorno={}", this->client_id, client_id, errorno);
+	Debug(net, Severity::Trace3, "client[{}] SendErrorQuit(): client_id={}, errorno={}", this->client_id, client_id, errorno);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerErrorQuit);
 
@@ -784,7 +784,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendErrorQuit(ClientID client_
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendQuit(ClientID client_id)
 {
-	Debug(net, 9, "client[{}] SendQuit(): client_id={}", this->client_id, client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendQuit(): client_id={}", this->client_id, client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerQuit);
 
@@ -800,7 +800,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendQuit(ClientID client_id)
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendShutdown()
 {
-	Debug(net, 9, "client[{}] SendShutdown()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendShutdown()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerShutdown);
 	this->SendPacket(std::move(p));
@@ -813,7 +813,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendShutdown()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGame()
 {
-	Debug(net, 9, "client[{}] SendNewGame()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendNewGame()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerNewGame);
 	this->SendPacket(std::move(p));
@@ -828,7 +828,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGame()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendRConResult(uint16_t colour, std::string_view command)
 {
-	Debug(net, 9, "client[{}] SendRConResult()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendRConResult()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerRemoteConsoleCommand);
 
@@ -846,7 +846,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendRConResult(uint16_t colour
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendMove(ClientID client_id, CompanyID company_id)
 {
-	Debug(net, 9, "client[{}] SendMove(): client_id={}", this->client_id, client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendMove(): client_id={}", this->client_id, client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerMove);
 
@@ -862,7 +862,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMove(ClientID client_id, C
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendConfigUpdate()
 {
-	Debug(net, 9, "client[{}] SendConfigUpdate()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] SendConfigUpdate()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerConfigurationUpdate);
 
@@ -878,7 +878,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendConfigUpdate()
 
 NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientGameInfo(Packet &)
 {
-	Debug(net, 9, "client[{}] ReceiveClientGameInfo()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientGameInfo()", this->client_id);
 
 	return this->SendGameInfo();
 }
@@ -890,7 +890,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientNewGRFsChecked(Pa
 		return this->SendError(NetworkErrorCode::NotExpected);
 	}
 
-	Debug(net, 9, "client[{}] ReceiveClientNewGRFsChecked()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientNewGRFsChecked()", this->client_id);
 
 	return this->SendWelcome();
 }
@@ -910,7 +910,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientJoin(Packet &p)
 	std::string client_revision = p.Recv_string(NETWORK_REVISION_LENGTH);
 	uint32_t newgrf_version = p.Recv_uint32();
 
-	Debug(net, 9, "client[{}] ReceiveClientJoin(): client_revision={}, newgrf_version={}", this->client_id, client_revision, newgrf_version);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientJoin(): client_revision={}, newgrf_version={}", this->client_id, client_revision, newgrf_version);
 
 	/* Check if the client has revision control enabled */
 	if (!IsNetworkCompatibleVersion(client_revision) || _openttd_newgrf_version != newgrf_version) {
@@ -925,7 +925,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientIdentify(Packet &
 {
 	if (this->status != ClientStatus::Identify) return this->SendError(NetworkErrorCode::NotExpected);
 
-	Debug(net, 9, "client[{}] ReceiveClientIdentify()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientIdentify()", this->client_id);
 
 	std::string client_name = p.Recv_string(NETWORK_CLIENT_NAME_LENGTH);
 	CompanyID playas = (Owner)p.Recv_uint8();
@@ -973,7 +973,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientIdentify(Packet &
 	ci->client_name = std::move(client_name);
 	ci->client_playas = playas;
 	ci->public_key = this->peer_public_key;
-	Debug(desync, 1, "client: {:08x}; {:02x}; {:02x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, ci->index);
+	Debug(desync, Severity::Error, "client: {:08x}; {:02x}; {:02x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, ci->index);
 
 	/* Make sure companies to which people try to join are not autocleaned */
 	Company *c = Company::GetIfValid(playas);
@@ -1006,7 +1006,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientAuthenticationRes
 		return this->SendError(NetworkErrorCode::NotExpected);
 	}
 
-	Debug(net, 9, "client[{}] ReceiveClientAuthenticationResponse()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientAuthenticationResponse()", this->client_id);
 
 	auto authentication_method = this->authentication_handler->GetAuthenticationMethod();
 	switch (this->authentication_handler->ReceiveResponse(p)) {
@@ -1029,7 +1029,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientAuthenticationRes
 	this->send_encryption_handler = this->authentication_handler->CreateServerToClientEncryptionHandler();
 	this->authentication_handler = nullptr;
 
-	Debug(net, 9, "client[{}] status = IDENTIFY", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] status = IDENTIFY", this->client_id);
 	this->status = ClientStatus::Identify;
 
 	/* Reset 'lag' counters */
@@ -1046,13 +1046,13 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientGetMap(Packet &)
 		return this->SendError(NetworkErrorCode::NotAuthorized);
 	}
 
-	Debug(net, 9, "client[{}] ReceiveClientGetMap()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientGetMap()", this->client_id);
 
 	/* Check if someone else is receiving the map */
 	for (NetworkClientSocket *new_cs : NetworkClientSocket::Iterate()) {
 		if (new_cs->status == ClientStatus::Map) {
 			/* Tell the new client to wait */
-			Debug(net, 9, "client[{}] status = MAP_WAIT", this->client_id);
+			Debug(net, Severity::Trace3, "client[{}] status = MAP_WAIT", this->client_id);
 			this->status = ClientStatus::MapWait;
 			return this->SendWait();
 		}
@@ -1066,18 +1066,18 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientMapOk(Packet &)
 {
 	/* Client has the map, now start syncing */
 	if (this->status == ClientStatus::DoneMap && !this->HasClientQuit()) {
-		Debug(net, 9, "client[{}] ReceiveClientMapOk()", this->client_id);
+		Debug(net, Severity::Trace3, "client[{}] ReceiveClientMapOk()", this->client_id);
 
 		std::string client_name = this->GetClientName();
 
 		NetworkTextMessage(NetworkAction::ClientJoin, CC_DEFAULT, false, client_name, "", this->client_id);
 		InvalidateWindowData(WindowClass::NetworkClientList, 0);
 
-		Debug(net, 3, "[{}] Client #{} ({}) joined as {}", ServerNetworkGameSocketHandler::GetName(), this->client_id, this->GetClientIP(), client_name);
+		Debug(net, Severity::Notice, "[{}] Client #{} ({}) joined as {}", ServerNetworkGameSocketHandler::GetName(), this->client_id, this->GetClientIP(), client_name);
 
 		/* Mark the client as pre-active, and wait for an ACK
 		 *  so we know it is done loading and in sync with us */
-		Debug(net, 9, "client[{}] status = PRE_ACTIVE", this->client_id);
+		Debug(net, Severity::Trace3, "client[{}] status = PRE_ACTIVE", this->client_id);
 		this->status = ClientStatus::PreActive;
 		NetworkHandleCommandQueue(this);
 		this->SendFrame();
@@ -1117,7 +1117,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientCommand(Packet &p
 		return this->SendError(NetworkErrorCode::TooManyCommands);
 	}
 
-	Debug(net, 9, "client[{}] ReceiveClientCommand()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientCommand()", this->client_id);
 
 	CommandPacket cp;
 	auto err = this->ReceiveCommand(p, cp);
@@ -1197,7 +1197,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientError(Packet &p)
 	 *  to us. Display the error and report it to the other clients */
 	NetworkErrorCode errorno = static_cast<NetworkErrorCode>(p.Recv_uint8());
 
-	Debug(net, 9, "client[{}] ReceiveClientError(): errorno={}", this->client_id, errorno);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientError(): errorno={}", this->client_id, errorno);
 
 	/* The client was never joined.. thank the client for the packet, but ignore it */
 	if (this->status < ClientStatus::DoneMap || this->HasClientQuit()) {
@@ -1207,7 +1207,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientError(Packet &p)
 	std::string client_name = this->GetClientName();
 	StringID strid = GetNetworkErrorMsg(errorno);
 
-	Debug(net, 1, "'{}' reported an error and is closing its connection: {}", client_name, GetString(strid));
+	Debug(net, Severity::Error, "'{}' reported an error and is closing its connection: {}", client_name, GetString(strid));
 
 	NetworkTextMessage(NetworkAction::ClientLeave, CC_DEFAULT, false, client_name, "", strid);
 
@@ -1229,7 +1229,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientQuit(Packet &)
 		return this->CloseConnection(NetworkRecvStatus::ClientQuit);
 	}
 
-	Debug(net, 9, "client[{}] ReceiveClientQuit()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientQuit()", this->client_id);
 
 	/* The client wants to leave. Display this and report it to the other clients. */
 	std::string client_name = this->GetClientName();
@@ -1255,7 +1255,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientAck(Packet &p)
 
 	uint32_t frame = p.Recv_uint32();
 
-	Debug(net, 9, "client[{}] ReceiveClientAck(): frame={}", this->client_id, frame);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientAck(): frame={}", this->client_id, frame);
 
 	/* The client is trying to catch up with the server */
 	if (this->status == ClientStatus::PreActive) {
@@ -1263,7 +1263,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientAck(Packet &p)
 		if (frame + Ticks::DAY_TICKS < _frame_counter) return NetworkRecvStatus::Okay;
 
 		/* Now it is! Unpause the game */
-		Debug(net, 9, "client[{}] status = ACTIVE", this->client_id);
+		Debug(net, Severity::Trace3, "client[{}] status = ACTIVE", this->client_id);
 		this->status = ClientStatus::Active;
 		this->last_token_frame = _frame_counter;
 
@@ -1397,7 +1397,7 @@ void NetworkServerSendChat(NetworkAction action, NetworkChatDestinationType dest
 			break;
 		}
 		default:
-			Debug(net, 1, "Received unknown chat destination type {}; doing broadcast instead", desttype);
+			Debug(net, Severity::Error, "Received unknown chat destination type {}; doing broadcast instead", desttype);
 			[[fallthrough]];
 
 		case NetworkChatDestinationType::Broadcast:
@@ -1441,7 +1441,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientChat(Packet &p)
 	NetworkChatDestinationType desttype = static_cast<NetworkChatDestinationType>(p.Recv_uint8());
 	int dest = p.Recv_uint32();
 
-	Debug(net, 9, "client[{}] ReceiveClientChat(): action={}, desttype={}, dest={}", this->client_id, action, desttype, dest);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientChat(): action={}, desttype={}, dest={}", this->client_id, action, desttype, dest);
 
 	std::string msg = p.Recv_string(NETWORK_CHAT_LENGTH);
 	int64_t data = p.Recv_uint64();
@@ -1467,7 +1467,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientSetName(Packet &p
 		return this->SendError(NetworkErrorCode::NotExpected);
 	}
 
-	Debug(net, 9, "client[{}] ReceiveClientSetName()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientSetName()", this->client_id);
 
 	NetworkClientInfo *ci;
 
@@ -1499,7 +1499,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientRemoteConsoleComm
 {
 	if (this->status != ClientStatus::Active) return this->SendError(NetworkErrorCode::NotExpected);
 
-	Debug(net, 9, "client[{}] ReceiveClientRemoteConsoleCommand()", this->client_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientRemoteConsoleCommand()", this->client_id);
 
 	std::string password = p.Recv_string(NETWORK_PASSWORD_LENGTH);
 	std::string command = p.Recv_string(NETWORK_RCONCOMMAND_LENGTH);
@@ -1509,11 +1509,11 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientRemoteConsoleComm
 	} else if (_settings_client.network.rcon_password.empty()) {
 		return NetworkRecvStatus::Okay;
 	} else if (_settings_client.network.rcon_password != password) {
-		Debug(net, 1, "[rcon] Wrong password from client-id {}", this->client_id);
+		Debug(net, Severity::Error, "[rcon] Wrong password from client-id {}", this->client_id);
 		return NetworkRecvStatus::Okay;
 	}
 
-	Debug(net, 3, "[rcon] Client-id {} executed: {}", this->client_id, command);
+	Debug(net, Severity::Notice, "[rcon] Client-id {} executed: {}", this->client_id, command);
 
 	_redirect_console_to_client = this->client_id;
 	IConsoleCmdExec(command);
@@ -1527,7 +1527,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientMove(Packet &p)
 
 	CompanyID company_id = (Owner)p.Recv_uint8();
 
-	Debug(net, 9, "client[{}] ReceiveClientMove(): company_id={}", this->client_id, company_id);
+	Debug(net, Severity::Trace3, "client[{}] ReceiveClientMove(): company_id={}", this->client_id, company_id);
 
 	/* Check if the company is valid, we don't allow moving to AI companies */
 	if (company_id != COMPANY_SPECTATOR) {
@@ -1535,7 +1535,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientMove(Packet &p)
 
 		const Company *c = Company::Get(company_id);
 		if (!c->allow_any && !c->allow_list.Contains(this->peer_public_key)) {
-			Debug(net, 2, "Wrong public key from client-id #{} for company #{}", this->client_id, company_id + 1);
+			Debug(net, Severity::Warning, "Wrong public key from client-id #{} for company #{}", this->client_id, company_id + 1);
 			return NetworkRecvStatus::Okay;
 		}
 	}
@@ -1593,7 +1593,7 @@ void NetworkUpdateClientInfo(ClientID client_id)
 
 	if (ci == nullptr) return;
 
-	Debug(desync, 1, "client: {:08x}; {:02x}; {:02x}; {:04x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, client_id);
+	Debug(desync, Severity::Error, "client: {:08x}; {:02x}; {:02x}; {:04x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, client_id);
 
 	for (NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {
 		if (cs->status >= ServerNetworkGameSocketHandler::ClientStatus::Authorized) {
@@ -1897,7 +1897,7 @@ static IntervalTimer<TimerGameRealtime> _network_restart_map_timer({std::chrono:
 	/* If setting is 0, this feature is disabled. */
 	if (_settings_client.network.restart_hours == 0) return;
 
-	Debug(net, 3, "Auto-restarting map: {} hours played", _settings_client.network.restart_hours);
+	Debug(net, Severity::Notice, "Auto-restarting map: {} hours played", _settings_client.network.restart_hours);
 	NetworkRestartMap();
 });
 
@@ -1919,7 +1919,7 @@ static void NetworkCheckRestartMapYear()
 	if (_settings_client.network.restart_game_year == 0) return;
 
 	if (TimerGameCalendar::year >= _settings_client.network.restart_game_year) {
-		Debug(net, 3, "Auto-restarting map: year {} reached", TimerGameCalendar::year);
+		Debug(net, Severity::Notice, "Auto-restarting map: year {} reached", TimerGameCalendar::year);
 		NetworkRestartMap();
 	}
 }

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -195,7 +195,7 @@ ServerNetworkGameSocketHandler::ServerNetworkGameSocketHandler(ClientPoolID inde
 	this->client_id = _network_client_id++;
 	this->receive_limit = _settings_client.network.bytes_per_frame_burst;
 
-	Debug(net, Severity::Trace3, "client[{}] status = INACTIVE", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] status = INACTIVE", this->client_id);
 
 	/* The Socket and Info pools need to be the same in size. After all,
 	 * each Socket will be associated with at most one Info object. As
@@ -271,7 +271,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 	}
 
 	NetworkAdminClientError(this->client_id, NetworkErrorCode::ConnectionLost);
-	Debug(net, Severity::Notice, "[{}] Client #{} closed connection", ServerNetworkGameSocketHandler::GetName(), this->client_id);
+	Debug(Facility::Net, Severity::Notice, "[{}] Client #{} closed connection", ServerNetworkGameSocketHandler::GetName(), this->client_id);
 
 	/* We just lost one client :( */
 	if (this->status >= ClientStatus::Authorized) _network_game_info.clients_on--;
@@ -327,7 +327,7 @@ static void NetworkHandleCommandQueue(NetworkClientSocket *cs);
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendClientInfo(NetworkClientInfo *ci)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendClientInfo(): client_id={}", this->client_id, ci->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendClientInfo(): client_id={}", this->client_id, ci->client_id);
 
 	if (ci->client_id != ClientID::Invalid) {
 		auto p = std::make_unique<Packet>(this, PacketGameType::ServerClientInfo);
@@ -347,7 +347,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendClientInfo(NetworkClientIn
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendGameInfo()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendGameInfo()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendGameInfo()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerGameInfo, TCP_MTU);
 	SerializeNetworkGameInfo(*p, GetCurrentNetworkServerGameInfo());
@@ -365,7 +365,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendGameInfo()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode error, std::string_view reason)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendError(): error={}", this->client_id, error);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendError(): error={}", this->client_id, error);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerError);
 
@@ -379,7 +379,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 	if (this->status >= ClientStatus::Authorized) {
 		std::string client_name = this->GetClientName();
 
-		Debug(net, Severity::Error, "'{}' made an error and has been disconnected: {}", client_name, GetString(strid));
+		Debug(Facility::Net, Severity::Error, "'{}' made an error and has been disconnected: {}", client_name, GetString(strid));
 
 		if (error == NetworkErrorCode::Kicked && !reason.empty()) {
 			NetworkTextMessage(NetworkAction::ClientKicked, CC_DEFAULT, false, client_name, reason, strid);
@@ -400,7 +400,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 
 		NetworkAdminClientError(this->client_id, error);
 	} else {
-		Debug(net, Severity::Error, "Client {} made an error and has been disconnected: {}", this->client_id, GetString(strid));
+		Debug(Facility::Net, Severity::Error, "Client {} made an error and has been disconnected: {}", this->client_id, GetString(strid));
 	}
 
 	/* The client made a mistake, so drop the connection now! */
@@ -413,12 +413,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGRFCheck()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendNewGRFCheck()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendNewGRFCheck()", this->client_id);
 
 	/* Invalid packet when status is anything but ClientStatus::Identify. */
 	if (this->status != ClientStatus::Identify) return this->CloseConnection(NetworkRecvStatus::MalformedPacket);
 
-	Debug(net, Severity::Trace3, "client[{}] status = NEWGRFS_CHECK", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] status = NEWGRFS_CHECK", this->client_id);
 	this->status = ClientStatus::NewGRFsCheck;
 
 	if (_grfconfig.empty()) {
@@ -445,12 +445,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGRFCheck()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendAuthRequest()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendAuthRequest()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendAuthRequest()", this->client_id);
 
 	/* Invalid packet when status is anything but ClientStatus::Inactive or ClientStatus::AuthGame. */
 	if (this->status != ClientStatus::Inactive && status != ClientStatus::AuthGame) return this->CloseConnection(NetworkRecvStatus::MalformedPacket);
 
-	Debug(net, Severity::Trace3, "client[{}] status = AUTH_GAME", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] status = AUTH_GAME", this->client_id);
 	this->status = ClientStatus::AuthGame;
 
 	/* Reset 'lag' counters */
@@ -473,7 +473,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendAuthRequest()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendEnableEncryption()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendEnableEncryption()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendEnableEncryption()", this->client_id);
 
 	/* Invalid packet when status is anything but ClientStatus::AuthGame. */
 	if (this->status != ClientStatus::AuthGame) return this->CloseConnection(NetworkRecvStatus::MalformedPacket);
@@ -490,12 +490,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendEnableEncryption()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendWelcome()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendWelcome()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendWelcome()", this->client_id);
 
 	/* Invalid packet when status is anything but ClientStatus::NewGRFsCheck. */
 	if (this->status != ClientStatus::NewGRFsCheck) return this->CloseConnection(NetworkRecvStatus::MalformedPacket);
 
-	Debug(net, Severity::Trace3, "client[{}] status = AUTHORIZED", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] status = AUTHORIZED", this->client_id);
 	this->status = ClientStatus::Authorized;
 
 	/* Reset 'lag' counters */
@@ -523,7 +523,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendWelcome()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendWait()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendWait()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendWait()", this->client_id);
 
 	int waiting = 1; // current player getting the map counts as 1
 
@@ -545,7 +545,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendWait()
  */
 void ServerNetworkGameSocketHandler::CheckNextClientToSendMap(NetworkClientSocket *ignore_cs)
 {
-	Debug(net, Severity::Trace3, "client[{}] CheckNextClientToSendMap()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] CheckNextClientToSendMap()", this->client_id);
 
 	/* Find the best candidate for joining, i.e. the first joiner. */
 	NetworkClientSocket *best = nullptr;
@@ -584,7 +584,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 	}
 
 	if (this->status == ClientStatus::Authorized) {
-		Debug(net, Severity::Trace3, "client[{}] SendMap(): first_packet", this->client_id);
+		Debug(Facility::Net, Severity::Trace3, "client[{}] SendMap(): first_packet", this->client_id);
 
 		WaitTillSaved();
 		this->savegame = std::make_shared<PacketWriter>(this);
@@ -595,7 +595,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 		this->SendPacket(std::move(p));
 
 		NetworkSyncCommandQueue(this);
-		Debug(net, Severity::Trace3, "client[{}] status = MAP", this->client_id);
+		Debug(Facility::Net, Severity::Trace3, "client[{}] status = MAP", this->client_id);
 		this->status = ClientStatus::Map;
 		/* Mark the start of download */
 		this->last_frame = _frame_counter;
@@ -608,7 +608,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 	if (this->status == ClientStatus::Map) {
 		bool last_packet = this->savegame->TransferToNetworkQueue();
 		if (last_packet) {
-			Debug(net, Severity::Trace3, "client[{}] SendMap(): last_packet", this->client_id);
+			Debug(Facility::Net, Severity::Trace3, "client[{}] SendMap(): last_packet", this->client_id);
 
 			/* Done reading, make sure saving is done as well */
 			this->savegame->Destroy();
@@ -616,7 +616,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 
 			/* Set the status to DONE_MAP, no we will wait for the client
 			 *  to send it is ready (maybe that happens like never ;)) */
-			Debug(net, Severity::Trace3, "client[{}] status = DONE_MAP", this->client_id);
+			Debug(Facility::Net, Severity::Trace3, "client[{}] status = DONE_MAP", this->client_id);
 			this->status = ClientStatus::DoneMap;
 
 			this->CheckNextClientToSendMap();
@@ -632,7 +632,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendJoin(ClientID client_id)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendJoin(): client_id={}", this->client_id, client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendJoin(): client_id={}", this->client_id, client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerClientJoined);
 
@@ -674,7 +674,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendFrame()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendSync()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendSync(), frame_counter={}, sync_seed_1={}", this->client_id, _frame_counter, _sync_seed_1);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendSync(), frame_counter={}, sync_seed_1={}", this->client_id, _frame_counter, _sync_seed_1);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerSync);
 	p->Send_uint32(_frame_counter);
@@ -694,7 +694,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendSync()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendCommand(const CommandPacket &cp)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendCommand(): cmd={}", this->client_id, cp.cmd);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendCommand(): cmd={}", this->client_id, cp.cmd);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerCommand);
 
@@ -717,7 +717,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendCommand(const CommandPacke
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendChat(NetworkAction action, ClientID client_id, bool self_send, std::string_view msg, int64_t data)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendChat(): action={}, client_id={}, self_send={}", this->client_id, action, client_id, self_send);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendChat(): action={}, client_id={}, self_send={}", this->client_id, action, client_id, self_send);
 
 	if (this->status < ClientStatus::PreActive) return NetworkRecvStatus::Okay;
 
@@ -743,7 +743,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendChat(NetworkAction action,
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendExternalChat(std::string_view source, ExtendedTextColour colour, std::string_view user, std::string_view msg)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendExternalChat(): source={}", this->client_id, source);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendExternalChat(): source={}", this->client_id, source);
 
 	if (this->status < ClientStatus::PreActive) return NetworkRecvStatus::Okay;
 
@@ -766,7 +766,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendExternalChat(std::string_v
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendErrorQuit(ClientID client_id, NetworkErrorCode errorno)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendErrorQuit(): client_id={}, errorno={}", this->client_id, client_id, errorno);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendErrorQuit(): client_id={}, errorno={}", this->client_id, client_id, errorno);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerErrorQuit);
 
@@ -784,7 +784,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendErrorQuit(ClientID client_
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendQuit(ClientID client_id)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendQuit(): client_id={}", this->client_id, client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendQuit(): client_id={}", this->client_id, client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerQuit);
 
@@ -800,7 +800,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendQuit(ClientID client_id)
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendShutdown()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendShutdown()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendShutdown()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerShutdown);
 	this->SendPacket(std::move(p));
@@ -813,7 +813,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendShutdown()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGame()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendNewGame()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendNewGame()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerNewGame);
 	this->SendPacket(std::move(p));
@@ -828,7 +828,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGame()
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendRConResult(uint16_t colour, std::string_view command)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendRConResult()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendRConResult()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerRemoteConsoleCommand);
 
@@ -846,7 +846,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendRConResult(uint16_t colour
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendMove(ClientID client_id, CompanyID company_id)
 {
-	Debug(net, Severity::Trace3, "client[{}] SendMove(): client_id={}", this->client_id, client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendMove(): client_id={}", this->client_id, client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerMove);
 
@@ -862,7 +862,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMove(ClientID client_id, C
  */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendConfigUpdate()
 {
-	Debug(net, Severity::Trace3, "client[{}] SendConfigUpdate()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] SendConfigUpdate()", this->client_id);
 
 	auto p = std::make_unique<Packet>(this, PacketGameType::ServerConfigurationUpdate);
 
@@ -878,7 +878,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendConfigUpdate()
 
 NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientGameInfo(Packet &)
 {
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientGameInfo()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientGameInfo()", this->client_id);
 
 	return this->SendGameInfo();
 }
@@ -890,7 +890,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientNewGRFsChecked(Pa
 		return this->SendError(NetworkErrorCode::NotExpected);
 	}
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientNewGRFsChecked()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientNewGRFsChecked()", this->client_id);
 
 	return this->SendWelcome();
 }
@@ -910,7 +910,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientJoin(Packet &p)
 	std::string client_revision = p.Recv_string(NETWORK_REVISION_LENGTH);
 	uint32_t newgrf_version = p.Recv_uint32();
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientJoin(): client_revision={}, newgrf_version={}", this->client_id, client_revision, newgrf_version);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientJoin(): client_revision={}, newgrf_version={}", this->client_id, client_revision, newgrf_version);
 
 	/* Check if the client has revision control enabled */
 	if (!IsNetworkCompatibleVersion(client_revision) || _openttd_newgrf_version != newgrf_version) {
@@ -925,7 +925,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientIdentify(Packet &
 {
 	if (this->status != ClientStatus::Identify) return this->SendError(NetworkErrorCode::NotExpected);
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientIdentify()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientIdentify()", this->client_id);
 
 	std::string client_name = p.Recv_string(NETWORK_CLIENT_NAME_LENGTH);
 	CompanyID playas = (Owner)p.Recv_uint8();
@@ -973,7 +973,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientIdentify(Packet &
 	ci->client_name = std::move(client_name);
 	ci->client_playas = playas;
 	ci->public_key = this->peer_public_key;
-	Debug(desync, Severity::Error, "client: {:08x}; {:02x}; {:02x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, ci->index);
+	Debug(Facility::Desync, Severity::Error, "client: {:08x}; {:02x}; {:02x}; {:02x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, ci->index);
 
 	/* Make sure companies to which people try to join are not autocleaned */
 	Company *c = Company::GetIfValid(playas);
@@ -1006,7 +1006,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientAuthenticationRes
 		return this->SendError(NetworkErrorCode::NotExpected);
 	}
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientAuthenticationResponse()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientAuthenticationResponse()", this->client_id);
 
 	auto authentication_method = this->authentication_handler->GetAuthenticationMethod();
 	switch (this->authentication_handler->ReceiveResponse(p)) {
@@ -1029,7 +1029,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientAuthenticationRes
 	this->send_encryption_handler = this->authentication_handler->CreateServerToClientEncryptionHandler();
 	this->authentication_handler = nullptr;
 
-	Debug(net, Severity::Trace3, "client[{}] status = IDENTIFY", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] status = IDENTIFY", this->client_id);
 	this->status = ClientStatus::Identify;
 
 	/* Reset 'lag' counters */
@@ -1046,13 +1046,13 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientGetMap(Packet &)
 		return this->SendError(NetworkErrorCode::NotAuthorized);
 	}
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientGetMap()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientGetMap()", this->client_id);
 
 	/* Check if someone else is receiving the map */
 	for (NetworkClientSocket *new_cs : NetworkClientSocket::Iterate()) {
 		if (new_cs->status == ClientStatus::Map) {
 			/* Tell the new client to wait */
-			Debug(net, Severity::Trace3, "client[{}] status = MAP_WAIT", this->client_id);
+			Debug(Facility::Net, Severity::Trace3, "client[{}] status = MAP_WAIT", this->client_id);
 			this->status = ClientStatus::MapWait;
 			return this->SendWait();
 		}
@@ -1066,18 +1066,18 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientMapOk(Packet &)
 {
 	/* Client has the map, now start syncing */
 	if (this->status == ClientStatus::DoneMap && !this->HasClientQuit()) {
-		Debug(net, Severity::Trace3, "client[{}] ReceiveClientMapOk()", this->client_id);
+		Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientMapOk()", this->client_id);
 
 		std::string client_name = this->GetClientName();
 
 		NetworkTextMessage(NetworkAction::ClientJoin, CC_DEFAULT, false, client_name, "", this->client_id);
 		InvalidateWindowData(WindowClass::NetworkClientList, 0);
 
-		Debug(net, Severity::Notice, "[{}] Client #{} ({}) joined as {}", ServerNetworkGameSocketHandler::GetName(), this->client_id, this->GetClientIP(), client_name);
+		Debug(Facility::Net, Severity::Notice, "[{}] Client #{} ({}) joined as {}", ServerNetworkGameSocketHandler::GetName(), this->client_id, this->GetClientIP(), client_name);
 
 		/* Mark the client as pre-active, and wait for an ACK
 		 *  so we know it is done loading and in sync with us */
-		Debug(net, Severity::Trace3, "client[{}] status = PRE_ACTIVE", this->client_id);
+		Debug(Facility::Net, Severity::Trace3, "client[{}] status = PRE_ACTIVE", this->client_id);
 		this->status = ClientStatus::PreActive;
 		NetworkHandleCommandQueue(this);
 		this->SendFrame();
@@ -1117,7 +1117,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientCommand(Packet &p
 		return this->SendError(NetworkErrorCode::TooManyCommands);
 	}
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientCommand()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientCommand()", this->client_id);
 
 	CommandPacket cp;
 	auto err = this->ReceiveCommand(p, cp);
@@ -1197,7 +1197,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientError(Packet &p)
 	 *  to us. Display the error and report it to the other clients */
 	NetworkErrorCode errorno = static_cast<NetworkErrorCode>(p.Recv_uint8());
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientError(): errorno={}", this->client_id, errorno);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientError(): errorno={}", this->client_id, errorno);
 
 	/* The client was never joined.. thank the client for the packet, but ignore it */
 	if (this->status < ClientStatus::DoneMap || this->HasClientQuit()) {
@@ -1207,7 +1207,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientError(Packet &p)
 	std::string client_name = this->GetClientName();
 	StringID strid = GetNetworkErrorMsg(errorno);
 
-	Debug(net, Severity::Error, "'{}' reported an error and is closing its connection: {}", client_name, GetString(strid));
+	Debug(Facility::Net, Severity::Error, "'{}' reported an error and is closing its connection: {}", client_name, GetString(strid));
 
 	NetworkTextMessage(NetworkAction::ClientLeave, CC_DEFAULT, false, client_name, "", strid);
 
@@ -1229,7 +1229,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientQuit(Packet &)
 		return this->CloseConnection(NetworkRecvStatus::ClientQuit);
 	}
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientQuit()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientQuit()", this->client_id);
 
 	/* The client wants to leave. Display this and report it to the other clients. */
 	std::string client_name = this->GetClientName();
@@ -1255,7 +1255,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientAck(Packet &p)
 
 	uint32_t frame = p.Recv_uint32();
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientAck(): frame={}", this->client_id, frame);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientAck(): frame={}", this->client_id, frame);
 
 	/* The client is trying to catch up with the server */
 	if (this->status == ClientStatus::PreActive) {
@@ -1263,7 +1263,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientAck(Packet &p)
 		if (frame + Ticks::DAY_TICKS < _frame_counter) return NetworkRecvStatus::Okay;
 
 		/* Now it is! Unpause the game */
-		Debug(net, Severity::Trace3, "client[{}] status = ACTIVE", this->client_id);
+		Debug(Facility::Net, Severity::Trace3, "client[{}] status = ACTIVE", this->client_id);
 		this->status = ClientStatus::Active;
 		this->last_token_frame = _frame_counter;
 
@@ -1397,7 +1397,7 @@ void NetworkServerSendChat(NetworkAction action, NetworkChatDestinationType dest
 			break;
 		}
 		default:
-			Debug(net, Severity::Error, "Received unknown chat destination type {}; doing broadcast instead", desttype);
+			Debug(Facility::Net, Severity::Error, "Received unknown chat destination type {}; doing broadcast instead", desttype);
 			[[fallthrough]];
 
 		case NetworkChatDestinationType::Broadcast:
@@ -1441,7 +1441,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientChat(Packet &p)
 	NetworkChatDestinationType desttype = static_cast<NetworkChatDestinationType>(p.Recv_uint8());
 	int dest = p.Recv_uint32();
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientChat(): action={}, desttype={}, dest={}", this->client_id, action, desttype, dest);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientChat(): action={}, desttype={}, dest={}", this->client_id, action, desttype, dest);
 
 	std::string msg = p.Recv_string(NETWORK_CHAT_LENGTH);
 	int64_t data = p.Recv_uint64();
@@ -1467,7 +1467,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientSetName(Packet &p
 		return this->SendError(NetworkErrorCode::NotExpected);
 	}
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientSetName()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientSetName()", this->client_id);
 
 	NetworkClientInfo *ci;
 
@@ -1499,7 +1499,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientRemoteConsoleComm
 {
 	if (this->status != ClientStatus::Active) return this->SendError(NetworkErrorCode::NotExpected);
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientRemoteConsoleCommand()", this->client_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientRemoteConsoleCommand()", this->client_id);
 
 	std::string password = p.Recv_string(NETWORK_PASSWORD_LENGTH);
 	std::string command = p.Recv_string(NETWORK_RCONCOMMAND_LENGTH);
@@ -1509,11 +1509,11 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientRemoteConsoleComm
 	} else if (_settings_client.network.rcon_password.empty()) {
 		return NetworkRecvStatus::Okay;
 	} else if (_settings_client.network.rcon_password != password) {
-		Debug(net, Severity::Error, "[rcon] Wrong password from client-id {}", this->client_id);
+		Debug(Facility::Net, Severity::Error, "[rcon] Wrong password from client-id {}", this->client_id);
 		return NetworkRecvStatus::Okay;
 	}
 
-	Debug(net, Severity::Notice, "[rcon] Client-id {} executed: {}", this->client_id, command);
+	Debug(Facility::Net, Severity::Notice, "[rcon] Client-id {} executed: {}", this->client_id, command);
 
 	_redirect_console_to_client = this->client_id;
 	IConsoleCmdExec(command);
@@ -1527,7 +1527,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientMove(Packet &p)
 
 	CompanyID company_id = (Owner)p.Recv_uint8();
 
-	Debug(net, Severity::Trace3, "client[{}] ReceiveClientMove(): company_id={}", this->client_id, company_id);
+	Debug(Facility::Net, Severity::Trace3, "client[{}] ReceiveClientMove(): company_id={}", this->client_id, company_id);
 
 	/* Check if the company is valid, we don't allow moving to AI companies */
 	if (company_id != COMPANY_SPECTATOR) {
@@ -1535,7 +1535,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::ReceiveClientMove(Packet &p)
 
 		const Company *c = Company::Get(company_id);
 		if (!c->allow_any && !c->allow_list.Contains(this->peer_public_key)) {
-			Debug(net, Severity::Warning, "Wrong public key from client-id #{} for company #{}", this->client_id, company_id + 1);
+			Debug(Facility::Net, Severity::Warning, "Wrong public key from client-id #{} for company #{}", this->client_id, company_id + 1);
 			return NetworkRecvStatus::Okay;
 		}
 	}
@@ -1593,7 +1593,7 @@ void NetworkUpdateClientInfo(ClientID client_id)
 
 	if (ci == nullptr) return;
 
-	Debug(desync, Severity::Error, "client: {:08x}; {:02x}; {:02x}; {:04x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, client_id);
+	Debug(Facility::Desync, Severity::Error, "client: {:08x}; {:02x}; {:02x}; {:04x}", TimerGameEconomy::date, TimerGameEconomy::date_fract, ci->client_playas, client_id);
 
 	for (NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {
 		if (cs->status >= ServerNetworkGameSocketHandler::ClientStatus::Authorized) {
@@ -1897,7 +1897,7 @@ static IntervalTimer<TimerGameRealtime> _network_restart_map_timer({std::chrono:
 	/* If setting is 0, this feature is disabled. */
 	if (_settings_client.network.restart_hours == 0) return;
 
-	Debug(net, Severity::Notice, "Auto-restarting map: {} hours played", _settings_client.network.restart_hours);
+	Debug(Facility::Net, Severity::Notice, "Auto-restarting map: {} hours played", _settings_client.network.restart_hours);
 	NetworkRestartMap();
 });
 
@@ -1919,7 +1919,7 @@ static void NetworkCheckRestartMapYear()
 	if (_settings_client.network.restart_game_year == 0) return;
 
 	if (TimerGameCalendar::year >= _settings_client.network.restart_game_year) {
-		Debug(net, Severity::Notice, "Auto-restarting map: year {} reached", TimerGameCalendar::year);
+		Debug(Facility::Net, Severity::Notice, "Auto-restarting map: year {} reached", TimerGameCalendar::year);
 		NetworkRestartMap();
 	}
 }

--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -40,7 +40,7 @@ public:
 
 	void OnFailure() override
 	{
-		Debug(net, Severity::Trace3, "Stun::OnFailure(): family={}", this->family);
+		Debug(Facility::Net, Severity::Trace3, "Stun::OnFailure(): family={}", this->family);
 
 		this->stun_handler->connecter = nullptr;
 
@@ -52,7 +52,7 @@ public:
 
 	void OnConnect(SOCKET s) override
 	{
-		Debug(net, Severity::Trace3, "Stun::OnConnect(): family={}", this->family);
+		Debug(Facility::Net, Severity::Trace3, "Stun::OnConnect(): family={}", this->family);
 
 		this->stun_handler->connecter = nullptr;
 
@@ -77,7 +77,7 @@ void ClientNetworkStunSocketHandler::Connect(std::string_view token, uint8_t fam
 	this->token = token;
 	this->family = family;
 
-	Debug(net, Severity::Trace3, "Stun::Connect(): family={}", this->family);
+	Debug(Facility::Net, Severity::Trace3, "Stun::Connect(): family={}", this->family);
 
 	this->connecter = TCPConnecter::Create<NetworkStunConnecter>(this, NetworkStunConnectionString(), token, family);
 }
@@ -99,7 +99,7 @@ std::unique_ptr<ClientNetworkStunSocketHandler> ClientNetworkStunSocketHandler::
 	p->Send_string(token);
 	p->Send_uint8(family);
 
-	Debug(net, Severity::Trace3, "Stun::SendStun({}, {})", token, family);
+	Debug(Facility::Net, Severity::Trace3, "Stun::SendStun({}, {})", token, family);
 	stun_handler->SendPacket(std::move(p));
 
 	return stun_handler;

--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -40,7 +40,7 @@ public:
 
 	void OnFailure() override
 	{
-		Debug(net, 9, "Stun::OnFailure(): family={}", this->family);
+		Debug(net, Severity::Trace3, "Stun::OnFailure(): family={}", this->family);
 
 		this->stun_handler->connecter = nullptr;
 
@@ -52,7 +52,7 @@ public:
 
 	void OnConnect(SOCKET s) override
 	{
-		Debug(net, 9, "Stun::OnConnect(): family={}", this->family);
+		Debug(net, Severity::Trace3, "Stun::OnConnect(): family={}", this->family);
 
 		this->stun_handler->connecter = nullptr;
 
@@ -77,7 +77,7 @@ void ClientNetworkStunSocketHandler::Connect(std::string_view token, uint8_t fam
 	this->token = token;
 	this->family = family;
 
-	Debug(net, 9, "Stun::Connect(): family={}", this->family);
+	Debug(net, Severity::Trace3, "Stun::Connect(): family={}", this->family);
 
 	this->connecter = TCPConnecter::Create<NetworkStunConnecter>(this, NetworkStunConnectionString(), token, family);
 }
@@ -99,7 +99,7 @@ std::unique_ptr<ClientNetworkStunSocketHandler> ClientNetworkStunSocketHandler::
 	p->Send_string(token);
 	p->Send_uint8(family);
 
-	Debug(net, 9, "Stun::SendStun({}, {})", token, family);
+	Debug(net, Severity::Trace3, "Stun::SendStun({}, {})", token, family);
 	stun_handler->SendPacket(std::move(p));
 
 	return stun_handler;

--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -89,16 +89,16 @@ std::string NetworkSurveyHandler::CreatePayload(Reason reason, bool for_preview)
 void NetworkSurveyHandler::Transmit(Reason reason, bool blocking)
 {
 	if constexpr (!NetworkSurveyHandler::IsSurveyPossible()) {
-		Debug(net, 4, "Survey: not possible to send survey; most likely due to missing JSON library at compile-time");
+		Debug(net, Severity::Info, "Survey: not possible to send survey; most likely due to missing JSON library at compile-time");
 		return;
 	}
 
 	if (_settings_client.network.participate_survey != ParticipateSurvey::Yes) {
-		Debug(net, 5, "Survey: user is not participating in survey; skipping survey");
+		Debug(net, Severity::Debug1, "Survey: user is not participating in survey; skipping survey");
 		return;
 	}
 
-	Debug(net, 1, "Survey: sending survey results");
+	Debug(net, Severity::Error, "Survey: sending survey results");
 	NetworkHTTPSocketHandler::Connect(NetworkSurveyUriString(), this, this->CreatePayload(reason));
 
 	if (blocking) {
@@ -116,7 +116,7 @@ void NetworkSurveyHandler::Transmit(Reason reason, bool blocking)
 
 void NetworkSurveyHandler::OnFailure()
 {
-	Debug(net, 1, "Survey: failed to send survey results");
+	Debug(net, Severity::Error, "Survey: failed to send survey results");
 	this->transmitted = true;
 	this->transmitted_cv.notify_all();
 }
@@ -124,7 +124,7 @@ void NetworkSurveyHandler::OnFailure()
 void NetworkSurveyHandler::OnReceiveData(std::unique_ptr<char[]> data, size_t)
 {
 	if (data == nullptr) {
-		Debug(net, 1, "Survey: survey results sent");
+		Debug(net, Severity::Error, "Survey: survey results sent");
 		this->transmitted = true;
 		this->transmitted_cv.notify_all();
 	}

--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -89,16 +89,16 @@ std::string NetworkSurveyHandler::CreatePayload(Reason reason, bool for_preview)
 void NetworkSurveyHandler::Transmit(Reason reason, bool blocking)
 {
 	if constexpr (!NetworkSurveyHandler::IsSurveyPossible()) {
-		Debug(net, Severity::Info, "Survey: not possible to send survey; most likely due to missing JSON library at compile-time");
+		Debug(Facility::Net, Severity::Info, "Survey: not possible to send survey; most likely due to missing JSON library at compile-time");
 		return;
 	}
 
 	if (_settings_client.network.participate_survey != ParticipateSurvey::Yes) {
-		Debug(net, Severity::Debug1, "Survey: user is not participating in survey; skipping survey");
+		Debug(Facility::Net, Severity::Debug1, "Survey: user is not participating in survey; skipping survey");
 		return;
 	}
 
-	Debug(net, Severity::Error, "Survey: sending survey results");
+	Debug(Facility::Net, Severity::Error, "Survey: sending survey results");
 	NetworkHTTPSocketHandler::Connect(NetworkSurveyUriString(), this, this->CreatePayload(reason));
 
 	if (blocking) {
@@ -116,7 +116,7 @@ void NetworkSurveyHandler::Transmit(Reason reason, bool blocking)
 
 void NetworkSurveyHandler::OnFailure()
 {
-	Debug(net, Severity::Error, "Survey: failed to send survey results");
+	Debug(Facility::Net, Severity::Error, "Survey: failed to send survey results");
 	this->transmitted = true;
 	this->transmitted_cv.notify_all();
 }
@@ -124,7 +124,7 @@ void NetworkSurveyHandler::OnFailure()
 void NetworkSurveyHandler::OnReceiveData(std::unique_ptr<char[]> data, size_t)
 {
 	if (data == nullptr) {
-		Debug(net, Severity::Error, "Survey: survey results sent");
+		Debug(Facility::Net, Severity::Error, "Survey: survey results sent");
 		this->transmitted = true;
 		this->transmitted_cv.notify_all();
 	}

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -30,7 +30,7 @@ public:
 
 	void OnFailure() override
 	{
-		Debug(net, 9, "Turn::OnFailure()");
+		Debug(net, Severity::Trace3, "Turn::OnFailure()");
 
 		this->handler->connecter = nullptr;
 
@@ -39,7 +39,7 @@ public:
 
 	void OnConnect(SOCKET s) override
 	{
-		Debug(net, 9, "Turn::OnConnect()");
+		Debug(net, Severity::Trace3, "Turn::OnConnect()");
 
 		this->handler->connecter = nullptr;
 
@@ -49,7 +49,7 @@ public:
 
 bool ClientNetworkTurnSocketHandler::ReceiveServerError(Packet &)
 {
-	Debug(net, 9, "ReceiveServerError()");
+	Debug(net, Severity::Trace3, "ReceiveServerError()");
 
 	this->ConnectFailure();
 
@@ -59,7 +59,7 @@ bool ClientNetworkTurnSocketHandler::ReceiveServerError(Packet &)
 bool ClientNetworkTurnSocketHandler::ReceiveServerConnected(Packet &p)
 {
 	std::string hostname = p.Recv_string(NETWORK_HOSTNAME_LENGTH);
-	Debug(net, 9, "Turn::ReceiveServerConnected({})", hostname);
+	Debug(net, Severity::Trace3, "Turn::ReceiveServerConnected({})", hostname);
 
 	/* Act like we no longer have a socket, as we are handing it over to the
 	 * game handler. */
@@ -77,7 +77,7 @@ bool ClientNetworkTurnSocketHandler::ReceiveServerConnected(Packet &p)
  */
 void ClientNetworkTurnSocketHandler::Connect()
 {
-	Debug(net, 9, "Turn::Connect()");
+	Debug(net, Severity::Trace3, "Turn::Connect()");
 
 	this->connect_started = true;
 	this->connecter = TCPConnecter::Create<NetworkTurnConnecter>(this, this->connection_string);
@@ -101,7 +101,7 @@ void ClientNetworkTurnSocketHandler::Connect()
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(ticket);
 
-	Debug(net, 9, "Turn::SendTurn({})", ticket);
+	Debug(net, Severity::Trace3, "Turn::SendTurn({})", ticket);
 	turn_handler->SendPacket(std::move(p));
 
 	return turn_handler;

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -30,7 +30,7 @@ public:
 
 	void OnFailure() override
 	{
-		Debug(net, Severity::Trace3, "Turn::OnFailure()");
+		Debug(Facility::Net, Severity::Trace3, "Turn::OnFailure()");
 
 		this->handler->connecter = nullptr;
 
@@ -39,7 +39,7 @@ public:
 
 	void OnConnect(SOCKET s) override
 	{
-		Debug(net, Severity::Trace3, "Turn::OnConnect()");
+		Debug(Facility::Net, Severity::Trace3, "Turn::OnConnect()");
 
 		this->handler->connecter = nullptr;
 
@@ -49,7 +49,7 @@ public:
 
 bool ClientNetworkTurnSocketHandler::ReceiveServerError(Packet &)
 {
-	Debug(net, Severity::Trace3, "ReceiveServerError()");
+	Debug(Facility::Net, Severity::Trace3, "ReceiveServerError()");
 
 	this->ConnectFailure();
 
@@ -59,7 +59,7 @@ bool ClientNetworkTurnSocketHandler::ReceiveServerError(Packet &)
 bool ClientNetworkTurnSocketHandler::ReceiveServerConnected(Packet &p)
 {
 	std::string hostname = p.Recv_string(NETWORK_HOSTNAME_LENGTH);
-	Debug(net, Severity::Trace3, "Turn::ReceiveServerConnected({})", hostname);
+	Debug(Facility::Net, Severity::Trace3, "Turn::ReceiveServerConnected({})", hostname);
 
 	/* Act like we no longer have a socket, as we are handing it over to the
 	 * game handler. */
@@ -77,7 +77,7 @@ bool ClientNetworkTurnSocketHandler::ReceiveServerConnected(Packet &p)
  */
 void ClientNetworkTurnSocketHandler::Connect()
 {
-	Debug(net, Severity::Trace3, "Turn::Connect()");
+	Debug(Facility::Net, Severity::Trace3, "Turn::Connect()");
 
 	this->connect_started = true;
 	this->connecter = TCPConnecter::Create<NetworkTurnConnecter>(this, this->connection_string);
@@ -101,7 +101,7 @@ void ClientNetworkTurnSocketHandler::Connect()
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	p->Send_string(ticket);
 
-	Debug(net, Severity::Trace3, "Turn::SendTurn({})", ticket);
+	Debug(Facility::Net, Severity::Trace3, "Turn::SendTurn({})", ticket);
 	turn_handler->SendPacket(std::move(p));
 
 	return turn_handler;

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -73,7 +73,7 @@ void ServerNetworkUDPSocketHandler::ReceiveClientFindServer(Packet &, NetworkAdd
 	Packet packet(this, PacketUDPType::ServerResponse);
 	this->SendPacket(packet, client_addr);
 
-	Debug(net, 7, "Queried from {}", client_addr.GetHostname());
+	Debug(net, Severity::Trace1, "Queried from {}", client_addr.GetHostname());
 }
 
 /* Communication with servers (we are client) */
@@ -88,7 +88,7 @@ public:
 
 void ClientNetworkUDPSocketHandler::ReceiveServerResponse(Packet &, NetworkAddress &client_addr)
 {
-	Debug(net, 3, "Server response from {}", client_addr.GetAddressAsString());
+	Debug(net, Severity::Notice, "Server response from {}", client_addr.GetAddressAsString());
 
 	NetworkAddServer(client_addr.GetAddressAsString(false), false, true);
 }
@@ -100,7 +100,7 @@ void ClientNetworkUDPSocketHandler::ReceiveServerResponse(Packet &, NetworkAddre
 static void NetworkUDPBroadCast(NetworkUDPSocketHandler &socket)
 {
 	for (NetworkAddress &addr : _broadcast_list) {
-		Debug(net, 5, "Broadcasting to {}", addr.GetHostname());
+		Debug(net, Severity::Debug1, "Broadcasting to {}", addr.GetHostname());
 
 		Packet p(&socket, PacketUDPType::ClientFindServer);
 		socket.SendPacket(p, addr, true, true);
@@ -113,7 +113,7 @@ void NetworkUDPSearchGame()
 	/* We are still searching.. */
 	if (_network_udp_broadcast > 0) return;
 
-	Debug(net, 3, "Searching server");
+	Debug(net, Severity::Notice, "Searching server");
 
 	NetworkUDPBroadCast(*_udp_client.socket);
 	_network_udp_broadcast = 300; // Stay searching for 300 ticks
@@ -125,7 +125,7 @@ void NetworkUDPInitialize()
 	/* If not closed, then do it. */
 	if (_udp_server.socket != nullptr) NetworkUDPClose();
 
-	Debug(net, 3, "Initializing UDP listeners");
+	Debug(net, Severity::Notice, "Initializing UDP listeners");
 	assert(_udp_client.socket == nullptr && _udp_server.socket == nullptr);
 
 	_udp_client.socket = std::make_unique<ClientNetworkUDPSocketHandler>();
@@ -152,7 +152,7 @@ void NetworkUDPClose()
 
 	_network_udp_server = false;
 	_network_udp_broadcast = 0;
-	Debug(net, 5, "Closed UDP listeners");
+	Debug(net, Severity::Debug1, "Closed UDP listeners");
 }
 
 /** Receive the UDP packets. */

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -73,7 +73,7 @@ void ServerNetworkUDPSocketHandler::ReceiveClientFindServer(Packet &, NetworkAdd
 	Packet packet(this, PacketUDPType::ServerResponse);
 	this->SendPacket(packet, client_addr);
 
-	Debug(net, Severity::Trace1, "Queried from {}", client_addr.GetHostname());
+	Debug(Facility::Net, Severity::Trace1, "Queried from {}", client_addr.GetHostname());
 }
 
 /* Communication with servers (we are client) */
@@ -88,7 +88,7 @@ public:
 
 void ClientNetworkUDPSocketHandler::ReceiveServerResponse(Packet &, NetworkAddress &client_addr)
 {
-	Debug(net, Severity::Notice, "Server response from {}", client_addr.GetAddressAsString());
+	Debug(Facility::Net, Severity::Notice, "Server response from {}", client_addr.GetAddressAsString());
 
 	NetworkAddServer(client_addr.GetAddressAsString(false), false, true);
 }
@@ -100,7 +100,7 @@ void ClientNetworkUDPSocketHandler::ReceiveServerResponse(Packet &, NetworkAddre
 static void NetworkUDPBroadCast(NetworkUDPSocketHandler &socket)
 {
 	for (NetworkAddress &addr : _broadcast_list) {
-		Debug(net, Severity::Debug1, "Broadcasting to {}", addr.GetHostname());
+		Debug(Facility::Net, Severity::Debug1, "Broadcasting to {}", addr.GetHostname());
 
 		Packet p(&socket, PacketUDPType::ClientFindServer);
 		socket.SendPacket(p, addr, true, true);
@@ -113,7 +113,7 @@ void NetworkUDPSearchGame()
 	/* We are still searching.. */
 	if (_network_udp_broadcast > 0) return;
 
-	Debug(net, Severity::Notice, "Searching server");
+	Debug(Facility::Net, Severity::Notice, "Searching server");
 
 	NetworkUDPBroadCast(*_udp_client.socket);
 	_network_udp_broadcast = 300; // Stay searching for 300 ticks
@@ -125,7 +125,7 @@ void NetworkUDPInitialize()
 	/* If not closed, then do it. */
 	if (_udp_server.socket != nullptr) NetworkUDPClose();
 
-	Debug(net, Severity::Notice, "Initializing UDP listeners");
+	Debug(Facility::Net, Severity::Notice, "Initializing UDP listeners");
 	assert(_udp_client.socket == nullptr && _udp_server.socket == nullptr);
 
 	_udp_client.socket = std::make_unique<ClientNetworkUDPSocketHandler>();
@@ -152,7 +152,7 @@ void NetworkUDPClose()
 
 	_network_udp_server = false;
 	_network_udp_broadcast = 0;
-	Debug(net, Severity::Debug1, "Closed UDP listeners");
+	Debug(Facility::Net, Severity::Debug1, "Closed UDP listeners");
 }
 
 /** Receive the UDP packets. */

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -81,7 +81,7 @@ TypedIndexContainer<std::vector<GRFTempEngineData>, EngineID> _gted;  ///< Tempo
 
 /**
  * Debug() function dedicated to newGRF debugging messages
- * Function is essentially the same as Debug(grf, severity, ...) with the
+ * Function is essentially the same as Debug(Facility::Grf, severity, ...) with the
  * addition of file:line information when parsing grf files.
  * @note for the above reason(s) GrfMsg() should ONLY be used for
  * loading/parsing grf files, not for runtime debug messages as there
@@ -92,9 +92,9 @@ TypedIndexContainer<std::vector<GRFTempEngineData>, EngineID> _gted;  ///< Tempo
 void GrfMsgI(Severity severity, const std::string &msg)
 {
 	if (_cur_gps.grfconfig == nullptr) {
-		Debug(grf, severity, "{}", msg);
+		Debug(Facility::Grf, severity, "{}", msg);
 	} else {
-		Debug(grf, severity, "[{}:{}] {}", _cur_gps.grfconfig->filename, _cur_gps.nfo_line, msg);
+		Debug(Facility::Grf, severity, "[{}:{}] {}", _cur_gps.grfconfig->filename, _cur_gps.nfo_line, msg);
 	}
 }
 
@@ -975,7 +975,7 @@ static bool IsHouseSpecValid(HouseSpec &hs, const HouseSpec *next1, const HouseS
 				(next2 == nullptr || !next2->enabled || next2->building_flags.Any(BUILDING_HAS_1_TILE) ||
 				next3 == nullptr || !next3->enabled || next3->building_flags.Any(BUILDING_HAS_1_TILE)))) {
 		hs.enabled = false;
-		if (!filename.empty()) Debug(grf, Severity::Error, "FinaliseHouseArray: {} defines house {} as multitile, but no suitable tiles follow. Disabling house.", filename, hs.grf_prop.local_id);
+		if (!filename.empty()) Debug(Facility::Grf, Severity::Error, "FinaliseHouseArray: {} defines house {} as multitile, but no suitable tiles follow. Disabling house.", filename, hs.grf_prop.local_id);
 		return false;
 	}
 
@@ -985,7 +985,7 @@ static bool IsHouseSpecValid(HouseSpec &hs, const HouseSpec *next1, const HouseS
 	if ((hs.building_flags.Any(BUILDING_HAS_2_TILES) && next1->population != 0) ||
 			(hs.building_flags.Any(BUILDING_HAS_4_TILES) && (next2->population != 0 || next3->population != 0))) {
 		hs.enabled = false;
-		if (!filename.empty()) Debug(grf, Severity::Error, "FinaliseHouseArray: {} defines multitile house {} with non-zero population on additional tiles. Disabling house.", filename, hs.grf_prop.local_id);
+		if (!filename.empty()) Debug(Facility::Grf, Severity::Error, "FinaliseHouseArray: {} defines multitile house {} with non-zero population on additional tiles. Disabling house.", filename, hs.grf_prop.local_id);
 		return false;
 	}
 
@@ -993,14 +993,14 @@ static bool IsHouseSpecValid(HouseSpec &hs, const HouseSpec *next1, const HouseS
 	 * This check should only be done for NewGRF houses because grf_prop.subst_id is not set for original houses.*/
 	if (!filename.empty() && (hs.building_flags & BUILDING_HAS_1_TILE) != (HouseSpec::Get(hs.grf_prop.subst_id)->building_flags & BUILDING_HAS_1_TILE)) {
 		hs.enabled = false;
-		Debug(grf, Severity::Error, "FinaliseHouseArray: {} defines house {} with different house size then it's substitute type. Disabling house.", filename, hs.grf_prop.local_id);
+		Debug(Facility::Grf, Severity::Error, "FinaliseHouseArray: {} defines house {} with different house size then it's substitute type. Disabling house.", filename, hs.grf_prop.local_id);
 		return false;
 	}
 
 	/* Make sure that additional parts of multitile houses are not available. */
 	if (!hs.building_flags.Any(BUILDING_HAS_1_TILE) && hs.building_availability.Any(HZ_ZONE_ALL) && hs.building_availability.Any(HZ_CLIMATE_ALL)) {
 		hs.enabled = false;
-		if (!filename.empty()) Debug(grf, Severity::Error, "FinaliseHouseArray: {} defines house {} without a size but marked it as available. Disabling house.", filename, hs.grf_prop.local_id);
+		if (!filename.empty()) Debug(Facility::Grf, Severity::Error, "FinaliseHouseArray: {} defines house {} without a size but marked it as available. Disabling house.", filename, hs.grf_prop.local_id);
 		return false;
 	}
 
@@ -1300,11 +1300,11 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 	AutoRestoreBackup cur_file(_cur_gps.file, &file);
 	AutoRestoreBackup cur_config(_cur_gps.grfconfig, &config);
 
-	Debug(grf, Severity::Warning, "LoadNewGRFFile: Reading NewGRF-file '{}'", config.filename);
+	Debug(Facility::Grf, Severity::Warning, "LoadNewGRFFile: Reading NewGRF-file '{}'", config.filename);
 
 	uint8_t grf_container_version = file.GetContainerVersion();
 	if (grf_container_version == 0) {
-		Debug(grf, Severity::Trace1, "LoadNewGRFFile: Custom .grf has invalid format");
+		Debug(Facility::Grf, Severity::Trace1, "LoadNewGRFFile: Custom .grf has invalid format");
 		return;
 	}
 
@@ -1321,7 +1321,7 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 		/* Read compression value. */
 		uint8_t compression = file.ReadByte();
 		if (compression != 0) {
-			Debug(grf, Severity::Trace1, "LoadNewGRFFile: Unsupported compression format");
+			Debug(Facility::Grf, Severity::Trace1, "LoadNewGRFFile: Unsupported compression format");
 			return;
 		}
 	}
@@ -1333,7 +1333,7 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 	if (num == 4 && file.ReadByte() == 0xFF) {
 		file.ReadDword();
 	} else {
-		Debug(grf, Severity::Trace1, "LoadNewGRFFile: Custom .grf has invalid format");
+		Debug(Facility::Grf, Severity::Trace1, "LoadNewGRFFile: Custom .grf has invalid format");
 		return;
 	}
 
@@ -1513,7 +1513,7 @@ static void FinalisePriceBaseMultipliers()
 		for (Price p : EnumRange(Price::End)) {
 			/* No price defined -> nothing to do */
 			if (!features.Test(_price_base_specs[p].grf_feature) || source.price_base_multipliers[p] == INVALID_PRICE_MODIFIER) continue;
-			Debug(grf, Severity::Notice, "'{}' overrides price base multiplier {} of '{}'", source.filename, p, dest.filename);
+			Debug(Facility::Grf, Severity::Notice, "'{}' overrides price base multiplier {} of '{}'", source.filename, p, dest.filename);
 			dest.price_base_multipliers[p] = source.price_base_multipliers[p];
 		}
 	}
@@ -1531,7 +1531,7 @@ static void FinalisePriceBaseMultipliers()
 		for (Price p : EnumRange(Price::End)) {
 			/* Already a price defined -> nothing to do */
 			if (!features.Test(_price_base_specs[p].grf_feature) || dest.price_base_multipliers[p] != INVALID_PRICE_MODIFIER) continue;
-			Debug(grf, Severity::Notice, "Price base multiplier {} from '{}' propagated to '{}'", p, source.filename, dest.filename);
+			Debug(Facility::Grf, Severity::Notice, "Price base multiplier {} from '{}' propagated to '{}'", p, source.filename, dest.filename);
 			dest.price_base_multipliers[p] = source.price_base_multipliers[p];
 		}
 	}
@@ -1549,7 +1549,7 @@ static void FinalisePriceBaseMultipliers()
 		for (Price p : EnumRange(Price::End)) {
 			if (!features.Test(_price_base_specs[p].grf_feature)) continue;
 			if (source.price_base_multipliers[p] != dest.price_base_multipliers[p]) {
-				Debug(grf, Severity::Notice, "Price base multiplier {} from '{}' propagated to '{}'", p, dest.filename, source.filename);
+				Debug(Facility::Grf, Severity::Notice, "Price base multiplier {} from '{}' propagated to '{}'", p, dest.filename, source.filename);
 			}
 			source.price_base_multipliers[p] = dest.price_base_multipliers[p];
 		}
@@ -1580,11 +1580,11 @@ static void FinalisePriceBaseMultipliers()
 				if (!file.grf_features.Test(_price_base_specs[p].grf_feature)) {
 					/* The grf does not define any objects of the feature,
 					 * so it must be a difficulty setting. Apply it globally */
-					Debug(grf, Severity::Notice, "'{}' sets global price base multiplier {}", file.filename, p);
+					Debug(Facility::Grf, Severity::Notice, "'{}' sets global price base multiplier {}", file.filename, p);
 					SetPriceBaseMultiplier(p, price_base_multipliers[p]);
 					price_base_multipliers[p] = 0;
 				} else {
-					Debug(grf, Severity::Notice, "'{}' sets local price base multiplier {}", file.filename, p);
+					Debug(Facility::Grf, Severity::Notice, "'{}' sets local price base multiplier {}", file.filename, p);
 				}
 			}
 		}
@@ -1835,7 +1835,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 
 			Subdirectory subdir = num_grfs < num_baseset ? Subdirectory::Baseset : Subdirectory::NewGrf;
 			if (!FioCheckFileExists(c->filename, subdir)) {
-				Debug(grf, Severity::Critical, "NewGRF file is missing '{}'; disabling", c->filename);
+				Debug(Facility::Grf, Severity::Critical, "NewGRF file is missing '{}'; disabling", c->filename);
 				c->status = GRFStatus::NotFound;
 				continue;
 			}
@@ -1844,7 +1844,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 
 			if (!c->flags.Test(GRFConfigFlag::Static) && !c->flags.Test(GRFConfigFlag::System)) {
 				if (num_non_static == NETWORK_MAX_GRF_COUNT) {
-					Debug(grf, Severity::Critical, "'{}' is not loaded as the maximum number of non-static GRFs has been reached", c->filename);
+					Debug(Facility::Grf, Severity::Critical, "'{}' is not loaded as the maximum number of non-static GRFs has been reached", c->filename);
 					c->status = GRFStatus::Disabled;
 					c->errors.emplace_back(STR_NEWGRF_ERROR_MSG_FATAL, 0, STR_NEWGRF_ERROR_TOO_MANY_NEWGRFS_LOADED);
 					continue;
@@ -1862,7 +1862,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 				assert(GetFileByGRFID(c->ident.grfid) == _cur_gps.grffile);
 				ClearTemporaryNewGRFData(_cur_gps.grffile);
 				BuildCargoTranslationMap();
-				Debug(sprite, Severity::Warning, "LoadNewGRF: Currently {} sprites are loaded", _cur_gps.spriteid);
+				Debug(Facility::Sprite, Severity::Warning, "LoadNewGRF: Currently {} sprites are loaded", _cur_gps.spriteid);
 			} else if (stage == GrfLoadingStage::Init && c->flags.Test(GRFConfigFlag::InitOnly)) {
 				/* We're not going to activate this, so free whatever data we allocated */
 				ClearTemporaryNewGRFData(_cur_gps.grffile);

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -89,7 +89,7 @@ TypedIndexContainer<std::vector<GRFTempEngineData>, EngineID> _gted;  ///< Tempo
  * @param severity debugging severity level, see debug.h
  * @param msg the message
  */
-void GrfMsgI(int severity, const std::string &msg)
+void GrfMsgI(Severity severity, const std::string &msg)
 {
 	if (_cur_gps.grfconfig == nullptr) {
 		Debug(grf, severity, "{}", msg);
@@ -187,10 +187,10 @@ void SetNewGRFOverride(GrfID source_grfid, GrfID target_grfid)
 {
 	if (target_grfid.Empty()) {
 		_grf_id_overrides.erase(source_grfid);
-		GrfMsg(5, "SetNewGRFOverride: Removed override of {}", FormatArrayAsHex(source_grfid));
+		GrfMsg(Severity::Debug1, "SetNewGRFOverride: Removed override of {}", FormatArrayAsHex(source_grfid));
 	} else {
 		_grf_id_overrides[source_grfid] = target_grfid;
-		GrfMsg(5, "SetNewGRFOverride: Added override of {} to {}", FormatArrayAsHex(source_grfid), FormatArrayAsHex(target_grfid));
+		GrfMsg(Severity::Debug1, "SetNewGRFOverride: Added override of {} to {}", FormatArrayAsHex(source_grfid), FormatArrayAsHex(target_grfid));
 	}
 }
 
@@ -228,9 +228,9 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
 			scope_grfid = it->second;
 			const GRFFile *grf_match = GetFileByGRFID(scope_grfid);
 			if (grf_match == nullptr) {
-				GrfMsg(5, "Tried mapping from GRFID {} to {} but target is not loaded", FormatArrayAsHex(file->grfid), FormatArrayAsHex(scope_grfid));
+				GrfMsg(Severity::Debug1, "Tried mapping from GRFID {} to {} but target is not loaded", FormatArrayAsHex(file->grfid), FormatArrayAsHex(scope_grfid));
 			} else {
-				GrfMsg(5, "Mapping from GRFID {} to {}", FormatArrayAsHex(file->grfid), FormatArrayAsHex(scope_grfid));
+				GrfMsg(Severity::Debug1, "Mapping from GRFID {} to {}", FormatArrayAsHex(file->grfid), FormatArrayAsHex(scope_grfid));
 			}
 		}
 
@@ -252,7 +252,7 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
 
 		if (!e->grf_prop.HasGrfFile()) {
 			e->grf_prop.SetGRFFile(file);
-			GrfMsg(5, "Replaced engine at index {} for GRFID {}, type {}, index {}", e->index, FormatArrayAsHex(file->grfid), type, internal_id);
+			GrfMsg(Severity::Debug1, "Replaced engine at index {} for GRFID {}, type {}, index {}", e->index, FormatArrayAsHex(file->grfid), type, internal_id);
 		}
 
 		return e;
@@ -261,7 +261,7 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
 	if (static_access) return nullptr;
 
 	if (!Engine::CanAllocateItem()) {
-		GrfMsg(0, "Can't allocate any more engines");
+		GrfMsg(Severity::Critical, "Can't allocate any more engines");
 		return nullptr;
 	}
 
@@ -283,7 +283,7 @@ Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t internal_id
 		for (RailType rt : e->VehInfo<RailVehicleInfo>().railtypes) _gted[e->index].railtypelabels.push_back(GetRailTypeInfo(rt)->label);
 	}
 
-	GrfMsg(5, "Created new engine at index {} for GRFID {}, type {}, index {}", e->index, FormatArrayAsHex(file->grfid), type, internal_id);
+	GrfMsg(Severity::Debug1, "Created new engine at index {} for GRFID {}, type {}, index {}", e->index, FormatArrayAsHex(file->grfid), type, internal_id);
 
 	return e;
 }
@@ -348,7 +348,7 @@ void ConvertTTDBasePrice(uint32_t base_pointer, std::string_view error_location,
 	static const uint32_t size  = 6;      ///< Size of each base price record
 
 	if (base_pointer < start || (base_pointer - start) % size != 0 || (base_pointer - start) / size >= to_underlying(Price::End)) {
-		GrfMsg(1, "{}: Unsupported running cost base 0x{:04X}, ignoring", error_location, base_pointer);
+		GrfMsg(Severity::Error, "{}: Unsupported running cost base 0x{:04X}, ignoring", error_location, base_pointer);
 		return;
 	}
 
@@ -924,7 +924,7 @@ static void FinaliseEngineArray()
 			/* Engine looped back on itself, so clear the variant. */
 			e->info.variant_id = EngineID::Invalid();
 
-			GrfMsg(1, "FinaliseEngineArray: Variant of engine {:x} in '{}' loops back on itself", e->grf_prop.local_id, e->GetGRF()->filename);
+			GrfMsg(Severity::Error, "FinaliseEngineArray: Variant of engine {:x} in '{}' loops back on itself", e->grf_prop.local_id, e->GetGRF()->filename);
 			break;
 		}
 
@@ -975,7 +975,7 @@ static bool IsHouseSpecValid(HouseSpec &hs, const HouseSpec *next1, const HouseS
 				(next2 == nullptr || !next2->enabled || next2->building_flags.Any(BUILDING_HAS_1_TILE) ||
 				next3 == nullptr || !next3->enabled || next3->building_flags.Any(BUILDING_HAS_1_TILE)))) {
 		hs.enabled = false;
-		if (!filename.empty()) Debug(grf, 1, "FinaliseHouseArray: {} defines house {} as multitile, but no suitable tiles follow. Disabling house.", filename, hs.grf_prop.local_id);
+		if (!filename.empty()) Debug(grf, Severity::Error, "FinaliseHouseArray: {} defines house {} as multitile, but no suitable tiles follow. Disabling house.", filename, hs.grf_prop.local_id);
 		return false;
 	}
 
@@ -985,7 +985,7 @@ static bool IsHouseSpecValid(HouseSpec &hs, const HouseSpec *next1, const HouseS
 	if ((hs.building_flags.Any(BUILDING_HAS_2_TILES) && next1->population != 0) ||
 			(hs.building_flags.Any(BUILDING_HAS_4_TILES) && (next2->population != 0 || next3->population != 0))) {
 		hs.enabled = false;
-		if (!filename.empty()) Debug(grf, 1, "FinaliseHouseArray: {} defines multitile house {} with non-zero population on additional tiles. Disabling house.", filename, hs.grf_prop.local_id);
+		if (!filename.empty()) Debug(grf, Severity::Error, "FinaliseHouseArray: {} defines multitile house {} with non-zero population on additional tiles. Disabling house.", filename, hs.grf_prop.local_id);
 		return false;
 	}
 
@@ -993,14 +993,14 @@ static bool IsHouseSpecValid(HouseSpec &hs, const HouseSpec *next1, const HouseS
 	 * This check should only be done for NewGRF houses because grf_prop.subst_id is not set for original houses.*/
 	if (!filename.empty() && (hs.building_flags & BUILDING_HAS_1_TILE) != (HouseSpec::Get(hs.grf_prop.subst_id)->building_flags & BUILDING_HAS_1_TILE)) {
 		hs.enabled = false;
-		Debug(grf, 1, "FinaliseHouseArray: {} defines house {} with different house size then it's substitute type. Disabling house.", filename, hs.grf_prop.local_id);
+		Debug(grf, Severity::Error, "FinaliseHouseArray: {} defines house {} with different house size then it's substitute type. Disabling house.", filename, hs.grf_prop.local_id);
 		return false;
 	}
 
 	/* Make sure that additional parts of multitile houses are not available. */
 	if (!hs.building_flags.Any(BUILDING_HAS_1_TILE) && hs.building_availability.Any(HZ_ZONE_ALL) && hs.building_availability.Any(HZ_CLIMATE_ALL)) {
 		hs.enabled = false;
-		if (!filename.empty()) Debug(grf, 1, "FinaliseHouseArray: {} defines house {} without a size but marked it as available. Disabling house.", filename, hs.grf_prop.local_id);
+		if (!filename.empty()) Debug(grf, Severity::Error, "FinaliseHouseArray: {} defines house {} without a size but marked it as available. Disabling house.", filename, hs.grf_prop.local_id);
 		return false;
 	}
 
@@ -1238,9 +1238,9 @@ struct InvokeGrfActionHandler {
 	{
 		Invoker func = action < std::size(funcs) ? funcs[action] : nullptr;
 		if (func == nullptr) {
-			GrfMsg(7, "DecodeSpecialSprite: Skipping unknown action 0x{:02X}", action);
+			GrfMsg(Severity::Trace1, "DecodeSpecialSprite: Skipping unknown action 0x{:02X}", action);
 		} else {
-			GrfMsg(7, "DecodeSpecialSprite: Handling action 0x{:02X} in stage {}", action, stage);
+			GrfMsg(Severity::Trace1, "DecodeSpecialSprite: Handling action 0x{:02X} in stage {}", action, stage);
 			func(buf, stage);
 		}
 	}
@@ -1265,7 +1265,7 @@ static void DecodeSpecialSprite(ReusableBuffer<uint8_t> &allocator, uint num, Gr
 		/* Use the preloaded sprite data. */
 		buf = it->second.data();
 		assert(it->second.size() == num);
-		GrfMsg(7, "DecodeSpecialSprite: Using preloaded pseudo sprite data");
+		GrfMsg(Severity::Trace1, "DecodeSpecialSprite: Using preloaded pseudo sprite data");
 
 		/* Skip the real (original) content of this action. */
 		_cur_gps.file->SeekTo(num, SEEK_CUR);
@@ -1277,14 +1277,14 @@ static void DecodeSpecialSprite(ReusableBuffer<uint8_t> &allocator, uint num, Gr
 		uint8_t action = br.ReadByte();
 
 		if (action == 0xFF) {
-			GrfMsg(2, "DecodeSpecialSprite: Unexpected data block, skipping");
+			GrfMsg(Severity::Warning, "DecodeSpecialSprite: Unexpected data block, skipping");
 		} else if (action == 0xFE) {
-			GrfMsg(2, "DecodeSpecialSprite: Unexpected import block, skipping");
+			GrfMsg(Severity::Warning, "DecodeSpecialSprite: Unexpected import block, skipping");
 		} else {
 			InvokeGrfActionHandler::Invoke(action, stage, br);
 		}
 	} catch (...) {
-		GrfMsg(1, "DecodeSpecialSprite: Tried to read past end of pseudo-sprite data");
+		GrfMsg(Severity::Error, "DecodeSpecialSprite: Tried to read past end of pseudo-sprite data");
 		DisableGrf(STR_NEWGRF_ERROR_READ_BOUNDS);
 	}
 }
@@ -1300,11 +1300,11 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 	AutoRestoreBackup cur_file(_cur_gps.file, &file);
 	AutoRestoreBackup cur_config(_cur_gps.grfconfig, &config);
 
-	Debug(grf, 2, "LoadNewGRFFile: Reading NewGRF-file '{}'", config.filename);
+	Debug(grf, Severity::Warning, "LoadNewGRFFile: Reading NewGRF-file '{}'", config.filename);
 
 	uint8_t grf_container_version = file.GetContainerVersion();
 	if (grf_container_version == 0) {
-		Debug(grf, 7, "LoadNewGRFFile: Custom .grf has invalid format");
+		Debug(grf, Severity::Trace1, "LoadNewGRFFile: Custom .grf has invalid format");
 		return;
 	}
 
@@ -1321,7 +1321,7 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 		/* Read compression value. */
 		uint8_t compression = file.ReadByte();
 		if (compression != 0) {
-			Debug(grf, 7, "LoadNewGRFFile: Unsupported compression format");
+			Debug(grf, Severity::Trace1, "LoadNewGRFFile: Unsupported compression format");
 			return;
 		}
 	}
@@ -1333,7 +1333,7 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 	if (num == 4 && file.ReadByte() == 0xFF) {
 		file.ReadDword();
 	} else {
-		Debug(grf, 7, "LoadNewGRFFile: Custom .grf has invalid format");
+		Debug(grf, Severity::Trace1, "LoadNewGRFFile: Custom .grf has invalid format");
 		return;
 	}
 
@@ -1349,7 +1349,7 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 			if (_cur_gps.skip_sprites == 0) {
 				/* Limit the special sprites to 1 MiB. */
 				if (num > 1024 * 1024) {
-					GrfMsg(0, "LoadNewGRFFile: Unexpectedly large sprite, disabling");
+					GrfMsg(Severity::Critical, "LoadNewGRFFile: Unexpectedly large sprite, disabling");
 					DisableGrf(STR_NEWGRF_ERROR_UNEXPECTED_SPRITE);
 					break;
 				}
@@ -1365,7 +1365,7 @@ static void LoadNewGRFFileFromFile(GRFConfig &config, GrfLoadingStage stage, Spr
 			}
 		} else {
 			if (_cur_gps.skip_sprites == 0) {
-				GrfMsg(0, "LoadNewGRFFile: Unexpected sprite, disabling");
+				GrfMsg(Severity::Critical, "LoadNewGRFFile: Unexpected sprite, disabling");
 				DisableGrf(STR_NEWGRF_ERROR_UNEXPECTED_SPRITE);
 				break;
 			}
@@ -1513,7 +1513,7 @@ static void FinalisePriceBaseMultipliers()
 		for (Price p : EnumRange(Price::End)) {
 			/* No price defined -> nothing to do */
 			if (!features.Test(_price_base_specs[p].grf_feature) || source.price_base_multipliers[p] == INVALID_PRICE_MODIFIER) continue;
-			Debug(grf, 3, "'{}' overrides price base multiplier {} of '{}'", source.filename, p, dest.filename);
+			Debug(grf, Severity::Notice, "'{}' overrides price base multiplier {} of '{}'", source.filename, p, dest.filename);
 			dest.price_base_multipliers[p] = source.price_base_multipliers[p];
 		}
 	}
@@ -1531,7 +1531,7 @@ static void FinalisePriceBaseMultipliers()
 		for (Price p : EnumRange(Price::End)) {
 			/* Already a price defined -> nothing to do */
 			if (!features.Test(_price_base_specs[p].grf_feature) || dest.price_base_multipliers[p] != INVALID_PRICE_MODIFIER) continue;
-			Debug(grf, 3, "Price base multiplier {} from '{}' propagated to '{}'", p, source.filename, dest.filename);
+			Debug(grf, Severity::Notice, "Price base multiplier {} from '{}' propagated to '{}'", p, source.filename, dest.filename);
 			dest.price_base_multipliers[p] = source.price_base_multipliers[p];
 		}
 	}
@@ -1549,7 +1549,7 @@ static void FinalisePriceBaseMultipliers()
 		for (Price p : EnumRange(Price::End)) {
 			if (!features.Test(_price_base_specs[p].grf_feature)) continue;
 			if (source.price_base_multipliers[p] != dest.price_base_multipliers[p]) {
-				Debug(grf, 3, "Price base multiplier {} from '{}' propagated to '{}'", p, dest.filename, source.filename);
+				Debug(grf, Severity::Notice, "Price base multiplier {} from '{}' propagated to '{}'", p, dest.filename, source.filename);
 			}
 			source.price_base_multipliers[p] = dest.price_base_multipliers[p];
 		}
@@ -1580,11 +1580,11 @@ static void FinalisePriceBaseMultipliers()
 				if (!file.grf_features.Test(_price_base_specs[p].grf_feature)) {
 					/* The grf does not define any objects of the feature,
 					 * so it must be a difficulty setting. Apply it globally */
-					Debug(grf, 3, "'{}' sets global price base multiplier {}", file.filename, p);
+					Debug(grf, Severity::Notice, "'{}' sets global price base multiplier {}", file.filename, p);
 					SetPriceBaseMultiplier(p, price_base_multipliers[p]);
 					price_base_multipliers[p] = 0;
 				} else {
-					Debug(grf, 3, "'{}' sets local price base multiplier {}", file.filename, p);
+					Debug(grf, Severity::Notice, "'{}' sets local price base multiplier {}", file.filename, p);
 				}
 			}
 		}
@@ -1835,7 +1835,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 
 			Subdirectory subdir = num_grfs < num_baseset ? Subdirectory::Baseset : Subdirectory::NewGrf;
 			if (!FioCheckFileExists(c->filename, subdir)) {
-				Debug(grf, 0, "NewGRF file is missing '{}'; disabling", c->filename);
+				Debug(grf, Severity::Critical, "NewGRF file is missing '{}'; disabling", c->filename);
 				c->status = GRFStatus::NotFound;
 				continue;
 			}
@@ -1844,7 +1844,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 
 			if (!c->flags.Test(GRFConfigFlag::Static) && !c->flags.Test(GRFConfigFlag::System)) {
 				if (num_non_static == NETWORK_MAX_GRF_COUNT) {
-					Debug(grf, 0, "'{}' is not loaded as the maximum number of non-static GRFs has been reached", c->filename);
+					Debug(grf, Severity::Critical, "'{}' is not loaded as the maximum number of non-static GRFs has been reached", c->filename);
 					c->status = GRFStatus::Disabled;
 					c->errors.emplace_back(STR_NEWGRF_ERROR_MSG_FATAL, 0, STR_NEWGRF_ERROR_TOO_MANY_NEWGRFS_LOADED);
 					continue;
@@ -1862,7 +1862,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 				assert(GetFileByGRFID(c->ident.grfid) == _cur_gps.grffile);
 				ClearTemporaryNewGRFData(_cur_gps.grffile);
 				BuildCargoTranslationMap();
-				Debug(sprite, 2, "LoadNewGRF: Currently {} sprites are loaded", _cur_gps.spriteid);
+				Debug(sprite, Severity::Warning, "LoadNewGRF: Currently {} sprites are loaded", _cur_gps.spriteid);
 			} else if (stage == GrfLoadingStage::Init && c->flags.Test(GRFConfigFlag::InitOnly)) {
 				/* We're not going to activate this, so free whatever data we allocated */
 				ClearTemporaryNewGRFData(_cur_gps.grffile);

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -241,7 +241,7 @@ void ResetNewGRFData();
 void ResetPersistentNewGRFData();
 
 void GrfMsgI(Severity severity, const std::string &msg);
-#define GrfMsg(severity, format_string, ...) do { if ((severity) == Severity::Critical || _debug_grf_level >= (severity)) GrfMsgI(severity, fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__)); } while (false)
+#define GrfMsg(severity, format_string, ...) do { if ((severity) == Severity::Critical || IsVisibleSeverity(Facility::Grf, (severity))) GrfMsgI(severity, fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__)); } while (false)
 
 bool GetGlobalVariable(uint8_t param, uint32_t *value, const GRFFile *grffile);
 

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -11,6 +11,7 @@
 #define NEWGRF_H
 
 #include "cargotype.h"
+#include "debug_type.h"
 #include "livery.h"
 #include "rail_type.h"
 #include "road_type.h"
@@ -239,8 +240,8 @@ void ReloadNewGRFData(); // in saveload/afterload.cpp
 void ResetNewGRFData();
 void ResetPersistentNewGRFData();
 
-void GrfMsgI(int severity, const std::string &msg);
-#define GrfMsg(severity, format_string, ...) do { if ((severity) == 0 || _debug_grf_level >= (severity)) GrfMsgI(severity, fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__)); } while (false)
+void GrfMsgI(Severity severity, const std::string &msg);
+#define GrfMsg(severity, format_string, ...) do { if ((severity) == Severity::Critical || _debug_grf_level >= (severity)) GrfMsgI(severity, fmt::format(FMT_STRING(format_string) __VA_OPT__(,) __VA_ARGS__)); } while (false)
 
 bool GetGlobalVariable(uint8_t param, uint32_t *value, const GRFFile *grffile);
 

--- a/src/newgrf/newgrf_act0.cpp
+++ b/src/newgrf/newgrf_act0.cpp
@@ -93,7 +93,7 @@ std::vector<BadgeID> ReadBadgeList(ByteReader &buf, GrfSpecFeature feature)
 	while (count-- > 0) {
 		uint16_t local_index = buf.ReadWord();
 		if (local_index >= std::size(_cur_gps.grffile->badge_list)) {
-			GrfMsg(1, "ReadBadgeList: Badge label {} out of range (max {}), skipping.", local_index, std::size(_cur_gps.grffile->badge_list) - 1);
+			GrfMsg(Severity::Error, "ReadBadgeList: Badge label {} out of range (max {}), skipping.", local_index, std::size(_cur_gps.grffile->badge_list) - 1);
 			continue;
 		}
 
@@ -122,11 +122,11 @@ bool HandleChangeInfoResult(std::string_view caller, ChangeInfoResult cir, GrfSp
 			return false;
 
 		case ChangeInfoResult::Unhandled:
-			GrfMsg(1, "{}: Ignoring property 0x{:02X} of feature 0x{:02X} (not implemented)", caller, property, feature);
+			GrfMsg(Severity::Error, "{}: Ignoring property 0x{:02X} of feature 0x{:02X} (not implemented)", caller, property, feature);
 			return false;
 
 		case ChangeInfoResult::Unknown:
-			GrfMsg(0, "{}: Unknown property 0x{:02X} of feature 0x{:02X}, disabling", caller, property, feature);
+			GrfMsg(Severity::Critical, "{}: Unknown property 0x{:02X} of feature 0x{:02X}, disabling", caller, property, feature);
 			[[fallthrough]];
 
 		case ChangeInfoResult::InvalidId: {
@@ -211,18 +211,18 @@ static void FeatureChangeInfo(ByteReader &buf)
 	uint engine   = buf.ReadExtendedByte();
 
 	if (feature >= GrfSpecFeature::End) {
-		GrfMsg(1, "FeatureChangeInfo: Unsupported feature 0x{:02X}, skipping", feature);
+		GrfMsg(Severity::Error, "FeatureChangeInfo: Unsupported feature 0x{:02X}, skipping", feature);
 		return;
 	}
 
-	GrfMsg(6, "FeatureChangeInfo: Feature 0x{:02X}, {} properties, to apply to {}+{}",
+	GrfMsg(Severity::Debug2, "FeatureChangeInfo: Feature 0x{:02X}, {} properties, to apply to {}+{}",
 	               feature, numprops, engine, numinfo);
 
 	/* Test if feature handles change. */
 	ChangeInfoResult cir_test = InvokeGrfChangeInfoHandler::Invoke(feature, 0, 0, 0, buf, GrfLoadingStage::Activation);
 	if (cir_test == ChangeInfoResult::Unhandled) return;
 	if (cir_test == ChangeInfoResult::Unknown) {
-		GrfMsg(1, "FeatureChangeInfo: Unsupported feature 0x{:02X}, skipping", feature);
+		GrfMsg(Severity::Error, "FeatureChangeInfo: Unsupported feature 0x{:02X}, skipping", feature);
 		return;
 	}
 
@@ -280,7 +280,7 @@ static void ReserveChangeInfo(ByteReader &buf)
 	ChangeInfoResult cir_test = InvokeGrfChangeInfoHandler::Invoke(feature, 0, 0, 0, buf, GrfLoadingStage::Reserve);
 	if (cir_test == ChangeInfoResult::Unhandled) return;
 	if (cir_test == ChangeInfoResult::Unknown) {
-		GrfMsg(1, "ReserveChangeInfo: Unsupported feature 0x{:02X}, skipping", feature);
+		GrfMsg(Severity::Error, "ReserveChangeInfo: Unsupported feature 0x{:02X}, skipping", feature);
 		return;
 	}
 

--- a/src/newgrf/newgrf_act0_aircraft.cpp
+++ b/src/newgrf/newgrf_act0_aircraft.cpp
@@ -50,7 +50,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint first, uint last, int pro
 				if (IsValidNewGRFImageIndex<VehicleType::Aircraft>(spriteid)) {
 					avi->image_index = spriteid;
 				} else {
-					GrfMsg(1, "AircraftVehicleChangeInfo: Invalid Sprite {} specified, ignoring", orig_spriteid);
+					GrfMsg(Severity::Error, "AircraftVehicleChangeInfo: Invalid Sprite {} specified, ignoring", orig_spriteid);
 					avi->image_index = 0;
 				}
 				break;

--- a/src/newgrf/newgrf_act0_airports.cpp
+++ b/src/newgrf/newgrf_act0_airports.cpp
@@ -52,7 +52,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > NUM_AIRPORTS_PER_GRF) {
-		GrfMsg(1, "AirportChangeInfo: Too many airports, trying id ({}), max ({}). Ignoring.", last, NUM_AIRPORTS_PER_GRF);
+		GrfMsg(Severity::Error, "AirportChangeInfo: Too many airports, trying id ({}), max ({}). Ignoring.", last, NUM_AIRPORTS_PER_GRF);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -63,7 +63,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 		auto &as = _cur_gps.grffile->airportspec[id];
 
 		if (as == nullptr && prop != 0x08 && prop != 0x09) {
-			GrfMsg(2, "AirportChangeInfo: Attempt to modify undefined airport {}, ignoring", id);
+			GrfMsg(Severity::Warning, "AirportChangeInfo: Attempt to modify undefined airport {}, ignoring", id);
 			return ChangeInfoResult::InvalidId;
 		}
 
@@ -77,7 +77,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 					continue;
 				} else if (subs_id >= NEW_AIRPORT_OFFSET) {
 					/* The substitute id must be one of the original airports. */
-					GrfMsg(2, "AirportChangeInfo: Attempt to use new airport {} as substitute airport for {}. Ignoring.", subs_id, id);
+					GrfMsg(Severity::Warning, "AirportChangeInfo: Attempt to use new airport {} as substitute airport for {}. Ignoring.", subs_id, id);
 					continue;
 				}
 
@@ -116,7 +116,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 
 					for (;;) {
 						if (definition_end < buf.GetBytesRead()) {
-							GrfMsg(3, "AirportChangeInfo: Incorrect size for airport tile layout definition for airport {}.", id);
+							GrfMsg(Severity::Notice, "AirportChangeInfo: Incorrect size for airport tile layout definition for airport {}.", id);
 							/* Avoid warning twice */
 							definition_end = SIZE_MAX;
 						}
@@ -140,7 +140,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 							uint16_t tempid = _airporttile_mngr.GetID(local_tile_id, _cur_gps.grffile->grfid);
 
 							if (tempid == INVALID_AIRPORTTILE) {
-								GrfMsg(2, "AirportChangeInfo: Attempt to use airport tile {} with airport id {}, not yet defined. Ignoring.", local_tile_id, id);
+								GrfMsg(Severity::Warning, "AirportChangeInfo: Attempt to use airport tile {} with airport id {}, not yet defined. Ignoring.", local_tile_id, id);
 								invalid_layout = true;
 							} else {
 								/* Declared as been valid, can be used */
@@ -150,7 +150,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 							tile.ti.x = static_cast<int8_t>(GB(tile.ti.x, 0, 8));
 							tile.ti.y = static_cast<int8_t>(GB(tile.ti.y, 0, 8));
 						} else if (tile.gfx >= NEW_AIRPORTTILE_OFFSET) {
-							GrfMsg(2, "AirportChangeInfo: Attempt to use invalid airport tile {} with airport id {}. Ignoring.", tile.gfx, id);
+							GrfMsg(Severity::Warning, "AirportChangeInfo: Attempt to use invalid airport tile {} with airport id {}. Ignoring.", tile.gfx, id);
 							invalid_layout = true;
 						}
 
@@ -168,7 +168,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 
 					if (!ValidateAirportLayout(layout)) {
 						/* The airport layout was not valid, so skip this one. */
-						GrfMsg(1, "AirportChangeInfo: Invalid airport layout for airport id {}. Ignoring", id);
+						GrfMsg(Severity::Error, "AirportChangeInfo: Invalid airport layout for airport id {}. Ignoring", id);
 					} else {
 						layouts.push_back(layout);
 					}
@@ -223,7 +223,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > NUM_AIRPORTTILES_PER_GRF) {
-		GrfMsg(1, "AirportTileChangeInfo: Too many airport tiles loaded ({}), max ({}). Ignoring.", last, NUM_AIRPORTTILES_PER_GRF);
+		GrfMsg(Severity::Error, "AirportTileChangeInfo: Too many airport tiles loaded ({}), max ({}). Ignoring.", last, NUM_AIRPORTTILES_PER_GRF);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -234,7 +234,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 		auto &tsp = _cur_gps.grffile->airtspec[id];
 
 		if (prop != 0x08 && tsp == nullptr) {
-			GrfMsg(2, "AirportTileChangeInfo: Attempt to modify undefined airport tile {}. Ignoring.", id);
+			GrfMsg(Severity::Warning, "AirportTileChangeInfo: Attempt to modify undefined airport tile {}. Ignoring.", id);
 			return ChangeInfoResult::InvalidId;
 		}
 
@@ -243,7 +243,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 				uint8_t subs_id = buf.ReadByte();
 				if (subs_id >= NEW_AIRPORTTILE_OFFSET) {
 					/* The substitute id must be one of the original airport tiles. */
-					GrfMsg(2, "AirportTileChangeInfo: Attempt to use new airport tile {} as substitute airport tile for {}. Ignoring.", subs_id, id);
+					GrfMsg(Severity::Warning, "AirportTileChangeInfo: Attempt to use new airport tile {} as substitute airport tile for {}. Ignoring.", subs_id, id);
 					continue;
 				}
 
@@ -268,7 +268,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 
 				/* The airport tile being overridden must be an original airport tile. */
 				if (override_id >= NEW_AIRPORTTILE_OFFSET) {
-					GrfMsg(2, "AirportTileChangeInfo: Attempt to override new airport tile {} with airport tile id {}. Ignoring.", override_id, id);
+					GrfMsg(Severity::Warning, "AirportTileChangeInfo: Attempt to override new airport tile {} with airport tile id {}. Ignoring.", override_id, id);
 					continue;
 				}
 

--- a/src/newgrf/newgrf_act0_badges.cpp
+++ b/src/newgrf/newgrf_act0_badges.cpp
@@ -21,14 +21,14 @@ static ChangeInfoResult BadgeChangeInfo(uint first, uint last, int prop, ByteRea
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last >= UINT16_MAX) {
-		GrfMsg(1, "BadgeChangeInfo: Tag {} is invalid, max {}, ignoring", last, UINT16_MAX - 1);
+		GrfMsg(Severity::Error, "BadgeChangeInfo: Tag {} is invalid, max {}, ignoring", last, UINT16_MAX - 1);
 		return ChangeInfoResult::InvalidId;
 	}
 
 	for (uint id = first; id < last; ++id) {
 		auto it = _cur_gps.grffile->badge_map.find(id);
 		if (prop != 0x08 && it == std::end(_cur_gps.grffile->badge_map)) {
-			GrfMsg(1, "BadgeChangeInfo: Attempt to modify undefined tag {}, ignoring", id);
+			GrfMsg(Severity::Error, "BadgeChangeInfo: Attempt to modify undefined tag {}, ignoring", id);
 			return ChangeInfoResult::InvalidId;
 		}
 

--- a/src/newgrf/newgrf_act0_bridges.cpp
+++ b/src/newgrf/newgrf_act0_bridges.cpp
@@ -29,7 +29,7 @@ static ChangeInfoResult BridgeChangeInfo(uint first, uint last, int prop, ByteRe
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > MAX_BRIDGES) {
-		GrfMsg(1, "BridgeChangeInfo: Bridge {} is invalid, max {}, ignoring", last, MAX_BRIDGES);
+		GrfMsg(Severity::Error, "BridgeChangeInfo: Bridge {} is invalid, max {}, ignoring", last, MAX_BRIDGES);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -74,7 +74,7 @@ static ChangeInfoResult BridgeChangeInfo(uint first, uint last, int prop, ByteRe
 
 				for (; numtables-- != 0; tableid++) {
 					if (tableid >= NUM_BRIDGE_PIECES) { // skip invalid data
-						GrfMsg(1, "BridgeChangeInfo: Table {} >= {}, skipping", tableid, NUM_BRIDGE_PIECES);
+						GrfMsg(Severity::Error, "BridgeChangeInfo: Table {} >= {}, skipping", tableid, NUM_BRIDGE_PIECES);
 						for (uint8_t sprite = 0; sprite < SPRITES_PER_BRIDGE_PIECE; sprite++) buf.ReadDWord();
 						continue;
 					}

--- a/src/newgrf/newgrf_act0_canals.cpp
+++ b/src/newgrf/newgrf_act0_canals.cpp
@@ -27,7 +27,7 @@ static ChangeInfoResult CanalChangeInfo(uint first, uint last, int prop, ByteRea
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > to_underlying(CanalFeature::End)) {
-		GrfMsg(1, "CanalChangeInfo: Canal feature 0x{:02X} is invalid, max {}, ignoring", last, CanalFeature::End);
+		GrfMsg(Severity::Error, "CanalChangeInfo: Canal feature 0x{:02X} is invalid, max {}, ignoring", last, CanalFeature::End);
 		return ChangeInfoResult::InvalidId;
 	}
 

--- a/src/newgrf/newgrf_act0_cargo.cpp
+++ b/src/newgrf/newgrf_act0_cargo.cpp
@@ -52,7 +52,7 @@ static ChangeInfoResult CargoReserveInfo(uint first, uint last, int prop, ByteRe
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > NUM_CARGO) {
-		GrfMsg(2, "CargoChangeInfo: Cargo type {} out of range (max {})", last, NUM_CARGO - 1);
+		GrfMsg(Severity::Warning, "CargoChangeInfo: Cargo type {} out of range (max {})", last, NUM_CARGO - 1);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -151,7 +151,7 @@ static ChangeInfoResult CargoReserveInfo(uint first, uint last, int prop, ByteRe
 					case 0x09: cs->town_acceptance_effect = TownAcceptanceEffect::Water; break;
 					case 0x0B: cs->town_acceptance_effect = TownAcceptanceEffect::Food; break;
 					default:
-						GrfMsg(1, "CargoChangeInfo: Unknown town growth substitute value {}, setting to none.", substitute_type);
+						GrfMsg(Severity::Error, "CargoChangeInfo: Unknown town growth substitute value {}, setting to none.", substitute_type);
 						[[fallthrough]];
 					case 0xFF: cs->town_acceptance_effect = TownAcceptanceEffect::None; break;
 				}
@@ -177,7 +177,7 @@ static ChangeInfoResult CargoReserveInfo(uint first, uint last, int prop, ByteRe
 					case 0x00: cs->town_production_effect = TownProductionEffect::Passengers; break;
 					case 0x02: cs->town_production_effect = TownProductionEffect::Mail; break;
 					default:
-						GrfMsg(1, "CargoChangeInfo: Unknown town production substitute value {}, setting to none.", substitute_type);
+						GrfMsg(Severity::Error, "CargoChangeInfo: Unknown town production substitute value {}, setting to none.", substitute_type);
 						[[fallthrough]];
 					case 0xFF: cs->town_production_effect = TownProductionEffect::None; break;
 				}

--- a/src/newgrf/newgrf_act0_globalvar.cpp
+++ b/src/newgrf/newgrf_act0_globalvar.cpp
@@ -45,7 +45,7 @@ template <typename T, typename TGetTableFunc>
 static ChangeInfoResult LoadTranslationTable(uint first, uint last, ByteReader &buf, TGetTableFunc gettable, std::string_view name)
 {
 	if (first != 0) {
-		GrfMsg(1, "LoadTranslationTable: {} translation table must start at zero", name);
+		GrfMsg(Severity::Error, "LoadTranslationTable: {} translation table must start at zero", name);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -59,7 +59,7 @@ static ChangeInfoResult LoadTranslationTable(uint first, uint last, ByteReader &
 	GRFFile *grf_override = GetCurrentGRFOverride();
 	if (grf_override != nullptr) {
 		/* GRF override is present, copy the translation table to the overridden GRF as well. */
-		GrfMsg(1, "LoadTranslationTable: Copying {} translation table to override GRFID {}", name, FormatArrayAsHex(grf_override->grfid));
+		GrfMsg(Severity::Error, "LoadTranslationTable: Copying {} translation table to override GRFID {}", name, FormatArrayAsHex(grf_override->grfid));
 		std::vector<T> &override_table = gettable(*grf_override);
 		override_table = translation_table;
 	}
@@ -70,7 +70,7 @@ static ChangeInfoResult LoadTranslationTable(uint first, uint last, ByteReader &
 static ChangeInfoResult LoadBadgeTranslationTable(uint first, uint last, ByteReader &buf, std::vector<BadgeID> &translation_table, std::string_view name)
 {
 	if (first != 0 && first != std::size(translation_table)) {
-		GrfMsg(1, "LoadBadgeTranslationTable: {} translation table must start at zero or {}", name, std::size(translation_table));
+		GrfMsg(Severity::Error, "LoadBadgeTranslationTable: {} translation table must start at zero or {}", name, std::size(translation_table));
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -140,7 +140,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 				if (id < to_underlying(Price::End)) {
 					_cur_gps.grffile->price_base_multipliers[static_cast<Price>(id)] = std::min<int>(factor - 8, MAX_PRICE_MODIFIER);
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Price {} out of range, ignoring", id);
+					GrfMsg(Severity::Error, "GlobalVarChangeInfo: Price {} out of range, ignoring", id);
 				}
 				break;
 			}
@@ -168,7 +168,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					 * to be compatible */
 					_currency_specs[curidx].rate = rate / 1000;
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Currency multipliers {} out of range, ignoring", id);
+					GrfMsg(Severity::Error, "GlobalVarChangeInfo: Currency multipliers {} out of range, ignoring", id);
 				}
 				break;
 			}
@@ -185,7 +185,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					 * since newgrf specs said that only 0 and 1 can be set for symbol_pos */
 					_currency_specs[curidx].symbol_pos = HasBit(options, 8) ? CurrencySymbolPosition::Suffix : CurrencySymbolPosition::Prefix;
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Currency option {} out of range, ignoring", id);
+					GrfMsg(Severity::Error, "GlobalVarChangeInfo: Currency option {} out of range, ignoring", id);
 				}
 				break;
 			}
@@ -197,7 +197,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 				if (curidx < Currency::End) {
 					_currency_specs[curidx].prefix = std::move(prefix);
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", id);
+					GrfMsg(Severity::Error, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", id);
 				}
 				break;
 			}
@@ -209,7 +209,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 				if (curidx < Currency::End) {
 					_currency_specs[curidx].suffix = std::move(suffix);
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", id);
+					GrfMsg(Severity::Error, "GlobalVarChangeInfo: Currency symbol {} out of range, ignoring", id);
 				}
 				break;
 			}
@@ -221,16 +221,16 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 				if (curidx < Currency::End) {
 					_currency_specs[curidx].to_euro = year_euro;
 				} else {
-					GrfMsg(1, "GlobalVarChangeInfo: Euro intro date {} out of range, ignoring", id);
+					GrfMsg(Severity::Error, "GlobalVarChangeInfo: Euro intro date {} out of range, ignoring", id);
 				}
 				break;
 			}
 
 			case 0x10: // Snow line height table
 				if (last > 1 || IsSnowLineSet()) {
-					GrfMsg(1, "GlobalVarChangeInfo: The snowline can only be set once ({})", last);
+					GrfMsg(Severity::Error, "GlobalVarChangeInfo: The snowline can only be set once ({})", last);
 				} else if (buf.Remaining() < SNOW_LINE_MONTHS * SNOW_LINE_DAYS) {
-					GrfMsg(1, "GlobalVarChangeInfo: Not enough entries set in the snowline table ({})", buf.Remaining());
+					GrfMsg(Severity::Error, "GlobalVarChangeInfo: Not enough entries set in the snowline table ({})", buf.Remaining());
 				} else {
 					auto snow_line = std::make_unique<SnowLine>();
 
@@ -269,7 +269,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 				GRFLanguage langid = static_cast<GRFLanguage>(id); // The current index, i.e. language.
 				const LanguageMetadata *lang = langid < GRFLanguage::End ? GetLanguage(langid) : nullptr;
 				if (lang == nullptr) {
-					GrfMsg(1, "GlobalVarChangeInfo: Language {} is not known, ignoring", langid);
+					GrfMsg(Severity::Error, "GlobalVarChangeInfo: Language {} is not known, ignoring", langid);
 					/* Skip over the data. */
 					if (prop == 0x15) {
 						buf.ReadByte();
@@ -284,7 +284,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 				if (prop == 0x15) {
 					uint plural_form = buf.ReadByte();
 					if (plural_form >= LANGUAGE_MAX_PLURAL) {
-						GrfMsg(1, "GlobalVarChanceInfo: Plural form {} is out of range, ignoring", plural_form);
+						GrfMsg(Severity::Error, "GlobalVarChanceInfo: Plural form {} is out of range, ignoring", plural_form);
 					} else {
 						_cur_gps.grffile->language_map[langid].plural_form = plural_form;
 					}
@@ -307,14 +307,14 @@ static ChangeInfoResult GlobalVarChangeInfo(uint first, uint last, int prop, Byt
 					if (prop == 0x13) {
 						map.openttd_id = lang->GetGenderIndex(name);
 						if (map.openttd_id >= MAX_NUM_GENDERS) {
-							GrfMsg(1, "GlobalVarChangeInfo: Gender name {} is not known, ignoring", StrMakeValid(name));
+							GrfMsg(Severity::Error, "GlobalVarChangeInfo: Gender name {} is not known, ignoring", StrMakeValid(name));
 						} else {
 							_cur_gps.grffile->language_map[langid].gender_map.push_back(map);
 						}
 					} else {
 						map.openttd_id = lang->GetCaseIndex(name);
 						if (map.openttd_id >= MAX_NUM_CASES) {
-							GrfMsg(1, "GlobalVarChangeInfo: Case name {} is not known, ignoring", StrMakeValid(name));
+							GrfMsg(Severity::Error, "GlobalVarChangeInfo: Case name {} is not known, ignoring", StrMakeValid(name));
 						} else {
 							_cur_gps.grffile->language_map[langid].case_map.push_back(map);
 						}

--- a/src/newgrf/newgrf_act0_houses.cpp
+++ b/src/newgrf/newgrf_act0_houses.cpp
@@ -98,7 +98,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > NUM_HOUSES_PER_GRF) {
-		GrfMsg(1, "TownHouseChangeInfo: Too many houses loaded ({}), max ({}). Ignoring.", last, NUM_HOUSES_PER_GRF);
+		GrfMsg(Severity::Error, "TownHouseChangeInfo: Too many houses loaded ({}), max ({}). Ignoring.", last, NUM_HOUSES_PER_GRF);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -125,7 +125,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 					continue;
 				} else if (subs_id >= NEW_HOUSE_OFFSET) {
 					/* The substitute id must be one of the original houses. */
-					GrfMsg(2, "TownHouseChangeInfo: Attempt to use new house {} as substitute house for {}. Ignoring.", subs_id, id);
+					GrfMsg(Severity::Warning, "TownHouseChangeInfo: Attempt to use new house {} as substitute house for {}. Ignoring.", subs_id, id);
 					continue;
 				}
 
@@ -229,7 +229,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 
 				/* The house being overridden must be an original house. */
 				if (override_id >= NEW_HOUSE_OFFSET) {
-					GrfMsg(2, "TownHouseChangeInfo: Attempt to override new house {} with house id {}. Ignoring.", override_id, id);
+					GrfMsg(Severity::Warning, "TownHouseChangeInfo: Attempt to override new house {} with house id {}. Ignoring.", override_id, id);
 					continue;
 				}
 

--- a/src/newgrf/newgrf_act0_industries.cpp
+++ b/src/newgrf/newgrf_act0_industries.cpp
@@ -76,7 +76,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > NUM_INDUSTRYTILES_PER_GRF) {
-		GrfMsg(1, "IndustryTilesChangeInfo: Too many industry tiles loaded ({}), max ({}). Ignoring.", last, NUM_INDUSTRYTILES_PER_GRF);
+		GrfMsg(Severity::Error, "IndustryTilesChangeInfo: Too many industry tiles loaded ({}), max ({}). Ignoring.", last, NUM_INDUSTRYTILES_PER_GRF);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -97,7 +97,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 				uint8_t subs_id = buf.ReadByte();
 				if (subs_id >= NEW_INDUSTRYTILEOFFSET) {
 					/* The substitute id must be one of the original industry tile. */
-					GrfMsg(2, "IndustryTilesChangeInfo: Attempt to use new industry tile {} as substitute industry tile for {}. Ignoring.", subs_id, id);
+					GrfMsg(Severity::Warning, "IndustryTilesChangeInfo: Attempt to use new industry tile {} as substitute industry tile for {}. Ignoring.", subs_id, id);
 					continue;
 				}
 
@@ -126,7 +126,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 
 				/* The industry being overridden must be an original industry. */
 				if (ovrid >= NEW_INDUSTRYTILEOFFSET) {
-					GrfMsg(2, "IndustryTilesChangeInfo: Attempt to override new industry tile {} with industry tile id {}. Ignoring.", ovrid, id);
+					GrfMsg(Severity::Warning, "IndustryTilesChangeInfo: Attempt to override new industry tile {} with industry tile id {}. Ignoring.", ovrid, id);
 					continue;
 				}
 
@@ -341,7 +341,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > NUM_INDUSTRYTYPES_PER_GRF) {
-		GrfMsg(1, "IndustriesChangeInfo: Too many industries loaded ({}), max ({}). Ignoring.", last, NUM_INDUSTRYTYPES_PER_GRF);
+		GrfMsg(Severity::Error, "IndustriesChangeInfo: Too many industries loaded ({}), max ({}). Ignoring.", last, NUM_INDUSTRYTYPES_PER_GRF);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -367,7 +367,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 					continue;
 				} else if (subs_id >= NEW_INDUSTRYOFFSET) {
 					/* The substitute id must be one of the original industry. */
-					GrfMsg(2, "_industry_specs: Attempt to use new industry {} as substitute industry for {}. Ignoring.", subs_id, id);
+					GrfMsg(Severity::Warning, "_industry_specs: Attempt to use new industry {} as substitute industry for {}. Ignoring.", subs_id, id);
 					continue;
 				}
 
@@ -393,7 +393,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 
 				/* The industry being overridden must be an original industry. */
 				if (ovrid >= NEW_INDUSTRYOFFSET) {
-					GrfMsg(2, "IndustriesChangeInfo: Attempt to override new industry {} with industry id {}. Ignoring.", ovrid, id);
+					GrfMsg(Severity::Warning, "IndustriesChangeInfo: Attempt to override new industry {} with industry id {}. Ignoring.", ovrid, id);
 					continue;
 				}
 				indsp->grf_prop.override_id = ovrid;
@@ -417,7 +417,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 
 					for (uint k = 0;; k++) {
 						if (definition_end < buf.GetBytesRead()) {
-							GrfMsg(3, "IndustriesChangeInfo: Incorrect size for industry tile layout definition for industry {}.", id);
+							GrfMsg(Severity::Notice, "IndustriesChangeInfo: Incorrect size for industry tile layout definition for industry {}.", id);
 							/* Avoid warning twice */
 							definition_end = SIZE_MAX;
 						}
@@ -432,12 +432,12 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 							uint8_t laynbr = buf.ReadByte();
 
 							if (type >= lengthof(_origin_industry_specs)) {
-								GrfMsg(1, "IndustriesChangeInfo: Invalid original industry number for layout import, industry {}", id);
+								GrfMsg(Severity::Error, "IndustriesChangeInfo: Invalid original industry number for layout import, industry {}", id);
 								DisableGrf(STR_NEWGRF_ERROR_INVALID_ID);
 								return ChangeInfoResult::Disabled;
 							}
 							if (laynbr >= _origin_industry_specs[type].layouts.size()) {
-								GrfMsg(1, "IndustriesChangeInfo: Invalid original industry layout index for layout import, industry {}", id);
+								GrfMsg(Severity::Error, "IndustriesChangeInfo: Invalid original industry layout index for layout import, industry {}", id);
 								DisableGrf(STR_NEWGRF_ERROR_INVALID_ID);
 								return ChangeInfoResult::Disabled;
 							}
@@ -463,7 +463,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 							int tempid = _industile_mngr.GetID(local_tile_id, _cur_gps.grffile->grfid);
 
 							if (tempid == INVALID_INDUSTRYTILE) {
-								GrfMsg(2, "IndustriesChangeInfo: Attempt to use industry tile {} with industry id {}, not yet defined. Ignoring.", local_tile_id, id);
+								GrfMsg(Severity::Warning, "IndustriesChangeInfo: Attempt to use industry tile {} with industry id {}, not yet defined. Ignoring.", local_tile_id, id);
 								invalid_layout = true;
 							} else {
 								/* Declared as been valid, can be used */
@@ -483,7 +483,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 							 */
 							if (_cur_gps.grffile->grf_version < 8 && it.ti.x < 0) it.ti.y += 1;
 						} else if (it.gfx >= NEW_INDUSTRYTILEOFFSET) {
-							GrfMsg(2, "IndustriesChangeInfo: Attempt to use invalid industry tile {} with industry id {}. Ignoring.", it.gfx, id);
+							GrfMsg(Severity::Warning, "IndustriesChangeInfo: Attempt to use invalid industry tile {} with industry id {}. Ignoring.", it.gfx, id);
 							invalid_layout = true;
 						}
 					}
@@ -492,7 +492,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 
 					if (!ValidateIndustryLayout(layout)) {
 						/* The industry layout was not valid, so skip this one. */
-						GrfMsg(1, "IndustriesChangeInfo: Invalid industry layout for industry id {}. Ignoring", id);
+						GrfMsg(Severity::Error, "IndustriesChangeInfo: Invalid industry layout for industry id {}. Ignoring", id);
 					} else {
 						layouts.push_back(layout);
 					}

--- a/src/newgrf/newgrf_act0_objects.cpp
+++ b/src/newgrf/newgrf_act0_objects.cpp
@@ -78,7 +78,7 @@ static ChangeInfoResult ObjectChangeInfo(uint first, uint last, int prop, ByteRe
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > NUM_OBJECTS_PER_GRF) {
-		GrfMsg(1, "ObjectChangeInfo: Too many objects loaded ({}), max ({}). Ignoring.", last, NUM_OBJECTS_PER_GRF);
+		GrfMsg(Severity::Error, "ObjectChangeInfo: Too many objects loaded ({}), max ({}). Ignoring.", last, NUM_OBJECTS_PER_GRF);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -122,7 +122,7 @@ static ChangeInfoResult ObjectChangeInfo(uint first, uint last, int prop, ByteRe
 			case 0x0C: // Size
 				spec->size = buf.ReadByte();
 				if (GB(spec->size, 0, 4) == 0 || GB(spec->size, 4, 4) == 0) {
-					GrfMsg(0, "ObjectChangeInfo: Invalid object size requested (0x{:X}) for object id {}. Ignoring.", spec->size, id);
+					GrfMsg(Severity::Critical, "ObjectChangeInfo: Invalid object size requested (0x{:X}) for object id {}. Ignoring.", spec->size, id);
 					spec->size = OBJECT_SIZE_1X1;
 				}
 				break;
@@ -173,7 +173,7 @@ static ChangeInfoResult ObjectChangeInfo(uint first, uint last, int prop, ByteRe
 			case 0x17: // Views
 				spec->views = buf.ReadByte();
 				if (spec->views != 1 && spec->views != 2 && spec->views != 4) {
-					GrfMsg(2, "ObjectChangeInfo: Invalid number of views ({}) for object id {}. Ignoring.", spec->views, id);
+					GrfMsg(Severity::Warning, "ObjectChangeInfo: Invalid number of views ({}) for object id {}. Ignoring.", spec->views, id);
 					spec->views = 1;
 				}
 				break;

--- a/src/newgrf/newgrf_act0_railtypes.cpp
+++ b/src/newgrf/newgrf_act0_railtypes.cpp
@@ -32,7 +32,7 @@ static ChangeInfoResult RailTypeChangeInfo(uint first, uint last, int prop, Byte
 	const auto &type_map = _cur_gps.grffile->railtype_map;
 
 	if (last > std::size(type_map)) {
-		GrfMsg(1, "RailTypeChangeInfo: Rail type {} is invalid, max {}, ignoring", last, std::size(type_map));
+		GrfMsg(Severity::Error, "RailTypeChangeInfo: Rail type {} is invalid, max {}, ignoring", last, std::size(type_map));
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -166,7 +166,7 @@ static ChangeInfoResult RailTypeReserveInfo(uint first, uint last, int prop, Byt
 	auto &type_map = _cur_gps.grffile->railtype_map;
 
 	if (last > std::size(type_map)) {
-		GrfMsg(1, "RailTypeReserveInfo: Rail type {} is invalid, max {}, ignoring", last, std::size(type_map));
+		GrfMsg(Severity::Error, "RailTypeReserveInfo: Rail type {} is invalid, max {}, ignoring", last, std::size(type_map));
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -205,7 +205,7 @@ static ChangeInfoResult RailTypeReserveInfo(uint first, uint last, int prop, Byt
 					}
 					break;
 				}
-				GrfMsg(1, "RailTypeReserveInfo: Ignoring property 1D for rail type {} because no label was set", id);
+				GrfMsg(Severity::Error, "RailTypeReserveInfo: Ignoring property 1D for rail type {} because no label was set", id);
 				[[fallthrough]];
 
 			case 0x0E: // Compatible railtype list

--- a/src/newgrf/newgrf_act0_roadstops.cpp
+++ b/src/newgrf/newgrf_act0_roadstops.cpp
@@ -71,7 +71,7 @@ static ChangeInfoResult RoadStopChangeInfo(uint first, uint last, int prop, Byte
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > NUM_ROADSTOPS_PER_GRF) {
-		GrfMsg(1, "RoadStopChangeInfo: RoadStop {} is invalid, max {}, ignoring", last, NUM_ROADSTOPS_PER_GRF);
+		GrfMsg(Severity::Error, "RoadStopChangeInfo: RoadStop {} is invalid, max {}, ignoring", last, NUM_ROADSTOPS_PER_GRF);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -81,7 +81,7 @@ static ChangeInfoResult RoadStopChangeInfo(uint first, uint last, int prop, Byte
 		auto &rs = _cur_gps.grffile->roadstops[id];
 
 		if (rs == nullptr && prop != 0x08) {
-			GrfMsg(1, "RoadStopChangeInfo: Attempt to modify undefined road stop {}, ignoring", id);
+			GrfMsg(Severity::Error, "RoadStopChangeInfo: Attempt to modify undefined road stop {}, ignoring", id);
 			ChangeInfoResult cir = IgnoreRoadStopProperty(prop, buf);
 			if (cir > ret) ret = cir;
 			continue;

--- a/src/newgrf/newgrf_act0_roadtypes.cpp
+++ b/src/newgrf/newgrf_act0_roadtypes.cpp
@@ -33,7 +33,7 @@ static ChangeInfoResult RoadTypeChangeInfo(uint first, uint last, int prop, Byte
 	const auto &type_map = (rtt == RoadTramType::Tram) ? _cur_gps.grffile->tramtype_map : _cur_gps.grffile->roadtype_map;
 
 	if (last > std::size(type_map)) {
-		GrfMsg(1, "RoadTypeChangeInfo: Road type {} is invalid, max {}, ignoring", last, std::size(type_map));
+		GrfMsg(Severity::Error, "RoadTypeChangeInfo: Road type {} is invalid, max {}, ignoring", last, std::size(type_map));
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -84,7 +84,7 @@ static ChangeInfoResult RoadTypeChangeInfo(uint first, uint last, int prop, Byte
 								if (GetRoadTramType(resolved_rt) == rtt) {
 									rti->powered_roadtypes.Set(resolved_rt);
 								} else {
-									GrfMsg(1, "RoadTypeChangeInfo: Powered road type list: Road type {} road/tram type does not match road type {}, ignoring", resolved_rt, rt);
+									GrfMsg(Severity::Error, "RoadTypeChangeInfo: Powered road type list: Road type {} road/tram type does not match road type {}, ignoring", resolved_rt, rt);
 								}
 								break;
 							case 0x18: rti->introduction_required_roadtypes.Set(resolved_rt); break;
@@ -153,7 +153,7 @@ static ChangeInfoResult RoadTypeReserveInfo(uint first, uint last, int prop, Byt
 	auto &type_map = (rtt == RoadTramType::Tram) ? _cur_gps.grffile->tramtype_map : _cur_gps.grffile->roadtype_map;
 
 	if (last > std::size(type_map)) {
-		GrfMsg(1, "RoadTypeReserveInfo: Road type {} is invalid, max {}, ignoring", last, std::size(type_map));
+		GrfMsg(Severity::Error, "RoadTypeReserveInfo: Road type {} is invalid, max {}, ignoring", last, std::size(type_map));
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -166,7 +166,7 @@ static ChangeInfoResult RoadTypeReserveInfo(uint first, uint last, int prop, Byt
 					/* Set up new road type */
 					rt = AllocateRoadType(rtl, rtt);
 				} else if (GetRoadTramType(rt) != rtt) {
-					GrfMsg(1, "RoadTypeReserveInfo: Road type {} is invalid type (road/tram), ignoring", id);
+					GrfMsg(Severity::Error, "RoadTypeReserveInfo: Road type {} is invalid type (road/tram), ignoring", id);
 					return ChangeInfoResult::InvalidId;
 				}
 
@@ -193,7 +193,7 @@ static ChangeInfoResult RoadTypeReserveInfo(uint first, uint last, int prop, Byt
 					}
 					break;
 				}
-				GrfMsg(1, "RoadTypeReserveInfo: Ignoring property 1D for road type {} because no label was set", id);
+				GrfMsg(Severity::Error, "RoadTypeReserveInfo: Ignoring property 1D for road type {} because no label was set", id);
 				/* FALL THROUGH */
 
 			case 0x0F: // Powered roadtype list

--- a/src/newgrf/newgrf_act0_roadvehs.cpp
+++ b/src/newgrf/newgrf_act0_roadvehs.cpp
@@ -69,7 +69,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 				if (IsValidNewGRFImageIndex<VehicleType::Road>(spriteid)) {
 					rvi->image_index = spriteid;
 				} else {
-					GrfMsg(1, "RoadVehicleChangeInfo: Invalid Sprite {} specified, ignoring", orig_spriteid);
+					GrfMsg(Severity::Error, "RoadVehicleChangeInfo: Invalid Sprite {} specified, ignoring", orig_spriteid);
 					rvi->image_index = 0;
 				}
 				break;
@@ -89,7 +89,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint first, uint last, int prop, B
 				} else {
 					/* Use translated cargo. Might result in INVALID_CARGO (first refittable), if cargo is not defined. */
 					ei->cargo_type = GetCargoTranslation(ctype, _cur_gps.grffile);
-					if (ei->cargo_type == INVALID_CARGO) GrfMsg(2, "RoadVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
+					if (ei->cargo_type == INVALID_CARGO) GrfMsg(Severity::Warning, "RoadVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
 				}
 				ei->cargo_label = CT_INVALID;
 				break;

--- a/src/newgrf/newgrf_act0_ships.cpp
+++ b/src/newgrf/newgrf_act0_ships.cpp
@@ -52,7 +52,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 				if (IsValidNewGRFImageIndex<VehicleType::Ship>(spriteid)) {
 					svi->image_index = spriteid;
 				} else {
-					GrfMsg(1, "ShipVehicleChangeInfo: Invalid Sprite {} specified, ignoring", orig_spriteid);
+					GrfMsg(Severity::Error, "ShipVehicleChangeInfo: Invalid Sprite {} specified, ignoring", orig_spriteid);
 					svi->image_index = 0;
 				}
 				break;
@@ -80,7 +80,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint first, uint last, int prop, B
 				} else {
 					/* Use translated cargo. Might result in INVALID_CARGO (first refittable), if cargo is not defined. */
 					ei->cargo_type = GetCargoTranslation(ctype, _cur_gps.grffile);
-					if (ei->cargo_type == INVALID_CARGO) GrfMsg(2, "ShipVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
+					if (ei->cargo_type == INVALID_CARGO) GrfMsg(Severity::Warning, "ShipVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
 				}
 				ei->cargo_label = CT_INVALID;
 				break;

--- a/src/newgrf/newgrf_act0_sounds.cpp
+++ b/src/newgrf/newgrf_act0_sounds.cpp
@@ -29,12 +29,12 @@ static ChangeInfoResult SoundEffectChangeInfo(uint first, uint last, int prop, B
 	if (first == last) return ret;
 
 	if (_cur_gps.grffile->sound_offset == 0) {
-		GrfMsg(1, "SoundEffectChangeInfo: No effects defined, skipping");
+		GrfMsg(Severity::Error, "SoundEffectChangeInfo: No effects defined, skipping");
 		return ChangeInfoResult::InvalidId;
 	}
 
 	if (last - ORIGINAL_SAMPLE_COUNT > _cur_gps.grffile->num_sounds) {
-		GrfMsg(1, "SoundEffectChangeInfo: Attempting to change undefined sound effect ({}), max ({}). Ignoring.", last, ORIGINAL_SAMPLE_COUNT + _cur_gps.grffile->num_sounds);
+		GrfMsg(Severity::Error, "SoundEffectChangeInfo: Attempting to change undefined sound effect ({}), max ({}). Ignoring.", last, ORIGINAL_SAMPLE_COUNT + _cur_gps.grffile->num_sounds);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -54,7 +54,7 @@ static ChangeInfoResult SoundEffectChangeInfo(uint first, uint last, int prop, B
 				SoundID orig_sound = buf.ReadByte();
 
 				if (orig_sound >= ORIGINAL_SAMPLE_COUNT) {
-					GrfMsg(1, "SoundEffectChangeInfo: Original sound {} not defined (max {})", orig_sound, ORIGINAL_SAMPLE_COUNT);
+					GrfMsg(Severity::Error, "SoundEffectChangeInfo: Original sound {} not defined (max {})", orig_sound, ORIGINAL_SAMPLE_COUNT);
 				} else {
 					SoundEntry *old_sound = GetSound(orig_sound);
 

--- a/src/newgrf/newgrf_act0_stations.cpp
+++ b/src/newgrf/newgrf_act0_stations.cpp
@@ -32,7 +32,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 	ChangeInfoResult ret = ChangeInfoResult::Success;
 
 	if (last > NUM_STATIONS_PER_GRF) {
-		GrfMsg(1, "StationChangeInfo: Station {} is invalid, max {}, ignoring", last, NUM_STATIONS_PER_GRF);
+		GrfMsg(Severity::Error, "StationChangeInfo: Station {} is invalid, max {}, ignoring", last, NUM_STATIONS_PER_GRF);
 		return ChangeInfoResult::InvalidId;
 	}
 
@@ -44,7 +44,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 
 		/* Check that the station we are modifying is defined. */
 		if (statspec == nullptr && prop != 0x08) {
-			GrfMsg(2, "StationChangeInfo: Attempt to modify undefined station {}, ignoring", id);
+			GrfMsg(Severity::Warning, "StationChangeInfo: Attempt to modify undefined station {}, ignoring", id);
 			return ChangeInfoResult::InvalidId;
 		}
 
@@ -103,7 +103,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 
 				/* Number of layouts must be even, alternating X and Y */
 				if (statspec->renderdata.size() & 1) {
-					GrfMsg(1, "StationChangeInfo: Station {} defines an odd number of sprite layouts, dropping the last item", id);
+					GrfMsg(Severity::Error, "StationChangeInfo: Station {} defines an odd number of sprite layouts, dropping the last item", id);
 					statspec->renderdata.pop_back();
 				}
 				break;
@@ -114,7 +114,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 				const StationSpec *srcstatspec = srcid >= _cur_gps.grffile->stations.size() ? nullptr : _cur_gps.grffile->stations[srcid].get();
 
 				if (srcstatspec == nullptr) {
-					GrfMsg(1, "StationChangeInfo: Station {} is not defined, cannot copy sprite layout to {}.", srcid, id);
+					GrfMsg(Severity::Error, "StationChangeInfo: Station {} is not defined, cannot copy sprite layout to {}.", srcid, id);
 					continue;
 				}
 
@@ -155,7 +155,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 					/* Ensure the first bit, axis, is zero. The rest of the value is validated during rendering, as we don't know the range yet. */
 					for (auto &tile : layout) {
 						if ((tile & ~1U) != tile) {
-							GrfMsg(1, "StationChangeInfo: Invalid tile {} in layout {}x{}", tile, length, number);
+							GrfMsg(Severity::Error, "StationChangeInfo: Invalid tile {} in layout {}x{}", tile, length, number);
 							tile &= ~1U;
 						}
 					}
@@ -167,7 +167,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 				const StationSpec *srcstatspec = srcid >= _cur_gps.grffile->stations.size() ? nullptr : _cur_gps.grffile->stations[srcid].get();
 
 				if (srcstatspec == nullptr) {
-					GrfMsg(1, "StationChangeInfo: Station {} is not defined, cannot copy tile layout to {}.", srcid, id);
+					GrfMsg(Severity::Error, "StationChangeInfo: Station {} is not defined, cannot copy tile layout to {}.", srcid, id);
 					continue;
 				}
 
@@ -259,7 +259,7 @@ static ChangeInfoResult StationChangeInfo(uint first, uint last, int prop, ByteR
 
 				/* Number of layouts must be even, alternating X and Y */
 				if (statspec->renderdata.size() & 1) {
-					GrfMsg(1, "StationChangeInfo: Station {} defines an odd number of sprite layouts, dropping the last item", id);
+					GrfMsg(Severity::Error, "StationChangeInfo: Station {} defines an odd number of sprite layouts, dropping the last item", id);
 					statspec->renderdata.pop_back();
 				}
 				break;

--- a/src/newgrf/newgrf_act0_trains.cpp
+++ b/src/newgrf/newgrf_act0_trains.cpp
@@ -52,7 +52,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 					case 1: _gted[e->index].railtypelabels.push_back(RAILTYPE_LABEL_MONO); break;
 					case 2: _gted[e->index].railtypelabels.push_back(RAILTYPE_LABEL_MAGLEV); break;
 					default:
-						GrfMsg(1, "RailVehicleChangeInfo: Invalid track type {} specified, ignoring", tracktype);
+						GrfMsg(Severity::Error, "RailVehicleChangeInfo: Invalid track type {} specified, ignoring", tracktype);
 						break;
 				}
 				break;
@@ -104,7 +104,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 				if (IsValidNewGRFImageIndex<VehicleType::Train>(spriteid)) {
 					rvi->image_index = spriteid;
 				} else {
-					GrfMsg(1, "RailVehicleChangeInfo: Invalid Sprite {} specified, ignoring", orig_spriteid);
+					GrfMsg(Severity::Error, "RailVehicleChangeInfo: Invalid Sprite {} specified, ignoring", orig_spriteid);
 					rvi->image_index = 0;
 				}
 				break;
@@ -136,7 +136,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 				} else {
 					/* Use translated cargo. Might result in INVALID_CARGO (first refittable), if cargo is not defined. */
 					ei->cargo_type = GetCargoTranslation(ctype, _cur_gps.grffile);
-					if (ei->cargo_type == INVALID_CARGO) GrfMsg(2, "RailVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
+					if (ei->cargo_type == INVALID_CARGO) GrfMsg(Severity::Warning, "RailVehicleChangeInfo: Invalid cargo type {}, using first refittable", ctype);
 				}
 				ei->cargo_label = CT_INVALID;
 				break;
@@ -151,7 +151,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 				break;
 
 			case 0x18: // AI rank
-				GrfMsg(2, "RailVehicleChangeInfo: Property 0x18 'AI rank' not used by NoAI, ignored.");
+				GrfMsg(Severity::Warning, "RailVehicleChangeInfo: Property 0x18 'AI rank' not used by NoAI, ignored.");
 				buf.ReadByte();
 				break;
 
@@ -248,7 +248,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 				uint8_t weight = buf.ReadByte();
 
 				if (weight > 4) {
-					GrfMsg(2, "RailVehicleChangeInfo: Nonsensical weight of {} tons, ignoring", weight << 8);
+					GrfMsg(Severity::Warning, "RailVehicleChangeInfo: Nonsensical weight of {} tons, ignoring", weight << 8);
 				} else {
 					SB(rvi->weight, 8, 8, weight);
 				}
@@ -338,7 +338,7 @@ ChangeInfoResult RailVehicleChangeInfo(uint first, uint last, int prop, ByteRead
 					if (tracktype < _cur_gps.grffile->railtype_list.size()) {
 						_gted[e->index].railtypelabels.push_back(_cur_gps.grffile->railtype_list[tracktype]);
 					} else {
-						GrfMsg(1, "RailVehicleChangeInfo: Invalid track type {} specified, ignoring", tracktype);
+						GrfMsg(Severity::Error, "RailVehicleChangeInfo: Invalid track type {} specified, ignoring", tracktype);
 					}
 				}
 				break;

--- a/src/newgrf/newgrf_act1.cpp
+++ b/src/newgrf/newgrf_act1.cpp
@@ -46,13 +46,13 @@ static void NewSpriteSet(ByteReader &buf)
 
 	if (feature >= GrfSpecFeature::End) {
 		_cur_gps.skip_sprites = num_sets * num_ents;
-		GrfMsg(1, "NewSpriteSet: Unsupported feature 0x{:02X}, skipping {} sprites", feature, _cur_gps.skip_sprites);
+		GrfMsg(Severity::Error, "NewSpriteSet: Unsupported feature 0x{:02X}, skipping {} sprites", feature, _cur_gps.skip_sprites);
 		return;
 	}
 
 	_cur_gps.AddSpriteSets(feature, _cur_gps.spriteid, first_set, num_sets, num_ents);
 
-	GrfMsg(7, "New sprite set at {} of feature 0x{:02X}, consisting of {} sets with {} views each (total {})",
+	GrfMsg(Severity::Trace1, "New sprite set at {} of feature 0x{:02X}, consisting of {} sets with {} views each (total {})",
 		_cur_gps.spriteid, feature, num_sets, num_ents, num_sets * num_ents
 	);
 
@@ -78,7 +78,7 @@ static void SkipAct1(ByteReader &buf)
 
 	_cur_gps.skip_sprites = num_sets * num_ents;
 
-	GrfMsg(3, "SkipAct1: Skipping {} sprites", _cur_gps.skip_sprites);
+	GrfMsg(Severity::Notice, "SkipAct1: Skipping {} sprites", _cur_gps.skip_sprites);
 }
 
 /** @copydoc GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_act10.cpp
+++ b/src/newgrf/newgrf_act10.cpp
@@ -29,7 +29,7 @@ static void DefineGotoLabel(ByteReader &buf)
 
 	_cur_gps.grffile->labels.emplace_back(nfo_label, _cur_gps.nfo_line, _cur_gps.file->GetPos());
 
-	GrfMsg(2, "DefineGotoLabel: GOTO target with label 0x{:02X}", nfo_label);
+	GrfMsg(Severity::Warning, "DefineGotoLabel: GOTO target with label 0x{:02X}", nfo_label);
 }
 
 /** @copybrief GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_act11.cpp
+++ b/src/newgrf/newgrf_act11.cpp
@@ -30,16 +30,16 @@ static void ImportGRFSound(SoundEntry *sound)
 
 	file = GetFileByGRFID(grfid);
 	if (file == nullptr || file->sound_offset == 0) {
-		GrfMsg(1, "ImportGRFSound: Source file not available");
+		GrfMsg(Severity::Error, "ImportGRFSound: Source file not available");
 		return;
 	}
 
 	if (sound_id >= file->num_sounds) {
-		GrfMsg(1, "ImportGRFSound: Sound effect {} is invalid", sound_id);
+		GrfMsg(Severity::Error, "ImportGRFSound: Sound effect {} is invalid", sound_id);
 		return;
 	}
 
-	GrfMsg(2, "ImportGRFSound: Copying sound {} ({}) from file {}", sound_id, file->sound_offset + sound_id, FormatArrayAsHex(grfid));
+	GrfMsg(Severity::Warning, "ImportGRFSound: Copying sound {} ({}) from file {}", sound_id, file->sound_offset + sound_id, FormatArrayAsHex(grfid));
 
 	*sound = *GetSound(file->sound_offset + sound_id);
 
@@ -104,10 +104,10 @@ static void GRFSound(ByteReader &buf)
 		if (grf_container_version >= 2 && type == 0xFD) {
 			/* Reference to sprite section. */
 			if (invalid) {
-				GrfMsg(1, "GRFSound: Sound index out of range (multiple Action 11?)");
+				GrfMsg(Severity::Error, "GRFSound: Sound index out of range (multiple Action 11?)");
 				file.SkipBytes(len);
 			} else if (len != 4) {
-				GrfMsg(1, "GRFSound: Invalid sprite section import");
+				GrfMsg(Severity::Error, "GRFSound: Invalid sprite section import");
 				file.SkipBytes(len);
 			} else {
 				uint32_t id = file.ReadDword();
@@ -117,14 +117,14 @@ static void GRFSound(ByteReader &buf)
 		}
 
 		if (type != 0xFF) {
-			GrfMsg(1, "GRFSound: Unexpected RealSprite found, skipping");
+			GrfMsg(Severity::Error, "GRFSound: Unexpected RealSprite found, skipping");
 			file.SkipBytes(7);
 			SkipSpriteData(*_cur_gps.file, type, len - 8);
 			continue;
 		}
 
 		if (invalid) {
-			GrfMsg(1, "GRFSound: Sound index out of range (multiple Action 11?)");
+			GrfMsg(Severity::Error, "GRFSound: Sound index out of range (multiple Action 11?)");
 			file.SkipBytes(len);
 		}
 
@@ -134,7 +134,7 @@ static void GRFSound(ByteReader &buf)
 				/* Allocate sound only in init stage. */
 				if (_cur_gps.stage == GrfLoadingStage::Init) {
 					if (grf_container_version >= 2) {
-						GrfMsg(1, "GRFSound: Inline sounds are not supported for container version >= 2");
+						GrfMsg(Severity::Error, "GRFSound: Inline sounds are not supported for container version >= 2");
 					} else {
 						LoadGRFSound(offs, sound + i);
 					}
@@ -146,7 +146,7 @@ static void GRFSound(ByteReader &buf)
 				if (_cur_gps.stage == GrfLoadingStage::Activation) {
 					/* XXX 'Action 0xFE' isn't really specified. It is only mentioned for
 					 * importing sounds, so this is probably all wrong... */
-					if (file.ReadByte() != 0) GrfMsg(1, "GRFSound: Import type mismatch");
+					if (file.ReadByte() != 0) GrfMsg(Severity::Error, "GRFSound: Import type mismatch");
 					ImportGRFSound(sound + i);
 				} else {
 					file.SkipBytes(len - 1); // already read <action>
@@ -154,7 +154,7 @@ static void GRFSound(ByteReader &buf)
 				break;
 
 			default:
-				GrfMsg(1, "GRFSound: Unexpected Action {:x} found, skipping", action);
+				GrfMsg(Severity::Error, "GRFSound: Unexpected Action {:x} found, skipping", action);
 				file.SkipBytes(len - 1); // already read <action>
 				break;
 		}
@@ -170,7 +170,7 @@ static void SkipAct11(ByteReader &buf)
 
 	_cur_gps.skip_sprites = buf.ReadWord();
 
-	GrfMsg(3, "SkipAct11: Skipping {} sprites", _cur_gps.skip_sprites);
+	GrfMsg(Severity::Notice, "SkipAct11: Skipping {} sprites", _cur_gps.skip_sprites);
 }
 
 /** @copydoc GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_act12.cpp
+++ b/src/newgrf/newgrf_act12.cpp
@@ -37,10 +37,10 @@ static void LoadFontGlyph(ByteReader &buf)
 		uint16_t base_char = buf.ReadWord();
 
 		if (size >= FontSize::End) {
-			GrfMsg(1, "LoadFontGlyph: Size {} is not supported, ignoring", size);
+			GrfMsg(Severity::Error, "LoadFontGlyph: Size {} is not supported, ignoring", size);
 		}
 
-		GrfMsg(7, "LoadFontGlyph: Loading {} glyph(s) at 0x{:04X} for size {}", num_char, base_char, size);
+		GrfMsg(Severity::Trace1, "LoadFontGlyph: Loading {} glyph(s) at 0x{:04X} for size {}", num_char, base_char, size);
 
 		for (uint c = 0; c < num_char; c++) {
 			if (size < FontSize::End) SetUnicodeGlyph(size, base_char + c, _cur_gps.spriteid);
@@ -76,7 +76,7 @@ static void SkipAct12(ByteReader &buf)
 		buf.ReadWord();
 	}
 
-	GrfMsg(3, "SkipAct12: Skipping {} sprites", _cur_gps.skip_sprites);
+	GrfMsg(Severity::Notice, "SkipAct12: Skipping {} sprites", _cur_gps.skip_sprites);
 }
 
 /** @copydoc GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_act13.cpp
+++ b/src/newgrf/newgrf_act13.cpp
@@ -35,7 +35,7 @@ static void TranslateGRFStrings(ByteReader &buf)
 	GrfID grfid = buf.ReadLabel<GrfID>();
 	const GRFConfig *c = GetGRFConfig(grfid);
 	if (c == nullptr || (c->status != GRFStatus::Initialised && c->status != GRFStatus::Activated)) {
-		GrfMsg(7, "TranslateGRFStrings: GRFID {} unknown, skipping action 13", FormatArrayAsHex(grfid));
+		GrfMsg(Severity::Trace1, "TranslateGRFStrings: GRFID {} unknown, skipping action 13", FormatArrayAsHex(grfid));
 		return;
 	}
 
@@ -59,7 +59,7 @@ static void TranslateGRFStrings(ByteReader &buf)
 	uint16_t first_id  = buf.ReadWord();
 
 	if (!((first_id >= 0xD000 && first_id + num_strings <= 0xD400) || (first_id >= 0xD800 && first_id + num_strings <= 0xE000))) {
-		GrfMsg(7, "TranslateGRFStrings: Attempting to set out-of-range string IDs in action 13 (first: 0x{:04X}, number: 0x{:02X})", first_id, num_strings);
+		GrfMsg(Severity::Trace1, "TranslateGRFStrings: Attempting to set out-of-range string IDs in action 13 (first: 0x{:04X}, number: 0x{:02X})", first_id, num_strings);
 		return;
 	}
 
@@ -67,7 +67,7 @@ static void TranslateGRFStrings(ByteReader &buf)
 		std::string_view string = buf.ReadString();
 
 		if (string.empty()) {
-			GrfMsg(7, "TranslateGRFString: Ignoring empty string.");
+			GrfMsg(Severity::Trace1, "TranslateGRFString: Ignoring empty string.");
 			continue;
 		}
 

--- a/src/newgrf/newgrf_act14.cpp
+++ b/src/newgrf/newgrf_act14.cpp
@@ -40,7 +40,7 @@ static bool ChangeGRFURL(GRFLanguage langid, std::string_view str)
 static bool ChangeGRFNumUsedParams(size_t len, ByteReader &buf)
 {
 	if (len != 1) {
-		GrfMsg(2, "StaticGRFInfo: expected only 1 byte for 'INFO'->'NPAR' but got {}, ignoring this field", len);
+		GrfMsg(Severity::Warning, "StaticGRFInfo: expected only 1 byte for 'INFO'->'NPAR' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
 		_cur_gps.grfconfig->num_valid_params = std::min(buf.ReadByte(), GRFConfig::MAX_NUM_PARAMS);
@@ -52,7 +52,7 @@ static bool ChangeGRFNumUsedParams(size_t len, ByteReader &buf)
 static bool ChangeGRFPalette(size_t len, ByteReader &buf)
 {
 	if (len != 1) {
-		GrfMsg(2, "StaticGRFInfo: expected only 1 byte for 'INFO'->'PALS' but got {}, ignoring this field", len);
+		GrfMsg(Severity::Warning, "StaticGRFInfo: expected only 1 byte for 'INFO'->'PALS' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
 		char data = buf.ReadByte();
@@ -63,7 +63,7 @@ static bool ChangeGRFPalette(size_t len, ByteReader &buf)
 			case 'W': pal = GRFP_GRF_WINDOWS; break;
 			case 'D': pal = GRFP_GRF_DOS;     break;
 			default:
-				GrfMsg(2, "StaticGRFInfo: unexpected value '{:02X}' for 'INFO'->'PALS', ignoring this field", data);
+				GrfMsg(Severity::Warning, "StaticGRFInfo: unexpected value '{:02X}' for 'INFO'->'PALS', ignoring this field", data);
 				break;
 		}
 		if (pal != GRFP_GRF_UNSET) {
@@ -78,7 +78,7 @@ static bool ChangeGRFPalette(size_t len, ByteReader &buf)
 static bool ChangeGRFBlitter(size_t len, ByteReader &buf)
 {
 	if (len != 1) {
-		GrfMsg(2, "StaticGRFInfo: expected only 1 byte for 'INFO'->'BLTR' but got {}, ignoring this field", len);
+		GrfMsg(Severity::Warning, "StaticGRFInfo: expected only 1 byte for 'INFO'->'BLTR' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
 		char data = buf.ReadByte();
@@ -87,7 +87,7 @@ static bool ChangeGRFBlitter(size_t len, ByteReader &buf)
 			case '8': pal = GRFP_BLT_UNSET; break;
 			case '3': pal = GRFP_BLT_32BPP;  break;
 			default:
-				GrfMsg(2, "StaticGRFInfo: unexpected value '{:02X}' for 'INFO'->'BLTR', ignoring this field", data);
+				GrfMsg(Severity::Warning, "StaticGRFInfo: unexpected value '{:02X}' for 'INFO'->'BLTR', ignoring this field", data);
 				return true;
 		}
 		_cur_gps.grfconfig->palette &= ~GRFP_BLT_MASK;
@@ -100,7 +100,7 @@ static bool ChangeGRFBlitter(size_t len, ByteReader &buf)
 static bool ChangeGRFVersion(size_t len, ByteReader &buf)
 {
 	if (len != 4) {
-		GrfMsg(2, "StaticGRFInfo: expected 4 bytes for 'INFO'->'VRSN' but got {}, ignoring this field", len);
+		GrfMsg(Severity::Warning, "StaticGRFInfo: expected 4 bytes for 'INFO'->'VRSN' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
 		/* Set min_loadable_version as well (default to minimal compatibility) */
@@ -113,16 +113,16 @@ static bool ChangeGRFVersion(size_t len, ByteReader &buf)
 static bool ChangeGRFMinVersion(size_t len, ByteReader &buf)
 {
 	if (len != 4) {
-		GrfMsg(2, "StaticGRFInfo: expected 4 bytes for 'INFO'->'MINV' but got {}, ignoring this field", len);
+		GrfMsg(Severity::Warning, "StaticGRFInfo: expected 4 bytes for 'INFO'->'MINV' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
 		_cur_gps.grfconfig->min_loadable_version = buf.ReadDWord();
 		if (_cur_gps.grfconfig->version == 0) {
-			GrfMsg(2, "StaticGRFInfo: 'MINV' defined before 'VRSN' or 'VRSN' set to 0, ignoring this field");
+			GrfMsg(Severity::Warning, "StaticGRFInfo: 'MINV' defined before 'VRSN' or 'VRSN' set to 0, ignoring this field");
 			_cur_gps.grfconfig->min_loadable_version = 0;
 		}
 		if (_cur_gps.grfconfig->version < _cur_gps.grfconfig->min_loadable_version) {
-			GrfMsg(2, "StaticGRFInfo: 'MINV' defined as {}, limiting it to 'VRSN'", _cur_gps.grfconfig->min_loadable_version);
+			GrfMsg(Severity::Warning, "StaticGRFInfo: 'MINV' defined as {}, limiting it to 'VRSN'", _cur_gps.grfconfig->min_loadable_version);
 			_cur_gps.grfconfig->min_loadable_version = _cur_gps.grfconfig->version;
 		}
 	}
@@ -149,7 +149,7 @@ static bool ChangeGRFParamDescription(GRFLanguage langid, std::string_view str)
 static bool ChangeGRFParamType(size_t len, ByteReader &buf)
 {
 	if (len != 1) {
-		GrfMsg(2, "StaticGRFInfo: expected 1 byte for 'INFO'->'PARA'->'TYPE' but got {}, ignoring this field", len);
+		GrfMsg(Severity::Warning, "StaticGRFInfo: expected 1 byte for 'INFO'->'PARA'->'TYPE' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
 		GRFParameterType type = static_cast<GRFParameterType>(buf.ReadByte());
@@ -160,7 +160,7 @@ static bool ChangeGRFParamType(size_t len, ByteReader &buf)
 				break;
 
 			default:
-				GrfMsg(3, "StaticGRFInfo: unknown parameter type {}, ignoring this field", type);
+				GrfMsg(Severity::Notice, "StaticGRFInfo: unknown parameter type {}, ignoring this field", type);
 				break;
 		}
 	}
@@ -171,10 +171,10 @@ static bool ChangeGRFParamType(size_t len, ByteReader &buf)
 static bool ChangeGRFParamLimits(size_t len, ByteReader &buf)
 {
 	if (_cur_parameter->type != GRFParameterType::UintEnum) {
-		GrfMsg(2, "StaticGRFInfo: 'INFO'->'PARA'->'LIMI' is only valid for parameters with type uint/enum, ignoring this field");
+		GrfMsg(Severity::Warning, "StaticGRFInfo: 'INFO'->'PARA'->'LIMI' is only valid for parameters with type uint/enum, ignoring this field");
 		buf.Skip(len);
 	} else if (len != 8) {
-		GrfMsg(2, "StaticGRFInfo: expected 8 bytes for 'INFO'->'PARA'->'LIMI' but got {}, ignoring this field", len);
+		GrfMsg(Severity::Warning, "StaticGRFInfo: expected 8 bytes for 'INFO'->'PARA'->'LIMI' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
 		uint32_t min_value = buf.ReadDWord();
@@ -183,7 +183,7 @@ static bool ChangeGRFParamLimits(size_t len, ByteReader &buf)
 			_cur_parameter->min_value = min_value;
 			_cur_parameter->max_value = max_value;
 		} else {
-			GrfMsg(2, "StaticGRFInfo: 'INFO'->'PARA'->'LIMI' values are incoherent, ignoring this field");
+			GrfMsg(Severity::Warning, "StaticGRFInfo: 'INFO'->'PARA'->'LIMI' values are incoherent, ignoring this field");
 		}
 	}
 	return true;
@@ -193,12 +193,12 @@ static bool ChangeGRFParamLimits(size_t len, ByteReader &buf)
 static bool ChangeGRFParamMask(size_t len, ByteReader &buf)
 {
 	if (len < 1 || len > 3) {
-		GrfMsg(2, "StaticGRFInfo: expected 1 to 3 bytes for 'INFO'->'PARA'->'MASK' but got {}, ignoring this field", len);
+		GrfMsg(Severity::Warning, "StaticGRFInfo: expected 1 to 3 bytes for 'INFO'->'PARA'->'MASK' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
 		uint8_t param_nr = buf.ReadByte();
 		if (param_nr >= GRFConfig::MAX_NUM_PARAMS) {
-			GrfMsg(2, "StaticGRFInfo: invalid parameter number in 'INFO'->'PARA'->'MASK', param {}, ignoring this field", param_nr);
+			GrfMsg(Severity::Warning, "StaticGRFInfo: invalid parameter number in 'INFO'->'PARA'->'MASK', param {}, ignoring this field", param_nr);
 			buf.Skip(len - 1);
 		} else {
 			_cur_parameter->param_nr = param_nr;
@@ -214,7 +214,7 @@ static bool ChangeGRFParamMask(size_t len, ByteReader &buf)
 static bool ChangeGRFParamDefault(size_t len, ByteReader &buf)
 {
 	if (len != 4) {
-		GrfMsg(2, "StaticGRFInfo: expected 4 bytes for 'INFO'->'PARA'->'DEFA' but got {}, ignoring this field", len);
+		GrfMsg(Severity::Warning, "StaticGRFInfo: expected 4 bytes for 'INFO'->'PARA'->'DEFA' but got {}, ignoring this field", len);
 		buf.Skip(len);
 	} else {
 		_cur_parameter->def_value = buf.ReadDWord();
@@ -279,7 +279,7 @@ static bool ChangeGRFParamValueNames(ByteReader &buf)
 	while (type != 0) {
 		uint32_t id = buf.ReadDWord();
 		if (type != 'T' || id > _cur_parameter->max_value) {
-			GrfMsg(2, "StaticGRFInfo: all child nodes of 'INFO'->'PARA'->param_num->'VALU' should have type 't' and the value/bit number as id");
+			GrfMsg(Severity::Warning, "StaticGRFInfo: all child nodes of 'INFO'->'PARA'->param_num->'VALU' should have type 't' and the value/bit number as id");
 			if (!SkipUnknownInfo(buf, type)) return false;
 			type = buf.ReadByte();
 			continue;
@@ -323,7 +323,7 @@ static bool HandleParameterInfo(ByteReader &buf)
 	while (type != 0) {
 		uint32_t id = buf.ReadDWord();
 		if (type != 'C' || id >= _cur_gps.grfconfig->num_valid_params) {
-			GrfMsg(2, "StaticGRFInfo: all child nodes of 'INFO'->'PARA' should have type 'C' and their parameter number as id");
+			GrfMsg(Severity::Warning, "StaticGRFInfo: all child nodes of 'INFO'->'PARA' should have type 'C' and their parameter number as id");
 			if (!SkipUnknownInfo(buf, type)) return false;
 			type = buf.ReadByte();
 			continue;
@@ -451,7 +451,7 @@ static bool HandleNode(uint8_t type, NodeID id, ByteReader &buf, std::span<const
 		return std::visit(evaluate_visitor{buf}, tag.handler);
 	}
 
-	GrfMsg(2, "StaticGRFInfo: unknown type/id combination found, type={:c}, id={}", type, id.AsString());
+	GrfMsg(Severity::Warning, "StaticGRFInfo: unknown type/id combination found, type={:c}, id={}", type, id.AsString());
 	return SkipUnknownInfo(buf, type);
 }
 

--- a/src/newgrf/newgrf_act2.cpp
+++ b/src/newgrf/newgrf_act2.cpp
@@ -74,7 +74,7 @@ TileLayoutFlags ReadSpriteLayoutSprite(ByteReader &buf, bool read_flags, bool in
 		/* Use sprite from Action 1 */
 		uint index = GB(grf_sprite->sprite, 0, 14);
 		if (use_cur_spritesets && (!_cur_gps.IsValidSpriteSet(feature, index) || _cur_gps.GetNumEnts(feature, index) == 0)) {
-			GrfMsg(1, "ReadSpriteLayoutSprite: Spritelayout uses undefined custom spriteset {}", index);
+			GrfMsg(Severity::Error, "ReadSpriteLayoutSprite: Spritelayout uses undefined custom spriteset {}", index);
 			grf_sprite->sprite = SPR_IMG_QUERY;
 			grf_sprite->pal = PAL_NONE;
 		} else {
@@ -84,7 +84,7 @@ TileLayoutFlags ReadSpriteLayoutSprite(ByteReader &buf, bool read_flags, bool in
 			SetBit(grf_sprite->sprite, SPRITE_MODIFIER_CUSTOM_SPRITE);
 		}
 	} else if ((flags & TLF_SPRITE_VAR10) && !(flags & TLF_SPRITE_REG_FLAGS)) {
-		GrfMsg(1, "ReadSpriteLayoutSprite: Spritelayout specifies var10 value for non-action-1 sprite");
+		GrfMsg(Severity::Error, "ReadSpriteLayoutSprite: Spritelayout specifies var10 value for non-action-1 sprite");
 		DisableGrf(STR_NEWGRF_ERROR_INVALID_SPRITE_LAYOUT);
 		return flags;
 	}
@@ -93,7 +93,7 @@ TileLayoutFlags ReadSpriteLayoutSprite(ByteReader &buf, bool read_flags, bool in
 		/* Use palette from Action 1 */
 		uint index = GB(grf_sprite->pal, 0, 14);
 		if (use_cur_spritesets && (!_cur_gps.IsValidSpriteSet(feature, index) || _cur_gps.GetNumEnts(feature, index) == 0)) {
-			GrfMsg(1, "ReadSpriteLayoutSprite: Spritelayout uses undefined custom spriteset {} for 'palette'", index);
+			GrfMsg(Severity::Error, "ReadSpriteLayoutSprite: Spritelayout uses undefined custom spriteset {} for 'palette'", index);
 			grf_sprite->pal = PAL_NONE;
 		} else {
 			SpriteID sprite = use_cur_spritesets ? _cur_gps.GetSprite(feature, index) : index;
@@ -102,7 +102,7 @@ TileLayoutFlags ReadSpriteLayoutSprite(ByteReader &buf, bool read_flags, bool in
 			SetBit(grf_sprite->pal, SPRITE_MODIFIER_CUSTOM_SPRITE);
 		}
 	} else if ((flags & TLF_PALETTE_VAR10) && !(flags & TLF_PALETTE_REG_FLAGS)) {
-		GrfMsg(1, "ReadSpriteLayoutRegisters: Spritelayout specifies var10 value for non-action-1 palette");
+		GrfMsg(Severity::Error, "ReadSpriteLayoutRegisters: Spritelayout specifies var10 value for non-action-1 palette");
 		DisableGrf(STR_NEWGRF_ERROR_INVALID_SPRITE_LAYOUT);
 		return flags;
 	}
@@ -144,7 +144,7 @@ static void ReadSpriteLayoutRegisters(ByteReader &buf, TileLayoutFlags flags, bo
 	if (flags & TLF_SPRITE_VAR10) {
 		regs.sprite_var10 = buf.ReadByte();
 		if (regs.sprite_var10 > TLR_MAX_VAR10) {
-			GrfMsg(1, "ReadSpriteLayoutRegisters: Spritelayout specifies var10 ({}) exceeding the maximal allowed value {}", regs.sprite_var10, TLR_MAX_VAR10);
+			GrfMsg(Severity::Error, "ReadSpriteLayoutRegisters: Spritelayout specifies var10 ({}) exceeding the maximal allowed value {}", regs.sprite_var10, TLR_MAX_VAR10);
 			DisableGrf(STR_NEWGRF_ERROR_INVALID_SPRITE_LAYOUT);
 			return;
 		}
@@ -153,7 +153,7 @@ static void ReadSpriteLayoutRegisters(ByteReader &buf, TileLayoutFlags flags, bo
 	if (flags & TLF_PALETTE_VAR10) {
 		regs.palette_var10 = buf.ReadByte();
 		if (regs.palette_var10 > TLR_MAX_VAR10) {
-			GrfMsg(1, "ReadSpriteLayoutRegisters: Spritelayout specifies var10 ({}) exceeding the maximal allowed value {}", regs.palette_var10, TLR_MAX_VAR10);
+			GrfMsg(Severity::Error, "ReadSpriteLayoutRegisters: Spritelayout specifies var10 ({}) exceeding the maximal allowed value {}", regs.palette_var10, TLR_MAX_VAR10);
 			DisableGrf(STR_NEWGRF_ERROR_INVALID_SPRITE_LAYOUT);
 			return;
 		}
@@ -187,7 +187,7 @@ bool ReadSpriteLayout(ByteReader &buf, uint num_building_sprites, bool use_cur_s
 	if (_cur_gps.skip_sprites < 0) return true;
 
 	if (flags & ~(valid_flags & ~TLF_NON_GROUND_FLAGS)) {
-		GrfMsg(1, "ReadSpriteLayout: Spritelayout uses invalid flag 0x{:X} for ground sprite", flags & ~(valid_flags & ~TLF_NON_GROUND_FLAGS));
+		GrfMsg(Severity::Error, "ReadSpriteLayout: Spritelayout uses invalid flag 0x{:X} for ground sprite", flags & ~(valid_flags & ~TLF_NON_GROUND_FLAGS));
 		DisableGrf(STR_NEWGRF_ERROR_INVALID_SPRITE_LAYOUT);
 		return true;
 	}
@@ -202,7 +202,7 @@ bool ReadSpriteLayout(ByteReader &buf, uint num_building_sprites, bool use_cur_s
 		if (_cur_gps.skip_sprites < 0) return true;
 
 		if (flags & ~valid_flags) {
-			GrfMsg(1, "ReadSpriteLayout: Spritelayout uses unknown flag 0x{:X}", flags & ~valid_flags);
+			GrfMsg(Severity::Error, "ReadSpriteLayout: Spritelayout uses unknown flag 0x{:X}", flags & ~valid_flags);
 			DisableGrf(STR_NEWGRF_ERROR_INVALID_SPRITE_LAYOUT);
 			return true;
 		}
@@ -299,7 +299,7 @@ static const SpriteGroup *GetGroupFromGroupID(uint8_t setid, uint8_t type, uint1
 	if (groupid == GROUPID_CALLBACK_FAILED) return nullptr;
 
 	if (groupid > MAX_SPRITEGROUP || _cur_gps.spritegroups[groupid] == nullptr) {
-		GrfMsg(1, "GetGroupFromGroupID(0x{:02X}:0x{:02X}): Groupid 0x{:04X} does not exist, leaving empty", setid, type, groupid);
+		GrfMsg(Severity::Error, "GetGroupFromGroupID(0x{:02X}:0x{:02X}): Groupid 0x{:04X} does not exist, leaving empty", setid, type, groupid);
 		return nullptr;
 	}
 
@@ -319,7 +319,7 @@ static const SpriteGroup *CreateGroupFromGroupID(GrfSpecFeature feature, uint8_t
 	if (HasBit(spriteid, 15)) return GetCallbackResultGroup(spriteid);
 
 	if (!_cur_gps.IsValidSpriteSet(feature, spriteid)) {
-		GrfMsg(1, "CreateGroupFromGroupID(0x{:02X}:0x{:02X}): Sprite set {} invalid", setid, type, spriteid);
+		GrfMsg(Severity::Error, "CreateGroupFromGroupID(0x{:02X}:0x{:02X}): Sprite set {} invalid", setid, type, spriteid);
 		return nullptr;
 	}
 
@@ -485,7 +485,7 @@ static const SpriteGroup *ReadRandomizedSpriteGroup(ByteReader &buf, GrfSpecFeat
 
 	uint8_t num_groups = buf.ReadByte();
 	if (!HasExactlyOneBit(num_groups)) {
-		GrfMsg(1, "NewSpriteGroup: Random Action 2 nrand should be power of 2");
+		GrfMsg(Severity::Error, "NewSpriteGroup: Random Action 2 nrand should be power of 2");
 	}
 
 	group->groups.reserve(num_groups);
@@ -510,21 +510,21 @@ static const SpriteGroup *ReadRealSpriteGroup(ByteReader &buf, GrfSpecFeature fe
 	uint8_t num_loading = buf.ReadByte();
 
 	if (!_cur_gps.HasValidSpriteSets(feature)) {
-		GrfMsg(0, "NewSpriteGroup: No sprite set to work on! Skipping");
+		GrfMsg(Severity::Critical, "NewSpriteGroup: No sprite set to work on! Skipping");
 		return nullptr;
 	}
 
-	GrfMsg(6, "NewSpriteGroup: New SpriteGroup 0x{:02X}, {} loaded, {} loading", setid, num_loaded, num_loading);
+	GrfMsg(Severity::Debug2, "NewSpriteGroup: New SpriteGroup 0x{:02X}, {} loaded, {} loading", setid, num_loaded, num_loading);
 
 	if (num_loaded + num_loading == 0) {
-		GrfMsg(1, "NewSpriteGroup: no result, skipping invalid RealSpriteGroup");
+		GrfMsg(Severity::Error, "NewSpriteGroup: no result, skipping invalid RealSpriteGroup");
 		return nullptr;
 	}
 
 	if (num_loaded + num_loading == 1) {
 		/* Avoid creating 'Real' sprite group if only one option. */
 		uint16_t spriteid = buf.ReadWord();
-		GrfMsg(8, "NewSpriteGroup: one result, skipping RealSpriteGroup = subset {}", spriteid);
+		GrfMsg(Severity::Trace2, "NewSpriteGroup: one result, skipping RealSpriteGroup = subset {}", spriteid);
 		return CreateGroupFromGroupID(feature, setid, type, spriteid);
 	}
 
@@ -534,20 +534,20 @@ static const SpriteGroup *ReadRealSpriteGroup(ByteReader &buf, GrfSpecFeature fe
 	loaded.reserve(num_loaded);
 	for (uint i = 0; i < num_loaded; i++) {
 		loaded.push_back(buf.ReadWord());
-		GrfMsg(8, "NewSpriteGroup: + rg->loaded[{}] = subset {}", i, loaded[i]);
+		GrfMsg(Severity::Trace2, "NewSpriteGroup: + rg->loaded[{}] = subset {}", i, loaded[i]);
 	}
 
 	loading.reserve(num_loading);
 	for (uint i = 0; i < num_loading; i++) {
 		loading.push_back(buf.ReadWord());
-		GrfMsg(8, "NewSpriteGroup: + rg->loading[{}] = subset {}", i, loading[i]);
+		GrfMsg(Severity::Trace2, "NewSpriteGroup: + rg->loading[{}] = subset {}", i, loading[i]);
 	}
 
 	bool loaded_same = !loaded.empty() && std::adjacent_find(loaded.begin(), loaded.end(), std::not_equal_to<>()) == loaded.end();
 	bool loading_same = !loading.empty() && std::adjacent_find(loading.begin(), loading.end(), std::not_equal_to<>()) == loading.end();
 	if (loaded_same && loading_same && loaded[0] == loading[0]) {
 		/* Both lists only contain the same value, so don't create 'Real' sprite group */
-		GrfMsg(8, "NewSpriteGroup: same result, skipping RealSpriteGroup = subset {}", loaded[0]);
+		GrfMsg(Severity::Trace2, "NewSpriteGroup: same result, skipping RealSpriteGroup = subset {}", loaded[0]);
 		return CreateGroupFromGroupID(feature, setid, type, loaded[0]);
 	}
 
@@ -602,7 +602,7 @@ static const SpriteGroup *ReadTileLayoutSpriteGroup(ByteReader &buf, GrfSpecFeat
 static const SpriteGroup *ReadIndustryProductionSpriteGroup(ByteReader &buf, uint8_t type)
 {
 	if (type > 2) {
-		GrfMsg(1, "NewSpriteGroup: Unsupported industry production version {}, skipping", type);
+		GrfMsg(Severity::Error, "NewSpriteGroup: Unsupported industry production version {}, skipping", type);
 		return nullptr;
 	}
 
@@ -693,7 +693,7 @@ static const SpriteGroup *ReadIndustryProductionSpriteGroup(ByteReader &buf, uin
 static const SpriteGroup *ReadSpriteGroup(ByteReader &buf, GrfSpecFeature feature, uint8_t setid, uint8_t type)
 {
 	if (feature >= GrfSpecFeature::End) {
-		GrfMsg(1, "NewSpriteGroup: Unsupported feature 0x{:02X}, skipping", feature);
+		GrfMsg(Severity::Error, "NewSpriteGroup: Unsupported feature 0x{:02X}, skipping", feature);
 		return nullptr;
 	}
 
@@ -719,7 +719,7 @@ static const SpriteGroup *ReadSpriteGroup(ByteReader &buf, GrfSpecFeature featur
 		/* Neither a variable or randomized sprite group... must be a real group */
 		default:
 			if (type >= 0x80) {
-				GrfMsg(0, "NewSpriteGroup: Reserved group type 0x{:02X}, skipping", type);
+				GrfMsg(Severity::Critical, "NewSpriteGroup: Reserved group type 0x{:02X}, skipping", type);
 				return nullptr;
 			}
 
@@ -749,7 +749,7 @@ static const SpriteGroup *ReadSpriteGroup(ByteReader &buf, GrfSpecFeature featur
 					return ReadIndustryProductionSpriteGroup(buf, type);
 
 				default:
-					GrfMsg(1, "NewSpriteGroup: Unsupported feature 0x{:02X}, skipping", feature);
+					GrfMsg(Severity::Error, "NewSpriteGroup: Unsupported feature 0x{:02X}, skipping", feature);
 					return nullptr;
 			}
 	}

--- a/src/newgrf/newgrf_act3.cpp
+++ b/src/newgrf/newgrf_act3.cpp
@@ -44,24 +44,24 @@ static CargoType TranslateCargo(GrfSpecFeature feature, uint8_t ctype)
 
 	/* Check if the cargo type is out of bounds of the cargo translation table */
 	if (ctype >= cargo_list.size()) {
-		GrfMsg(1, "TranslateCargo: Cargo type {} out of range (max {}), skipping.", ctype, (unsigned int)_cur_gps.grffile->cargo_list.size() - 1);
+		GrfMsg(Severity::Error, "TranslateCargo: Cargo type {} out of range (max {}), skipping.", ctype, (unsigned int)_cur_gps.grffile->cargo_list.size() - 1);
 		return INVALID_CARGO;
 	}
 
 	/* Look up the cargo label from the translation table */
 	CargoLabel cl = cargo_list[ctype];
 	if (cl == CT_INVALID) {
-		GrfMsg(5, "TranslateCargo: Cargo type {} not available in this climate, skipping.", ctype);
+		GrfMsg(Severity::Debug1, "TranslateCargo: Cargo type {} not available in this climate, skipping.", ctype);
 		return INVALID_CARGO;
 	}
 
 	CargoType cargo_type = GetCargoTypeByLabel(cl);
 	if (!IsValidCargoType(cargo_type)) {
-		GrfMsg(5, "TranslateCargo: Cargo '{}' unsupported, skipping.", cl.AsString());
+		GrfMsg(Severity::Debug1, "TranslateCargo: Cargo '{}' unsupported, skipping.", cl.AsString());
 		return INVALID_CARGO;
 	}
 
-	GrfMsg(6, "TranslateCargo: Cargo '{}' mapped to cargo type {}.", cl.AsString(), cargo_type);
+	GrfMsg(Severity::Debug2, "TranslateCargo: Cargo '{}' mapped to cargo type {}.", cl.AsString(), cargo_type);
 	return cargo_type;
 }
 
@@ -69,7 +69,7 @@ static CargoType TranslateCargo(GrfSpecFeature feature, uint8_t ctype)
 static bool IsValidGroupID(uint16_t groupid, std::string_view function)
 {
 	if (groupid > MAX_SPRITEGROUP || _cur_gps.spritegroups[groupid] == nullptr) {
-		GrfMsg(1, "{}: Spritegroup 0x{:04X} out of range or empty, skipping.", function, groupid);
+		GrfMsg(Severity::Error, "{}: Spritegroup 0x{:04X} out of range or empty, skipping.", function, groupid);
 		return false;
 	}
 
@@ -88,11 +88,11 @@ static void VehicleMapSpriteGroup(ByteReader &buf, GrfSpecFeature feature, uint8
 		idcount = GB(idcount, 0, 7);
 
 		if (last_engines.empty()) {
-			GrfMsg(0, "VehicleMapSpriteGroup: WagonOverride: No engine to do override with");
+			GrfMsg(Severity::Critical, "VehicleMapSpriteGroup: WagonOverride: No engine to do override with");
 			return;
 		}
 
-		GrfMsg(6, "VehicleMapSpriteGroup: WagonOverride: {} engines, {} wagons", last_engines.size(), idcount);
+		GrfMsg(Severity::Debug2, "VehicleMapSpriteGroup: WagonOverride: {} engines, {} wagons", last_engines.size(), idcount);
 	} else {
 		last_engines.resize(idcount);
 	}
@@ -119,7 +119,7 @@ static void VehicleMapSpriteGroup(ByteReader &buf, GrfSpecFeature feature, uint8
 		uint16_t groupid = buf.ReadWord();
 		if (!IsValidGroupID(groupid, "VehicleMapSpriteGroup")) continue;
 
-		GrfMsg(8, "VehicleMapSpriteGroup: * [{}] Cargo type 0x{:X}, group id 0x{:02X}", c, ctype, groupid);
+		GrfMsg(Severity::Trace2, "VehicleMapSpriteGroup: * [{}] Cargo type 0x{:X}, group id 0x{:02X}", c, ctype, groupid);
 
 		CargoType cargo_type = TranslateCargo(feature, ctype);
 		if (!IsValidCargoType(cargo_type)) continue;
@@ -127,7 +127,7 @@ static void VehicleMapSpriteGroup(ByteReader &buf, GrfSpecFeature feature, uint8
 		for (uint i = 0; i < idcount; i++) {
 			EngineID engine = engines[i];
 
-			GrfMsg(7, "VehicleMapSpriteGroup: [{}] Engine {}...", i, engine);
+			GrfMsg(Severity::Trace1, "VehicleMapSpriteGroup: [{}] Engine {}...", i, engine);
 
 			if (wagover) {
 				SetWagonOverrideSprites(engine, cargo_type, _cur_gps.spritegroups[groupid], last_engines);
@@ -140,7 +140,7 @@ static void VehicleMapSpriteGroup(ByteReader &buf, GrfSpecFeature feature, uint8
 	uint16_t groupid = buf.ReadWord();
 	if (!IsValidGroupID(groupid, "VehicleMapSpriteGroup")) return;
 
-	GrfMsg(8, "-- Default group id 0x{:04X}", groupid);
+	GrfMsg(Severity::Trace2, "-- Default group id 0x{:04X}", groupid);
 
 	for (uint i = 0; i < idcount; i++) {
 		EngineID engine = engines[i];
@@ -189,9 +189,9 @@ struct PurchaseDefaultMapSpriteGroupHandler : MapSpriteGroupHandler {
 	void MapSpecific(uint16_t local_id, uint8_t cid, const SpriteGroup *group) override
 	{
 		if (cid != 0xFF) {
-			GrfMsg(1, "MapSpriteGroup: Invalid cargo bitnum {}, skipping.", cid);
+			GrfMsg(Severity::Error, "MapSpriteGroup: Invalid cargo bitnum {}, skipping.", cid);
 		} else if (T *spec = GetSpec<T>(_cur_gps.grffile, local_id); spec == nullptr) {
-			GrfMsg(1, "MapSpriteGroup: {} undefined, skipping.", local_id);
+			GrfMsg(Severity::Error, "MapSpriteGroup: {} undefined, skipping.", local_id);
 		} else {
 			spec->grf_prop.SetSpriteGroup(StandardSpriteGroup::Purchase, group);
 		}
@@ -200,7 +200,7 @@ struct PurchaseDefaultMapSpriteGroupHandler : MapSpriteGroupHandler {
 	void MapDefault(uint16_t local_id, const SpriteGroup *group) override
 	{
 		if (T *spec = GetSpec<T>(_cur_gps.grffile, local_id); spec == nullptr) {
-			GrfMsg(1, "MapSpriteGroup: {} undefined, skipping.", local_id);
+			GrfMsg(Severity::Error, "MapSpriteGroup: {} undefined, skipping.", local_id);
 		} else {
 			spec->grf_prop.SetSpriteGroup(StandardSpriteGroup::Default, group);
 			spec->grf_prop.SetGRFFile(_cur_gps.grffile);
@@ -218,7 +218,7 @@ struct CargoTypeMapSpriteGroupHandler : MapSpriteGroupHandler {
 		if (!IsValidCargoType(cargo_type)) return;
 
 		if (T *spec = GetSpec<T>(_cur_gps.grffile, local_id); spec == nullptr) {
-			GrfMsg(1, "MapSpriteGroup: {} undefined, skipping", local_id);
+			GrfMsg(Severity::Error, "MapSpriteGroup: {} undefined, skipping", local_id);
 		} else {
 			spec->grf_prop.SetSpriteGroup(cargo_type, group);
 		}
@@ -227,9 +227,9 @@ struct CargoTypeMapSpriteGroupHandler : MapSpriteGroupHandler {
 	void MapDefault(uint16_t local_id, const SpriteGroup *group) override
 	{
 		if (T *spec = GetSpec<T>(_cur_gps.grffile, local_id); spec == nullptr) {
-			GrfMsg(1, "MapSpriteGroup: {} undefined, skipping", local_id);
+			GrfMsg(Severity::Error, "MapSpriteGroup: {} undefined, skipping", local_id);
 		} else if (spec->grf_prop.HasGrfFile()) {
-			GrfMsg(1, "MapSpriteGroup: {} mapped multiple times, skipping", local_id);
+			GrfMsg(Severity::Error, "MapSpriteGroup: {} mapped multiple times, skipping", local_id);
 		} else {
 			spec->grf_prop.SetSpriteGroup(CargoGRFFileProps::SG_DEFAULT, group);
 			spec->grf_prop.SetGRFFile(_cur_gps.grffile);
@@ -245,7 +245,7 @@ struct CanalMapSpriteGroupHandler : MapSpriteGroupHandler {
 	void MapDefault(uint16_t local_id, const SpriteGroup *group) override
 	{
 		if (local_id >= to_underlying(CanalFeature::End)) {
-			GrfMsg(1, "CanalMapSpriteGroup: Canal subset {} out of range, skipping", local_id);
+			GrfMsg(Severity::Error, "CanalMapSpriteGroup: Canal subset {} out of range, skipping", local_id);
 		} else {
 			auto &feature = _water_feature[static_cast<CanalFeature>(local_id)];
 			feature.grffile = _cur_gps.grffile;
@@ -272,7 +272,7 @@ struct CargoMapSpriteGroupHandler : MapSpriteGroupHandler {
 	void MapDefault(uint16_t local_id, const SpriteGroup *group) override
 	{
 		if (local_id >= NUM_CARGO) {
-			GrfMsg(1, "CargoMapSpriteGroup: Cargo type {} out of range, skipping", local_id);
+			GrfMsg(Severity::Error, "CargoMapSpriteGroup: Cargo type {} out of range, skipping", local_id);
 		} else {
 			CargoSpec *cs = CargoSpec::Get(local_id);
 			cs->grffile = _cur_gps.grffile;
@@ -339,7 +339,7 @@ struct BadgeMapSpriteGroupHandler : MapSpriteGroupHandler {
 
 		auto found = _cur_gps.grffile->badge_map.find(local_id);
 		if (found == std::end(_cur_gps.grffile->badge_map)) {
-			GrfMsg(1, "BadgeMapSpriteGroup: Badge {} undefined, skipping", local_id);
+			GrfMsg(Severity::Error, "BadgeMapSpriteGroup: Badge {} undefined, skipping", local_id);
 		} else {
 			auto &badge = *GetBadge(found->second);
 			badge.grf_prop.SetSpriteGroup(static_cast<GrfSpecFeature>(cid), group);
@@ -350,7 +350,7 @@ struct BadgeMapSpriteGroupHandler : MapSpriteGroupHandler {
 	{
 		auto found = _cur_gps.grffile->badge_map.find(local_id);
 		if (found == std::end(_cur_gps.grffile->badge_map)) {
-			GrfMsg(1, "BadgeMapSpriteGroup: Badge {} undefined, skipping", local_id);
+			GrfMsg(Severity::Error, "BadgeMapSpriteGroup: Badge {} undefined, skipping", local_id);
 		} else {
 			auto &badge = *GetBadge(found->second);
 			badge.grf_prop.SetSpriteGroup(GrfSpecFeature::Default, group);
@@ -409,7 +409,7 @@ static void FeatureMapSpriteGroup(ByteReader &buf)
 	uint8_t idcount = buf.ReadByte();
 
 	if (feature >= GrfSpecFeature::End) {
-		GrfMsg(1, "FeatureMapSpriteGroup: Unsupported feature 0x{:02X}, skipping", feature);
+		GrfMsg(Severity::Error, "FeatureMapSpriteGroup: Unsupported feature 0x{:02X}, skipping", feature);
 		return;
 	}
 
@@ -420,7 +420,7 @@ static void FeatureMapSpriteGroup(ByteReader &buf)
 		uint16_t groupid = buf.ReadWord();
 		if (!IsValidGroupID(groupid, "FeatureMapSpriteGroup")) return;
 
-		GrfMsg(6, "FeatureMapSpriteGroup: Adding generic feature callback for feature 0x{:02X}", feature);
+		GrfMsg(Severity::Debug2, "FeatureMapSpriteGroup: Adding generic feature callback for feature 0x{:02X}", feature);
 
 		AddGenericCallback(feature, _cur_gps.grffile, _cur_gps.spritegroups[groupid]);
 		return;
@@ -429,7 +429,7 @@ static void FeatureMapSpriteGroup(ByteReader &buf)
 	/* Mark the feature as used by the grf (generic callbacks do not count) */
 	_cur_gps.grffile->grf_features.Set(feature);
 
-	GrfMsg(6, "FeatureMapSpriteGroup: Feature 0x{:02X}, {} ids", feature, idcount);
+	GrfMsg(Severity::Debug2, "FeatureMapSpriteGroup: Feature 0x{:02X}, {} ids", feature, idcount);
 
 	switch (feature) {
 		case GrfSpecFeature::Trains:
@@ -452,7 +452,7 @@ static void FeatureMapSpriteGroup(ByteReader &buf)
 		case GrfSpecFeature::Badges: MapSpriteGroup(buf, idcount, BadgeMapSpriteGroupHandler{}); return;
 
 		default:
-			GrfMsg(1, "FeatureMapSpriteGroup: Unsupported feature 0x{:02X}, skipping", feature);
+			GrfMsg(Severity::Error, "FeatureMapSpriteGroup: Unsupported feature 0x{:02X}, skipping", feature);
 			return;
 	}
 }

--- a/src/newgrf/newgrf_act4.cpp
+++ b/src/newgrf/newgrf_act4.cpp
@@ -50,7 +50,7 @@ static void FeatureNewName(ByteReader &buf)
 
 	GrfSpecFeature feature{buf.ReadByte()};
 	if (feature >= GrfSpecFeature::End && feature != GrfSpecFeature::OriginalStrings) {
-		GrfMsg(1, "FeatureNewName: Unsupported feature 0x{:02X}, skipping", feature);
+		GrfMsg(Severity::Error, "FeatureNewName: Unsupported feature 0x{:02X}, skipping", feature);
 		return;
 	}
 
@@ -70,7 +70,7 @@ static void FeatureNewName(ByteReader &buf)
 
 	uint16_t endid = id + num;
 
-	GrfMsg(6, "FeatureNewName: About to rename engines {}..{} (feature 0x{:02X}) in language 0x{:02X}",
+	GrfMsg(Severity::Debug2, "FeatureNewName: About to rename engines {}..{} (feature 0x{:02X}) in language 0x{:02X}",
 	               id, endid, feature, lang);
 
 	/* Feature overlay to make non-generic strings unique in their feature. We use feature + 1 so that generic strings stay as they are. */
@@ -78,7 +78,7 @@ static void FeatureNewName(ByteReader &buf)
 
 	for (; id < endid && buf.HasData(); id++) {
 		std::string_view name = buf.ReadString();
-		GrfMsg(8, "FeatureNewName: 0x{:04X} <- {}", id, StrMakeValid(name));
+		GrfMsg(Severity::Trace2, "FeatureNewName: 0x{:04X} <- {}", id, StrMakeValid(name));
 
 		switch (feature) {
 			case GrfSpecFeature::Trains:
@@ -99,7 +99,7 @@ static void FeatureNewName(ByteReader &buf)
 				if (!generic) {
 					auto found = _cur_gps.grffile->badge_map.find(id);
 					if (found == std::end(_cur_gps.grffile->badge_map)) {
-						GrfMsg(1, "FeatureNewName: Attempt to name undefined badge 0x{:X}, ignoring", id);
+						GrfMsg(Severity::Error, "FeatureNewName: Attempt to name undefined badge 0x{:X}, ignoring", id);
 					} else {
 						Badge &badge = *GetBadge(found->second);
 						badge.name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{feature_overlay | id}, lang, true, false, name, STR_UNDEFINED);
@@ -119,7 +119,7 @@ static void FeatureNewName(ByteReader &buf)
 				switch (GB(id, 8, 8)) {
 					case 0xC4: // Station class name
 						if (GB(id, 0, 8) >= _cur_gps.grffile->stations.size() || _cur_gps.grffile->stations[GB(id, 0, 8)] == nullptr) {
-							GrfMsg(1, "FeatureNewName: Attempt to name undefined station 0x{:X}, ignoring", GB(id, 0, 8));
+							GrfMsg(Severity::Error, "FeatureNewName: Attempt to name undefined station 0x{:X}, ignoring", GB(id, 0, 8));
 						} else {
 							StationClassID class_index = _cur_gps.grffile->stations[GB(id, 0, 8)]->class_index;
 							StationClass::Get(class_index)->name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
@@ -128,7 +128,7 @@ static void FeatureNewName(ByteReader &buf)
 
 					case 0xC5: // Station name
 						if (GB(id, 0, 8) >= _cur_gps.grffile->stations.size() || _cur_gps.grffile->stations[GB(id, 0, 8)] == nullptr) {
-							GrfMsg(1, "FeatureNewName: Attempt to name undefined station 0x{:X}, ignoring", GB(id, 0, 8));
+							GrfMsg(Severity::Error, "FeatureNewName: Attempt to name undefined station 0x{:X}, ignoring", GB(id, 0, 8));
 						} else {
 							_cur_gps.grffile->stations[GB(id, 0, 8)]->name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 						}
@@ -136,7 +136,7 @@ static void FeatureNewName(ByteReader &buf)
 
 					case 0xC7: // Airporttile name
 						if (GB(id, 0, 8) >= _cur_gps.grffile->airtspec.size() || _cur_gps.grffile->airtspec[GB(id, 0, 8)] == nullptr) {
-							GrfMsg(1, "FeatureNewName: Attempt to name undefined airport tile 0x{:X}, ignoring", GB(id, 0, 8));
+							GrfMsg(Severity::Error, "FeatureNewName: Attempt to name undefined airport tile 0x{:X}, ignoring", GB(id, 0, 8));
 						} else {
 							_cur_gps.grffile->airtspec[GB(id, 0, 8)]->name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 						}
@@ -144,14 +144,14 @@ static void FeatureNewName(ByteReader &buf)
 
 					case 0xC9: // House name
 						if (GB(id, 0, 8) >= _cur_gps.grffile->housespec.size() || _cur_gps.grffile->housespec[GB(id, 0, 8)] == nullptr) {
-							GrfMsg(1, "FeatureNewName: Attempt to name undefined house 0x{:X}, ignoring.", GB(id, 0, 8));
+							GrfMsg(Severity::Error, "FeatureNewName: Attempt to name undefined house 0x{:X}, ignoring.", GB(id, 0, 8));
 						} else {
 							_cur_gps.grffile->housespec[GB(id, 0, 8)]->building_name = AddGRFString(_cur_gps.grffile->grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 						}
 						break;
 
 					default:
-						GrfMsg(7, "FeatureNewName: Unsupported ID (0x{:04X})", id);
+						GrfMsg(Severity::Trace1, "FeatureNewName: Unsupported ID (0x{:04X})", id);
 						break;
 				}
 				break;

--- a/src/newgrf/newgrf_act5.cpp
+++ b/src/newgrf/newgrf_act5.cpp
@@ -31,14 +31,14 @@ static uint16_t SanitizeSpriteOffset(uint16_t &num, uint16_t offset, int max_spr
 {
 
 	if (offset >= max_sprites) {
-		GrfMsg(1, "GraphicsNew: {} sprite offset must be less than {}, skipping", name, max_sprites);
+		GrfMsg(Severity::Error, "GraphicsNew: {} sprite offset must be less than {}, skipping", name, max_sprites);
 		uint orig_num = num;
 		num = 0;
 		return orig_num;
 	}
 
 	if (offset + num > max_sprites) {
-		GrfMsg(4, "GraphicsNew: {} sprite overflow, truncating...", name);
+		GrfMsg(Severity::Info, "GraphicsNew: {} sprite overflow, truncating...", name);
 		uint orig_num = num;
 		num = std::max(max_sprites - offset, 0);
 		return orig_num - num;
@@ -107,7 +107,7 @@ static void GraphicsNew(ByteReader &buf)
 	if ((type == 0x0D) && (num == 10) && _cur_gps.grfconfig->flags.Test(GRFConfigFlag::System)) {
 		/* Special not-TTDP-compatible case used in openttd.grf
 		 * Missing shore sprites and initialisation of SPR_SHORE_BASE */
-		GrfMsg(2, "GraphicsNew: Loading 10 missing shore sprites from extra grf.");
+		GrfMsg(Severity::Warning, "GraphicsNew: Loading 10 missing shore sprites from extra grf.");
 		LoadNextSprite(SPR_SHORE_BASE +  0, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_STEEP_S
 		LoadNextSprite(SPR_SHORE_BASE +  5, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_STEEP_W
 		LoadNextSprite(SPR_SHORE_BASE +  7, *_cur_gps.file, _cur_gps.nfo_line++); // SLOPE_WSE
@@ -124,7 +124,7 @@ static void GraphicsNew(ByteReader &buf)
 
 	/* Supported type? */
 	if ((type >= std::size(_action5_types)) || (_action5_types[type].block_type == Action5BlockType::Invalid)) {
-		GrfMsg(2, "GraphicsNew: Custom graphics (type 0x{:02X}) sprite block of length {} (unimplemented, ignoring)", type, num);
+		GrfMsg(Severity::Warning, "GraphicsNew: Custom graphics (type 0x{:02X}) sprite block of length {} (unimplemented, ignoring)", type, num);
 		_cur_gps.skip_sprites = num;
 		return;
 	}
@@ -135,14 +135,14 @@ static void GraphicsNew(ByteReader &buf)
 	 * except for the long version of the shore type:
 	 * Ignore offset if not allowed */
 	if ((action5_type->block_type != Action5BlockType::AllowOffset) && (offset != 0)) {
-		GrfMsg(1, "GraphicsNew: {} (type 0x{:02X}) do not allow an <offset> field. Ignoring offset.", action5_type->name, type);
+		GrfMsg(Severity::Error, "GraphicsNew: {} (type 0x{:02X}) do not allow an <offset> field. Ignoring offset.", action5_type->name, type);
 		offset = 0;
 	}
 
 	/* Ignore action5 if too few sprites are specified. (for TTDP compatibility)
 	 * This does not make sense, if <offset> is allowed */
 	if ((action5_type->block_type == Action5BlockType::Fixed) && (num < action5_type->min_sprites)) {
-		GrfMsg(1, "GraphicsNew: {} (type 0x{:02X}) count must be at least {}. Only {} were specified. Skipping.", action5_type->name, type, action5_type->min_sprites, num);
+		GrfMsg(Severity::Error, "GraphicsNew: {} (type 0x{:02X}) count must be at least {}. Only {} were specified. Skipping.", action5_type->name, type, action5_type->min_sprites, num);
 		_cur_gps.skip_sprites = num;
 		return;
 	}
@@ -152,7 +152,7 @@ static void GraphicsNew(ByteReader &buf)
 	SpriteID replace = action5_type->sprite_base + offset;
 
 	/* Load <num> sprites starting from <replace>, then skip <skip_num> sprites. */
-	GrfMsg(2, "GraphicsNew: Replacing sprites {} to {} of {} (type 0x{:02X}) at SpriteID 0x{:04X}", offset, offset + num - 1, action5_type->name, type, replace);
+	GrfMsg(Severity::Warning, "GraphicsNew: Replacing sprites {} to {} of {} (type 0x{:02X}) at SpriteID 0x{:04X}", offset, offset + num - 1, action5_type->name, type, replace);
 
 	if (type == 0x0D) _loaded_newgrf_features.shore = ShoreReplacement::Action5;
 
@@ -192,7 +192,7 @@ static void SkipAct5(ByteReader &buf)
 	/* Skip the sprites of this action */
 	_cur_gps.skip_sprites = buf.ReadExtendedByte();
 
-	GrfMsg(3, "SkipAct5: Skipping {} sprites", _cur_gps.skip_sprites);
+	GrfMsg(Severity::Notice, "SkipAct5: Skipping {} sprites", _cur_gps.skip_sprites);
 }
 
 /** @copydoc GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_act6.cpp
+++ b/src/newgrf/newgrf_act6.cpp
@@ -39,7 +39,7 @@ static void CfgApply(ByteReader &buf)
 
 	/* Check if the sprite is a pseudo sprite. We can't operate on real sprites. */
 	if (type != 0xFF) {
-		GrfMsg(2, "CfgApply: Ignoring (next sprite is real, unsupported)");
+		GrfMsg(Severity::Warning, "CfgApply: Ignoring (next sprite is real, unsupported)");
 
 		/* Reset the file position to the start of the next sprite */
 		file.SeekTo(pos, SEEK_SET);
@@ -80,11 +80,11 @@ static void CfgApply(ByteReader &buf)
 		/* If the parameter is a GRF parameter (not an internal variable) check
 		 * if it (and all further sequential parameters) has been defined. */
 		if (param_num < 0x80 && (param_num + (param_size - 1) / 4) >= std::size(_cur_gps.grffile->param)) {
-			GrfMsg(2, "CfgApply: Ignoring (param {} not set)", (param_num + (param_size - 1) / 4));
+			GrfMsg(Severity::Warning, "CfgApply: Ignoring (param {} not set)", (param_num + (param_size - 1) / 4));
 			break;
 		}
 
-		GrfMsg(8, "CfgApply: Applying {} bytes from parameter 0x{:02X} at offset 0x{:04X}", param_size, param_num, offset);
+		GrfMsg(Severity::Trace2, "CfgApply: Applying {} bytes from parameter 0x{:02X} at offset 0x{:04X}", param_size, param_num, offset);
 
 		bool carry = false;
 		for (uint i = 0; i < param_size && offset + i < num; i++) {

--- a/src/newgrf/newgrf_act7_9.cpp
+++ b/src/newgrf/newgrf_act7_9.cpp
@@ -168,7 +168,7 @@ uint32_t GetParamVal(uint8_t param, uint32_t *cond_val)
 			if (param < 0x80) return _cur_gps.grffile->GetParam(param);
 
 			/* In-game variable. */
-			GrfMsg(1, "Unsupported in-game variable 0x{:02X}", param);
+			GrfMsg(Severity::Error, "Unsupported in-game variable 0x{:02X}", param);
 			return UINT_MAX;
 	}
 }
@@ -206,11 +206,11 @@ static void SkipIf(ByteReader &buf)
 	}
 
 	if (param < 0x80 && std::size(_cur_gps.grffile->param) <= param) {
-		GrfMsg(7, "SkipIf: Param {} undefined, skipping test", param);
+		GrfMsg(Severity::Trace1, "SkipIf: Param {} undefined, skipping test", param);
 		return;
 	}
 
-	GrfMsg(7, "SkipIf: Test condtype {}, param 0x{:02X}, condval 0x{:08X}", condtype, param, cond_val);
+	GrfMsg(Severity::Trace1, "SkipIf: Test condtype {}, param 0x{:02X}, condval 0x{:08X}", condtype, param, cond_val);
 
 	/* condtypes that do not use 'param' are always valid.
 	 * condtypes that use 'param' are either not valid for param 0x88, or they are only valid for param 0x88.
@@ -246,7 +246,7 @@ static void SkipIf(ByteReader &buf)
 				result = rt != INVALID_ROADTYPE && RoadTypeIsTram(rt);
 				break;
 			}
-			default: GrfMsg(1, "SkipIf: Unsupported condition type {:02X}. Ignoring", condtype); return;
+			default: GrfMsg(Severity::Error, "SkipIf: Unsupported condition type {:02X}. Ignoring", condtype); return;
 		}
 	} else if (param == 0x88) {
 		/* GRF ID checks */
@@ -260,7 +260,7 @@ static void SkipIf(ByteReader &buf)
 		}
 
 		if (condtype != 10 && c == nullptr) {
-			GrfMsg(7, "SkipIf: GRFID {} unknown, skipping test", FormatArrayAsHex(grfid));
+			GrfMsg(Severity::Trace1, "SkipIf: GRFID {} unknown, skipping test", FormatArrayAsHex(grfid));
 			return;
 		}
 
@@ -287,7 +287,7 @@ static void SkipIf(ByteReader &buf)
 				result = c == nullptr || c->status == GRFStatus::Disabled || c->status == GRFStatus::NotFound;
 				break;
 
-			default: GrfMsg(1, "SkipIf: Unsupported GRF condition type {:02X}. Ignoring", condtype); return;
+			default: GrfMsg(Severity::Error, "SkipIf: Unsupported GRF condition type {:02X}. Ignoring", condtype); return;
 		}
 	} else {
 		/* Tests that use 'param' and are not GRF ID checks.  */
@@ -305,12 +305,12 @@ static void SkipIf(ByteReader &buf)
 				break;
 			case 0x05: result = (param_val & mask) > cond_val;
 				break;
-			default: GrfMsg(1, "SkipIf: Unsupported condition type {:02X}. Ignoring", condtype); return;
+			default: GrfMsg(Severity::Error, "SkipIf: Unsupported condition type {:02X}. Ignoring", condtype); return;
 		}
 	}
 
 	if (!result) {
-		GrfMsg(2, "SkipIf: Not skipping sprites, test was false");
+		GrfMsg(Severity::Warning, "SkipIf: Not skipping sprites, test was false");
 		return;
 	}
 
@@ -334,13 +334,13 @@ static void SkipIf(ByteReader &buf)
 	}
 
 	if (choice != nullptr) {
-		GrfMsg(2, "SkipIf: Jumping to label 0x{:X} at line {}, test was true", choice->label, choice->nfo_line);
+		GrfMsg(Severity::Warning, "SkipIf: Jumping to label 0x{:X} at line {}, test was true", choice->label, choice->nfo_line);
 		_cur_gps.file->SeekTo(choice->pos, SEEK_SET);
 		_cur_gps.nfo_line = choice->nfo_line;
 		return;
 	}
 
-	GrfMsg(2, "SkipIf: Skipping {} sprites, test was true", numsprites);
+	GrfMsg(Severity::Warning, "SkipIf: Skipping {} sprites, test was true", numsprites);
 	_cur_gps.skip_sprites = numsprites;
 	if (_cur_gps.skip_sprites == 0) {
 		/* Zero means there are no sprites to skip, so

--- a/src/newgrf/newgrf_act8.cpp
+++ b/src/newgrf/newgrf_act8.cpp
@@ -28,7 +28,7 @@ static void ScanInfo(ByteReader &buf)
 
 	if (grf_version < 2 || grf_version > 8) {
 		_cur_gps.grfconfig->flags.Set(GRFConfigFlag::Invalid);
-		Debug(grf, 0, "{}: NewGRF \"{}\" (GRFID {}) uses GRF version {}, which is incompatible with this version of OpenTTD.", _cur_gps.grfconfig->filename, StrMakeValid(name), FormatArrayAsHex(grfid), grf_version);
+		Debug(grf, Severity::Critical, "{}: NewGRF \"{}\" (GRFID {}) uses GRF version {}, which is incompatible with this version of OpenTTD.", _cur_gps.grfconfig->filename, StrMakeValid(name), FormatArrayAsHex(grfid), grf_version);
 	}
 
 	/* GRF IDs starting with 0xFF are reserved for internal TTDPatch use */
@@ -65,7 +65,7 @@ static void GRFInfo(ByteReader &buf)
 	}
 
 	if (_cur_gps.grffile->grfid != grfid) {
-		Debug(grf, 0, "GRFInfo: GRFID {} in FILESCAN stage does not match GRFID {} in INIT/RESERVE/ACTIVATION stage", FormatArrayAsHex(_cur_gps.grffile->grfid), FormatArrayAsHex(grfid));
+		Debug(grf, Severity::Critical, "GRFInfo: GRFID {} in FILESCAN stage does not match GRFID {} in INIT/RESERVE/ACTIVATION stage", FormatArrayAsHex(_cur_gps.grffile->grfid), FormatArrayAsHex(grfid));
 		_cur_gps.grffile->grfid = grfid;
 	}
 
@@ -73,7 +73,7 @@ static void GRFInfo(ByteReader &buf)
 	_cur_gps.grfconfig->status = _cur_gps.stage < GrfLoadingStage::Reserve ? GRFStatus::Initialised : GRFStatus::Activated;
 
 	/* Do swap the GRFID for displaying purposes since people expect that */
-	Debug(grf, 1, "GRFInfo: Loaded GRFv{} set {} - {} (palette: {}, version: {})", version, FormatArrayAsHex(grfid), StrMakeValid(name), (_cur_gps.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur_gps.grfconfig->version);
+	Debug(grf, Severity::Error, "GRFInfo: Loaded GRFv{} set {} - {} (palette: {}, version: {})", version, FormatArrayAsHex(grfid), StrMakeValid(name), (_cur_gps.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur_gps.grfconfig->version);
 }
 
 /** @copydoc GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_act8.cpp
+++ b/src/newgrf/newgrf_act8.cpp
@@ -28,7 +28,7 @@ static void ScanInfo(ByteReader &buf)
 
 	if (grf_version < 2 || grf_version > 8) {
 		_cur_gps.grfconfig->flags.Set(GRFConfigFlag::Invalid);
-		Debug(grf, Severity::Critical, "{}: NewGRF \"{}\" (GRFID {}) uses GRF version {}, which is incompatible with this version of OpenTTD.", _cur_gps.grfconfig->filename, StrMakeValid(name), FormatArrayAsHex(grfid), grf_version);
+		Debug(Facility::Grf, Severity::Critical, "{}: NewGRF \"{}\" (GRFID {}) uses GRF version {}, which is incompatible with this version of OpenTTD.", _cur_gps.grfconfig->filename, StrMakeValid(name), FormatArrayAsHex(grfid), grf_version);
 	}
 
 	/* GRF IDs starting with 0xFF are reserved for internal TTDPatch use */
@@ -65,7 +65,7 @@ static void GRFInfo(ByteReader &buf)
 	}
 
 	if (_cur_gps.grffile->grfid != grfid) {
-		Debug(grf, Severity::Critical, "GRFInfo: GRFID {} in FILESCAN stage does not match GRFID {} in INIT/RESERVE/ACTIVATION stage", FormatArrayAsHex(_cur_gps.grffile->grfid), FormatArrayAsHex(grfid));
+		Debug(Facility::Grf, Severity::Critical, "GRFInfo: GRFID {} in FILESCAN stage does not match GRFID {} in INIT/RESERVE/ACTIVATION stage", FormatArrayAsHex(_cur_gps.grffile->grfid), FormatArrayAsHex(grfid));
 		_cur_gps.grffile->grfid = grfid;
 	}
 
@@ -73,7 +73,7 @@ static void GRFInfo(ByteReader &buf)
 	_cur_gps.grfconfig->status = _cur_gps.stage < GrfLoadingStage::Reserve ? GRFStatus::Initialised : GRFStatus::Activated;
 
 	/* Do swap the GRFID for displaying purposes since people expect that */
-	Debug(grf, Severity::Error, "GRFInfo: Loaded GRFv{} set {} - {} (palette: {}, version: {})", version, FormatArrayAsHex(grfid), StrMakeValid(name), (_cur_gps.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur_gps.grfconfig->version);
+	Debug(Facility::Grf, Severity::Error, "GRFInfo: Loaded GRFv{} set {} - {} (palette: {}, version: {})", version, FormatArrayAsHex(grfid), StrMakeValid(name), (_cur_gps.grfconfig->palette & GRFP_USE_MASK) ? "Windows" : "DOS", _cur_gps.grfconfig->version);
 }
 
 /** @copydoc GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_acta.cpp
+++ b/src/newgrf/newgrf_acta.cpp
@@ -49,14 +49,14 @@ static void SpriteReplace(ByteReader &buf)
 		uint8_t num_sprites = buf.ReadByte();
 		uint16_t first_sprite = buf.ReadWord();
 
-		GrfMsg(2, "SpriteReplace: [Set {}] Changing {} sprites, beginning with {}",
+		GrfMsg(Severity::Warning, "SpriteReplace: [Set {}] Changing {} sprites, beginning with {}",
 			i, num_sprites, first_sprite
 		);
 
 		if (first_sprite + num_sprites >= SPR_OPENTTD_BASE) {
 			/* Outside allowed range, check for GRM sprite reservations. */
 			if (!IsGRMReservedSprite(first_sprite, num_sprites)) {
-				GrfMsg(0, "SpriteReplace: [Set {}] Changing {} sprites, beginning with {}, above limit of {} and not within reserved range, ignoring.",
+				GrfMsg(Severity::Critical, "SpriteReplace: [Set {}] Changing {} sprites, beginning with {}, above limit of {} and not within reserved range, ignoring.",
 					i, num_sprites, first_sprite, SPR_OPENTTD_BASE);
 
 				/* Load the sprites at the current location so they will do nothing instead of appearing to work. */
@@ -91,7 +91,7 @@ static void SkipActA(ByteReader &buf)
 		buf.ReadWord();
 	}
 
-	GrfMsg(3, "SkipActA: Skipping {} sprites", _cur_gps.skip_sprites);
+	GrfMsg(Severity::Notice, "SkipActA: Skipping {} sprites", _cur_gps.skip_sprites);
 }
 
 /** @copydoc GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_actb.cpp
+++ b/src/newgrf/newgrf_actb.cpp
@@ -62,13 +62,13 @@ static void GRFLoadError(ByteReader &buf)
 	/* Skip the error until the activation stage unless bit 7 of the severity
 	 * is set. */
 	if (!HasBit(severity, 7) && _cur_gps.stage == GrfLoadingStage::Init) {
-		GrfMsg(7, "GRFLoadError: Skipping non-fatal GRFLoadError in stage {}", _cur_gps.stage);
+		GrfMsg(Severity::Trace1, "GRFLoadError: Skipping non-fatal GRFLoadError in stage {}", _cur_gps.stage);
 		return;
 	}
 	ClrBit(severity, 7);
 
 	if (severity >= lengthof(sevstr)) {
-		GrfMsg(7, "GRFLoadError: Invalid severity id {}. Setting to 2 (non-fatal error).", severity);
+		GrfMsg(Severity::Trace1, "GRFLoadError: Invalid severity id {}. Setting to 2 (non-fatal error).", severity);
 		severity = 2;
 	} else if (severity == 3) {
 		/* This is a fatal error, so make sure the GRF is deactivated and no
@@ -77,12 +77,12 @@ static void GRFLoadError(ByteReader &buf)
 	}
 
 	if (message_id >= lengthof(msgstr) && message_id != 0xFF) {
-		GrfMsg(7, "GRFLoadError: Invalid message id.");
+		GrfMsg(Severity::Trace1, "GRFLoadError: Invalid message id.");
 		return;
 	}
 
 	if (buf.Remaining() <= 1) {
-		GrfMsg(7, "GRFLoadError: No message data supplied.");
+		GrfMsg(Severity::Trace1, "GRFLoadError: No message data supplied.");
 		return;
 	}
 
@@ -101,7 +101,7 @@ static void GRFLoadError(ByteReader &buf)
 
 			error.custom_message = TranslateTTDPatchCodes(_cur_gps.grffile->grfid, _current_language->newgrflangid, true, message, SCC_RAW_STRING_POINTER);
 		} else {
-			GrfMsg(7, "GRFLoadError: No custom message supplied.");
+			GrfMsg(Severity::Trace1, "GRFLoadError: No custom message supplied.");
 			error.custom_message.clear();
 		}
 	} else {
@@ -113,7 +113,7 @@ static void GRFLoadError(ByteReader &buf)
 
 		error.data = TranslateTTDPatchCodes(_cur_gps.grffile->grfid, _current_language->newgrflangid, true, data);
 	} else {
-		GrfMsg(7, "GRFLoadError: No message data supplied.");
+		GrfMsg(Severity::Trace1, "GRFLoadError: No message data supplied.");
 		error.data.clear();
 	}
 

--- a/src/newgrf/newgrf_actc.cpp
+++ b/src/newgrf/newgrf_actc.cpp
@@ -25,7 +25,7 @@ static void GRFComment(ByteReader &buf)
 	if (!buf.HasData()) return;
 
 	std::string_view text = buf.ReadString();
-	GrfMsg(2, "GRFComment: {}", StrMakeValid(text));
+	GrfMsg(Severity::Warning, "GRFComment: {}", StrMakeValid(text));
 }
 
 /** @copybrief GrfActionHandler::FileScan */

--- a/src/newgrf/newgrf_actd.cpp
+++ b/src/newgrf/newgrf_actd.cpp
@@ -127,7 +127,7 @@ static uint32_t GetPatchVariable(uint8_t param)
 			return _settings_game.game_creation.generation_seed;
 
 		default:
-			GrfMsg(2, "ParamSet: Unknown Patch variable 0x{:02X}.", param);
+			GrfMsg(Severity::Warning, "ParamSet: Unknown Patch variable 0x{:02X}.", param);
 			return 0;
 	}
 }
@@ -151,7 +151,7 @@ static uint32_t PerformGRM(std::span<GrfID> grm, uint16_t count, uint8_t op, uin
 		uint32_t index = _cur_gps.grffile->GetParam(target);
 		if (index < std::size(grm)) return FlattenNewGRFLabel(grm[index]);
 
-		GrfMsg(1, "ParamSet: GRM: Parameter {} refers to invalid {} id {}", target, type, index);
+		GrfMsg(Severity::Error, "ParamSet: GRM: Parameter {} refers to invalid {} id {}", target, type, index);
 		return 0;
 	}
 
@@ -173,7 +173,7 @@ static uint32_t PerformGRM(std::span<GrfID> grm, uint16_t count, uint8_t op, uin
 	if (size == count) {
 		/* Got the slot... */
 		if (op == 0 || op == 3) {
-			GrfMsg(2, "ParamSet: GRM: Reserving {} {} at {}", count, type, start);
+			GrfMsg(Severity::Warning, "ParamSet: GRM: Reserving {} {} at {}", count, type, start);
 			for (uint i = 0; i < count; i++) grm[start + i] = _cur_gps.grffile->grfid;
 		}
 		return start;
@@ -182,12 +182,12 @@ static uint32_t PerformGRM(std::span<GrfID> grm, uint16_t count, uint8_t op, uin
 	/* Unable to allocate */
 	if (op != 4 && op != 5) {
 		/* Deactivate GRF */
-		GrfMsg(0, "ParamSet: GRM: Unable to allocate {} {}, deactivating", count, type);
+		GrfMsg(Severity::Critical, "ParamSet: GRM: Unable to allocate {} {}, deactivating", count, type);
 		DisableGrf(STR_NEWGRF_ERROR_GRM_FAILED);
 		return UINT_MAX;
 	}
 
-	GrfMsg(1, "ParamSet: GRM: Unable to allocate {} {}", count, type);
+	GrfMsg(Severity::Error, "ParamSet: GRM: Unable to allocate {} {}", count, type);
 	return UINT_MAX;
 }
 
@@ -235,7 +235,7 @@ static void ParamSet(ByteReader &buf)
 	 *   an earlier action D */
 	if (HasBit(oper, 7)) {
 		if (target < 0x80 && target < std::size(_cur_gps.grffile->param)) {
-			GrfMsg(7, "ParamSet: Param {} already defined, skipping", target);
+			GrfMsg(Severity::Trace1, "ParamSet: Param {} already defined, skipping", target);
 			return;
 		}
 
@@ -259,13 +259,13 @@ static void ParamSet(ByteReader &buf)
 						if (op == 0) {
 							/* Check if the allocated sprites will fit below the original sprite limit */
 							if (_cur_gps.spriteid + count >= 16384) {
-								GrfMsg(0, "ParamSet: GRM: Unable to allocate {} sprites; try changing NewGRF order", count);
+								GrfMsg(Severity::Critical, "ParamSet: GRM: Unable to allocate {} sprites; try changing NewGRF order", count);
 								DisableGrf(STR_NEWGRF_ERROR_GRM_FAILED);
 								return;
 							}
 
 							/* Reserve space at the current sprite ID */
-							GrfMsg(4, "ParamSet: GRM: Allocated {} sprites at {}", count, _cur_gps.spriteid);
+							GrfMsg(Severity::Info, "ParamSet: GRM: Allocated {} sprites at {}", count, _cur_gps.spriteid);
 							_grm_sprites[GRFLocation{_cur_gps.grffile->grfid, _cur_gps.nfo_line}] = std::make_pair(_cur_gps.spriteid, count);
 							_cur_gps.spriteid += count;
 						}
@@ -301,7 +301,7 @@ static void ParamSet(ByteReader &buf)
 								case 0:
 									/* Return space reserved during reservation stage */
 									src1 = _grm_sprites[GRFLocation{_cur_gps.grffile->grfid, _cur_gps.nfo_line}].first;
-									GrfMsg(4, "ParamSet: GRM: Using pre-allocated sprites at {}", src1);
+									GrfMsg(Severity::Info, "ParamSet: GRM: Using pre-allocated sprites at {}", src1);
 									break;
 
 								case 1:
@@ -309,7 +309,7 @@ static void ParamSet(ByteReader &buf)
 									break;
 
 								default:
-									GrfMsg(1, "ParamSet: GRM: Unsupported operation {} for general sprites", op);
+									GrfMsg(Severity::Error, "ParamSet: GRM: Unsupported operation {} for general sprites", op);
 									return;
 							}
 							break;
@@ -320,7 +320,7 @@ static void ParamSet(ByteReader &buf)
 							if (_cur_gps.skip_sprites == -1) return;
 							break;
 
-						default: GrfMsg(1, "ParamSet: GRM: Unsupported feature 0x{:X}", feature); return;
+						default: GrfMsg(Severity::Error, "ParamSet: GRM: Unsupported feature 0x{:X}", feature); return;
 					}
 				} else {
 					/* Ignore GRM during initialization */
@@ -432,7 +432,7 @@ static void ParamSet(ByteReader &buf)
 			}
 			break;
 
-		default: GrfMsg(0, "ParamSet: Unknown operation {}, skipping", oper); return;
+		default: GrfMsg(Severity::Critical, "ParamSet: Unknown operation {}, skipping", oper); return;
 	}
 
 	switch (target) {
@@ -461,7 +461,7 @@ static void ParamSet(ByteReader &buf)
 		case 0x96: // Tile refresh offset downwards
 		case 0x97: // Snow line height -- Better supported by feature 8 property 10h (snow line table) TODO: implement by filling the entire snow line table with the given value
 		case 0x99: // Global ID offset -- Not necessary since IDs are remapped automatically
-			GrfMsg(7, "ParamSet: Skipping unimplemented target 0x{:02X}", target);
+			GrfMsg(Severity::Trace1, "ParamSet: Skipping unimplemented target 0x{:02X}", target);
 			break;
 
 		case 0x9E: { // Miscellaneous GRF features
@@ -485,7 +485,7 @@ static void ParamSet(ByteReader &buf)
 		}
 
 		case 0x9F: // locale-dependent settings
-			GrfMsg(7, "ParamSet: Skipping unimplemented target 0x{:02X}", target);
+			GrfMsg(Severity::Trace1, "ParamSet: Skipping unimplemented target 0x{:02X}", target);
 			break;
 
 		default:
@@ -494,7 +494,7 @@ static void ParamSet(ByteReader &buf)
 				if (target >= std::size(_cur_gps.grffile->param)) _cur_gps.grffile->param.resize(target + 1);
 				_cur_gps.grffile->param[target] = res;
 			} else {
-				GrfMsg(7, "ParamSet: Skipping unknown target 0x{:02X}", target);
+				GrfMsg(Severity::Trace1, "ParamSet: Skipping unknown target 0x{:02X}", target);
 			}
 			break;
 	}

--- a/src/newgrf/newgrf_acte.cpp
+++ b/src/newgrf/newgrf_acte.cpp
@@ -53,7 +53,7 @@ static void GRFInhibit(ByteReader &buf)
 
 		/* Unset activation flag */
 		if (file != nullptr && file != _cur_gps.grfconfig) {
-			GrfMsg(2, "GRFInhibit: Deactivating file '{}'", file->filename);
+			GrfMsg(Severity::Warning, "GRFInhibit: Deactivating file '{}'", file->filename);
 			GRFError *error = DisableGrf(STR_NEWGRF_ERROR_FORCEFULLY_DISABLED, file);
 			error->data = _cur_gps.grfconfig->GetName();
 		}

--- a/src/newgrf/newgrf_actf.cpp
+++ b/src/newgrf/newgrf_actf.cpp
@@ -35,7 +35,7 @@ static void FeatureTownName(ByteReader &buf)
 	GRFTownName *townname = AddGRFTownName(grfid);
 
 	uint8_t id = buf.ReadByte();
-	GrfMsg(6, "FeatureTownName: definition 0x{:02X}", id & 0x7F);
+	GrfMsg(Severity::Debug2, "FeatureTownName: definition 0x{:02X}", id & 0x7F);
 
 	if (HasBit(id, 7)) {
 		/* Final definition */
@@ -50,7 +50,7 @@ static void FeatureTownName(ByteReader &buf)
 
 			std::string_view name = buf.ReadString();
 
-			GrfMsg(6, "FeatureTownName: lang 0x{:X} (new_scheme: {}) -> '{}'", lang, new_scheme, TranslateTTDPatchCodes(grfid, GRFLanguage::Fallback, false, name));
+			GrfMsg(Severity::Debug2, "FeatureTownName: lang 0x{:X} (new_scheme: {}) -> '{}'", lang, new_scheme, TranslateTTDPatchCodes(grfid, GRFLanguage::Fallback, false, name));
 
 			style = AddGRFString(grfid, GRFStringID{id}, lang, new_scheme, false, name, STR_UNDEFINED);
 
@@ -60,7 +60,7 @@ static void FeatureTownName(ByteReader &buf)
 	}
 
 	uint8_t parts = buf.ReadByte();
-	GrfMsg(6, "FeatureTownName: {} parts", parts);
+	GrfMsg(Severity::Debug2, "FeatureTownName: {} parts", parts);
 
 	townname->partlists[id].reserve(parts);
 	for (uint partnum = 0; partnum < parts; partnum++) {
@@ -69,7 +69,7 @@ static void FeatureTownName(ByteReader &buf)
 		partlist.bitstart = buf.ReadByte();
 		partlist.bitcount = buf.ReadByte();
 		partlist.maxprob  = 0;
-		GrfMsg(6, "FeatureTownName: part {} contains {} texts and will use GB(seed, {}, {})", partnum, texts, partlist.bitstart, partlist.bitcount);
+		GrfMsg(Severity::Debug2, "FeatureTownName: part {} contains {} texts and will use GB(seed, {}, {})", partnum, texts, partlist.bitstart, partlist.bitcount);
 
 		partlist.parts.reserve(texts);
 		for (uint textnum = 0; textnum < texts; textnum++) {
@@ -79,21 +79,21 @@ static void FeatureTownName(ByteReader &buf)
 			if (HasBit(part.prob, 7)) {
 				uint8_t ref_id = buf.ReadByte();
 				if (ref_id >= GRFTownName::MAX_LISTS || townname->partlists[ref_id].empty()) {
-					GrfMsg(0, "FeatureTownName: definition 0x{:02X} doesn't exist, deactivating", ref_id);
+					GrfMsg(Severity::Critical, "FeatureTownName: definition 0x{:02X} doesn't exist, deactivating", ref_id);
 					DelGRFTownName(grfid);
 					DisableGrf(STR_NEWGRF_ERROR_INVALID_ID);
 					return;
 				}
 				part.id = ref_id;
-				GrfMsg(6, "FeatureTownName: part {}, text {}, uses intermediate definition 0x{:02X} (with probability {})", partnum, textnum, ref_id, part.prob & 0x7F);
+				GrfMsg(Severity::Debug2, "FeatureTownName: part {}, text {}, uses intermediate definition 0x{:02X} (with probability {})", partnum, textnum, ref_id, part.prob & 0x7F);
 			} else {
 				std::string_view text = buf.ReadString();
 				part.text = TranslateTTDPatchCodes(grfid, GRFLanguage::Fallback, false, text);
-				GrfMsg(6, "FeatureTownName: part {}, text {}, '{}' (with probability {})", partnum, textnum, part.text, part.prob);
+				GrfMsg(Severity::Debug2, "FeatureTownName: part {}, text {}, '{}' (with probability {})", partnum, textnum, part.text, part.prob);
 			}
 			partlist.maxprob += GB(part.prob, 0, 7);
 		}
-		GrfMsg(6, "FeatureTownName: part {}, total probability {}", partnum, partlist.maxprob);
+		GrfMsg(Severity::Debug2, "FeatureTownName: part {}, total probability {}", partnum, partlist.maxprob);
 	}
 }
 

--- a/src/newgrf/newgrf_stringmapping.cpp
+++ b/src/newgrf/newgrf_stringmapping.cpp
@@ -112,7 +112,7 @@ static StringID TTDPStringIDToOTTDStringIDMapping(GRFStringID str)
 
 	if (str.base() == 0) return STR_EMPTY;
 
-	Debug(grf, 0, "Unknown StringID 0x{:04X} remapped to STR_EMPTY. Please open a Feature Request if you need it", str);
+	Debug(grf, Severity::Critical, "Unknown StringID 0x{:04X} remapped to STR_EMPTY. Please open a Feature Request if you need it", str);
 
 	return STR_EMPTY;
 }

--- a/src/newgrf/newgrf_stringmapping.cpp
+++ b/src/newgrf/newgrf_stringmapping.cpp
@@ -112,7 +112,7 @@ static StringID TTDPStringIDToOTTDStringIDMapping(GRFStringID str)
 
 	if (str.base() == 0) return STR_EMPTY;
 
-	Debug(grf, Severity::Critical, "Unknown StringID 0x{:04X} remapped to STR_EMPTY. Please open a Feature Request if you need it", str);
+	Debug(Facility::Grf, Severity::Critical, "Unknown StringID 0x{:04X} remapped to STR_EMPTY. Please open a Feature Request if you need it", str);
 
 	return STR_EMPTY;
 }

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -142,7 +142,7 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec &&as)
 	uint8_t airport_id = this->AddEntityID(as.grf_prop.local_id, as.grf_prop.grfid, as.grf_prop.subst_id);
 
 	if (airport_id == this->invalid_id) {
-		GrfMsg(1, "Airport.SetEntitySpec: Too many airports allocated. Ignoring.");
+		GrfMsg(Severity::Error, "Airport.SetEntitySpec: Too many airports allocated. Ignoring.");
 		return;
 	}
 

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -196,7 +196,7 @@ static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, GrfI
 		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->ats->badges, parameter);
 	}
 
-	Debug(grf, Severity::Error, "Unhandled airport tile variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled airport tile variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -71,7 +71,7 @@ void AirportTileOverrideManager::SetEntitySpec(AirportTileSpec &&airpts)
 	StationGfx airpt_id = this->AddEntityID(airpts.grf_prop.local_id, airpts.grf_prop.grfid, airpts.grf_prop.subst_id);
 
 	if (airpt_id == this->invalid_id) {
-		GrfMsg(1, "AirportTile.SetEntitySpec: Too many airport tiles allocated. Ignoring.");
+		GrfMsg(Severity::Error, "AirportTile.SetEntitySpec: Too many airport tiles allocated. Ignoring.");
 		return;
 	}
 
@@ -196,7 +196,7 @@ static uint32_t GetAirportTileIDAtOffset(TileIndex tile, const Station *st, GrfI
 		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, this->ats->badges, parameter);
 	}
 
-	Debug(grf, 1, "Unhandled airport tile variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled airport tile variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -99,7 +99,7 @@ struct CanalResolverObject : public ResolverObject {
 		case 0x83: return IsTileType(this->tile, TileType::Water) ? GetWaterTileRandomBits(this->tile) : 0;
 	}
 
-	Debug(grf, 1, "Unhandled canal variable 0x{:02X}", variable);
+	Debug(grf, Severity::Error, "Unhandled canal variable 0x{:02X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -99,7 +99,7 @@ struct CanalResolverObject : public ResolverObject {
 		case 0x83: return IsTileType(this->tile, TileType::Water) ? GetWaterTileRandomBits(this->tile) : 0;
 	}
 
-	Debug(grf, Severity::Error, "Unhandled canal variable 0x{:02X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled canal variable 0x{:02X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -43,7 +43,7 @@ Tindex NewGRFClass<Tspec, Tindex>::Allocate(GlobalID global_id)
 		return it->Index();
 	}
 
-	GrfMsg(2, "ClassAllocate: already allocated {} classes, using default", Tindex::End().base());
+	GrfMsg(Severity::Warning, "ClassAllocate: already allocated {} classes, using default", Tindex::End().base());
 	return static_cast<Tindex>(0);
 }
 

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -156,7 +156,7 @@ void HouseOverrideManager::SetEntitySpec(HouseSpec &&hs)
 	HouseID house_id = this->AddEntityID(hs.grf_prop.local_id, hs.grf_prop.grfid, hs.grf_prop.subst_id);
 
 	if (house_id == this->invalid_id) {
-		GrfMsg(1, "House.SetEntitySpec: Too many houses allocated. Ignoring.");
+		GrfMsg(Severity::Error, "House.SetEntitySpec: Too many houses allocated. Ignoring.");
 		return;
 	}
 
@@ -254,7 +254,7 @@ void IndustryOverrideManager::SetEntitySpec(IndustrySpec &&inds)
 	}
 
 	if (ind_id == this->invalid_id) {
-		GrfMsg(1, "Industry.SetEntitySpec: Too many industries allocated. Ignoring.");
+		GrfMsg(Severity::Error, "Industry.SetEntitySpec: Too many industries allocated. Ignoring.");
 		return;
 	}
 
@@ -269,7 +269,7 @@ void IndustryTileOverrideManager::SetEntitySpec(IndustryTileSpec &&its)
 	IndustryGfx indt_id = this->AddEntityID(its.grf_prop.local_id, its.grf_prop.grfid, its.grf_prop.subst_id);
 
 	if (indt_id == this->invalid_id) {
-		GrfMsg(1, "IndustryTile.SetEntitySpec: Too many industry tiles allocated. Ignoring.");
+		GrfMsg(Severity::Error, "IndustryTile.SetEntitySpec: Too many industry tiles allocated. Ignoring.");
 		return;
 	}
 
@@ -308,7 +308,7 @@ void ObjectOverrideManager::SetEntitySpec(ObjectSpec &&spec)
 	}
 
 	if (type == this->invalid_id) {
-		GrfMsg(1, "Object.SetEntitySpec: Too many objects allocated. Ignoring.");
+		GrfMsg(Severity::Error, "Object.SetEntitySpec: Too many objects allocated. Ignoring.");
 		return;
 	}
 
@@ -520,9 +520,9 @@ void ErrorUnknownCallbackResult(GrfID grfid, uint16_t cbid, uint16_t cb_res)
 	}
 
 	/* debug output */
-	Debug(grf, 0, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY, grfconfig->GetName())));
+	Debug(grf, Severity::Critical, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY, grfconfig->GetName())));
 
-	Debug(grf, 0, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY_UNKNOWN_CALLBACK_RESULT, std::monostate{}, cbid, cb_res)));
+	Debug(grf, Severity::Critical, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY_UNKNOWN_CALLBACK_RESULT, std::monostate{}, cbid, cb_res)));
 }
 
 /**

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -520,9 +520,9 @@ void ErrorUnknownCallbackResult(GrfID grfid, uint16_t cbid, uint16_t cb_res)
 	}
 
 	/* debug output */
-	Debug(grf, Severity::Critical, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY, grfconfig->GetName())));
+	Debug(Facility::Grf, Severity::Critical, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY, grfconfig->GetName())));
 
-	Debug(grf, Severity::Critical, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY_UNKNOWN_CALLBACK_RESULT, std::monostate{}, cbid, cb_res)));
+	Debug(Facility::Grf, Severity::Critical, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY_UNKNOWN_CALLBACK_RESULT, std::monostate{}, cbid, cb_res)));
 }
 
 /**

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -237,7 +237,7 @@ size_t GRFGetSizeOfDataSection(FileHandle &f)
 			/* Valid container version 2, get data section size. */
 			size_t offset = (static_cast<size_t>(data[13]) << 24) | (static_cast<size_t>(data[12]) << 16) | (static_cast<size_t>(data[11]) << 8) | static_cast<size_t>(data[10]);
 			if (offset >= 1 * 1024 * 1024 * 1024) {
-				Debug(grf, 0, "Unexpectedly large offset for NewGRF");
+				Debug(grf, Severity::Critical, "Unexpectedly large offset for NewGRF");
 				/* Having more than 1 GiB of data is very implausible. Mostly because then
 				 * all pools in OpenTTD are flooded already. Or it's just Action C all over.
 				 * In any case, the offsets to graphics will likely not work either. */
@@ -438,7 +438,7 @@ GRFListCompatibility IsGoodGRFConfigList(GRFConfigList &grfconfig)
 			 * same grfid, as it most likely is compatible */
 			f = FindGRFConfig(c->ident.grfid, FindGRFConfigMode::Compatible, nullptr, c->version);
 			if (f != nullptr) {
-				Debug(grf, 1, "NewGRF {} ({}) not found; checksum {}. Compatibility mode on", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
+				Debug(grf, Severity::Error, "NewGRF {} ({}) not found; checksum {}. Compatibility mode on", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
 				if (!c->flags.Test(GRFConfigFlag::Compatible)) {
 					/* Preserve original_md5sum after it has been assigned */
 					c->flags.Set(GRFConfigFlag::Compatible);
@@ -451,13 +451,13 @@ GRFListCompatibility IsGoodGRFConfigList(GRFConfigList &grfconfig)
 			}
 
 			/* No compatible grf was found, mark it as disabled */
-			Debug(grf, 0, "NewGRF {} ({}) not found; checksum {}", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
+			Debug(grf, Severity::Critical, "NewGRF {} ({}) not found; checksum {}", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
 
 			c->status = GRFStatus::NotFound;
 			res = GRFListCompatibility::NotFound;
 		} else {
 compatible_grf:
-			Debug(grf, 1, "Loading GRF {} from {}", FormatArrayAsHex(f->ident.grfid), f->filename);
+			Debug(grf, Severity::Error, "Loading GRF {} from {}", FormatArrayAsHex(f->ident.grfid), f->filename);
 			/* The filename could be the filename as in the savegame. As we need
 			 * to load the GRF here, we need the correct filename, so overwrite that
 			 * in any case and set the name and info when it is not set already.
@@ -558,10 +558,10 @@ void DoScanNewGRFFiles(NewGRFScanCallback *callback)
 	ClearGRFConfigList(_all_grfs);
 	TarScanner::DoScan(TarScanner::Mode::NewGRF);
 
-	Debug(grf, 1, "Scanning for NewGRFs");
+	Debug(grf, Severity::Error, "Scanning for NewGRFs");
 	uint num = GRFFileScanner::DoScan();
 
-	Debug(grf, 1, "Scan complete, found {} files", num);
+	Debug(grf, Severity::Error, "Scan complete, found {} files", num);
 	std::ranges::sort(_all_grfs, GRFSorter);
 	NetworkAfterNewGRFScan();
 

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -237,7 +237,7 @@ size_t GRFGetSizeOfDataSection(FileHandle &f)
 			/* Valid container version 2, get data section size. */
 			size_t offset = (static_cast<size_t>(data[13]) << 24) | (static_cast<size_t>(data[12]) << 16) | (static_cast<size_t>(data[11]) << 8) | static_cast<size_t>(data[10]);
 			if (offset >= 1 * 1024 * 1024 * 1024) {
-				Debug(grf, Severity::Critical, "Unexpectedly large offset for NewGRF");
+				Debug(Facility::Grf, Severity::Critical, "Unexpectedly large offset for NewGRF");
 				/* Having more than 1 GiB of data is very implausible. Mostly because then
 				 * all pools in OpenTTD are flooded already. Or it's just Action C all over.
 				 * In any case, the offsets to graphics will likely not work either. */
@@ -438,7 +438,7 @@ GRFListCompatibility IsGoodGRFConfigList(GRFConfigList &grfconfig)
 			 * same grfid, as it most likely is compatible */
 			f = FindGRFConfig(c->ident.grfid, FindGRFConfigMode::Compatible, nullptr, c->version);
 			if (f != nullptr) {
-				Debug(grf, Severity::Error, "NewGRF {} ({}) not found; checksum {}. Compatibility mode on", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
+				Debug(Facility::Grf, Severity::Error, "NewGRF {} ({}) not found; checksum {}. Compatibility mode on", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
 				if (!c->flags.Test(GRFConfigFlag::Compatible)) {
 					/* Preserve original_md5sum after it has been assigned */
 					c->flags.Set(GRFConfigFlag::Compatible);
@@ -451,13 +451,13 @@ GRFListCompatibility IsGoodGRFConfigList(GRFConfigList &grfconfig)
 			}
 
 			/* No compatible grf was found, mark it as disabled */
-			Debug(grf, Severity::Critical, "NewGRF {} ({}) not found; checksum {}", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
+			Debug(Facility::Grf, Severity::Critical, "NewGRF {} ({}) not found; checksum {}", FormatArrayAsHex(c->ident.grfid), c->filename, FormatArrayAsHex(c->ident.md5sum));
 
 			c->status = GRFStatus::NotFound;
 			res = GRFListCompatibility::NotFound;
 		} else {
 compatible_grf:
-			Debug(grf, Severity::Error, "Loading GRF {} from {}", FormatArrayAsHex(f->ident.grfid), f->filename);
+			Debug(Facility::Grf, Severity::Error, "Loading GRF {} from {}", FormatArrayAsHex(f->ident.grfid), f->filename);
 			/* The filename could be the filename as in the savegame. As we need
 			 * to load the GRF here, we need the correct filename, so overwrite that
 			 * in any case and set the name and info when it is not set already.
@@ -558,10 +558,10 @@ void DoScanNewGRFFiles(NewGRFScanCallback *callback)
 	ClearGRFConfigList(_all_grfs);
 	TarScanner::DoScan(TarScanner::Mode::NewGRF);
 
-	Debug(grf, Severity::Error, "Scanning for NewGRFs");
+	Debug(Facility::Grf, Severity::Error, "Scanning for NewGRFs");
 	uint num = GRFFileScanner::DoScan();
 
-	Debug(grf, Severity::Error, "Scan complete, found {} files", num);
+	Debug(Facility::Grf, Severity::Error, "Scan complete, found {} files", num);
 	std::ranges::sort(_all_grfs, GRFSorter);
 	NetworkAfterNewGRFScan();
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -57,7 +57,7 @@ void SetCustomEngineSprites(EngineID engine, CargoType cargo, const SpriteGroup 
 	Engine *e = Engine::Get(engine);
 
 	if (e->grf_prop.GetSpriteGroup(cargo) != nullptr) {
-		GrfMsg(6, "SetCustomEngineSprites: engine {} cargo {} already has group -- replacing", engine, cargo);
+		GrfMsg(Severity::Debug2, "SetCustomEngineSprites: engine {} cargo {} already has group -- replacing", engine, cargo);
 	}
 	e->grf_prop.SetSpriteGroup(cargo, group);
 }
@@ -972,7 +972,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		default: break;
 	}
 
-	Debug(grf, 1, "Unhandled vehicle variable 0x{:X}, type 0x{:X}", variable, (uint)v->type);
+	Debug(grf, Severity::Error, "Unhandled vehicle variable 0x{:X}, type 0x{:X}", variable, (uint)v->type);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -972,7 +972,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 		default: break;
 	}
 
-	Debug(grf, Severity::Error, "Unhandled vehicle variable 0x{:X}, type 0x{:X}", variable, (uint)v->type);
+	Debug(Facility::Grf, Severity::Error, "Unhandled vehicle variable 0x{:X}, type 0x{:X}", variable, (uint)v->type);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -139,7 +139,7 @@ void AddGenericCallback(GrfSpecFeature feature, const GRFFile *file, const Sprit
 		}
 	}
 
-	Debug(grf, Severity::Error, "Unhandled generic feature variable 0x{:02X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled generic feature variable 0x{:02X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -109,7 +109,7 @@ void ResetGenericCallbacks()
 void AddGenericCallback(GrfSpecFeature feature, const GRFFile *file, const SpriteGroup *group)
 {
 	if (to_underlying(feature) >= std::size(_gcl)) {
-		GrfMsg(5, "AddGenericCallback: Unsupported feature 0x{:02X}", feature);
+		GrfMsg(Severity::Debug1, "AddGenericCallback: Unsupported feature 0x{:02X}", feature);
 		return;
 	}
 
@@ -139,7 +139,7 @@ void AddGenericCallback(GrfSpecFeature feature, const GRFFile *file, const Sprit
 		}
 	}
 
-	Debug(grf, 1, "Unhandled generic feature variable 0x{:02X}", variable);
+	Debug(grf, Severity::Error, "Unhandled generic feature variable 0x{:02X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -336,7 +336,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 			case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, HouseSpec::Get(this->house_id)->badges, parameter);
 		}
 
-		Debug(grf, 1, "Unhandled house variable 0x{:X}", variable);
+		Debug(grf, Severity::Error, "Unhandled house variable 0x{:X}", variable);
 		available = false;
 		return UINT_MAX;
 	}
@@ -451,7 +451,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, HouseSpec::Get(this->house_id)->badges, parameter);
 	}
 
-	Debug(grf, 1, "Unhandled house variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled house variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -336,7 +336,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 			case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, HouseSpec::Get(this->house_id)->badges, parameter);
 		}
 
-		Debug(grf, Severity::Error, "Unhandled house variable 0x{:X}", variable);
+		Debug(Facility::Grf, Severity::Error, "Unhandled house variable 0x{:X}", variable);
 		available = false;
 		return UINT_MAX;
 	}
@@ -451,7 +451,7 @@ static uint32_t GetDistanceFromNearbyHouse(uint8_t parameter, TileIndex start_ti
 		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, HouseSpec::Get(this->house_id)->badges, parameter);
 	}
 
-	Debug(grf, Severity::Error, "Unhandled house variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled house variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -177,7 +177,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 			case 0x82: return this->industry->town->index.base();
 			case 0x83:
 			case 0x84:
-			case 0x85: Debug(grf, 0, "NewGRFs shouldn't be doing pointer magic"); break; // not supported
+			case 0x85: Debug(grf, Severity::Critical, "NewGRFs shouldn't be doing pointer magic"); break; // not supported
 
 			/* Number of the layout */
 			case 0x86: return this->industry->selected_layout;
@@ -208,7 +208,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 	const IndustrySpec *indspec = GetIndustrySpec(this->type);
 
 	if (this->industry == nullptr) {
-		Debug(grf, 1, "Unhandled variable 0x{:X} (no available industry) in callback 0x{:x}", variable, this->ro.callback);
+		Debug(grf, Severity::Error, "Unhandled variable 0x{:X} (no available industry) in callback 0x{:x}", variable, this->ro.callback);
 
 		available = false;
 		return UINT_MAX;
@@ -364,7 +364,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 		case 0x82: return this->industry->town->index.base();
 		case 0x83:
 		case 0x84:
-		case 0x85: Debug(grf, 0, "NewGRFs shouldn't be doing pointer magic"); break; // not supported
+		case 0x85: Debug(grf, Severity::Critical, "NewGRFs shouldn't be doing pointer magic"); break; // not supported
 		case 0x86: return this->industry->location.w;
 		case 0x87: return this->industry->location.h;// xy dimensions
 
@@ -421,7 +421,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 		}
 	}
 
-	Debug(grf, 1, "Unhandled industry variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled industry variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -177,7 +177,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 			case 0x82: return this->industry->town->index.base();
 			case 0x83:
 			case 0x84:
-			case 0x85: Debug(grf, Severity::Critical, "NewGRFs shouldn't be doing pointer magic"); break; // not supported
+			case 0x85: Debug(Facility::Grf, Severity::Critical, "NewGRFs shouldn't be doing pointer magic"); break; // not supported
 
 			/* Number of the layout */
 			case 0x86: return this->industry->selected_layout;
@@ -208,7 +208,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 	const IndustrySpec *indspec = GetIndustrySpec(this->type);
 
 	if (this->industry == nullptr) {
-		Debug(grf, Severity::Error, "Unhandled variable 0x{:X} (no available industry) in callback 0x{:x}", variable, this->ro.callback);
+		Debug(Facility::Grf, Severity::Error, "Unhandled variable 0x{:X} (no available industry) in callback 0x{:x}", variable, this->ro.callback);
 
 		available = false;
 		return UINT_MAX;
@@ -364,7 +364,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 		case 0x82: return this->industry->town->index.base();
 		case 0x83:
 		case 0x84:
-		case 0x85: Debug(grf, Severity::Critical, "NewGRFs shouldn't be doing pointer magic"); break; // not supported
+		case 0x85: Debug(Facility::Grf, Severity::Critical, "NewGRFs shouldn't be doing pointer magic"); break; // not supported
 		case 0x86: return this->industry->location.w;
 		case 0x87: return this->industry->location.h;// xy dimensions
 
@@ -421,7 +421,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 		}
 	}
 
-	Debug(grf, Severity::Error, "Unhandled industry variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled industry variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -97,7 +97,7 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, GetIndustryTileSpec(GetIndustryGfx(this->tile))->badges, parameter);
 	}
 
-	Debug(grf, Severity::Error, "Unhandled industry tile variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled industry tile variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -97,7 +97,7 @@ uint32_t GetRelativePosition(TileIndex tile, TileIndex ind_tile)
 		case 0x7A: return GetBadgeVariableResult(*this->ro.grffile, GetIndustryTileSpec(GetIndustryGfx(this->tile))->badges, parameter);
 	}
 
-	Debug(grf, 1, "Unhandled industry tile variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled industry tile variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -370,7 +370,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 	}
 
 unhandled:
-	Debug(grf, Severity::Error, "Unhandled object variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled object variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -370,7 +370,7 @@ static uint32_t GetCountAndDistanceOfClosestInstance(const ResolverObject &objec
 	}
 
 unhandled:
-	Debug(grf, 1, "Unhandled object variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled object variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -63,7 +63,7 @@
 			return GetTrackTypes(this->tile, ro.grffile);
 	}
 
-	Debug(grf, Severity::Error, "Unhandled rail type tile variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled rail type tile variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -63,7 +63,7 @@
 			return GetTrackTypes(this->tile, ro.grffile);
 	}
 
-	Debug(grf, 1, "Unhandled rail type tile variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled rail type tile variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -104,7 +104,7 @@ uint32_t GetTrackTypes(TileIndex tile, const GRFFile *grffile)
 			return GetTrackTypes(this->tile, ro.grffile);
 	}
 
-	Debug(grf, Severity::Error, "Unhandled road type tile variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled road type tile variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -104,7 +104,7 @@ uint32_t GetTrackTypes(TileIndex tile, const GRFFile *grffile)
 			return GetTrackTypes(this->tile, ro.grffile);
 	}
 
-	Debug(grf, 1, "Unhandled road type tile variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled road type tile variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_sound.cpp
+++ b/src/newgrf_sound.cpp
@@ -104,13 +104,13 @@ bool LoadNewGRFSound(SoundEntry &sound, SoundID sound_id)
 
 	/* Test string termination */
 	if (name[name_len] != '\0') {
-		Debug(grf, Severity::Warning, "LoadNewGRFSound [{}]: Name not properly terminated", file.GetSimplifiedFilename());
+		Debug(Facility::Grf, Severity::Warning, "LoadNewGRFSound [{}]: Name not properly terminated", file.GetSimplifiedFilename());
 		return false;
 	}
 
 	if (LoadSoundData(sound, true, sound_id, StrMakeValid(name))) return true;
 
-	Debug(grf, Severity::Error, "LoadNewGRFSound [{}]: does not contain any sound data", file.GetSimplifiedFilename());
+	Debug(Facility::Grf, Severity::Error, "LoadNewGRFSound [{}]: does not contain any sound data", file.GetSimplifiedFilename());
 
 	/* Clear everything that was read */
 	sound = {};

--- a/src/newgrf_sound.cpp
+++ b/src/newgrf_sound.cpp
@@ -104,13 +104,13 @@ bool LoadNewGRFSound(SoundEntry &sound, SoundID sound_id)
 
 	/* Test string termination */
 	if (name[name_len] != '\0') {
-		Debug(grf, 2, "LoadNewGRFSound [{}]: Name not properly terminated", file.GetSimplifiedFilename());
+		Debug(grf, Severity::Warning, "LoadNewGRFSound [{}]: Name not properly terminated", file.GetSimplifiedFilename());
 		return false;
 	}
 
 	if (LoadSoundData(sound, true, sound_id, StrMakeValid(name))) return true;
 
-	Debug(grf, 1, "LoadNewGRFSound [{}]: does not contain any sound data", file.GetSimplifiedFilename());
+	Debug(grf, Severity::Error, "LoadNewGRFSound [{}]: does not contain any sound data", file.GetSimplifiedFilename());
 
 	/* Clear everything that was read */
 	sound = {};

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -103,7 +103,7 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
  */
 /* virtual */ uint32_t ScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const
 {
-	Debug(grf, 1, "Unhandled scope variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled scope variable 0x{:X}", variable);
 	available = false;
 	return UINT_MAX;
 }

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -103,7 +103,7 @@ static inline uint32_t GetVariable(const ResolverObject &object, ScopeResolver *
  */
 /* virtual */ uint32_t ScopeResolver::GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const
 {
-	Debug(grf, Severity::Error, "Unhandled scope variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled scope variable 0x{:X}", variable);
 	available = false;
 	return UINT_MAX;
 }

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -477,7 +477,7 @@ uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variab
 		}
 	}
 
-	Debug(grf, 1, "Unhandled station variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled station variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;
@@ -509,7 +509,7 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 		}
 	}
 
-	Debug(grf, 1, "Unhandled station variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled station variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -477,7 +477,7 @@ uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variab
 		}
 	}
 
-	Debug(grf, Severity::Error, "Unhandled station variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled station variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;
@@ -509,7 +509,7 @@ uint32_t Waypoint::GetNewGRFVariable(const ResolverObject &, uint8_t variable, [
 		}
 	}
 
-	Debug(grf, Severity::Error, "Unhandled station variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled station variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_storage.cpp
+++ b/src/newgrf_storage.cpp
@@ -89,7 +89,7 @@ void AddChangedPersistentStorage(BasePersistentStorageArray *storage)
 
 	/* Discard all temporary changes */
 	for (auto &it : *_changed_storage_arrays) {
-		Debug(desync, Severity::Warning, "warning: discarding persistent storage changes: Feature {}, GrfID {}, Tile {}", it->feature, FormatArrayAsHex(it->grfid), it->tile);
+		Debug(Facility::Desync, Severity::Warning, "warning: discarding persistent storage changes: Feature {}, GrfID {}, Tile {}", it->feature, FormatArrayAsHex(it->grfid), it->tile);
 		it->ClearChanges();
 	}
 	_changed_storage_arrays->clear();

--- a/src/newgrf_storage.cpp
+++ b/src/newgrf_storage.cpp
@@ -89,7 +89,7 @@ void AddChangedPersistentStorage(BasePersistentStorageArray *storage)
 
 	/* Discard all temporary changes */
 	for (auto &it : *_changed_storage_arrays) {
-		Debug(desync, 2, "warning: discarding persistent storage changes: Feature {}, GrfID {}, Tile {}", it->feature, FormatArrayAsHex(it->grfid), it->tile);
+		Debug(desync, Severity::Warning, "warning: discarding persistent storage changes: Feature {}, GrfID {}, Tile {}", it->feature, FormatArrayAsHex(it->grfid), it->tile);
 		it->ClearChanges();
 	}
 	_changed_storage_arrays->clear();

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -113,7 +113,7 @@ struct UnmappedChoiceList {
 		if (this->strings.find(0) == this->strings.end()) {
 			/* In case of a (broken) NewGRF without a default,
 			 * assume an empty string. */
-			GrfMsg(1, "choice list misses default value");
+			GrfMsg(Severity::Error, "choice list misses default value");
 			this->strings[0] = std::string();
 		}
 
@@ -189,7 +189,7 @@ struct UnmappedChoiceList {
 				int idx = (this->type == SCC_GENDER_LIST ? lm->GetReverseMapping(i, true) : i + 1);
 				const auto &str = this->strings[this->strings.find(idx) != this->strings.end() ? idx : 0];
 				size_t len = str.size();
-				if (len > UINT8_MAX) GrfMsg(1, "choice list string is too long");
+				if (len > UINT8_MAX) GrfMsg(Severity::Error, "choice list string is too long");
 				builder.PutUint8(ClampTo<uint8_t>(len));
 			}
 
@@ -257,7 +257,7 @@ std::string TranslateTTDPatchCodes(GrfID grfid, GRFLanguage language_id, bool al
 				if (allow_newlines) {
 					builder.PutChar(0x0A);
 				} else {
-					GrfMsg(1, "Detected newline in string that does not allow one");
+					GrfMsg(Severity::Error, "Detected newline in string that does not allow one");
 				}
 				break;
 			case 0x0E: builder.PutUtf8(SCC_TINYFONT); break;
@@ -347,13 +347,13 @@ std::string TranslateTTDPatchCodes(GrfID grfid, GRFLanguage language_id, bool al
 					case 0x11:
 						if (!mapping_pg.has_value() && !mapping_c.has_value()) {
 							if (code == 0x10) consumer.SkipUint8(); // Skip the index
-							GrfMsg(1, "choice list {} marker found when not expected", code == 0x10 ? "next" : "default");
+							GrfMsg(Severity::Error, "choice list {} marker found when not expected", code == 0x10 ? "next" : "default");
 							break;
 						} else {
 							auto &mapping = mapping_pg ? mapping_pg : mapping_c;
 							int index = (code == 0x10 ? consumer.ReadUint8() : 0);
 							if (mapping->strings.find(index) != mapping->strings.end()) {
-								GrfMsg(1, "duplicate choice list string, ignoring");
+								GrfMsg(Severity::Error, "duplicate choice list string, ignoring");
 							} else {
 								builder = StringBuilder(mapping->strings[index]);
 								if (!mapping_pg) dest_c = mapping->strings[index];
@@ -363,7 +363,7 @@ std::string TranslateTTDPatchCodes(GrfID grfid, GRFLanguage language_id, bool al
 
 					case 0x12:
 						if (!mapping_pg.has_value() && !mapping_c.has_value()) {
-							GrfMsg(1, "choice list end marker found when not expected");
+							GrfMsg(Severity::Error, "choice list end marker found when not expected");
 						} else {
 							auto &mapping = mapping_pg ? mapping_pg : mapping_c;
 							auto &new_dest = mapping_pg && dest_c ? dest_c->get() : dest;
@@ -382,7 +382,7 @@ std::string TranslateTTDPatchCodes(GrfID grfid, GRFLanguage language_id, bool al
 						auto &mapping = code == 0x14 ? mapping_c : mapping_pg;
 						/* Case mapping can have nested plural/gender mapping. Otherwise nesting is invalid. */
 						if (mapping.has_value() || mapping_pg.has_value()) {
-							GrfMsg(1, "choice lists can't be stacked, it's going to get messy now...");
+							GrfMsg(Severity::Error, "choice lists can't be stacked, it's going to get messy now...");
 							if (code != 0x14) consumer.SkipUint8();
 						} else {
 							static const StringControlCode mp[] = { SCC_GENDER_LIST, SCC_SWITCH_CASE, SCC_PLURAL_LIST };
@@ -409,7 +409,7 @@ std::string TranslateTTDPatchCodes(GrfID grfid, GRFLanguage language_id, bool al
 					case 0x21: builder.PutUtf8(SCC_NEWGRF_PRINT_DWORD_FORCE); break;
 
 					default:
-						GrfMsg(1, "missing handler for extended format code");
+						GrfMsg(Severity::Error, "missing handler for extended format code");
 						break;
 				}
 				break;
@@ -442,7 +442,7 @@ std::string TranslateTTDPatchCodes(GrfID grfid, GRFLanguage language_id, bool al
 
 string_end:
 	if (mapping_pg.has_value() || mapping_c.has_value()) {
-		GrfMsg(1, "choice list was incomplete, the whole list is ignored");
+		GrfMsg(Severity::Error, "choice list was incomplete, the whole list is ignored");
 	}
 
 	return dest;
@@ -537,7 +537,7 @@ static StringID AddGRFString(GrfID grfid, GRFStringID stringid, GRFLanguage lang
 	std::string newtext = TranslateTTDPatchCodes(grfid, langid_to_add, allow_newlines, text_to_add);
 	AddGRFTextToList(it->textholder, langid_to_add, newtext);
 
-	GrfMsg(3, "Added 0x{:X} grfid {} string 0x{:X} lang 0x{:X} string '{}' ({:X})", id, FormatArrayAsHex(grfid), stringid, langid_to_add, newtext, MakeStringID(TEXT_TAB_NEWGRF_START, id));
+	GrfMsg(Severity::Notice, "Added 0x{:X} grfid {} string 0x{:X} lang 0x{:X} string '{}' ({:X})", id, FormatArrayAsHex(grfid), stringid, langid_to_add, newtext, MakeStringID(TEXT_TAB_NEWGRF_START, id));
 
 	return MakeStringID(TEXT_TAB_NEWGRF_START, id);
 }

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -147,7 +147,7 @@ static uint32_t GetNearbyTileInformation(uint8_t parameter, TileIndex tile, bool
 		case 0xD5: return this->t->fund_buildings_months;
 	}
 
-	Debug(grf, Severity::Error, "Unhandled town variable 0x{:X}", variable);
+	Debug(Facility::Grf, Severity::Error, "Unhandled town variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/newgrf_town.cpp
+++ b/src/newgrf_town.cpp
@@ -147,7 +147,7 @@ static uint32_t GetNearbyTileInformation(uint8_t parameter, TileIndex tile, bool
 		case 0xD5: return this->t->fund_buildings_months;
 	}
 
-	Debug(grf, 1, "Unhandled town variable 0x{:X}", variable);
+	Debug(grf, Severity::Error, "Unhandled town variable 0x{:X}", variable);
 
 	available = false;
 	return UINT_MAX;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -666,7 +666,7 @@ int openttd_main(std::span<std::string_view> arguments)
 	DeterminePaths(arguments[0], only_local_path);
 	TarScanner::DoScan(TarScanner::Mode::Baseset);
 
-	if (dedicated) Debug(net, Severity::Notice, "Starting dedicated server, version {}", _openttd_revision);
+	if (dedicated) Debug(Facility::Net, Severity::Notice, "Starting dedicated server, version {}", _openttd_revision);
 	if (_dedicated_forks && !dedicated) _dedicated_forks = false;
 
 #if defined(UNIX)
@@ -730,7 +730,7 @@ int openttd_main(std::span<std::string_view> arguments)
 	/* Initialize game palette */
 	GfxInitPalettes();
 
-	Debug(misc, Severity::Error, "Loading blitter...");
+	Debug(Facility::Misc, Severity::Error, "Loading blitter...");
 	if (blitter.empty() && !_ini_blitter.empty()) blitter = _ini_blitter;
 	_blitter_autodetected = blitter.empty();
 	/* Activate the initial blitter.
@@ -953,7 +953,7 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 		 * server is a better reaction than starting the server with a newly
 		 * generated map as it is quite likely to be started from a script.
 		 */
-		Debug(net, Severity::Critical, "Loading requested map failed; closing server.");
+		Debug(Facility::Net, Severity::Critical, "Loading requested map failed; closing server.");
 		_exit_game = true;
 		return false;
 	}
@@ -972,7 +972,7 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 		 * nothing else to do than start a new game, as it might have failed
 		 * trying to reload the originally loaded savegame/scenario.
 		 */
-		Debug(net, Severity::Critical, "Loading game failed, so a new (random) game will be started");
+		Debug(Facility::Net, Severity::Critical, "Loading game failed, so a new (random) game will be started");
 		MakeNewGame(false, true);
 		return false;
 	}
@@ -1241,7 +1241,7 @@ void StateGameLoop()
 		CallWindowGameTickEvent();
 		NewsLoop();
 	} else {
-		if (_debug_desync_level > Severity::Warning && TimerGameEconomy::date_fract == 0 && (TimerGameEconomy::date.base() & 0x1F) == 0) {
+		if (IsVisibleSeverity(Facility::Desync, Severity::Error) && TimerGameEconomy::date_fract == 0 && (TimerGameEconomy::date.base() & 0x1F) == 0) {
 			/* Save the desync savegame if needed. */
 			std::string name = fmt::format("dmp_cmds_{:08x}_{:08x}.sav", _settings_game.game_creation.generation_seed, TimerGameEconomy::date);
 			SaveOrLoad(name, SaveLoadOperation::Save, DetailedFileType::GameFile, Subdirectory::Autosave, false);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -666,7 +666,7 @@ int openttd_main(std::span<std::string_view> arguments)
 	DeterminePaths(arguments[0], only_local_path);
 	TarScanner::DoScan(TarScanner::Mode::Baseset);
 
-	if (dedicated) Debug(net, 3, "Starting dedicated server, version {}", _openttd_revision);
+	if (dedicated) Debug(net, Severity::Notice, "Starting dedicated server, version {}", _openttd_revision);
 	if (_dedicated_forks && !dedicated) _dedicated_forks = false;
 
 #if defined(UNIX)
@@ -730,7 +730,7 @@ int openttd_main(std::span<std::string_view> arguments)
 	/* Initialize game palette */
 	GfxInitPalettes();
 
-	Debug(misc, 1, "Loading blitter...");
+	Debug(misc, Severity::Error, "Loading blitter...");
 	if (blitter.empty() && !_ini_blitter.empty()) blitter = _ini_blitter;
 	_blitter_autodetected = blitter.empty();
 	/* Activate the initial blitter.
@@ -953,7 +953,7 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 		 * server is a better reaction than starting the server with a newly
 		 * generated map as it is quite likely to be started from a script.
 		 */
-		Debug(net, 0, "Loading requested map failed; closing server.");
+		Debug(net, Severity::Critical, "Loading requested map failed; closing server.");
 		_exit_game = true;
 		return false;
 	}
@@ -972,7 +972,7 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 		 * nothing else to do than start a new game, as it might have failed
 		 * trying to reload the originally loaded savegame/scenario.
 		 */
-		Debug(net, 0, "Loading game failed, so a new (random) game will be started");
+		Debug(net, Severity::Critical, "Loading game failed, so a new (random) game will be started");
 		MakeNewGame(false, true);
 		return false;
 	}
@@ -1241,7 +1241,7 @@ void StateGameLoop()
 		CallWindowGameTickEvent();
 		NewsLoop();
 	} else {
-		if (_debug_desync_level > 2 && TimerGameEconomy::date_fract == 0 && (TimerGameEconomy::date.base() & 0x1F) == 0) {
+		if (_debug_desync_level > Severity::Warning && TimerGameEconomy::date_fract == 0 && (TimerGameEconomy::date.base() & 0x1F) == 0) {
 			/* Save the desync savegame if needed. */
 			std::string name = fmt::format("dmp_cmds_{:08x}_{:08x}.sav", _settings_game.game_creation.generation_seed, TimerGameEconomy::date);
 			SaveOrLoad(name, SaveLoadOperation::Save, DetailedFileType::GameFile, Subdirectory::Autosave, false);

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -505,7 +505,7 @@ void OrderList::DebugCheckSanity() const
 	TimerGameTick::Ticks check_timetable_duration = 0;
 	TimerGameTick::Ticks check_total_duration = 0;
 
-	Debug(misc, 6, "Checking OrderList {} for sanity...", this->index);
+	Debug(misc, Severity::Debug2, "Checking OrderList {} for sanity...", this->index);
 
 	for (const Order &o : this->orders) {
 		++check_num_orders;
@@ -523,7 +523,7 @@ void OrderList::DebugCheckSanity() const
 		assert(v->orders == this);
 	}
 	assert(this->num_vehicles == check_num_vehicles);
-	Debug(misc, 6, "... detected {} orders ({} manual), {} vehicles, {} timetabled, {} total",
+	Debug(misc, Severity::Debug2, "... detected {} orders ({} manual), {} vehicles, {} timetabled, {} total",
 			(uint)this->GetNumOrders(), (uint)this->num_manual_orders,
 			this->num_vehicles, this->timetable_duration, this->total_duration);
 }

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -505,7 +505,7 @@ void OrderList::DebugCheckSanity() const
 	TimerGameTick::Ticks check_timetable_duration = 0;
 	TimerGameTick::Ticks check_total_duration = 0;
 
-	Debug(misc, Severity::Debug2, "Checking OrderList {} for sanity...", this->index);
+	Debug(Facility::Misc, Severity::Debug2, "Checking OrderList {} for sanity...", this->index);
 
 	for (const Order &o : this->orders) {
 		++check_num_orders;
@@ -523,7 +523,7 @@ void OrderList::DebugCheckSanity() const
 		assert(v->orders == this);
 	}
 	assert(this->num_vehicles == check_num_vehicles);
-	Debug(misc, Severity::Debug2, "... detected {} orders ({} manual), {} vehicles, {} timetabled, {} total",
+	Debug(Facility::Misc, Severity::Debug2, "... detected {} orders ({} manual), {} vehicles, {} timetabled, {} total",
 			(uint)this->GetNumOrders(), (uint)this->num_manual_orders,
 			this->num_vehicles, this->timetable_duration, this->total_duration);
 }

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -91,7 +91,7 @@ void CoreTextFontCache::SetFontSize(int pixels)
 	CFStringGetCString(font_name.get(), name, lengthof(name), kCFStringEncodingUTF8);
 	this->font_name = name;
 
-	Debug(fontcache, 2, "Loaded font '{}' with size {}", this->font_name, pixels);
+	Debug(fontcache, Severity::Warning, "Loaded font '{}' with size {}", this->font_name, pixels);
 }
 
 GlyphID CoreTextFontCache::MapCharToGlyph(char32_t key, bool allow_fallback)
@@ -301,7 +301,7 @@ public:
 				result = FontCache::TryFallback(callback->missing_fontsizes, callback->missing_glyphs, std::string{name});
 				if (result) {
 					FontCache::AddFallback(callback->missing_fontsizes, name);
-					Debug(fontcache, 2, "CT-Font for {}: {}", language_isocode, name);
+					Debug(fontcache, Severity::Warning, "CT-Font for {}: {}", language_isocode, name);
 					break;
 				}
 			}

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -91,7 +91,7 @@ void CoreTextFontCache::SetFontSize(int pixels)
 	CFStringGetCString(font_name.get(), name, lengthof(name), kCFStringEncodingUTF8);
 	this->font_name = name;
 
-	Debug(fontcache, Severity::Warning, "Loaded font '{}' with size {}", this->font_name, pixels);
+	Debug(Facility::Fontcache, Severity::Warning, "Loaded font '{}' with size {}", this->font_name, pixels);
 }
 
 GlyphID CoreTextFontCache::MapCharToGlyph(char32_t key, bool allow_fallback)
@@ -301,7 +301,7 @@ public:
 				result = FontCache::TryFallback(callback->missing_fontsizes, callback->missing_glyphs, std::string{name});
 				if (result) {
 					FontCache::AddFallback(callback->missing_fontsizes, name);
-					Debug(fontcache, Severity::Warning, "CT-Font for {}: {}", language_isocode, name);
+					Debug(Facility::Fontcache, Severity::Warning, "CT-Font for {}: {}", language_isocode, name);
 					break;
 				}
 			}

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -201,7 +201,7 @@ bool FontConfigFindFallbackFont(const std::string &language_isocode, MissingGlyp
 		}
 
 		if (matching_chars < callback->missing_glyphs.size()) {
-			Debug(fontcache, 1, "Font \"{}\" misses {} glyphs", FromFcString(file), callback->missing_glyphs.size() - matching_chars);
+			Debug(fontcache, Severity::Error, "Font \"{}\" misses {} glyphs", FromFcString(file), callback->missing_glyphs.size() - matching_chars);
 			continue;
 		}
 

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -201,7 +201,7 @@ bool FontConfigFindFallbackFont(const std::string &language_isocode, MissingGlyp
 		}
 
 		if (matching_chars < callback->missing_glyphs.size()) {
-			Debug(fontcache, Severity::Error, "Font \"{}\" misses {} glyphs", FromFcString(file), callback->missing_glyphs.size() - matching_chars);
+			Debug(Facility::Fontcache, Severity::Error, "Font \"{}\" misses {} glyphs", FromFcString(file), callback->missing_glyphs.size() - matching_chars);
 			continue;
 		}
 

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -135,7 +135,7 @@ static std::string convert_tofrom_fs(iconv_t convd, std::string_view name)
 	char *outbuf = buf.data();
 	iconv(convd, nullptr, nullptr, nullptr, nullptr);
 	if (iconv(convd, &inbuf, &inlen, &outbuf, &outlen) == SIZE_MAX) {
-		Debug(misc, Severity::Critical, "[iconv] error converting '{}'. Errno {}", name, errno);
+		Debug(Facility::Misc, Severity::Critical, "[iconv] error converting '{}'. Errno {}", name, errno);
 		return std::string{name};
 	}
 
@@ -150,7 +150,7 @@ static std::optional<iconv_t> OpenIconv(std::string from, std::string to)
 {
 	iconv_t convd = iconv_open(from.c_str(), to.c_str());
 	if (convd == reinterpret_cast<iconv_t>(-1)) {
-		Debug(misc, Severity::Critical, "[iconv] conversion from codeset '{}' to '{}' unsupported", from, to);
+		Debug(Facility::Misc, Severity::Critical, "[iconv] conversion from codeset '{}' to '{}' unsupported", from, to);
 		return std::nullopt;
 	}
 	return convd;
@@ -237,7 +237,7 @@ void OSOpenBrowser(const std::string &url)
 	args[1] = url.c_str();
 	args[2] = nullptr;
 	execvp(args[0], const_cast<char * const *>(args));
-	Debug(misc, Severity::Critical, "Failed to open url: {}", url);
+	Debug(Facility::Misc, Severity::Critical, "Failed to open url: {}", url);
 	exit(0);
 }
 #endif /* __APPLE__ */

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -135,7 +135,7 @@ static std::string convert_tofrom_fs(iconv_t convd, std::string_view name)
 	char *outbuf = buf.data();
 	iconv(convd, nullptr, nullptr, nullptr, nullptr);
 	if (iconv(convd, &inbuf, &inlen, &outbuf, &outlen) == SIZE_MAX) {
-		Debug(misc, 0, "[iconv] error converting '{}'. Errno {}", name, errno);
+		Debug(misc, Severity::Critical, "[iconv] error converting '{}'. Errno {}", name, errno);
 		return std::string{name};
 	}
 
@@ -150,7 +150,7 @@ static std::optional<iconv_t> OpenIconv(std::string from, std::string to)
 {
 	iconv_t convd = iconv_open(from.c_str(), to.c_str());
 	if (convd == reinterpret_cast<iconv_t>(-1)) {
-		Debug(misc, 0, "[iconv] conversion from codeset '{}' to '{}' unsupported", from, to);
+		Debug(misc, Severity::Critical, "[iconv] conversion from codeset '{}' to '{}' unsupported", from, to);
 		return std::nullopt;
 	}
 	return convd;
@@ -237,7 +237,7 @@ void OSOpenBrowser(const std::string &url)
 	args[1] = url.c_str();
 	args[2] = nullptr;
 	execvp(args[0], const_cast<char * const *>(args));
-	Debug(misc, 0, "Failed to open url: {}", url);
+	Debug(misc, Severity::Critical, "Failed to open url: {}", url);
 	exit(0);
 }
 #endif /* __APPLE__ */

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -79,7 +79,7 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	if (!FontCache::TryFallback(info->callback->missing_fontsizes, info->callback->missing_glyphs, font_name, logfont->elfLogFont)) return 1;
 
 	FontCache::AddFallback(info->callback->missing_fontsizes, font_name, logfont->elfLogFont);
-	Debug(fontcache, Severity::Error, "Fallback font: {}", font_name);
+	Debug(Facility::Fontcache, Severity::Error, "Fallback font: {}", font_name);
 	return 0; // stop enumerating
 }
 
@@ -159,7 +159,7 @@ void Win32FontCache::SetFontSize(int pixels)
 
 	this->fontname = FS2OTTD((LPWSTR)((BYTE *)otm + (ptrdiff_t)otm->otmpFaceName));
 
-	Debug(fontcache, Severity::Warning, "Loaded font '{}' with size {}", this->fontname, pixels);
+	Debug(Facility::Fontcache, Severity::Warning, "Loaded font '{}' with size {}", this->fontname, pixels);
 	delete[] (BYTE*)otm;
 }
 
@@ -302,12 +302,12 @@ public:
 
 	bool FindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback) const override
 	{
-		Debug(fontcache, Severity::Error, "Trying fallback fonts");
+		Debug(Facility::Fontcache, Severity::Error, "Trying fallback fonts");
 		EFCParam langInfo;
 		std::wstring lang = OTTD2FS(language_isocode.substr(0, language_isocode.find('_')));
 		if (GetLocaleInfoEx(lang.c_str(), LOCALE_FONTSIGNATURE, reinterpret_cast<LPWSTR>(&langInfo.locale), sizeof(langInfo.locale) / sizeof(wchar_t)) == 0) {
 			/* Invalid isocode or some other mysterious error, can't determine fallback font. */
-			Debug(fontcache, Severity::Error, "Can't get locale info for fallback font (isocode={})", language_isocode);
+			Debug(Facility::Fontcache, Severity::Error, "Can't get locale info for fallback font (isocode={})", language_isocode);
 			return false;
 		}
 		langInfo.callback = callback;

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -79,7 +79,7 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	if (!FontCache::TryFallback(info->callback->missing_fontsizes, info->callback->missing_glyphs, font_name, logfont->elfLogFont)) return 1;
 
 	FontCache::AddFallback(info->callback->missing_fontsizes, font_name, logfont->elfLogFont);
-	Debug(fontcache, 1, "Fallback font: {}", font_name);
+	Debug(fontcache, Severity::Error, "Fallback font: {}", font_name);
 	return 0; // stop enumerating
 }
 
@@ -159,7 +159,7 @@ void Win32FontCache::SetFontSize(int pixels)
 
 	this->fontname = FS2OTTD((LPWSTR)((BYTE *)otm + (ptrdiff_t)otm->otmpFaceName));
 
-	Debug(fontcache, 2, "Loaded font '{}' with size {}", this->fontname, pixels);
+	Debug(fontcache, Severity::Warning, "Loaded font '{}' with size {}", this->fontname, pixels);
 	delete[] (BYTE*)otm;
 }
 
@@ -302,12 +302,12 @@ public:
 
 	bool FindFallbackFont(const std::string &language_isocode, MissingGlyphSearcher *callback) const override
 	{
-		Debug(fontcache, 1, "Trying fallback fonts");
+		Debug(fontcache, Severity::Error, "Trying fallback fonts");
 		EFCParam langInfo;
 		std::wstring lang = OTTD2FS(language_isocode.substr(0, language_isocode.find('_')));
 		if (GetLocaleInfoEx(lang.c_str(), LOCALE_FONTSIGNATURE, reinterpret_cast<LPWSTR>(&langInfo.locale), sizeof(langInfo.locale) / sizeof(wchar_t)) == 0) {
 			/* Invalid isocode or some other mysterious error, can't determine fallback font. */
-			Debug(fontcache, 1, "Can't get locale info for fallback font (isocode={})", language_isocode);
+			Debug(fontcache, Severity::Error, "Can't get locale info for fallback font (isocode={})", language_isocode);
 			return false;
 		}
 		langInfo.callback = callback;

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -292,7 +292,7 @@ void DetermineBasePaths(std::string_view exe)
 		wchar_t config_dir[MAX_PATH];
 		convert_to_fs(_config_file, path);
 		if (!GetFullPathName(path, static_cast<DWORD>(std::size(config_dir)), config_dir, nullptr)) {
-			Debug(misc, Severity::Critical, "GetFullPathName failed ({})", GetLastError());
+			Debug(Facility::Misc, Severity::Critical, "GetFullPathName failed ({})", GetLastError());
 			_searchpaths[Searchpath::WorkingDir].clear();
 		} else {
 			std::string tmp(FS2OTTD(config_dir));
@@ -304,13 +304,13 @@ void DetermineBasePaths(std::string_view exe)
 	}
 
 	if (!GetModuleFileName(nullptr, path, static_cast<DWORD>(std::size(path)))) {
-		Debug(misc, Severity::Critical, "GetModuleFileName failed ({})", GetLastError());
+		Debug(Facility::Misc, Severity::Critical, "GetModuleFileName failed ({})", GetLastError());
 		_searchpaths[Searchpath::BinaryDir].clear();
 	} else {
 		wchar_t exec_dir[MAX_PATH];
 		convert_to_fs(exe, path);
 		if (!GetFullPathName(path, static_cast<DWORD>(std::size(exec_dir)), exec_dir, nullptr)) {
-			Debug(misc, Severity::Critical, "GetFullPathName failed ({})", GetLastError());
+			Debug(Facility::Misc, Severity::Critical, "GetFullPathName failed ({})", GetLastError());
 			_searchpaths[Searchpath::BinaryDir].clear();
 		} else {
 			std::string tmp(FS2OTTD(exec_dir));

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -292,7 +292,7 @@ void DetermineBasePaths(std::string_view exe)
 		wchar_t config_dir[MAX_PATH];
 		convert_to_fs(_config_file, path);
 		if (!GetFullPathName(path, static_cast<DWORD>(std::size(config_dir)), config_dir, nullptr)) {
-			Debug(misc, 0, "GetFullPathName failed ({})", GetLastError());
+			Debug(misc, Severity::Critical, "GetFullPathName failed ({})", GetLastError());
 			_searchpaths[Searchpath::WorkingDir].clear();
 		} else {
 			std::string tmp(FS2OTTD(config_dir));
@@ -304,13 +304,13 @@ void DetermineBasePaths(std::string_view exe)
 	}
 
 	if (!GetModuleFileName(nullptr, path, static_cast<DWORD>(std::size(path)))) {
-		Debug(misc, 0, "GetModuleFileName failed ({})", GetLastError());
+		Debug(misc, Severity::Critical, "GetModuleFileName failed ({})", GetLastError());
 		_searchpaths[Searchpath::BinaryDir].clear();
 	} else {
 		wchar_t exec_dir[MAX_PATH];
 		convert_to_fs(exe, path);
 		if (!GetFullPathName(path, static_cast<DWORD>(std::size(exec_dir)), exec_dir, nullptr)) {
-			Debug(misc, 0, "GetFullPathName failed ({})", GetLastError());
+			Debug(misc, Severity::Critical, "GetFullPathName failed ({})", GetLastError());
 			_searchpaths[Searchpath::BinaryDir].clear();
 		} else {
 			std::string tmp(FS2OTTD(exec_dir));

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -126,7 +126,7 @@ public:
 	 */
 	void ForceUpdate()
 	{
-		Debug(map, Severity::Notice, "Updating water region ({},{})", GetWaterRegionX(this->tile_area.tile), GetWaterRegionY(this->tile_area.tile));
+		Debug(Facility::Map, Severity::Notice, "Updating water region ({},{})", GetWaterRegionX(this->tile_area.tile), GetWaterRegionY(this->tile_area.tile));
 		this->data.has_cross_region_aqueducts = false;
 
 		/* Acquire a tile patch label array if this region does not already have one */
@@ -194,13 +194,13 @@ public:
 
 	void PrintDebugInfo()
 	{
-		Debug(map, Severity::Trace3, "Water region {},{} labels and edge traversability = ...", GetWaterRegionX(this->tile_area.tile), GetWaterRegionY(this->tile_area.tile));
+		Debug(Facility::Map, Severity::Trace3, "Water region {},{} labels and edge traversability = ...", GetWaterRegionX(this->tile_area.tile), GetWaterRegionY(this->tile_area.tile));
 
 		const size_t max_element_width = fmt::format("{}", this->NumberOfPatches()).size();
 
 		std::string traversability = fmt::format("{:0{}b}", this->GetEdgeTraversabilityBits(DiagDirection::NW), WATER_REGION_EDGE_LENGTH);
-		Debug(map, Severity::Trace3, "    {:{}}", fmt::join(traversability, " "), max_element_width);
-		Debug(map, Severity::Trace3, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
+		Debug(Facility::Map, Severity::Trace3, "    {:{}}", fmt::join(traversability, " "), max_element_width);
+		Debug(Facility::Map, Severity::Trace3, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
 
 		for (int y = 0; y < WATER_REGION_EDGE_LENGTH; ++y) {
 			std::string line{};
@@ -212,12 +212,12 @@ public:
 					line = fmt::format("{:{}} {}", label, max_element_width, line);
 				}
 			}
-			Debug(map, Severity::Trace3, "{} | {}| {}", GB(this->GetEdgeTraversabilityBits(DiagDirection::SW), y, 1), line, GB(this->GetEdgeTraversabilityBits(DiagDirection::NE), y, 1));
+			Debug(Facility::Map, Severity::Trace3, "{} | {}| {}", GB(this->GetEdgeTraversabilityBits(DiagDirection::SW), y, 1), line, GB(this->GetEdgeTraversabilityBits(DiagDirection::NE), y, 1));
 		}
 
-		Debug(map, Severity::Trace3, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
+		Debug(Facility::Map, Severity::Trace3, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
 		traversability = fmt::format("{:0{}b}", this->GetEdgeTraversabilityBits(DiagDirection::SE), WATER_REGION_EDGE_LENGTH);
-		Debug(map, Severity::Trace3, "    {:{}}", fmt::join(traversability, " "), max_element_width);
+		Debug(Facility::Map, Severity::Trace3, "    {:{}}", fmt::join(traversability, " "), max_element_width);
 	}
 };
 
@@ -320,7 +320,7 @@ void InvalidateWaterRegion(TileIndex tile)
 
 	auto invalidate_region = [](TileIndex tile) {
 		const WaterRegionIndex water_region_index = GetWaterRegionIndex(tile);
-		if (!_is_water_region_valid[water_region_index]) Debug(map, Severity::Notice, "Invalidated water region ({},{})", GetWaterRegionX(tile), GetWaterRegionY(tile));
+		if (!_is_water_region_valid[water_region_index]) Debug(Facility::Map, Severity::Notice, "Invalidated water region ({},{})", GetWaterRegionX(tile), GetWaterRegionY(tile));
 		_is_water_region_valid[water_region_index] = false;
 	};
 
@@ -425,7 +425,7 @@ void AllocateWaterRegions()
 	_is_water_region_valid.clear();
 	_is_water_region_valid.resize(number_of_regions, false);
 
-	Debug(map, Severity::Warning, "Allocating {} x {} water regions", GetWaterRegionMapSizeX(), GetWaterRegionMapSizeY());
+	Debug(Facility::Map, Severity::Warning, "Allocating {} x {} water regions", GetWaterRegionMapSizeX(), GetWaterRegionMapSizeY());
 	assert(_is_water_region_valid.size() == _water_region_data.size());
 }
 

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -126,7 +126,7 @@ public:
 	 */
 	void ForceUpdate()
 	{
-		Debug(map, 3, "Updating water region ({},{})", GetWaterRegionX(this->tile_area.tile), GetWaterRegionY(this->tile_area.tile));
+		Debug(map, Severity::Notice, "Updating water region ({},{})", GetWaterRegionX(this->tile_area.tile), GetWaterRegionY(this->tile_area.tile));
 		this->data.has_cross_region_aqueducts = false;
 
 		/* Acquire a tile patch label array if this region does not already have one */
@@ -194,13 +194,13 @@ public:
 
 	void PrintDebugInfo()
 	{
-		Debug(map, 9, "Water region {},{} labels and edge traversability = ...", GetWaterRegionX(this->tile_area.tile), GetWaterRegionY(this->tile_area.tile));
+		Debug(map, Severity::Trace3, "Water region {},{} labels and edge traversability = ...", GetWaterRegionX(this->tile_area.tile), GetWaterRegionY(this->tile_area.tile));
 
 		const size_t max_element_width = fmt::format("{}", this->NumberOfPatches()).size();
 
 		std::string traversability = fmt::format("{:0{}b}", this->GetEdgeTraversabilityBits(DiagDirection::NW), WATER_REGION_EDGE_LENGTH);
-		Debug(map, 9, "    {:{}}", fmt::join(traversability, " "), max_element_width);
-		Debug(map, 9, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
+		Debug(map, Severity::Trace3, "    {:{}}", fmt::join(traversability, " "), max_element_width);
+		Debug(map, Severity::Trace3, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
 
 		for (int y = 0; y < WATER_REGION_EDGE_LENGTH; ++y) {
 			std::string line{};
@@ -212,12 +212,12 @@ public:
 					line = fmt::format("{:{}} {}", label, max_element_width, line);
 				}
 			}
-			Debug(map, 9, "{} | {}| {}", GB(this->GetEdgeTraversabilityBits(DiagDirection::SW), y, 1), line, GB(this->GetEdgeTraversabilityBits(DiagDirection::NE), y, 1));
+			Debug(map, Severity::Trace3, "{} | {}| {}", GB(this->GetEdgeTraversabilityBits(DiagDirection::SW), y, 1), line, GB(this->GetEdgeTraversabilityBits(DiagDirection::NE), y, 1));
 		}
 
-		Debug(map, 9, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
+		Debug(map, Severity::Trace3, "  +{:->{}}+", "", WATER_REGION_EDGE_LENGTH * (max_element_width + 1) + 1);
 		traversability = fmt::format("{:0{}b}", this->GetEdgeTraversabilityBits(DiagDirection::SE), WATER_REGION_EDGE_LENGTH);
-		Debug(map, 9, "    {:{}}", fmt::join(traversability, " "), max_element_width);
+		Debug(map, Severity::Trace3, "    {:{}}", fmt::join(traversability, " "), max_element_width);
 	}
 };
 
@@ -320,7 +320,7 @@ void InvalidateWaterRegion(TileIndex tile)
 
 	auto invalidate_region = [](TileIndex tile) {
 		const WaterRegionIndex water_region_index = GetWaterRegionIndex(tile);
-		if (!_is_water_region_valid[water_region_index]) Debug(map, 3, "Invalidated water region ({},{})", GetWaterRegionX(tile), GetWaterRegionY(tile));
+		if (!_is_water_region_valid[water_region_index]) Debug(map, Severity::Notice, "Invalidated water region ({},{})", GetWaterRegionX(tile), GetWaterRegionY(tile));
 		_is_water_region_valid[water_region_index] = false;
 	};
 
@@ -425,7 +425,7 @@ void AllocateWaterRegions()
 	_is_water_region_valid.clear();
 	_is_water_region_valid.resize(number_of_regions, false);
 
-	Debug(map, 2, "Allocating {} x {} water regions", GetWaterRegionMapSizeX(), GetWaterRegionMapSizeY());
+	Debug(map, Severity::Warning, "Allocating {} x {} water regions", GetWaterRegionMapSizeX(), GetWaterRegionMapSizeY());
 	assert(_is_water_region_valid.size() == _water_region_data.size());
 }
 

--- a/src/pathfinder/yapf/yapf_base.hpp
+++ b/src/pathfinder/yapf/yapf_base.hpp
@@ -176,14 +176,14 @@ public:
 
 		const bool destination_found = (this->best_dest_node != nullptr);
 
-		if (_debug_yapf_level >= 3) {
+		if (_debug_yapf_level >= Severity::Notice) {
 			const UnitID veh_idx = (this->vehicle != nullptr) ? this->vehicle->unitnumber : 0;
 			const char ttc = Yapf().TransportTypeChar();
 			const float cache_hit_ratio = (this->stats_cache_hits == 0) ? 0.0f : ((float)this->stats_cache_hits / (float)(this->stats_cache_hits + this->stats_cost_calcs) * 100.0f);
 			const int cost = destination_found ? this->best_dest_node->cost : -1;
 			const int dist = destination_found ? this->best_dest_node->estimate - this->best_dest_node->cost : -1;
 
-			Debug(yapf, 3, "[YAPF{}]{}{:4d} - {} rounds - {} open - {} closed - CHR {:4.1f}% - C {} D {}",
+			Debug(yapf, Severity::Notice, "[YAPF{}]{}{:4d} - {} rounds - {} open - {} closed - CHR {:4.1f}% - C {} D {}",
 				ttc, destination_found ? '-' : '!', veh_idx, this->num_steps, this->nodes.OpenCount(), this->nodes.ClosedCount(), cache_hit_ratio, cost, dist
 			);
 		}

--- a/src/pathfinder/yapf/yapf_base.hpp
+++ b/src/pathfinder/yapf/yapf_base.hpp
@@ -176,14 +176,14 @@ public:
 
 		const bool destination_found = (this->best_dest_node != nullptr);
 
-		if (_debug_yapf_level >= Severity::Notice) {
+		if (IsVisibleSeverity(Facility::Yapf, Severity::Notice)) {
 			const UnitID veh_idx = (this->vehicle != nullptr) ? this->vehicle->unitnumber : 0;
 			const char ttc = Yapf().TransportTypeChar();
 			const float cache_hit_ratio = (this->stats_cache_hits == 0) ? 0.0f : ((float)this->stats_cache_hits / (float)(this->stats_cache_hits + this->stats_cost_calcs) * 100.0f);
 			const int cost = destination_found ? this->best_dest_node->cost : -1;
 			const int dist = destination_found ? this->best_dest_node->estimate - this->best_dest_node->cost : -1;
 
-			Debug(yapf, Severity::Notice, "[YAPF{}]{}{:4d} - {} rounds - {} open - {} closed - CHR {:4.1f}% - C {} D {}",
+			Debug(Facility::Yapf, Severity::Notice, "[YAPF{}]{}{:4d} - {} rounds - {} open - {} closed - CHR {:4.1f}% - C {} D {}",
 				ttc, destination_found ? '-' : '!', veh_idx, this->num_steps, this->nodes.OpenCount(), this->nodes.ClosedCount(), cache_hit_ratio, cost, dist
 			);
 		}

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -280,12 +280,12 @@ public:
 		if (max_penalty != 0) pf1.DisableCache(true);
 		FindDepotData result1 = pf1.FindNearestDepotTwoWay(v, t1, td1, t2, td2, max_penalty, reverse_penalty);
 
-		if (_debug_desync_level >= Severity::Warning) {
+		if (IsVisibleSeverity(Facility::Desync, Severity::Warning)) {
 			Tpf pf2;
 			pf2.DisableCache(true);
 			FindDepotData result2 = pf2.FindNearestDepotTwoWay(v, t1, td1, t2, td2, max_penalty, reverse_penalty);
 			if (result1.tile != result2.tile || (result1.reverse != result2.reverse)) {
-				Debug(desync, Severity::Warning, "warning: FindNearestDepotTwoWay cache mismatch: {} vs {}",
+				Debug(Facility::Desync, Severity::Warning, "warning: FindNearestDepotTwoWay cache mismatch: {} vs {}",
 						result1.tile != INVALID_TILE ? "T" : "F",
 						result2.tile != INVALID_TILE ? "T" : "F");
 				DumpState(pf1, pf2);
@@ -357,7 +357,7 @@ public:
 		/* Create pathfinder instance */
 		Tpf pf1;
 		bool result1;
-		if (_debug_desync_level < Severity::Warning) {
+		if (!IsVisibleSeverity(Facility::Desync, Severity::Warning)) {
 			result1 = pf1.FindNearestSafeTile(v, t1, td, override_railtype, false);
 		} else {
 			bool result2 = pf1.FindNearestSafeTile(v, t1, td, override_railtype, true);
@@ -365,7 +365,7 @@ public:
 			pf2.DisableCache(true);
 			result1 = pf2.FindNearestSafeTile(v, t1, td, override_railtype, false);
 			if (result1 != result2) {
-				Debug(desync, Severity::Warning, "warning: FindSafeTile cache mismatch: {} vs {}", result2 ? "T" : "F", result1 ? "T" : "F");
+				Debug(Facility::Desync, Severity::Warning, "warning: FindSafeTile cache mismatch: {} vs {}", result2 ? "T" : "F", result1 ? "T" : "F");
 				DumpState(pf1, pf2);
 			}
 		}
@@ -436,7 +436,7 @@ public:
 		Tpf pf1;
 		Trackdir result1;
 
-		if (_debug_desync_level < Severity::Warning) {
+		if (!IsVisibleSeverity(Facility::Desync, Severity::Warning)) {
 			result1 = pf1.ChooseRailTrack(v, tile, enterdir, tracks, path_found, reserve_track, target, dest);
 		} else {
 			result1 = pf1.ChooseRailTrack(v, tile, enterdir, tracks, path_found, false, nullptr, nullptr);
@@ -444,7 +444,7 @@ public:
 			pf2.DisableCache(true);
 			Trackdir result2 = pf2.ChooseRailTrack(v, tile, enterdir, tracks, path_found, reserve_track, target, dest);
 			if (result1 != result2) {
-				Debug(desync, Severity::Warning, "warning: ChooseRailTrack cache mismatch: {} vs {}", result1, result2);
+				Debug(Facility::Desync, Severity::Warning, "warning: ChooseRailTrack cache mismatch: {} vs {}", result1, result2);
 				DumpState(pf1, pf2);
 			}
 		}
@@ -507,12 +507,12 @@ public:
 		Tpf pf1;
 		bool result1 = pf1.CheckReverseTrain(v, t1, td1, t2, td2, reverse_penalty);
 
-		if (_debug_desync_level >= Severity::Warning) {
+		if (IsVisibleSeverity(Facility::Desync, Severity::Warning)) {
 			Tpf pf2;
 			pf2.DisableCache(true);
 			bool result2 = pf2.CheckReverseTrain(v, t1, td1, t2, td2, reverse_penalty);
 			if (result1 != result2) {
-				Debug(desync, Severity::Warning, "warning: CheckReverseTrain cache mismatch: {} vs {}", result1 ? "T" : "F", result2 ? "T" : "F");
+				Debug(Facility::Desync, Severity::Warning, "warning: CheckReverseTrain cache mismatch: {} vs {}", result1 ? "T" : "F", result2 ? "T" : "F");
 				DumpState(pf1, pf2);
 			}
 		}

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -280,12 +280,12 @@ public:
 		if (max_penalty != 0) pf1.DisableCache(true);
 		FindDepotData result1 = pf1.FindNearestDepotTwoWay(v, t1, td1, t2, td2, max_penalty, reverse_penalty);
 
-		if (_debug_desync_level >= 2) {
+		if (_debug_desync_level >= Severity::Warning) {
 			Tpf pf2;
 			pf2.DisableCache(true);
 			FindDepotData result2 = pf2.FindNearestDepotTwoWay(v, t1, td1, t2, td2, max_penalty, reverse_penalty);
 			if (result1.tile != result2.tile || (result1.reverse != result2.reverse)) {
-				Debug(desync, 2, "warning: FindNearestDepotTwoWay cache mismatch: {} vs {}",
+				Debug(desync, Severity::Warning, "warning: FindNearestDepotTwoWay cache mismatch: {} vs {}",
 						result1.tile != INVALID_TILE ? "T" : "F",
 						result2.tile != INVALID_TILE ? "T" : "F");
 				DumpState(pf1, pf2);
@@ -357,7 +357,7 @@ public:
 		/* Create pathfinder instance */
 		Tpf pf1;
 		bool result1;
-		if (_debug_desync_level < 2) {
+		if (_debug_desync_level < Severity::Warning) {
 			result1 = pf1.FindNearestSafeTile(v, t1, td, override_railtype, false);
 		} else {
 			bool result2 = pf1.FindNearestSafeTile(v, t1, td, override_railtype, true);
@@ -365,7 +365,7 @@ public:
 			pf2.DisableCache(true);
 			result1 = pf2.FindNearestSafeTile(v, t1, td, override_railtype, false);
 			if (result1 != result2) {
-				Debug(desync, 2, "warning: FindSafeTile cache mismatch: {} vs {}", result2 ? "T" : "F", result1 ? "T" : "F");
+				Debug(desync, Severity::Warning, "warning: FindSafeTile cache mismatch: {} vs {}", result2 ? "T" : "F", result1 ? "T" : "F");
 				DumpState(pf1, pf2);
 			}
 		}
@@ -436,7 +436,7 @@ public:
 		Tpf pf1;
 		Trackdir result1;
 
-		if (_debug_desync_level < 2) {
+		if (_debug_desync_level < Severity::Warning) {
 			result1 = pf1.ChooseRailTrack(v, tile, enterdir, tracks, path_found, reserve_track, target, dest);
 		} else {
 			result1 = pf1.ChooseRailTrack(v, tile, enterdir, tracks, path_found, false, nullptr, nullptr);
@@ -444,7 +444,7 @@ public:
 			pf2.DisableCache(true);
 			Trackdir result2 = pf2.ChooseRailTrack(v, tile, enterdir, tracks, path_found, reserve_track, target, dest);
 			if (result1 != result2) {
-				Debug(desync, 2, "warning: ChooseRailTrack cache mismatch: {} vs {}", result1, result2);
+				Debug(desync, Severity::Warning, "warning: ChooseRailTrack cache mismatch: {} vs {}", result1, result2);
 				DumpState(pf1, pf2);
 			}
 		}
@@ -507,12 +507,12 @@ public:
 		Tpf pf1;
 		bool result1 = pf1.CheckReverseTrain(v, t1, td1, t2, td2, reverse_penalty);
 
-		if (_debug_desync_level >= 2) {
+		if (_debug_desync_level >= Severity::Warning) {
 			Tpf pf2;
 			pf2.DisableCache(true);
 			bool result2 = pf2.CheckReverseTrain(v, t1, td1, t2, td2, reverse_penalty);
 			if (result1 != result2) {
-				Debug(desync, 2, "warning: CheckReverseTrain cache mismatch: {} vs {}", result1 ? "T" : "F", result2 ? "T" : "F");
+				Debug(desync, Severity::Warning, "warning: CheckReverseTrain cache mismatch: {} vs {}", result1 ? "T" : "F", result2 ? "T" : "F");
 				DumpState(pf1, pf2);
 			}
 		}

--- a/src/random_access_file.cpp
+++ b/src/random_access_file.cpp
@@ -93,7 +93,7 @@ void RandomAccessFile::SeekTo(size_t pos, int mode)
 
 	this->pos = pos;
 	if (fseek(*this->file_handle, this->pos, SEEK_SET) < 0) {
-		Debug(misc, 0, "Seeking in {} failed", this->filename);
+		Debug(misc, Severity::Critical, "Seeking in {} failed", this->filename);
 	}
 
 	/* Reset the buffer, so the next ReadByte will read bytes from the file. */

--- a/src/random_access_file.cpp
+++ b/src/random_access_file.cpp
@@ -93,7 +93,7 @@ void RandomAccessFile::SeekTo(size_t pos, int mode)
 
 	this->pos = pos;
 	if (fseek(*this->file_handle, this->pos, SEEK_SET) < 0) {
-		Debug(misc, Severity::Critical, "Seeking in {} failed", this->filename);
+		Debug(Facility::Misc, Severity::Critical, "Seeking in {} failed", this->filename);
 	}
 
 	/* Reset the buffer, so the next ReadByte will read bytes from the file. */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -585,8 +585,8 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SaveLoadVersion::PauseModes)) {
 		_pause_mode = (_pause_mode.base() == 2) ? PauseMode::Normal : PauseModes{};
 	} else if (_network_dedicated && _pause_mode.Test(PauseMode::Error)) {
-		Debug(net, 0, "The loading savegame was paused due to an error state");
-		Debug(net, 0, "  This savegame cannot be used for multiplayer");
+		Debug(net, Severity::Critical, "The loading savegame was paused due to an error state");
+		Debug(net, Severity::Critical, "  This savegame cannot be used for multiplayer");
 		/* Restore the signals */
 		ResetSignalHandlers();
 		return false;
@@ -2403,7 +2403,7 @@ bool AfterLoadGame()
 			/* At some point, invalid depots were saved into the game (possibly those removed in the past?)
 			 * Remove them here, so they don't cause issues further down the line */
 			if (!IsDepotTile(tile)) {
-				Debug(sl, 0, "Removing invalid depot {} at {}, {}", d->index, TileX(d->xy), TileY(d->xy));
+				Debug(sl, Severity::Critical, "Removing invalid depot {} at {}, {}", d->index, TileX(d->xy), TileY(d->xy));
 				delete d;
 				d = nullptr;
 				continue;
@@ -3434,7 +3434,7 @@ bool AfterLoadGame()
 	AfterLoadCompanyStats();
 	AfterLoadStoryBook();
 
-	_gamelog.PrintDebug(1);
+	_gamelog.PrintDebug(Severity::Error);
 
 	InitializeWindowsAndCaches();
 	/* Restore the signals */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -585,8 +585,8 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SaveLoadVersion::PauseModes)) {
 		_pause_mode = (_pause_mode.base() == 2) ? PauseMode::Normal : PauseModes{};
 	} else if (_network_dedicated && _pause_mode.Test(PauseMode::Error)) {
-		Debug(net, Severity::Critical, "The loading savegame was paused due to an error state");
-		Debug(net, Severity::Critical, "  This savegame cannot be used for multiplayer");
+		Debug(Facility::Net, Severity::Critical, "The loading savegame was paused due to an error state");
+		Debug(Facility::Net, Severity::Critical, "  This savegame cannot be used for multiplayer");
 		/* Restore the signals */
 		ResetSignalHandlers();
 		return false;
@@ -2403,7 +2403,7 @@ bool AfterLoadGame()
 			/* At some point, invalid depots were saved into the game (possibly those removed in the past?)
 			 * Remove them here, so they don't cause issues further down the line */
 			if (!IsDepotTile(tile)) {
-				Debug(sl, Severity::Critical, "Removing invalid depot {} at {}, {}", d->index, TileX(d->xy), TileY(d->xy));
+				Debug(Facility::Sl, Severity::Critical, "Removing invalid depot {} at {}, {}", d->index, TileX(d->xy), TileY(d->xy));
 				delete d;
 				d = nullptr;
 				continue;

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -112,12 +112,12 @@ struct AIPLChunkHandler : ChunkHandler {
 					config->Change(_ai_saveload_name, -1, false);
 					if (!config->HasScript()) {
 						if (_ai_saveload_name != "%_dummy") {
-							Debug(script, 0, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-							Debug(script, 0, "Configuration switched to Random AI.");
+							Debug(script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+							Debug(script, Severity::Critical, "Configuration switched to Random AI.");
 						}
 					} else {
-						Debug(script, 0, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-						Debug(script, 0, "The latest version of that AI has been configured instead");
+						Debug(script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+						Debug(script, Severity::Critical, "The latest version of that AI has been configured instead");
 					}
 				}
 			}
@@ -137,15 +137,15 @@ struct AIPLChunkHandler : ChunkHandler {
 				config->Change(_ai_saveload_name, -1, false);
 				if (!config->HasScript()) {
 					if (_ai_saveload_name != "%_dummy") {
-						Debug(script, 0, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-						Debug(script, 0, "A random other AI will be loaded in its place.");
+						Debug(script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+						Debug(script, Severity::Critical, "A random other AI will be loaded in its place.");
 					} else {
-						Debug(script, 0, "The savegame had no AIs available at the time of saving.");
-						Debug(script, 0, "A random available AI will be loaded now.");
+						Debug(script, Severity::Critical, "The savegame had no AIs available at the time of saving.");
+						Debug(script, Severity::Critical, "A random available AI will be loaded now.");
 					}
 				} else {
-					Debug(script, 0, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-					Debug(script, 0, "The latest version of that AI has been loaded instead, but it'll not get the savegame data as it's incompatible.");
+					Debug(script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+					Debug(script, Severity::Critical, "The latest version of that AI has been loaded instead, but it'll not get the savegame data as it's incompatible.");
 				}
 				/* Make sure the AI doesn't get the saveload data, as it was not the
 				 *  writer of the saveload data in the first place */

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -112,12 +112,12 @@ struct AIPLChunkHandler : ChunkHandler {
 					config->Change(_ai_saveload_name, -1, false);
 					if (!config->HasScript()) {
 						if (_ai_saveload_name != "%_dummy") {
-							Debug(script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-							Debug(script, Severity::Critical, "Configuration switched to Random AI.");
+							Debug(Facility::Script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+							Debug(Facility::Script, Severity::Critical, "Configuration switched to Random AI.");
 						}
 					} else {
-						Debug(script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-						Debug(script, Severity::Critical, "The latest version of that AI has been configured instead");
+						Debug(Facility::Script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+						Debug(Facility::Script, Severity::Critical, "The latest version of that AI has been configured instead");
 					}
 				}
 			}
@@ -137,15 +137,15 @@ struct AIPLChunkHandler : ChunkHandler {
 				config->Change(_ai_saveload_name, -1, false);
 				if (!config->HasScript()) {
 					if (_ai_saveload_name != "%_dummy") {
-						Debug(script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-						Debug(script, Severity::Critical, "A random other AI will be loaded in its place.");
+						Debug(Facility::Script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+						Debug(Facility::Script, Severity::Critical, "A random other AI will be loaded in its place.");
 					} else {
-						Debug(script, Severity::Critical, "The savegame had no AIs available at the time of saving.");
-						Debug(script, Severity::Critical, "A random available AI will be loaded now.");
+						Debug(Facility::Script, Severity::Critical, "The savegame had no AIs available at the time of saving.");
+						Debug(Facility::Script, Severity::Critical, "A random available AI will be loaded now.");
 					}
 				} else {
-					Debug(script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
-					Debug(script, Severity::Critical, "The latest version of that AI has been loaded instead, but it'll not get the savegame data as it's incompatible.");
+					Debug(Facility::Script, Severity::Critical, "The savegame has an AI by the name '{}', version {} which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+					Debug(Facility::Script, Severity::Critical, "The latest version of that AI has been loaded instead, but it'll not get the savegame data as it's incompatible.");
 				}
 				/* Make sure the AI doesn't get the saveload data, as it was not the
 				 *  writer of the saveload data in the first place */

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -81,15 +81,15 @@ struct GSDTChunkHandler : ChunkHandler {
 				config->Change(_game_saveload_name, -1, false);
 				if (!config->HasScript()) {
 					if (_game_saveload_name != "%_dummy") {
-						Debug(script, 0, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
-						Debug(script, 0, "This game will continue to run without GameScript.");
+						Debug(script, Severity::Critical, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
+						Debug(script, Severity::Critical, "This game will continue to run without GameScript.");
 					} else {
-						Debug(script, 0, "The savegame had no GameScript available at the time of saving.");
-						Debug(script, 0, "This game will continue to run without GameScript.");
+						Debug(script, Severity::Critical, "The savegame had no GameScript available at the time of saving.");
+						Debug(script, Severity::Critical, "This game will continue to run without GameScript.");
 					}
 				} else {
-					Debug(script, 0, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
-					Debug(script, 0, "The latest version of that GameScript has been loaded instead, but it'll not get the savegame data as it's incompatible.");
+					Debug(script, Severity::Critical, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
+					Debug(script, Severity::Critical, "The latest version of that GameScript has been loaded instead, but it'll not get the savegame data as it's incompatible.");
 				}
 				/* Make sure the GameScript doesn't get the saveload data, as it was not the
 				 *  writer of the saveload data in the first place */

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -81,15 +81,15 @@ struct GSDTChunkHandler : ChunkHandler {
 				config->Change(_game_saveload_name, -1, false);
 				if (!config->HasScript()) {
 					if (_game_saveload_name != "%_dummy") {
-						Debug(script, Severity::Critical, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
-						Debug(script, Severity::Critical, "This game will continue to run without GameScript.");
+						Debug(Facility::Script, Severity::Critical, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
+						Debug(Facility::Script, Severity::Critical, "This game will continue to run without GameScript.");
 					} else {
-						Debug(script, Severity::Critical, "The savegame had no GameScript available at the time of saving.");
-						Debug(script, Severity::Critical, "This game will continue to run without GameScript.");
+						Debug(Facility::Script, Severity::Critical, "The savegame had no GameScript available at the time of saving.");
+						Debug(Facility::Script, Severity::Critical, "This game will continue to run without GameScript.");
 					}
 				} else {
-					Debug(script, Severity::Critical, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
-					Debug(script, Severity::Critical, "The latest version of that GameScript has been loaded instead, but it'll not get the savegame data as it's incompatible.");
+					Debug(Facility::Script, Severity::Critical, "The savegame has an GameScript by the name '{}', version {} which is no longer available.", _game_saveload_name, _game_saveload_version);
+					Debug(Facility::Script, Severity::Critical, "The latest version of that GameScript has been loaded instead, but it'll not get the savegame data as it's incompatible.");
 				}
 				/* Make sure the GameScript doesn't get the saveload data, as it was not the
 				 *  writer of the saveload data in the first place */

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -67,7 +67,7 @@ static uint8_t ReadByteFromFile(LoadgameState &ls)
 
 		/* We tried to read, but there is nothing in the file anymore.. */
 		if (count == 0) {
-			Debug(oldloader, 0, "Read past end of file, loading failed");
+			Debug(oldloader, Severity::Critical, "Read past end of file, loading failed");
 			throw std::exception();
 		}
 
@@ -144,7 +144,7 @@ bool LoadChunk(LoadgameState &ls, void *base, const OldChunks *chunks)
 						break;
 
 					case OC_ASSERT:
-						Debug(oldloader, 4, "Assert point: 0x{:X} / 0x{:X}", ls.total_read, reinterpret_cast<size_t>(chunk->ptr) + _bump_assert_value);
+						Debug(oldloader, Severity::Info, "Assert point: 0x{:X} / 0x{:X}", ls.total_read, reinterpret_cast<size_t>(chunk->ptr) + _bump_assert_value);
 						if (ls.total_read != reinterpret_cast<size_t>(chunk->ptr) + _bump_assert_value) throw std::exception();
 					default: break;
 				}
@@ -237,7 +237,7 @@ bool LoadOldSaveGame(std::string_view file)
 {
 	LoadgameState ls{};
 
-	Debug(oldloader, 3, "Trying to load a TTD(Patch) savegame");
+	Debug(oldloader, Severity::Notice, "Trying to load a TTD(Patch) savegame");
 
 	_bump_assert_value = 0;
 	_settings_game.construction.freeform_edges = false; // disable so we can convert map array (SetTileType is still used)
@@ -246,7 +246,7 @@ bool LoadOldSaveGame(std::string_view file)
 	ls.file = FioFOpenFile(file, "rb", Subdirectory::None);
 
 	if (!ls.file.has_value()) {
-		Debug(oldloader, 0, "Cannot open file '{}'", file);
+		Debug(oldloader, Severity::Critical, "Cannot open file '{}'", file);
 		SetSaveLoadError(STR_GAME_SAVELOAD_ERROR_FILE_NOT_READABLE);
 		return false;
 	}
@@ -260,7 +260,7 @@ bool LoadOldSaveGame(std::string_view file)
 		case SavegameType::TTO: proc = &LoadTTOMain; break;
 		case SavegameType::TTD: proc = &LoadTTDMain; break;
 		default:
-			Debug(oldloader, 0, "Unknown savegame type; cannot be loaded");
+			Debug(oldloader, Severity::Critical, "Unknown savegame type; cannot be loaded");
 			break;
 	}
 

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -67,7 +67,7 @@ static uint8_t ReadByteFromFile(LoadgameState &ls)
 
 		/* We tried to read, but there is nothing in the file anymore.. */
 		if (count == 0) {
-			Debug(oldloader, Severity::Critical, "Read past end of file, loading failed");
+			Debug(Facility::Oldloader, Severity::Critical, "Read past end of file, loading failed");
 			throw std::exception();
 		}
 
@@ -144,7 +144,7 @@ bool LoadChunk(LoadgameState &ls, void *base, const OldChunks *chunks)
 						break;
 
 					case OC_ASSERT:
-						Debug(oldloader, Severity::Info, "Assert point: 0x{:X} / 0x{:X}", ls.total_read, reinterpret_cast<size_t>(chunk->ptr) + _bump_assert_value);
+						Debug(Facility::Oldloader, Severity::Info, "Assert point: 0x{:X} / 0x{:X}", ls.total_read, reinterpret_cast<size_t>(chunk->ptr) + _bump_assert_value);
 						if (ls.total_read != reinterpret_cast<size_t>(chunk->ptr) + _bump_assert_value) throw std::exception();
 					default: break;
 				}
@@ -237,7 +237,7 @@ bool LoadOldSaveGame(std::string_view file)
 {
 	LoadgameState ls{};
 
-	Debug(oldloader, Severity::Notice, "Trying to load a TTD(Patch) savegame");
+	Debug(Facility::Oldloader, Severity::Notice, "Trying to load a TTD(Patch) savegame");
 
 	_bump_assert_value = 0;
 	_settings_game.construction.freeform_edges = false; // disable so we can convert map array (SetTileType is still used)
@@ -246,7 +246,7 @@ bool LoadOldSaveGame(std::string_view file)
 	ls.file = FioFOpenFile(file, "rb", Subdirectory::None);
 
 	if (!ls.file.has_value()) {
-		Debug(oldloader, Severity::Critical, "Cannot open file '{}'", file);
+		Debug(Facility::Oldloader, Severity::Critical, "Cannot open file '{}'", file);
 		SetSaveLoadError(STR_GAME_SAVELOAD_ERROR_FILE_NOT_READABLE);
 		return false;
 	}
@@ -260,7 +260,7 @@ bool LoadOldSaveGame(std::string_view file)
 		case SavegameType::TTO: proc = &LoadTTOMain; break;
 		case SavegameType::TTD: proc = &LoadTTDMain; break;
 		default:
-			Debug(oldloader, Severity::Critical, "Unknown savegame type; cannot be loaded");
+			Debug(Facility::Oldloader, Severity::Critical, "Unknown savegame type; cannot be loaded");
 			break;
 	}
 

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -126,7 +126,7 @@ static uint32_t RemapOldTownName(uint32_t townnameparts, uint8_t old_town_name_t
 			return fix_num(townnameparts - 86, lengthof(_name_french_real), 0);
 
 		case 2: // German
-			Debug(misc, 0, "German Townnames are buggy ({})", townnameparts);
+			Debug(misc, Severity::Critical, "German Townnames are buggy ({})", townnameparts);
 			return townnameparts;
 
 		case 4: // Latin-American
@@ -561,9 +561,9 @@ static void ReadTTDPatchFlags(LoadgameState &ls)
 	for (TileIndex i{}; i < 9; i++) ClearOldMap3(i);
 	for (TileIndex i = TileXY(0, Map::MaxY()); i < Map::Size(); i++) ClearOldMap3(i);
 
-	if (_savegame_type == SavegameType::TTDP2) Debug(oldloader, 2, "Found TTDPatch game");
+	if (_savegame_type == SavegameType::TTDP2) Debug(oldloader, Severity::Warning, "Found TTDPatch game");
 
-	Debug(oldloader, 3, "Vehicle-multiplier is set to {} ({} vehicles)", ls.vehicle_multiplier, ls.vehicle_multiplier * 850);
+	Debug(oldloader, Severity::Notice, "Vehicle-multiplier is set to {} ({} vehicles)", ls.vehicle_multiplier, ls.vehicle_multiplier * 850);
 }
 
 static std::array<Town::SuppliedHistory, 2> _old_pass_supplied{};
@@ -1153,7 +1153,7 @@ static bool LoadOldVehicleUnion(LoadgameState &ls, int)
 
 	/* This chunk size should always be 10 bytes */
 	if (ls.total_read - temp != 10) {
-		Debug(oldloader, 0, "Assert failed in VehicleUnion: invalid chunk size");
+		Debug(oldloader, Severity::Critical, "Assert failed in VehicleUnion: invalid chunk size");
 		return false;
 	}
 
@@ -1364,7 +1364,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 
 			/* This should be consistent, else we have a big problem... */
 			if (v->index != _current_vehicle_id) {
-				Debug(oldloader, 0, "Loading failed - vehicle-array is invalid");
+				Debug(oldloader, Severity::Critical, "Loading failed - vehicle-array is invalid");
 				return false;
 			}
 		}
@@ -1568,7 +1568,7 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 {
 	ReadTTDPatchFlags(ls);
 
-	Debug(oldloader, 2, "Found {} extra chunk(s)", _old_extra_chunk_nums);
+	Debug(oldloader, Severity::Warning, "Found {} extra chunk(s)", _old_extra_chunk_nums);
 
 	for (int i = 0; i != _old_extra_chunk_nums; i++) {
 		uint16_t id = ReadUint16(ls);
@@ -1590,7 +1590,7 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 						auto c = std::make_unique<GRFConfig>("TTDP game, no information");
 						c->ident.grfid = grfid;
 
-						Debug(oldloader, 3, "TTDPatch game using GRF file with GRFID {}", FormatArrayAsHex(c->ident.grfid));
+						Debug(oldloader, Severity::Notice, "TTDPatch game using GRF file with GRFID {}", FormatArrayAsHex(c->ident.grfid));
 						AppendToGRFConfigList(_grfconfig, std::move(c));
 					}
 					len -= 5;
@@ -1604,14 +1604,14 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 			/* TTDPatch version and configuration */
 			case 0x3:
 				_ttdp_version = ReadUint32(ls);
-				Debug(oldloader, 3, "Game saved with TTDPatch version {}.{}.{} r{}",
+				Debug(oldloader, Severity::Notice, "Game saved with TTDPatch version {}.{}.{} r{}",
 					GB(_ttdp_version, 24, 8), GB(_ttdp_version, 20, 4), GB(_ttdp_version, 16, 4), GB(_ttdp_version, 0, 16));
 				len -= 4;
 				while (len-- != 0) ReadByte(ls); // skip the configuration
 				break;
 
 			default:
-				Debug(oldloader, 4, "Skipping unknown extra chunk {}", id);
+				Debug(oldloader, Severity::Info, "Skipping unknown extra chunk {}", id);
 				while (len-- != 0) ReadByte(ls);
 				break;
 		}
@@ -1798,17 +1798,17 @@ static const OldChunks main_chunk[] = {
 
 bool LoadTTDMain(LoadgameState &ls)
 {
-	Debug(oldloader, 3, "Reading main chunk...");
+	Debug(oldloader, Severity::Notice, "Reading main chunk...");
 
 	_read_ttdpatch_flags = false;
 
 	/* Load the biggest chunk */
 	if (!LoadChunk(ls, nullptr, main_chunk)) {
-		Debug(oldloader, 0, "Loading failed");
+		Debug(oldloader, Severity::Critical, "Loading failed");
 		return false;
 	}
 
-	Debug(oldloader, 3, "Done, converting game data...");
+	Debug(oldloader, Severity::Notice, "Done, converting game data...");
 
 	FixTTDMapArray();
 	FixTTDDepots();
@@ -1823,15 +1823,15 @@ bool LoadTTDMain(LoadgameState &ls)
 	/* We have a new difficulty setting */
 	_settings_game.difficulty.town_council_tolerance = Clamp(_old_diff_level, 0, 2);
 
-	Debug(oldloader, 3, "Finished converting game data");
-	Debug(oldloader, 1, "TTD(Patch) savegame successfully converted");
+	Debug(oldloader, Severity::Notice, "Finished converting game data");
+	Debug(oldloader, Severity::Error, "TTD(Patch) savegame successfully converted");
 
 	return true;
 }
 
 bool LoadTTOMain(LoadgameState &ls)
 {
-	Debug(oldloader, 3, "Reading main chunk...");
+	Debug(oldloader, Severity::Notice, "Reading main chunk...");
 
 	_read_ttdpatch_flags = false;
 
@@ -1840,10 +1840,10 @@ bool LoadTTOMain(LoadgameState &ls)
 
 	/* Load the biggest chunk */
 	if (!LoadChunk(ls, nullptr, main_chunk)) {
-		Debug(oldloader, 0, "Loading failed");
+		Debug(oldloader, Severity::Critical, "Loading failed");
 		return false;
 	}
-	Debug(oldloader, 3, "Done, converting game data...");
+	Debug(oldloader, Severity::Notice, "Done, converting game data...");
 
 	if (_settings_game.game_creation.town_name != 0) _settings_game.game_creation.town_name++;
 
@@ -1851,7 +1851,7 @@ bool LoadTTOMain(LoadgameState &ls)
 	_trees_tick_ctr = 0xFF;
 
 	if (!FixTTOMapArray() || !FixTTOEngines()) {
-		Debug(oldloader, 0, "Conversion failed");
+		Debug(oldloader, Severity::Critical, "Conversion failed");
 		return false;
 	}
 
@@ -1868,8 +1868,8 @@ bool LoadTTOMain(LoadgameState &ls)
 	 * the vehicles stay the same" */
 	_economy.inflation_payment = std::min(_economy.inflation_payment * 124 / 74, MAX_INFLATION);
 
-	Debug(oldloader, 3, "Finished converting game data");
-	Debug(oldloader, 1, "TTO savegame successfully converted");
+	Debug(oldloader, Severity::Notice, "Finished converting game data");
+	Debug(oldloader, Severity::Error, "TTO savegame successfully converted");
 
 	return true;
 }

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -126,7 +126,7 @@ static uint32_t RemapOldTownName(uint32_t townnameparts, uint8_t old_town_name_t
 			return fix_num(townnameparts - 86, lengthof(_name_french_real), 0);
 
 		case 2: // German
-			Debug(misc, Severity::Critical, "German Townnames are buggy ({})", townnameparts);
+			Debug(Facility::Misc, Severity::Critical, "German Townnames are buggy ({})", townnameparts);
 			return townnameparts;
 
 		case 4: // Latin-American
@@ -561,9 +561,9 @@ static void ReadTTDPatchFlags(LoadgameState &ls)
 	for (TileIndex i{}; i < 9; i++) ClearOldMap3(i);
 	for (TileIndex i = TileXY(0, Map::MaxY()); i < Map::Size(); i++) ClearOldMap3(i);
 
-	if (_savegame_type == SavegameType::TTDP2) Debug(oldloader, Severity::Warning, "Found TTDPatch game");
+	if (_savegame_type == SavegameType::TTDP2) Debug(Facility::Oldloader, Severity::Warning, "Found TTDPatch game");
 
-	Debug(oldloader, Severity::Notice, "Vehicle-multiplier is set to {} ({} vehicles)", ls.vehicle_multiplier, ls.vehicle_multiplier * 850);
+	Debug(Facility::Oldloader, Severity::Notice, "Vehicle-multiplier is set to {} ({} vehicles)", ls.vehicle_multiplier, ls.vehicle_multiplier * 850);
 }
 
 static std::array<Town::SuppliedHistory, 2> _old_pass_supplied{};
@@ -1153,7 +1153,7 @@ static bool LoadOldVehicleUnion(LoadgameState &ls, int)
 
 	/* This chunk size should always be 10 bytes */
 	if (ls.total_read - temp != 10) {
-		Debug(oldloader, Severity::Critical, "Assert failed in VehicleUnion: invalid chunk size");
+		Debug(Facility::Oldloader, Severity::Critical, "Assert failed in VehicleUnion: invalid chunk size");
 		return false;
 	}
 
@@ -1364,7 +1364,7 @@ bool LoadOldVehicle(LoadgameState &ls, int num)
 
 			/* This should be consistent, else we have a big problem... */
 			if (v->index != _current_vehicle_id) {
-				Debug(oldloader, Severity::Critical, "Loading failed - vehicle-array is invalid");
+				Debug(Facility::Oldloader, Severity::Critical, "Loading failed - vehicle-array is invalid");
 				return false;
 			}
 		}
@@ -1568,7 +1568,7 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 {
 	ReadTTDPatchFlags(ls);
 
-	Debug(oldloader, Severity::Warning, "Found {} extra chunk(s)", _old_extra_chunk_nums);
+	Debug(Facility::Oldloader, Severity::Warning, "Found {} extra chunk(s)", _old_extra_chunk_nums);
 
 	for (int i = 0; i != _old_extra_chunk_nums; i++) {
 		uint16_t id = ReadUint16(ls);
@@ -1590,7 +1590,7 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 						auto c = std::make_unique<GRFConfig>("TTDP game, no information");
 						c->ident.grfid = grfid;
 
-						Debug(oldloader, Severity::Notice, "TTDPatch game using GRF file with GRFID {}", FormatArrayAsHex(c->ident.grfid));
+						Debug(Facility::Oldloader, Severity::Notice, "TTDPatch game using GRF file with GRFID {}", FormatArrayAsHex(c->ident.grfid));
 						AppendToGRFConfigList(_grfconfig, std::move(c));
 					}
 					len -= 5;
@@ -1604,14 +1604,14 @@ static bool LoadTTDPatchExtraChunks(LoadgameState &ls, int)
 			/* TTDPatch version and configuration */
 			case 0x3:
 				_ttdp_version = ReadUint32(ls);
-				Debug(oldloader, Severity::Notice, "Game saved with TTDPatch version {}.{}.{} r{}",
+				Debug(Facility::Oldloader, Severity::Notice, "Game saved with TTDPatch version {}.{}.{} r{}",
 					GB(_ttdp_version, 24, 8), GB(_ttdp_version, 20, 4), GB(_ttdp_version, 16, 4), GB(_ttdp_version, 0, 16));
 				len -= 4;
 				while (len-- != 0) ReadByte(ls); // skip the configuration
 				break;
 
 			default:
-				Debug(oldloader, Severity::Info, "Skipping unknown extra chunk {}", id);
+				Debug(Facility::Oldloader, Severity::Info, "Skipping unknown extra chunk {}", id);
 				while (len-- != 0) ReadByte(ls);
 				break;
 		}
@@ -1798,17 +1798,17 @@ static const OldChunks main_chunk[] = {
 
 bool LoadTTDMain(LoadgameState &ls)
 {
-	Debug(oldloader, Severity::Notice, "Reading main chunk...");
+	Debug(Facility::Oldloader, Severity::Notice, "Reading main chunk...");
 
 	_read_ttdpatch_flags = false;
 
 	/* Load the biggest chunk */
 	if (!LoadChunk(ls, nullptr, main_chunk)) {
-		Debug(oldloader, Severity::Critical, "Loading failed");
+		Debug(Facility::Oldloader, Severity::Critical, "Loading failed");
 		return false;
 	}
 
-	Debug(oldloader, Severity::Notice, "Done, converting game data...");
+	Debug(Facility::Oldloader, Severity::Notice, "Done, converting game data...");
 
 	FixTTDMapArray();
 	FixTTDDepots();
@@ -1823,15 +1823,15 @@ bool LoadTTDMain(LoadgameState &ls)
 	/* We have a new difficulty setting */
 	_settings_game.difficulty.town_council_tolerance = Clamp(_old_diff_level, 0, 2);
 
-	Debug(oldloader, Severity::Notice, "Finished converting game data");
-	Debug(oldloader, Severity::Error, "TTD(Patch) savegame successfully converted");
+	Debug(Facility::Oldloader, Severity::Notice, "Finished converting game data");
+	Debug(Facility::Oldloader, Severity::Error, "TTD(Patch) savegame successfully converted");
 
 	return true;
 }
 
 bool LoadTTOMain(LoadgameState &ls)
 {
-	Debug(oldloader, Severity::Notice, "Reading main chunk...");
+	Debug(Facility::Oldloader, Severity::Notice, "Reading main chunk...");
 
 	_read_ttdpatch_flags = false;
 
@@ -1840,10 +1840,10 @@ bool LoadTTOMain(LoadgameState &ls)
 
 	/* Load the biggest chunk */
 	if (!LoadChunk(ls, nullptr, main_chunk)) {
-		Debug(oldloader, Severity::Critical, "Loading failed");
+		Debug(Facility::Oldloader, Severity::Critical, "Loading failed");
 		return false;
 	}
-	Debug(oldloader, Severity::Notice, "Done, converting game data...");
+	Debug(Facility::Oldloader, Severity::Notice, "Done, converting game data...");
 
 	if (_settings_game.game_creation.town_name != 0) _settings_game.game_creation.town_name++;
 
@@ -1851,7 +1851,7 @@ bool LoadTTOMain(LoadgameState &ls)
 	_trees_tick_ctr = 0xFF;
 
 	if (!FixTTOMapArray() || !FixTTOEngines()) {
-		Debug(oldloader, Severity::Critical, "Conversion failed");
+		Debug(Facility::Oldloader, Severity::Critical, "Conversion failed");
 		return false;
 	}
 
@@ -1868,8 +1868,8 @@ bool LoadTTOMain(LoadgameState &ls)
 	 * the vehicles stay the same" */
 	_economy.inflation_payment = std::min(_economy.inflation_payment * 124 / 74, MAX_INFLATION);
 
-	Debug(oldloader, Severity::Notice, "Finished converting game data");
-	Debug(oldloader, Severity::Error, "TTO savegame successfully converted");
+	Debug(Facility::Oldloader, Severity::Notice, "Finished converting game data");
+	Debug(Facility::Oldloader, Severity::Error, "TTO savegame successfully converted");
 
 	return true;
 }

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -321,7 +321,7 @@ static void SlNullPointers()
 	_sl_version = SAVEGAME_VERSION;
 
 	for (const ChunkHandler &ch : ChunkHandlers()) {
-		Debug(sl, 3, "Nulling pointers for {}", ch.GetName());
+		Debug(sl, Severity::Notice, "Nulling pointers for {}", ch.GetName());
 		ch.FixPointers();
 	}
 
@@ -773,7 +773,7 @@ int SlIterateArray()
 			case ChunkType::Table:
 			case ChunkType::Array: index = _sl.array_index++; break;
 			default:
-				Debug(sl, 0, "SlIterateArray error");
+				Debug(sl, Severity::Critical, "SlIterateArray error");
 				return -1; // error
 		}
 
@@ -1981,7 +1981,7 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 				auto sld_it = key_lookup.find(key);
 				if (sld_it == key_lookup.end()) {
 					/* SLA_LOADCHECK triggers this debug statement a lot and is perfectly normal. */
-					Debug(sl, _sl.action == SaveLoadAction::Load ? 2 : 6, "Field '{}' of type 0x{:02x} not found, skipping", key, type.storage);
+					Debug(sl, _sl.action == SaveLoadAction::Load ? Severity::Warning : Severity::Debug2, "Field '{}' of type 0x{:02x} not found, skipping", key, type.storage);
 
 					std::shared_ptr<SaveLoadHandler> handler = nullptr;
 					SaveLoadType saveload_type;
@@ -2012,7 +2012,7 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 				 * the savegame version and add conversion code. */
 				SavegameFileType correct_type = GetSavegameFileType(*sld_it->second);
 				if (correct_type.storage != type.storage) {
-					Debug(sl, 1, "Field type for '{}' was expected to be 0x{:02x} but 0x{:02x} was found", key, correct_type.storage, type.storage);
+					Debug(sl, Severity::Error, "Field type for '{}' was expected to be 0x{:02x} but 0x{:02x} was found", key, correct_type.storage, type.storage);
 					SlErrorCorrupt("Field type is different than expected");
 				}
 				saveloads.emplace_back(*sld_it->second);
@@ -2117,7 +2117,7 @@ std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLo
 			if (sld_it == key_lookup.end()) {
 				/* This isn't an assert, as that leaves no information what
 				 * field was to blame. This way at least we have breadcrumbs. */
-				Debug(sl, 0, "internal error: saveload compatibility field '{}' not found", slc.name);
+				Debug(sl, Severity::Critical, "internal error: saveload compatibility field '{}' not found", slc.name);
 				SlErrorCorrupt("Internal error with savegame compatibility");
 			}
 			for (auto &sld : sld_it->second) {
@@ -2306,7 +2306,7 @@ static void SlSaveChunk(const ChunkHandler &ch)
 	if (ch.type == ChunkType::ReadOnly) return;
 
 	for (uint8_t b : ch.id) SlWriteByte(b);
-	Debug(sl, 2, "Saving chunk {}", ch.GetName());
+	Debug(sl, Severity::Warning, "Saving chunk {}", ch.GetName());
 
 	_sl.chunk_type = ch.type;
 	_sl.expect_table_header = (_sl.chunk_type == ChunkType::Table || _sl.chunk_type == ChunkType::SparseTable);
@@ -2363,7 +2363,7 @@ static const ChunkHandler *SlFindChunkHandler(ChunkId id)
 static void SlLoadChunks()
 {
 	for (ChunkId id = SlReadChunkId(); !id.Empty(); id = SlReadChunkId()) {
-		Debug(sl, 2, "Loading chunk {}", id.AsString());
+		Debug(sl, Severity::Warning, "Loading chunk {}", id.AsString());
 
 		const ChunkHandler *ch = SlFindChunkHandler(id);
 		if (ch == nullptr) SlErrorCorrupt("Unknown chunk type");
@@ -2375,7 +2375,7 @@ static void SlLoadChunks()
 static void SlLoadCheckChunks()
 {
 	for (ChunkId id = SlReadChunkId(); !id.Empty(); id = SlReadChunkId()) {
-		Debug(sl, 2, "Loading chunk {}", id.AsString());
+		Debug(sl, Severity::Warning, "Loading chunk {}", id.AsString());
 
 		const ChunkHandler *ch = SlFindChunkHandler(id);
 		if (ch == nullptr) SlErrorCorrupt("Unknown chunk type");
@@ -2389,7 +2389,7 @@ static void SlFixPointers()
 	_sl.action = SaveLoadAction::Ptrs;
 
 	for (const ChunkHandler &ch : ChunkHandlers()) {
-		Debug(sl, 3, "Fixing pointers for {}", ch.GetName());
+		Debug(sl, Severity::Notice, "Fixing pointers for {}", ch.GetName());
 		ch.FixPointers();
 	}
 
@@ -2430,7 +2430,7 @@ struct FileReader : LoadFilter {
 	{
 		clearerr(*this->file);
 		if (fseek(*this->file, this->begin, SEEK_SET)) {
-			Debug(sl, 1, "Could not reset the file reading");
+			Debug(sl, Severity::Error, "Could not reset the file reading");
 		}
 	}
 };
@@ -3073,7 +3073,7 @@ static SaveLoadResult SaveFileToDisk(bool threaded)
 		/* We don't want to shout when saving is just
 		 * cancelled due to a client disconnecting. */
 		if (_sl.error_str != STR_NETWORK_ERROR_LOSTCONNECTION) {
-			Debug(sl, 0, "{} {}", GetSaveLoadErrorType().GetDecodedString(), GetSaveLoadErrorMessage().GetDecodedString());
+			Debug(sl, Severity::Critical, "{} {}", GetSaveLoadErrorType().GetDecodedString(), GetSaveLoadErrorMessage().GetDecodedString());
 			asfp = SaveFileError;
 		}
 
@@ -3119,7 +3119,7 @@ static SaveLoadResult DoSave(std::shared_ptr<SaveFilter> writer, bool threaded)
 	SaveFileStart();
 
 	if (!threaded || !StartNewThread(&_save_thread, "ottd:savegame", &SaveFileToDisk, true)) {
-		if (threaded) Debug(sl, 1, "Cannot create savegame thread, reverting to single-threaded mode...");
+		if (threaded) Debug(sl, Severity::Error, "Cannot create savegame thread, reverting to single-threaded mode...");
 
 		SaveLoadResult result = SaveFileToDisk(false);
 		SaveFileDone();
@@ -3166,7 +3166,7 @@ static const SaveLoadFormat *DetermineSaveLoadFormat(SaveLoadFormatTag tag, uint
 		 * Therefore it is loaded, but never saved (or, it saves a 0 in any scenario). */
 		_sl_minor_version = (TO_BE32(raw_version) >> 8) & 0xFF;
 
-		Debug(sl, 1, "Loading savegame version {}", _sl_version);
+		Debug(sl, Severity::Error, "Loading savegame version {}", _sl_version);
 
 		/* Is the version higher than the current? */
 		if (_sl_version > SAVEGAME_VERSION) SlError(STR_GAME_SAVELOAD_ERROR_TOO_NEW_SAVEGAME);
@@ -3174,7 +3174,7 @@ static const SaveLoadFormat *DetermineSaveLoadFormat(SaveLoadFormatTag tag, uint
 		return fmt;
 	}
 
-	Debug(sl, 0, "Unknown savegame type, trying to load it as the buggy format");
+	Debug(sl, Severity::Critical, "Unknown savegame type, trying to load it as the buggy format");
 	_sl.lf->Reset();
 	_sl_version = SaveLoadVersion::MinVersion;
 	_sl_minor_version = 0;
@@ -3384,7 +3384,7 @@ SaveLoadResult SaveOrLoad(std::string_view filename, SaveLoadOperation fop, Deta
 		}
 
 		if (fop == SaveLoadOperation::Save) { // SAVE game
-			Debug(desync, 1, "save: {:08x}; {:02x}; {}", TimerGameEconomy::date, TimerGameEconomy::date_fract, filename);
+			Debug(desync, Severity::Error, "save: {:08x}; {:02x}; {}", TimerGameEconomy::date, TimerGameEconomy::date_fract, filename);
 			if (!_settings_client.gui.threaded_saves) threaded = false;
 
 			return DoSave(std::make_shared<FileWriter>(std::move(*fh)), threaded);
@@ -3392,13 +3392,13 @@ SaveLoadResult SaveOrLoad(std::string_view filename, SaveLoadOperation fop, Deta
 
 		/* LOAD game */
 		assert(fop == SaveLoadOperation::Load || fop == SaveLoadOperation::Check);
-		Debug(desync, 1, "load: {}", filename);
+		Debug(desync, Severity::Error, "load: {}", filename);
 		return DoLoad(std::make_shared<FileReader>(std::move(*fh)), fop == SaveLoadOperation::Check);
 	} catch (...) {
 		/* This code may be executed both for old and new save games. */
 		ClearSaveLoadState();
 
-		if (fop != SaveLoadOperation::Check) Debug(sl, 0, "{} {}", GetSaveLoadErrorType().GetDecodedString(), GetSaveLoadErrorMessage().GetDecodedString());
+		if (fop != SaveLoadOperation::Check) Debug(sl, Severity::Critical, "{} {}", GetSaveLoadErrorType().GetDecodedString(), GetSaveLoadErrorMessage().GetDecodedString());
 
 		/* A saver/loader exception!! reinitialize all variables to prevent crash! */
 		return (fop == SaveLoadOperation::Load) ? SaveLoadResult::ReInit : SaveLoadResult::Error;
@@ -3419,7 +3419,7 @@ void DoAutoOrNetsave(FiosNumberedSaveName &counter)
 		filename = counter.Filename();
 	}
 
-	Debug(sl, 2, "Autosaving to '{}'", filename);
+	Debug(sl, Severity::Warning, "Autosaving to '{}'", filename);
 	if (SaveOrLoad(filename, SaveLoadOperation::Save, DetailedFileType::GameFile, Subdirectory::Autosave) != SaveLoadResult::Ok) {
 		ShowErrorMessage(GetEncodedString(STR_ERROR_AUTOSAVE_FAILED), {}, WarningLevel::Error);
 	}

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -321,7 +321,7 @@ static void SlNullPointers()
 	_sl_version = SAVEGAME_VERSION;
 
 	for (const ChunkHandler &ch : ChunkHandlers()) {
-		Debug(sl, Severity::Notice, "Nulling pointers for {}", ch.GetName());
+		Debug(Facility::Sl, Severity::Notice, "Nulling pointers for {}", ch.GetName());
 		ch.FixPointers();
 	}
 
@@ -773,7 +773,7 @@ int SlIterateArray()
 			case ChunkType::Table:
 			case ChunkType::Array: index = _sl.array_index++; break;
 			default:
-				Debug(sl, Severity::Critical, "SlIterateArray error");
+				Debug(Facility::Sl, Severity::Critical, "SlIterateArray error");
 				return -1; // error
 		}
 
@@ -1981,7 +1981,7 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 				auto sld_it = key_lookup.find(key);
 				if (sld_it == key_lookup.end()) {
 					/* SLA_LOADCHECK triggers this debug statement a lot and is perfectly normal. */
-					Debug(sl, _sl.action == SaveLoadAction::Load ? Severity::Warning : Severity::Debug2, "Field '{}' of type 0x{:02x} not found, skipping", key, type.storage);
+					Debug(Facility::Sl, _sl.action == SaveLoadAction::Load ? Severity::Warning : Severity::Debug2, "Field '{}' of type 0x{:02x} not found, skipping", key, type.storage);
 
 					std::shared_ptr<SaveLoadHandler> handler = nullptr;
 					SaveLoadType saveload_type;
@@ -2012,7 +2012,7 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 				 * the savegame version and add conversion code. */
 				SavegameFileType correct_type = GetSavegameFileType(*sld_it->second);
 				if (correct_type.storage != type.storage) {
-					Debug(sl, Severity::Error, "Field type for '{}' was expected to be 0x{:02x} but 0x{:02x} was found", key, correct_type.storage, type.storage);
+					Debug(Facility::Sl, Severity::Error, "Field type for '{}' was expected to be 0x{:02x} but 0x{:02x} was found", key, correct_type.storage, type.storage);
 					SlErrorCorrupt("Field type is different than expected");
 				}
 				saveloads.emplace_back(*sld_it->second);
@@ -2117,7 +2117,7 @@ std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLo
 			if (sld_it == key_lookup.end()) {
 				/* This isn't an assert, as that leaves no information what
 				 * field was to blame. This way at least we have breadcrumbs. */
-				Debug(sl, Severity::Critical, "internal error: saveload compatibility field '{}' not found", slc.name);
+				Debug(Facility::Sl, Severity::Critical, "internal error: saveload compatibility field '{}' not found", slc.name);
 				SlErrorCorrupt("Internal error with savegame compatibility");
 			}
 			for (auto &sld : sld_it->second) {
@@ -2306,7 +2306,7 @@ static void SlSaveChunk(const ChunkHandler &ch)
 	if (ch.type == ChunkType::ReadOnly) return;
 
 	for (uint8_t b : ch.id) SlWriteByte(b);
-	Debug(sl, Severity::Warning, "Saving chunk {}", ch.GetName());
+	Debug(Facility::Sl, Severity::Warning, "Saving chunk {}", ch.GetName());
 
 	_sl.chunk_type = ch.type;
 	_sl.expect_table_header = (_sl.chunk_type == ChunkType::Table || _sl.chunk_type == ChunkType::SparseTable);
@@ -2363,7 +2363,7 @@ static const ChunkHandler *SlFindChunkHandler(ChunkId id)
 static void SlLoadChunks()
 {
 	for (ChunkId id = SlReadChunkId(); !id.Empty(); id = SlReadChunkId()) {
-		Debug(sl, Severity::Warning, "Loading chunk {}", id.AsString());
+		Debug(Facility::Sl, Severity::Warning, "Loading chunk {}", id.AsString());
 
 		const ChunkHandler *ch = SlFindChunkHandler(id);
 		if (ch == nullptr) SlErrorCorrupt("Unknown chunk type");
@@ -2375,7 +2375,7 @@ static void SlLoadChunks()
 static void SlLoadCheckChunks()
 {
 	for (ChunkId id = SlReadChunkId(); !id.Empty(); id = SlReadChunkId()) {
-		Debug(sl, Severity::Warning, "Loading chunk {}", id.AsString());
+		Debug(Facility::Sl, Severity::Warning, "Loading chunk {}", id.AsString());
 
 		const ChunkHandler *ch = SlFindChunkHandler(id);
 		if (ch == nullptr) SlErrorCorrupt("Unknown chunk type");
@@ -2389,7 +2389,7 @@ static void SlFixPointers()
 	_sl.action = SaveLoadAction::Ptrs;
 
 	for (const ChunkHandler &ch : ChunkHandlers()) {
-		Debug(sl, Severity::Notice, "Fixing pointers for {}", ch.GetName());
+		Debug(Facility::Sl, Severity::Notice, "Fixing pointers for {}", ch.GetName());
 		ch.FixPointers();
 	}
 
@@ -2430,7 +2430,7 @@ struct FileReader : LoadFilter {
 	{
 		clearerr(*this->file);
 		if (fseek(*this->file, this->begin, SEEK_SET)) {
-			Debug(sl, Severity::Error, "Could not reset the file reading");
+			Debug(Facility::Sl, Severity::Error, "Could not reset the file reading");
 		}
 	}
 };
@@ -3073,7 +3073,7 @@ static SaveLoadResult SaveFileToDisk(bool threaded)
 		/* We don't want to shout when saving is just
 		 * cancelled due to a client disconnecting. */
 		if (_sl.error_str != STR_NETWORK_ERROR_LOSTCONNECTION) {
-			Debug(sl, Severity::Critical, "{} {}", GetSaveLoadErrorType().GetDecodedString(), GetSaveLoadErrorMessage().GetDecodedString());
+			Debug(Facility::Sl, Severity::Critical, "{} {}", GetSaveLoadErrorType().GetDecodedString(), GetSaveLoadErrorMessage().GetDecodedString());
 			asfp = SaveFileError;
 		}
 
@@ -3119,7 +3119,7 @@ static SaveLoadResult DoSave(std::shared_ptr<SaveFilter> writer, bool threaded)
 	SaveFileStart();
 
 	if (!threaded || !StartNewThread(&_save_thread, "ottd:savegame", &SaveFileToDisk, true)) {
-		if (threaded) Debug(sl, Severity::Error, "Cannot create savegame thread, reverting to single-threaded mode...");
+		if (threaded) Debug(Facility::Sl, Severity::Error, "Cannot create savegame thread, reverting to single-threaded mode...");
 
 		SaveLoadResult result = SaveFileToDisk(false);
 		SaveFileDone();
@@ -3166,7 +3166,7 @@ static const SaveLoadFormat *DetermineSaveLoadFormat(SaveLoadFormatTag tag, uint
 		 * Therefore it is loaded, but never saved (or, it saves a 0 in any scenario). */
 		_sl_minor_version = (TO_BE32(raw_version) >> 8) & 0xFF;
 
-		Debug(sl, Severity::Error, "Loading savegame version {}", _sl_version);
+		Debug(Facility::Sl, Severity::Error, "Loading savegame version {}", _sl_version);
 
 		/* Is the version higher than the current? */
 		if (_sl_version > SAVEGAME_VERSION) SlError(STR_GAME_SAVELOAD_ERROR_TOO_NEW_SAVEGAME);
@@ -3174,7 +3174,7 @@ static const SaveLoadFormat *DetermineSaveLoadFormat(SaveLoadFormatTag tag, uint
 		return fmt;
 	}
 
-	Debug(sl, Severity::Critical, "Unknown savegame type, trying to load it as the buggy format");
+	Debug(Facility::Sl, Severity::Critical, "Unknown savegame type, trying to load it as the buggy format");
 	_sl.lf->Reset();
 	_sl_version = SaveLoadVersion::MinVersion;
 	_sl_minor_version = 0;
@@ -3384,7 +3384,7 @@ SaveLoadResult SaveOrLoad(std::string_view filename, SaveLoadOperation fop, Deta
 		}
 
 		if (fop == SaveLoadOperation::Save) { // SAVE game
-			Debug(desync, Severity::Error, "save: {:08x}; {:02x}; {}", TimerGameEconomy::date, TimerGameEconomy::date_fract, filename);
+			Debug(Facility::Desync, Severity::Error, "save: {:08x}; {:02x}; {}", TimerGameEconomy::date, TimerGameEconomy::date_fract, filename);
 			if (!_settings_client.gui.threaded_saves) threaded = false;
 
 			return DoSave(std::make_shared<FileWriter>(std::move(*fh)), threaded);
@@ -3392,13 +3392,13 @@ SaveLoadResult SaveOrLoad(std::string_view filename, SaveLoadOperation fop, Deta
 
 		/* LOAD game */
 		assert(fop == SaveLoadOperation::Load || fop == SaveLoadOperation::Check);
-		Debug(desync, Severity::Error, "load: {}", filename);
+		Debug(Facility::Desync, Severity::Error, "load: {}", filename);
 		return DoLoad(std::make_shared<FileReader>(std::move(*fh)), fop == SaveLoadOperation::Check);
 	} catch (...) {
 		/* This code may be executed both for old and new save games. */
 		ClearSaveLoadState();
 
-		if (fop != SaveLoadOperation::Check) Debug(sl, Severity::Critical, "{} {}", GetSaveLoadErrorType().GetDecodedString(), GetSaveLoadErrorMessage().GetDecodedString());
+		if (fop != SaveLoadOperation::Check) Debug(Facility::Sl, Severity::Critical, "{} {}", GetSaveLoadErrorType().GetDecodedString(), GetSaveLoadErrorMessage().GetDecodedString());
 
 		/* A saver/loader exception!! reinitialize all variables to prevent crash! */
 		return (fop == SaveLoadOperation::Load) ? SaveLoadResult::ReInit : SaveLoadResult::Error;
@@ -3419,7 +3419,7 @@ void DoAutoOrNetsave(FiosNumberedSaveName &counter)
 		filename = counter.Filename();
 	}
 
-	Debug(sl, Severity::Warning, "Autosaving to '{}'", filename);
+	Debug(Facility::Sl, Severity::Warning, "Autosaving to '{}'", filename);
 	if (SaveOrLoad(filename, SaveLoadOperation::Save, DetailedFileType::GameFile, Subdirectory::Autosave) != SaveLoadResult::Ok) {
 		ShowErrorMessage(GetEncodedString(STR_ERROR_AUTOSAVE_FAILED), {}, WarningLevel::Error);
 	}

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -875,7 +875,7 @@ public:
 	{
 		/* The two vectors should be the same size, but if not we can just ignore the cache and not cause more issues. */
 		if (rv_path_td.size() != rv_path_tile.size()) {
-			Debug(sl, 1, "Found RoadVehicle {} with invalid path cache, ignoring.", rv.index);
+			Debug(sl, Severity::Error, "Found RoadVehicle {} with invalid path cache, ignoring.", rv.index);
 			return;
 		}
 		size_t n = std::min(rv_path_td.size(), rv_path_tile.size());

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -875,7 +875,7 @@ public:
 	{
 		/* The two vectors should be the same size, but if not we can just ignore the cache and not cause more issues. */
 		if (rv_path_td.size() != rv_path_tile.size()) {
-			Debug(sl, Severity::Error, "Found RoadVehicle {} with invalid path cache, ignoring.", rv.index);
+			Debug(Facility::Sl, Severity::Error, "Found RoadVehicle {} with invalid path cache, ignoring.", rv.index);
 			return;
 		}
 		size_t n = std::min(rv_path_td.size(), rv_path_tile.size());

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -101,12 +101,12 @@ void MoveWaypointsToBaseStations()
 		/* Sometimes waypoint (sign) locations became disconnected from their actual location in
 		 * the map array. If this is the case, try to locate the actual location in the map array */
 		if (!IsTileType(t, TileType::Railway) || GetRailTileType(t) != RailTileType{2} /* RAIL_TILE_WAYPOINT */ || Tile(t).m2() != wp.index) {
-			Debug(sl, Severity::Critical, "Found waypoint tile {} with invalid position", t);
+			Debug(Facility::Sl, Severity::Critical, "Found waypoint tile {} with invalid position", t);
 			t = INVALID_TILE;
 			for (auto tile : Map::Iterate()) {
 				if (IsTileType(tile, TileType::Railway) && GetRailTileType(tile) == RailTileType{2} /* RAIL_TILE_WAYPOINT */ && tile.m2() == wp.index) {
 					t = TileIndex(tile);
-					Debug(sl, Severity::Critical, "Found actual waypoint position at {}", TileIndex(tile));
+					Debug(Facility::Sl, Severity::Critical, "Found actual waypoint position at {}", TileIndex(tile));
 					break;
 				}
 			}

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -101,12 +101,12 @@ void MoveWaypointsToBaseStations()
 		/* Sometimes waypoint (sign) locations became disconnected from their actual location in
 		 * the map array. If this is the case, try to locate the actual location in the map array */
 		if (!IsTileType(t, TileType::Railway) || GetRailTileType(t) != RailTileType{2} /* RAIL_TILE_WAYPOINT */ || Tile(t).m2() != wp.index) {
-			Debug(sl, 0, "Found waypoint tile {} with invalid position", t);
+			Debug(sl, Severity::Critical, "Found waypoint tile {} with invalid position", t);
 			t = INVALID_TILE;
 			for (auto tile : Map::Iterate()) {
 				if (IsTileType(tile, TileType::Railway) && GetRailTileType(tile) == RailTileType{2} /* RAIL_TILE_WAYPOINT */ && tile.m2() == wp.index) {
 					t = TileIndex(tile);
-					Debug(sl, 0, "Found actual waypoint position at {}", TileIndex(tile));
+					Debug(sl, Severity::Critical, "Found actual waypoint position at {}", TileIndex(tile));
 					break;
 				}
 			}

--- a/src/screenshot_pcx.cpp
+++ b/src/screenshot_pcx.cpp
@@ -48,7 +48,7 @@ public:
 		bool success;
 
 		if (pixelformat == 32) {
-			Debug(misc, 0, "Can't convert a 32bpp screenshot to PCX format. Please pick another format.");
+			Debug(misc, Severity::Critical, "Can't convert a 32bpp screenshot to PCX format. Please pick another format.");
 			return false;
 		}
 		if (pixelformat != 8 || w == 0) return false;

--- a/src/screenshot_pcx.cpp
+++ b/src/screenshot_pcx.cpp
@@ -48,7 +48,7 @@ public:
 		bool success;
 
 		if (pixelformat == 32) {
-			Debug(misc, Severity::Critical, "Can't convert a 32bpp screenshot to PCX format. Please pick another format.");
+			Debug(Facility::Misc, Severity::Critical, "Can't convert a 32bpp screenshot to PCX format. Please pick another format.");
 			return false;
 		}
 		if (pixelformat != 8 || w == 0) return false;

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -169,13 +169,13 @@ public:
 private:
 	static void PNGAPI png_my_error(png_structp png_ptr, png_const_charp message)
 	{
-		Debug(misc, Severity::Critical, "[libpng] error: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
+		Debug(Facility::Misc, Severity::Critical, "[libpng] error: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
 		longjmp(png_jmpbuf(png_ptr), 1);
 	}
 
 	static void PNGAPI png_my_warning(png_structp png_ptr, png_const_charp message)
 	{
-		Debug(misc, Severity::Error, "[libpng] warning: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
+		Debug(Facility::Misc, Severity::Error, "[libpng] warning: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
 	}
 
 private:

--- a/src/screenshot_png.cpp
+++ b/src/screenshot_png.cpp
@@ -169,13 +169,13 @@ public:
 private:
 	static void PNGAPI png_my_error(png_structp png_ptr, png_const_charp message)
 	{
-		Debug(misc, 0, "[libpng] error: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
+		Debug(misc, Severity::Critical, "[libpng] error: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
 		longjmp(png_jmpbuf(png_ptr), 1);
 	}
 
 	static void PNGAPI png_my_warning(png_structp png_ptr, png_const_charp message)
 	{
-		Debug(misc, 1, "[libpng] warning: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
+		Debug(misc, Severity::Error, "[libpng] warning: {} - {}", message, *static_cast<std::string_view *>(png_get_error_ptr(png_ptr)));
 	}
 
 private:

--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -455,7 +455,7 @@ SQInteger ScriptList::Begin()
 SQInteger ScriptList::Next()
 {
 	if (!this->initialized) {
-		Debug(script, 0, "Next() is invalid as Begin() is never called");
+		Debug(script, Severity::Critical, "Next() is invalid as Begin() is never called");
 		return 0;
 	}
 	return this->sorter->Next().value_or(0);
@@ -469,7 +469,7 @@ bool ScriptList::IsEmpty() const
 bool ScriptList::IsEnd() const
 {
 	if (!this->initialized) {
-		Debug(script, 0, "IsEnd() is invalid as Begin() is never called");
+		Debug(script, Severity::Critical, "IsEnd() is invalid as Begin() is never called");
 		return true;
 	}
 	return this->sorter->IsEnd();

--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -455,7 +455,7 @@ SQInteger ScriptList::Begin()
 SQInteger ScriptList::Next()
 {
 	if (!this->initialized) {
-		Debug(script, Severity::Critical, "Next() is invalid as Begin() is never called");
+		Debug(Facility::Script, Severity::Critical, "Next() is invalid as Begin() is never called");
 		return 0;
 	}
 	return this->sorter->Next().value_or(0);
@@ -469,7 +469,7 @@ bool ScriptList::IsEmpty() const
 bool ScriptList::IsEnd() const
 {
 	if (!this->initialized) {
-		Debug(script, Severity::Critical, "IsEnd() is invalid as Begin() is never called");
+		Debug(Facility::Script, Severity::Critical, "IsEnd() is invalid as Begin() is never called");
 		return true;
 	}
 	return this->sorter->IsEnd();

--- a/src/script/api/script_log.cpp
+++ b/src/script/api/script_log.cpp
@@ -56,6 +56,6 @@
 	}
 
 	/* Also still print to debug window */
-	Debug(script, static_cast<Severity>(level), "[{}] [{}] {}", ScriptObject::GetRootCompany(), logc, line.text);
+	Debug(Facility::Script, static_cast<Severity>(level), "[{}] [{}] {}", ScriptObject::GetRootCompany(), logc, line.text);
 	InvalidateWindowClassesData(WindowClass::ScriptDebug, ScriptObject::GetRootCompany());
 }

--- a/src/script/api/script_log.cpp
+++ b/src/script/api/script_log.cpp
@@ -56,6 +56,6 @@
 	}
 
 	/* Also still print to debug window */
-	Debug(script, level, "[{}] [{}] {}", ScriptObject::GetRootCompany(), logc, line.text);
+	Debug(script, static_cast<Severity>(level), "[{}] [{}] {}", ScriptObject::GetRootCompany(), logc, line.text);
 	InvalidateWindowClassesData(WindowClass::ScriptDebug, ScriptObject::GetRootCompany());
 }

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -121,7 +121,7 @@ ScriptObject::DisableDoCommandScope::DisableDoCommandScope()
 /* static */ void ScriptObject::SetLastCommand(const CommandDataBuffer &data, Commands cmd)
 {
 	ScriptStorage &s = GetStorage();
-	Debug(script, 6, "SetLastCommand company={:02d} cmd={} data={}", s.root_company, cmd, FormatArrayAsHex(data));
+	Debug(script, Severity::Debug2, "SetLastCommand company={:02d} cmd={} data={}", s.root_company, cmd, FormatArrayAsHex(data));
 	s.last_data = data;
 	s.last_cmd = cmd;
 }
@@ -129,7 +129,7 @@ ScriptObject::DisableDoCommandScope::DisableDoCommandScope()
 /* static */ bool ScriptObject::CheckLastCommand(const CommandDataBuffer &data, Commands cmd)
 {
 	ScriptStorage &s = GetStorage();
-	Debug(script, 6, "CheckLastCommand company={:02d} cmd={} data={}", s.root_company, cmd, FormatArrayAsHex(data));
+	Debug(script, Severity::Debug2, "CheckLastCommand company={:02d} cmd={} data={}", s.root_company, cmd, FormatArrayAsHex(data));
 	if (s.last_cmd != cmd) return false;
 	if (s.last_data != data) return false;
 	return true;

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -121,7 +121,7 @@ ScriptObject::DisableDoCommandScope::DisableDoCommandScope()
 /* static */ void ScriptObject::SetLastCommand(const CommandDataBuffer &data, Commands cmd)
 {
 	ScriptStorage &s = GetStorage();
-	Debug(script, Severity::Debug2, "SetLastCommand company={:02d} cmd={} data={}", s.root_company, cmd, FormatArrayAsHex(data));
+	Debug(Facility::Script, Severity::Debug2, "SetLastCommand company={:02d} cmd={} data={}", s.root_company, cmd, FormatArrayAsHex(data));
 	s.last_data = data;
 	s.last_cmd = cmd;
 }
@@ -129,7 +129,7 @@ ScriptObject::DisableDoCommandScope::DisableDoCommandScope()
 /* static */ bool ScriptObject::CheckLastCommand(const CommandDataBuffer &data, Commands cmd)
 {
 	ScriptStorage &s = GetStorage();
-	Debug(script, Severity::Debug2, "CheckLastCommand company={:02d} cmd={} data={}", s.root_company, cmd, FormatArrayAsHex(data));
+	Debug(Facility::Script, Severity::Debug2, "CheckLastCommand company={:02d} cmd={} data={}", s.root_company, cmd, FormatArrayAsHex(data));
 	if (s.last_cmd != cmd) return false;
 	if (s.last_data != data) return false;
 	return true;

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -589,7 +589,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance &instance)
 	/* Make sure we don't go into an infinite loop */
 	int retry = ScriptObject::GetCallbackVariable(3) - 1;
 	if (retry < 0) {
-		Debug(script, 0, "Possible infinite loop in SetOrderFlags() detected");
+		Debug(script, Severity::Critical, "Possible infinite loop in SetOrderFlags() detected");
 		return false;
 	}
 	ScriptObject::SetCallbackVariable(3, retry);

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -589,7 +589,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance &instance)
 	/* Make sure we don't go into an infinite loop */
 	int retry = ScriptObject::GetCallbackVariable(3) - 1;
 	if (retry < 0) {
-		Debug(script, Severity::Critical, "Possible infinite loop in SetOrderFlags() detected");
+		Debug(Facility::Script, Severity::Critical, "Possible infinite loop in SetOrderFlags() detected");
 		return false;
 	}
 	ScriptObject::SetCallbackVariable(3, retry);

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -204,7 +204,7 @@
 	if (res.second != CALLBACK_FAILED) {
 		const StationSpec *spec = StationClass::GetByGrf(res.first->grfid, res.second);
 		if (spec == nullptr) {
-			Debug(grf, Severity::Error, "{} returned an invalid station ID for 'AI construction/purchase selection (18)' callback", res.first->filename);
+			Debug(Facility::Grf, Severity::Error, "{} returned an invalid station ID for 'AI construction/purchase selection (18)' callback", res.first->filename);
 		} else {
 			/* We might have gotten an usable station spec. Try to build it, but if it fails we'll fall back to the original station. */
 			if (ScriptObject::Command<Commands::BuildRailStation>::Do(tile, (::RailType)GetCurrentRailType(), axis, num_platforms, platform_length, spec->class_index, spec->index, to_join, adjacent)) return true;

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -204,7 +204,7 @@
 	if (res.second != CALLBACK_FAILED) {
 		const StationSpec *spec = StationClass::GetByGrf(res.first->grfid, res.second);
 		if (spec == nullptr) {
-			Debug(grf, 1, "{} returned an invalid station ID for 'AI construction/purchase selection (18)' callback", res.first->filename);
+			Debug(grf, Severity::Error, "{} returned an invalid station ID for 'AI construction/purchase selection (18)' callback", res.first->filename);
 		} else {
 			/* We might have gotten an usable station spec. Try to build it, but if it fails we'll fall back to the original station. */
 			if (ScriptObject::Command<Commands::BuildRailStation>::Do(tile, (::RailType)GetCurrentRailType(), axis, num_platforms, platform_length, spec->class_index, spec->index, to_join, adjacent)) return true;

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -114,7 +114,7 @@ bool ScriptInstance::LoadCompatibilityScript(std::string_view api_version, Subdi
 		if (this->engine->LoadScript(buf)) return true;
 
 		ScriptLog::Error(fmt::format("Failed to load API compatibility script for {}", api_version));
-		Debug(script, 0, "Error compiling / running API compatibility script: {}", buf);
+		Debug(script, Severity::Critical, "Error compiling / running API compatibility script: {}", buf);
 		return false;
 	}
 
@@ -172,7 +172,7 @@ void ScriptInstance::Continue()
 
 void ScriptInstance::Died()
 {
-	Debug(script, 0, "The script died unexpectedly.");
+	Debug(script, Severity::Critical, "The script died unexpectedly.");
 	this->is_dead = true;
 	this->in_shutdown = true;
 
@@ -815,7 +815,7 @@ bool ScriptInstance::DoCommandCallback(const CommandCost &result, const CommandD
 	ScriptObject::ActiveInstance active(*this);
 
 	if (!ScriptObject::CheckLastCommand(data, cmd)) {
-		Debug(script, 1, "DoCommandCallback terminating a script, last command does not match expected command");
+		Debug(script, Severity::Error, "DoCommandCallback terminating a script, last command does not match expected command");
 		return false;
 	}
 

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -114,7 +114,7 @@ bool ScriptInstance::LoadCompatibilityScript(std::string_view api_version, Subdi
 		if (this->engine->LoadScript(buf)) return true;
 
 		ScriptLog::Error(fmt::format("Failed to load API compatibility script for {}", api_version));
-		Debug(script, Severity::Critical, "Error compiling / running API compatibility script: {}", buf);
+		Debug(Facility::Script, Severity::Critical, "Error compiling / running API compatibility script: {}", buf);
 		return false;
 	}
 
@@ -172,7 +172,7 @@ void ScriptInstance::Continue()
 
 void ScriptInstance::Died()
 {
-	Debug(script, Severity::Critical, "The script died unexpectedly.");
+	Debug(Facility::Script, Severity::Critical, "The script died unexpectedly.");
 	this->is_dead = true;
 	this->in_shutdown = true;
 
@@ -815,7 +815,7 @@ bool ScriptInstance::DoCommandCallback(const CommandCost &result, const CommandD
 	ScriptObject::ActiveInstance active(*this);
 
 	if (!ScriptObject::CheckLastCommand(data, cmd)) {
-		Debug(script, Severity::Error, "DoCommandCallback terminating a script, last command does not match expected command");
+		Debug(Facility::Script, Severity::Error, "DoCommandCallback terminating a script, last command does not match expected command");
 		return false;
 	}
 

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -38,7 +38,7 @@ bool ScriptScanner::AddFile(const std::string &filename, size_t, const std::stri
 	try {
 		this->engine->LoadScript(filename);
 	} catch (Script_FatalError &e) {
-		Debug(script, 0, "Fatal error '{}' when trying to load the script '{}'.", e.GetErrorMessage(), filename);
+		Debug(script, Severity::Critical, "Fatal error '{}' when trying to load the script '{}'.", e.GetErrorMessage(), filename);
 		return false;
 	}
 	return true;
@@ -90,7 +90,7 @@ void ScriptScanner::RegisterScript(std::unique_ptr<ScriptInfo> &&info)
 
 	/* Check if GetShortName follows the rules */
 	if (info->GetShortName().size() != 4) {
-		Debug(script, 0, "The script '{}' returned a string from GetShortName() which is not four characters. Unable to load the script.", info->GetName());
+		Debug(script, Severity::Critical, "The script '{}' returned a string from GetShortName() which is not four characters. Unable to load the script.", info->GetName());
 		return;
 	}
 
@@ -105,10 +105,10 @@ void ScriptScanner::RegisterScript(std::unique_ptr<ScriptInfo> &&info)
 			return;
 		}
 
-		Debug(script, 1, "Registering two scripts with the same name and version");
-		Debug(script, 1, "  1: {}", it->second->GetMainScript());
-		Debug(script, 1, "  2: {}", info->GetMainScript());
-		Debug(script, 1, "The first is taking precedence.");
+		Debug(script, Severity::Error, "Registering two scripts with the same name and version");
+		Debug(script, Severity::Error, "  1: {}", it->second->GetMainScript());
+		Debug(script, Severity::Error, "  2: {}", info->GetMainScript());
+		Debug(script, Severity::Error, "The first is taking precedence.");
 
 		return;
 	}

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -38,7 +38,7 @@ bool ScriptScanner::AddFile(const std::string &filename, size_t, const std::stri
 	try {
 		this->engine->LoadScript(filename);
 	} catch (Script_FatalError &e) {
-		Debug(script, Severity::Critical, "Fatal error '{}' when trying to load the script '{}'.", e.GetErrorMessage(), filename);
+		Debug(Facility::Script, Severity::Critical, "Fatal error '{}' when trying to load the script '{}'.", e.GetErrorMessage(), filename);
 		return false;
 	}
 	return true;
@@ -90,7 +90,7 @@ void ScriptScanner::RegisterScript(std::unique_ptr<ScriptInfo> &&info)
 
 	/* Check if GetShortName follows the rules */
 	if (info->GetShortName().size() != 4) {
-		Debug(script, Severity::Critical, "The script '{}' returned a string from GetShortName() which is not four characters. Unable to load the script.", info->GetName());
+		Debug(Facility::Script, Severity::Critical, "The script '{}' returned a string from GetShortName() which is not four characters. Unable to load the script.", info->GetName());
 		return;
 	}
 
@@ -105,10 +105,10 @@ void ScriptScanner::RegisterScript(std::unique_ptr<ScriptInfo> &&info)
 			return;
 		}
 
-		Debug(script, Severity::Error, "Registering two scripts with the same name and version");
-		Debug(script, Severity::Error, "  1: {}", it->second->GetMainScript());
-		Debug(script, Severity::Error, "  2: {}", info->GetMainScript());
-		Debug(script, Severity::Error, "The first is taking precedence.");
+		Debug(Facility::Script, Severity::Error, "Registering two scripts with the same name and version");
+		Debug(Facility::Script, Severity::Error, "  1: {}", it->second->GetMainScript());
+		Debug(Facility::Script, Severity::Error, "  2: {}", info->GetMainScript());
+		Debug(Facility::Script, Severity::Error, "The first is taking precedence.");
 
 		return;
 	}

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -191,7 +191,7 @@ void Squirrel::CompileError(HSQUIRRELVM vm, std::string_view desc, std::string_v
 	engine->crashed = true;
 	SQPrintFunc *func = engine->print_func;
 	if (func == nullptr) {
-		Debug(misc, 0, "[Squirrel] Compile error: {}", msg);
+		Debug(misc, Severity::Critical, "[Squirrel] Compile error: {}", msg);
 	} else {
 		(*func)(true, msg);
 	}
@@ -326,8 +326,8 @@ void Squirrel::AddClassBegin(std::string_view class_name, std::string_view paren
 	sq_pushstring(this->vm, class_name);
 	sq_pushstring(this->vm, parent_class);
 	if (SQ_FAILED(sq_get(this->vm, -3))) {
-		Debug(misc, 0, "[squirrel] Failed to initialize class '{}' based on parent class '{}'", class_name, parent_class);
-		Debug(misc, 0, "[squirrel] Make sure that '{}' exists before trying to define '{}'", parent_class, class_name);
+		Debug(misc, Severity::Critical, "[squirrel] Failed to initialize class '{}' based on parent class '{}'", class_name, parent_class);
+		Debug(misc, Severity::Critical, "[squirrel] Make sure that '{}' exists before trying to define '{}'", parent_class, class_name);
 		return;
 	}
 	sq_newclass(this->vm, SQTrue);
@@ -426,7 +426,7 @@ bool Squirrel::CallMethod(HSQOBJECT instance, std::string_view method_name, HSQO
 	/* Find the function-name inside the script */
 	sq_pushstring(this->vm, method_name);
 	if (SQ_FAILED(sq_get(this->vm, -2))) {
-		Debug(misc, 0, "[squirrel] Could not find '{}' in the class", method_name);
+		Debug(misc, Severity::Critical, "[squirrel] Could not find '{}' in the class", method_name);
 		sq_settop(this->vm, top);
 		return false;
 	}
@@ -490,14 +490,14 @@ bool Squirrel::CallBoolMethod(HSQOBJECT instance, std::string_view method_name, 
 	}
 
 	if (SQ_FAILED(sq_get(vm, -2))) {
-		Debug(misc, 0, "[squirrel] Failed to find class by the name '{}{}'", prepend_API_name ? engine->GetAPIName() : "", class_name);
+		Debug(misc, Severity::Critical, "[squirrel] Failed to find class by the name '{}{}'", prepend_API_name ? engine->GetAPIName() : "", class_name);
 		sq_settop(vm, oldtop);
 		return false;
 	}
 
 	/* Create the instance */
 	if (SQ_FAILED(sq_createinstance(vm, -1))) {
-		Debug(misc, 0, "[squirrel] Failed to create instance for class '{}{}'", prepend_API_name ? engine->GetAPIName() : "", class_name);
+		Debug(misc, Severity::Critical, "[squirrel] Failed to create instance for class '{}{}'", prepend_API_name ? engine->GetAPIName() : "", class_name);
 		sq_settop(vm, oldtop);
 		return false;
 	}
@@ -561,7 +561,7 @@ void Squirrel::Initialize()
 
 	/* Handle compile-errors ourself, so we can display it nicely */
 	sq_setcompilererrorhandler(this->vm, &Squirrel::CompileError);
-	sq_notifyallexceptions(this->vm, _debug_script_level > 5);
+	sq_notifyallexceptions(this->vm, _debug_script_level > Severity::Debug1);
 	/* Set a good print-function */
 	sq_setprintfunc(this->vm, &Squirrel::PrintFunc);
 	/* Handle runtime-errors ourself, so we can display it nicely */
@@ -742,7 +742,7 @@ bool Squirrel::LoadScript(HSQUIRRELVM vm, const std::string &script, bool in_roo
 	}
 
 	vm->_ops_till_suspend = ops_left;
-	Debug(misc, 0, "[squirrel] Failed to compile '{}'", script);
+	Debug(misc, Severity::Critical, "[squirrel] Failed to compile '{}'", script);
 	return false;
 }
 

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -191,7 +191,7 @@ void Squirrel::CompileError(HSQUIRRELVM vm, std::string_view desc, std::string_v
 	engine->crashed = true;
 	SQPrintFunc *func = engine->print_func;
 	if (func == nullptr) {
-		Debug(misc, Severity::Critical, "[Squirrel] Compile error: {}", msg);
+		Debug(Facility::Misc, Severity::Critical, "[Squirrel] Compile error: {}", msg);
 	} else {
 		(*func)(true, msg);
 	}
@@ -326,8 +326,8 @@ void Squirrel::AddClassBegin(std::string_view class_name, std::string_view paren
 	sq_pushstring(this->vm, class_name);
 	sq_pushstring(this->vm, parent_class);
 	if (SQ_FAILED(sq_get(this->vm, -3))) {
-		Debug(misc, Severity::Critical, "[squirrel] Failed to initialize class '{}' based on parent class '{}'", class_name, parent_class);
-		Debug(misc, Severity::Critical, "[squirrel] Make sure that '{}' exists before trying to define '{}'", parent_class, class_name);
+		Debug(Facility::Misc, Severity::Critical, "[squirrel] Failed to initialize class '{}' based on parent class '{}'", class_name, parent_class);
+		Debug(Facility::Misc, Severity::Critical, "[squirrel] Make sure that '{}' exists before trying to define '{}'", parent_class, class_name);
 		return;
 	}
 	sq_newclass(this->vm, SQTrue);
@@ -426,7 +426,7 @@ bool Squirrel::CallMethod(HSQOBJECT instance, std::string_view method_name, HSQO
 	/* Find the function-name inside the script */
 	sq_pushstring(this->vm, method_name);
 	if (SQ_FAILED(sq_get(this->vm, -2))) {
-		Debug(misc, Severity::Critical, "[squirrel] Could not find '{}' in the class", method_name);
+		Debug(Facility::Misc, Severity::Critical, "[squirrel] Could not find '{}' in the class", method_name);
 		sq_settop(this->vm, top);
 		return false;
 	}
@@ -490,14 +490,14 @@ bool Squirrel::CallBoolMethod(HSQOBJECT instance, std::string_view method_name, 
 	}
 
 	if (SQ_FAILED(sq_get(vm, -2))) {
-		Debug(misc, Severity::Critical, "[squirrel] Failed to find class by the name '{}{}'", prepend_API_name ? engine->GetAPIName() : "", class_name);
+		Debug(Facility::Misc, Severity::Critical, "[squirrel] Failed to find class by the name '{}{}'", prepend_API_name ? engine->GetAPIName() : "", class_name);
 		sq_settop(vm, oldtop);
 		return false;
 	}
 
 	/* Create the instance */
 	if (SQ_FAILED(sq_createinstance(vm, -1))) {
-		Debug(misc, Severity::Critical, "[squirrel] Failed to create instance for class '{}{}'", prepend_API_name ? engine->GetAPIName() : "", class_name);
+		Debug(Facility::Misc, Severity::Critical, "[squirrel] Failed to create instance for class '{}{}'", prepend_API_name ? engine->GetAPIName() : "", class_name);
 		sq_settop(vm, oldtop);
 		return false;
 	}
@@ -561,7 +561,7 @@ void Squirrel::Initialize()
 
 	/* Handle compile-errors ourself, so we can display it nicely */
 	sq_setcompilererrorhandler(this->vm, &Squirrel::CompileError);
-	sq_notifyallexceptions(this->vm, _debug_script_level > Severity::Debug1);
+	sq_notifyallexceptions(this->vm, IsVisibleSeverity(Facility::Script, Severity::Debug2));
 	/* Set a good print-function */
 	sq_setprintfunc(this->vm, &Squirrel::PrintFunc);
 	/* Handle runtime-errors ourself, so we can display it nicely */
@@ -742,7 +742,7 @@ bool Squirrel::LoadScript(HSQUIRRELVM vm, const std::string &script, bool in_roo
 	}
 
 	vm->_ops_till_suspend = ops_left;
-	Debug(misc, Severity::Critical, "[squirrel] Failed to compile '{}'", script);
+	Debug(Facility::Misc, Severity::Critical, "[squirrel] Failed to compile '{}'", script);
 	return false;
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -981,7 +981,7 @@ static void AILoadConfig(const IniFile &ini, std::string_view grpname)
 		config->Change(item.name);
 		if (!config->HasScript()) {
 			if (item.name != "none") {
-				Debug(script, 0, "The AI by the name '{}' was no longer found, and removed from the list.", item.name);
+				Debug(script, Severity::Critical, "The AI by the name '{}' was no longer found, and removed from the list.", item.name);
 				continue;
 			}
 		}
@@ -1008,7 +1008,7 @@ static void GameLoadConfig(const IniFile &ini, std::string_view grpname)
 	config->Change(item.name);
 	if (!config->HasScript()) {
 		if (item.name != "none") {
-			Debug(script, 0, "The GameScript by the name '{}' was no longer found, and removed from the list.", item.name);
+			Debug(script, Severity::Critical, "The GameScript by the name '{}' was no longer found, and removed from the list.", item.name);
 			return;
 		}
 	}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -981,7 +981,7 @@ static void AILoadConfig(const IniFile &ini, std::string_view grpname)
 		config->Change(item.name);
 		if (!config->HasScript()) {
 			if (item.name != "none") {
-				Debug(script, Severity::Critical, "The AI by the name '{}' was no longer found, and removed from the list.", item.name);
+				Debug(Facility::Script, Severity::Critical, "The AI by the name '{}' was no longer found, and removed from the list.", item.name);
 				continue;
 			}
 		}
@@ -1008,7 +1008,7 @@ static void GameLoadConfig(const IniFile &ini, std::string_view grpname)
 	config->Change(item.name);
 	if (!config->HasScript()) {
 		if (item.name != "none") {
-			Debug(script, Severity::Critical, "The GameScript by the name '{}' was no longer found, and removed from the list.", item.name);
+			Debug(Facility::Script, Severity::Critical, "The GameScript by the name '{}' was no longer found, and removed from the list.", item.name);
 			return;
 		}
 	}

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -159,7 +159,7 @@ public:
 	{
 		if (this->IsFull()) {
 			overflowed = true;
-			Debug(misc, 0, "SignalSegment too complex. Set {} is full (maximum {})", name, items);
+			Debug(misc, Severity::Critical, "SignalSegment too complex. Set {} is full (maximum {})", name, items);
 			return false; // set is full
 		}
 

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -159,7 +159,7 @@ public:
 	{
 		if (this->IsFull()) {
 			overflowed = true;
-			Debug(misc, Severity::Critical, "SignalSegment too complex. Set {} is full (maximum {})", name, items);
+			Debug(Facility::Misc, Severity::Critical, "SignalSegment too complex. Set {} is full (maximum {})", name, items);
 			return false; // set is full
 		}
 

--- a/src/signature.cpp
+++ b/src/signature.cpp
@@ -73,17 +73,17 @@ static bool ValidateChecksum(const std::string &filename, const std::string &che
 	if (version == "1") {
 		calculated_hash = CalculateHashV1(filename);
 	} else {
-		Debug(misc, 0, "Failed to validate signature: unknown checksum version: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: unknown checksum version: {}", filename);
 		return false;
 	}
 
 	/* Validate the checksum is the same. */
 	if (calculated_hash.empty()) {
-		Debug(misc, 0, "Failed to validate signature: couldn't calculate checksum for: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: couldn't calculate checksum for: {}", filename);
 		return false;
 	}
 	if (calculated_hash != hash) {
-		Debug(misc, 0, "Failed to validate signature: checksum mismatch for: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: checksum mismatch for: {}", filename);
 		return false;
 	}
 
@@ -113,7 +113,7 @@ static bool ValidateSignature(const std::string &signature, const nlohmann::json
 	if (version == "1") {
 		std::array<uint8_t, 64> sig;
 		if (sig_value.size() != 128 || !ConvertHexToBytes(sig_value, sig)) {
-			Debug(misc, 0, "Failed to validate signature: invalid signature: {}", filename);
+			Debug(misc, Severity::Critical, "Failed to validate signature: invalid signature: {}", filename);
 			return false;
 		}
 
@@ -125,10 +125,10 @@ static bool ValidateSignature(const std::string &signature, const nlohmann::json
 			}
 		}
 
-		Debug(misc, 0, "Failed to validate signature: signature validation failed: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: signature validation failed: {}", filename);
 		return false;
 	} else {
-		Debug(misc, 0, "Failed to validate signature: unknown signature version: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: unknown signature version: {}", filename);
 		return false;
 	}
 
@@ -145,18 +145,18 @@ static bool ValidateSignature(const std::string &signature, const nlohmann::json
 static bool ValidateSchema(const nlohmann::json &signatures, const std::string &filename)
 {
 	if (signatures["files"].is_null()) {
-		Debug(misc, 0, "Failed to validate signature: no files found: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: no files found: {}", filename);
 		return false;
 	}
 
 	if (signatures["signature"].is_null()) {
-		Debug(misc, 0, "Failed to validate signature: no signature found: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: no signature found: {}", filename);
 		return false;
 	}
 
 	for (auto &signature : signatures["files"]) {
 		if (signature["filename"].is_null() || signature["checksum"].is_null()) {
-			Debug(misc, 0, "Failed to validate signature: invalid entry in files: {}", filename);
+			Debug(misc, Severity::Critical, "Failed to validate signature: invalid entry in files: {}", filename);
 			return false;
 		}
 
@@ -164,13 +164,13 @@ static bool ValidateSchema(const nlohmann::json &signatures, const std::string &
 		const std::string sig_checksum = signature["checksum"];
 
 		if (sig_filename.empty() || sig_checksum.empty()) {
-			Debug(misc, 0, "Failed to validate signature: invalid entry in files: {}", filename);
+			Debug(misc, Severity::Critical, "Failed to validate signature: invalid entry in files: {}", filename);
 			return false;
 		}
 
 		auto pos = sig_checksum.find('$');
 		if (pos == std::string::npos) {
-			Debug(misc, 0, "Failed to validate signature: invalid checksum format: {}", filename);
+			Debug(misc, Severity::Critical, "Failed to validate signature: invalid checksum format: {}", filename);
 			return false;
 		}
 	}
@@ -178,7 +178,7 @@ static bool ValidateSchema(const nlohmann::json &signatures, const std::string &
 	const std::string signature = signatures["signature"];
 	auto pos = signature.find('$');
 	if (pos == std::string::npos) {
-		Debug(misc, 0, "Failed to validate signature: invalid signature format: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: invalid signature format: {}", filename);
 		return false;
 	}
 
@@ -197,14 +197,14 @@ static bool _ValidateSignatureFile(const std::string &filename)
 	size_t filesize;
 	auto f = FioFOpenFile(filename, "rb", Subdirectory::None, &filesize);
 	if (!f.has_value()) {
-		Debug(misc, 0, "Failed to validate signature: file not found: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: file not found: {}", filename);
 		return false;
 	}
 
 	std::string text(filesize, '\0');
 	size_t len = fread(text.data(), filesize, 1, *f);
 	if (len != 1) {
-		Debug(misc, 0, "Failed to validate signature: failed to read file: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: failed to read file: {}", filename);
 		return false;
 	}
 
@@ -212,7 +212,7 @@ static bool _ValidateSignatureFile(const std::string &filename)
 	try {
 		signatures = nlohmann::json::parse(text);
 	} catch (nlohmann::json::exception &) {
-		Debug(misc, 0, "Failed to validate signature: not a valid JSON file: {}", filename);
+		Debug(misc, Severity::Critical, "Failed to validate signature: not a valid JSON file: {}", filename);
 		return false;
 	}
 

--- a/src/signature.cpp
+++ b/src/signature.cpp
@@ -73,17 +73,17 @@ static bool ValidateChecksum(const std::string &filename, const std::string &che
 	if (version == "1") {
 		calculated_hash = CalculateHashV1(filename);
 	} else {
-		Debug(misc, Severity::Critical, "Failed to validate signature: unknown checksum version: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: unknown checksum version: {}", filename);
 		return false;
 	}
 
 	/* Validate the checksum is the same. */
 	if (calculated_hash.empty()) {
-		Debug(misc, Severity::Critical, "Failed to validate signature: couldn't calculate checksum for: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: couldn't calculate checksum for: {}", filename);
 		return false;
 	}
 	if (calculated_hash != hash) {
-		Debug(misc, Severity::Critical, "Failed to validate signature: checksum mismatch for: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: checksum mismatch for: {}", filename);
 		return false;
 	}
 
@@ -113,7 +113,7 @@ static bool ValidateSignature(const std::string &signature, const nlohmann::json
 	if (version == "1") {
 		std::array<uint8_t, 64> sig;
 		if (sig_value.size() != 128 || !ConvertHexToBytes(sig_value, sig)) {
-			Debug(misc, Severity::Critical, "Failed to validate signature: invalid signature: {}", filename);
+			Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: invalid signature: {}", filename);
 			return false;
 		}
 
@@ -125,10 +125,10 @@ static bool ValidateSignature(const std::string &signature, const nlohmann::json
 			}
 		}
 
-		Debug(misc, Severity::Critical, "Failed to validate signature: signature validation failed: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: signature validation failed: {}", filename);
 		return false;
 	} else {
-		Debug(misc, Severity::Critical, "Failed to validate signature: unknown signature version: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: unknown signature version: {}", filename);
 		return false;
 	}
 
@@ -145,18 +145,18 @@ static bool ValidateSignature(const std::string &signature, const nlohmann::json
 static bool ValidateSchema(const nlohmann::json &signatures, const std::string &filename)
 {
 	if (signatures["files"].is_null()) {
-		Debug(misc, Severity::Critical, "Failed to validate signature: no files found: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: no files found: {}", filename);
 		return false;
 	}
 
 	if (signatures["signature"].is_null()) {
-		Debug(misc, Severity::Critical, "Failed to validate signature: no signature found: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: no signature found: {}", filename);
 		return false;
 	}
 
 	for (auto &signature : signatures["files"]) {
 		if (signature["filename"].is_null() || signature["checksum"].is_null()) {
-			Debug(misc, Severity::Critical, "Failed to validate signature: invalid entry in files: {}", filename);
+			Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: invalid entry in files: {}", filename);
 			return false;
 		}
 
@@ -164,13 +164,13 @@ static bool ValidateSchema(const nlohmann::json &signatures, const std::string &
 		const std::string sig_checksum = signature["checksum"];
 
 		if (sig_filename.empty() || sig_checksum.empty()) {
-			Debug(misc, Severity::Critical, "Failed to validate signature: invalid entry in files: {}", filename);
+			Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: invalid entry in files: {}", filename);
 			return false;
 		}
 
 		auto pos = sig_checksum.find('$');
 		if (pos == std::string::npos) {
-			Debug(misc, Severity::Critical, "Failed to validate signature: invalid checksum format: {}", filename);
+			Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: invalid checksum format: {}", filename);
 			return false;
 		}
 	}
@@ -178,7 +178,7 @@ static bool ValidateSchema(const nlohmann::json &signatures, const std::string &
 	const std::string signature = signatures["signature"];
 	auto pos = signature.find('$');
 	if (pos == std::string::npos) {
-		Debug(misc, Severity::Critical, "Failed to validate signature: invalid signature format: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: invalid signature format: {}", filename);
 		return false;
 	}
 
@@ -197,14 +197,14 @@ static bool _ValidateSignatureFile(const std::string &filename)
 	size_t filesize;
 	auto f = FioFOpenFile(filename, "rb", Subdirectory::None, &filesize);
 	if (!f.has_value()) {
-		Debug(misc, Severity::Critical, "Failed to validate signature: file not found: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: file not found: {}", filename);
 		return false;
 	}
 
 	std::string text(filesize, '\0');
 	size_t len = fread(text.data(), filesize, 1, *f);
 	if (len != 1) {
-		Debug(misc, Severity::Critical, "Failed to validate signature: failed to read file: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: failed to read file: {}", filename);
 		return false;
 	}
 
@@ -212,7 +212,7 @@ static bool _ValidateSignatureFile(const std::string &filename)
 	try {
 		signatures = nlohmann::json::parse(text);
 	} catch (nlohmann::json::exception &) {
-		Debug(misc, Severity::Critical, "Failed to validate signature: not a valid JSON file: {}", filename);
+		Debug(Facility::Misc, Severity::Critical, "Failed to validate signature: not a valid JSON file: {}", filename);
 		return false;
 	}
 

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -63,7 +63,7 @@ struct SignList {
 	{
 		if (!this->signs.NeedRebuild()) return;
 
-		Debug(misc, 3, "Building sign list");
+		Debug(misc, Severity::Notice, "Building sign list");
 
 		this->signs.clear();
 		this->signs.reserve(Sign::GetNumItems());

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -63,7 +63,7 @@ struct SignList {
 	{
 		if (!this->signs.NeedRebuild()) return;
 
-		Debug(misc, Severity::Notice, "Building sign list");
+		Debug(Facility::Misc, Severity::Notice, "Building sign list");
 
 		this->signs.clear();
 		this->signs.reserve(Sign::GetNumItems());

--- a/src/social_integration.cpp
+++ b/src/social_integration.cpp
@@ -69,7 +69,7 @@ public:
 	bool AddFile(const std::string &filename, size_t basepath_length, const std::string &) override
 	{
 		std::string basepath = filename.substr(basepath_length);
-		Debug(misc, Severity::Error, "[Social Integration: {}] Loading ...", basepath);
+		Debug(Facility::Misc, Severity::Error, "[Social Integration: {}] Loading ...", basepath);
 
 		auto &plugin = _plugins.emplace_back(std::make_unique<InternalSocialIntegrationPlugin>(filename, basepath));
 
@@ -81,7 +81,7 @@ public:
 		if (plugin->library->HasError()) {
 			plugin->external.state = SocialIntegrationPlugin::FAILED;
 
-			Debug(misc, Severity::Critical, "[Social Integration: {}] Failed to load library: {}", basepath, plugin->library->GetLastError());
+			Debug(Facility::Misc, Severity::Critical, "[Social Integration: {}] Failed to load library: {}", basepath, plugin->library->GetLastError());
 			return false;
 		}
 
@@ -89,7 +89,7 @@ public:
 		if (plugin->library->HasError()) {
 			plugin->external.state = SocialIntegrationPlugin::UNSUPPORTED_API;
 
-			Debug(misc, Severity::Critical, "[Social Integration: {}] Failed to find symbol SocialPlugin_v1_GetInfo: {}", basepath, plugin->library->GetLastError());
+			Debug(Facility::Misc, Severity::Critical, "[Social Integration: {}] Failed to find symbol SocialPlugin_v1_GetInfo: {}", basepath, plugin->library->GetLastError());
 			return false;
 		}
 
@@ -97,7 +97,7 @@ public:
 		if (plugin->library->HasError()) {
 			plugin->external.state = SocialIntegrationPlugin::UNSUPPORTED_API;
 
-			Debug(misc, Severity::Critical, "[Social Integration: {}] Failed to find symbol SocialPlugin_v1_Init: {}", basepath, plugin->library->GetLastError());
+			Debug(Facility::Misc, Severity::Critical, "[Social Integration: {}] Failed to find symbol SocialPlugin_v1_Init: {}", basepath, plugin->library->GetLastError());
 			return false;
 		}
 
@@ -115,7 +115,7 @@ public:
 		if (_loaded_social_platform.find(lc_social_platform) != _loaded_social_platform.end()) {
 			plugin->external.state = SocialIntegrationPlugin::DUPLICATE;
 
-			Debug(misc, Severity::Critical, "[Social Integration: {}] Another plugin for {} is already loaded", basepath, plugin->plugin_info.social_platform);
+			Debug(Facility::Misc, Severity::Critical, "[Social Integration: {}] Another plugin for {} is already loaded", basepath, plugin->plugin_info.social_platform);
 			return false;
 		}
 		_loaded_social_platform.insert(std::move(lc_social_platform));
@@ -125,19 +125,19 @@ public:
 			case OTTD_SOCIAL_INTEGRATION_V1_INIT_SUCCESS:
 				plugin->external.state = SocialIntegrationPlugin::RUNNING;
 
-				Debug(misc, Severity::Error, "[Social Integration: {}] Loaded for {}: {} ({})", basepath, plugin->plugin_info.social_platform, plugin->plugin_info.name, plugin->plugin_info.version);
+				Debug(Facility::Misc, Severity::Error, "[Social Integration: {}] Loaded for {}: {} ({})", basepath, plugin->plugin_info.social_platform, plugin->plugin_info.name, plugin->plugin_info.version);
 				return true;
 
 			case OTTD_SOCIAL_INTEGRATION_V1_INIT_FAILED:
 				plugin->external.state = SocialIntegrationPlugin::FAILED;
 
-				Debug(misc, Severity::Critical, "[Social Integration: {}] Failed to initialize", basepath);
+				Debug(Facility::Misc, Severity::Critical, "[Social Integration: {}] Failed to initialize", basepath);
 				return false;
 
 			case OTTD_SOCIAL_INTEGRATION_V1_INIT_PLATFORM_NOT_RUNNING:
 				plugin->external.state = SocialIntegrationPlugin::PLATFORM_NOT_RUNNING;
 
-				Debug(misc, Severity::Error, "[Social Integration: {}] Failed to initialize: {} is not running", basepath, plugin->plugin_info.social_platform);
+				Debug(Facility::Misc, Severity::Error, "[Social Integration: {}] Failed to initialize: {} is not running", basepath, plugin->plugin_info.social_platform);
 				return false;
 
 			default:
@@ -201,7 +201,7 @@ void SocialIntegration::RunCallbacks()
 
 		if (plugin->plugin_api.run_callbacks != nullptr) {
 			if (!plugin->plugin_api.run_callbacks()) {
-				Debug(misc, Severity::Error, "[Social Plugin: {}] Requested to be unloaded", plugin->external.basepath);
+				Debug(Facility::Misc, Severity::Error, "[Social Plugin: {}] Requested to be unloaded", plugin->external.basepath);
 
 				_loaded_social_platform.erase(plugin->plugin_info.social_platform);
 				plugin->external.state = SocialIntegrationPlugin::UNLOADED;

--- a/src/social_integration.cpp
+++ b/src/social_integration.cpp
@@ -69,7 +69,7 @@ public:
 	bool AddFile(const std::string &filename, size_t basepath_length, const std::string &) override
 	{
 		std::string basepath = filename.substr(basepath_length);
-		Debug(misc, 1, "[Social Integration: {}] Loading ...", basepath);
+		Debug(misc, Severity::Error, "[Social Integration: {}] Loading ...", basepath);
 
 		auto &plugin = _plugins.emplace_back(std::make_unique<InternalSocialIntegrationPlugin>(filename, basepath));
 
@@ -81,7 +81,7 @@ public:
 		if (plugin->library->HasError()) {
 			plugin->external.state = SocialIntegrationPlugin::FAILED;
 
-			Debug(misc, 0, "[Social Integration: {}] Failed to load library: {}", basepath, plugin->library->GetLastError());
+			Debug(misc, Severity::Critical, "[Social Integration: {}] Failed to load library: {}", basepath, plugin->library->GetLastError());
 			return false;
 		}
 
@@ -89,7 +89,7 @@ public:
 		if (plugin->library->HasError()) {
 			plugin->external.state = SocialIntegrationPlugin::UNSUPPORTED_API;
 
-			Debug(misc, 0, "[Social Integration: {}] Failed to find symbol SocialPlugin_v1_GetInfo: {}", basepath, plugin->library->GetLastError());
+			Debug(misc, Severity::Critical, "[Social Integration: {}] Failed to find symbol SocialPlugin_v1_GetInfo: {}", basepath, plugin->library->GetLastError());
 			return false;
 		}
 
@@ -97,7 +97,7 @@ public:
 		if (plugin->library->HasError()) {
 			plugin->external.state = SocialIntegrationPlugin::UNSUPPORTED_API;
 
-			Debug(misc, 0, "[Social Integration: {}] Failed to find symbol SocialPlugin_v1_Init: {}", basepath, plugin->library->GetLastError());
+			Debug(misc, Severity::Critical, "[Social Integration: {}] Failed to find symbol SocialPlugin_v1_Init: {}", basepath, plugin->library->GetLastError());
 			return false;
 		}
 
@@ -115,7 +115,7 @@ public:
 		if (_loaded_social_platform.find(lc_social_platform) != _loaded_social_platform.end()) {
 			plugin->external.state = SocialIntegrationPlugin::DUPLICATE;
 
-			Debug(misc, 0, "[Social Integration: {}] Another plugin for {} is already loaded", basepath, plugin->plugin_info.social_platform);
+			Debug(misc, Severity::Critical, "[Social Integration: {}] Another plugin for {} is already loaded", basepath, plugin->plugin_info.social_platform);
 			return false;
 		}
 		_loaded_social_platform.insert(std::move(lc_social_platform));
@@ -125,19 +125,19 @@ public:
 			case OTTD_SOCIAL_INTEGRATION_V1_INIT_SUCCESS:
 				plugin->external.state = SocialIntegrationPlugin::RUNNING;
 
-				Debug(misc, 1, "[Social Integration: {}] Loaded for {}: {} ({})", basepath, plugin->plugin_info.social_platform, plugin->plugin_info.name, plugin->plugin_info.version);
+				Debug(misc, Severity::Error, "[Social Integration: {}] Loaded for {}: {} ({})", basepath, plugin->plugin_info.social_platform, plugin->plugin_info.name, plugin->plugin_info.version);
 				return true;
 
 			case OTTD_SOCIAL_INTEGRATION_V1_INIT_FAILED:
 				plugin->external.state = SocialIntegrationPlugin::FAILED;
 
-				Debug(misc, 0, "[Social Integration: {}] Failed to initialize", basepath);
+				Debug(misc, Severity::Critical, "[Social Integration: {}] Failed to initialize", basepath);
 				return false;
 
 			case OTTD_SOCIAL_INTEGRATION_V1_INIT_PLATFORM_NOT_RUNNING:
 				plugin->external.state = SocialIntegrationPlugin::PLATFORM_NOT_RUNNING;
 
-				Debug(misc, 1, "[Social Integration: {}] Failed to initialize: {} is not running", basepath, plugin->plugin_info.social_platform);
+				Debug(misc, Severity::Error, "[Social Integration: {}] Failed to initialize: {} is not running", basepath, plugin->plugin_info.social_platform);
 				return false;
 
 			default:
@@ -201,7 +201,7 @@ void SocialIntegration::RunCallbacks()
 
 		if (plugin->plugin_api.run_callbacks != nullptr) {
 			if (!plugin->plugin_api.run_callbacks()) {
-				Debug(misc, 1, "[Social Plugin: {}] Requested to be unloaded", plugin->external.basepath);
+				Debug(misc, Severity::Error, "[Social Plugin: {}] Requested to be unloaded", plugin->external.basepath);
 
 				_loaded_social_platform.erase(plugin->plugin_info.social_platform);
 				plugin->external.state = SocialIntegrationPlugin::UNLOADED;

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -51,7 +51,7 @@ static void OpenBankFile(const std::string &filename)
 		/* Corrupt sample data? Just leave the allocated memory as those tell
 		 * there is no sound to play (size = 0 due to calloc). Not allocating
 		 * the memory disables valid NewGRFs that replace sounds. */
-		Debug(misc, Severity::Debug2, "Incorrect number of sounds in '{}', ignoring.", filename);
+		Debug(Facility::Misc, Severity::Debug2, "Incorrect number of sounds in '{}', ignoring.", filename);
 		return;
 	}
 
@@ -89,7 +89,7 @@ static bool SetBankSource(MixerChannel *mc, SoundEntry *sound, SoundID sound_id)
 
 void InitializeSound()
 {
-	Debug(misc, Severity::Error, "Loading sound effects...");
+	Debug(Facility::Misc, Severity::Error, "Loading sound effects...");
 	OpenBankFile(BaseSounds::GetUsedSet()->files[0].filename);
 }
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -51,7 +51,7 @@ static void OpenBankFile(const std::string &filename)
 		/* Corrupt sample data? Just leave the allocated memory as those tell
 		 * there is no sound to play (size = 0 due to calloc). Not allocating
 		 * the memory disables valid NewGRFs that replace sounds. */
-		Debug(misc, 6, "Incorrect number of sounds in '{}', ignoring.", filename);
+		Debug(misc, Severity::Debug2, "Incorrect number of sounds in '{}', ignoring.", filename);
 		return;
 	}
 
@@ -89,7 +89,7 @@ static bool SetBankSource(MixerChannel *mc, SoundEntry *sound, SoundID sound_id)
 
 void InitializeSound()
 {
-	Debug(misc, 1, "Loading sound effects...");
+	Debug(misc, Severity::Error, "Loading sound effects...");
 	OpenBankFile(BaseSounds::GetUsedSet()->files[0].filename);
 }
 

--- a/src/sound/allegro_s.cpp
+++ b/src/sound/allegro_s.cpp
@@ -53,20 +53,20 @@ extern int _allegro_instance_count;
 std::optional<std::string_view> SoundDriver_Allegro::Start(const StringList &parm)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
-		Debug(driver, 0, "allegro: install_allegro failed '{}'", allegro_error);
+		Debug(driver, Severity::Critical, "allegro: install_allegro failed '{}'", allegro_error);
 		return "Failed to set up Allegro";
 	}
 	_allegro_instance_count++;
 
 	/* Initialise the sound */
 	if (install_sound(DIGI_AUTODETECT, MIDI_AUTODETECT, nullptr) != 0) {
-		Debug(driver, 0, "allegro: install_sound failed '{}'", allegro_error);
+		Debug(driver, Severity::Critical, "allegro: install_sound failed '{}'", allegro_error);
 		return "Failed to set up Allegro sound";
 	}
 
 	/* Okay, there's no soundcard */
 	if (digi_card == DIGI_NONE) {
-		Debug(driver, 0, "allegro: no sound card found");
+		Debug(driver, Severity::Critical, "allegro: no sound card found");
 		return "No sound card found";
 	}
 

--- a/src/sound/allegro_s.cpp
+++ b/src/sound/allegro_s.cpp
@@ -53,20 +53,20 @@ extern int _allegro_instance_count;
 std::optional<std::string_view> SoundDriver_Allegro::Start(const StringList &parm)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
-		Debug(driver, Severity::Critical, "allegro: install_allegro failed '{}'", allegro_error);
+		Debug(Facility::Driver, Severity::Critical, "allegro: install_allegro failed '{}'", allegro_error);
 		return "Failed to set up Allegro";
 	}
 	_allegro_instance_count++;
 
 	/* Initialise the sound */
 	if (install_sound(DIGI_AUTODETECT, MIDI_AUTODETECT, nullptr) != 0) {
-		Debug(driver, Severity::Critical, "allegro: install_sound failed '{}'", allegro_error);
+		Debug(Facility::Driver, Severity::Critical, "allegro: install_sound failed '{}'", allegro_error);
 		return "Failed to set up Allegro sound";
 	}
 
 	/* Okay, there's no soundcard */
 	if (digi_card == DIGI_NONE) {
-		Debug(driver, Severity::Critical, "allegro: no sound card found");
+		Debug(Facility::Driver, Severity::Critical, "allegro: no sound card found");
 		return "No sound card found";
 	}
 

--- a/src/sound/cocoa_s.cpp
+++ b/src/sound/cocoa_s.cpp
@@ -117,7 +117,7 @@ void SoundDriver_Cocoa::Stop()
 
 	/* stop processing the audio unit */
 	if (AudioOutputUnitStop(_outputAudioUnit) != noErr) {
-		Debug(driver, Severity::Critical, "cocoa_s: Core_CloseAudio: AudioOutputUnitStop failed");
+		Debug(Facility::Driver, Severity::Critical, "cocoa_s: Core_CloseAudio: AudioOutputUnitStop failed");
 		return;
 	}
 
@@ -125,12 +125,12 @@ void SoundDriver_Cocoa::Stop()
 	callback.inputProc = 0;
 	callback.inputProcRefCon = 0;
 	if (AudioUnitSetProperty(_outputAudioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callback, sizeof(callback)) != noErr) {
-		Debug(driver, Severity::Critical, "cocoa_s: Core_CloseAudio: AudioUnitSetProperty (kAudioUnitProperty_SetRenderCallback) failed");
+		Debug(Facility::Driver, Severity::Critical, "cocoa_s: Core_CloseAudio: AudioUnitSetProperty (kAudioUnitProperty_SetRenderCallback) failed");
 		return;
 	}
 
 	if (AudioComponentInstanceDispose(_outputAudioUnit) != noErr) {
-		Debug(driver, Severity::Critical, "cocoa_s: Core_CloseAudio: AudioComponentInstanceDispose failed");
+		Debug(Facility::Driver, Severity::Critical, "cocoa_s: Core_CloseAudio: AudioComponentInstanceDispose failed");
 		return;
 	}
 }

--- a/src/sound/cocoa_s.cpp
+++ b/src/sound/cocoa_s.cpp
@@ -117,7 +117,7 @@ void SoundDriver_Cocoa::Stop()
 
 	/* stop processing the audio unit */
 	if (AudioOutputUnitStop(_outputAudioUnit) != noErr) {
-		Debug(driver, 0, "cocoa_s: Core_CloseAudio: AudioOutputUnitStop failed");
+		Debug(driver, Severity::Critical, "cocoa_s: Core_CloseAudio: AudioOutputUnitStop failed");
 		return;
 	}
 
@@ -125,12 +125,12 @@ void SoundDriver_Cocoa::Stop()
 	callback.inputProc = 0;
 	callback.inputProcRefCon = 0;
 	if (AudioUnitSetProperty(_outputAudioUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &callback, sizeof(callback)) != noErr) {
-		Debug(driver, 0, "cocoa_s: Core_CloseAudio: AudioUnitSetProperty (kAudioUnitProperty_SetRenderCallback) failed");
+		Debug(driver, Severity::Critical, "cocoa_s: Core_CloseAudio: AudioUnitSetProperty (kAudioUnitProperty_SetRenderCallback) failed");
 		return;
 	}
 
 	if (AudioComponentInstanceDispose(_outputAudioUnit) != noErr) {
-		Debug(driver, 0, "cocoa_s: Core_CloseAudio: AudioComponentInstanceDispose failed");
+		Debug(driver, Severity::Critical, "cocoa_s: Core_CloseAudio: AudioComponentInstanceDispose failed");
 		return;
 	}
 }

--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -142,7 +142,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 	HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
 	if (FAILED(hr)) {
-		Debug(driver, Severity::Critical, "xaudio2_s: CoInitializeEx failed ({:08x})", (uint)hr);
+		Debug(Facility::Driver, Severity::Critical, "xaudio2_s: CoInitializeEx failed ({:08x})", (uint)hr);
 		return "Failed to initialise COM";
 	}
 
@@ -151,7 +151,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 	if (_xaudio_dll_handle == nullptr) {
 		CoUninitialize();
 
-		Debug(driver, Severity::Critical, "xaudio2_s: Unable to load " XAUDIO2_DLL_A);
+		Debug(Facility::Driver, Severity::Critical, "xaudio2_s: Unable to load " XAUDIO2_DLL_A);
 		return "Failed to load XAudio2 DLL";
 	}
 
@@ -161,7 +161,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		Debug(driver, Severity::Critical, "xaudio2_s: Unable to find XAudio2Create function in DLL");
+		Debug(Facility::Driver, Severity::Critical, "xaudio2_s: Unable to find XAudio2Create function in DLL");
 		return "Failed to load XAudio2 DLL";
 	}
 
@@ -172,7 +172,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		Debug(driver, Severity::Critical, "xaudio2_s: XAudio2Create failed ({:08x})", (uint)hr);
+		Debug(Facility::Driver, Severity::Critical, "xaudio2_s: XAudio2Create failed ({:08x})", (uint)hr);
 		return "Failed to initialise the XAudio2 engine";
 	}
 
@@ -184,7 +184,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		Debug(driver, Severity::Critical, "xaudio2_s: CreateMasteringVoice failed ({:08x})", (uint)hr);
+		Debug(Facility::Driver, Severity::Critical, "xaudio2_s: CreateMasteringVoice failed ({:08x})", (uint)hr);
 		return "Failed to create a mastering voice";
 	}
 
@@ -221,7 +221,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		Debug(driver, Severity::Critical, "xaudio2_s: CreateSourceVoice failed ({:08x})", (uint)hr);
+		Debug(Facility::Driver, Severity::Critical, "xaudio2_s: CreateSourceVoice failed ({:08x})", (uint)hr);
 		return "Failed to create a source voice";
 	}
 
@@ -229,7 +229,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 	hr = _source_voice->Start(0, 0);
 
 	if (FAILED(hr)) {
-		Debug(driver, Severity::Critical, "xaudio2_s: _source_voice->Start failed ({:08x})", (uint)hr);
+		Debug(Facility::Driver, Severity::Critical, "xaudio2_s: _source_voice->Start failed ({:08x})", (uint)hr);
 
 		Stop();
 		return "Failed to start the source voice";
@@ -241,7 +241,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 	hr = _voice_context->SubmitBuffer();
 
 	if (FAILED(hr)) {
-		Debug(driver, Severity::Critical, "xaudio2_s: _voice_context->SubmitBuffer failed ({:08x})", (uint)hr);
+		Debug(Facility::Driver, Severity::Critical, "xaudio2_s: _voice_context->SubmitBuffer failed ({:08x})", (uint)hr);
 
 		Stop();
 		return "Failed to submit the first audio buffer";

--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -142,7 +142,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 	HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
 	if (FAILED(hr)) {
-		Debug(driver, 0, "xaudio2_s: CoInitializeEx failed ({:08x})", (uint)hr);
+		Debug(driver, Severity::Critical, "xaudio2_s: CoInitializeEx failed ({:08x})", (uint)hr);
 		return "Failed to initialise COM";
 	}
 
@@ -151,7 +151,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 	if (_xaudio_dll_handle == nullptr) {
 		CoUninitialize();
 
-		Debug(driver, 0, "xaudio2_s: Unable to load " XAUDIO2_DLL_A);
+		Debug(driver, Severity::Critical, "xaudio2_s: Unable to load " XAUDIO2_DLL_A);
 		return "Failed to load XAudio2 DLL";
 	}
 
@@ -161,7 +161,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		Debug(driver, 0, "xaudio2_s: Unable to find XAudio2Create function in DLL");
+		Debug(driver, Severity::Critical, "xaudio2_s: Unable to find XAudio2Create function in DLL");
 		return "Failed to load XAudio2 DLL";
 	}
 
@@ -172,7 +172,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		Debug(driver, 0, "xaudio2_s: XAudio2Create failed ({:08x})", (uint)hr);
+		Debug(driver, Severity::Critical, "xaudio2_s: XAudio2Create failed ({:08x})", (uint)hr);
 		return "Failed to initialise the XAudio2 engine";
 	}
 
@@ -184,7 +184,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		Debug(driver, 0, "xaudio2_s: CreateMasteringVoice failed ({:08x})", (uint)hr);
+		Debug(driver, Severity::Critical, "xaudio2_s: CreateMasteringVoice failed ({:08x})", (uint)hr);
 		return "Failed to create a mastering voice";
 	}
 
@@ -221,7 +221,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		Debug(driver, 0, "xaudio2_s: CreateSourceVoice failed ({:08x})", (uint)hr);
+		Debug(driver, Severity::Critical, "xaudio2_s: CreateSourceVoice failed ({:08x})", (uint)hr);
 		return "Failed to create a source voice";
 	}
 
@@ -229,7 +229,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 	hr = _source_voice->Start(0, 0);
 
 	if (FAILED(hr)) {
-		Debug(driver, 0, "xaudio2_s: _source_voice->Start failed ({:08x})", (uint)hr);
+		Debug(driver, Severity::Critical, "xaudio2_s: _source_voice->Start failed ({:08x})", (uint)hr);
 
 		Stop();
 		return "Failed to start the source voice";
@@ -241,7 +241,7 @@ std::optional<std::string_view> SoundDriver_XAudio2::Start(const StringList &par
 	hr = _voice_context->SubmitBuffer();
 
 	if (FAILED(hr)) {
-		Debug(driver, 0, "xaudio2_s: _voice_context->SubmitBuffer failed ({:08x})", (uint)hr);
+		Debug(driver, Severity::Critical, "xaudio2_s: _voice_context->SubmitBuffer failed ({:08x})", (uint)hr);
 
 		Stop();
 		return "Failed to submit the first audio buffer";

--- a/src/soundloader.cpp
+++ b/src/soundloader.cpp
@@ -36,7 +36,7 @@ bool LoadSoundData(SoundEntry &sound, bool new_format, SoundID sound_id, const s
 	}
 
 	if (sound.data->empty()) {
-		Debug(grf, 0, "LoadSound [{}]: Failed to load sound '{}' for slot {}", sound.file->GetSimplifiedFilename(), name, sound_id);
+		Debug(grf, Severity::Critical, "LoadSound [{}]: Failed to load sound '{}' for slot {}", sound.file->GetSimplifiedFilename(), name, sound_id);
 		return false;
 	}
 
@@ -44,7 +44,7 @@ bool LoadSoundData(SoundEntry &sound, bool new_format, SoundID sound_id, const s
 	assert(sound.channels == 1);
 	assert(sound.rate != 0);
 
-	Debug(grf, 2, "LoadSound [{}]: channels {}, sample rate {}, bits per sample {}, length {}", sound.file->GetSimplifiedFilename(), sound.channels, sound.rate, sound.bits_per_sample, sound.file_size);
+	Debug(grf, Severity::Warning, "LoadSound [{}]: channels {}, sample rate {}, bits per sample {}, length {}", sound.file->GetSimplifiedFilename(), sound.channels, sound.rate, sound.bits_per_sample, sound.file_size);
 
 	/* Convert sample rate if needed. */
 	const uint32_t play_rate = MxGetRate();

--- a/src/soundloader.cpp
+++ b/src/soundloader.cpp
@@ -36,7 +36,7 @@ bool LoadSoundData(SoundEntry &sound, bool new_format, SoundID sound_id, const s
 	}
 
 	if (sound.data->empty()) {
-		Debug(grf, Severity::Critical, "LoadSound [{}]: Failed to load sound '{}' for slot {}", sound.file->GetSimplifiedFilename(), name, sound_id);
+		Debug(Facility::Grf, Severity::Critical, "LoadSound [{}]: Failed to load sound '{}' for slot {}", sound.file->GetSimplifiedFilename(), name, sound_id);
 		return false;
 	}
 
@@ -44,7 +44,7 @@ bool LoadSoundData(SoundEntry &sound, bool new_format, SoundID sound_id, const s
 	assert(sound.channels == 1);
 	assert(sound.rate != 0);
 
-	Debug(grf, Severity::Warning, "LoadSound [{}]: channels {}, sample rate {}, bits per sample {}, length {}", sound.file->GetSimplifiedFilename(), sound.channels, sound.rate, sound.bits_per_sample, sound.file_size);
+	Debug(Facility::Grf, Severity::Warning, "LoadSound [{}]: channels {}, sample rate {}, bits per sample {}, length {}", sound.file->GetSimplifiedFilename(), sound.channels, sound.rate, sound.bits_per_sample, sound.file_size);
 
 	/* Convert sample rate if needed. */
 	const uint32_t play_rate = MxGetRate();

--- a/src/soundloader_opus.cpp
+++ b/src/soundloader_opus.cpp
@@ -58,7 +58,7 @@ public:
 		int error = 0;
 		auto of = AutoRelease<OggOpusFile, op_free>(op_open_memory(tmp.data(), tmp.size(), &error));
 		if (error != 0) {
-			Debug(grf, Severity::Critical, "SoundLoader_Opus: Unable to open stream.");
+			Debug(Facility::Grf, Severity::Critical, "SoundLoader_Opus: Unable to open stream.");
 			return false;
 		}
 
@@ -71,14 +71,14 @@ public:
 			if (read == 0) break;
 
 			if (read < 0) {
-				Debug(grf, Severity::Critical, "SoundLoader_Opus: Unexpected end of stream.");
+				Debug(Facility::Grf, Severity::Critical, "SoundLoader_Opus: Unexpected end of stream.");
 				data.clear();
 				return false;
 			}
 
 			int channels = op_channel_count(of.get(), link_index);
 			if (channels != 1) {
-				Debug(grf, Severity::Critical, "SoundLoader_Opus: Unsupported channels {}, expected 1.", channels);
+				Debug(Facility::Grf, Severity::Critical, "SoundLoader_Opus: Unsupported channels {}, expected 1.", channels);
 				data.clear();
 				return false;
 			}

--- a/src/soundloader_opus.cpp
+++ b/src/soundloader_opus.cpp
@@ -58,7 +58,7 @@ public:
 		int error = 0;
 		auto of = AutoRelease<OggOpusFile, op_free>(op_open_memory(tmp.data(), tmp.size(), &error));
 		if (error != 0) {
-			Debug(grf, 0, "SoundLoader_Opus: Unable to open stream.");
+			Debug(grf, Severity::Critical, "SoundLoader_Opus: Unable to open stream.");
 			return false;
 		}
 
@@ -71,14 +71,14 @@ public:
 			if (read == 0) break;
 
 			if (read < 0) {
-				Debug(grf, 0, "SoundLoader_Opus: Unexpected end of stream.");
+				Debug(grf, Severity::Critical, "SoundLoader_Opus: Unexpected end of stream.");
 				data.clear();
 				return false;
 			}
 
 			int channels = op_channel_count(of.get(), link_index);
 			if (channels != 1) {
-				Debug(grf, 0, "SoundLoader_Opus: Unsupported channels {}, expected 1.", channels);
+				Debug(grf, Severity::Critical, "SoundLoader_Opus: Unsupported channels {}, expected 1.", channels);
 				data.clear();
 				return false;
 			}

--- a/src/soundloader_wav.cpp
+++ b/src/soundloader_wav.cpp
@@ -55,13 +55,13 @@ public:
 			if (tag == WavTag{"fmt "}) {
 				uint16_t format = file.ReadWord();
 				if (format != 1) {
-					Debug(grf, 0, "SoundLoader_Wav: Unsupported format {}, expected 1 (uncompressed PCM).", format);
+					Debug(grf, Severity::Critical, "SoundLoader_Wav: Unsupported format {}, expected 1 (uncompressed PCM).", format);
 					return false;
 				}
 
 				sound.channels = file.ReadWord();
 				if (sound.channels != 1) {
-					Debug(grf, 0, "SoundLoader_Wav: Unsupported channels {}, expected 1.", sound.channels);
+					Debug(grf, Severity::Critical, "SoundLoader_Wav: Unsupported channels {}, expected 1.", sound.channels);
 					return false;
 				}
 
@@ -73,7 +73,7 @@ public:
 
 				sound.bits_per_sample = file.ReadWord();
 				if (sound.bits_per_sample != 8 && sound.bits_per_sample != 16) {
-					Debug(grf, 0, "SoundLoader_Wav: Unsupported bits_per_sample {}, expected 8 or 16.", sound.bits_per_sample);
+					Debug(grf, Severity::Critical, "SoundLoader_Wav: Unsupported bits_per_sample {}, expected 8 or 16.", sound.bits_per_sample);
 					return false;
 				}
 
@@ -83,7 +83,7 @@ public:
 				uint align = sound.channels * sound.bits_per_sample / 8;
 				if (Align(size, align) != size) {
 					/* Ensure length is aligned correctly for channels and BPS. */
-					Debug(grf, 0, "SoundLoader_Wav: Unexpected end of stream.");
+					Debug(grf, Severity::Critical, "SoundLoader_Wav: Unexpected end of stream.");
 					return false;
 				}
 

--- a/src/soundloader_wav.cpp
+++ b/src/soundloader_wav.cpp
@@ -55,13 +55,13 @@ public:
 			if (tag == WavTag{"fmt "}) {
 				uint16_t format = file.ReadWord();
 				if (format != 1) {
-					Debug(grf, Severity::Critical, "SoundLoader_Wav: Unsupported format {}, expected 1 (uncompressed PCM).", format);
+					Debug(Facility::Grf, Severity::Critical, "SoundLoader_Wav: Unsupported format {}, expected 1 (uncompressed PCM).", format);
 					return false;
 				}
 
 				sound.channels = file.ReadWord();
 				if (sound.channels != 1) {
-					Debug(grf, Severity::Critical, "SoundLoader_Wav: Unsupported channels {}, expected 1.", sound.channels);
+					Debug(Facility::Grf, Severity::Critical, "SoundLoader_Wav: Unsupported channels {}, expected 1.", sound.channels);
 					return false;
 				}
 
@@ -73,7 +73,7 @@ public:
 
 				sound.bits_per_sample = file.ReadWord();
 				if (sound.bits_per_sample != 8 && sound.bits_per_sample != 16) {
-					Debug(grf, Severity::Critical, "SoundLoader_Wav: Unsupported bits_per_sample {}, expected 8 or 16.", sound.bits_per_sample);
+					Debug(Facility::Grf, Severity::Critical, "SoundLoader_Wav: Unsupported bits_per_sample {}, expected 8 or 16.", sound.bits_per_sample);
 					return false;
 				}
 
@@ -83,7 +83,7 @@ public:
 				uint align = sound.channels * sound.bits_per_sample / 8;
 				if (Align(size, align) != size) {
 					/* Ensure length is aligned correctly for channels and BPS. */
-					Debug(grf, Severity::Critical, "SoundLoader_Wav: Unexpected end of stream.");
+					Debug(Facility::Grf, Severity::Critical, "SoundLoader_Wav: Unexpected end of stream.");
 					return false;
 				}
 

--- a/src/soundresampler_soxr.cpp
+++ b/src/soundresampler_soxr.cpp
@@ -72,7 +72,7 @@ public:
 
 		if (error != nullptr) {
 			/* Could not resample, try using the original data as-is without resampling instead. */
-			Debug(misc, Severity::Critical, "Failed to resample: {}", soxr_strerror(error));
+			Debug(Facility::Misc, Severity::Critical, "Failed to resample: {}", soxr_strerror(error));
 			data.swap(tmp);
 		} else {
 			sound.rate = play_rate;

--- a/src/soundresampler_soxr.cpp
+++ b/src/soundresampler_soxr.cpp
@@ -72,7 +72,7 @@ public:
 
 		if (error != nullptr) {
 			/* Could not resample, try using the original data as-is without resampling instead. */
-			Debug(misc, 0, "Failed to resample: {}", soxr_strerror(error));
+			Debug(misc, Severity::Critical, "Failed to resample: {}", soxr_strerror(error));
 			data.swap(tmp);
 		} else {
 			sound.rate = play_rate;

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -45,7 +45,7 @@ SpriteCache *AllocateSpriteCache(uint index)
 		/* Add another 1024 items to the 'pool' */
 		uint items = Align(index + 1, 1024);
 
-		Debug(sprite, Severity::Info, "Increasing sprite cache to {} items ({} bytes)", items, items * sizeof(SpriteCache));
+		Debug(Facility::Sprite, Severity::Info, "Increasing sprite cache to {} items ({} bytes)", items, items * sizeof(SpriteCache));
 
 		_spritecache.resize(items);
 	}
@@ -185,7 +185,7 @@ uint GetSpriteCountForFile(const std::string &filename, SpriteID begin, SpriteID
 			SpriteCache *sc = GetSpriteCache(i);
 			if (sc->file == file) {
 				count++;
-				Debug(sprite, Severity::Info, "Sprite: {}", i);
+				Debug(Facility::Sprite, Severity::Info, "Sprite: {}", i);
 			}
 		}
 	}
@@ -463,7 +463,7 @@ static void *ReadSprite(const SpriteCache *sc, SpriteID id, SpriteType sprite_ty
 	assert(IsMapgenSpriteID(id) == (sprite_type == SpriteType::MapGen));
 	assert(sc->type == sprite_type);
 
-	Debug(sprite, Severity::Trace3, "Load sprite {}", id);
+	Debug(Facility::Sprite, Severity::Trace3, "Load sprite {}", id);
 
 	SpriteLoader::SpriteCollection sprite;
 	ZoomLevels sprite_avail;
@@ -753,7 +753,7 @@ static void DeleteEntriesFromSpriteCache(size_t to_remove)
 		GetSpriteCache(it.id)->ClearSpriteData();
 	}
 
-	Debug(sprite, Severity::Notice, "DeleteEntriesFromSpriteCache, deleted: {}, freed: {}, in use: {} --> {}, requested: {}",
+	Debug(Facility::Sprite, Severity::Notice, "DeleteEntriesFromSpriteCache, deleted: {}, freed: {}, in use: {} --> {}, requested: {}",
 			candidates.size(), candidate_bytes, initial_in_use, _spritecache_bytes_used, to_remove);
 }
 
@@ -766,7 +766,7 @@ void IncreaseSpriteLRU()
 	}
 
 	if (_sprite_lru_counter >= 0xC0000000) {
-		Debug(sprite, Severity::Notice, "Fixing lru {}, inuse={}", _sprite_lru_counter, _spritecache_bytes_used);
+		Debug(Facility::Sprite, Severity::Notice, "Fixing lru {}, inuse={}", _sprite_lru_counter, _spritecache_bytes_used);
 
 		for (SpriteCache &sc : _spritecache) {
 			if (sc.ptr != nullptr) {
@@ -822,7 +822,7 @@ static void *HandleInvalidSpriteRequest(SpriteID sprite, SpriteType requested, S
 
 	Severity warning_level = sc->warned ? Severity::Debug2 : Severity::Critical;
 	sc->warned = true;
-	Debug(sprite, warning_level, "Tried to load {} sprite #{} as a {} sprite. Probable cause: NewGRF interference", sprite_types[static_cast<uint8_t>(available)], sprite, sprite_types[static_cast<uint8_t>(requested)]);
+	Debug(Facility::Sprite, warning_level, "Tried to load {} sprite #{} as a {} sprite. Probable cause: NewGRF interference", sprite_types[static_cast<uint8_t>(available)], sprite, sprite_types[static_cast<uint8_t>(requested)]);
 
 	switch (requested) {
 		case SpriteType::Normal:
@@ -856,7 +856,7 @@ void *GetRawSprite(SpriteID sprite, SpriteType type, SpriteAllocator *allocator,
 	assert(type < SpriteType::Invalid);
 
 	if (!SpriteExists(sprite)) {
-		Debug(sprite, Severity::Error, "Tried to load non-existing sprite #{}. Probable cause: Wrong/missing NewGRFs", sprite);
+		Debug(Facility::Sprite, Severity::Error, "Tried to load non-existing sprite #{}. Probable cause: Wrong/missing NewGRFs", sprite);
 
 		/* SPR_IMG_QUERY is a BIG FAT RED ? */
 		sprite = SPR_IMG_QUERY;

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -45,7 +45,7 @@ SpriteCache *AllocateSpriteCache(uint index)
 		/* Add another 1024 items to the 'pool' */
 		uint items = Align(index + 1, 1024);
 
-		Debug(sprite, 4, "Increasing sprite cache to {} items ({} bytes)", items, items * sizeof(SpriteCache));
+		Debug(sprite, Severity::Info, "Increasing sprite cache to {} items ({} bytes)", items, items * sizeof(SpriteCache));
 
 		_spritecache.resize(items);
 	}
@@ -185,7 +185,7 @@ uint GetSpriteCountForFile(const std::string &filename, SpriteID begin, SpriteID
 			SpriteCache *sc = GetSpriteCache(i);
 			if (sc->file == file) {
 				count++;
-				Debug(sprite, 4, "Sprite: {}", i);
+				Debug(sprite, Severity::Info, "Sprite: {}", i);
 			}
 		}
 	}
@@ -463,7 +463,7 @@ static void *ReadSprite(const SpriteCache *sc, SpriteID id, SpriteType sprite_ty
 	assert(IsMapgenSpriteID(id) == (sprite_type == SpriteType::MapGen));
 	assert(sc->type == sprite_type);
 
-	Debug(sprite, 9, "Load sprite {}", id);
+	Debug(sprite, Severity::Trace3, "Load sprite {}", id);
 
 	SpriteLoader::SpriteCollection sprite;
 	ZoomLevels sprite_avail;
@@ -753,7 +753,7 @@ static void DeleteEntriesFromSpriteCache(size_t to_remove)
 		GetSpriteCache(it.id)->ClearSpriteData();
 	}
 
-	Debug(sprite, 3, "DeleteEntriesFromSpriteCache, deleted: {}, freed: {}, in use: {} --> {}, requested: {}",
+	Debug(sprite, Severity::Notice, "DeleteEntriesFromSpriteCache, deleted: {}, freed: {}, in use: {} --> {}, requested: {}",
 			candidates.size(), candidate_bytes, initial_in_use, _spritecache_bytes_used, to_remove);
 }
 
@@ -766,7 +766,7 @@ void IncreaseSpriteLRU()
 	}
 
 	if (_sprite_lru_counter >= 0xC0000000) {
-		Debug(sprite, 3, "Fixing lru {}, inuse={}", _sprite_lru_counter, _spritecache_bytes_used);
+		Debug(sprite, Severity::Notice, "Fixing lru {}, inuse={}", _sprite_lru_counter, _spritecache_bytes_used);
 
 		for (SpriteCache &sc : _spritecache) {
 			if (sc.ptr != nullptr) {
@@ -820,7 +820,7 @@ static void *HandleInvalidSpriteRequest(SpriteID sprite, SpriteType requested, S
 		return GetRawSprite(sprite, sc->type, allocator, encoder);
 	}
 
-	uint8_t warning_level = sc->warned ? 6 : 0;
+	Severity warning_level = sc->warned ? Severity::Debug2 : Severity::Critical;
 	sc->warned = true;
 	Debug(sprite, warning_level, "Tried to load {} sprite #{} as a {} sprite. Probable cause: NewGRF interference", sprite_types[static_cast<uint8_t>(available)], sprite, sprite_types[static_cast<uint8_t>(requested)]);
 
@@ -856,7 +856,7 @@ void *GetRawSprite(SpriteID sprite, SpriteType type, SpriteAllocator *allocator,
 	assert(type < SpriteType::Invalid);
 
 	if (!SpriteExists(sprite)) {
-		Debug(sprite, 1, "Tried to load non-existing sprite #{}. Probable cause: Wrong/missing NewGRFs", sprite);
+		Debug(sprite, Severity::Error, "Tried to load non-existing sprite #{}. Probable cause: Wrong/missing NewGRFs", sprite);
 
 		/* SPR_IMG_QUERY is a BIG FAT RED ? */
 		sprite = SPR_IMG_QUERY;

--- a/src/spriteloader/grf.cpp
+++ b/src/spriteloader/grf.cpp
@@ -32,12 +32,12 @@ extern const uint8_t _palmap_w2d[];
  */
 static bool WarnCorruptSprite(const SpriteFile &file, size_t file_pos, int line)
 {
-	static Severity warning_level = Severity::Critical;
-	if (warning_level == Severity::Critical) {
+	static Severity severity = Severity::Critical;
+	if (severity == Severity::Critical) {
 		ShowErrorMessage(GetEncodedString(STR_NEWGRF_ERROR_CORRUPT_SPRITE, file.GetSimplifiedFilename()), {}, WarningLevel::Error);
 	}
-	Debug(Facility::Sprite, warning_level, "[{}] Loading corrupted sprite from {} at position {}", line, file.GetSimplifiedFilename(), file_pos);
-	warning_level = Severity::Debug2;
+	Debug(Facility::Sprite, severity, "[{}] Loading corrupted sprite from {} at position {}", line, file.GetSimplifiedFilename(), file_pos);
+	severity = Severity::Debug2;
 	return false;
 }
 
@@ -180,9 +180,9 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 		}
 
 		if (dest_size > sprite_size) {
-			static Severity warning_level = Severity::Critical;
-			Debug(Facility::Sprite, warning_level, "Ignoring {} unused extra bytes from the sprite from {} at position {}", dest_size - sprite_size, file.GetSimplifiedFilename(), file_pos);
-			warning_level = Severity::Debug2;
+			static Severity severity = Severity::Critical;
+			Debug(Facility::Sprite, severity, "Ignoring {} unused extra bytes from the sprite from {} at position {}", dest_size - sprite_size, file.GetSimplifiedFilename(), file_pos);
+			severity = Severity::Debug2;
 		}
 
 		dest = dest_orig.get();

--- a/src/spriteloader/grf.cpp
+++ b/src/spriteloader/grf.cpp
@@ -32,12 +32,12 @@ extern const uint8_t _palmap_w2d[];
  */
 static bool WarnCorruptSprite(const SpriteFile &file, size_t file_pos, int line)
 {
-	static uint8_t warning_level = 0;
-	if (warning_level == 0) {
+	static Severity warning_level = Severity::Critical;
+	if (warning_level == Severity::Critical) {
 		ShowErrorMessage(GetEncodedString(STR_NEWGRF_ERROR_CORRUPT_SPRITE, file.GetSimplifiedFilename()), {}, WarningLevel::Error);
 	}
 	Debug(sprite, warning_level, "[{}] Loading corrupted sprite from {} at position {}", line, file.GetSimplifiedFilename(), file_pos);
-	warning_level = 6;
+	warning_level = Severity::Debug2;
 	return false;
 }
 
@@ -180,9 +180,9 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 		}
 
 		if (dest_size > sprite_size) {
-			static uint8_t warning_level = 0;
+			static Severity warning_level = Severity::Critical;
 			Debug(sprite, warning_level, "Ignoring {} unused extra bytes from the sprite from {} at position {}", dest_size - sprite_size, file.GetSimplifiedFilename(), file_pos);
-			warning_level = 6;
+			warning_level = Severity::Debug2;
 		}
 
 		dest = dest_orig.get();
@@ -311,7 +311,7 @@ static ZoomLevels LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFil
 
 			if (loaded_sprites.Test(zoom_lvl)) {
 				/* We already have this zoom level, skip sprite. */
-				Debug(sprite, 1, "Ignoring duplicate zoom level sprite {} from {}", id, file.GetSimplifiedFilename());
+				Debug(sprite, Severity::Error, "Ignoring duplicate zoom level sprite {} from {}", id, file.GetSimplifiedFilename());
 				file.SkipBytes(num - 2);
 				continue;
 			}

--- a/src/spriteloader/grf.cpp
+++ b/src/spriteloader/grf.cpp
@@ -36,7 +36,7 @@ static bool WarnCorruptSprite(const SpriteFile &file, size_t file_pos, int line)
 	if (warning_level == Severity::Critical) {
 		ShowErrorMessage(GetEncodedString(STR_NEWGRF_ERROR_CORRUPT_SPRITE, file.GetSimplifiedFilename()), {}, WarningLevel::Error);
 	}
-	Debug(sprite, warning_level, "[{}] Loading corrupted sprite from {} at position {}", line, file.GetSimplifiedFilename(), file_pos);
+	Debug(Facility::Sprite, warning_level, "[{}] Loading corrupted sprite from {} at position {}", line, file.GetSimplifiedFilename(), file_pos);
 	warning_level = Severity::Debug2;
 	return false;
 }
@@ -181,7 +181,7 @@ bool DecodeSingleSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t f
 
 		if (dest_size > sprite_size) {
 			static Severity warning_level = Severity::Critical;
-			Debug(sprite, warning_level, "Ignoring {} unused extra bytes from the sprite from {} at position {}", dest_size - sprite_size, file.GetSimplifiedFilename(), file_pos);
+			Debug(Facility::Sprite, warning_level, "Ignoring {} unused extra bytes from the sprite from {} at position {}", dest_size - sprite_size, file.GetSimplifiedFilename(), file_pos);
 			warning_level = Severity::Debug2;
 		}
 
@@ -311,7 +311,7 @@ static ZoomLevels LoadSpriteV2(SpriteLoader::SpriteCollection &sprite, SpriteFil
 
 			if (loaded_sprites.Test(zoom_lvl)) {
 				/* We already have this zoom level, skip sprite. */
-				Debug(sprite, Severity::Error, "Ignoring duplicate zoom level sprite {} from {}", id, file.GetSimplifiedFilename());
+				Debug(Facility::Sprite, Severity::Error, "Ignoring duplicate zoom level sprite {} from {}", id, file.GetSimplifiedFilename());
 				file.SkipBytes(num - 2);
 				continue;
 			}

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4261,7 +4261,7 @@ void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint
 				ge2.link_graph = lg->index;
 				ge2.node = lg->AddNode(st2);
 			} else {
-				Debug(misc, 0, "Can't allocate link graph");
+				Debug(misc, Severity::Critical, "Can't allocate link graph");
 			}
 		} else {
 			lg = LinkGraph::Get(ge2.link_graph);
@@ -4411,7 +4411,7 @@ static uint UpdateStationWaiting(Station *st, CargoType cargo, uint amount, Sour
 			ge.link_graph = lg->index;
 			ge.node = lg->AddNode(st);
 		} else {
-			Debug(misc, 0, "Can't allocate link graph");
+			Debug(misc, Severity::Critical, "Can't allocate link graph");
 		}
 	} else {
 		lg = LinkGraph::Get(ge.link_graph);
@@ -4698,7 +4698,7 @@ void UpdateStationDockingTiles(Station *st)
 void BuildOilRig(TileIndex tile)
 {
 	if (!Station::CanAllocateItem()) {
-		Debug(misc, 0, "Can't allocate station for oilrig at 0x{:X}, reverting to oilrig only", tile);
+		Debug(misc, Severity::Critical, "Can't allocate station for oilrig at 0x{:X}, reverting to oilrig only", tile);
 		return;
 	}
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4261,7 +4261,7 @@ void IncreaseStats(Station *st, CargoType cargo, StationID next_station_id, uint
 				ge2.link_graph = lg->index;
 				ge2.node = lg->AddNode(st2);
 			} else {
-				Debug(misc, Severity::Critical, "Can't allocate link graph");
+				Debug(Facility::Misc, Severity::Critical, "Can't allocate link graph");
 			}
 		} else {
 			lg = LinkGraph::Get(ge2.link_graph);
@@ -4411,7 +4411,7 @@ static uint UpdateStationWaiting(Station *st, CargoType cargo, uint amount, Sour
 			ge.link_graph = lg->index;
 			ge.node = lg->AddNode(st);
 		} else {
-			Debug(misc, Severity::Critical, "Can't allocate link graph");
+			Debug(Facility::Misc, Severity::Critical, "Can't allocate link graph");
 		}
 	} else {
 		lg = LinkGraph::Get(ge.link_graph);
@@ -4698,7 +4698,7 @@ void UpdateStationDockingTiles(Station *st)
 void BuildOilRig(TileIndex tile)
 {
 	if (!Station::CanAllocateItem()) {
-		Debug(misc, Severity::Critical, "Can't allocate station for oilrig at 0x{:X}, reverting to oilrig only", tile);
+		Debug(Facility::Misc, Severity::Critical, "Can't allocate station for oilrig at 0x{:X}, reverting to oilrig only", tile);
 		return;
 	}
 

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -308,7 +308,7 @@ protected:
 	{
 		if (!this->stations.NeedRebuild()) return;
 
-		Debug(misc, 3, "Building station list for company {}", owner);
+		Debug(misc, Severity::Notice, "Building station list for company {}", owner);
 
 		this->stations.clear();
 		this->stations_per_cargo_type.fill(0);
@@ -738,7 +738,7 @@ public:
 	void OnGameTick() override
 	{
 		if (this->stations.NeedResort()) {
-			Debug(misc, 3, "Periodic rebuild station list company {}", static_cast<int>(this->window_number));
+			Debug(misc, Severity::Notice, "Periodic rebuild station list company {}", static_cast<int>(this->window_number));
 			this->SetDirty();
 		}
 	}

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -308,7 +308,7 @@ protected:
 	{
 		if (!this->stations.NeedRebuild()) return;
 
-		Debug(misc, Severity::Notice, "Building station list for company {}", owner);
+		Debug(Facility::Misc, Severity::Notice, "Building station list for company {}", owner);
 
 		this->stations.clear();
 		this->stations_per_cargo_type.fill(0);
@@ -738,7 +738,7 @@ public:
 	void OnGameTick() override
 	{
 		if (this->stations.NeedResort()) {
-			Debug(misc, Severity::Notice, "Periodic rebuild station list company {}", static_cast<int>(this->window_number));
+			Debug(Facility::Misc, Severity::Notice, "Periodic rebuild station list company {}", static_cast<int>(this->window_number));
 			this->SetDirty();
 		}
 	}

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -60,7 +60,7 @@ void strecpy(std::span<char> dst, std::string_view src)
 #if defined(STRGEN) || defined(SETTINGSGEN)
 		FatalError("String too long for destination buffer");
 #else /* STRGEN || SETTINGSGEN */
-		Debug(misc, 0, "String too long for destination buffer");
+		Debug(misc, Severity::Critical, "String too long for destination buffer");
 		src = src.substr(0, std::size(dst) - 1U);
 #endif /* STRGEN || SETTINGSGEN */
 	}

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -60,7 +60,7 @@ void strecpy(std::span<char> dst, std::string_view src)
 #if defined(STRGEN) || defined(SETTINGSGEN)
 		FatalError("String too long for destination buffer");
 #else /* STRGEN || SETTINGSGEN */
-		Debug(misc, Severity::Critical, "String too long for destination buffer");
+		Debug(Facility::Misc, Severity::Critical, "String too long for destination buffer");
 		src = src.substr(0, std::size(dst) - 1U);
 #endif /* STRGEN || SETTINGSGEN */
 	}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -349,7 +349,7 @@ void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters
 				try {
 					GenerateTownNameString(builder, (string - SPECSTR_TOWNNAME_START).base(), args.GetNextParameter<uint32_t>());
 				} catch (const std::runtime_error &e) {
-					Debug(misc, Severity::Critical, "GetStringWithArgs: {}", e.what());
+					Debug(Facility::Misc, Severity::Critical, "GetStringWithArgs: {}", e.what());
 					builder += "(invalid string parameter)";
 				}
 				return;
@@ -361,7 +361,7 @@ void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters
 				try {
 					if (GetSpecialNameString(builder, string, args)) return;
 				} catch (const std::runtime_error &e) {
-					Debug(misc, Severity::Critical, "GetStringWithArgs: {}", e.what());
+					Debug(Facility::Misc, Severity::Critical, "GetStringWithArgs: {}", e.what());
 					builder += "(invalid string parameter)";
 					return;
 				}
@@ -1862,7 +1862,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 					break;
 			}
 		} catch (std::out_of_range &e) {
-			Debug(misc, Severity::Critical, "FormatString: {}", e.what());
+			Debug(Facility::Misc, Severity::Critical, "FormatString: {}", e.what());
 			builder += "(invalid parameter)";
 		}
 	}
@@ -2232,15 +2232,15 @@ static void FillLanguageList(const std::string &path)
 		/* Check whether the file is of the correct version */
 		std::string file = FS2OTTD(lmd.file.native());
 		if (!GetLanguageFileHeader(file, &lmd)) {
-			Debug(misc, Severity::Notice, "{} is not a valid language file", file);
+			Debug(Facility::Misc, Severity::Notice, "{} is not a valid language file", file);
 		} else if (GetLanguage(lmd.newgrflangid) != nullptr) {
-			Debug(misc, Severity::Notice, "{}'s language ID is already known", file);
+			Debug(Facility::Misc, Severity::Notice, "{}'s language ID is already known", file);
 		} else {
 			_languages.push_back(std::move(lmd));
 		}
 	}
 	if (error_code) {
-		Debug(misc, Severity::Trace3, "Unable to open directory {}: {}", path, error_code.message());
+		Debug(Facility::Misc, Severity::Trace3, "Unable to open directory {}: {}", path, error_code.message());
 	}
 }
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -349,7 +349,7 @@ void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters
 				try {
 					GenerateTownNameString(builder, (string - SPECSTR_TOWNNAME_START).base(), args.GetNextParameter<uint32_t>());
 				} catch (const std::runtime_error &e) {
-					Debug(misc, 0, "GetStringWithArgs: {}", e.what());
+					Debug(misc, Severity::Critical, "GetStringWithArgs: {}", e.what());
 					builder += "(invalid string parameter)";
 				}
 				return;
@@ -361,7 +361,7 @@ void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters
 				try {
 					if (GetSpecialNameString(builder, string, args)) return;
 				} catch (const std::runtime_error &e) {
-					Debug(misc, 0, "GetStringWithArgs: {}", e.what());
+					Debug(misc, Severity::Critical, "GetStringWithArgs: {}", e.what());
 					builder += "(invalid string parameter)";
 					return;
 				}
@@ -1862,7 +1862,7 @@ static void FormatString(StringBuilder &builder, std::string_view str_arg, Strin
 					break;
 			}
 		} catch (std::out_of_range &e) {
-			Debug(misc, 0, "FormatString: {}", e.what());
+			Debug(misc, Severity::Critical, "FormatString: {}", e.what());
 			builder += "(invalid parameter)";
 		}
 	}
@@ -2232,15 +2232,15 @@ static void FillLanguageList(const std::string &path)
 		/* Check whether the file is of the correct version */
 		std::string file = FS2OTTD(lmd.file.native());
 		if (!GetLanguageFileHeader(file, &lmd)) {
-			Debug(misc, 3, "{} is not a valid language file", file);
+			Debug(misc, Severity::Notice, "{} is not a valid language file", file);
 		} else if (GetLanguage(lmd.newgrflangid) != nullptr) {
-			Debug(misc, 3, "{}'s language ID is already known", file);
+			Debug(misc, Severity::Notice, "{}'s language ID is already known", file);
 		} else {
 			_languages.push_back(std::move(lmd));
 		}
 	}
 	if (error_code) {
-		Debug(misc, 9, "Unable to open directory {}: {}", path, error_code.message());
+		Debug(misc, Severity::Trace3, "Unable to open directory {}: {}", path, error_code.message());
 	}
 }
 

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -297,7 +297,7 @@ const TextfileWindow::Hyperlink *TextfileWindow::GetHyperlink(Point pt) const
 
 	size_t line_index = it - this->lines.cbegin();
 	size_t subline = clicked_row - (visible_line - it->num_lines);
-	Debug(misc, Severity::Info, "TextfileWindow check hyperlink: clicked_row={}, line_index={}, line.top={}, subline={}", clicked_row, line_index, visible_line - it->num_lines, subline);
+	Debug(Facility::Misc, Severity::Info, "TextfileWindow check hyperlink: clicked_row={}, line_index={}, line.top={}, subline={}", clicked_row, line_index, visible_line - it->num_lines, subline);
 
 	/* Find hyperlinks in this line. */
 	std::vector<const Hyperlink *> found_links;
@@ -312,13 +312,13 @@ const TextfileWindow::Hyperlink *TextfileWindow::GetHyperlink(Point pt) const
 	assert(subline < layout.size());
 	ptrdiff_t char_index = layout.GetCharAtPosition(pt.x - WidgetDimensions::scaled.frametext.left, subline);
 	if (char_index < 0) return nullptr;
-	Debug(misc, Severity::Info, "TextfileWindow check hyperlink click: line={}, subline={}, char_index={}", line_index, subline, char_index);
+	Debug(Facility::Misc, Severity::Info, "TextfileWindow check hyperlink click: line={}, subline={}, char_index={}", line_index, subline, char_index);
 
 	/* Found character index in line, check if any links are at that position. */
 	for (const Hyperlink *link : found_links) {
-		Debug(misc, Severity::Info, "Checking link from char {} to {}", link->begin, link->end);
+		Debug(Facility::Misc, Severity::Info, "Checking link from char {} to {}", link->begin, link->end);
 		if (static_cast<size_t>(char_index) >= link->begin && static_cast<size_t>(char_index) < link->end) {
-			Debug(misc, Severity::Info, "Returning link with destination: {}", link->destination);
+			Debug(Facility::Misc, Severity::Info, "Returning link with destination: {}", link->destination);
 			return link;
 		}
 	}

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -297,7 +297,7 @@ const TextfileWindow::Hyperlink *TextfileWindow::GetHyperlink(Point pt) const
 
 	size_t line_index = it - this->lines.cbegin();
 	size_t subline = clicked_row - (visible_line - it->num_lines);
-	Debug(misc, 4, "TextfileWindow check hyperlink: clicked_row={}, line_index={}, line.top={}, subline={}", clicked_row, line_index, visible_line - it->num_lines, subline);
+	Debug(misc, Severity::Info, "TextfileWindow check hyperlink: clicked_row={}, line_index={}, line.top={}, subline={}", clicked_row, line_index, visible_line - it->num_lines, subline);
 
 	/* Find hyperlinks in this line. */
 	std::vector<const Hyperlink *> found_links;
@@ -312,13 +312,13 @@ const TextfileWindow::Hyperlink *TextfileWindow::GetHyperlink(Point pt) const
 	assert(subline < layout.size());
 	ptrdiff_t char_index = layout.GetCharAtPosition(pt.x - WidgetDimensions::scaled.frametext.left, subline);
 	if (char_index < 0) return nullptr;
-	Debug(misc, 4, "TextfileWindow check hyperlink click: line={}, subline={}, char_index={}", line_index, subline, char_index);
+	Debug(misc, Severity::Info, "TextfileWindow check hyperlink click: line={}, subline={}, char_index={}", line_index, subline, char_index);
 
 	/* Found character index in line, check if any links are at that position. */
 	for (const Hyperlink *link : found_links) {
-		Debug(misc, 4, "Checking link from char {} to {}", link->begin, link->end);
+		Debug(misc, Severity::Info, "Checking link from char {} to {}", link->begin, link->end);
 		if (static_cast<size_t>(char_index) >= link->begin && static_cast<size_t>(char_index) < link->end) {
-			Debug(misc, 4, "Returning link with destination: {}", link->destination);
+			Debug(misc, Severity::Info, "Returning link with destination: {}", link->destination);
 			return link;
 		}
 	}

--- a/src/thread.h
+++ b/src/thread.h
@@ -79,7 +79,7 @@ inline bool StartNewThread(std::thread *thr, std::string_view name, TFn&& _Fx, T
 		return true;
 	} catch (const std::system_error &e) {
 		/* Something went wrong, the system we are running on might not support threads. */
-		Debug(misc, 1, "Can't create thread '{}': {}", name, e.what());
+		Debug(misc, Severity::Error, "Can't create thread '{}': {}", name, e.what());
 	}
 
 	return false;

--- a/src/thread.h
+++ b/src/thread.h
@@ -79,7 +79,7 @@ inline bool StartNewThread(std::thread *thr, std::string_view name, TFn&& _Fx, T
 		return true;
 	} catch (const std::system_error &e) {
 		/* Something went wrong, the system we are running on might not support threads. */
-		Debug(misc, Severity::Error, "Can't create thread '{}': {}", name, e.what());
+		Debug(Facility::Misc, Severity::Error, "Can't create thread '{}': {}", name, e.what());
 	}
 
 	return false;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -351,9 +351,9 @@ void ShowNewGrfVehicleError(EngineID engine, StringID part1, StringID part2, GRF
 	}
 
 	/* debug output */
-	Debug(grf, 0, "{}", StrMakeValid(GetString(part1, grfconfig->GetName())));
+	Debug(grf, Severity::Critical, "{}", StrMakeValid(GetString(part1, grfconfig->GetName())));
 
-	Debug(grf, 0, "{}", StrMakeValid(GetString(part2, std::monostate{}, engine)));
+	Debug(grf, Severity::Critical, "{}", StrMakeValid(GetString(part2, std::monostate{}, engine)));
 }
 
 /**
@@ -2358,7 +2358,7 @@ void Vehicle::CancelReservation(StationID next, Station *st)
 	for (Vehicle *v = this; v != nullptr; v = v->next) {
 		VehicleCargoList &cargo = v->cargo;
 		if (cargo.ActionCount(VehicleCargoList::MoveToAction::Load) > 0) {
-			Debug(misc, 1, "cancelling cargo reservation");
+			Debug(misc, Severity::Error, "cancelling cargo reservation");
 			cargo.Return(UINT_MAX, &st->goods[v->cargo_type].GetOrCreateData().cargo, next, v->tile);
 		}
 		cargo.KeepAll();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -351,9 +351,9 @@ void ShowNewGrfVehicleError(EngineID engine, StringID part1, StringID part2, GRF
 	}
 
 	/* debug output */
-	Debug(grf, Severity::Critical, "{}", StrMakeValid(GetString(part1, grfconfig->GetName())));
+	Debug(Facility::Grf, Severity::Critical, "{}", StrMakeValid(GetString(part1, grfconfig->GetName())));
 
-	Debug(grf, Severity::Critical, "{}", StrMakeValid(GetString(part2, std::monostate{}, engine)));
+	Debug(Facility::Grf, Severity::Critical, "{}", StrMakeValid(GetString(part2, std::monostate{}, engine)));
 }
 
 /**
@@ -2358,7 +2358,7 @@ void Vehicle::CancelReservation(StationID next, Station *st)
 	for (Vehicle *v = this; v != nullptr; v = v->next) {
 		VehicleCargoList &cargo = v->cargo;
 		if (cargo.ActionCount(VehicleCargoList::MoveToAction::Load) > 0) {
-			Debug(misc, Severity::Error, "cancelling cargo reservation");
+			Debug(Facility::Misc, Severity::Error, "cancelling cargo reservation");
 			cargo.Return(UINT_MAX, &st->goods[v->cargo_type].GetOrCreateData().cargo, next, v->tile);
 		}
 		cargo.KeepAll();

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -221,7 +221,7 @@ void BaseVehicleListWindow::BuildVehicleList()
 {
 	if (!this->vehgroups.NeedRebuild()) return;
 
-	Debug(misc, 3, "Building vehicle list type {} for company {} given index {}", this->vli.type, this->vli.company, this->vli.index);
+	Debug(misc, Severity::Notice, "Building vehicle list type {} for company {} given index {}", this->vli.type, this->vli.company, this->vli.index);
 
 	this->vehgroups.clear();
 
@@ -2246,7 +2246,7 @@ public:
 		if (this->vehgroups.NeedResort()) {
 			StationID station = (this->vli.type == VehicleListType::Station) ? this->vli.ToStationID() : StationID::Invalid();
 
-			Debug(misc, 3, "Periodic resort {} list company {} at station {}", this->vli.vtype, this->owner, station);
+			Debug(misc, Severity::Notice, "Periodic resort {} list company {} at station {}", this->vli.vtype, this->owner, station);
 			this->SetDirty();
 		}
 	}

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -221,7 +221,7 @@ void BaseVehicleListWindow::BuildVehicleList()
 {
 	if (!this->vehgroups.NeedRebuild()) return;
 
-	Debug(misc, Severity::Notice, "Building vehicle list type {} for company {} given index {}", this->vli.type, this->vli.company, this->vli.index);
+	Debug(Facility::Misc, Severity::Notice, "Building vehicle list type {} for company {} given index {}", this->vli.type, this->vli.company, this->vli.index);
 
 	this->vehgroups.clear();
 
@@ -2246,7 +2246,7 @@ public:
 		if (this->vehgroups.NeedResort()) {
 			StationID station = (this->vli.type == VehicleListType::Station) ? this->vli.ToStationID() : StationID::Invalid();
 
-			Debug(misc, Severity::Notice, "Periodic resort {} list company {} at station {}", this->vli.vtype, this->owner, station);
+			Debug(Facility::Misc, Severity::Notice, "Periodic resort {} list company {} at station {}", this->vli.vtype, this->owner, station);
 			this->SetDirty();
 		}
 	}

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -190,7 +190,7 @@ static bool CreateMainSurface(uint w, uint h)
 
 	GetAvailableVideoMode(&w, &h);
 	if (set_gfx_mode(_fullscreen ? GFX_AUTODETECT_FULLSCREEN : GFX_AUTODETECT_WINDOWED, w, h, 0, 0) != 0) {
-		Debug(driver, 0, "Allegro: Couldn't allocate a window to draw on '{}'", allegro_error);
+		Debug(driver, Severity::Critical, "Allegro: Couldn't allocate a window to draw on '{}'", allegro_error);
 		return false;
 	}
 
@@ -323,8 +323,8 @@ static uint32_t ConvertAllegroKeyIntoMy(char32_t *character)
 	if (key_shifts & KB_CTRL_FLAG)  key |= WKC_CTRL;
 	if (key_shifts & KB_ALT_FLAG)   key |= WKC_ALT;
 #if 0
-	Debug(driver, 0, "Scancode character pressed {}", scancode);
-	Debug(driver, 0, "Unicode character pressed {}", unicode);
+	Debug(driver, Severity::Critical, "Scancode character pressed {}", scancode);
+	Debug(driver, Severity::Critical, "Unicode character pressed {}", unicode);
 #endif
 
 	*character = unicode;
@@ -421,7 +421,7 @@ int _allegro_instance_count = 0;
 std::optional<std::string_view> VideoDriver_Allegro::Start(const StringList &param)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
-		Debug(driver, 0, "allegro: install_allegro failed '{}'", allegro_error);
+		Debug(driver, Severity::Critical, "allegro: install_allegro failed '{}'", allegro_error);
 		return "Failed to set up Allegro";
 	}
 	_allegro_instance_count++;

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -190,7 +190,7 @@ static bool CreateMainSurface(uint w, uint h)
 
 	GetAvailableVideoMode(&w, &h);
 	if (set_gfx_mode(_fullscreen ? GFX_AUTODETECT_FULLSCREEN : GFX_AUTODETECT_WINDOWED, w, h, 0, 0) != 0) {
-		Debug(driver, Severity::Critical, "Allegro: Couldn't allocate a window to draw on '{}'", allegro_error);
+		Debug(Facility::Driver, Severity::Critical, "Allegro: Couldn't allocate a window to draw on '{}'", allegro_error);
 		return false;
 	}
 
@@ -323,8 +323,8 @@ static uint32_t ConvertAllegroKeyIntoMy(char32_t *character)
 	if (key_shifts & KB_CTRL_FLAG)  key |= WKC_CTRL;
 	if (key_shifts & KB_ALT_FLAG)   key |= WKC_ALT;
 #if 0
-	Debug(driver, Severity::Critical, "Scancode character pressed {}", scancode);
-	Debug(driver, Severity::Critical, "Unicode character pressed {}", unicode);
+	Debug(Facility::Driver, Severity::Critical, "Scancode character pressed {}", scancode);
+	Debug(Facility::Driver, Severity::Critical, "Unicode character pressed {}", unicode);
 #endif
 
 	*character = unicode;
@@ -421,7 +421,7 @@ int _allegro_instance_count = 0;
 std::optional<std::string_view> VideoDriver_Allegro::Start(const StringList &param)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
-		Debug(driver, Severity::Critical, "allegro: install_allegro failed '{}'", allegro_error);
+		Debug(Facility::Driver, Severity::Critical, "allegro: install_allegro failed '{}'", allegro_error);
 		return "Failed to set up Allegro";
 	}
 	_allegro_instance_count++;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -359,7 +359,7 @@ bool VideoDriver_Cocoa::MakeWindow(int width, int height)
 	unsigned int style = NSWindowStyleMaskTitled | NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskClosable;
 	this->window = [ [ OTTD_CocoaWindow alloc ] initWithContentRect:contentRect styleMask:style backing:NSBackingStoreBuffered defer:NO driver:this ];
 	if (this->window == nil) {
-		Debug(driver, Severity::Critical, "Could not create the Cocoa window.");
+		Debug(Facility::Driver, Severity::Critical, "Could not create the Cocoa window.");
 		this->setup = false;
 		return false;
 	}
@@ -387,7 +387,7 @@ bool VideoDriver_Cocoa::MakeWindow(int width, int height)
 	NSRect view_frame = [ this->window contentRectForFrameRect:[ this->window frame ] ];
 	this->cocoaview = [ [ OTTD_CocoaView alloc ] initWithFrame:view_frame ];
 	if (this->cocoaview == nil) {
-		Debug(driver, Severity::Critical, "Could not create the event wrapper view.");
+		Debug(Facility::Driver, Severity::Critical, "Could not create the event wrapper view.");
 		this->setup = false;
 		return false;
 	}
@@ -396,7 +396,7 @@ bool VideoDriver_Cocoa::MakeWindow(int width, int height)
 	/* Create content view. */
 	NSView *draw_view = this->AllocateDrawView();
 	if (draw_view == nil) {
-		Debug(driver, Severity::Critical, "Could not create the drawing view.");
+		Debug(Facility::Driver, Severity::Critical, "Could not create the drawing view.");
 		this->setup = false;
 		return false;
 	}

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -359,7 +359,7 @@ bool VideoDriver_Cocoa::MakeWindow(int width, int height)
 	unsigned int style = NSWindowStyleMaskTitled | NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskClosable;
 	this->window = [ [ OTTD_CocoaWindow alloc ] initWithContentRect:contentRect styleMask:style backing:NSBackingStoreBuffered defer:NO driver:this ];
 	if (this->window == nil) {
-		Debug(driver, 0, "Could not create the Cocoa window.");
+		Debug(driver, Severity::Critical, "Could not create the Cocoa window.");
 		this->setup = false;
 		return false;
 	}
@@ -387,7 +387,7 @@ bool VideoDriver_Cocoa::MakeWindow(int width, int height)
 	NSRect view_frame = [ this->window contentRectForFrameRect:[ this->window frame ] ];
 	this->cocoaview = [ [ OTTD_CocoaView alloc ] initWithFrame:view_frame ];
 	if (this->cocoaview == nil) {
-		Debug(driver, 0, "Could not create the event wrapper view.");
+		Debug(driver, Severity::Critical, "Could not create the event wrapper view.");
 		this->setup = false;
 		return false;
 	}
@@ -396,7 +396,7 @@ bool VideoDriver_Cocoa::MakeWindow(int width, int height)
 	/* Create content view. */
 	NSView *draw_view = this->AllocateDrawView();
 	if (draw_view == nil) {
-		Debug(driver, 0, "Could not create the drawing view.");
+		Debug(driver, Severity::Critical, "Could not create the drawing view.");
 		this->setup = false;
 		return false;
 	}

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -340,7 +340,7 @@ bool CocoaSetupApplication()
 
 	/* Tell the dock about us */
 	OSStatus returnCode = TransformProcessType(&psn, kProcessTransformToForegroundApplication);
-	if (returnCode != 0) Debug(driver, 0, "Could not change to foreground application. Error {}", (int)returnCode);
+	if (returnCode != 0) Debug(driver, Severity::Critical, "Could not change to foreground application. Error {}", (int)returnCode);
 
 	/* Disable the system-wide tab feature as we only have one window. */
 	if ([ NSWindow respondsToSelector:@selector(setAllowsAutomaticWindowTabbing:) ]) {
@@ -911,9 +911,9 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 		if (!EditBoxInGlobalFocus() || IsInsideMM(pressed_key & ~WKC_SPECIAL_KEYS, WKC_F1, WKC_PAUSE + 1)) {
 			HandleKeypress(pressed_key, unicode);
 		}
-		Debug(driver, 3, "cocoa_v: QZ_KeyEvent: {:x} ({:x}), down, mapping: {:x}", keycode, (int)unicode, pressed_key);
+		Debug(driver, Severity::Notice, "cocoa_v: QZ_KeyEvent: {:x} ({:x}), down, mapping: {:x}", keycode, (int)unicode, pressed_key);
 	} else {
-		Debug(driver, 3, "cocoa_v: QZ_KeyEvent: {:x} ({:x}), up", keycode, (int)unicode);
+		Debug(driver, Severity::Notice, "cocoa_v: QZ_KeyEvent: {:x} ({:x}), up", keycode, (int)unicode);
 	}
 
 	return interpret_keys;

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -340,7 +340,7 @@ bool CocoaSetupApplication()
 
 	/* Tell the dock about us */
 	OSStatus returnCode = TransformProcessType(&psn, kProcessTransformToForegroundApplication);
-	if (returnCode != 0) Debug(driver, Severity::Critical, "Could not change to foreground application. Error {}", (int)returnCode);
+	if (returnCode != 0) Debug(Facility::Driver, Severity::Critical, "Could not change to foreground application. Error {}", (int)returnCode);
 
 	/* Disable the system-wide tab feature as we only have one window. */
 	if ([ NSWindow respondsToSelector:@selector(setAllowsAutomaticWindowTabbing:) ]) {
@@ -911,9 +911,9 @@ void CocoaDialog(std::string_view title, std::string_view message, std::string_v
 		if (!EditBoxInGlobalFocus() || IsInsideMM(pressed_key & ~WKC_SPECIAL_KEYS, WKC_F1, WKC_PAUSE + 1)) {
 			HandleKeypress(pressed_key, unicode);
 		}
-		Debug(driver, Severity::Notice, "cocoa_v: QZ_KeyEvent: {:x} ({:x}), down, mapping: {:x}", keycode, (int)unicode, pressed_key);
+		Debug(Facility::Driver, Severity::Notice, "cocoa_v: QZ_KeyEvent: {:x} ({:x}), down, mapping: {:x}", keycode, (int)unicode, pressed_key);
 	} else {
-		Debug(driver, Severity::Notice, "cocoa_v: QZ_KeyEvent: {:x} ({:x}), up", keycode, (int)unicode);
+		Debug(Facility::Driver, Severity::Notice, "cocoa_v: QZ_KeyEvent: {:x} ({:x}), up", keycode, (int)unicode);
 	}
 
 	return interpret_keys;

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -78,7 +78,7 @@ static void CreateWindowsConsoleThread()
 	_hThread = CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)CheckForConsoleInput, nullptr, 0, &dwThreadId);
 	if (_hThread == nullptr) UserError("Cannot create console thread!");
 
-	Debug(driver, Severity::Warning, "Windows console thread started");
+	Debug(Facility::Driver, Severity::Warning, "Windows console thread started");
 }
 
 static void CloseWindowsConsoleThread()
@@ -86,7 +86,7 @@ static void CloseWindowsConsoleThread()
 	CloseHandle(_hThread);
 	CloseHandle(_hInputReady);
 	CloseHandle(_hWaitForInputHandling);
-	Debug(driver, Severity::Warning, "Windows console thread shut down");
+	Debug(Facility::Driver, Severity::Warning, "Windows console thread shut down");
 }
 
 #endif
@@ -131,7 +131,7 @@ std::optional<std::string_view> VideoDriver_Dedicated::Start(const StringList &)
 	_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif
 
-	Debug(driver, Severity::Error, "Loading dedicated server");
+	Debug(Facility::Driver, Severity::Error, "Loading dedicated server");
 	return std::nullopt;
 }
 

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -78,7 +78,7 @@ static void CreateWindowsConsoleThread()
 	_hThread = CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)CheckForConsoleInput, nullptr, 0, &dwThreadId);
 	if (_hThread == nullptr) UserError("Cannot create console thread!");
 
-	Debug(driver, 2, "Windows console thread started");
+	Debug(driver, Severity::Warning, "Windows console thread started");
 }
 
 static void CloseWindowsConsoleThread()
@@ -86,7 +86,7 @@ static void CloseWindowsConsoleThread()
 	CloseHandle(_hThread);
 	CloseHandle(_hInputReady);
 	CloseHandle(_hWaitForInputHandling);
-	Debug(driver, 2, "Windows console thread shut down");
+	Debug(driver, Severity::Warning, "Windows console thread shut down");
 }
 
 #endif
@@ -131,7 +131,7 @@ std::optional<std::string_view> VideoDriver_Dedicated::Start(const StringList &)
 	_CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif
 
-	Debug(driver, 1, "Loading dedicated server");
+	Debug(driver, Severity::Error, "Loading dedicated server");
 	return std::nullopt;
 }
 

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -37,7 +37,7 @@ std::optional<std::string_view> VideoDriver_Null::Start(const StringList &parm)
 	ScreenSizeChanged();
 
 	/* Do not render, nor blit */
-	Debug(misc, 1, "Forcing blitter 'null'...");
+	Debug(misc, Severity::Error, "Forcing blitter 'null'...");
 	BlitterFactory::SelectBlitter("null");
 	return std::nullopt;
 }

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -37,7 +37,7 @@ std::optional<std::string_view> VideoDriver_Null::Start(const StringList &parm)
 	ScreenSizeChanged();
 
 	/* Do not render, nor blit */
-	Debug(misc, Severity::Error, "Forcing blitter 'null'...");
+	Debug(Facility::Misc, Severity::Error, "Forcing blitter 'null'...");
 	BlitterFactory::SelectBlitter("null");
 	return std::nullopt;
 }

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -448,14 +448,14 @@ void APIENTRY DebugOutputCallback(GLenum, GLenum type, GLuint, GLenum severity, 
 		case GL_DEBUG_TYPE_PORTABILITY:         type_str = "Portability"; break;
 	}
 
-	Debug(driver, 6, "OpenGL: {} ({}) - {}", type_str, severity_str, message);
+	Debug(driver, Severity::Debug2, "OpenGL: {} ({}) - {}", type_str, severity_str, message);
 }
 
 /** Enable OpenGL debug messages if supported. */
 void SetupDebugOutput()
 {
 #ifndef NO_DEBUG_MESSAGES
-	if (_debug_driver_level < 6) return;
+	if (_debug_driver_level < Severity::Debug2) return;
 
 	if (IsOpenGLVersionAtLeast(4, 3)) {
 		BindGLProc(_glDebugMessageControl, "glDebugMessageControl");
@@ -468,11 +468,11 @@ void SetupDebugOutput()
 	if (_glDebugMessageControl != nullptr && _glDebugMessageCallback != nullptr) {
 		/* Enable debug output. As synchronous debug output costs performance, we only enable it with a high debug level. */
 		_glEnable(GL_DEBUG_OUTPUT);
-		if (_debug_driver_level >= 8) _glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+		if (_debug_driver_level >= Severity::Trace2) _glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
 
 		_glDebugMessageCallback(&DebugOutputCallback, nullptr);
 		/* Enable all messages on highest debug level.*/
-		_glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, _debug_driver_level >= 9 ? GL_TRUE : GL_FALSE);
+		_glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, _debug_driver_level >= Severity::Trace3 ? GL_TRUE : GL_FALSE);
 		/* Get debug messages for errors and undefined/deprecated behaviour. */
 		_glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_ERROR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
 		_glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
@@ -564,7 +564,7 @@ std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 
 	if (!ver.has_value() || !vend.has_value() || !renderer.has_value()) return "OpenGL not supported";
 
-	Debug(driver, 1, "OpenGL driver: {} - {} ({})", *vend, *renderer, *ver);
+	Debug(driver, Severity::Error, "OpenGL driver: {} - {} ({})", *vend, *renderer, *ver);
 
 #ifndef GL_ALLOW_SOFTWARE_RENDERER
 	/* Don't use MESA software rendering backends as they are slower than
@@ -610,10 +610,10 @@ std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 #endif
 
 	if (this->persistent_mapping_supported && !BindPersistentBufferExtensions()) {
-		Debug(driver, 1, "OpenGL claims to support persistent buffer mapping but doesn't export all functions, not using persistent mapping.");
+		Debug(driver, Severity::Error, "OpenGL claims to support persistent buffer mapping but doesn't export all functions, not using persistent mapping.");
 		this->persistent_mapping_supported = false;
 	}
-	if (this->persistent_mapping_supported) Debug(driver, 3, "OpenGL: Using persistent buffer mapping");
+	if (this->persistent_mapping_supported) Debug(driver, Severity::Notice, "OpenGL: Using persistent buffer mapping");
 
 	/* Check maximum texture size against screen resolution. */
 	GLint max_tex_size = 0;
@@ -625,7 +625,7 @@ std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 	_glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_tex_units);
 	if (max_tex_units < 4) return "Not enough simultaneous textures supported";
 
-	Debug(driver, 2, "OpenGL shading language version: {}, texture units = {}", GlGetString(GL_SHADING_LANGUAGE_VERSION).value_or("Unknown version"), max_tex_units);
+	Debug(driver, Severity::Warning, "OpenGL shading language version: {}, texture units = {}", GlGetString(GL_SHADING_LANGUAGE_VERSION).value_or("Unknown version"), max_tex_units);
 
 	if (!this->InitShaders()) return "Failed to initialize shaders";
 
@@ -795,7 +795,7 @@ static bool VerifyShader(GLuint shader)
 	_glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &log_len);
 	if (log_len > 0) {
 		_glGetShaderInfoLog(shader, log_len, nullptr, log_buf.Allocate(log_len));
-		Debug(driver, result != GL_TRUE ? 0 : 2, "{}", log_buf.GetBuffer()); // Always print on failure.
+		Debug(driver, result != GL_TRUE ? Severity::Critical : Severity::Warning, "{}", log_buf.GetBuffer()); // Always print on failure.
 	}
 
 	return result == GL_TRUE;
@@ -818,7 +818,7 @@ static bool VerifyProgram(GLuint program)
 	_glGetProgramiv(program, GL_INFO_LOG_LENGTH, &log_len);
 	if (log_len > 0) {
 		_glGetProgramInfoLog(program, log_len, nullptr, log_buf.Allocate(log_len));
-		Debug(driver, result != GL_TRUE ? 0 : 2, "{}", log_buf.GetBuffer()); // Always print on failure.
+		Debug(driver, result != GL_TRUE ? Severity::Critical : Severity::Warning, "{}", log_buf.GetBuffer()); // Always print on failure.
 	}
 
 	return result == GL_TRUE;

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -448,14 +448,14 @@ void APIENTRY DebugOutputCallback(GLenum, GLenum type, GLuint, GLenum severity, 
 		case GL_DEBUG_TYPE_PORTABILITY:         type_str = "Portability"; break;
 	}
 
-	Debug(driver, Severity::Debug2, "OpenGL: {} ({}) - {}", type_str, severity_str, message);
+	Debug(Facility::Driver, Severity::Debug2, "OpenGL: {} ({}) - {}", type_str, severity_str, message);
 }
 
 /** Enable OpenGL debug messages if supported. */
 void SetupDebugOutput()
 {
 #ifndef NO_DEBUG_MESSAGES
-	if (_debug_driver_level < Severity::Debug2) return;
+	if (!IsVisibleSeverity(Facility::Driver, Severity::Debug2)) return;
 
 	if (IsOpenGLVersionAtLeast(4, 3)) {
 		BindGLProc(_glDebugMessageControl, "glDebugMessageControl");
@@ -468,11 +468,11 @@ void SetupDebugOutput()
 	if (_glDebugMessageControl != nullptr && _glDebugMessageCallback != nullptr) {
 		/* Enable debug output. As synchronous debug output costs performance, we only enable it with a high debug level. */
 		_glEnable(GL_DEBUG_OUTPUT);
-		if (_debug_driver_level >= Severity::Trace2) _glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+		if (IsVisibleSeverity(Facility::Driver, Severity::Trace2)) _glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
 
 		_glDebugMessageCallback(&DebugOutputCallback, nullptr);
 		/* Enable all messages on highest debug level.*/
-		_glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, _debug_driver_level >= Severity::Trace3 ? GL_TRUE : GL_FALSE);
+		_glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, IsVisibleSeverity(Facility::Driver, Severity::Trace3) ? GL_TRUE : GL_FALSE);
 		/* Get debug messages for errors and undefined/deprecated behaviour. */
 		_glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_ERROR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
 		_glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
@@ -564,7 +564,7 @@ std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 
 	if (!ver.has_value() || !vend.has_value() || !renderer.has_value()) return "OpenGL not supported";
 
-	Debug(driver, Severity::Error, "OpenGL driver: {} - {} ({})", *vend, *renderer, *ver);
+	Debug(Facility::Driver, Severity::Error, "OpenGL driver: {} - {} ({})", *vend, *renderer, *ver);
 
 #ifndef GL_ALLOW_SOFTWARE_RENDERER
 	/* Don't use MESA software rendering backends as they are slower than
@@ -610,10 +610,10 @@ std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 #endif
 
 	if (this->persistent_mapping_supported && !BindPersistentBufferExtensions()) {
-		Debug(driver, Severity::Error, "OpenGL claims to support persistent buffer mapping but doesn't export all functions, not using persistent mapping.");
+		Debug(Facility::Driver, Severity::Error, "OpenGL claims to support persistent buffer mapping but doesn't export all functions, not using persistent mapping.");
 		this->persistent_mapping_supported = false;
 	}
-	if (this->persistent_mapping_supported) Debug(driver, Severity::Notice, "OpenGL: Using persistent buffer mapping");
+	if (this->persistent_mapping_supported) Debug(Facility::Driver, Severity::Notice, "OpenGL: Using persistent buffer mapping");
 
 	/* Check maximum texture size against screen resolution. */
 	GLint max_tex_size = 0;
@@ -625,7 +625,7 @@ std::optional<std::string_view> OpenGLBackend::Init(const Dimension &screen_res)
 	_glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_tex_units);
 	if (max_tex_units < 4) return "Not enough simultaneous textures supported";
 
-	Debug(driver, Severity::Warning, "OpenGL shading language version: {}, texture units = {}", GlGetString(GL_SHADING_LANGUAGE_VERSION).value_or("Unknown version"), max_tex_units);
+	Debug(Facility::Driver, Severity::Warning, "OpenGL shading language version: {}, texture units = {}", GlGetString(GL_SHADING_LANGUAGE_VERSION).value_or("Unknown version"), max_tex_units);
 
 	if (!this->InitShaders()) return "Failed to initialize shaders";
 
@@ -795,7 +795,7 @@ static bool VerifyShader(GLuint shader)
 	_glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &log_len);
 	if (log_len > 0) {
 		_glGetShaderInfoLog(shader, log_len, nullptr, log_buf.Allocate(log_len));
-		Debug(driver, result != GL_TRUE ? Severity::Critical : Severity::Warning, "{}", log_buf.GetBuffer()); // Always print on failure.
+		Debug(Facility::Driver, result != GL_TRUE ? Severity::Critical : Severity::Warning, "{}", log_buf.GetBuffer()); // Always print on failure.
 	}
 
 	return result == GL_TRUE;
@@ -818,7 +818,7 @@ static bool VerifyProgram(GLuint program)
 	_glGetProgramiv(program, GL_INFO_LOG_LENGTH, &log_len);
 	if (log_len > 0) {
 		_glGetProgramInfoLog(program, log_len, nullptr, log_buf.Allocate(log_len));
-		Debug(driver, result != GL_TRUE ? Severity::Critical : Severity::Warning, "{}", log_buf.GetBuffer()); // Always print on failure.
+		Debug(Facility::Driver, result != GL_TRUE ? Severity::Critical : Severity::Warning, "{}", log_buf.GetBuffer()); // Always print on failure.
 	}
 
 	return result == GL_TRUE;

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -121,7 +121,7 @@ std::optional<std::string_view> VideoDriver_SDL_OpenGL::AllocateContext()
 	SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
-	if (_debug_driver_level >= 8) {
+	if (_debug_driver_level >= Severity::Trace2) {
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
 	}
 

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -121,7 +121,7 @@ std::optional<std::string_view> VideoDriver_SDL_OpenGL::AllocateContext()
 	SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
-	if (_debug_driver_level >= Severity::Trace2) {
+	if (IsVisibleSeverity(Facility::Driver, Severity::Trace2)) {
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
 	}
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -124,7 +124,7 @@ static uint FindStartupDisplay(uint startup_display)
 	for (int display = 0; display < num_displays; ++display) {
 		SDL_Rect r;
 		if (SDL_GetDisplayBounds(display, &r) == 0 && IsInsideBS(mx, r.x, r.w) && IsInsideBS(my, r.y, r.h)) {
-			Debug(driver, 1, "SDL2: Mouse is at ({}, {}), use display {} ({}, {}, {}, {})", mx, my, display, r.x, r.y, r.w, r.h);
+			Debug(driver, Severity::Error, "SDL2: Mouse is at ({}, {}), use display {} ({}, {}, {}, {})", mx, my, display, r.x, r.y, r.w, r.h);
 			return display;
 		}
 	}
@@ -175,7 +175,7 @@ bool VideoDriver_SDL_Base::CreateMainWindow(uint w, uint h, uint flags)
 		flags);
 
 	if (this->sdl_window == nullptr) {
-		Debug(driver, 0, "SDL2: Couldn't allocate a window to draw on: {}", SDL_GetError());
+		Debug(driver, Severity::Critical, "SDL2: Couldn't allocate a window to draw on: {}", SDL_GetError());
 		return false;
 	}
 
@@ -206,7 +206,7 @@ bool VideoDriver_SDL_Base::CreateMainWindow(uint w, uint h, uint flags)
 bool VideoDriver_SDL_Base::CreateMainSurface(uint w, uint h, bool resize)
 {
 	GetAvailableVideoMode(&w, &h);
-	Debug(driver, 1, "SDL2: using mode {}x{}", w, h);
+	Debug(driver, Severity::Error, "SDL2: using mode {}x{}", w, h);
 
 	if (!this->CreateMainWindow(w, h)) return false;
 	if (resize) SDL_SetWindowSize(this->sdl_window, w, h);
@@ -595,7 +595,7 @@ std::optional<std::string_view> VideoDriver_SDL_Base::Initialize()
 	if (error) return error;
 
 	FindResolutions();
-	Debug(driver, 2, "Resolution for display: {}x{}", _cur_resolution.width, _cur_resolution.height);
+	Debug(driver, Severity::Warning, "Resolution for display: {}x{}", _cur_resolution.width, _cur_resolution.height);
 
 	return std::nullopt;
 }
@@ -623,7 +623,7 @@ std::optional<std::string_view> VideoDriver_SDL_Base::Start(const StringList &pa
 	}
 
 	const char *dname = SDL_GetCurrentVideoDriver();
-	Debug(driver, 1, "SDL2: using driver '{}'", dname);
+	Debug(driver, Severity::Error, "SDL2: using driver '{}'", dname);
 
 	this->driver_info = this->GetName();
 	this->driver_info += " (";
@@ -743,20 +743,20 @@ bool VideoDriver_SDL_Base::ToggleFullscreen(bool fullscreen)
 		/* Find fullscreen window size */
 		SDL_DisplayMode dm;
 		if (SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(this->sdl_window), &dm) < 0) {
-			Debug(driver, 0, "SDL_GetCurrentDisplayMode() failed: {}", SDL_GetError());
+			Debug(driver, Severity::Critical, "SDL_GetCurrentDisplayMode() failed: {}", SDL_GetError());
 		} else {
 			SDL_SetWindowSize(this->sdl_window, dm.w, dm.h);
 		}
 	}
 
-	Debug(driver, 1, "SDL2: Setting {}", fullscreen ? "fullscreen" : "windowed");
+	Debug(driver, Severity::Error, "SDL2: Setting {}", fullscreen ? "fullscreen" : "windowed");
 	int ret = SDL_SetWindowFullscreen(this->sdl_window, fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
 	if (ret == 0) {
 		/* Switching resolution succeeded, set fullscreen value of window. */
 		_fullscreen = fullscreen;
 		if (!fullscreen) SDL_SetWindowSize(this->sdl_window, w, h);
 	} else {
-		Debug(driver, 0, "SDL_SetWindowFullscreen() failed: {}", SDL_GetError());
+		Debug(driver, Severity::Critical, "SDL_SetWindowFullscreen() failed: {}", SDL_GetError());
 	}
 
 	InvalidateWindowClassesData(WindowClass::GameOptions, 3);

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -124,7 +124,7 @@ static uint FindStartupDisplay(uint startup_display)
 	for (int display = 0; display < num_displays; ++display) {
 		SDL_Rect r;
 		if (SDL_GetDisplayBounds(display, &r) == 0 && IsInsideBS(mx, r.x, r.w) && IsInsideBS(my, r.y, r.h)) {
-			Debug(driver, Severity::Error, "SDL2: Mouse is at ({}, {}), use display {} ({}, {}, {}, {})", mx, my, display, r.x, r.y, r.w, r.h);
+			Debug(Facility::Driver, Severity::Error, "SDL2: Mouse is at ({}, {}), use display {} ({}, {}, {}, {})", mx, my, display, r.x, r.y, r.w, r.h);
 			return display;
 		}
 	}
@@ -175,7 +175,7 @@ bool VideoDriver_SDL_Base::CreateMainWindow(uint w, uint h, uint flags)
 		flags);
 
 	if (this->sdl_window == nullptr) {
-		Debug(driver, Severity::Critical, "SDL2: Couldn't allocate a window to draw on: {}", SDL_GetError());
+		Debug(Facility::Driver, Severity::Critical, "SDL2: Couldn't allocate a window to draw on: {}", SDL_GetError());
 		return false;
 	}
 
@@ -206,7 +206,7 @@ bool VideoDriver_SDL_Base::CreateMainWindow(uint w, uint h, uint flags)
 bool VideoDriver_SDL_Base::CreateMainSurface(uint w, uint h, bool resize)
 {
 	GetAvailableVideoMode(&w, &h);
-	Debug(driver, Severity::Error, "SDL2: using mode {}x{}", w, h);
+	Debug(Facility::Driver, Severity::Error, "SDL2: using mode {}x{}", w, h);
 
 	if (!this->CreateMainWindow(w, h)) return false;
 	if (resize) SDL_SetWindowSize(this->sdl_window, w, h);
@@ -595,7 +595,7 @@ std::optional<std::string_view> VideoDriver_SDL_Base::Initialize()
 	if (error) return error;
 
 	FindResolutions();
-	Debug(driver, Severity::Warning, "Resolution for display: {}x{}", _cur_resolution.width, _cur_resolution.height);
+	Debug(Facility::Driver, Severity::Warning, "Resolution for display: {}x{}", _cur_resolution.width, _cur_resolution.height);
 
 	return std::nullopt;
 }
@@ -623,7 +623,7 @@ std::optional<std::string_view> VideoDriver_SDL_Base::Start(const StringList &pa
 	}
 
 	const char *dname = SDL_GetCurrentVideoDriver();
-	Debug(driver, Severity::Error, "SDL2: using driver '{}'", dname);
+	Debug(Facility::Driver, Severity::Error, "SDL2: using driver '{}'", dname);
 
 	this->driver_info = this->GetName();
 	this->driver_info += " (";
@@ -743,20 +743,20 @@ bool VideoDriver_SDL_Base::ToggleFullscreen(bool fullscreen)
 		/* Find fullscreen window size */
 		SDL_DisplayMode dm;
 		if (SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(this->sdl_window), &dm) < 0) {
-			Debug(driver, Severity::Critical, "SDL_GetCurrentDisplayMode() failed: {}", SDL_GetError());
+			Debug(Facility::Driver, Severity::Critical, "SDL_GetCurrentDisplayMode() failed: {}", SDL_GetError());
 		} else {
 			SDL_SetWindowSize(this->sdl_window, dm.w, dm.h);
 		}
 	}
 
-	Debug(driver, Severity::Error, "SDL2: Setting {}", fullscreen ? "fullscreen" : "windowed");
+	Debug(Facility::Driver, Severity::Error, "SDL2: Setting {}", fullscreen ? "fullscreen" : "windowed");
 	int ret = SDL_SetWindowFullscreen(this->sdl_window, fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
 	if (ret == 0) {
 		/* Switching resolution succeeded, set fullscreen value of window. */
 		_fullscreen = fullscreen;
 		if (!fullscreen) SDL_SetWindowSize(this->sdl_window, w, h);
 	} else {
-		Debug(driver, Severity::Critical, "SDL_SetWindowFullscreen() failed: {}", SDL_GetError());
+		Debug(Facility::Driver, Severity::Critical, "SDL_SetWindowFullscreen() failed: {}", SDL_GetError());
 	}
 
 	InvalidateWindowClassesData(WindowClass::GameOptions, 3);

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -91,7 +91,7 @@ void VideoDriver::StartGameThread()
 		this->is_game_threaded = StartNewThread(&this->game_thread, "ottd:game", &VideoDriver::GameThreadThunk, this);
 	}
 
-	Debug(driver, 1, "using {}thread for game-loop", this->is_game_threaded ? "" : "no ");
+	Debug(driver, Severity::Error, "using {}thread for game-loop", this->is_game_threaded ? "" : "no ");
 }
 
 void VideoDriver::StopGameThread()

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -91,7 +91,7 @@ void VideoDriver::StartGameThread()
 		this->is_game_threaded = StartNewThread(&this->game_thread, "ottd:game", &VideoDriver::GameThreadThunk, this);
 	}
 
-	Debug(driver, Severity::Error, "using {}thread for game-loop", this->is_game_threaded ? "" : "no ");
+	Debug(Facility::Driver, Severity::Error, "using {}thread for game-loop", this->is_game_threaded ? "" : "no ");
 }
 
 void VideoDriver::StopGameThread()

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -262,7 +262,7 @@ static LRESULT HandleCharMsg(uint keycode, char32_t charcode)
 
 	/* Did we get a lead surrogate? If yes, store and exit. */
 	if (Utf16IsLeadSurrogate(charcode)) {
-		if (prev_char != 0) Debug(driver, Severity::Error, "Got two UTF-16 lead surrogates, dropping the first one");
+		if (prev_char != 0) Debug(Facility::Driver, Severity::Error, "Got two UTF-16 lead surrogates, dropping the first one");
 		prev_char = charcode;
 		return 0;
 	}
@@ -272,7 +272,7 @@ static LRESULT HandleCharMsg(uint keycode, char32_t charcode)
 		if (Utf16IsTrailSurrogate(charcode)) {
 			charcode = Utf16DecodeSurrogate(prev_char, charcode);
 		} else {
-			Debug(driver, Severity::Error, "Got an UTF-16 lead surrogate without a trail surrogate, dropping the lead surrogate");
+			Debug(Facility::Driver, Severity::Error, "Got an UTF-16 lead surrogate without a trail surrogate, dropping the lead surrogate");
 		}
 	}
 	prev_char = 0;
@@ -975,7 +975,7 @@ std::optional<std::string_view> VideoDriver_Win32Base::Initialize()
 	this->width  = this->width_org  = _cur_resolution.width;
 	this->height = this->height_org = _cur_resolution.height;
 
-	Debug(driver, Severity::Warning, "Resolution for display: {}x{}", _cur_resolution.width, _cur_resolution.height);
+	Debug(Facility::Driver, Severity::Warning, "Resolution for display: {}x{}", _cur_resolution.width, _cur_resolution.height);
 	return std::nullopt;
 }
 
@@ -1509,7 +1509,7 @@ void VideoDriver_Win32OpenGL::ToggleVsync(bool vsync)
 	if (_wglSwapIntervalEXT != nullptr) {
 		_wglSwapIntervalEXT(vsync);
 	} else if (vsync) {
-		Debug(driver, Severity::Critical, "OpenGL: Vsync requested, but not supported by driver");
+		Debug(Facility::Driver, Severity::Critical, "OpenGL: Vsync requested, but not supported by driver");
 	}
 }
 
@@ -1528,7 +1528,7 @@ std::optional<std::string_view> VideoDriver_Win32OpenGL::AllocateContext()
 		int attribs[] = {
 			WGL_CONTEXT_MAJOR_VERSION_ARB, 4,
 			WGL_CONTEXT_MINOR_VERSION_ARB, 5,
-			WGL_CONTEXT_FLAGS_ARB, _debug_driver_level >= Severity::Trace2 ? WGL_CONTEXT_DEBUG_BIT_ARB : 0,
+			WGL_CONTEXT_FLAGS_ARB, IsVisibleSeverity(Facility::Driver, Severity::Trace2) ? WGL_CONTEXT_DEBUG_BIT_ARB : 0,
 			_hasWGLARBCreateContextProfile ? WGL_CONTEXT_PROFILE_MASK_ARB : 0, WGL_CONTEXT_CORE_PROFILE_BIT_ARB, // Terminate list if WGL_ARB_create_context_profile isn't supported.
 			0
 		};

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -262,7 +262,7 @@ static LRESULT HandleCharMsg(uint keycode, char32_t charcode)
 
 	/* Did we get a lead surrogate? If yes, store and exit. */
 	if (Utf16IsLeadSurrogate(charcode)) {
-		if (prev_char != 0) Debug(driver, 1, "Got two UTF-16 lead surrogates, dropping the first one");
+		if (prev_char != 0) Debug(driver, Severity::Error, "Got two UTF-16 lead surrogates, dropping the first one");
 		prev_char = charcode;
 		return 0;
 	}
@@ -272,7 +272,7 @@ static LRESULT HandleCharMsg(uint keycode, char32_t charcode)
 		if (Utf16IsTrailSurrogate(charcode)) {
 			charcode = Utf16DecodeSurrogate(prev_char, charcode);
 		} else {
-			Debug(driver, 1, "Got an UTF-16 lead surrogate without a trail surrogate, dropping the lead surrogate");
+			Debug(driver, Severity::Error, "Got an UTF-16 lead surrogate without a trail surrogate, dropping the lead surrogate");
 		}
 	}
 	prev_char = 0;
@@ -975,7 +975,7 @@ std::optional<std::string_view> VideoDriver_Win32Base::Initialize()
 	this->width  = this->width_org  = _cur_resolution.width;
 	this->height = this->height_org = _cur_resolution.height;
 
-	Debug(driver, 2, "Resolution for display: {}x{}", _cur_resolution.width, _cur_resolution.height);
+	Debug(driver, Severity::Warning, "Resolution for display: {}x{}", _cur_resolution.width, _cur_resolution.height);
 	return std::nullopt;
 }
 
@@ -1509,7 +1509,7 @@ void VideoDriver_Win32OpenGL::ToggleVsync(bool vsync)
 	if (_wglSwapIntervalEXT != nullptr) {
 		_wglSwapIntervalEXT(vsync);
 	} else if (vsync) {
-		Debug(driver, 0, "OpenGL: Vsync requested, but not supported by driver");
+		Debug(driver, Severity::Critical, "OpenGL: Vsync requested, but not supported by driver");
 	}
 }
 
@@ -1528,7 +1528,7 @@ std::optional<std::string_view> VideoDriver_Win32OpenGL::AllocateContext()
 		int attribs[] = {
 			WGL_CONTEXT_MAJOR_VERSION_ARB, 4,
 			WGL_CONTEXT_MINOR_VERSION_ARB, 5,
-			WGL_CONTEXT_FLAGS_ARB, _debug_driver_level >= 8 ? WGL_CONTEXT_DEBUG_BIT_ARB : 0,
+			WGL_CONTEXT_FLAGS_ARB, _debug_driver_level >= Severity::Trace2 ? WGL_CONTEXT_DEBUG_BIT_ARB : 0,
 			_hasWGLARBCreateContextProfile ? WGL_CONTEXT_PROFILE_MASK_ARB : 0, WGL_CONTEXT_CORE_PROFILE_BIT_ARB, // Terminate list if WGL_ARB_create_context_profile isn't supported.
 			0
 		};

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2512,7 +2512,7 @@ bool HandleViewportClicked(const Viewport &vp, int x, int y)
 	bool result = CheckClickOnLandscape(vp, x, y);
 
 	if (v != nullptr) {
-		Debug(misc, 2, "Vehicle {} (index {}) at {}", v->unitnumber, v->index, fmt::ptr(v));
+		Debug(misc, Severity::Warning, "Vehicle {} (index {}) at {}", v->unitnumber, v->index, fmt::ptr(v));
 		if (IsCompanyBuildableVehicleType(v)) {
 			v = v->First();
 			if (_ctrl_pressed && v->owner == _local_company) {

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2512,7 +2512,7 @@ bool HandleViewportClicked(const Viewport &vp, int x, int y)
 	bool result = CheckClickOnLandscape(vp, x, y);
 
 	if (v != nullptr) {
-		Debug(misc, Severity::Warning, "Vehicle {} (index {}) at {}", v->unitnumber, v->index, fmt::ptr(v));
+		Debug(Facility::Misc, Severity::Warning, "Vehicle {} (index {}) at {}", v->unitnumber, v->index, fmt::ptr(v));
 		if (IsCompanyBuildableVehicleType(v)) {
 			v = v->First();
 			if (_ctrl_pressed && v->owner == _local_company) {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3505,7 +3505,7 @@ static int PositionWindow(Window *w, WindowClass clss, int setting)
  */
 int PositionMainToolbar(Window *w)
 {
-	Debug(misc, Severity::Debug1, "Repositioning Main Toolbar...");
+	Debug(Facility::Misc, Severity::Debug1, "Repositioning Main Toolbar...");
 	return PositionWindow(w, WindowClass::MainToolbar, _settings_client.gui.toolbar_pos);
 }
 
@@ -3516,7 +3516,7 @@ int PositionMainToolbar(Window *w)
  */
 int PositionStatusbar(Window *w)
 {
-	Debug(misc, Severity::Debug1, "Repositioning statusbar...");
+	Debug(Facility::Misc, Severity::Debug1, "Repositioning statusbar...");
 	return PositionWindow(w, WindowClass::Statusbar, _settings_client.gui.statusbar_pos);
 }
 
@@ -3527,7 +3527,7 @@ int PositionStatusbar(Window *w)
  */
 int PositionNewsMessage(Window *w)
 {
-	Debug(misc, Severity::Debug1, "Repositioning news message...");
+	Debug(Facility::Misc, Severity::Debug1, "Repositioning news message...");
 	return PositionWindow(w, WindowClass::News, _settings_client.gui.statusbar_pos);
 }
 
@@ -3538,7 +3538,7 @@ int PositionNewsMessage(Window *w)
  */
 int PositionNetworkChatWindow(Window *w)
 {
-	Debug(misc, Severity::Debug1, "Repositioning network chat window...");
+	Debug(Facility::Misc, Severity::Debug1, "Repositioning network chat window...");
 	return PositionWindow(w, WindowClass::NetworkChat, _settings_client.gui.statusbar_pos);
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3505,7 +3505,7 @@ static int PositionWindow(Window *w, WindowClass clss, int setting)
  */
 int PositionMainToolbar(Window *w)
 {
-	Debug(misc, 5, "Repositioning Main Toolbar...");
+	Debug(misc, Severity::Debug1, "Repositioning Main Toolbar...");
 	return PositionWindow(w, WindowClass::MainToolbar, _settings_client.gui.toolbar_pos);
 }
 
@@ -3516,7 +3516,7 @@ int PositionMainToolbar(Window *w)
  */
 int PositionStatusbar(Window *w)
 {
-	Debug(misc, 5, "Repositioning statusbar...");
+	Debug(misc, Severity::Debug1, "Repositioning statusbar...");
 	return PositionWindow(w, WindowClass::Statusbar, _settings_client.gui.statusbar_pos);
 }
 
@@ -3527,7 +3527,7 @@ int PositionStatusbar(Window *w)
  */
 int PositionNewsMessage(Window *w)
 {
-	Debug(misc, 5, "Repositioning news message...");
+	Debug(misc, Severity::Debug1, "Repositioning news message...");
 	return PositionWindow(w, WindowClass::News, _settings_client.gui.statusbar_pos);
 }
 
@@ -3538,7 +3538,7 @@ int PositionNewsMessage(Window *w)
  */
 int PositionNetworkChatWindow(Window *w)
 {
-	Debug(misc, 5, "Repositioning network chat window...");
+	Debug(misc, Severity::Debug1, "Repositioning network chat window...");
 	return PositionWindow(w, WindowClass::NetworkChat, _settings_client.gui.statusbar_pos);
 }
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Debug messages use a macro to convert an unquoted category string into variable name, and a literal string. This means it cannot be properly be autocompleted or searched, and is generally just a bit ugly.

Debug level is a number starting from 0 with no particular meaning, just some guidance.

In trying to make sense of debug levels, I found that network debug levels were the most sane sane due to #9251.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

* Replace the unquoted category with a scoped enum called `Facility`.
* Replace level with a scoped enum called `Severity`.

`Severity` names are based on #9251, except with `Notice` replacing `Info` which is moved down a slot.

`SetDebugString()` used to use a `std::map` to handle tracking changes. Because `Facility` can be used as in index, this is now a simple array.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Oh god not another refactor!?

All calls maintain the existing facility/category and severity/level. This means the message's `Severity` doesn't necessarily match the meaning of the scoped enum value. Changes to debug severity level can come later as desired.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
