### PR TITLE
Change: Convert lighthouse and transmitter build rules to object flags and properties

### DIFF
--- a/src/core/container_func.hpp
+++ b/src/core/container_func.hpp
@@ -10,6 +10,8 @@
 #ifndef CONTAINER_FUNC_HPP
 #define CONTAINER_FUNC_HPP
 
+#include "random_func.hpp"
+
 /**
  * Helper function to append an item to a container if it is not already contained.
  * The container must have a \c emplace_back function.
@@ -59,6 +61,21 @@ auto Slide(TIter first, TIter last, TIter position) -> std::pair<TIter, TIter>
 	if (last < position) return { std::rotate(first, last, position), position };
 	if (position < first) return { position, std::rotate(position, first, last) };
 	return { first, last };
+}
+
+/**
+ * Shuffle the contents of a container.
+ * @tparam Tcontainer The container type.
+ * @param container A reference to the container to be shuffled.
+ * @param randomizer The randomizer to use to shuffle the container.
+ */
+template <typename Tcontainer>
+void Shuffle(Tcontainer &container, Randomizer &randomizer)
+{
+	for (int i = static_cast<int>(container.size()) - 1; i >= 0; --i) {
+		int j = randomizer.Next() % (i + 1);
+		if (i != j) std::swap(container[i], container[j]);
+	}
 }
 
 #endif /* CONTAINER_FUNC_HPP */

--- a/src/newgrf/newgrf_act0_objects.cpp
+++ b/src/newgrf/newgrf_act0_objects.cpp
@@ -35,6 +35,9 @@ static ChangeInfoResult IgnoreObjectProperty(uint prop, ByteReader &buf)
 		case 0x16:
 		case 0x17:
 		case 0x18:
+		case 0x1B:
+		case 0x1C:
+		case 0x1D:
 			buf.ReadByte();
 			break;
 
@@ -50,6 +53,7 @@ static ChangeInfoResult IgnoreObjectProperty(uint prop, ByteReader &buf)
 		case 0x08:
 		case 0x0E:
 		case 0x0F:
+		case 0x1A:
 			buf.ReadDWord();
 			break;
 
