### PR TITLE
Fix #15636: Allow shift and ctrl modifiers in hotkeys

### DIFF
--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -8,6 +8,8 @@
 /** @file hotkeys.cpp Implementation of hotkey related functions. */
 
 #include "stdafx.h"
+#include "core/backup_type.hpp"
+#include "gfx_func.h"
 #include "openttd.h"
 #include "hotkeys.h"
 #include "ini_type.h"
@@ -341,13 +343,29 @@ void SaveHotkeysToConfig()
 	SaveLoadHotkeys(true);
 }
 
+/**
+ * Call the global handler for a hotkey.
+ * @note Clears shift and ctrl keystate to allow hotkeys to use modifiers.
+ * @param func The global hotkey handler.
+ * @param hotkey The hotkey.
+ * @return EventState of the hotkey handler.
+ */
+static EventState HandleGlobalHotkey(HotkeyList::GlobalHotkeyHandlerFunc func, int hotkey)
+{
+	/* Clear global modifier keys so they do not interfere with modifiers assigned to hotkeys. */
+	AutoRestoreBackup _shift_backup{_shift_pressed, false};
+	AutoRestoreBackup _ctrl_backup{_ctrl_pressed, false};
+
+	return func(hotkey);
+}
+
 void HandleGlobalHotkeys([[maybe_unused]] char32_t key, uint16_t keycode)
 {
 	for (HotkeyList *list : *_hotkey_lists) {
 		if (list->global_hotkey_handler == nullptr) continue;
 
 		int hotkey = list->CheckMatch(keycode, true);
-		if (hotkey >= 0 && (list->global_hotkey_handler(hotkey) == EventState::Handled)) return;
+		if (hotkey >= 0 && HandleGlobalHotkey(list->global_hotkey_handler, hotkey) == EventState::Handled) return;
 	}
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2639,6 +2639,22 @@ EventState Window::HandleEditBoxKey(WidgetID wid, char32_t key, uint16_t keycode
 }
 
 /**
+ * Call the OnHotkey handler for a window.
+ * @note Clears shift and ctrl keystate to allow hotkeys to use modifiers.
+ * @param w The window.
+ * @param hotkey The hotkey.
+ * @return EventState of the hotkey handler.
+ */
+static EventState HandleHotkey(Window *w, int hotkey)
+{
+	/* Clear global modifier keys so they do not interfere with modifiers assigned to hotkeys. */
+	AutoRestoreBackup _shift_backup{_shift_pressed, false};
+	AutoRestoreBackup _ctrl_backup{_ctrl_pressed, false};
+
+	return w->OnHotkey(hotkey);
+}
+
+/**
  * Handle Toolbar hotkey events - can come from a source like the MacBook Touch Bar.
  * @param hotkey Hotkey code
  */
@@ -2649,7 +2665,7 @@ void HandleToolbarHotkey(int hotkey)
 	Window *w = FindWindowById(WindowClass::MainToolbar, 0);
 	if (w != nullptr) {
 		if (w->window_desc.hotkeys != nullptr) {
-			if (hotkey >= 0 && w->OnHotkey(hotkey) == EventState::Handled) return;
+			if (hotkey >= 0 && HandleHotkey(w, hotkey) == EventState::Handled) return;
 		}
 	}
 }
@@ -2694,7 +2710,7 @@ void HandleKeypress(uint keycode, char32_t key)
 		if (w->window_class == WindowClass::MainToolbar) continue;
 		if (w->window_desc.hotkeys != nullptr) {
 			int hotkey = w->window_desc.hotkeys->CheckMatch(keycode);
-			if (hotkey >= 0 && w->OnHotkey(hotkey) == EventState::Handled) return;
+			if (hotkey >= 0 && HandleHotkey(w, hotkey) == EventState::Handled) return;
 		}
 		if (w->OnKeyPress(key, keycode) == EventState::Handled) return;
 	}
@@ -2704,7 +2720,7 @@ void HandleKeypress(uint keycode, char32_t key)
 	if (w != nullptr) {
 		if (w->window_desc.hotkeys != nullptr) {
 			int hotkey = w->window_desc.hotkeys->CheckMatch(keycode);
-			if (hotkey >= 0 && w->OnHotkey(hotkey) == EventState::Handled) return;
+			if (hotkey >= 0 && HandleHotkey(w, hotkey) == EventState::Handled) return;
 		}
 		if (w->OnKeyPress(key, keycode) == EventState::Handled) return;
 	}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #15636.

Custom hotkey configurations that use shift may behave unexpectedly as the shift-modifier is treated as requesting a cost estimate. Any hotkey that issues a command will therefore not work if the shift is involved.

Similar caveats apply to the ctrl modifier, although that is less universal.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Reset shift and ctrl modifier state when handling hotkeys, to allow hotkeys with modifiers to be processed as expected. State is automatically restored once the hotkey handler is complete.

This allows shift and ctrl modifiers to be used with hotkeys that issue commands.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
