### PR TITLE
Fix d89d6831: Crash when placing trees on coast tiles with rocks

### DIFF
--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -527,7 +527,8 @@ CommandCost CmdPlantTree(DoCommandFlags flags, TileIndex tile, TileIndex start_t
 	std::unique_ptr<TileIterator> iter = TileIterator::Create(tile, start_tile, diagonal);
 	for (; *iter != INVALID_TILE; ++(*iter)) {
 		TileIndex current_tile = *iter;
-		switch (GetTileType(current_tile)) {
+		TileType tile_type = GetTileType(current_tile);
+		switch (tile_type) {
 			case TileType::Trees:
 				/* no more space for trees? */
 				if (GetTreeCount(current_tile) == 4) {
@@ -582,19 +583,26 @@ CommandCost CmdPlantTree(DoCommandFlags flags, TileIndex tile, TileIndex start_t
 					break;
 				}
 
-				if (IsTileType(current_tile, TileType::Clear)) {
+				bool tile_needs_to_be_cleared = false;
+				if (tile_type == TileType::Clear) {
 					/* Remove fields or rocks. Note that the ground will get barrened */
 					switch (GetClearGround(current_tile)) {
 						case ClearGround::Fields:
-						case ClearGround::Rocks: {
-							CommandCost ret = Command<Commands::LandscapeClear>::Do(flags, current_tile);
-							if (ret.Failed()) return ret;
-							cost.AddCost(ret.GetCost());
+						case ClearGround::Rocks:
+							tile_needs_to_be_cleared = true;
 							break;
-						}
 
-						default: break;
+						default:
+							break;
 					}
+				} else if (tile_type == TileType::Water) {
+					tile_needs_to_be_cleared = GetWaterTileType(current_tile) != WaterTileType::Coast;
+				}
+
+				if (tile_needs_to_be_cleared) {
+					CommandCost ret = Command<Commands::LandscapeClear>::Do(flags, current_tile);
+					if (ret.Failed()) return ret;
+					cost.AddCost(ret.GetCost());
 				}
 
 				if (_game_mode != GameMode::Editor && Company::IsValidID(_current_company)) {


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Since d89d6831ba6c721d252a75eb0e764678aa02754b coastal tiles can have rocks. These are still considered coast tiles. Placing trees is allowed on coast tiles, but the command still assumed the tile did not need to be cleared.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Clear rocky coast tiles before placing trees. As the tile is cleared, it does not immediately become a tree with coast ground, but will 'flood' to become a tree with coast ground later.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