@@ -141,7 +145,7 @@ static ChangeInfoResult ObjectChangeInfo(uint first, uint last, int prop, ByteRe
 				break;
 
 			case 0x10: // Flags
-				spec->flags = (ObjectFlags)buf.ReadWord();
+				spec->flags = static_cast<ObjectFlags>(buf.ReadWord());
 				_loaded_newgrf_features.has_2CC |= spec->flags.Test(ObjectFlag::Uses2CC);
 				break;
 
@@ -184,6 +188,23 @@ static ChangeInfoResult ObjectChangeInfo(uint first, uint last, int prop, ByteRe
 
 			case 0x19: // Badge list
 				spec->badges = ReadBadgeList(buf, GrfSpecFeature::Objects);
+				break;
+
+			case 0x1A: // More flags
+				spec->flags = static_cast<ObjectFlags>(buf.ReadDWord());
+				_loaded_newgrf_features.has_2CC |= spec->flags.Test(ObjectFlag::Uses2CC);
+				break;
+
+			case 0x1B: // Diameter to avoid same objects.
+				spec->clear_diameter = buf.ReadByte();
+				break;
+
+			case 0x1C: // Minimum tile height.
+				spec->min_tile_height = buf.ReadByte();
+				break;
+
+			case 0x1D: // Maximum tile height.
+				spec->max_tile_height = buf.ReadByte();
 				break;
 
 			default:

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -38,10 +38,14 @@ enum class ObjectFlag : uint8_t {
 	AllowUnderBridge = 11, ///< Object can built under a bridge.
 	AnimRandomBits   = 12, ///< Object wants random bits in "next animation frame" callback.
 	ScaleByWater     = 13, ///< Object count is roughly scaled by water amount at edges.
+	PlaceNearTowns   = 14, ///< Object should be placed near towns.
+	PlaceNearCoast   = 15, ///< Object should be placed near coast.
+	CreateRocks      = 16, ///< Create rocky tiles around the object.
+	FlatLand         = 17, ///< Create object only on flat land.
 };
 
 /** Bitset of \c ObjectFlag elements. */
-using ObjectFlags = EnumBitSet<ObjectFlag, uint16_t>;
+using ObjectFlags = EnumBitSet<ObjectFlag, uint32_t>;
 
 static const uint8_t OBJECT_SIZE_1X1 = 0x11; ///< The value of a NewGRF's size property when the object is 1x1 tiles: low nibble for X, high nibble for Y.
 
@@ -71,6 +75,9 @@ struct ObjectSpec : NewGRFSpecBase<ObjectClassID> {
 	uint8_t height;                 ///< The height of this structure, in heightlevels; max MAX_TILE_HEIGHT.
 	uint8_t views;                  ///< The number of views.
 	uint8_t generate_amount;        ///< Number of objects which are attempted to be generated per 256^2 map during world generation.
+	uint8_t clear_diameter = 0; ///< Diameter to avoid objects of the same type.
+	uint8_t min_tile_height = 0; ///< Minimum tile height for the centre of this object.
+	uint8_t max_tile_height = UINT8_MAX; ///< Maximum tile height for the centre of this object.
 	std::vector<BadgeID> badges;
 
 	/**

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -25,6 +25,7 @@
 #include "cheat_type.h"
 #include "object.h"
 #include "cargopacket.h"
+#include "core/container_func.hpp"
 #include "core/random_func.hpp"
 #include "core/pool_func.hpp"
 #include "object_map.h"
@@ -833,14 +834,31 @@ static bool TryBuildObjectNearTown(Town *town, const ObjectSpec &spec)
 }
 
 /**
+ * Get a randomised list of town indexes.
+ * @return List of town indexes.
+ */
+std::vector<TownID> GetRandomisedTownList()
+{
+	std::vector<TownID> towns;
+	towns.reserve(Town::GetNumItems());
+	for (const Town *t : Town::Iterate()) {
+		towns.push_back(t->index);
+	}
+	Shuffle(towns, _random);
+	return towns;
+}
+
+/**
  * Try to build objects near every town.
  * @param spec The object spec.
  * @param amount The number of objects to try to generate.
  */
 static void BuildTownObjects(const ObjectSpec &spec, uint16_t &amount)
 {
-	for (Town *town : Town::Iterate()) {
-		if (!TryBuildObjectNearTown(town, spec)) continue;
+	std::vector<TownID> towns = GetRandomisedTownList();
+
+	for (TownID town : towns) {
+		if (!TryBuildObjectNearTown(Town::Get(town), spec)) continue;
 
 		--amount;
 		if (amount == 0) break;

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -231,6 +231,26 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 		if (!IsValidTile(t)) return CommandCost(STR_ERROR_TOO_CLOSE_TO_EDGE_OF_MAP); // Might be off the map
 	}
 
+	if (_current_company > MAX_COMPANIES) {
+		/* Placement restrictions don't apply to player-placed objects. */
+
+		TileIndex centre_tile = ta.GetCenterTile();
+		if (spec->clear_diameter > 0) {
+			/* Ensure no object of the same type is within range. */
+			uint diameter = spec->clear_diameter + std::max(size_x, size_y) - 1;
+			for (auto t : SpiralTileSequence(centre_tile, diameter)) {
+				if (IsObjectTypeTile(t, spec->Index())) return CMD_ERROR;
+			}
+		}
+
+		/* Check the tile is between the minimum and maximum height levels. */
+		if (spec->min_tile_height > 0 || spec->max_tile_height < UINT8_MAX) {
+			uint z = GetTileZ(centre_tile);
+			if (spec->min_tile_height > z) return CMD_ERROR;
+			if (z > spec->max_tile_height) return CMD_ERROR;
+		}
+	}
+
 	if (type == OBJECT_OWNED_LAND) {
 		/* Owned land is special as it can be placed on any slope. */
 		cost.AddCost(Command<Commands::LandscapeClear>::Do(flags, tile));
@@ -322,14 +342,11 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 		}
 	}
 
+	if (spec->flags.Test(ObjectFlag::FlatLand) && !IsTileFlat(tile)) return CommandCost(STR_ERROR_FLAT_LAND_REQUIRED);
+
 	int hq_score = 0;
 	uint build_object_size = 1;
 	switch (type) {
-		case OBJECT_TRANSMITTER:
-		case OBJECT_LIGHTHOUSE:
-			if (!IsTileFlat(tile)) return CommandCost(STR_ERROR_FLAT_LAND_REQUIRED);
-			break;
-
 		case OBJECT_OWNED_LAND:
 			if (IsTileType(tile, TileType::Object) &&
 					IsTileOwner(tile, _current_company) &&
@@ -380,6 +397,17 @@ CommandCost CmdBuildObject(DoCommandFlags flags, TileIndex tile, ObjectType type
 
 		/* Subtract the tile from the build limit. */
 		if (c != nullptr) c->build_object_limit -= build_object_size << 16;
+
+		if (spec->flags.Test(ObjectFlag::CreateRocks)) {
+			/* Generate rocks from each coast tile surrounding the chosen coast tile. This is done because we don't have
+			 * control of the direction of GenerateRocks, so this gives more chance for rocks to be generated in water. */
+			uint32_t r = Random();
+			for (TileIndex rock_tile : SpiralTileSequence(tile, 3)) {
+				if (!IsCoastTile(rock_tile)) continue;
+				GenerateRocks(rock_tile, GB(r, 0, 4) + 5);
+				r >>= 4;
+			}
+		}
 	}
 
 	cost.AddCost(spec->GetBuildCost() * build_object_size);
@@ -743,54 +771,49 @@ static bool ClickTile_Object(TileIndex tile)
 }
 
 /**
- * Try to build a lighthouse near a coast tile.
- * @param coast_tile The tile to try building near.
- * @return \c true iff a lighthouse was built.
+ * Try to build an object near a tile.
+ * @param tile The tile to try building near.
+ * @param spec The object spec.
+ * @return \c true iff an object was built.
  */
-static bool TryBuildLighthouseNearTile(TileIndex coast_tile)
+static bool TryBuildObjectNearTile(TileIndex tile, const ObjectSpec &spec)
 {
 	if (!Object::CanAllocateItem()) return false;
-	if (!IsValidTile(coast_tile)) return false;
+	if (!IsValidTile(tile)) return false;
 
-	/* We always start on a coast tile. */
-	if (!IsTileType(coast_tile, TileType::Water) || GetWaterTileType(coast_tile) != WaterTileType::Coast) return false;
+	if (spec.flags.Test(ObjectFlag::PlaceNearCoast)) {
+		/* We always start on a coast tile. */
+		if (!IsTileType(tile, TileType::Water) || GetWaterTileType(tile) != WaterTileType::Coast) return false;
+	}
 
-	/* Don't build near another lighthouse. */
-	constexpr uint LIGHTHOUSE_MIN_DISTANCE_DIAMETER = 16 * 2 + 1; // 16 tile radius, plus middle tile.
-	for (auto t : SpiralTileSequence(coast_tile, LIGHTHOUSE_MIN_DISTANCE_DIAMETER)) {
-		if (IsObjectTypeTile(t, OBJECT_LIGHTHOUSE)) return false;
+	/* Don't build near another object of the same tile. */
+	for (auto t : SpiralTileSequence(tile, spec.clear_diameter)) {
+		if (IsObjectTypeTile(t, spec.Index())) return false;
 	}
 
 	/* Find a suitable tile nearby to build. */
-	for (TileIndex build_tile : SpiralTileSequence(coast_tile, 3)) {
+	for (TileIndex build_tile : SpiralTileSequence(tile, 3)) {
 		if (!IsTileType(build_tile, TileType::Clear) || !IsTileFlat(build_tile) || IsBridgeAbove(build_tile)) continue;
-		BuildObject(OBJECT_LIGHTHOUSE, build_tile);
 
-		/* Generate rocks from each coast tile surrounding the chosen coast tile. This is done because we don't have
-		 * control of the direction of GenerateRocks, so this gives more chance for rocks to be generated in water. */
-		uint32_t r = Random();
-		for (TileIndex rock_tile : SpiralTileSequence(coast_tile, 3)) {
-			if (!IsCoastTile(rock_tile)) continue;
-			GenerateRocks(rock_tile, GB(r, 0, 4) + 5);
-			r >>= 4;
-		}
-
-		return true;
+		uint8_t view = RandomRange(spec.views);
+		if (CmdBuildObject({DoCommandFlag::Execute, DoCommandFlag::Auto, DoCommandFlag::NoTestTownRating, DoCommandFlag::NoModifyTownRating}, build_tile, spec.Index(), view).Succeeded()) return true;
 	}
 
 	return false;
 }
 
 /**
- * Try to build a lighthouse near a town.
- * @param town The town to build the lighthouse near.
+ * Try to build an object near a town.
+ * @param town The town to build the object near.
+ * @param spec The object spec.
+ * @return \c true iff an object was built.
  */
-static void TryBuildTownLighthouse(Town *town)
+static bool TryBuildObjectNearTown(Town *town, const ObjectSpec &spec)
 {
 	TileIndex start_tile = town->xy;
 
-	/* As a sanity check to speed up generation, a town in the mountains is unlikely to have a lighthouse. */
-	if (GetTileZ(start_tile) > 4) return;
+	/* As a sanity check to speed up generation, a town in the mountains is unlikely to have an object near the coast. */
+	if (spec.flags.Test(ObjectFlag::PlaceNearCoast) && GetTileZ(start_tile) > spec.max_tile_height) return false;
 
 	/* Create a perimeter a random distance around the town to search. */
 	int radius = town->cache.squared_town_zone_radius[to_underlying(HouseZone::TownEdge)];
@@ -799,29 +822,37 @@ static void TryBuildTownLighthouse(Town *town)
 
 	/* Find the northern tile of the perimeter for the SpiralTileSequence. */
 	start_tile = TileAddWrap(town->xy, -radius, -radius);
-	if (!IsValidTile(start_tile)) return;
+	if (!IsValidTile(start_tile)) return false;
 
 	/* Search the perimeter for a suitable tile. */
-	for (TileIndex coast_tile : SpiralTileSequence(start_tile, 1, radius * 2, radius * 2)) {
-		if (TryBuildLighthouseNearTile(coast_tile)) return;
+	for (TileIndex tile : SpiralTileSequence(start_tile, 1, radius * 2, radius * 2)) {
+		if (TryBuildObjectNearTile(tile, spec)) return true;
 	}
+
+	return false;
 }
 
 /**
- * Try to build lighthouses near every town.
+ * Try to build objects near every town.
+ * @param spec The object spec.
+ * @param amount The number of objects to try to generate.
  */
-static void BuildTownLighthouses()
+static void BuildTownObjects(const ObjectSpec &spec, uint16_t &amount)
 {
 	for (Town *town : Town::Iterate()) {
-		TryBuildTownLighthouse(town);
+		if (!TryBuildObjectNearTown(town, spec)) continue;
+
+		--amount;
+		if (amount == 0) break;
 	}
 }
 
 /**
- * Try to build a lighthouse along the coast.
- * @return \c true iff a lighthouse was built.
+ * Try to build an object along the coast.
+ * @param spec The object spec.
+ * @return \c true iff an object was built.
  */
-static bool TryBuildCoastLighthouse()
+static bool TryBuildCoastObject(const ObjectSpec &spec)
 {
 	uint maxx = Map::MaxX();
 	uint maxy = Map::MaxY();
@@ -845,7 +876,7 @@ static bool TryBuildCoastLighthouse()
 
 	/* Now walk inwards until we find a valid tile, or hit the other edge of the map. */
 	while (IsValidTile(tile)) {
-		if (TryBuildLighthouseNearTile(tile)) return true;
+		if (TryBuildObjectNearTile(tile, spec)) return true;
 		tile += TileOffsByDiagDir(dir);
 	}
 
@@ -853,32 +884,16 @@ static bool TryBuildCoastLighthouse()
 }
 
 /**
- * Try to build lighthouses along coasts.
- * @param amount The number of lighthouses to try to generate.
+ * Try to build objects along coasts.
+ * @param spec The object spec.
+ * @param amount The number of objects to try to generate.
  */
-static void BuildCoastLighthouses(uint16_t amount)
+static void BuildCoastObjects(const ObjectSpec &spec, uint16_t &amount)
 {
 	for (uint j = amount; j != 0; j--) {
-		TryBuildCoastLighthouse();
+		if (!TryBuildCoastObject(spec)) continue;
+		--amount;
 	}
-}
-
-/**
- * Try to build a transmitter.
- * @return True iff a transmitter was built.
- */
-static bool TryBuildTransmitter()
-{
-	TileIndex tile = RandomTile();
-	int h;
-	if (IsTileType(tile, TileType::Clear) && IsTileFlat(tile, &h) && h >= 4 && !IsBridgeAbove(tile)) {
-		for (auto t : SpiralTileSequence(tile, 9)) {
-			if (IsObjectTypeTile(t, OBJECT_TRANSMITTER)) return false;
-		}
-		BuildObject(OBJECT_TRANSMITTER, tile);
-		return true;
-	}
-	return false;
 }
 
 /**
@@ -923,25 +938,14 @@ void GenerateObjects()
 		}
 
 		/* Ready to place objects. */
-		switch (spec.Index()) {
-			case OBJECT_TRANSMITTER:
-				for (uint j = Map::ScaleBySize(1000); j != 0 && amount != 0 && Object::CanAllocateItem(); j--) {
-					if (TryBuildTransmitter()) amount--;
-				}
-				break;
+		if (spec.flags.Test(ObjectFlag::PlaceNearTowns)) BuildTownObjects(spec, amount);
+		if (spec.flags.Test(ObjectFlag::PlaceNearCoast)) BuildCoastObjects(spec, amount);
 
-			case OBJECT_LIGHTHOUSE:
-				BuildTownLighthouses();
-				BuildCoastLighthouses(amount);
-				break;
-
-			default:
-				for (uint j = Map::ScaleBySize(1000); j != 0 && amount != 0 && Object::CanAllocateItem(); j--) {
-					uint8_t view = RandomRange(spec.views);
-					if (CmdBuildObject({ DoCommandFlag::Execute, DoCommandFlag::Auto, DoCommandFlag::NoTestTownRating, DoCommandFlag::NoModifyTownRating }, RandomTile(), spec.Index(), view).Succeeded()) amount--;
-				}
-				break;
+		for (uint j = Map::ScaleBySize(1000); j != 0 && amount != 0 && Object::CanAllocateItem(); j--) {
+			uint8_t view = RandomRange(spec.views);
+			if (CmdBuildObject({ DoCommandFlag::Execute, DoCommandFlag::Auto, DoCommandFlag::NoTestTownRating, DoCommandFlag::NoModifyTownRating }, RandomTile(), spec.Index(), view).Succeeded()) --amount;
 		}
+
 		IncreaseGeneratingWorldProgress(GenWorldProgress::Objects);
 	}
 }
@@ -987,12 +991,13 @@ static void ChangeTileOwner_Object(TileIndex tile, Owner old_owner, Owner new_ow
 static CommandCost TerraformTile_Object(TileIndex tile, DoCommandFlags flags, int z_new, Slope tileh_new)
 {
 	ObjectType type = GetObjectType(tile);
+	const ObjectSpec *spec = ObjectSpec::Get(type);
 
 	if (type == OBJECT_OWNED_LAND) {
 		/* Owned land remains unsold */
 		CommandCost ret = CheckTileOwnership(tile);
 		if (ret.Succeeded()) return CommandCost();
-	} else if (AutoslopeEnabled() && type != OBJECT_TRANSMITTER && type != OBJECT_LIGHTHOUSE) {
+	} else if (AutoslopeEnabled() && !spec->flags.Test(ObjectFlag::FlatLand)) {
 		/* Behaviour:
 		 *  - Both new and old slope must not be steep.
 		 *  - TileMaxZ must not be changed.
@@ -1002,8 +1007,6 @@ static CommandCost TerraformTile_Object(TileIndex tile, DoCommandFlags flags, in
 		Slope tileh_old = GetTileSlope(tile);
 		/* TileMaxZ must not be changed. Slopes must not be steep. */
 		if (!IsSteepSlope(tileh_old) && !IsSteepSlope(tileh_new) && (GetTileMaxZ(tile) == z_new + GetSlopeMaxZ(tileh_new))) {
-			const ObjectSpec *spec = ObjectSpec::Get(type);
-
 			/* Call callback 'disable autosloping for objects'. */
 			if (spec->callback_mask.Test(ObjectCallbackMask::Autoslope)) {
 				/* If the callback fails, allow autoslope. */

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -106,7 +106,26 @@ static const DrawTileSpriteSpan _object_hq[] = {
 #undef TILE_SPRITE_LINE
 #undef TILE_SPRITE_LINE_NOTHING
 
-#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, introduction_date, climate, gen_amount, flags) {{ObjectClassID::Invalid(), 0}, StandardGRFFileProps{}, AnimationInfo<ObjectAnimationTriggers>{}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, introduction_date, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount, {}}
+/**
+ * Define an object spec.
+ * @param name ///< The name for this object.
+ * @param size ///< The size of this objects; low nibble for X, high nibble for Y.
+ * @param build_cost_multiplier ///< Build cost multiplier per tile.
+ * @param clear_cost_multiplier ///< Clear cost multiplier per tile.
+ * @param height ///< The height of this structure, in heightlevels; max MAX_TILE_HEIGHT.
+ * @param diameter ///< Diameter to avoid objects of the same type.
+ * @param min_tile_height ///< Minimum tile height for the centre of this object.
+ * @param max_tile_height ///< Maximum tile height for the centre of this object.
+ * @param introduction_date ///< From when can this object be built.
+ * @param climate ///< In which climates is this object available?
+ * @param gen_amount ///< Number of objects which are attempted to be generated per 256^2 map during world generation.
+ * @param flags ///< Flags/settings related to the object.
+ * @return The object spec.
+ */
+constexpr ObjectSpec DefineObject(StringID name, uint8_t size, uint8_t build_cost_multiplier, uint8_t clear_cost_multiplier, uint8_t height, uint8_t diameter, uint8_t min_tile_height, uint8_t max_tile_height, TimerGameCalendar::Date introduction_date, LandscapeTypes climate, uint8_t gen_amount, ObjectFlags flags)
+{
+	return {{ObjectClassID::Invalid(), 0}, StandardGRFFileProps{}, AnimationInfo<ObjectAnimationTriggers>{}, name, climate, size, build_cost_multiplier, clear_cost_multiplier, introduction_date, CalendarTime::MAX_DATE + 1, flags, ObjectCallbackMasks{}, height, 1, gen_amount, diameter, min_tile_height, max_tile_height, {}};
+}
 
 /** Climate temperate. */
 #define T LandscapeType::Temperate
@@ -118,14 +137,13 @@ static const DrawTileSpriteSpan _object_hq[] = {
 #define Y LandscapeType::Toyland
 /** Specification of the original object structures. */
 extern const ObjectSpec _original_objects[] = {
-	M(STR_LAI_OBJECT_DESCRIPTION_TRANSMITTER,          0x11,   0,   0, 10, TimerGameCalendar::DateAtStartOfYear(CalendarTime::ORIGINAL_BASE_YEAR), LandscapeTypes({T,A,S  }), 15, ObjectFlags({ObjectFlag::CannotRemove, ObjectFlag::OnlyInScenedit})), // Not available before original starting year.
-	M(STR_LAI_OBJECT_DESCRIPTION_LIGHTHOUSE,           0x11,   0,   0,  8, TimerGameCalendar::Date{}, LandscapeTypes({T,A    }),  8, ObjectFlags({ObjectFlag::CannotRemove, ObjectFlag::OnlyInScenedit, ObjectFlag::ScaleByWater})),
-	M(STR_TOWN_BUILDING_NAME_STATUE_1,                 0x11,   0,   0,  5, TimerGameCalendar::Date{}, LandscapeTypes({T,S,A,Y}),  0, ObjectFlags({ObjectFlag::CannotRemove, ObjectFlag::OnlyInGame, ObjectFlag::OnlyInScenedit})), // Yes, we disallow building this everywhere. Happens in "special" case!
-	M(STR_LAI_OBJECT_DESCRIPTION_COMPANY_OWNED_LAND,   0x11,  10,  10,  0, TimerGameCalendar::Date{}, LandscapeTypes({T,S,A,Y}),  0, ObjectFlags({ObjectFlag::Autoremove, ObjectFlag::OnlyInGame, ObjectFlag::ClearIncome, ObjectFlag::HasNoFoundation})), // Only non-silly use case is to use it when you cannot build a station, so disallow bridges
-	M(STR_LAI_OBJECT_DESCRIPTION_COMPANY_HEADQUARTERS, 0x22,   0,   0,  7, TimerGameCalendar::Date{}, LandscapeTypes({T,S,A,Y}),  0, ObjectFlags({ObjectFlag::CannotRemove, ObjectFlag::OnlyInGame})),
+	DefineObject(STR_LAI_OBJECT_DESCRIPTION_TRANSMITTER,          0x11,   0,   0, 10,  9, 4, 255, TimerGameCalendar::DateAtStartOfYear(CalendarTime::ORIGINAL_BASE_YEAR), {T,A,S  }, 15, {ObjectFlag::CannotRemove, ObjectFlag::OnlyInScenedit, ObjectFlag::FlatLand}), // Not available before original starting year.
+	DefineObject(STR_LAI_OBJECT_DESCRIPTION_LIGHTHOUSE,           0x11,   0,   0,  8, 33, 0,   4, TimerGameCalendar::Date{}, {T,A    },  8, {ObjectFlag::CannotRemove, ObjectFlag::OnlyInScenedit, ObjectFlag::ScaleByWater, ObjectFlag::PlaceNearTowns, ObjectFlag::PlaceNearCoast, ObjectFlag::CreateRocks, ObjectFlag::FlatLand}),
+	DefineObject(STR_TOWN_BUILDING_NAME_STATUE_1,                 0x11,   0,   0,  5,  0, 0, 255, TimerGameCalendar::Date{}, {T,S,A,Y},  0, {ObjectFlag::CannotRemove, ObjectFlag::OnlyInGame, ObjectFlag::OnlyInScenedit}), // Yes, we disallow building this everywhere. Happens in "special" case!
+	DefineObject(STR_LAI_OBJECT_DESCRIPTION_COMPANY_OWNED_LAND,   0x11,  10,  10,  0,  0, 0, 255, TimerGameCalendar::Date{}, {T,S,A,Y},  0, {ObjectFlag::Autoremove, ObjectFlag::OnlyInGame, ObjectFlag::ClearIncome, ObjectFlag::HasNoFoundation}), // Only non-silly use case is to use it when you cannot build a station, so disallow bridges
+	DefineObject(STR_LAI_OBJECT_DESCRIPTION_COMPANY_HEADQUARTERS, 0x22,   0,   0,  7,  0, 0, 255, TimerGameCalendar::Date{}, {T,S,A,Y},  0, {ObjectFlag::CannotRemove, ObjectFlag::OnlyInGame}),
 };
 
-#undef M
 #undef Y
 #undef S
 #undef A


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Object placement rules for lighthouses and transmitters are hardcoded, and can only used for those object types. This means that new objects can't fully replicate their behaviour.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Convert lighthouse and transmitter build rules to object flags and properties.

New flags:

* PlaceNearTowns: try to create the object near towns.
* PlaceNearCoast: try to create the object near coasts.
* CreateRocks: create rocks when placing the object.
* FlatLand: object must be placed on flat land.

New properties:

* Clear Diameter: diameter to avoid objects of same type.
* Min Tile Height: minimum tile height for centre of object.
* Max Tile Height: maximum tile height for centre of object.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Overlaps with NewGRF object placement callback. Shouldn't be a problem as both will apply.

Object rules apply to manually placed objects, so you can no longer spam lighthouses and transmitters anywhere in the scenario editor.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
