### PR TITLE
Fix #15985: Incorrect train station area after adding to a station

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1518,9 +1518,9 @@ CommandCost CmdBuildRailStation(DoCommandFlags flags, TileIndex tile_org, RailTy
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		st->train_station = new_location;
 		st->AddFacility(StationFacility::Train, new_location.tile);
 
+		st->train_station.Add(new_location);
 		st->spread.Add(new_location);
 
 		if (specindex.has_value()) AssignSpecToStation(statspec, st, *specindex);

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -301,13 +301,14 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlags flags, TileIndex start_tile, Axi
 		wp->owner = GetTileOwner(start_tile);
 
 		wp->spread.Add(new_location);
+		wp->train_station.Add(new_location);
+
 		if (specindex.has_value()) AssignSpecToStation(spec, wp, *specindex);
 
 		wp->delete_ctr = 0;
 		wp->facilities.Set(StationFacility::Train);
 		wp->build_date = TimerGameCalendar::date;
 		wp->string_id = STR_SV_STNAME_WAYPOINT;
-		wp->train_station = new_location;
 
 		if (wp->town == nullptr) MakeDefaultName(wp);
 


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

As per #15985, since dc39225d60, removing rail station or waypoint parts can crash. This is because building parts replaces the recorded station tile area (`train_station`) instead of adding to it.

An unfortunate case of a previous function having side effects, modifying one of its input parameters.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Resolved by adding to the `train_station` tile area when adding new parts to a station/waypoint.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Games saved since dc39225d60 will still crash, as the incorrect station tile area is saved in the savegame.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
