### PR TITLE
Change: Don't save station tile areas that can be recalculated on load.

### DIFF
--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -59,7 +59,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	CargoTypes cached_cargo_triggers{}; ///< NOSAVE: Combined cargo trigger bitmask
 	CargoTypes cached_roadstop_cargo_triggers{}; ///< NOSAVE: Combined cargo trigger bitmask for road stops
 
-	TileArea train_station{INVALID_TILE, 0, 0}; ///< Tile area the train 'station' part covers
+	TileArea train_station{INVALID_TILE, 0, 0}; ///< NOSAVE: Tile area the train 'station' part covers
 	TileArea spread{}; ///< NOSAVE: Station spread tile area.
 
 	std::vector<RoadStopTileData> custom_roadstop_tile_data{}; ///< List of custom road stop tile data

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -601,29 +601,6 @@ bool AfterLoadGame()
 		_pause_mode.Reset({PauseMode::ActiveClients, PauseMode::Join});
 	}
 
-	/* In very old versions, size of train stations was stored differently.
-	 * They had swapped width and height if station was built along the Y axis.
-	 * TTO and TTD used 3 bits for width/height, while OpenTTD used 4.
-	 * Because the data stored by TTDPatch are unusable for rail stations > 7x7,
-	 * recompute the width and height. Doing this unconditionally for all old
-	 * savegames simplifies the code. */
-	if (IsSavegameVersionBefore(SaveLoadVersion::VehicleCurrencyStationChanges)) {
-		for (Station *st : Station::Iterate()) {
-			st->train_station.w = st->train_station.h = 0;
-		}
-		for (auto t : Map::Iterate()) {
-			if (!IsTileType(t, TileType::Station)) continue;
-			if (t.m5() > 7) continue; // is it a rail station tile?
-			Station *st = Station::Get(t.m2());
-			assert(st->train_station.tile != 0);
-			int dx = TileX(t) - TileX(st->train_station.tile);
-			int dy = TileY(t) - TileY(st->train_station.tile);
-			assert(dx >= 0 && dy >= 0);
-			st->train_station.w = std::max<uint16_t>(st->train_station.w, dx + 1);
-			st->train_station.h = std::max<uint16_t>(st->train_station.h, dy + 1);
-		}
-	}
-
 	if (IsSavegameVersionBefore(SaveLoadVersion::MaxBridgeMapHeight)) {
 		_settings_game.construction.map_height_limit = 15;
 
@@ -686,12 +663,6 @@ bool AfterLoadGame()
 	ResetOldNames();
 
 	if (IsSavegameVersionBefore(SaveLoadVersion::DistantStationJoining)) {
-		/* no station is determined by 'tile == INVALID_TILE' now (instead of '0') */
-		for (Station *st : Station::Iterate()) {
-			if (st->airport.tile       == 0) st->airport.tile = INVALID_TILE;
-			if (st->train_station.tile == 0) st->train_station.tile   = INVALID_TILE;
-		}
-
 		/* the same applies to Company::location_of_HQ */
 		for (Company *c : Company::Iterate()) {
 			if (c->location_of_HQ == 0 || (IsSavegameVersionBefore(SaveLoadVersion::TownTolerancePauseMode) && c->location_of_HQ == 0xFFFF)) {
@@ -2305,17 +2276,23 @@ bool AfterLoadGame()
 		}
 	}
 
-	if (IsSavegameVersionBefore(SaveLoadVersion::MultiTileWaypoints) && !IsSavegameVersionBeforeOrAt(SaveLoadVersion::MinVersion)) {
-		/* The train station tile area was added, but for really old (TTDPatch) it's already valid. */
-		for (Waypoint *wp : Waypoint::Iterate()) {
-			if (wp->facilities.Test(StationFacility::Train)) {
-				wp->train_station.tile = wp->xy;
-				wp->train_station.w = 1;
-				wp->train_station.h = 1;
-			} else {
-				wp->train_station.tile = INVALID_TILE;
-				wp->train_station.w = 0;
-				wp->train_station.h = 0;
+	{
+		for (auto t : Map::Iterate()) {
+			if (!IsTileType(t, TileType::Station)) continue;
+
+			BaseStation *st = BaseStation::GetByTile(t);
+			assert(st != nullptr);
+
+			st->spread.Add(t);
+
+			switch (GetStationType(t)) {
+				case StationType::Rail: Station::From(st)->train_station.Add(t); break;
+				case StationType::Airport: Station::From(st)->airport.Add(t); break;
+				case StationType::Oilrig: Station::From(st)->ship_station.Add(t); break;
+				case StationType::Dock: Station::From(st)->ship_station.Add(t); break;
+				case StationType::RailWaypoint: Waypoint::From(st)->train_station.Add(t); break;
+				case StationType::RoadWaypoint: Waypoint::From(st)->road_waypoint_area.Add(t); break;
+				default: break;
 			}
 		}
 	}
@@ -2496,15 +2473,6 @@ bool AfterLoadGame()
 		for (Station *st : Station::Iterate()) {
 			if (!st->airport.IsEmpty() && st->airport.type == 15) {
 				st->airport.type = AT_OILRIG;
-			}
-		}
-	}
-
-	if (IsSavegameVersionBefore(SaveLoadVersion::StoreAirportSize)) {
-		for (Station *st : Station::Iterate()) {
-			if (!st->airport.IsEmpty()) {
-				st->airport.w = st->airport.GetSpec()->size_x;
-				st->airport.h = st->airport.GetSpec()->size_y;
 			}
 		}
 	}
@@ -3240,18 +3208,11 @@ bool AfterLoadGame()
 			if (IsTileType(t, TileType::Water) || IsTileType(t, TileType::Railway) || IsTileType(t, TileType::Station) || IsTileType(t, TileType::TunnelBridge)) {
 				SetDockingTile(t, false);
 			}
-			/* Add docks and oilrigs to Station::ship_station. */
-			if (IsTileType(t, TileType::Station)) {
-				if (IsDock(t) || IsOilRig(t)) Station::GetByTile(t)->ship_station.Add(t);
-			}
 		}
 	}
 
-	if (IsSavegameVersionBefore(SaveLoadVersion::RepairObjectDockingTiles)) {
-		/* Placing objects on docking tiles was not updating adjacent station's docking tiles. */
-		for (Station *st : Station::Iterate()) {
-			if (!st->ship_station.IsEmpty()) UpdateStationDockingTiles(st);
-		}
+	for (Station *st : Station::Iterate()) {
+		if (!st->ship_station.IsEmpty()) UpdateStationDockingTiles(st);
 	}
 
 	/* Make sure all industries exclusive supplier/consumer set correctly. */

--- a/src/saveload/compat/station_sl_compat.h
+++ b/src/saveload/compat/station_sl_compat.h
@@ -89,21 +89,21 @@ const SaveLoadCompat _station_base_sl_compat[] = {
 /** Original field order for SlStationNormal. */
 const SaveLoadCompat _station_normal_sl_compat[] = {
 	SLC_VAR("base"),
-	SLC_VAR("train_station.tile"),
-	SLC_VAR("train_station.w"),
-	SLC_VAR("train_station.h"),
+	SLC_NULL(4, SaveLoadVersion::MinVersion, SaveLoadVersion::DontSaveStationArea), // train_station.tile
+	SLC_NULL(1, SaveLoadVersion::MinVersion, SaveLoadVersion::DontSaveStationArea), // train_station.w
+	SLC_NULL(1, SaveLoadVersion::MinVersion, SaveLoadVersion::DontSaveStationArea), // train_station.h
 	SLC_VAR("bus_stops"),
 	SLC_VAR("truck_stops"),
 	SLC_NULL(4, SaveLoadVersion::MinVersion, SaveLoadVersion::MultitileDocks),
-	SLC_VAR("ship_station.tile"),
-	SLC_VAR("ship_station.w"),
-	SLC_VAR("ship_station.h"),
-	SLC_VAR("docking_station.tile"),
-	SLC_VAR("docking_station.w"),
-	SLC_VAR("docking_station.h"),
-	SLC_VAR("airport.tile"),
-	SLC_VAR("airport.w"),
-	SLC_VAR("airport.h"),
+	SLC_NULL(4, SaveLoadVersion::MultitileDocks, SaveLoadVersion::DontSaveStationArea), // ship_station.tile
+	SLC_NULL(1, SaveLoadVersion::MultitileDocks, SaveLoadVersion::DontSaveStationArea), // ship_station.w
+	SLC_NULL(1, SaveLoadVersion::MultitileDocks, SaveLoadVersion::DontSaveStationArea), // ship_station.h
+	SLC_NULL(4, SaveLoadVersion::MultitileDocks, SaveLoadVersion::DontSaveStationArea), // docking_station.tile
+	SLC_NULL(1, SaveLoadVersion::MultitileDocks, SaveLoadVersion::DontSaveStationArea), // docking_station.w
+	SLC_NULL(1, SaveLoadVersion::MultitileDocks, SaveLoadVersion::DontSaveStationArea), // docking_station.h
+	SLC_NULL(4, SaveLoadVersion::MinVersion, SaveLoadVersion::DontSaveStationArea), // airport.tile
+	SLC_NULL(1, SaveLoadVersion::StoreAirportSize, SaveLoadVersion::DontSaveStationArea), // airport.w
+	SLC_NULL(1, SaveLoadVersion::StoreAirportSize, SaveLoadVersion::DontSaveStationArea), // airport.h
 	SLC_VAR("airport.type"),
 	SLC_VAR("airport.layout"),
 	SLC_VAR("airport.flags"),
@@ -124,9 +124,9 @@ const SaveLoadCompat _station_normal_sl_compat[] = {
 const SaveLoadCompat _station_waypoint_sl_compat[] = {
 	SLC_VAR("base"),
 	SLC_VAR("town_cn"),
-	SLC_VAR("train_station.tile"),
-	SLC_VAR("train_station.w"),
-	SLC_VAR("train_station.h"),
+	SLC_NULL(4, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::DontSaveStationArea), // train_station.tile
+	SLC_NULL(1, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::DontSaveStationArea), // train_station.w
+	SLC_NULL(1, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::DontSaveStationArea), // train_station.h
 };
 
 /** Original field order for _station_desc. */
@@ -141,13 +141,15 @@ const SaveLoadCompat _station_sl_compat[] = {
 const SaveLoadCompat _old_station_sl_compat[] = {
 	SLC_VAR("xy"),
 	SLC_NULL(4, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLC_VAR("train_station.tile"),
-	SLC_VAR("airport.tile"),
+	SLC_NULL(2, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops), // train_station.tile
+	SLC_NULL(4, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::DontSaveStationArea), // train_station.tile
+	SLC_NULL(2, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops), // airport.tile
+	SLC_NULL(4, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::DontSaveStationArea), // airport.tile
 	SLC_NULL(2, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
 	SLC_NULL(4, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MultitileDocks),
 	SLC_VAR("town"),
-	SLC_VAR("train_station.w"),
-	SLC_VAR("train_station.h"),
+	SLC_NULL(1, SaveLoadVersion::MinVersion, SaveLoadVersion::DontSaveStationArea), // train_station.w
+	SLC_NULL(1, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::DontSaveStationArea), // train_station.h
 	SLC_NULL(1, SaveLoadVersion::MinVersion, SaveLoadVersion::TownTolerancePauseMode),
 	SLC_VAR("string_id"),
 	SLC_VAR("name"),

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -421,6 +421,7 @@ enum class SaveLoadVersion : uint16_t {
 	DriveBackwards, ///< Saveload version: 365, GitHub pull request: 15379\n Trains can drive backwards.
 	DepotsUnderBridges, ///< Saveload version: 366, GitHub pull request: 15836\n Allow depots under bridges.
 	LabelOrientationUnification, ///< Saveload version: 367, GitHub pull request: 15888\n Unify the orientation in which labels are written.
+	DontSaveStationArea, ///< Saveload version: 368, GitHub pull request: 15987\n Station tile areas are no longer stored.
 
 	MaxVersion, ///< Highest possible saveload version.
 };

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -487,13 +487,7 @@ public:
 static const SaveLoad _old_station_desc[] = {
 	SLE_CONDVAR(Station, xy, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
 	SLE_CONDVAR(Station, xy, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Station, train_station.tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(Station, train_station.tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
-	SLE_CONDVAR(Station, airport.tile, VarFileType::U16 | VarMemType::U32, SaveLoadVersion::MinVersion, SaveLoadVersion::MultipleRoadStops),
-	SLE_CONDVAR(Station, airport.tile, VarTypes::U32, SaveLoadVersion::MultipleRoadStops, SaveLoadVersion::MaxVersion),
 	    SLE_REF(Station, town,                       SLRefType::Town),
-	    SLE_VAR(Station, train_station.w,            VarFileType::U8 | VarMemType::U16),
-	SLE_CONDVAR(Station, train_station.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::VehicleCurrencyStationChanges, SaveLoadVersion::MaxVersion),
 
 	    SLE_VAR(Station, string_id,                  VarTypes::STRINGID),
 	SLE_CONDSSTR(Station, name, VarTypes::STR | StringValidationSetting::AllowControlCode, SaveLoadVersion::ReplaceCustomNameArray, SaveLoadVersion::MaxVersion),
@@ -622,21 +616,8 @@ class SlStationNormal : public DefaultSaveLoadHandler<SlStationNormal, BaseStati
 public:
 	static inline const SaveLoad description[] = {
 		SLEG_STRUCT("base", SlStationBase),
-		    SLE_VAR(Station, train_station.tile,         VarTypes::U32),
-		    SLE_VAR(Station, train_station.w,            VarFileType::U8 | VarMemType::U16),
-		    SLE_VAR(Station, train_station.h,            VarFileType::U8 | VarMemType::U16),
-
 		    SLE_REF(Station, bus_stops,                  SLRefType::RoadStop),
 		    SLE_REF(Station, truck_stops,                SLRefType::RoadStop),
-		SLE_CONDVAR(Station, ship_station.tile, VarTypes::U32, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Station, ship_station.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Station, ship_station.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Station, docking_station.tile, VarTypes::U32, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Station, docking_station.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Station, docking_station.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultitileDocks, SaveLoadVersion::MaxVersion),
-		    SLE_VAR(Station, airport.tile,               VarTypes::U32),
-		SLE_CONDVAR(Station, airport.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::StoreAirportSize, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Station, airport.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::StoreAirportSize, SaveLoadVersion::MaxVersion),
 		    SLE_VAR(Station, airport.type,               VarTypes::U8),
 		SLE_CONDVAR(Station, airport.layout, VarTypes::U8, SaveLoadVersion::NewGRFAirportSmoke, SaveLoadVersion::MaxVersion),
 		SLE_VARNAME(Station, airport.blocks, "airport.flags", VarTypes::U64),
@@ -682,14 +663,7 @@ public:
 	static inline const SaveLoad description[] = {
 		SLEG_STRUCT("base", SlStationBase),
 		    SLE_VAR(Waypoint, town_cn,                   VarTypes::U16),
-
-		SLE_CONDVAR(Waypoint, train_station.tile, VarTypes::U32, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Waypoint, train_station.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Waypoint, train_station.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::MultiTileWaypoints, SaveLoadVersion::MaxVersion),
 		SLE_CONDVAR(Waypoint, waypoint_flags, VarTypes::U16, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Waypoint, road_waypoint_area.tile, VarTypes::U32, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Waypoint, road_waypoint_area.w, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
-		SLE_CONDVAR(Waypoint, road_waypoint_area.h, VarFileType::U8 | VarMemType::U16, SaveLoadVersion::RoadWaypoints, SaveLoadVersion::MaxVersion),
 	};
 	static inline const SaveLoadCompatTable compat_description = _station_waypoint_sl_compat;
 

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -536,13 +536,13 @@ public:
 	RoadStop *GetPrimaryRoadStop(const RoadVehicle *v) const;
 
 	RoadStop *bus_stops = nullptr; ///< All the road stops
-	TileArea bus_station{}; ///< Tile area the bus 'station' part covers
+	TileArea bus_station{}; ///< NOSAVE: Tile area the bus 'station' part covers
 	RoadStop *truck_stops = nullptr; ///< All the truck stops
-	TileArea truck_station{}; ///< Tile area the truck 'station' part covers
+	TileArea truck_station{}; ///< NOSAVE: Tile area the truck 'station' part covers
 
 	Airport airport{}; ///< Tile area the airport covers
-	TileArea ship_station{}; ///< Tile area the ship 'station' part covers
-	TileArea docking_station{}; ///< Tile area the docking tiles cover
+	TileArea ship_station{}; ///< NOSAVE: Tile area the ship 'station' part covers
+	TileArea docking_station{}; ///< NOSAVE: Tile area the docking tiles cover
 
 	IndustryType indtype = IT_INVALID; ///< Industry type to get the name from
 

--- a/src/waypoint_base.h
+++ b/src/waypoint_base.h
@@ -23,7 +23,7 @@ enum WaypointFlags : uint8_t {
 struct Waypoint final : SpecializedStation<Waypoint, true> {
 	uint16_t town_cn = 0; ///< The N-1th waypoint for this town (consecutive number)
 	uint16_t waypoint_flags{}; ///< Waypoint flags, see WaypointFlags
-	TileArea road_waypoint_area{}; ///< Tile area the road waypoint part covers
+	TileArea road_waypoint_area{}; ///< NOSAVE: Tile area the road waypoint part covers
 
 	/**
 	 * Create a waypoint at the given tile.


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

Station tile areas are saved in the savegame, but can be recalculated on load by scanning the map.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove storage of station tile areas in favour of always calculating on load.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Recalculating may not be in the right place.

3rd party tools might use this data, now they would have to parse the map array.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
