### PR TITLE
Codechange: Reload only changed font when using console command

### DIFF
--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -381,7 +381,7 @@ bool HandleBootstrap()
 	/* Initialise the font cache. */
 	InitializeUnicodeGlyphMap();
 	/* Next "force" finding a suitable non-sprite font as the local font is missing. */
-	CheckForMissingGlyphs();
+	CheckForMissingGlyphs(FontSize::Normal);
 
 	/* Initialise the palette. The biggest step is 'faking' some recolour sprites.
 	 * This way the mauve and gray colours work and we can show the user interface. */

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -132,14 +132,7 @@ void SetFont(FontSize fontsize, const std::string &font, uint size)
 
 	if (fontsize != FontSize::Monospace) {
 		/* Try to reload only the modified font. */
-		FontCacheSettings backup = _fcsettings;
-		for (FontSize fs : EnumRange(FontSize::End)) {
-			if (fs == fontsize) continue;
-			FontCache *fc = FontCache::Get(fs);
-			GetFontCacheSubSetting(fs)->font = fc->HasParent() ? fc->GetFontName() : "";
-		}
-		CheckForMissingGlyphs();
-		_fcsettings = std::move(backup);
+		CheckForMissingGlyphs(fontsize);
 	} else {
 		FontCache::LoadFontCaches(fontsize);
 	}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2331,12 +2331,6 @@ void BaseStringMissingGlyphSearcher::DetermineRequiredGlyphs(FontSizes fontsizes
 
 /** Helper for searching through the language pack. */
 class LanguagePackGlyphSearcher : public BaseStringMissingGlyphSearcher {
-public:
-	/**
-	 * Create this language pack glyph searcher.
-	 */
-	LanguagePackGlyphSearcher() : BaseStringMissingGlyphSearcher(FONTSIZES_REQUIRED) {}
-
 private:
 	uint i; ///< Iterator for the primary language tables.
 	uint j; ///< Iterator for the secondary language tables.
@@ -2377,17 +2371,18 @@ private:
  * mean it might use characters that are not in the
  * font, which is the whole reason this check has
  * been added.
+ * @param fontsizes Font sizes to consider.
  * @param searcher  The methods to use to search for strings to check.
  *                  If nullptr the loaded language pack searcher is used.
  */
-void CheckForMissingGlyphs(MissingGlyphSearcher *searcher)
+void CheckForMissingGlyphs(FontSizes fontsizes, MissingGlyphSearcher *searcher)
 {
 	static LanguagePackGlyphSearcher pack_searcher;
 	if (searcher == nullptr) searcher = &pack_searcher;
 
-	FontCache::LoadFontCaches(searcher->fontsizes);
+	FontCache::LoadFontCaches(fontsizes);
 
-	searcher->DetermineRequiredGlyphs(searcher->fontsizes);
+	searcher->DetermineRequiredGlyphs(fontsizes);
 	bool bad_font = searcher->missing_fontsizes.Any();
 
 #if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
@@ -2418,7 +2413,7 @@ void CheckForMissingGlyphs(MissingGlyphSearcher *searcher)
 #endif
 
 	/* Update the font width cache */
-	LoadStringWidthTable(searcher->fontsizes);
+	LoadStringWidthTable(fontsizes);
 
 	if (bad_font) {
 		/* All attempts have failed. Display an error. As we do not want the string to be translated by

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -156,16 +156,9 @@ EncodedString GetEncodedString(StringID string, const Args&... args)
  */
 class MissingGlyphSearcher {
 public:
-	/**
-	 * Create this glyph searcher.
-	 * @param fontsizes Font sizes to consider.
-	 */
-	MissingGlyphSearcher(FontSizes fontsizes) : fontsizes(fontsizes) {}
-
 	/** Ensure the destructor of the sub classes are called as well. */
 	virtual ~MissingGlyphSearcher() = default;
 
-	const FontSizes fontsizes; ///< Font sizes this searcher will try to find.
 	FontSizes missing_fontsizes{}; ///< Font sizes to actually search for.
 	std::set<char32_t> missing_glyphs{}; ///< Glyphs to search for.
 
@@ -179,12 +172,6 @@ public:
 /** Base for missing glyph searchers that look for missing glyphs in strings. */
 class BaseStringMissingGlyphSearcher : public MissingGlyphSearcher {
 public:
-	/**
-	 * Create this string glyph searcher.
-	 * @param fontsizes Font sizes to consider.
-	 */
-	BaseStringMissingGlyphSearcher(FontSizes fontsizes) : MissingGlyphSearcher(fontsizes) {}
-
 	void DetermineRequiredGlyphs(FontSizes fontsizes) override;
 
 	/**
@@ -205,6 +192,6 @@ public:
 	virtual void Reset() = 0;
 };
 
-void CheckForMissingGlyphs(MissingGlyphSearcher *searcher = nullptr);
+void CheckForMissingGlyphs(FontSizes fontsizes = FONTSIZES_REQUIRED, MissingGlyphSearcher *searcher = nullptr);
 
 #endif /* STRINGS_FUNC_H */

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -83,7 +83,7 @@ static WindowDesc _textfile_desc(
 	_nested_textfile_widgets
 );
 
-TextfileWindow::TextfileWindow(Window *parent, TextfileType file_type) : Window(_textfile_desc), BaseStringMissingGlyphSearcher(FontSize::Monospace), file_type(file_type)
+TextfileWindow::TextfileWindow(Window *parent, TextfileType file_type) : Window(_textfile_desc), file_type(file_type)
 {
 	/* Init of nested tree is deferred.
 	 * TextfileWindow::ConstructWindow must be called by the inheriting window. */
@@ -912,7 +912,7 @@ void TextfileWindow::LoadText(std::string_view buf)
 	this->AfterLoadText();
 	this->ReflowContent();
 
-	CheckForMissingGlyphs(this);
+	CheckForMissingGlyphs(FontSize::Monospace, this);
 
 	/* The font may have changed when searching for glyphs, so ensure widget sizes are updated just in case. */
 	this->ReInit();


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

When using the `font` console command, all fonts (except monospace) are reloaded even though you can only change one font at a time.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Tweak `CheckForMissingGlyphs()` to allow only specific fontsizes to be searched, replacing the Searcher's hardcoded fontsizes.

When using the font console command, only reload the changed font install of all.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
