### PR TITLE
Codechange: Add method to test if a TileArea is empty

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -155,8 +155,8 @@ static StationID FindNearestHangar(const Aircraft *v)
 
 		/* Check if our last and next destinations can be reached from the depot airport. */
 		if (max_range != 0) {
-			uint last_dist = (last_dest != nullptr && last_dest->airport.tile != INVALID_TILE) ? DistanceSquare(st->airport.tile, last_dest->airport.tile) : 0;
-			uint next_dist = (next_dest != nullptr && next_dest->airport.tile != INVALID_TILE) ? DistanceSquare(st->airport.tile, next_dest->airport.tile) : 0;
+			uint last_dist = (last_dest != nullptr && !last_dest->airport.IsEmpty()) ? DistanceSquare(st->airport.tile, last_dest->airport.tile) : 0;
+			uint next_dist = (next_dest != nullptr && !next_dest->airport.IsEmpty()) ? DistanceSquare(st->airport.tile, next_dest->airport.tile) : 0;
 			if (last_dist > max_range || next_dist > max_range) continue;
 		}
 
@@ -835,7 +835,7 @@ static uint8_t AircraftGetEntryPoint(const Aircraft *v, const AirportFTAClass *a
 	const Station *st = Station::GetIfValid(v->targetairport);
 	if (st != nullptr) {
 		/* Make sure we don't go to INVALID_TILE if the airport has been removed. */
-		tile = (st->airport.tile != INVALID_TILE) ? st->airport.tile : st->xy;
+		tile = !st->airport.IsEmpty() ? st->airport.tile : st->xy;
 	}
 
 	int delta_x = v->x_pos - TileX(tile) * TILE_SIZE;
@@ -872,7 +872,7 @@ static bool AircraftController(Aircraft *v)
 	Direction rotation = Direction::N;
 	uint size_x = 1, size_y = 1;
 	if (st != nullptr) {
-		if (st->airport.tile != INVALID_TILE) {
+		if (!st->airport.IsEmpty()) {
 			tile = st->airport.tile;
 			rotation = st->airport.rotation;
 			size_x = st->airport.w;
@@ -885,7 +885,7 @@ static bool AircraftController(Aircraft *v)
 	const AirportFTAClass *afc = tile == INVALID_TILE ? GetAirport(AT_DUMMY) : st->airport.GetFTA();
 
 	/* prevent going to INVALID_TILE if airport is deleted. */
-	if (st == nullptr || st->airport.tile == INVALID_TILE) {
+	if (st == nullptr || st->airport.IsEmpty()) {
 		/* Jump into our "holding pattern" state machine if possible */
 		if (v->pos >= afc->nofelements) {
 			v->pos = v->previous_pos = AircraftGetEntryPoint(v, afc, Direction::N);
@@ -1144,7 +1144,7 @@ static bool AircraftController(Aircraft *v)
 				continue;
 			}
 
-			if (st->airport.tile == INVALID_TILE) {
+			if (st->airport.IsEmpty()) {
 				/* Airport has been removed, abort the landing procedure */
 				v->state = FLYING;
 				UpdateAircraftCache(v);
@@ -2130,7 +2130,7 @@ static bool AircraftEventHandler(Aircraft *v, int loop)
 		Station *cur_st = Station::GetIfValid(v->targetairport);
 		Station *next_st = v->current_order.IsType(OT_GOTO_STATION) || v->current_order.IsType(OT_GOTO_DEPOT) ? Station::GetIfValid(v->current_order.GetDestination().ToStationID()) : nullptr;
 
-		if (cur_st != nullptr && cur_st->airport.tile != INVALID_TILE && next_st != nullptr && next_st->airport.tile != INVALID_TILE) {
+		if (cur_st != nullptr && !cur_st->airport.IsEmpty() && next_st != nullptr && !next_st->airport.IsEmpty()) {
 			uint dist = DistanceSquare(cur_st->airport.tile, next_st->airport.tile);
 			AircraftHandleDestTooFar(v, dist > v->acache.cached_max_range_sqr);
 		}
@@ -2177,7 +2177,7 @@ Station *GetTargetAirportIfValid(const Aircraft *v)
 	Station *st = Station::GetIfValid(v->targetairport);
 	if (st == nullptr) return nullptr;
 
-	return st->airport.tile == INVALID_TILE ? nullptr : st;
+	return st->airport.IsEmpty() ? nullptr : st;
 }
 
 /**
@@ -2188,7 +2188,7 @@ void UpdateAirplanesOnNewStation(const Station *st)
 {
 	/* only 1 station is updated per function call, so it is enough to get entry_point once */
 	const AirportFTAClass *ap = st->airport.GetFTA();
-	Direction rotation = st->airport.tile == INVALID_TILE ? Direction::N : st->airport.rotation;
+	Direction rotation = st->airport.IsEmpty() ? Direction::N : st->airport.rotation;
 
 	for (Aircraft *v : Aircraft::Iterate()) {
 		if (!v->IsNormalAircraft() || v->targetairport != st->index) continue;

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -758,7 +758,7 @@ static void Disaster_Zeppeliner_Init()
 	int x = TileX(RandomTile()) * TILE_SIZE + TILE_SIZE / 2;
 
 	for (const Station *st : Station::Iterate()) {
-		if (st->airport.tile != INVALID_TILE && (st->airport.type == AT_SMALL || st->airport.type == AT_LARGE)) {
+		if (!st->airport.IsEmpty() && (st->airport.type == AT_SMALL || st->airport.type == AT_LARGE)) {
 			x = (TileX(st->airport.tile) + 2) * TILE_SIZE;
 			break;
 		}

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -321,7 +321,7 @@ bool TriggerAirportTileAnimation(Station *st, TileIndex tile, AirportAnimationTr
 
 bool TriggerAirportAnimation(Station *st, AirportAnimationTrigger trigger, CargoType cargo_type)
 {
-	if (st->airport.tile == INVALID_TILE) return false;
+	if (st->airport.IsEmpty()) return false;
 
 	bool ret = true;
 	uint32_t random = Random();

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -515,7 +515,7 @@ static uint32_t VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *objec
 
 				const Station *st = GetTargetAirportIfValid(Aircraft::From(v));
 
-				if (st != nullptr && st->airport.tile != INVALID_TILE) {
+				if (st != nullptr && !st->airport.IsEmpty()) {
 					airporttype = st->airport.GetSpec()->ttd_airport_type;
 				}
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -431,7 +431,7 @@ uint32_t Station::GetNewGRFVariable(const ResolverObject &object, uint8_t variab
 		}
 
 		case 0x8A: return this->had_vehicle_of_type.base();
-		case 0xF1: return (this->airport.tile != INVALID_TILE) ? this->airport.GetSpec()->ttd_airport_type : ATP_TTDP_LARGE;
+		case 0xF1: return !this->airport.IsEmpty() ? this->airport.GetSpec()->ttd_airport_type : ATP_TTDP_LARGE;
 		case 0xF2: return (this->truck_stops != nullptr) ? this->truck_stops->status.base() : 0;
 		case 0xF3: return (this->bus_stops != nullptr)   ? this->bus_stops->status.base()   : 0;
 		case 0xF6: return this->airport.blocks.base();

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -2159,7 +2159,7 @@ bool ProcessOrders(Vehicle *v)
 
 	/* If it is unchanged, keep it. */
 	if (order->Equals(v->current_order) && (v->type == VehicleType::Aircraft || v->dest_tile != INVALID_TILE) &&
-			(v->type != VehicleType::Ship || !order->IsType(OT_GOTO_STATION) || Station::Get(order->GetDestination().ToStationID())->ship_station.tile != INVALID_TILE)) {
+			(v->type != VehicleType::Ship || !order->IsType(OT_GOTO_STATION) || !Station::Get(order->GetDestination().ToStationID())->ship_station.IsEmpty())) {
 		return false;
 	}
 

--- a/src/pathfinder/pathfinder_func.h
+++ b/src/pathfinder/pathfinder_func.h
@@ -28,7 +28,7 @@ inline TileIndex CalcClosestStationTile(StationID station, TileIndex tile, Stati
 	TileArea ta = st->GetTileArea(station_type);
 
 	/* If the rail station is (temporarily) not present, use the station sign to drive near the station */
-	if (ta.tile == INVALID_TILE) return st->xy;
+	if (ta.IsEmpty()) return st->xy;
 
 	uint minx = TileX(ta.tile);  // topmost corner of station
 	uint miny = TileY(ta.tile);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2494,7 +2494,7 @@ bool AfterLoadGame()
 	/* Oilrig was moved from id 15 to 9. */
 	if (IsSavegameVersionBefore(SaveLoadVersion::RvRealisticAcceleration)) {
 		for (Station *st : Station::Iterate()) {
-			if (st->airport.tile != INVALID_TILE && st->airport.type == 15) {
+			if (!st->airport.IsEmpty() && st->airport.type == 15) {
 				st->airport.type = AT_OILRIG;
 			}
 		}
@@ -2502,7 +2502,7 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBefore(SaveLoadVersion::StoreAirportSize)) {
 		for (Station *st : Station::Iterate()) {
-			if (st->airport.tile != INVALID_TILE) {
+			if (!st->airport.IsEmpty()) {
 				st->airport.w = st->airport.GetSpec()->size_x;
 				st->airport.h = st->airport.GetSpec()->size_y;
 			}
@@ -3250,7 +3250,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SaveLoadVersion::RepairObjectDockingTiles)) {
 		/* Placing objects on docking tiles was not updating adjacent station's docking tiles. */
 		for (Station *st : Station::Iterate()) {
-			if (st->ship_station.tile != INVALID_TILE) UpdateStationDockingTiles(st);
+			if (!st->ship_station.IsEmpty()) UpdateStationDockingTiles(st);
 		}
 	}
 

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -70,7 +70,7 @@ void MoveBuoysToWaypoints()
 		std::string name   = st->name;
 		TimerGameCalendar::Date build_date = st->build_date;
 		/* TTDPatch could use "buoys with rail station" for rail waypoints */
-		bool train         = st->train_station.tile != INVALID_TILE;
+		bool train         = !st->train_station.IsEmpty();
 		TileArea train_st  = st->train_station;
 
 		/* Delete the station, so we can make it a real waypoint. */

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -260,11 +260,11 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 
 		case OT_GOTO_STATION: {
 			const Station *st = ::Station::Get(order->GetDestination().ToStationID());
-			if (st->train_station.tile != INVALID_TILE) {
+			if (!st->train_station.IsEmpty()) {
 				for (TileIndex t : st->train_station) {
 					if (st->TileBelongsToRailStation(t)) return t;
 				}
-			} else if (st->ship_station.tile != INVALID_TILE) {
+			} else if (!st->ship_station.IsEmpty()) {
 				for (TileIndex t : st->ship_station) {
 					if (IsTileType(t, TileType::Station) && (IsDock(t) || IsOilRig(t)) && GetStationIndex(t) == st->index) return t;
 				}
@@ -272,7 +272,7 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 				return st->bus_stops->xy;
 			} else if (st->truck_stops != nullptr) {
 				return st->truck_stops->xy;
-			} else if (st->airport.tile != INVALID_TILE) {
+			} else if (!st->airport.IsEmpty()) {
 				for (TileIndex tile : st->airport) {
 					if (st->TileBelongsToAirport(tile) && !::IsHangar(tile)) return tile;
 				}
@@ -282,11 +282,11 @@ static ScriptOrder::OrderPosition RealOrderPositionToScriptOrderPosition(Vehicle
 
 		case OT_GOTO_WAYPOINT: {
 			const Waypoint *wp = ::Waypoint::Get(order->GetDestination().ToStationID());
-			if (wp->train_station.tile != INVALID_TILE) {
+			if (!wp->train_station.IsEmpty()) {
 				for (TileIndex t : wp->train_station) {
 					if (wp->TileBelongsToRailStation(t)) return t;
 				}
-			} else if (wp->road_waypoint_area.tile != INVALID_TILE) {
+			} else if (!wp->road_waypoint_area.IsEmpty()) {
 				for (TileIndex t : wp->road_waypoint_area) {
 					if (::IsRoadWaypointTile(t) && ::GetStationIndex(t) == wp->index) return t;
 				}
@@ -699,11 +699,11 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance &instance)
 	if (vehicle_type == ScriptVehicle::VT_AIR) {
 		if (ScriptTile::IsStationTile(origin_tile)) {
 			const Station *orig_station = ::Station::GetByTile(origin_tile);
-			if (orig_station != nullptr && orig_station->airport.tile != INVALID_TILE) origin_tile = orig_station->airport.tile;
+			if (orig_station != nullptr && !orig_station->airport.IsEmpty()) origin_tile = orig_station->airport.tile;
 		}
 		if (ScriptTile::IsStationTile(dest_tile)) {
 			const Station *dest_station = ::Station::GetByTile(dest_tile);
-			if (dest_station != nullptr && dest_station->airport.tile != INVALID_TILE) dest_tile = dest_station->airport.tile;
+			if (dest_station != nullptr && !dest_station->airport.IsEmpty()) dest_tile = dest_station->airport.tile;
 		}
 
 		return ScriptMap::DistanceSquare(origin_tile, dest_tile);

--- a/src/script/api/script_tilelist.cpp
+++ b/src/script/api/script_tilelist.cpp
@@ -206,7 +206,7 @@ ScriptTileList_StationCoverage::ScriptTileList_StationCoverage(StationID station
 	if (!ScriptStation::IsValidStation(station_id)) return;
 
 	const BitmapTileArea &ta = ::Station::Get(station_id)->catchment_tiles;
-	if (ta.tile == INVALID_TILE) return;
+	if (ta.IsEmpty()) return;
 
 	BitmapTileIterator it(ta);
 	for (TileIndex tile = it; tile != INVALID_TILE; tile = ++it) {

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -249,7 +249,7 @@ void Station::AddFacility(StationFacility new_facility_bit, TileIndex facil_xy)
  */
 void Station::MarkTilesDirty(bool cargo_change) const
 {
-	if (this->train_station.tile == INVALID_TILE) return;
+	if (this->train_station.IsEmpty()) return;
 
 	/* cargo_change is set if we're refreshing the tiles due to cargo moving
 	 * around. */
@@ -348,13 +348,13 @@ uint Station::GetCatchmentRadius() const
 	uint ret = CA_NONE;
 
 	if (_settings_game.station.modified_catchment) {
-		if (this->bus_stops          != nullptr)      ret = std::max<uint>(ret, CA_BUS);
-		if (this->truck_stops        != nullptr)      ret = std::max<uint>(ret, CA_TRUCK);
-		if (this->train_station.tile != INVALID_TILE) ret = std::max<uint>(ret, CA_TRAIN);
-		if (this->ship_station.tile  != INVALID_TILE) ret = std::max<uint>(ret, CA_DOCK);
-		if (this->airport.tile       != INVALID_TILE) ret = std::max<uint>(ret, this->airport.GetSpec()->catchment);
+		if (this->bus_stops != nullptr) ret = std::max<uint>(ret, CA_BUS);
+		if (this->truck_stops != nullptr) ret = std::max<uint>(ret, CA_TRUCK);
+		if (!this->train_station.IsEmpty()) ret = std::max<uint>(ret, CA_TRAIN);
+		if (!this->ship_station.IsEmpty()) ret = std::max<uint>(ret, CA_DOCK);
+		if (!this->airport.IsEmpty()) ret = std::max<uint>(ret, this->airport.GetSpec()->catchment);
 	} else {
-		if (this->bus_stops != nullptr || this->truck_stops != nullptr || this->train_station.tile != INVALID_TILE || this->ship_station.tile != INVALID_TILE || this->airport.tile != INVALID_TILE) {
+		if (this->bus_stops != nullptr || this->truck_stops != nullptr || !this->train_station.IsEmpty() || !this->ship_station.IsEmpty() || !this->airport.IsEmpty()) {
 			ret = CA_UNMODIFIED;
 		}
 	}

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1494,7 +1494,7 @@ CommandCost CmdBuildRailStation(DoCommandFlags flags, TileIndex tile_org, RailTy
 	ret = BuildStationPart(&st, flags, reuse, new_location, StationNaming::Rail);
 	if (ret.Failed()) return ret;
 
-	if (st != nullptr && st->train_station.tile != INVALID_TILE) {
+	if (st != nullptr && !st->train_station.IsEmpty()) {
 		ret = CanExpandRailStation(st, new_location);
 		if (ret.Failed()) return ret;
 	}
@@ -1836,7 +1836,7 @@ CommandCost RemoveFromRailBaseStation(TileArea ta, std::vector<T *> &affected_st
 		UpdateStationSignCoord(st);
 
 		/* if we deleted the whole station, delete the train facility. */
-		if (st->train_station.tile == INVALID_TILE) {
+		if (st->train_station.IsEmpty()) {
 			st->facilities.Reset(StationFacility::Train);
 			SetWindowClassesDirty(WindowClass::VehicleOrders);
 			SetWindowWidgetDirty(WindowClass::StationView, st->index, WID_SV_TRAINS);
@@ -1873,7 +1873,7 @@ CommandCost CmdRemoveFromRailStation(DoCommandFlags flags, TileIndex start, Tile
 	/* Do all station specific functions here. */
 	for (Station *st : affected_stations) {
 
-		if (st->train_station.tile == INVALID_TILE) SetWindowWidgetDirty(WindowClass::StationView, st->index, WID_SV_TRAINS);
+		if (st->train_station.IsEmpty()) SetWindowWidgetDirty(WindowClass::StationView, st->index, WID_SV_TRAINS);
 		st->MarkTilesDirty(false);
 		MarkCatchmentTilesDirty();
 		st->RecomputeCatchment();
@@ -2400,7 +2400,7 @@ CommandCost RemoveRoadWaypointStop(TileIndex tile, DoCommandFlags flags, int rep
 			UpdateStationSignCoord(wp);
 
 			/* if we deleted the whole waypoint, delete the road facility. */
-			if (wp->road_waypoint_area.tile == INVALID_TILE) {
+			if (wp->road_waypoint_area.IsEmpty()) {
 				wp->facilities.Reset({StationFacility::BusStop, StationFacility::TruckStop});
 				SetWindowWidgetDirty(WindowClass::StationView, wp->index, WID_SV_ROADVEHS);
 				wp->UpdateVirtCoord();
@@ -2609,7 +2609,7 @@ void UpdateAirportsNoise()
 	for (Town *t : Town::Iterate()) t->noise_reached = 0;
 
 	for (const Station *st : Station::Iterate()) {
-		if (st->airport.tile != INVALID_TILE && st->airport.type != AT_OILRIG) {
+		if (!st->airport.IsEmpty() && st->airport.type != AT_OILRIG) {
 			uint dist;
 			Town *nearest = AirportGetNearestTown(st, dist);
 			nearest->noise_reached += GetAirportNoiseLevelForDistance(st->airport.GetSpec(), dist);
@@ -2700,7 +2700,7 @@ CommandCost CmdBuildAirport(DoCommandFlags flags, TileIndex tile, uint8_t airpor
 	ret = BuildStationPart(&st, flags, reuse, airport_area, GetAirport(airport_type)->flags.Test(AirportFTAClass::Flag::Airplanes) ? StationNaming::Airport : StationNaming::Heliport);
 	if (ret.Failed()) return ret;
 
-	if (st != nullptr && st->airport.tile != INVALID_TILE) {
+	if (st != nullptr && !st->airport.IsEmpty()) {
 		return CommandCost(STR_ERROR_TOO_CLOSE_TO_ANOTHER_AIRPORT);
 	}
 
@@ -3074,8 +3074,7 @@ static CommandCost RemoveDock(TileIndex tile, DoCommandFlags flags)
 		st->rect.AfterRemoveTile(st, tile2);
 
 		MakeShipStationAreaSmaller(st);
-		if (st->ship_station.tile == INVALID_TILE) {
-			st->ship_station.Clear();
+		if (st->ship_station.IsEmpty()) {
 			st->docking_station.Clear();
 			st->facilities.Reset(StationFacility::Dock);
 			SetWindowClassesDirty(WindowClass::VehicleOrders);

--- a/src/tilearea_type.h
+++ b/src/tilearea_type.h
@@ -32,6 +32,12 @@ struct OrthogonalTileArea {
 
 	OrthogonalTileArea(TileIndex start, TileIndex end);
 
+	/**
+	 * Test if this tile area is empty.
+	 * @return \c true iff the tile area is empty.
+	 */
+	inline bool IsEmpty() const { return this->tile == INVALID_TILE; }
+
 	void Add(TileIndex to_add);
 
 	/**

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -3672,7 +3672,7 @@ void MarkCatchmentTilesDirty()
 	}
 
 	if (_viewport_highlight_station != nullptr) {
-		if (_viewport_highlight_station->catchment_tiles.tile == INVALID_TILE) {
+		if (_viewport_highlight_station->catchment_tiles.IsEmpty()) {
 			MarkWholeScreenDirty();
 			_viewport_highlight_station = nullptr;
 		} else {

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -281,7 +281,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 		if (wp->owner != _current_company) return CommandCost(STR_ERROR_TOO_CLOSE_TO_ANOTHER_WAYPOINT);
 
 		/* Check if we want to expand an already existing waypoint. */
-		if (wp->train_station.tile != INVALID_TILE) {
+		if (!wp->train_station.IsEmpty()) {
 			ret = CanExpandRailStation(wp, new_location);
 			if (ret.Failed()) return ret;
 		}


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

> That fact this is the way of checking for an empty TileArea feels really odd

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Add `TileArea::IsEmpty()` member function to test if a `TileArea` is considered empty, and is in places which currently test for `INVALID_TILE`.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

`IsEmpty()` vs `!IsEmpty()` may need double-checking.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
