### PR TITLE
Codechange: Remove unused Clone() member from TileArea

### DIFF
--- a/src/bitmap_type.h
+++ b/src/bitmap_type.h
@@ -112,11 +112,6 @@ public:
 		}
 		return *this;
 	}
-
-	std::unique_ptr<TileIterator> Clone() const override
-	{
-		return std::make_unique<BitmapTileIterator>(*this);
-	}
 };
 
 #endif /* BITMAP_TYPE_HPP */

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -66,11 +66,6 @@ public:
 	{
 		return this->iter->gfx;
 	}
-
-	std::unique_ptr<TileIterator> Clone() const override
-	{
-		return std::make_unique<AirportTileTableIterator>(*this);
-	}
 };
 
 /** Class IDs for airports. */

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -633,11 +633,6 @@ public:
 		}
 		return *this;
 	}
-
-	std::unique_ptr<TileIterator> Clone() const override
-	{
-		return std::make_unique<AirportTileIterator>(*this);
-	}
 };
 
 void RebuildStationKdtree();

--- a/src/tilearea_type.h
+++ b/src/tilearea_type.h
@@ -160,12 +160,6 @@ public:
 	virtual TileIterator& operator ++() = 0;
 
 	/**
-	 * Allocate a new iterator that is a copy of this one.
-	 * @return A clone of this iterator.
-	 */
-	virtual std::unique_ptr<TileIterator> Clone() const = 0;
-
-	/**
 	 * Equality comparison.
 	 * @param rhs The other iterator to compare to.
 	 * @return \c true iff the tile of both iterators is the same.
@@ -232,11 +226,6 @@ public:
 		}
 		return *this;
 	}
-
-	std::unique_ptr<TileIterator> Clone() const override
-	{
-		return std::make_unique<OrthogonalTileIterator>(*this);
-	}
 };
 
 /** Iterator to iterate over a diagonal area of the map. */
@@ -271,11 +260,6 @@ public:
 	}
 
 	TileIterator& operator ++() override;
-
-	std::unique_ptr<TileIterator> Clone() const override
-	{
-		return std::make_unique<DiagonalTileIterator>(*this);
-	}
 };
 
 /**


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Feature: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem

`TileArea` has a `Clone()` virtual member function which is never called.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Remove `Clone()` from `TileArea`

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
